### PR TITLE
Some buttons should not be allowed to wrap

### DIFF
--- a/admin-dev/themes/default/scss/vendor/bootstrap-sass/_input-groups.scss
+++ b/admin-dev/themes/default/scss/vendor/bootstrap-sass/_input-groups.scss
@@ -62,6 +62,11 @@
   width: 1%;
   white-space: nowrap;
   vertical-align: middle; // Match the inputs
+
+  // Do not wrap buttons child buttons (file selectors etc.)
+  > .btn {
+      white-space: nowrap;
+  }
 }
 
 // Text input groups

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_main.scss
@@ -12,6 +12,11 @@
     word-break: normal;
   }
 
+  // Do not break order status change button
+  .column-osname .btn {
+    white-space: nowrap;
+  }
+
   .order-preview-content {
     .details th,
     .product th,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fix small regressions - the status change button in order list should not wrap, file input group append buttons should not wrap.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25740
| How to test?      | -
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25741)
<!-- Reviewable:end -->
