### PR TITLE
Multistore - Orders > Credit Slips - Add checkboxes

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/credit-slip/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/credit-slip/index.ts
@@ -43,4 +43,12 @@ $(() => {
   creditSlipGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
 
   new TranslatableInput();
+
+  $(() => {
+    window.prestashop.component.initComponents(
+      [
+        'MultistoreConfigField',
+      ],
+    );
+  });
 });

--- a/src/Core/CreditSlip/CreditSlipOptionsConfiguration.php
+++ b/src/Core/CreditSlip/CreditSlipOptionsConfiguration.php
@@ -27,20 +27,34 @@
 namespace PrestaShop\PrestaShop\Core\CreditSlip;
 
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Responsible for saving configuration options for credit slip
  */
 final class CreditSlipOptionsConfiguration extends AbstractMultistoreConfiguration
 {
+    private const CONFIGURATION_FIELDS = ['slip_prefix'];
+
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration()
+    public function getConfiguration(): array
     {
         return [
             'slip_prefix' => $this->configuration->get('PS_CREDIT_SLIP_PREFIX'),
         ];
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return OptionsResolver
+     */
+    protected function buildResolver(): OptionsResolver
+    {
+        return (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('slip_prefix', ['string[]']);
     }
 
     /**
@@ -64,13 +78,5 @@ final class CreditSlipOptionsConfiguration extends AbstractMultistoreConfigurati
         }
 
         return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function validateConfiguration(array $configuration)
-    {
-        return isset($configuration['slip_prefix']);
     }
 }

--- a/src/Core/CreditSlip/CreditSlipOptionsConfiguration.php
+++ b/src/Core/CreditSlip/CreditSlipOptionsConfiguration.php
@@ -26,27 +26,13 @@
 
 namespace PrestaShop\PrestaShop\Core\CreditSlip;
 
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 
 /**
  * Responsible for saving configuration options for credit slip
  */
-final class CreditSlipOptionsConfiguration implements DataConfigurationInterface
+final class CreditSlipOptionsConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var ConfigurationInterface
-     */
-    private $configuration;
-
-    /**
-     * @param ConfigurationInterface $configuration
-     */
-    public function __construct(ConfigurationInterface $configuration)
-    {
-        $this->configuration = $configuration;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -63,7 +49,18 @@ final class CreditSlipOptionsConfiguration implements DataConfigurationInterface
     public function updateConfiguration(array $configuration)
     {
         if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set('PS_CREDIT_SLIP_PREFIX', $configuration['slip_prefix']);
+            if (
+                array_key_exists('multistore_slip_prefix', $configuration)
+                && $configuration['multistore_slip_prefix'] === false) {
+                unset($configuration['multistore_slip_prefix']);
+            }
+
+            $this->updateConfigurationValue(
+                'PS_CREDIT_SLIP_PREFIX',
+                'slip_prefix',
+                $configuration,
+                $this->getShopConstraint()
+            );
         }
 
         return [];

--- a/src/Core/CreditSlip/CreditSlipOptionsConfiguration.php
+++ b/src/Core/CreditSlip/CreditSlipOptionsConfiguration.php
@@ -48,6 +48,7 @@ final class CreditSlipOptionsConfiguration extends AbstractMultistoreConfigurati
 
     /**
      * {@inheritdoc}
+     *
      * @return OptionsResolver
      */
     protected function buildResolver(): OptionsResolver

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -26,6 +26,8 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Order\CreditSlip;
 
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -43,12 +45,35 @@ final class CreditSlipOptionsType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $builder->setMethod('POST');
         $builder->add('slip_prefix', TranslatableType::class, [
             'label' => $this->trans('Credit slip prefix', 'Admin.Orderscustomers.Feature'),
             'help' => $this->trans('Prefix used for credit slips.', 'Admin.Orderscustomers.Help'),
             'required' => false,
             'error_bubbling' => true,
             'type' => TextType::class,
+            'options' => [
+                'constraints' => [
+                    new TypedRegex([
+                        'type' => 'file_name',
+                        'message' => $this->trans(
+                            '%s is invalid.',
+                            'Admin.Notifications.Error'
+                        ),
+                    ]),
+                ],
+            ],
+            'multistore_configuration_key' => 'PS_CREDIT_SLIP_PREFIX',
         ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/credit_slips.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/credit_slips.yml
@@ -38,7 +38,7 @@ _admin_credit_slips_pdf_by_date:
 
 admin_credit_slips_process_options:
   path: /
-  methods: [PATCH, POST]
+  methods: [ PATCH , POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Order\CreditSlipController::indexAction'
     _legacy_controller: AdminSlip

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/credit_slips.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/credit_slips.yml
@@ -38,7 +38,7 @@ _admin_credit_slips_pdf_by_date:
 
 admin_credit_slips_process_options:
   path: /
-  methods: [ PATCH , POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Order\CreditSlipController::indexAction'
     _legacy_controller: AdminSlip

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/credit_slips.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/credit_slips.yml
@@ -38,7 +38,7 @@ _admin_credit_slips_pdf_by_date:
 
 admin_credit_slips_process_options:
   path: /
-  methods: [ POST ]
+  methods: [PATCH, POST]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Order\CreditSlipController::indexAction'
     _legacy_controller: AdminSlip

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -266,6 +266,8 @@ services:
     class: 'PrestaShop\PrestaShop\Core\CreditSlip\CreditSlipOptionsConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.core.feature_flags.modifier:
     class: 'PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagsModifier'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | new feature 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19382.
| How to test?      | Multistore - Checkbox should be visible on field slip_prefix on page Orders > Credit Slips
| Possible impacts? | Change the way the data are saved with multistore


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25793)
<!-- Reviewable:end -->
