### PR TITLE
Fix that check all order statuses to enable RMA in FO

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -926,8 +926,12 @@ class OrderCore extends ObjectModel
      */
     public function isPaidAndShipped()
     {
-        $order_state = $this->getCurrentOrderState();
-        if ($order_state && $order_state->paid && $order_state->shipped) {
+        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
+			SELECT SUM(os.`paid`) AS `paid`, SUM(os.`shipped`) AS `shipped` FROM `' . _DB_PREFIX_ . 'order_history` oh 
+			LEFT JOIN `' . _DB_PREFIX_ . 'order_state` os ON (os.`id_order_state` = oh.`id_order_state`) 
+			WHERE oh.`id_order`= ' . (int) $this->id );
+		
+        if ($result['paid'] > 0 && $result['shipped'] > 0) {
             return true;
         }
 


### PR DESCRIPTION
Ticket #25651

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Changed method isPaidAndShipped() for check all status of an order.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #25651.
| How to test?      | Reproduce https://github.com/PrestaShop/PrestaShop/issues/25651#issuecomment-907259558 behaviour, see it is solved now 
| Possible impacts? | N/A.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25727)
<!-- Reviewable:end -->
