### PR TITLE
Addresses in BO order page better to be show as tab

### DIFF
--- a/tests/UI/.docker/prestashop/Dockerfile
+++ b/tests/UI/.docker/prestashop/Dockerfile
@@ -13,11 +13,11 @@ RUN apt install -y \
     curl \
     git \
     software-properties-common \
-    nodejs \
     poppler-utils
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt update
 RUN apt install -y nodejs
 
 COPY ["./.docker/prestashop/wait-for-it.sh", "./.docker/prestashop/docker_run.sh", "/tmp/"]

--- a/tests/UI/campaigns/data/faker/CMScategory.js
+++ b/tests/UI/campaigns/data/faker/CMScategory.js
@@ -10,22 +10,22 @@ class CMSCategoryData {
    * @param categoryToCreate {Object} Could be used to force the value of some members
    */
   constructor(categoryToCreate = {}) {
-    /** @member {string} Name of the page category */
+    /** @type {string} Name of the page category */
     this.name = categoryToCreate.name || faker.commerce.department();
 
-    /** @member {boolean} True to display the category on FO */
+    /** @type {boolean} True to display the category on FO */
     this.displayed = categoryToCreate.displayed === undefined ? true : categoryToCreate.displayed;
 
-    /** @member {string} Description of the category */
+    /** @type {string} Description of the category */
     this.description = faker.lorem.sentence();
 
-    /** @member {string} Meta title of the category */
+    /** @type {string} Meta title of the category */
     this.metaTitle = categoryToCreate.metaTitle || faker.name.title();
 
-    /** @member {string} Meta description of the category */
+    /** @type {string} Meta description of the category */
     this.metaDescription = faker.lorem.sentence();
 
-    /** @member {string} Meta keyword of the category */
+    /** @type {string} Meta keyword of the category */
     this.metaKeywords = faker.commerce.department();
   }
 }

--- a/tests/UI/campaigns/data/faker/CMScategory.js
+++ b/tests/UI/campaigns/data/faker/CMScategory.js
@@ -1,12 +1,33 @@
 const faker = require('faker');
 
