### PR TITLE
Fix when duplicating product, out of stock ordering behavior is not copied

### DIFF
--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -39,6 +39,7 @@ use Product;
 use Search;
 use Shop;
 use ShopGroup;
+use StockAvailable;
 use Validate;
 
 /**
@@ -233,7 +234,7 @@ class AdminProductDataUpdater implements ProductInterface
                 if (in_array($product->visibility, ['both', 'search']) && Configuration::get('PS_SEARCH_INDEXATION')) {
                     Search::indexation(false, $product->id);
                 }
-
+                StockAvailable::setProductOutOfStock($product->id, StockAvailable::outOfStock($id_product_old));
                 return $product->id;
             }
         } else {

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -235,6 +235,7 @@ class AdminProductDataUpdater implements ProductInterface
                     Search::indexation(false, $product->id);
                 }
                 StockAvailable::setProductOutOfStock($product->id, StockAvailable::outOfStock($id_product_old));
+                
                 return $product->id;
             }
         } else {

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -235,7 +235,6 @@ class AdminProductDataUpdater implements ProductInterface
                     Search::indexation(false, $product->id);
                 }
                 StockAvailable::setProductOutOfStock($product->id, StockAvailable::outOfStock($id_product_old));
-                
                 return $product->id;
             }
         } else {

--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -235,6 +235,7 @@ class AdminProductDataUpdater implements ProductInterface
                     Search::indexation(false, $product->id);
                 }
                 StockAvailable::setProductOutOfStock($product->id, StockAvailable::outOfStock($id_product_old));
+
                 return $product->id;
             }
         } else {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Fixes ps_stock_available "out_of_stock" status not being copied when duplicating a product
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #25448 
| How to test?      | Follow 25448 reproduction steps before / after this patch
| Possible impacts? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25787)
<!-- Reviewable:end -->
