### PR TITLE
BO - Fix bug saving product with combination

### DIFF
--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -148,6 +148,7 @@ class AdminProductWrapper
             $combinationValues['attribute_ecotax'] = 0;
         } else {
             // Value is displayed tax included but must be saved tax excluded
+            $combinationValues['attribute_ecotax'] = str_replace(',', '.', $combinationValues['attribute_ecotax']);
             $combinationValues['attribute_ecotax'] = Tools::ps_round(
                 $combinationValues['attribute_ecotax'] / (1 + Tax::getProductEcotaxRate() / 100),
                 $computingPrecision


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Product with combination cannot be saved with french language if mode debug is enabled (because of "," decimal separator in ecotax calculation)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25761 and Fixes #25797 
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | No impact

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25815)
<!-- Reviewable:end -->
