### PR TITLE
Fix incorrect whitelist management in ProductLazyArray

### DIFF
--- a/classes/ProductPresenterFactory.php
+++ b/classes/ProductPresenterFactory.php
@@ -102,7 +102,8 @@ class ProductPresenterFactoryCore
             new ProductColorsRetriever(),
             $this->context->getTranslator(),
             new HookManager(),
-            new AdapterConfiguration()
+            new AdapterConfiguration(),
+            new \PrestaShop\PrestaShop\Core\Filter\FrontEndObject\EmbeddedAttributesFilter()
         );
     }
 }

--- a/classes/ProductPresenterFactory.php
+++ b/classes/ProductPresenterFactory.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
+use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\EmbeddedAttributesFilter;
 
 /**
  * Class ProductPresenterFactoryCore.
@@ -103,7 +104,7 @@ class ProductPresenterFactoryCore
             $this->context->getTranslator(),
             new HookManager(),
             new AdapterConfiguration(),
-            new \PrestaShop\PrestaShop\Core\Filter\FrontEndObject\EmbeddedAttributesFilter()
+            new EmbeddedAttributesFilter()
         );
     }
 }

--- a/classes/ProductPresenterFactory.php
+++ b/classes/ProductPresenterFactory.php
@@ -31,8 +31,8 @@ use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
-use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\EmbeddedAttributesFilter;
+use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 
 /**
  * Class ProductPresenterFactoryCore.

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -125,7 +125,7 @@ class ProductLazyArray extends AbstractLazyArray
         $this->translator = $translator;
         $this->hookManager = $hookManager ?? new HookManager();
         $this->configuration = $configuration ?? new Configuration();
-        $this->embeddedAttributesFilter = $embeddedAttributesFilter;
+        $this->embeddedAttributesFilter = $embeddedAttributesFilter ?? new EmbeddedAttributesFilter();
 
         $this->fillImages(
             $product,

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\EmbeddedAttributesFilter;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 use Product;
 use Symfony\Component\Translation\Exception\InvalidArgumentException;
@@ -96,6 +97,11 @@ class ProductLazyArray extends AbstractLazyArray
      */
     private $configuration;
 
