### PR TITLE
Added API status block in WebService page

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use Exception;
+use GuzzleHttp\Client;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\DuplicateWebserviceKeyException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceConstraintException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
@@ -46,6 +47,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class WebserviceController extends FrameworkBundleAdminController
 {
+    private const WEBSERVICE_ENTRY_ENDPOINT = '/api';
+
     /**
      * Displays the Webservice main page.
      *
@@ -58,24 +61,7 @@ class WebserviceController extends FrameworkBundleAdminController
      */
     public function indexAction(WebserviceKeyFilters $filters, Request $request)
     {
-        $form = $this->getFormHandler()->getForm();
-        $gridWebserviceFactory = $this->get('prestashop.core.grid.factory.webservice_key');
-        $grid = $gridWebserviceFactory->getGrid($filters);
-
-        $gridPresenter = $this->get('prestashop.core.grid.presenter.grid_presenter');
-        $presentedGrid = $gridPresenter->present($grid);
-
-        $configurationWarnings = $this->lookForWarnings();
-
-        return $this->render(
-            '@PrestaShop/Admin/Configure/AdvancedParameters/Webservice/index.html.twig',
-            [
-                'help_link' => $this->generateSidebarLink($request->get('_legacy_controller')),
-                'webserviceConfigurationForm' => $form->createView(),
-                'grid' => $presentedGrid,
-                'configurationWarnings' => $configurationWarnings,
-            ]
-        );
+        return $this->renderPage($request, $filters, $this->getFormHandler()->getForm());
     }
 
     /**
@@ -375,6 +361,7 @@ class WebserviceController extends FrameworkBundleAdminController
                 'webserviceConfigurationForm' => $form->createView(),
                 'grid' => $presentedGrid,
                 'configurationWarnings' => $configurationWarnings,
+                'webserviceStatus' => $this->getWebServiceStatus($request),
             ]
         );
     }
@@ -408,5 +395,51 @@ class WebserviceController extends FrameworkBundleAdminController
             ],
             DuplicateWebserviceKeyException::class => $this->trans('This key already exists.', 'Admin.Advparameters.Notification'),
         ];
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return array<string, bool|string|null>
+     */
+    private function getWebServiceStatus(Request $request): array
+    {
+        $webserviceConfiguration = $this->get('prestashop.admin.webservice.form_data_provider')->getData();
+        $webserviceStatus = [
+            'isEnabled' => (bool) $webserviceConfiguration['enable_webservice'],
+            'isFunctional' => false,
+            'endpoint' => null,
+        ];
+
+        if ($webserviceStatus['isEnabled']) {
+            $webserviceStatus['endpoint'] = rtrim($request->getSchemeAndHttpHost(), '/');
+            $webserviceStatus['endpoint'] .= rtrim($this->getContext()->shop->getBaseURI(), '/');
+            $webserviceStatus['endpoint'] .= self::WEBSERVICE_ENTRY_ENDPOINT;
+            $webserviceStatus['isFunctional'] = $this->checkWebserviceEndpoint($webserviceStatus['endpoint']);
+        }
+
+        return $webserviceStatus;
+    }
+
+    /**
+     * @param string $url
+     *
+     * @return bool
+     */
+    private function checkWebserviceEndpoint(string $url): bool
+    {
+        $client = new Client();
+        $response = $client->request('GET', $url, [
+            'http_errors' => false,
+            'allow_redirects' => true,
+        ]);
+
+        if ($response->getStatusCode() >= Response::HTTP_OK && $response->getStatusCode() < Response::HTTP_MULTIPLE_CHOICES) {
+            return true;
+        } elseif ($response->getStatusCode() == Response::HTTP_UNAUTHORIZED) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/index.html.twig
@@ -34,7 +34,7 @@
     'desc': 'Add new webservice key'|trans({}, 'Admin.Advparameters.Feature'),
     'icon': 'add_circle_outline'
   }
-  } %}
+} %}
 
 {% block content %}
 
@@ -47,6 +47,36 @@
               <p class="alert-text">{{ warning }}</p>
             {% endfor %}
           </div>
+        </div>
+      </div>
+    {% endif %}
+  {% endblock %}
+
+  {% block webservice_api_status %}
+    {% set devdocUrl = 'https://devdocs.prestashop.com/1.7/development/webservice/' %}
+
+    {% if webserviceStatus.isEnabled == true %}
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">info_outline</i> {{ 'Webservice status'|trans }}
+        </h3>
+        <div class="card-block">
+          <p>
+            {{ 'Webservice is enabled. Main entry point is' |trans }}
+            <a href="{{ webserviceStatus.endpoint }}" target="_blank">
+              {{ webserviceStatus.endpoint }}
+            </a>
+          </p>
+          {% if webserviceStatus.isFunctional == false %}
+            <p>
+              {{ 'It seems that the webservice endpoint is not functional. If you are using httpd/apache2, you need to enable URL rewriting on your server.'|trans }}
+            </p>
+          {% endif %}
+          <p>
+            {{ "Read the [1]developer documentation[/1]."|trans({
+              '[1]': '<a href="'~devdocUrl~'" target="_blank">', '[/1]': "</a>"
+            }, 'Admin.Advparameters.Feature')|raw }}
+          </p>
         </div>
       </div>
     {% endif %}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Initial code from @matks <br>Adds a block to indicate API endpoint URL, attempt to check whether it seems working and provide documentation link. Idea is to hep people struggling with API setup.
| Type?         | new feature
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/19590
| How to test?  | Open webservice page and enable API. See new block, as displayed just below
### How it looks

#### API is enabled and functional

![image](https://user-images.githubusercontent.com/1533248/131145896-7cd92086-01c8-4339-8ad9-0e68fb1847cf.png)

#### API is enabled but we think there is an issue

![image](https://user-images.githubusercontent.com/1533248/131145979-50dac2cd-5019-4eb7-a2ea-a044d8d72e5c.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25726)
<!-- Reviewable:end -->
