### PR TITLE
Fix the save "meta_keywords" field on suppliers

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/SupplierFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/SupplierFormDataHandler.php
@@ -158,6 +158,9 @@ final class SupplierFormDataHandler implements FormDataHandlerInterface
         if (null !== $data['meta_description']) {
             $command->setLocalizedMetaDescriptions($data['meta_description']);
         }
+        if (null !== $data['meta_keyword']) {
+            $command->setLocalizedMetaKeywords($data['meta_keyword']);
+        }
         if (null !== $data['is_enabled']) {
             $command->setEnabled((bool) $data['is_enabled']);
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x 
| Description?      | Add forgotten meta keyword field in SupplierFormDataHandler
| Type?             | bug fix
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25705 
| How to test?      | Reproduce #25705 behaviour, see it is solved now
| Possible impacts? | N/A
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25725)
<!-- Reviewable:end -->
