### PR TITLE
When saving product in BO, show errors to BO user

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -607,7 +607,9 @@ class ProductController extends FrameworkBundleAdminController
             // so we need to return the right type of response if an exception it thrown
             if ($request->isXmlHttpRequest()) {
                 return $this->returnErrorJsonResponse(
-                    [],
+                    // this is not perfect, but if there was an exception during saving or in a hook
+                    // atleast show the message near the name to help user identify what happened
+                    ['step1_name_1' => [$e->getMessage()]],
                     Response::HTTP_INTERNAL_SERVER_ERROR
                 );
             }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  While saving product don't eat exceptions but show them to the user so they can have an idea what happened
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25691
| How to test?      | Please see comment on the issue for testing one case (https://github.com/PrestaShop/PrestaShop/issues/25691#issuecomment-907164171)
| Possible impacts? | Saving products in BO


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25734)
<!-- Reviewable:end -->