-module.exports = class PageCategory {
-  constructor(pageCategoryToCreate = {}) {
-    this.name = pageCategoryToCreate.name || faker.commerce.department();
-    this.displayed = pageCategoryToCreate.displayed === undefined ? true : pageCategoryToCreate.displayed;
+/**
+ * Create new cms category to use on creation cms category form on BO
+ * @class
+ */
+class CMSCategoryData {
+  /**
+   * Constructor for class CMSCategoryData
+   * @param categoryToCreate {Object} Could be used to force the value of some members
+   */
+  constructor(categoryToCreate = {}) {
+    /** @member {string} Name of the page category */
+    this.name = categoryToCreate.name || faker.commerce.department();
+
+    /** @member {boolean} True to display the category on FO */
+    this.displayed = categoryToCreate.displayed === undefined ? true : categoryToCreate.displayed;
+
+    /** @member {string} Description of the category */
     this.description = faker.lorem.sentence();
-    this.metaTitle = pageCategoryToCreate.metaTitle || faker.name.title();
+
+    /** @member {string} Meta title of the category */
+    this.metaTitle = categoryToCreate.metaTitle || faker.name.title();
+
+    /** @member {string} Meta description of the category */
     this.metaDescription = faker.lorem.sentence();
+
+    /** @member {string} Meta keyword of the category */
     this.metaKeywords = faker.commerce.department();
   }
-};
+}
+
+module.exports = CMSCategoryData;

--- a/tests/UI/campaigns/data/faker/CMSpage.js
+++ b/tests/UI/campaigns/data/faker/CMSpage.js
@@ -10,25 +10,25 @@ class CMSPageData {
    * @param pageToCreate {Object} Could be used to force the value of some members
    */
   constructor(pageToCreate = {}) {
-    /** @member {string} Title of the page */
+    /** @type {string} Title of the page */
     this.title = pageToCreate.title || faker.random.word();
 
-    /** @member {string} Meta title of the page */
+    /** @type {string} Meta title of the page */
     this.metaTitle = pageToCreate.metaTitle || faker.name.title();
 
-    /** @member {string} Meta description for the page */
+    /** @type {string} Meta description for the page */
     this.metaDescription = faker.lorem.sentence();
 
-    /** @member {string} Meta keyword for the page */
+    /** @type {string} Meta keyword for the page */
     this.metaKeywords = faker.lorem.word();
 
-    /** @member {string} Content of the page */
+    /** @type {string} Content of the page */
     this.content = faker.lorem.sentence();
 
-    /** @member {boolean} True to display the page on FO */
+    /** @type {boolean} True to display the page on FO */
     this.displayed = pageToCreate.displayed === undefined ? true : pageToCreate.displayed;
 
-    /** @member {boolean} True to index the page */
+    /** @type {boolean} True to index the page */
     this.indexation = pageToCreate.indexation === undefined ? true : pageToCreate.indexation;
   }
 }

--- a/tests/UI/campaigns/data/faker/CMSpage.js
+++ b/tests/UI/campaigns/data/faker/CMSpage.js
@@ -1,13 +1,36 @@
 const faker = require('faker');
 
-module.exports = class Page {
+/**
+ * Create new cms page to use on creation cms page form on BO
+ * @class
+ */
+class CMSPageData {
+  /**
+   * Constructor for class CMSPageData
+   * @param pageToCreate {Object} Could be used to force the value of some members
+   */
   constructor(pageToCreate = {}) {
+    /** @member {string} Title of the page */
     this.title = pageToCreate.title || faker.random.word();
+
+    /** @member {string} Meta title of the page */
     this.metaTitle = pageToCreate.metaTitle || faker.name.title();
+
+    /** @member {string} Meta description for the page */
     this.metaDescription = faker.lorem.sentence();
+
+    /** @member {string} Meta keyword for the page */
     this.metaKeywords = faker.lorem.word();
+
+    /** @member {string} Content of the page */
     this.content = faker.lorem.sentence();
+
+    /** @member {boolean} True to display the page on FO */
     this.displayed = pageToCreate.displayed === undefined ? true : pageToCreate.displayed;
+
+    /** @member {boolean} True to index the page */
     this.indexation = pageToCreate.indexation === undefined ? true : pageToCreate.indexation;
   }
-};
+}
+
+module.exports = CMSPageData;

--- a/tests/UI/campaigns/data/faker/cartRule.js
+++ b/tests/UI/campaigns/data/faker/cartRule.js
@@ -17,8 +17,8 @@ class CartRuleData {
     /** @type {string} Name of the cart rule */
     this.description = faker.lorem.sentence();
 
-    /** @type {string} Code to apply the cart rule */
-    this.code = cartRuleToCreate.code;
+    /** @type {?string} Code to apply the cart rule */
+    this.code = cartRuleToCreate.code || null;
 
     /** @type {boolean} True to generate code */
     this.generateCode = cartRuleToCreate.generateCode || false;

--- a/tests/UI/campaigns/data/faker/cartRule.js
+++ b/tests/UI/campaigns/data/faker/cartRule.js
@@ -1,53 +1,113 @@
 const faker = require('faker');
 
-module.exports = class CartRule {
+/**
+ * Create new cart rule to use on creation cart rule form on BO
+ * @class
+ */
+class CartRuleData {
+  /**
+   * Constructor for class CartRuleData
+   * @param cartRuleToCreate {Object} Could be used to force the value of some members
+   */
   constructor(cartRuleToCreate = {}) {
     // Information
+    /** @member {string} Name of the cart rule */
     this.name = cartRuleToCreate.name || faker.commerce.department();
+
+    /** @member {string} Name of the cart rule */
     this.description = faker.lorem.sentence();
-    this.code = cartRuleToCreate.code || null;
+
+    /** @member {string} Code to apply the cart rule */
+    this.code = cartRuleToCreate.code;
+
+    /** @member {boolean} True to generate code */
     this.generateCode = cartRuleToCreate.generateCode || false;
+
+    /** @member {boolean} True to display cart rule gighlight */
     this.highlight = cartRuleToCreate.highlight === undefined ? false : cartRuleToCreate.highlight;
+
+    /** @member {string} True to enable partial use */
     this.partialUse = cartRuleToCreate.partialUse === undefined ? true : cartRuleToCreate.partialUse;
+
+    /** @member {number} Priority of the cart rule */
     this.priority = cartRuleToCreate.priority || 1;
+
+    /** @member {boolean} Status of the cart rule */
     this.status = cartRuleToCreate.status === undefined ? true : cartRuleToCreate.status;
 
     // Conditions
+    /** @member {string|boolean} Specific customer for the cart rule or false to disable it */
     this.customer = cartRuleToCreate.customer || false;
+
+    /** @member {string|boolean} Starting date for the cart rule or false to disable it */
     this.dateFrom = cartRuleToCreate.dateFrom || false;
+
+    /** @member {string|boolean} Ending date for the cart rule or false to disable it */
     this.dateTo = cartRuleToCreate.dateTo || false;
 
+
+    /** @member {{shipping: string, currency: string, tax: string, value: number}} Minimum amount parameters */
     this.minimumAmount = {
+      /** @member {number} Value of the minimum amount */
       value: cartRuleToCreate.minimumAmount === undefined ? 0 : cartRuleToCreate.minimumAmount.value,
+
+      /** @member {string} Currency used on minimum amount */
       currency: cartRuleToCreate.minimumAmount === undefined ? 'EUR' : cartRuleToCreate.minimumAmount.currency,
+
+      /** @member {string} Tax used on the minimum amount */
       tax: cartRuleToCreate.minimumAmount === undefined ? 'Tax included' : cartRuleToCreate.minimumAmount.tax,
+
+      /** @member {string} Shipping used on minimum amount */
       shipping: cartRuleToCreate.minimumAmount === undefined
         ? 'Shipping included' : cartRuleToCreate.minimumAmount.shipping,
     };
 
+    /** @member {number} Amount of times that cart rule could be used */
     this.quantity = cartRuleToCreate.quantity || 1;
+
+    /** @member {number} Amount of times a user can use the cart rule */
     this.quantityPerUser = cartRuleToCreate.quantityPerUser || 1;
 
     // Actions
+    /** @member {boolean} True to enable free shipping on the cart rule */
     this.freeShipping = cartRuleToCreate.freeShipping === undefined ? false : cartRuleToCreate.freeShipping;
 
+    /** @member {string} Discount type of the cart rule */
     this.discountType = cartRuleToCreate.discountType || 'None';
+
+    /** @member {number|undefined} Discount percent for the cart rule */
+    this.discountPercent = undefined;
+
+    /** @member {{currency: string, tax: string, value: number}|undefined} Discount amount values for the cart rule */
+    this.discountAmount = undefined;
+
     if (this.discountType === 'Percent') {
       this.discountPercent = cartRuleToCreate.discountPercent || faker.random.number({min: 10, max: 80});
     } else if (this.discountPercent === 'Amount') {
       this.discountAmount = {
+        /** @member {number} Value of the discount amount */
         value: cartRuleToCreate.discountAmount === undefined ? 0 : cartRuleToCreate.discountAmount.value,
+
+        /** @member {string} Currency used for the discount amount */
         currency: cartRuleToCreate.discountAmount === undefined ? 'EUR' : cartRuleToCreate.discountAmount.currency,
+
+        /** @member {string} Tax that will be used for the discount amount */
         tax: cartRuleToCreate.discountAmount === undefined ? 'Tax included' : cartRuleToCreate.discountAmount.tax,
       };
     }
 
+    /** @member {boolean} True to exclude discount of specific products */
     this.excludeDiscountProducts = cartRuleToCreate.excludeDiscountProducts === undefined
       ? false : cartRuleToCreate.excludeDiscountProducts;
 
+    /** @member {boolean} True to enable free gift */
     this.freeGift = cartRuleToCreate.freeGift === undefined ? false : cartRuleToCreate.freeGift;
+
     if (this.freeGift) {
+      /** @member {string} Product to set for the free gift */
       this.freeGiftProduct = cartRuleToCreate.freeGiftProduct;
     }
   }
-};
+}
+
+module.exports = CartRuleData;

--- a/tests/UI/campaigns/data/faker/cartRule.js
+++ b/tests/UI/campaigns/data/faker/cartRule.js
@@ -11,100 +11,100 @@ class CartRuleData {
    */
   constructor(cartRuleToCreate = {}) {
     // Information
-    /** @member {string} Name of the cart rule */
+    /** @type {string} Name of the cart rule */
     this.name = cartRuleToCreate.name || faker.commerce.department();
 
-    /** @member {string} Name of the cart rule */
+    /** @type {string} Name of the cart rule */
     this.description = faker.lorem.sentence();
 
-    /** @member {string} Code to apply the cart rule */
+    /** @type {string} Code to apply the cart rule */
     this.code = cartRuleToCreate.code;
 
-    /** @member {boolean} True to generate code */
+    /** @type {boolean} True to generate code */
     this.generateCode = cartRuleToCreate.generateCode || false;
 
-    /** @member {boolean} True to display cart rule gighlight */
+    /** @type {boolean} True to display cart rule highlight */
     this.highlight = cartRuleToCreate.highlight === undefined ? false : cartRuleToCreate.highlight;
 
-    /** @member {string} True to enable partial use */
+    /** @type {string} True to enable partial use */
     this.partialUse = cartRuleToCreate.partialUse === undefined ? true : cartRuleToCreate.partialUse;
 
-    /** @member {number} Priority of the cart rule */
+    /** @type {number} Priority of the cart rule */
     this.priority = cartRuleToCreate.priority || 1;
 
-    /** @member {boolean} Status of the cart rule */
+    /** @type {boolean} Status of the cart rule */
     this.status = cartRuleToCreate.status === undefined ? true : cartRuleToCreate.status;
 
     // Conditions
-    /** @member {string|boolean} Specific customer for the cart rule or false to disable it */
+    /** @type {string|boolean} Specific customer for the cart rule or false to disable it */
     this.customer = cartRuleToCreate.customer || false;
 
-    /** @member {string|boolean} Starting date for the cart rule or false to disable it */
+    /** @type {string|boolean} Starting date for the cart rule or false to disable it */
     this.dateFrom = cartRuleToCreate.dateFrom || false;
 
-    /** @member {string|boolean} Ending date for the cart rule or false to disable it */
+    /** @type {string|boolean} Ending date for the cart rule or false to disable it */
     this.dateTo = cartRuleToCreate.dateTo || false;
 
 
-    /** @member {{shipping: string, currency: string, tax: string, value: number}} Minimum amount parameters */
+    /** @type {{shipping: string, currency: string, tax: string, value: number}} Minimum amount parameters */
     this.minimumAmount = {
-      /** @member {number} Value of the minimum amount */
+      /** @type {number} Value of the minimum amount */
       value: cartRuleToCreate.minimumAmount === undefined ? 0 : cartRuleToCreate.minimumAmount.value,
 
-      /** @member {string} Currency used on minimum amount */
+      /** @type {string} Currency used on minimum amount */
       currency: cartRuleToCreate.minimumAmount === undefined ? 'EUR' : cartRuleToCreate.minimumAmount.currency,
 
-      /** @member {string} Tax used on the minimum amount */
+      /** @type {string} Tax used on the minimum amount */
       tax: cartRuleToCreate.minimumAmount === undefined ? 'Tax included' : cartRuleToCreate.minimumAmount.tax,
 
-      /** @member {string} Shipping used on minimum amount */
+      /** @type {string} Shipping used on minimum amount */
       shipping: cartRuleToCreate.minimumAmount === undefined
         ? 'Shipping included' : cartRuleToCreate.minimumAmount.shipping,
     };
 
-    /** @member {number} Amount of times that cart rule could be used */
+    /** @type {number} Amount of times that cart rule could be used */
     this.quantity = cartRuleToCreate.quantity || 1;
 
-    /** @member {number} Amount of times a user can use the cart rule */
+    /** @type {number} Amount of times a user can use the cart rule */
     this.quantityPerUser = cartRuleToCreate.quantityPerUser || 1;
 
     // Actions
-    /** @member {boolean} True to enable free shipping on the cart rule */
+    /** @type {boolean} True to enable free shipping on the cart rule */
     this.freeShipping = cartRuleToCreate.freeShipping === undefined ? false : cartRuleToCreate.freeShipping;
 
-    /** @member {string} Discount type of the cart rule */
+    /** @type {string} Discount type of the cart rule */
     this.discountType = cartRuleToCreate.discountType || 'None';
 
-    /** @member {number|undefined} Discount percent for the cart rule */
+    /** @type {number|undefined} Discount percent for the cart rule */
     this.discountPercent = undefined;
 
-    /** @member {{currency: string, tax: string, value: number}|undefined} Discount amount values for the cart rule */
+    /** @type {{currency: string, tax: string, value: number}|undefined} Discount amount values for the cart rule */
     this.discountAmount = undefined;
 
     if (this.discountType === 'Percent') {
       this.discountPercent = cartRuleToCreate.discountPercent || faker.random.number({min: 10, max: 80});
     } else if (this.discountPercent === 'Amount') {
       this.discountAmount = {
-        /** @member {number} Value of the discount amount */
+        /** @type {number} Value of the discount amount */
         value: cartRuleToCreate.discountAmount === undefined ? 0 : cartRuleToCreate.discountAmount.value,
 
-        /** @member {string} Currency used for the discount amount */
+        /** @type {string} Currency used for the discount amount */
         currency: cartRuleToCreate.discountAmount === undefined ? 'EUR' : cartRuleToCreate.discountAmount.currency,
 
-        /** @member {string} Tax that will be used for the discount amount */
+        /** @type {string} Tax that will be used for the discount amount */
         tax: cartRuleToCreate.discountAmount === undefined ? 'Tax included' : cartRuleToCreate.discountAmount.tax,
       };
     }
 
-    /** @member {boolean} True to exclude discount of specific products */
+    /** @type {boolean} True to exclude discount of specific products */
     this.excludeDiscountProducts = cartRuleToCreate.excludeDiscountProducts === undefined
       ? false : cartRuleToCreate.excludeDiscountProducts;
 
-    /** @member {boolean} True to enable free gift */
+    /** @type {boolean} True to enable free gift */
     this.freeGift = cartRuleToCreate.freeGift === undefined ? false : cartRuleToCreate.freeGift;
 
     if (this.freeGift) {
-      /** @member {string} Product to set for the free gift */
+      /** @type {string} Product to set for the free gift */
       this.freeGiftProduct = cartRuleToCreate.freeGiftProduct;
     }
   }

--- a/tests/UI/campaigns/data/faker/catalogPriceRule.js
+++ b/tests/UI/campaigns/data/faker/catalogPriceRule.js
@@ -20,36 +20,36 @@ class CatalogPriceRuleData {
    * @param priceRuleToCreate {Object} Could be used to force the value of some members
    */
   constructor(priceRuleToCreate = {}) {
-    /** @member {string} Name of the price rule */
+    /** @type {string} Name of the price rule */
     this.name = priceRuleToCreate.name || faker.commerce.department();
 
-    /** @member {string} Currency of the price rule */
+    /** @type {string} Currency of the price rule */
     this.currency = priceRuleToCreate.currency || faker.random.arrayElement(currencies);
 
-    /** @member {string} Country that could use the cart rule */
+    /** @type {string} Country that could use the cart rule */
     this.country = priceRuleToCreate.country || faker.random.arrayElement(countriesNames);
 
-    /** @member {string} Customer group that could use the price rule */
+    /** @type {string} Customer group that could use the price rule */
     this.group = priceRuleToCreate.group || faker.random.arrayElement(groupAccessNames);
 
-    /** @member {string} Minimum quantity to apply price rule */
+    /** @type {number} Minimum quantity to apply price rule */
     this.fromQuantity = priceRuleToCreate.fromQuantity === undefined
       ? faker.random.number({min: 1, max: 9})
       : priceRuleToCreate.fromQuantity;
 
-    /** @member {string} Starting date to apply the price rule  */
+    /** @type {string} Starting date to apply the price rule  */
     this.fromDate = priceRuleToCreate.fromDate || '';
 
-    /** @member {string} Ending date to apply price rule */
+    /** @type {string} Ending date to apply price rule */
     this.toDate = priceRuleToCreate.toDate || '';
 
-    /** @member {string} Reduction type of the price rule */
+    /** @type {string} Reduction type of the price rule */
     this.reductionType = priceRuleToCreate.reductionType || faker.random.arrayElement(reductionType);
 
-    /** @member {string} Reduction tax for the price rule */
+    /** @type {string} Reduction tax for the price rule */
     this.reductionTax = priceRuleToCreate.reductionTax || faker.random.arrayElement(reductionTax);
 
-    /** @member {number} Reduction value of the price rule */
+    /** @type {number} Reduction value of the price rule */
     this.reduction = priceRuleToCreate.reduction || faker.random.number({min: 20, max: 30});
   }
 }

--- a/tests/UI/campaigns/data/faker/catalogPriceRule.js
+++ b/tests/UI/campaigns/data/faker/catalogPriceRule.js
@@ -10,19 +10,48 @@ const currencies = ['All currencies', 'Euro'];
 const reductionType = ['Amount', 'Percentage'];
 const reductionTax = ['Tax excluded', 'Tax included'];
 
-module.exports = class Category {
+/**
+ * Create new catalog price rule to use on creation catalog price rule form on BO
+ * @class
+ */
+class CatalogPriceRuleData {
+  /**
+   * Constructor for class CatalogPriceRuleData
+   * @param priceRuleToCreate {Object} Could be used to force the value of some members
+   */
   constructor(priceRuleToCreate = {}) {
+    /** @member {string} Name of the price rule */
     this.name = priceRuleToCreate.name || faker.commerce.department();
+
+    /** @member {string} Currency of the price rule */
     this.currency = priceRuleToCreate.currency || faker.random.arrayElement(currencies);
+
+    /** @member {string} Country that could use the cart rule */
     this.country = priceRuleToCreate.country || faker.random.arrayElement(countriesNames);
+
+    /** @member {string} Customer group that could use the price rule */
     this.group = priceRuleToCreate.group || faker.random.arrayElement(groupAccessNames);
+
+    /** @member {string} Minimum quantity to apply price rule */
     this.fromQuantity = priceRuleToCreate.fromQuantity === undefined
       ? faker.random.number({min: 1, max: 9})
       : priceRuleToCreate.fromQuantity;
+
+    /** @member {string} Starting date to apply the price rule  */
     this.fromDate = priceRuleToCreate.fromDate || '';
+
+    /** @member {string} Ending date to apply price rule */
     this.toDate = priceRuleToCreate.toDate || '';
+
+    /** @member {string} Reduction type of the price rule */
     this.reductionType = priceRuleToCreate.reductionType || faker.random.arrayElement(reductionType);
+
+    /** @member {string} Reduction tax for the price rule */
     this.reductionTax = priceRuleToCreate.reductionTax || faker.random.arrayElement(reductionTax);
+
+    /** @member {number} Reduction value of the price rule */
     this.reduction = priceRuleToCreate.reduction || faker.random.number({min: 20, max: 30});
   }
-};
+}
+
+module.exports = CatalogPriceRuleData;

--- a/tests/UI/campaigns/data/faker/category.js
+++ b/tests/UI/campaigns/data/faker/category.js
@@ -2,14 +2,35 @@ const faker = require('faker');
 
 const {groupAccess} = require('@data/demo/groupAccess');
 
-module.exports = class Category {
+/**
+ * Create new category to use on creation category form on BO
+ * @class
+ */
+class CategoryData {
+  /**
+   * Constructor for class CategoryData
+   * @param categoryToCreate {Object} Could be used to force the value of some members
+   */
   constructor(categoryToCreate = {}) {
+    /** @member {string} Name of the category */
     this.name = categoryToCreate.name || `${faker.commerce.color()} ${faker.commerce.department()}`;
+
+    /** @member {boolean} True to display the category on FO */
     this.displayed = categoryToCreate.displayed === undefined ? true : categoryToCreate.displayed;
+
+    /** @member {string} Description of the category */
     this.description = faker.lorem.sentence();
+
+    /** @member {string} Meta title of the category */
     this.metaTitle = categoryToCreate.metaTitle || faker.name.title();
+
+    /** @member {string} Meta description of the category */
     this.metaDescription = faker.lorem.sentence();
+
+    /** @member {string} Customer group that could access to the category */
     this.groupAccess = categoryToCreate.groupAccess
       || faker.random.arrayElement(groupAccess);
   }
-};
+}
+
+module.exports = CategoryData;

--- a/tests/UI/campaigns/data/faker/category.js
+++ b/tests/UI/campaigns/data/faker/category.js
@@ -12,22 +12,22 @@ class CategoryData {
    * @param categoryToCreate {Object} Could be used to force the value of some members
    */
   constructor(categoryToCreate = {}) {
-    /** @member {string} Name of the category */
+    /** @type {string} Name of the category */
     this.name = categoryToCreate.name || `${faker.commerce.color()} ${faker.commerce.department()}`;
 
-    /** @member {boolean} True to display the category on FO */
+    /** @type {boolean} True to display the category on FO */
     this.displayed = categoryToCreate.displayed === undefined ? true : categoryToCreate.displayed;
 
-    /** @member {string} Description of the category */
+    /** @type {string} Description of the category */
     this.description = faker.lorem.sentence();
 
-    /** @member {string} Meta title of the category */
+    /** @type {string} Meta title of the category */
     this.metaTitle = categoryToCreate.metaTitle || faker.name.title();
 
-    /** @member {string} Meta description of the category */
+    /** @type {string} Meta description of the category */
     this.metaDescription = faker.lorem.sentence();
 
-    /** @member {string} Customer group that could access to the category */
+    /** @type {string} Customer group that could access to the category */
     this.groupAccess = categoryToCreate.groupAccess
       || faker.random.arrayElement(groupAccess);
   }

--- a/tests/UI/campaigns/data/faker/contact.js
+++ b/tests/UI/campaigns/data/faker/contact.js
@@ -1,12 +1,33 @@
 const faker = require('faker');
 
-module.exports = class Contact {
+/**
+ * Create new contact to use on creation contact form on BO
+ * @class
+ */
+class ContactData {
+  /**
+   * Constructor for class ContactData
+   * @param contactToCreate {Object} Could be used to force the value of some members
+   */
   constructor(contactToCreate = {}) {
+    /** @member {string} Firstname of the contact */
     this.firstName = contactToCreate.firstName || faker.name.firstName();
+
+    /** @member {string} Lastname of the contact */
     this.lastName = contactToCreate.lastName || faker.name.lastName();
+
+    /** @member {string} Title of the contact */
     this.title = contactToCreate.title || `${this.firstName} ${this.lastName}`;
+
+    /** @member {string} Email of the contact */
     this.email = contactToCreate.email || faker.internet.email(this.firstName, this.lastName, 'prestashop.com');
+
+    /** @member {boolean} True to save messages sent for the contact */
     this.saveMessage = contactToCreate.saveMessage === undefined ? true : contactToCreate.saveMessage;
+
+    /** @member {string} Description of the contact */
     this.description = contactToCreate.description || faker.lorem.sentence();
   }
-};
+}
+
+module.exports = ContactData;

--- a/tests/UI/campaigns/data/faker/contact.js
+++ b/tests/UI/campaigns/data/faker/contact.js
@@ -10,22 +10,22 @@ class ContactData {
    * @param contactToCreate {Object} Could be used to force the value of some members
    */
   constructor(contactToCreate = {}) {
-    /** @member {string} Firstname of the contact */
+    /** @type {string} Firstname of the contact */
     this.firstName = contactToCreate.firstName || faker.name.firstName();
 
-    /** @member {string} Lastname of the contact */
+    /** @type {string} Lastname of the contact */
     this.lastName = contactToCreate.lastName || faker.name.lastName();
 
-    /** @member {string} Title of the contact */
+    /** @type {string} Title of the contact */
     this.title = contactToCreate.title || `${this.firstName} ${this.lastName}`;
 
-    /** @member {string} Email of the contact */
+    /** @type {string} Email of the contact */
     this.email = contactToCreate.email || faker.internet.email(this.firstName, this.lastName, 'prestashop.com');
 
-    /** @member {boolean} True to save messages sent for the contact */
+    /** @type {boolean} True to save messages sent for the contact */
     this.saveMessage = contactToCreate.saveMessage === undefined ? true : contactToCreate.saveMessage;
 
-    /** @member {string} Description of the contact */
+    /** @type {string} Description of the contact */
     this.description = contactToCreate.description || faker.lorem.sentence();
   }
 }

--- a/tests/UI/campaigns/data/faker/contactUs.js
+++ b/tests/UI/campaigns/data/faker/contactUs.js
@@ -2,16 +2,38 @@ const faker = require('faker');
 
 const subject = ['Customer service', 'Webmaster'];
 
-module.exports = class ContactUs {
+/**
+ * Create new message to use on contact us form page on FO
+ * @class
+ */
+class MessageData {
+  /**
+   * Constructor for class MessageData
+   * @param messageToCreate {Object} Could be used to force the value of some members
+   */
   constructor(messageToCreate = {}) {
+    /** @member {string} Subject of the message */
     this.subject = messageToCreate.subject || faker.random.arrayElement(subject);
+
+    /** @member {string} Firstname of the customer */
     this.firstName = messageToCreate.firstName || faker.name.firstName();
+
+    /** @member {string} Firstname of the customer */
     this.lastName = messageToCreate.lastName || faker.name.lastName();
+
+    /** @member {string} Email of the customer */
     this.emailAddress = messageToCreate.emailAddress
       || faker.internet.email(this.firstName, this.lastName, 'prestashop.com');
 
+    /** @member {string} Reference for on order if used */
     this.reference = messageToCreate.reference;
+
+    /** @member {string} Attachment name to add to the message */
     this.fileName = faker.lorem.word();
+
+    /** @member {string} Content of the message */
     this.message = faker.lorem.sentence().substring(0, 35).trim();
   }
-};
+}
+
+module.exports = MessageData;

--- a/tests/UI/campaigns/data/faker/contactUs.js
+++ b/tests/UI/campaigns/data/faker/contactUs.js
@@ -12,26 +12,26 @@ class MessageData {
    * @param messageToCreate {Object} Could be used to force the value of some members
    */
   constructor(messageToCreate = {}) {
-    /** @member {string} Subject of the message */
+    /** @type {string} Subject of the message */
     this.subject = messageToCreate.subject || faker.random.arrayElement(subject);
 
-    /** @member {string} Firstname of the customer */
+    /** @type {string} Firstname of the customer */
     this.firstName = messageToCreate.firstName || faker.name.firstName();
 
-    /** @member {string} Firstname of the customer */
+    /** @type {string} Firstname of the customer */
     this.lastName = messageToCreate.lastName || faker.name.lastName();
 
-    /** @member {string} Email of the customer */
+    /** @type {string} Email of the customer */
     this.emailAddress = messageToCreate.emailAddress
       || faker.internet.email(this.firstName, this.lastName, 'prestashop.com');
 
-    /** @member {string} Reference for on order if used */
+    /** @type {string} Reference for on order if used */
     this.reference = messageToCreate.reference;
 
-    /** @member {string} Attachment name to add to the message */
+    /** @type {string} Attachment name to add to the message */
     this.fileName = faker.lorem.word();
 
-    /** @member {string} Content of the message */
+    /** @type {string} Content of the message */
     this.message = faker.lorem.sentence().substring(0, 35).trim();
   }
 }

--- a/tests/UI/campaigns/data/faker/country.js
+++ b/tests/UI/campaigns/data/faker/country.js
@@ -5,19 +5,50 @@ const {Currencies} = require('@data/demo/currencies');
 const zones = Object.values(Zones).map(zone => zone.name);
 const currencies = Object.values(Currencies).map(currency => currency.name);
 
-module.exports = class Country {
+/**
+ * Create new country to use on creation form on country page on BO
+ * @class
+ */
+class CountryData {
+  /**
+   * Constructor for class CountryData
+   * @param countryToCreate {Object} Could be used to force the value of some members
+   */
   constructor(countryToCreate = {}) {
+    /** @member {string} Name of the country */
     this.name = countryToCreate.name || `test${faker.address.country()}`;
+
+    /** @member {string} Country iso code */
     this.isoCode = countryToCreate.isoCode || faker.address.countryCode();
+
+    /** @member {string} Country call Prefix */
     this.callPrefix = countryToCreate.callPrefix;
+
+    /** @member {string} Currency used in the country */
     this.currency = countryToCreate.currency || faker.random.arrayElement(currencies);
+
+    /** @member {string} In which zone the country belongs */
     this.zone = countryToCreate.zone || faker.random.arrayElement(zones);
+
+    /** @member {string} True if the country used zip codes */
     this.needZipCode = countryToCreate.needZipCode === undefined ? false : countryToCreate.needZipCode;
+
+    /** @member {string} Format of the zip code if used */
     this.zipCodeFormat = countryToCreate.zipCodeFormat;
+
+    /** @member {string} Status of the country */
     this.active = countryToCreate.active === undefined ? false : countryToCreate.active;
+
+    /** @member {string} True if the country have states */
     this.containsStates = countryToCreate.containsStates === undefined ? false : countryToCreate.containsStates;
+
+    /** @member {string} True if need identification number for the country */
     this.needIdentificationNumber = countryToCreate.needIdentificationNumber === undefined
       ? false : countryToCreate.needIdentificationNumber;
+
+    /** @member {string} True to display tax number when located on the country */
     this.displayTaxNumber = countryToCreate.displayTaxNumber === undefined ? false : countryToCreate.displayTaxNumber;
   }
-};
+}
+
+module.exports = CountryData;

--- a/tests/UI/campaigns/data/faker/country.js
+++ b/tests/UI/campaigns/data/faker/country.js
@@ -15,38 +15,38 @@ class CountryData {
    * @param countryToCreate {Object} Could be used to force the value of some members
    */
   constructor(countryToCreate = {}) {
-    /** @member {string} Name of the country */
+    /** @type {string} Name of the country */
     this.name = countryToCreate.name || `test${faker.address.country()}`;
 
-    /** @member {string} Country iso code */
+    /** @type {string} Country iso code */
     this.isoCode = countryToCreate.isoCode || faker.address.countryCode();
 
-    /** @member {string} Country call Prefix */
+    /** @type {string} Country call Prefix */
     this.callPrefix = countryToCreate.callPrefix;
 
-    /** @member {string} Currency used in the country */
+    /** @type {string} Currency used in the country */
     this.currency = countryToCreate.currency || faker.random.arrayElement(currencies);
 
-    /** @member {string} In which zone the country belongs */
+    /** @type {string} In which zone the country belongs */
     this.zone = countryToCreate.zone || faker.random.arrayElement(zones);
 
-    /** @member {string} True if the country used zip codes */
+    /** @type {string} True if the country used zip codes */
     this.needZipCode = countryToCreate.needZipCode === undefined ? false : countryToCreate.needZipCode;
 
-    /** @member {string} Format of the zip code if used */
+    /** @type {string} Format of the zip code if used */
     this.zipCodeFormat = countryToCreate.zipCodeFormat;
 
-    /** @member {string} Status of the country */
+    /** @type {string} Status of the country */
     this.active = countryToCreate.active === undefined ? false : countryToCreate.active;
 
-    /** @member {string} True if the country have states */
+    /** @type {string} True if the country have states */
     this.containsStates = countryToCreate.containsStates === undefined ? false : countryToCreate.containsStates;
 
-    /** @member {string} True if need identification number for the country */
+    /** @type {string} True if need identification number for the country */
     this.needIdentificationNumber = countryToCreate.needIdentificationNumber === undefined
       ? false : countryToCreate.needIdentificationNumber;
 
-    /** @member {string} True to display tax number when located on the country */
+    /** @type {string} True to display tax number when located on the country */
     this.displayTaxNumber = countryToCreate.displayTaxNumber === undefined ? false : countryToCreate.displayTaxNumber;
   }
 }

--- a/tests/UI/campaigns/data/faker/customer.js
+++ b/tests/UI/campaigns/data/faker/customer.js
@@ -3,24 +3,58 @@ const faker = require('faker');
 const {Titles} = require('@data/demo/titles');
 const {groupAccess} = require('@data/demo/groupAccess');
 
-
 const genders = Object.values(Titles).map(title => title.name);
 const groups = Object.values(groupAccess).map(group => group.name);
 
-module.exports = class Customer {
+/**
+ * Create new customer to use on creation form on customer page on BO and FO
+ * @class
+ */
+class CustomerData {
+  /**
+   * Constructor for class CustomerData
+   * @param customerToCreate {Object} Could be used to force the value of some members
+   */
   constructor(customerToCreate = {}) {
+    /** @member {string} Social title of the customer (Mr, Mrs) */
     this.socialTitle = customerToCreate.socialTitle || faker.random.arrayElement(genders);
+
+    /** @member {string} Firstname of the customer */
     this.firstName = customerToCreate.firstName || faker.name.firstName();
+
+    /** @member {string} Lastname of the customer */
     this.lastName = customerToCreate.lastName || faker.name.lastName();
+
+    /** @member {string} Email for the customer account */
     this.email = customerToCreate.email || faker.internet.email(this.firstName, this.lastName, 'prestashop.com');
+
+    /** @member {string} Password for the customer account */
     this.password = customerToCreate.password === undefined ? '123456789' : customerToCreate.password;
+
+    /** @member {Date} Birthdate of the customer */
     this.birthDate = faker.date.between('1950-01-01', '2000-12-31');
+
+    /** @member {string} Year of the birth 'yyyy' */
     this.yearOfBirth = customerToCreate.yearOfBirth || this.birthDate.getFullYear().toString();
+
+    /** @member {string} Month of the birth 'mm' */
     this.monthOfBirth = customerToCreate.monthOfBirth || (this.birthDate.getMonth() + 1).toString();
+
+    /** @member {string} Day of the birth 'dd'  */
     this.dayOfBirth = customerToCreate.dayOfBirth || this.birthDate.getDate().toString();
+
+    /** @member {boolean} Status of the customer */
     this.enabled = customerToCreate.enabled === undefined ? true : customerToCreate.enabled;
+
+    /** @member {boolean} True to enable partner offers */
     this.partnerOffers = customerToCreate.partnerOffers === undefined ? true : customerToCreate.partnerOffers;
+
+    /** @member {string} Default group for the customer */
     this.defaultCustomerGroup = customerToCreate.defaultCustomerGroup || faker.random.arrayElement(groups);
+
+    /** @member {boolean} True to enable sending newsletter to the customer */
     this.newsletter = customerToCreate.newsletter === undefined ? false : customerToCreate.newsletter;
   }
-};
+}
+
+module.exports = CustomerData;

--- a/tests/UI/campaigns/data/faker/customer.js
+++ b/tests/UI/campaigns/data/faker/customer.js
@@ -16,43 +16,43 @@ class CustomerData {
    * @param customerToCreate {Object} Could be used to force the value of some members
    */
   constructor(customerToCreate = {}) {
-    /** @member {string} Social title of the customer (Mr, Mrs) */
+    /** @type {string} Social title of the customer (Mr, Mrs) */
     this.socialTitle = customerToCreate.socialTitle || faker.random.arrayElement(genders);
 
-    /** @member {string} Firstname of the customer */
+    /** @type {string} Firstname of the customer */
     this.firstName = customerToCreate.firstName || faker.name.firstName();
 
-    /** @member {string} Lastname of the customer */
+    /** @type {string} Lastname of the customer */
     this.lastName = customerToCreate.lastName || faker.name.lastName();
 
-    /** @member {string} Email for the customer account */
+    /** @type {string} Email for the customer account */
     this.email = customerToCreate.email || faker.internet.email(this.firstName, this.lastName, 'prestashop.com');
 
-    /** @member {string} Password for the customer account */
+    /** @type {string} Password for the customer account */
     this.password = customerToCreate.password === undefined ? '123456789' : customerToCreate.password;
 
-    /** @member {Date} Birthdate of the customer */
+    /** @type {Date} Birthdate of the customer */
     this.birthDate = faker.date.between('1950-01-01', '2000-12-31');
 
-    /** @member {string} Year of the birth 'yyyy' */
+    /** @type {string} Year of the birth 'yyyy' */
     this.yearOfBirth = customerToCreate.yearOfBirth || this.birthDate.getFullYear().toString();
 
-    /** @member {string} Month of the birth 'mm' */
+    /** @type {string} Month of the birth 'mm' */
     this.monthOfBirth = customerToCreate.monthOfBirth || (this.birthDate.getMonth() + 1).toString();
 
-    /** @member {string} Day of the birth 'dd'  */
+    /** @type {string} Day of the birth 'dd'  */
     this.dayOfBirth = customerToCreate.dayOfBirth || this.birthDate.getDate().toString();
 
-    /** @member {boolean} Status of the customer */
+    /** @type {boolean} Status of the customer */
     this.enabled = customerToCreate.enabled === undefined ? true : customerToCreate.enabled;
 
-    /** @member {boolean} True to enable partner offers */
+    /** @type {boolean} True to enable partner offers */
     this.partnerOffers = customerToCreate.partnerOffers === undefined ? true : customerToCreate.partnerOffers;
 
-    /** @member {string} Default group for the customer */
+    /** @type {string} Default group for the customer */
     this.defaultCustomerGroup = customerToCreate.defaultCustomerGroup || faker.random.arrayElement(groups);
 
-    /** @member {boolean} True to enable sending newsletter to the customer */
+    /** @type {boolean} True to enable sending newsletter to the customer */
     this.newsletter = customerToCreate.newsletter === undefined ? false : customerToCreate.newsletter;
   }
 }

--- a/tests/UI/campaigns/data/faker/deliverySlipOptions.js
+++ b/tests/UI/campaigns/data/faker/deliverySlipOptions.js
@@ -1,8 +1,21 @@
 const faker = require('faker');
 
-module.exports = class Invoice {
+/**
+ * Create new delivery slip to use on creation form on delivery slip page on BO
+ * @class
+ */
+class DeliverySlipData {
+  /**
+   * Constructor for class DeliverySlipData
+   * @param deliverySlipOptions {Object} Could be used to force the value of some members
+   */
   constructor(deliverySlipOptions = {}) {
+    /** @member {string} Prefix to add to the delivery slip files */
     this.prefix = deliverySlipOptions.prefix || `#${faker.lorem.word()}`;
+
+    /** @member {Number} Number of delivery slips created */
     this.number = deliverySlipOptions.number || faker.random.number({min: 10, max: 200}).toString();
   }
-};
+}
+
+module.exports = DeliverySlipData;

--- a/tests/UI/campaigns/data/faker/deliverySlipOptions.js
+++ b/tests/UI/campaigns/data/faker/deliverySlipOptions.js
@@ -10,10 +10,10 @@ class DeliverySlipData {
    * @param deliverySlipOptions {Object} Could be used to force the value of some members
    */
   constructor(deliverySlipOptions = {}) {
-    /** @member {string} Prefix to add to the delivery slip files */
+    /** @type {string} Prefix to add to the delivery slip files */
     this.prefix = deliverySlipOptions.prefix || `#${faker.lorem.word()}`;
 
-    /** @member {Number} Number of delivery slips created */
+    /** @type {Number} Number of delivery slips created */
     this.number = deliverySlipOptions.number || faker.random.number({min: 10, max: 200}).toString();
   }
 }

--- a/tests/UI/campaigns/data/faker/employee.js
+++ b/tests/UI/campaigns/data/faker/employee.js
@@ -13,29 +13,29 @@ class EmployeeData {
    * @param employeeToCreate {Object} Could be used to force the value of some members
    */
   constructor(employeeToCreate = {}) {
-    /** @member {string} Employee fistname */
+    /** @type {string} Employee fistname */
     this.firstName = employeeToCreate.firstName || faker.name.firstName();
 
-    /** @member {string} Employee lastname */
+    /** @type {string} Employee lastname */
     this.lastName = employeeToCreate.lastName || faker.name.lastName();
 
-    /** @member {string} Email of the employee */
+    /** @type {string} Email of the employee */
     this.email = employeeToCreate.email || faker.internet.email(this.firstName, this.lastName, 'prestashop.com');
 
-    /** @member {string} Password for the employee account */
+    /** @type {string} Password for the employee account */
     this.password = employeeToCreate.password || 'prestashop_demo';
 
-    /** @member {string} Default page where employee should access after login */
+    /** @type {string} Default page where employee should access after login */
     this.defaultPage = employeeToCreate.defaultPage || faker.random.arrayElement(Pages);
 
-    /** @member {string} Default BO language for the employee */
+    /** @type {string} Default BO language for the employee */
     this.language = employeeToCreate.language
       || faker.random.arrayElement((Object.values(Languages).map(lang => lang.name)).slice(0, 2));
 
-    /** @member {string} Status of the employee */
+    /** @type {string} Status of the employee */
     this.active = employeeToCreate.active === undefined ? true : employeeToCreate.active;
 
-    /** @member {string} Permission profile to set on the employee */
+    /** @type {string} Permission profile to set on the employee */
     this.permissionProfile = employeeToCreate.permissionProfile || faker.random.arrayElement(Profiles);
   }
 }

--- a/tests/UI/campaigns/data/faker/employee.js
+++ b/tests/UI/campaigns/data/faker/employee.js
@@ -3,16 +3,41 @@ const {Profiles} = require('@data/demo/profiles');
 const {Languages} = require('@data/demo/languages');
 const {Pages} = require('@data/demo/pages');
 
-module.exports = class Employee {
+/**
+ * Create new employee to use on creation form on employee page on BO
+ * @class
+ */
+class EmployeeData {
+  /**
+   * Constructor for class EmployeeData
+   * @param employeeToCreate {Object} Could be used to force the value of some members
+   */
   constructor(employeeToCreate = {}) {
+    /** @member {string} Employee fistname */
     this.firstName = employeeToCreate.firstName || faker.name.firstName();
+
+    /** @member {string} Employee lastname */
     this.lastName = employeeToCreate.lastName || faker.name.lastName();
+
+    /** @member {string} Email of the employee */
     this.email = employeeToCreate.email || faker.internet.email(this.firstName, this.lastName, 'prestashop.com');
+
+    /** @member {string} Password for the employee account */
     this.password = employeeToCreate.password || 'prestashop_demo';
+
+    /** @member {string} Default page where employee should access after login */
     this.defaultPage = employeeToCreate.defaultPage || faker.random.arrayElement(Pages);
+
+    /** @member {string} Default BO language for the employee */
     this.language = employeeToCreate.language
       || faker.random.arrayElement((Object.values(Languages).map(lang => lang.name)).slice(0, 2));
+
+    /** @member {string} Status of the employee */
     this.active = employeeToCreate.active === undefined ? true : employeeToCreate.active;
+
+    /** @member {string} Permission profile to set on the employee */
     this.permissionProfile = employeeToCreate.permissionProfile || faker.random.arrayElement(Profiles);
   }
-};
+}
+
+module.exports = EmployeeData;

--- a/tests/UI/campaigns/data/faker/featureAndValue.js
+++ b/tests/UI/campaigns/data/faker/featureAndValue.js
@@ -14,16 +14,16 @@ class FeatureData {
    * @param featureToCreate {Object} Could be used to force the value of some members
    */
   constructor(featureToCreate = {}) {
-    /** @member {string} Name of the feature */
+    /** @type {string} Name of the feature */
     this.name = featureToCreate.name || faker.lorem.word();
 
-    /** @member {string} Name used on the feature URL */
+    /** @type {string} Name used on the feature URL */
     this.url = featureToCreate.url || this.name.replace(/\s/gi, '-');
 
-    /** @member {string} Feature meta title */
+    /** @type {string} Feature meta title */
     this.metaTitle = featureToCreate.metaTitle || faker.lorem.word();
 
-    /** @member {boolean} True for the feature to be indexed */
+    /** @type {boolean} True for the feature to be indexed */
     this.indexable = featureToCreate.indexable === undefined ? true : featureToCreate.indexable;
   }
 }
@@ -38,16 +38,16 @@ class ValueData {
    * @param valueToCreate {Object} Could be used to force the value of some members
    */
   constructor(valueToCreate = {}) {
-    /** @member {string} Name of the parent feature */
+    /** @type {string} Name of the parent feature */
     this.featureName = valueToCreate.featureName || faker.random.arrayElement(featuresNames);
 
-    /** @member {string} Name of the value */
+    /** @type {string} Name of the value */
     this.value = valueToCreate.value || `${faker.lorem.word()}${faker.commerce.productMaterial()}`;
 
-    /** @member {string} Name used on the value URL */
+    /** @type {string} Name used on the value URL */
     this.url = valueToCreate.url || this.value.replace(/\s/gi, '-');
 
-    /** @member {string} Feature value meta title */
+    /** @type {string} Feature value meta title */
     this.metaTitle = valueToCreate.metaTitle || faker.lorem.word();
   }
 }

--- a/tests/UI/campaigns/data/faker/featureAndValue.js
+++ b/tests/UI/campaigns/data/faker/featureAndValue.js
@@ -4,21 +4,52 @@ const {Features} = require('@data/demo/features');
 
 const featuresNames = Object.values(Features).map(feature => feature.name);
 
-module.exports = {
-  Feature: class Attribute {
-    constructor(featureToCreate = {}) {
-      this.name = featureToCreate.name || faker.lorem.word();
-      this.url = featureToCreate.url || this.name.replace(/\s/gi, '-');
-      this.metaTitle = featureToCreate.metaTitle || faker.lorem.word();
-      this.indexable = featureToCreate.indexable === undefined ? true : featureToCreate.indexable;
-    }
-  },
-  Value: class Value {
-    constructor(valueToCreate = {}) {
-      this.featureName = valueToCreate.featureName || faker.random.arrayElement(featuresNames);
-      this.value = valueToCreate.value || `${faker.lorem.word()}${faker.commerce.productMaterial()}`;
-      this.url = valueToCreate.url || this.value.replace(/\s/gi, '-');
-      this.metaTitle = valueToCreate.metaTitle || faker.lorem.word();
-    }
-  },
-};
+/**
+ * Create new feature to use on feature form on BO
+ * @class
+ */
+class FeatureData {
+  /**
+   * Constructor for class FeatureData
+   * @param featureToCreate {Object} Could be used to force the value of some members
+   */
+  constructor(featureToCreate = {}) {
+    /** @member {string} Name of the feature */
+    this.name = featureToCreate.name || faker.lorem.word();
+
+    /** @member {string} Name used on the feature URL */
+    this.url = featureToCreate.url || this.name.replace(/\s/gi, '-');
+
+    /** @member {string} Feature meta title */
+    this.metaTitle = featureToCreate.metaTitle || faker.lorem.word();
+
+    /** @member {boolean} True for the feature to be indexed */
+    this.indexable = featureToCreate.indexable === undefined ? true : featureToCreate.indexable;
+  }
+}
+
+/**
+ * Create new feature value to use on feature value form on BO
+ * @class
+ */
+class ValueData {
+  /**
+   * Constructor for class ValueData
+   * @param valueToCreate {Object} Could be used to force the value of some members
+   */
+  constructor(valueToCreate = {}) {
+    /** @member {string} Name of the parent feature */
+    this.featureName = valueToCreate.featureName || faker.random.arrayElement(featuresNames);
+
+    /** @member {string} Name of the value */
+    this.value = valueToCreate.value || `${faker.lorem.word()}${faker.commerce.productMaterial()}`;
+
+    /** @member {string} Name used on the value URL */
+    this.url = valueToCreate.url || this.value.replace(/\s/gi, '-');
+
+    /** @member {string} Feature value meta title */
+    this.metaTitle = valueToCreate.metaTitle || faker.lorem.word();
+  }
+}
+
+module.exports = {FeatureData, ValueData};

--- a/tests/UI/campaigns/data/faker/file.js
+++ b/tests/UI/campaigns/data/faker/file.js
@@ -1,11 +1,30 @@
 const faker = require('faker');
 
-module.exports = class File {
+/**
+ * Create new file to use on creation form on file page on BO
+ * @class
+ */
+class FileData {
+  /**
+   * Constructor for class FileData
+   * @param fileToCreate {Object} Could be used to force the value of some members
+   */
   constructor(fileToCreate = {}) {
+    /** @member {string} Name of the file on the list */
     this.name = fileToCreate.name || faker.system.fileName().substring(0, 32);
+
+    /** @member {string} French name of the file */
     this.frName = fileToCreate.frName || this.name;
+
+    /** @member {string} Description of the file */
     this.description = fileToCreate.description || faker.lorem.sentence();
+
+    /** @member {string} French description of the file */
     this.frDescription = fileToCreate.frDescription || this.description;
+
+    /** @member {string} Name of the file for filepath */
     this.filename = `${this.name}.text`;
   }
-};
+}
+
+module.exports = FileData;

--- a/tests/UI/campaigns/data/faker/file.js
+++ b/tests/UI/campaigns/data/faker/file.js
@@ -10,20 +10,20 @@ class FileData {
    * @param fileToCreate {Object} Could be used to force the value of some members
    */
   constructor(fileToCreate = {}) {
-    /** @member {string} Name of the file on the list */
+    /** @type {string} Name of the file on the list */
     this.name = fileToCreate.name || faker.system.fileName().substring(0, 32);
 
-    /** @member {string} French name of the file */
+    /** @type {string} French name of the file */
     this.frName = fileToCreate.frName || this.name;
 
-    /** @member {string} Description of the file */
+    /** @type {string} Description of the file */
     this.description = fileToCreate.description || faker.lorem.sentence();
 
-    /** @member {string} French description of the file */
+    /** @type {string} French description of the file */
     this.frDescription = fileToCreate.frDescription || this.description;
 
-    /** @member {string} Name of the file for filepath */
-    this.filename = `${this.name}.text`;
+    /** @type {string} Name of the file for the filepath */
+    this.filename = `${this.name}.txt`;
   }
 }
 

--- a/tests/UI/campaigns/data/faker/group.js
+++ b/tests/UI/campaigns/data/faker/group.js
@@ -2,12 +2,31 @@ const faker = require('faker');
 
 const priceDisplayMethod = ['Tax included', 'Tax excluded'];
 
-module.exports = class Group {
+/**
+ * Create new group to use on creation form on group page on BO
+ * @class
+ */
+class GroupData {
+  /**
+   * Constructor for class GroupData
+   * @param groupToCreate {Object} Could be used to force the value of some members
+   */
   constructor(groupToCreate = {}) {
+    /** @member {string} Name of the group */
     this.name = groupToCreate.name || faker.name.jobType();
+
+    /** @member {string} French name of the group */
     this.frName = groupToCreate.frName || this.name;
+
+    /** @member {string} Basic discount for the group */
     this.discount = groupToCreate.discount || 0;
+
+    /** @member {string} Price display method of the group */
     this.priceDisplayMethod = groupToCreate.priceDisplayMethod || faker.random.arrayElement(priceDisplayMethod);
+
+    /** @member {boolean} True to show prices for the group */
     this.shownPrices = groupToCreate.shownPrices === undefined ? true : groupToCreate.shownPrices;
   }
-};
+}
+
+module.exports = GroupData;

--- a/tests/UI/campaigns/data/faker/group.js
+++ b/tests/UI/campaigns/data/faker/group.js
@@ -12,19 +12,19 @@ class GroupData {
    * @param groupToCreate {Object} Could be used to force the value of some members
    */
   constructor(groupToCreate = {}) {
-    /** @member {string} Name of the group */
+    /** @type {string} Name of the group */
     this.name = groupToCreate.name || faker.name.jobType();
 
-    /** @member {string} French name of the group */
+    /** @type {string} French name of the group */
     this.frName = groupToCreate.frName || this.name;
 
-    /** @member {string} Basic discount for the group */
+    /** @type {string} Basic discount for the group */
     this.discount = groupToCreate.discount || 0;
 
-    /** @member {string} Price display method of the group */
+    /** @type {string} Price display method of the group */
     this.priceDisplayMethod = groupToCreate.priceDisplayMethod || faker.random.arrayElement(priceDisplayMethod);
 
-    /** @member {boolean} True to show prices for the group */
+    /** @type {boolean} True to show prices for the group */
     this.shownPrices = groupToCreate.shownPrices === undefined ? true : groupToCreate.shownPrices;
   }
 }

--- a/tests/UI/campaigns/data/faker/product.js
+++ b/tests/UI/campaigns/data/faker/product.js
@@ -75,7 +75,7 @@ class ProductData {
       : productToCreate.minimumQuantity;
 
     /** @member {string} Stock location of the product */
-    this.stockLocation = productToCreate.stockLocation || 'Stock location';
+    this.stockLocation = productToCreate.stockLocation || '';
 
     /** @member {string} Low stock level of the product */
     this.lowStockLevel = productToCreate.lowStockLevel;

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/02_productBlock.js
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/02_productBlock.js
@@ -326,7 +326,6 @@ describe('BO - Orders - view and edit order : Check product block in view order 
 
         await viewOrderPage.searchProduct(page, combinationProduct.name);
         const result = await viewOrderPage.getSearchedProductDetails(page);
-        console.log(result.stockLocation);
         await Promise.all([
           expect(result.stockLocation).to.equal(combinationProduct.stockLocation),
           expect(result.available).to.equal(combinationProduct.quantity - 1),

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/02_productBlock.js
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/viewAndEditOrder/02_productBlock.js
@@ -85,7 +85,6 @@ const combinationProduct = new ProductFaker({
   taxRule: 'No tax',
   quantity: 197,
   minimumQuantity: 1,
-  stockLocation: 'stock 3',
   lowStockLevel: 3,
   behaviourOutOfStock: 'Default behavior',
 });
@@ -327,6 +326,7 @@ describe('BO - Orders - view and edit order : Check product block in view order 
 
         await viewOrderPage.searchProduct(page, combinationProduct.name);
         const result = await viewOrderPage.getSearchedProductDetails(page);
+        console.log(result.stockLocation);
         await Promise.all([
           expect(result.stockLocation).to.equal(combinationProduct.stockLocation),
           expect(result.available).to.equal(combinationProduct.quantity - 1),

--- a/tests/UI/campaigns/functional/BO/03_catalog/04_attributesAndFeatures/02_features/features/02_sortPaginationAndBulkDelete.js
+++ b/tests/UI/campaigns/functional/BO/03_catalog/04_attributesAndFeatures/02_features/features/02_sortPaginationAndBulkDelete.js
@@ -13,7 +13,7 @@ const featuresPage = require('@pages/BO/catalog/features');
 const addFeaturePage = require('@pages/BO/catalog/features/addFeature');
 
 // Import data
-const {Feature} = require('@data/faker/featureAndValue');
+const {FeatureData} = require('@data/faker/featureAndValue');
 
 // Import test context
 const testContext = require('@utils/testContext');
@@ -83,7 +83,7 @@ describe('BO - Catalog - Attributes & Features : Sort, pagination and delete by 
   const creationTests = new Array(19).fill(0, 0, 19);
   describe('Create 19 new features in BO', async () => {
     creationTests.forEach((test, index) => {
-      const createFeatureData = new Feature({name: `todelete${index}`});
+      const createFeatureData = new FeatureData({name: `todelete${index}`});
       it('should go to add new feature page', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `goToAddNewFeaturePage${index}`, baseContext);
 

--- a/tests/UI/campaigns/functional/BO/03_catalog/04_attributesAndFeatures/02_features/values/02_sortPaginationAndBulkDelete.js
+++ b/tests/UI/campaigns/functional/BO/03_catalog/04_attributesAndFeatures/02_features/values/02_sortPaginationAndBulkDelete.js
@@ -14,7 +14,7 @@ const viewFeaturePage = require('@pages/BO/catalog/features/view');
 const addValuePage = require('@pages/BO/catalog/features/addValue');
 
 // Import data
-const {Value} = require('@data/faker/featureAndValue');
+const {ValueData} = require('@data/faker/featureAndValue');
 
 // Import test context
 const testContext = require('@utils/testContext');
@@ -113,7 +113,7 @@ describe('BO - Catalog - Catalog > Attributes & Features : Sort, pagination and 
     });
 
     creationTests.forEach((test, index) => {
-      const createValueData = new Value({featureName: 'Composition', value: `todelete${index}`});
+      const createValueData = new ValueData({featureName: 'Composition', value: `todelete${index}`});
       it(`should create value n°${index + 1}`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `createNewValue${index}`, baseContext);
 

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/01_filterAndQuickEditCustomers.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/01_filterAndQuickEditCustomers.js
@@ -1,6 +1,5 @@
 require('module-alias/register');
 
-// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
@@ -30,8 +29,11 @@ const dd = (`0${today.getDate()}`).slice(-2); // Current day
 const yyyy = today.getFullYear(); // Current year
 const dateToday = `${yyyy}-${mm}-${dd}`;
 
-// Filter and quick edit customers
-describe('BO - Customers : Filter and quick edit customers', async () => {
+/*
+Filter customers table by Id, social title, first name, last name, email, active, newsletter and optin
+Quick edit customer enable/disable - status, newsletter and partner offers
+ */
+describe('BO - Customers - Customers : Filter and quick edit Customers table', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -69,7 +71,7 @@ describe('BO - Customers : Filter and quick edit customers', async () => {
   });
 
   // 1 : Filter Customers with all inputs and selects in grid table
-  describe('Filter Customers', async () => {
+  describe('Filter customers table', async () => {
     const tests = [
       {
         args:
@@ -234,7 +236,7 @@ describe('BO - Customers : Filter and quick edit customers', async () => {
 
   // 2 : Editing customers from grid table
   describe('Quick edit customers', async () => {
-    it(`should filter by Email '${DefaultCustomer.email}'`, async function () {
+    it(`should filter by email '${DefaultCustomer.email}'`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'filterToQuickEdit', baseContext);
 
       await customersPage.filterCustomers(
@@ -301,10 +303,10 @@ describe('BO - Customers : Filter and quick edit customers', async () => {
     });
 
     it('should reset all filters', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'resetFilterAfterQuickEdit', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', 'resetAllFilters', baseContext);
 
       const numberOfCustomersAfterReset = await customersPage.resetAndGetNumberOfLines(page);
-      await expect(numberOfCustomersAfterReset).to.be.equal(numberOfCustomers);
+      await expect(numberOfCustomersAfterReset).to.equal(numberOfCustomers);
     });
   });
 });

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/02_CRUDCustomer.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/02_CRUDCustomer.js
@@ -24,7 +24,7 @@ const foHomePage = require('@pages/FO/home');
 // Import data
 const CustomerFaker = require('@data/faker/customer');
 
-const baseContext = 'functional_BO_customers_customers_CRUDCustomerInBO';
+const baseContext = 'functional_BO_customers_customers_CRUDCustomer';
 
 let browserContext;
 let page;

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/02_CRUDCustomer.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/02_CRUDCustomer.js
@@ -1,10 +1,12 @@
 require('module-alias/register');
 
-// Import expect from chai
 const {expect} = require('chai');
 
 // Helpers to open and close browser
 const helper = require('@utils/helpers');
+
+// Import login steps
+const testContext = require('@utils/testContext');
 
 // Import login steps
 const loginCommon = require('@commonTests/loginBO');
@@ -22,10 +24,7 @@ const foHomePage = require('@pages/FO/home');
 // Import data
 const CustomerFaker = require('@data/faker/customer');
 
-// Import test context
-const testContext = require('@utils/testContext');
-
-const baseContext = 'functional_BO_customers_customers_CRUDCustomer';
+const baseContext = 'functional_BO_customers_customers_CRUDCustomerInBO';
 
 let browserContext;
 let page;
@@ -35,7 +34,7 @@ const createCustomerData = new CustomerFaker();
 const editCustomerData = new CustomerFaker({enabled: false});
 
 // Create, Read, Update and Delete Customer in BO
-describe('BO - Customers : CRUD customer in BO', async () => {
+describe('BO - Customers - Customers : CRUD Customer in BO', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -72,8 +71,8 @@ describe('BO - Customers : CRUD customer in BO', async () => {
     await expect(numberOfCustomers).to.be.above(0);
   });
 
-  // 1 : Create customer in BO
-  describe('Create customer in BO', async () => {
+  // 1 : Create customer and go to FO to check sign in is OK
+  describe('Create customer in BO and check sign in in FO', async () => {
     it('should go to add new customer page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToAddNewCustomerPage', baseContext);
 
@@ -146,12 +145,7 @@ describe('BO - Customers : CRUD customer in BO', async () => {
 
       await customersPage.resetFilter(page);
 
-      await customersPage.filterCustomers(
-        page,
-        'input',
-        'email',
-        createCustomerData.email,
-      );
+      await customersPage.filterCustomers(page, 'input', 'email', createCustomerData.email);
 
       const textEmail = await customersPage.getTextColumnFromTableCustomers(page, 1, 'email');
       await expect(textEmail).to.contains(createCustomerData.email);
@@ -195,12 +189,7 @@ describe('BO - Customers : CRUD customer in BO', async () => {
 
       await customersPage.resetFilter(page);
 
-      await customersPage.filterCustomers(
-        page,
-        'input',
-        'email',
-        createCustomerData.email,
-      );
+      await customersPage.filterCustomers(page, 'input', 'email', createCustomerData.email);
 
       const textEmail = await customersPage.getTextColumnFromTableCustomers(page, 1, 'email');
       await expect(textEmail).to.contains(createCustomerData.email);
@@ -246,6 +235,7 @@ describe('BO - Customers : CRUD customer in BO', async () => {
       // Try to login
       await foHomePage.goToLoginPage(page);
       await foLoginPage.customerLogin(page, editCustomerData);
+
       const isCustomerConnected = await foLoginPage.isCustomerConnected(page);
       await expect(isCustomerConnected).to.be.false;
     });
@@ -268,12 +258,7 @@ describe('BO - Customers : CRUD customer in BO', async () => {
 
       await customersPage.resetFilter(page);
 
-      await customersPage.filterCustomers(
-        page,
-        'input',
-        'email',
-        editCustomerData.email,
-      );
+      await customersPage.filterCustomers(page, 'input', 'email', editCustomerData.email);
 
       const textEmail = await customersPage.getTextColumnFromTableCustomers(page, 1, 'email');
       await expect(textEmail).to.contains(editCustomerData.email);
@@ -297,7 +282,7 @@ describe('BO - Customers : CRUD customer in BO', async () => {
     });
   });
 
-  // 7 : Delete Customer from BO
+  // 7 : Delete customer from BO
   describe('Delete customer', async () => {
     it('should go to \'Customers > Customers\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToCustomersPageToDelete', baseContext);
@@ -317,12 +302,7 @@ describe('BO - Customers : CRUD customer in BO', async () => {
 
       await customersPage.resetFilter(page);
 
-      await customersPage.filterCustomers(
-        page,
-        'input',
-        'email',
-        editCustomerData.email,
-      );
+      await customersPage.filterCustomers(page, 'input', 'email', editCustomerData.email);
 
       const textEmail = await customersPage.getTextColumnFromTableCustomers(page, 1, 'email');
       await expect(textEmail).to.contains(editCustomerData.email);

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/03_customersBulkActions.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/03_customersBulkActions.js
@@ -1,6 +1,5 @@
 require('module-alias/register');
 
-// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
@@ -27,8 +26,11 @@ let numberOfCustomers = 0;
 const firstCustomerData = new CustomerFaker({firstName: 'todelete'});
 const secondCustomerData = new CustomerFaker({firstName: 'todelete'});
 
-// Create Customers, Then disable / Enable and Delete with Bulk actions
-describe('BO - Customers : Enable/Disable/Delete customer by bulk actions', async () => {
+/*
+Create Customer
+Enable/Disable/Delete by Bulk actions
+*/
+describe('BO - Customers - Customers : Customers bulk actions', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -79,7 +81,7 @@ describe('BO - Customers : Enable/Disable/Delete customer by bulk actions', asyn
         await expect(pageTitle).to.contains(addCustomerPage.pageTitleCreate);
       });
 
-      it(`should create customer n°${index + 1}`, async function () {
+      it(`should create customer n°${index + 1} and check result`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `createCustomer${index + 1}`, baseContext);
 
         const textResult = await addCustomerPage.createEditCustomer(page, test.args.customerToCreate);
@@ -106,14 +108,10 @@ describe('BO - Customers : Enable/Disable/Delete customer by bulk actions', asyn
       {args: {action: 'disable', enabledValue: false}},
       {args: {action: 'enable', enabledValue: true}},
     ].forEach((test) => {
-      it(`should ${test.args.action} customers by bulk actions and check result`, async function () {
+      it(`should ${test.args.action} customers with bulk actions and check result`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `${test.args.action}Customers`, baseContext);
 
-        const textResult = await customersPage.bulkSetStatus(
-          page,
-          test.args.enabledValue,
-        );
-
+        const textResult = await customersPage.bulkSetStatus(page, test.args.enabledValue);
         await expect(textResult).to.be.equal(customersPage.successfulUpdateMessage);
 
         const numberOfCustomersInGrid = await customersPage.getNumberOfElementInGrid(page);
@@ -138,7 +136,7 @@ describe('BO - Customers : Enable/Disable/Delete customer by bulk actions', asyn
       await expect(textResult).to.contains('todelete');
     });
 
-    it('should delete customers by bulk actions and check result', async function () {
+    it('should delete customers', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'bulkDeleteCustomers', baseContext);
 
       const deleteTextResult = await customersPage.deleteCustomersBulkActions(page);

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/04_paginationAndSortCustomers.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/04_paginationAndSortCustomers.js
@@ -1,6 +1,5 @@
 require('module-alias/register');
 
-// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
@@ -30,7 +29,7 @@ Paginate between pages
 Sort customers table
 Delete customers with bulk actions
  */
-describe('BO - Customers : Pagination and sort customers table', async () => {
+describe('BO - Customers - Customers : Pagination and sort customers table', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -72,25 +71,24 @@ describe('BO - Customers : Pagination and sort customers table', async () => {
     const creationTests = new Array(10).fill(0, 0, 10);
 
     creationTests.forEach((test, index) => {
-      describe(`Create customer n°${index + 1}`, async () => {
-        const createCustomerData = new CustomerFaker({email: `test@prestashop.com${index}`});
-        it('should go to add new customer page', async function () {
-          await testContext.addContextItem(this, 'testIdentifier', `goToAddNewCustomerPage${index}`, baseContext);
+      const createCustomerData = new CustomerFaker({email: `test@prestashop.com${index}`});
 
-          await customersPage.goToAddNewCustomerPage(page);
-          const pageTitle = await addCustomerPage.getPageTitle(page);
-          await expect(pageTitle).to.contains(addCustomerPage.pageTitleCreate);
-        });
+      it('should go to add new customer page', async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `goToAddNewCustomerPage${index}`, baseContext);
 
-        it('should create customer', async function () {
-          await testContext.addContextItem(this, 'testIdentifier', `createCustomer${index}`, baseContext);
+        await customersPage.goToAddNewCustomerPage(page);
+        const pageTitle = await addCustomerPage.getPageTitle(page);
+        await expect(pageTitle).to.contains(addCustomerPage.pageTitleCreate);
+      });
 
-          const textResult = await addCustomerPage.createEditCustomer(page, createCustomerData);
-          await expect(textResult).to.equal(customersPage.successfulCreationMessage);
+      it(`should create customer n°${index + 1} and check result`, async function () {
+        await testContext.addContextItem(this, 'testIdentifier', `createCustomer${index}`, baseContext);
 
-          const numberOfCustomersAfterCreation = await customersPage.getNumberOfElementInGrid(page);
-          await expect(numberOfCustomersAfterCreation).to.be.equal(numberOfCustomers + 1 + index);
-        });
+        const textResult = await addCustomerPage.createEditCustomer(page, createCustomerData);
+        await expect(textResult).to.equal(customersPage.successfulCreationMessage);
+
+        const numberOfCustomersAfterCreation = await customersPage.getNumberOfElementInGrid(page);
+        await expect(numberOfCustomersAfterCreation).to.be.equal(numberOfCustomers + 1 + index);
       });
     });
   });
@@ -203,7 +201,7 @@ describe('BO - Customers : Pagination and sort customers table', async () => {
       await expect(textResult).to.contains('test@prestashop.com');
     });
 
-    it('should delete customers and check result', async function () {
+    it('should delete customers', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'bulkDeleteCustomers', baseContext);
 
       const deleteTextResult = await customersPage.deleteCustomersBulkActions(page);

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/05_setRequiredFields.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/05_setRequiredFields.js
@@ -1,10 +1,10 @@
 require('module-alias/register');
 
-// Import expect from chai
 const {expect} = require('chai');
 
 // Helpers to open and close browser
 const helper = require('@utils/helpers');
+const testContext = require('@utils/testContext');
 
 // Import login steps
 const loginCommon = require('@commonTests/loginBO');
@@ -18,15 +18,12 @@ const foLoginPage = require('@pages/FO/login');
 const foHomePage = require('@pages/FO/home');
 const foCreateAccountPage = require('@pages/FO/myAccount/add');
 
-// Import test context
-const testContext = require('@utils/testContext');
-
 const baseContext = 'functional_BO_customers_customers_setRequiredFields';
 
 let browserContext;
 let page;
 
-describe('BO - Customers : Set required fields', async () => {
+describe('BO - Customers - Customers : Set required fields', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -68,7 +65,7 @@ describe('BO - Customers : Set required fields', async () => {
     });
 
     it('should view my shop', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', `goToFO${index}`, baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', `viewMyShop${index}`, baseContext);
 
       // View shop
       page = await customersPage.viewMyShop(page);
@@ -80,8 +77,8 @@ describe('BO - Customers : Set required fields', async () => {
       await expect(isHomePage, 'Fail to open FO home page').to.be.true;
     });
 
-    it('should go to create account page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', `goToCreateAccountPage${index}`, baseContext);
+    it('should go to create account FO and check \'Receive offers from our partners\' checkbox', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', `checkPartnersOffers${index}`, baseContext);
 
       // Go to create account page
       await foHomePage.goToLoginPage(page);
@@ -104,9 +101,6 @@ describe('BO - Customers : Set required fields', async () => {
 
       // Go back to BO
       page = await foCreateAccountPage.closePage(browserContext, page, 0);
-
-      const pageTitle = await customersPage.getPageTitle(page);
-      await expect(pageTitle).to.contains(customersPage.pageTitle);
     });
   });
 });

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/05_setRequiredFields.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/05_setRequiredFields.js
@@ -101,6 +101,9 @@ describe('BO - Customers - Customers : Set required fields', async () => {
 
       // Go back to BO
       page = await foCreateAccountPage.closePage(browserContext, page, 0);
+
+      const pageTitle = await customersPage.getPageTitle(page);
+      await expect(pageTitle).to.contains(customersPage.pageTitle);
     });
   });
 });

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/06_exportCustomers.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/06_exportCustomers.js
@@ -1,11 +1,11 @@
 require('module-alias/register');
 
-// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
 const helper = require('@utils/helpers');
 const files = require('@utils/files');
+const testContext = require('@utils/testContext');
 
 // Import login steps
 const loginCommon = require('@commonTests/loginBO');
@@ -13,9 +13,6 @@ const loginCommon = require('@commonTests/loginBO');
 // Import pages
 const dashboardPage = require('@pages/BO/dashboard');
 const customersPage = require('@pages/BO/customers');
-
-// Import test context
-const testContext = require('@utils/testContext');
 
 const baseContext = 'functional_BO_customers_customers_exportCustomers';
 
@@ -29,7 +26,7 @@ Export customers
 Check csv file was downloaded
 Check existence of customers data in csv file
  */
-describe('BO - Customers : Export customers', async () => {
+describe('BO - Customers - Customers : Export customers', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/07_helpCard.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/07_helpCard.js
@@ -1,10 +1,10 @@
 require('module-alias/register');
 
-// Import expect from chai
 const {expect} = require('chai');
 
 // Helpers to open and close browser
 const helper = require('@utils/helpers');
+const testContext = require('@utils/testContext');
 
 // Import login steps
 const loginCommon = require('@commonTests/loginBO');
@@ -13,16 +13,13 @@ const loginCommon = require('@commonTests/loginBO');
 const dashboardPage = require('@pages/BO/dashboard');
 const customersPage = require('@pages/BO/customers');
 
-// Import test context
-const testContext = require('@utils/testContext');
-
 const baseContext = 'functional_BO_customers_customers_helpCard';
 
 let browserContext;
 let page;
 
 // Check that help card is in english in customers page
-describe('BO - Customers : Help card in customers page', async () => {
+describe('BO - Customers - Customers : Help card on customers page', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/08_viewCustomer.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/08_viewCustomer.js
@@ -1,6 +1,5 @@
 require('module-alias/register');
 
-// Import export from chai
 const {expect} = require('chai');
 
 // Import utils
@@ -65,8 +64,18 @@ const ddEditBirth = `0${editCustomerData.dayOfBirth}`.slice(-2);
 const yyyyEditBirth = editCustomerData.yearOfBirth;
 const editCustomerBirthDate = `${mmEditBirth}/${ddEditBirth}/${yyyyEditBirth}`;
 
-// View customer
-describe('BO - Customers : View information about customer', async () => {
+/*
+Create customer
+View customer
+Create order
+View customer after creating the order
+Edit customer then check customer information page
+Edit order then check customer information page
+Edit address then check customer information page
+View carts page
+Delete customer
+ */
+describe('BO - Customers - Customers : View information about customer', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -125,7 +134,7 @@ describe('BO - Customers : View information about customer', async () => {
   });
 
   // 2 : View customer
-  describe('View customer and check information', async () => {
+  describe('View customer created', async () => {
     it(`should filter list by email '${createCustomerData.email}'`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'filterToViewCreatedCustomer', baseContext);
 
@@ -174,15 +183,13 @@ describe('BO - Customers : View information about customer', async () => {
       await expect(cardHeaderText).to.contains('Active');
     });
 
-    const tests = [
+    [
       {args: {blockName: 'Orders', number: 0}},
       {args: {blockName: 'Carts', number: 0}},
       {args: {blockName: 'Messages', number: 0}},
       {args: {blockName: 'Vouchers', number: 0}},
       {args: {blockName: 'Groups', number: 3}},
-    ];
-
-    tests.forEach((test) => {
+    ].forEach((test) => {
       it(`should check ${test.args.blockName} number`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `check${test.args.blockName}Number`, baseContext);
 
@@ -194,21 +201,21 @@ describe('BO - Customers : View information about customer', async () => {
 
   // 3 : Create order
   describe('Create order in FO', async () => {
-    it('should go to FO page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToFO', baseContext);
+    it('should view my shop', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'viewMyShop', baseContext);
 
       // Click on view my shop
       page = await viewCustomerPage.viewMyShop(page);
 
-      // Change FO language
+      // Change language
       await foHomePage.changeLanguage(page, 'en');
 
       const isHomePage = await foHomePage.isHomePage(page);
       await expect(isHomePage, 'Fail to open FO home page').to.be.true;
     });
 
-    it('should add product to cart', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'addProductToCart', baseContext);
+    it('should add the first product to the cart', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'addFirstProductToCart', baseContext);
 
       // Go to the first product page
       await foHomePage.goToProductPage(page, 1);
@@ -221,7 +228,7 @@ describe('BO - Customers : View information about customer', async () => {
     });
 
     it('should proceed to checkout', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'goToDeliveryStep', baseContext);
+      await testContext.addContextItem(this, 'testIdentifier', 'proceedToCheckout', baseContext);
 
       // Proceed to checkout the shopping cart
       await cartPage.clickOnProceedToCheckout(page);
@@ -278,7 +285,7 @@ describe('BO - Customers : View information about customer', async () => {
   });
 
   // 4 : View customer after creating the order
-  describe('View customer and check information', async () => {
+  describe('View customer after creating the order', async () => {
     it('should go to \'Customers > Customers\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToViewCustomersPage', baseContext);
 
@@ -335,7 +342,7 @@ describe('BO - Customers : View information about customer', async () => {
       await expect(cardHeaderText).to.contains('Active');
     });
 
-    const tests = [
+    [
       {args: {blockName: 'Orders', number: 1}},
       {args: {blockName: 'Carts', number: 1}},
       {args: {blockName: 'Viewed products', number: 1}},
@@ -344,9 +351,7 @@ describe('BO - Customers : View information about customer', async () => {
       {args: {blockName: 'Last emails', number: 2}},
       {args: {blockName: 'Last connections', number: 1}},
       {args: {blockName: 'Groups', number: 3}},
-    ];
-
-    tests.forEach((test) => {
+    ].forEach((test) => {
       it(`should check ${test.args.blockName} number`, async function () {
         await testContext.addContextItem(
           this, 'testIdentifier',
@@ -599,7 +604,7 @@ describe('BO - Customers : View information about customer', async () => {
   });
 
   // 9 : Delete customer from BO
-  describe('Delete Customer', async () => {
+  describe('Delete customer', async () => {
     it('should go to \'Customers > Customers\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToCustomersPageToDelete', baseContext);
 

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/09_subscribeToNewsletter.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/09_subscribeToNewsletter.js
@@ -1,6 +1,5 @@
 require('module-alias/register');
 
-// Import export from chai
 const {expect} = require('chai');
 
 // Import utils
@@ -23,11 +22,10 @@ const psEmailSubscriptionPage = require('@pages/BO/modules/psEmailSubscription')
 const baseContext = 'BO_customers_customers_subscribeToNewsletter';
 
 let numberOfCustomers = 0;
-
 let browserContext;
 let page;
 
-describe('BO - Customers : Check customer subscription to newsletter from BO', async () => {
+describe('BO - Customers - Customers : Check customer subscription to newsletter from BO', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -67,23 +65,16 @@ describe('BO - Customers : Check customer subscription to newsletter from BO', a
   it(`should filter by email '${DefaultCustomer.email}'`, async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'filterByEmail', baseContext);
 
-    await customersPage.filterCustomers(
-      page,
-      'input',
-      'email',
-      DefaultCustomer.email,
-    );
+    await customersPage.filterCustomers(page, 'input', 'email', DefaultCustomer.email);
 
     const numberOfCustomersAfterFilter = await customersPage.getNumberOfElementInGrid(page);
     await expect(numberOfCustomersAfterFilter).to.equal(1);
   });
 
-  const tests = [
+  [
     {args: {action: 'disable', value: false}},
     {args: {action: 'enable', value: true}},
-  ];
-
-  tests.forEach((test) => {
+  ].forEach((test, index) => {
     it(`should ${test.args.action} newsletters`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', `${test.args.action}NewsLetters`, baseContext);
 
@@ -94,12 +85,7 @@ describe('BO - Customers : Check customer subscription to newsletter from BO', a
     });
 
     it('should go to \'Modules > Module Manager\' page', async function () {
-      await testContext.addContextItem(
-        this,
-        'testIdentifier',
-        `goToModuleManageTo${test.args.action}`,
-        baseContext,
-      );
+      await testContext.addContextItem(this, 'testIdentifier', `goToModuleManageTo${index}`, baseContext);
 
       await customersPage.goToSubMenu(
         page,
@@ -112,12 +98,7 @@ describe('BO - Customers : Check customer subscription to newsletter from BO', a
     });
 
     it(`should go to '${psEmailSubscription.name}' module`, async function () {
-      await testContext.addContextItem(
-        this,
-        'testIdentifier',
-        `goToEmailSubscriptionModulePageAfter${test.args.action}`,
-        baseContext,
-      );
+      await testContext.addContextItem(this, 'testIdentifier', `goToEmailSubscriptionModule${index}`, baseContext);
 
       // Search and go to configure module page
       await moduleManagerPage.searchModule(page, psEmailSubscription.tag, psEmailSubscription.name);
@@ -128,12 +109,7 @@ describe('BO - Customers : Check customer subscription to newsletter from BO', a
     });
 
     it('should check customer registration to newsletter', async function () {
-      await testContext.addContextItem(
-        this,
-        'testIdentifier',
-        `checkCustomerRegistrationAfter${test.args.action}`,
-        baseContext,
-      );
+      await testContext.addContextItem(this, 'testIdentifier', `checkCustomerRegistration${index}`, baseContext);
 
       // Get list of emails registered to newsletter
       const listOfEmails = await psEmailSubscriptionPage.getListOfNewsletterRegistrationEmails(page);
@@ -146,12 +122,7 @@ describe('BO - Customers : Check customer subscription to newsletter from BO', a
     });
 
     it('should go to \'Customers > Customers\' page', async function () {
-      await testContext.addContextItem(
-        this,
-        'testIdentifier',
-        `gotoCustomersPageAfterCheck${test.args.action}`,
-        baseContext,
-      );
+      await testContext.addContextItem(this, 'testIdentifier', `gotoCustomersPage${index}`, baseContext);
 
       await psEmailSubscriptionPage.goToSubMenu(
         page,

--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/01_filterAddresses.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/01_filterAddresses.js
@@ -1,9 +1,13 @@
 require('module-alias/register');
 
+// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
 const helper = require('@utils/helpers');
+const testContext = require('@utils/testContext');
+
+// Import login steps
 const loginCommon = require('@commonTests/loginBO');
 
 // Import pages
@@ -13,18 +17,16 @@ const addressesPage = require('@pages/BO/customers/addresses');
 // Import data
 const Address = require('@data/demo/address');
 
-// Import test context
-const testContext = require('@utils/testContext');
-
 const baseContext = 'functional_BO_customers_addresses_filterAddresses';
-
 
 let browserContext;
 let page;
 let numberOfAddresses = 0;
 
-// Filter addresses
-describe('Filter Addresses', async () => {
+/*
+Filter addresses table by Id, firstname, lastname, address, postcode, city and country
+ */
+describe('BO - Customers - Addresses : Filter Addresses table', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -39,7 +41,7 @@ describe('Filter Addresses', async () => {
     await loginCommon.loginBO(this, page);
   });
 
-  it('should go to \'Customer>Addresses\' page', async function () {
+  it('should go to \'Customer > Addresses\' page', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'goToAddressesPage', baseContext);
 
     await dashboardPage.goToSubMenu(
@@ -60,7 +62,7 @@ describe('Filter Addresses', async () => {
   });
 
   // Filter addresses with all inputs and selects in grid table
-  describe('Filter addresses', async () => {
+  describe('Filter addresses table', async () => {
     const tests = [
       {
         args:

--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/02_CRUDAddressInBO.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/02_CRUDAddressInBO.js
@@ -1,9 +1,13 @@
 require('module-alias/register');
 
+// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
 const helper = require('@utils/helpers');
+const testContext = require('@utils/testContext');
+
+// Import login steps
 const loginCommon = require('@commonTests/loginBO');
 
 // Import pages
@@ -14,11 +18,7 @@ const addAddressPage = require('@pages/BO/customers/addresses/add');
 // Import data
 const AddressFaker = require('@data/faker/address');
 
-// Import test context
-const testContext = require('@utils/testContext');
-
 const baseContext = 'functional_BO_customers_addresses_CRUDAddressesInBO';
-
 
 let browserContext;
 let page;
@@ -28,7 +28,7 @@ const createAddressData = new AddressFaker({email: 'pub@prestashop.com', country
 const editAddressData = new AddressFaker({country: 'France'});
 
 // Create, Read, Update and Delete address in BO
-describe('Create, Read, Update and Delete address in BO', async () => {
+describe('BO - Customers - Addresses : CRUD Address in BO', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -43,7 +43,7 @@ describe('Create, Read, Update and Delete address in BO', async () => {
     await loginCommon.loginBO(this, page);
   });
 
-  it('should go to \'Customers>Addresses\' page', async function () {
+  it('should go to \'Customers > Addresses\' page', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'goToAddressesPage', baseContext);
 
     await dashboardPage.goToSubMenu(
@@ -64,6 +64,7 @@ describe('Create, Read, Update and Delete address in BO', async () => {
     numberOfAddresses = await addressesPage.resetAndGetNumberOfLines(page);
     await expect(numberOfAddresses).to.be.above(0);
   });
+
   // 1 : Create address
   describe('Create address in BO', async () => {
     it('should go to add new address page', async function () {
@@ -86,8 +87,8 @@ describe('Create, Read, Update and Delete address in BO', async () => {
   });
 
   // 2 : Update address
-  describe('Update address Created', async () => {
-    it('should go to \'Customers>Addresses\' page', async function () {
+  describe('Update address', async () => {
+    it('should go to \'Customers > Addresses\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToAddressesPageToUpdate', baseContext);
 
       await addressesPage.goToSubMenu(
@@ -105,19 +106,9 @@ describe('Create, Read, Update and Delete address in BO', async () => {
 
       await addressesPage.resetFilter(page);
 
-      await addressesPage.filterAddresses(
-        page,
-        'input',
-        'firstname',
-        createAddressData.firstName,
-      );
+      await addressesPage.filterAddresses(page, 'input', 'firstname', createAddressData.firstName);
 
-      await addressesPage.filterAddresses(
-        page,
-        'input',
-        'lastname',
-        createAddressData.lastName,
-      );
+      await addressesPage.filterAddresses(page, 'input', 'lastname', createAddressData.lastName);
 
       const firstName = await addressesPage.getTextColumnFromTableAddresses(page, 1, 'firstname');
       await expect(firstName).to.contains(createAddressData.firstName);
@@ -147,7 +138,7 @@ describe('Create, Read, Update and Delete address in BO', async () => {
 
   // 3 : Delete address from BO
   describe('Delete address', async () => {
-    it('should go to \'Customers>Addresses\' page', async function () {
+    it('should go to \'Customers > Addresses\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'goToAddressesPageToDelete', baseContext);
 
       await addressesPage.goToSubMenu(
@@ -165,19 +156,9 @@ describe('Create, Read, Update and Delete address in BO', async () => {
 
       await addressesPage.resetFilter(page);
 
-      await addressesPage.filterAddresses(
-        page,
-        'input',
-        'firstname',
-        editAddressData.firstName,
-      );
+      await addressesPage.filterAddresses(page, 'input', 'firstname', editAddressData.firstName);
 
-      await addressesPage.filterAddresses(
-        page,
-        'input',
-        'lastname',
-        editAddressData.lastName,
-      );
+      await addressesPage.filterAddresses(page, 'input', 'lastname', editAddressData.lastName);
 
       const firstName = await addressesPage.getTextColumnFromTableAddresses(page, 1, 'firstname');
       await expect(firstName).to.contains(editAddressData.firstName);
@@ -194,6 +175,13 @@ describe('Create, Read, Update and Delete address in BO', async () => {
 
       const numberOfAddressesAfterDelete = await addressesPage.resetAndGetNumberOfLines(page);
       await expect(numberOfAddressesAfterDelete).to.be.equal(numberOfAddresses);
+    });
+
+    it('should reset all filters', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'resetAfterDelete', baseContext);
+
+      const numberOfAddressesAfterReset = await addressesPage.resetAndGetNumberOfLines(page);
+      await expect(numberOfAddressesAfterReset).to.equal(numberOfAddresses);
     });
   });
 });

--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/03_addressesBulkActions.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/03_addressesBulkActions.js
@@ -1,5 +1,6 @@
 require('module-alias/register');
 
+// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
@@ -19,7 +20,6 @@ const testContext = require('@utils/testContext');
 
 const baseContext = 'functional_BO_customers_addresses_addressesBulkActions';
 
-
 let browserContext;
 let page;
 let numberOfAddresses = 0;
@@ -27,7 +27,7 @@ let numberOfAddresses = 0;
 const addressData = new AddressFaker({address: 'todelete', email: 'pub@prestashop.com', country: 'France'});
 
 // Create addresses then delete with Bulk actions
-describe('Create Addresses then delete with Bulk actions', async () => {
+describe('BO - Customers - Addresses : Addresses bulk actions', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -42,7 +42,7 @@ describe('Create Addresses then delete with Bulk actions', async () => {
     await loginCommon.loginBO(this, page);
   });
 
-  it('should go to \'Customers>Addresses\' page', async function () {
+  it('should go to \'Customers > Addresses\' page', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'goToAddressesPage', baseContext);
 
     await dashboardPage.goToSubMenu(
@@ -66,12 +66,10 @@ describe('Create Addresses then delete with Bulk actions', async () => {
 
   // 1 : Create 2 addresses in BO
   describe('Create 2 addresses in BO', async () => {
-    const tests = [
+    [
       {args: {addressToCreate: addressData}},
       {args: {addressToCreate: addressData}},
-    ];
-
-    tests.forEach((test, index) => {
+    ].forEach((test, index) => {
       it('should go to add new address page', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `goToAddAddressPage${index + 1}`, baseContext);
 
@@ -80,7 +78,7 @@ describe('Create Addresses then delete with Bulk actions', async () => {
         await expect(pageTitle).to.contains(addAddressPage.pageTitleCreate);
       });
 
-      it('should create address and check result', async function () {
+      it(`should create address n°${index + 1} and check result`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `createAddress${index + 1}`, baseContext);
 
         const textResult = await addAddressPage.createEditAddress(page, test.args.addressToCreate);
@@ -94,17 +92,12 @@ describe('Create Addresses then delete with Bulk actions', async () => {
 
   // 2 : Delete addresses created with bulk actions
   describe('Delete addresses with Bulk Actions', async () => {
-    it('should filter list by address', async function () {
+    it(`should filter list by address ${addressData.address}`, async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'filterToBulkDelete', baseContext);
 
       await addressesPage.resetFilter(page);
 
-      await addressesPage.filterAddresses(
-        page,
-        'input',
-        'address1',
-        addressData.address,
-      );
+      await addressesPage.filterAddresses(page, 'input', 'address1', addressData.address);
 
       const address = await addressesPage.getTextColumnFromTableAddresses(page, 1, 'address1');
       await expect(address).to.contains(addressData.address);

--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/04_paginationAndSortAddresses.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/04_paginationAndSortAddresses.js
@@ -1,9 +1,13 @@
 require('module-alias/register');
 
+// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
 const helper = require('@utils/helpers');
+const testContext = require('@utils/testContext');
+
+// Import login steps
 const loginCommon = require('@commonTests/loginBO');
 
 // Import pages
@@ -13,11 +17,8 @@ const addAddressPage = require('@pages/BO/customers/addresses/add');
 
 // Import data
 const AddressFaker = require('@data/faker/address');
-// Import test context
-const testContext = require('@utils/testContext');
 
 const baseContext = 'functional_BO_customers_addresses_paginationAndSortAddresses';
-
 
 let browserContext;
 let page;
@@ -29,7 +30,7 @@ Paginate between pages
 Sort addresses by id, firstname, lastname, address, post code, city and country
 Delete addresses with bulk actions
  */
-describe('Pagination and sort addresses', async () => {
+describe('BO - Customers - Addresses : Pagination and sort addresses table', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -44,7 +45,7 @@ describe('Pagination and sort addresses', async () => {
     await loginCommon.loginBO(this, page);
   });
 
-  it('should go to addresses page', async function () {
+  it('should go to \'Customers > Addresses\' page', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'goToAddressesPage', baseContext);
 
     await dashboardPage.goToSubMenu(
@@ -67,9 +68,10 @@ describe('Pagination and sort addresses', async () => {
   });
 
   // 1 : Create 11 new addresses
-  const creationTests = new Array(10).fill(0, 0, 10);
-  creationTests.forEach((test, index) => {
-    describe(`Create address n°${index + 1} in BO`, async () => {
+  // 1 : Create 10 new addresses
+  describe('Create 10 addresses in BO', async () => {
+    const creationTests = new Array(10).fill(0, 0, 10);
+    creationTests.forEach((test, index) => {
       const createAddressData = new AddressFaker(
         {
           email: 'pub@prestashop.com',
@@ -86,7 +88,7 @@ describe('Pagination and sort addresses', async () => {
         await expect(pageTitle).to.contains(addAddressPage.pageTitleCreate);
       });
 
-      it('should create address and check result', async function () {
+      it(`should create address n°${index + 1} and check result`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `createAddress${index}`, baseContext);
 
         const textResult = await addAddressPage.createEditAddress(page, createAddressData);
@@ -100,8 +102,8 @@ describe('Pagination and sort addresses', async () => {
 
   // 2 : Pagination
   describe('Pagination next and previous', async () => {
-    it('should change the item number to 10 per page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'changeItemNumberTo10', baseContext);
+    it('should change the items number to 10 per page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'changeItemsNumberTo10', baseContext);
 
       const paginationNumber = await addressesPage.selectPaginationLimit(page, '10');
       expect(paginationNumber).to.contains('(page 1 / 2)');
@@ -121,8 +123,8 @@ describe('Pagination and sort addresses', async () => {
       expect(paginationNumber).to.contains('(page 1 / 2)');
     });
 
-    it('should change the item number to 50 per page', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'changeItemNumberTo50', baseContext);
+    it('should change the items number to 50 per page', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'changeItemsNumberTo50', baseContext);
 
       const paginationNumber = await addressesPage.selectPaginationLimit(page, '50');
       expect(paginationNumber).to.contains('(page 1 / 1)');
@@ -194,7 +196,7 @@ describe('Pagination and sort addresses', async () => {
       await expect(address).to.contains('My address');
     });
 
-    it('should delete addresses with Bulk Actions and check addresses page', async function () {
+    it('should delete addresses', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'bulkDeleteAddresses', baseContext);
 
       const deleteTextResult = await addressesPage.deleteAddressesBulkActions(page);

--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/05_helpCard.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/05_helpCard.js
@@ -1,26 +1,26 @@
 require('module-alias/register');
 
+// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
 const helper = require('@utils/helpers');
+const testContext = require('@utils/testContext');
+
+// Import login steps
 const loginCommon = require('@commonTests/loginBO');
 
 // Import pages
 const dashboardPage = require('@pages/BO/dashboard');
 const addressesPage = require('@pages/BO/customers/addresses');
 
-// Import test context
-const testContext = require('@utils/testContext');
-
 const baseContext = 'functional_BO_customers_addresses_helpCard';
-
 
 let browserContext;
 let page;
 
 // Check that help card is in english in addresses page
-describe('Addresses help card', async () => {
+describe('BO - Customers - Addresses - Help card on addresses page', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -35,7 +35,7 @@ describe('Addresses help card', async () => {
     await loginCommon.loginBO(this, page);
   });
 
-  it('should go to addresses page', async function () {
+  it('should go to \'Customers > Addresses\' page', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'goToAddressesPage', baseContext);
 
     await dashboardPage.goToSubMenu(

--- a/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
+++ b/tests/UI/campaigns/functional/BO/04_customers/02_addresses/06_setRequiredFields.js
@@ -1,22 +1,25 @@
 require('module-alias/register');
 
+// Import expect from chai
 const {expect} = require('chai');
 
 // Import utils
 const helper = require('@utils/helpers');
+const testContext = require('@utils/testContext');
+
+// Import login steps
 const loginCommon = require('@commonTests/loginBO');
 
-// Import pages
+// Import BO pages
 const dashboardPage = require('@pages/BO/dashboard');
 const addressesPage = require('@pages/BO/customers/addresses');
+
+// Import FO pages
 const foLoginPage = require('@pages/FO/login');
 const foHomePage = require('@pages/FO/home');
 const foMyAccountPage = require('@pages/FO/myAccount');
 const foAddressesPage = require('@pages/FO/myAccount/addresses');
 const foAddAddressesPage = require('@pages/FO/myAccount/addAddress');
-
-// Import test context
-const testContext = require('@utils/testContext');
 
 const baseContext = 'functional_BO_customers_addresses_setRequiredFields';
 
@@ -35,7 +38,7 @@ Go to FO, new address page and verify that 'Vat number' is required
 Uncheck 'Vat number'
 Go to FO, new address page and verify that 'Vat number' is not required
  */
-describe('Set required fields for addresses', async () => {
+describe('BO - Customers - Addresses : Set required fields for addresses', async () => {
   // before and after functions
   before(async function () {
     browserContext = await helper.createBrowserContext(this.browser);
@@ -85,6 +88,12 @@ describe('Set required fields for addresses', async () => {
       // Change language in FO
       await foHomePage.changeLanguage(page, 'en');
 
+      const isHomePage = await foHomePage.isHomePage(page);
+      await expect(isHomePage, 'Fail to open FO home page').to.be.true;
+    });
+
+    it('should login in FO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', `loginFO${index}`, baseContext);
       // Go to create account page
       await foHomePage.goToLoginPage(page);
       await foLoginPage.customerLogin(page, DefaultCustomer);
@@ -94,7 +103,7 @@ describe('Set required fields for addresses', async () => {
     });
 
 
-    it('should go to addresses page', async function () {
+    it('should go to \'Customers > Addresses\' page', async function () {
       await testContext.addContextItem(this, 'testIdentifier', `goToFOAddressesPage${index}`, baseContext);
 
       await foMyAccountPage.goToAddressesPage(page);
@@ -125,9 +134,16 @@ describe('Set required fields for addresses', async () => {
 
       const isCustomerConnected = await foAddAddressesPage.isCustomerConnected(page);
       await expect(isCustomerConnected, 'Customer is connected').to.be.false;
+    });
+
+    it('should go back to BO', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', `goBackToBO${index}`, baseContext);
 
       // Go back to BO
       page = await foAddAddressesPage.closePage(browserContext, page, 0);
+
+      const pageTitle = await addressesPage.getPageTitle(page);
+      await expect(pageTitle).to.contains(addressesPage.pageTitle);
     });
   });
 });

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/07_database/sqlManager/01_CRUDSqlQuery.js
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/07_database/sqlManager/01_CRUDSqlQuery.js
@@ -25,8 +25,9 @@ let browserContext;
 let page;
 let numberOfSQLQuery = 0;
 
-const sqlQueryData = new SQLQueryFaker({tableName: 'ps_alias'});
-const editSqlQueryData = new SQLQueryFaker({name: `edit${sqlQueryData.name}`, tableName: 'ps_access'});
+const dbPrefix = global.INSTALL.DB_PREFIX;
+const sqlQueryData = new SQLQueryFaker({tableName: `${dbPrefix}alias`});
+const editSqlQueryData = new SQLQueryFaker({name: `edit${sqlQueryData.name}`, tableName: `${dbPrefix}access`});
 
 describe('CRUD SQL query', async () => {
   // before and after functions

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/07_database/sqlManager/03_exportSqlQuery.js
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/07_database/sqlManager/03_exportSqlQuery.js
@@ -27,7 +27,8 @@ let filePath;
 
 let numberOfSQLQueries = 0;
 
-const sqlQueryData = new SQLQueryFaker({tableName: 'ps_alias'});
+const dbPrefix = global.INSTALL.DB_PREFIX;
+const sqlQueryData = new SQLQueryFaker({tableName: `${dbPrefix}alias`});
 const fileContent = `${Tables.ps_alias.columns[1]};${Tables.ps_alias.columns[2]};${Tables.ps_alias.columns[3]}`;
 
 describe('Export SQL query', async () => {

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/07_database/sqlManager/04_filterSortAndPagination.js
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/07_database/sqlManager/04_filterSortAndPagination.js
@@ -14,6 +14,8 @@ const addSqlQueryPage = require('@pages/BO/advancedParameters/database/sqlManage
 // Import data
 const SQLQueryFaker = require('@data/faker/sqlQuery');
 
+const dbPrefix = global.INSTALL.DB_PREFIX;
+
 // Import test context
 const testContext = require('@utils/testContext');
 
@@ -78,7 +80,7 @@ describe('Filter, sort and pagination SQL manager', async () => {
 
   creationTests.forEach((test, index) => {
     describe(`Create SQL query n°${index + 1} in BO`, async () => {
-      const sqlQueryData = new SQLQueryFaker({name: `todelete${index}`, tableName: 'ps_alias'});
+      const sqlQueryData = new SQLQueryFaker({name: `todelete${index}`, tableName: `${dbPrefix}alias`});
 
       it('should go to add new SQL manager group page', async function () {
         await testContext.addContextItem(this, 'testIdentifier', `goToAddSqlQueryPage${index}`, baseContext);
@@ -156,7 +158,7 @@ describe('Filter, sort and pagination SQL manager', async () => {
           testIdentifier: 'filterBySqlQuery',
           filterType: 'input',
           filterBy: 'sql',
-          filterValue: 'select * from ps_alias',
+          filterValue: `select * from ${global.INSTALL.DB_PREFIX}alias`,
         },
       },
     ];

--- a/tests/UI/campaigns/functional/BO/14_advancedParameters/07_database/sqlManager/04_filterSortAndPagination.js
+++ b/tests/UI/campaigns/functional/BO/14_advancedParameters/07_database/sqlManager/04_filterSortAndPagination.js
@@ -158,7 +158,7 @@ describe('Filter, sort and pagination SQL manager', async () => {
           testIdentifier: 'filterBySqlQuery',
           filterType: 'input',
           filterBy: 'sql',
-          filterValue: `select * from ${global.INSTALL.DB_PREFIX}alias`,
+          filterValue: `select * from ${dbPrefix}alias`,
         },
       },
     ];

--- a/tests/UI/campaigns/regression/currencies/computingPrecision_FO.js
+++ b/tests/UI/campaigns/regression/currencies/computingPrecision_FO.js
@@ -64,10 +64,11 @@ const giftCartRule = new CartRuleFaker(
 );
 
 // Create sql query data to get last order discount and total price
+const dbPrefix = global.INSTALL.DB_PREFIX;
 const sqlQueryData = {
   name: 'Discount and ATI from last order',
   sqlQuery: orderRef => 'SELECT total_discounts, total_paid_tax_incl '
-    + 'from  ps_orders '
+    + `from  ${dbPrefix}orders `
     + `WHERE reference = '${orderRef}'`,
 };
 

--- a/tests/UI/pages/BO/catalog/stocks/index.js
+++ b/tests/UI/pages/BO/catalog/stocks/index.js
@@ -175,7 +175,7 @@ class Stocks extends BOBasePage {
     await page.type(this.searchInput, value);
     await Promise.all([
       page.click(this.searchButton),
-      this.waitForVisibleSelector(page, this.productListLoading),
+      this.waitForVisibleSelector(page, this.productListLoading, 20000),
     ]);
     await this.waitForHiddenSelector(page, this.productListLoading);
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x / 1.7.7.x
| Description?      | Column size of delivery address and invoice address in order page is too narrow. For more readability, it is better to show it as tab layout.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | Order page in BO
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

![Screenshot 2021-08-27 133201](https://user-images.githubusercontent.com/85633460/131103894-21f8661a-ee7e-461e-acc0-b30799698f89.png)

![Screenshot 2021-08-27 133250](https://user-images.githubusercontent.com/85633460/131104976-9650fda0-5a47-4d2c-bc4c-f3d6a5fb0b52.png)

_**The addresses shown in the images are generated by fakeaddressgenerator.com**_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25719)
<!-- Reviewable:end -->
