### PR TITLE
OLD - Fix wrapping order status dropdown

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
@@ -11,7 +11,7 @@
   .column-shop_name {
     word-break: normal;
   }
-  
+
   // Do not break order status change button
   .column-osname .btn {
     white-space: nowrap;

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
@@ -11,6 +11,11 @@
   .column-shop_name {
     word-break: normal;
   }
+  
+  // Do not break order status change button
+  .column-osname .btn {
+    white-space: nowrap;
+  }
 
   .order-preview-content {
     .details th,


### PR DESCRIPTION
DO NOT USE

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix small regression - the status change button in order list should not wrap.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes 
| How to test?      | -
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25739)
<!-- Reviewable:end -->
