### PR TITLE
Change jQuery-ui position before theme.js to avoid overriding bootstrap ones

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1224,7 +1224,7 @@ class FrontControllerCore extends Controller
 
         $this->registerStylesheet('jquery-ui-theme', $css_theme_path, ['media' => 'all', 'priority' => 95]);
         $this->registerStylesheet('jquery-ui', $css_path, ['media' => 'all', 'priority' => 90]);
-        $this->registerJavascript('jquery-ui', $js_path, ['position' => 'bottom', 'priority' => 90]);
+        $this->registerJavascript('jquery-ui', $js_path, ['position' => 'bottom', 'priority' => 49]);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Bootstrap tooltips were overridden by JQuery-ui one which make it difficult to style it with Bootstrap variables
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #25738.
| How to test?      | See issue and follow steps
| Possible impacts? | Classic theme tooltips use

# Breaking changes
As this was here from years, theme developers may adapted their stylesheets to change the JQuery-ui ones, now they'll see bootstrap ones and needs to adapt their themes

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25818)
<!-- Reviewable:end -->
