### PR TITLE
Remove "select" case and fix "editable" one in HelperList

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -717,18 +717,7 @@ class HelperListCore extends Helper
 
                     break;
 
-                case 'select':
-                    foreach ($params['list'] as $option_value => $option_display) {
-                        if (isset(Context::getContext()->cookie->{$prefix . $this->list_id . 'Filter_' . $params['filter_key']})
-                            && Context::getContext()->cookie->{$prefix . $this->list_id . 'Filter_' . $params['filter_key']} == $option_value
-                            && Context::getContext()->cookie->{$prefix . $this->list_id . 'Filter_' . $params['filter_key']} != '') {
-                            $this->fields_list[$key]['select'][$option_value]['selected'] = 'selected';
-                        }
-                    }
-
-                    break;
-
-                case 'text':
+                case 'editable':
                     if (!Validate::isCleanHtml($value)) {
                         $value = '';
                     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | HelperList doesn't show select type, this is not needed to handle there it. Also, HelperList use "editable" instead of text type.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Simple init an HelperList with editable and select option in them.
| Possible impacts? | Nothing.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25770)
<!-- Reviewable:end -->