+    /**
+     * @var EmbeddedAttributesFilter
+     */
+    private $embeddedAttributesFilter;
+
     public function __construct(
         ProductPresentationSettings $settings,
         array $product,
@@ -106,7 +112,8 @@ class ProductLazyArray extends AbstractLazyArray
         ProductColorsRetriever $productColorsRetriever,
         TranslatorInterface $translator,
         HookManager $hookManager = null,
-        Configuration $configuration = null
+        Configuration $configuration = null,
+        EmbeddedAttributesFilter $embeddedAttributesFilter = null
     ) {
         $this->settings = $settings;
         $this->product = $product;
@@ -118,6 +125,7 @@ class ProductLazyArray extends AbstractLazyArray
         $this->translator = $translator;
         $this->hookManager = $hookManager ?? new HookManager();
         $this->configuration = $configuration ?? new Configuration();
+        $this->embeddedAttributesFilter = $embeddedAttributesFilter;
 
         $this->fillImages(
             $product,
@@ -290,6 +298,10 @@ class ProductLazyArray extends AbstractLazyArray
             if (in_array($attribute, $whitelist)) {
                 $embeddedProductAttributes[$attribute] = $value;
             }
+        }
+
+        if ($this->embeddedAttributesFilter !== null) {
+            $embeddedProductAttributes = $this->embeddedAttributesFilter->filter($embeddedProductAttributes);
         }
 
         return $embeddedProductAttributes;

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -292,19 +292,11 @@ class ProductLazyArray extends AbstractLazyArray
      */
     public function getEmbeddedAttributes()
     {
-        $whitelist = $this->getProductAttributeWhitelist();
-        $embeddedProductAttributes = [];
-        foreach ($this->product as $attribute => $value) {
-            if (in_array($attribute, $whitelist)) {
-                $embeddedProductAttributes[$attribute] = $value;
-            }
-        }
-
         if ($this->embeddedAttributesFilter !== null) {
-            $embeddedProductAttributes = $this->embeddedAttributesFilter->filter($embeddedProductAttributes);
+            return $this->embeddedAttributesFilter->filter($this->product);
         }
 
-        return $embeddedProductAttributes;
+        return [];
     }
 
     /**
@@ -990,119 +982,6 @@ class ProductLazyArray extends AbstractLazyArray
         }
 
         return $key;
-    }
-
-    /**
-     * @return array
-     */
-    protected function getProductAttributeWhitelist()
-    {
-        return [
-            'add_to_cart_url',
-            'additional_shipping_cost',
-            'advanced_stock_management',
-            'allow_oosp',
-            'attachments',
-            'attribute_price',
-            'attributes',
-            'availability',
-            'availability_date',
-            'availability_message',
-            'available_date',
-            'available_for_order',
-            'available_later',
-            'available_now',
-            'cache_default_attribute',
-            'canonical_url',
-            'category',
-            'category_name',
-            'condition',
-            'cover',
-            'customer_group_discount',
-            'customizable',
-            'customization_required',
-            'customizations',
-            'date_add',
-            'date_upd',
-            'delivery_in_stock',
-            'delivery_out_stock',
-            'description',
-            'description_short',
-            'discount_amount',
-            'discount_amount_to_display',
-            'discount_percentage',
-            'discount_percentage_absolute',
-            'discount_type',
-            'ecotax',
-            'ecotax_rate',
-            'extraContent',
-            'features',
-            'flags',
-            'has_discount',
-            'id',
-            'id_category_default',
-            'id_customization',
-            'id_image',
-            'id_manufacturer',
-            'id_product',
-            'id_product_attribute',
-            'id_shop_default',
-            'id_supplier',
-            'id_type_redirected',
-            'images',
-            'indexed',
-            'is_customizable',
-            'is_virtual',
-            'labels',
-            'link',
-            'link_rewrite',
-            'low_stock_alert',
-            'low_stock_threshold',
-            'main_variants',
-            'meta_description',
-            'meta_keywords',
-            'meta_title',
-            'minimal_quantity',
-            'name',
-            'new',
-            'nopackprice',
-            'on_sale',
-            'online_only',
-            'out_of_stock',
-            'pack',
-            'pack_stock_type',
-            'packItems',
-            'price',
-            'price_amount',
-            'price_tax_exc',
-            'price_without_reduction',
-            'quantity',
-            'quantity_all_versions',
-            'quantity_discounts',
-            'quantity_label',
-            'quantity_wanted',
-            'rate',
-            'redirect_type',
-            'reduction',
-            'reference',
-            'reference_to_display',
-            'show_availability',
-            'show_condition',
-            'show_price',
-            'show_quantities',
-            'specific_prices',
-            'tax_name',
-            'text_fields',
-            'unit_price',
-            'unit_price_full',
-            'unit_price_ratio',
-            'unity',
-            'uploadable_files',
-            'url',
-            'virtual',
-            'visibility',
-            'weight_unit',
-        ];
     }
 
     /**

--- a/src/Adapter/Presenter/Product/ProductPresenter.php
+++ b/src/Adapter/Presenter/Product/ProductPresenter.php
@@ -97,7 +97,7 @@ class ProductPresenter
         $this->translator = $translator;
         $this->hookManager = $hookManager ?? new HookManager();
         $this->configuration = $configuration ?? new Configuration();
-        $this->embeddedAttributesFilter = $embeddedAttributesFilter;
+        $this->embeddedAttributesFilter = $embeddedAttributesFilter ?? new EmbeddedAttributesFilter();
     }
 
     public function present(

--- a/src/Adapter/Presenter/Product/ProductPresenter.php
+++ b/src/Adapter/Presenter/Product/ProductPresenter.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
+use PrestaShop\PrestaShop\Core\Filter\FrontEndObject\EmbeddedAttributesFilter;
 use PrestaShop\PrestaShop\Core\Product\ProductPresentationSettings;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -74,6 +75,11 @@ class ProductPresenter
      */
     protected $translator;
 
+    /**
+     * @var EmbeddedAttributesFilter
+     */
+    private $embeddedAttributesFilter;
+
     public function __construct(
         ImageRetriever $imageRetriever,
         Link $link,
@@ -81,7 +87,8 @@ class ProductPresenter
         ProductColorsRetriever $productColorsRetriever,
         TranslatorInterface $translator,
         HookManager $hookManager = null,
-        Configuration $configuration = null
+        Configuration $configuration = null,
+        EmbeddedAttributesFilter $embeddedAttributesFilter = null
     ) {
         $this->imageRetriever = $imageRetriever;
         $this->link = $link;
@@ -90,6 +97,7 @@ class ProductPresenter
         $this->translator = $translator;
         $this->hookManager = $hookManager ?? new HookManager();
         $this->configuration = $configuration ?? new Configuration();
+        $this->embeddedAttributesFilter = $embeddedAttributesFilter;
     }
 
     public function present(
@@ -107,7 +115,8 @@ class ProductPresenter
             $this->productColorsRetriever,
             $this->translator,
             $this->hookManager,
-            $this->configuration
+            $this->configuration,
+            $this->embeddedAttributesFilter
         );
 
         Hook::exec('actionPresentProduct',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Stop data exposure for presented product thanks to EmbeddedAttributesFilter.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25633
| How to test?      | Follow ticket instructions
| Possible impacts? | N/A

It appears that the work that was carried out in https://github.com/PrestaShop/PrestaShop/pull/8803 was not applied to the 'embedded attributes' array inside a presented product, which is an instance of ProductLazyArray. I simply follow https://github.com/PrestaShop/PrestaShop/pull/8803 design using EmbeddedAttributesFilter to filter unwanted data for this array.

#### BC Break

`PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray::getProductAttributeWhitelist()` removed because not used anymore (orphan method)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25755)
<!-- Reviewable:end -->
