### PR TITLE
Fix exception when switching shop context after pushing a form on some configuration pages

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -314,7 +314,7 @@ class WebserviceController extends FrameworkBundleAdminController
      * @param Request $request
      * @param WebserviceKeyFilters $filters
      *
-     * @return Response
+     * @return Response|RedirectResponse
      */
     public function saveSettingsAction(Request $request, WebserviceKeyFilters $filters)
     {
@@ -331,6 +331,8 @@ class WebserviceController extends FrameworkBundleAdminController
             } else {
                 $this->flashErrors($saveErrors);
             }
+
+            return $this->redirectToRoute('admin_webservice_keys_index');
         }
 
         $form = $this->getFormHandler()->getForm();

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -316,7 +316,7 @@ class WebserviceController extends FrameworkBundleAdminController
      *
      * @return Response|RedirectResponse
      */
-    public function saveSettingsAction(Request $request, WebserviceKeyFilters $filters)
+    public function saveSettingsAction(Request $request, WebserviceKeyFilters $filters): Response
     {
         $this->dispatchHook('actionAdminAdminWebserviceControllerPostProcessBefore', ['controller' => $this]);
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -328,14 +328,12 @@ class WebserviceController extends FrameworkBundleAdminController
 
             if (0 === count($saveErrors)) {
                 $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_webservice_keys_index');
             } else {
                 $this->flashErrors($saveErrors);
             }
-
-            return $this->redirectToRoute('admin_webservice_keys_index');
         }
-
-        $form = $this->getFormHandler()->getForm();
 
         return $this->renderPage($request, $filters, $form);
     }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -316,7 +316,7 @@ class WebserviceController extends FrameworkBundleAdminController
      *
      * @return Response|RedirectResponse
      */
-    public function saveSettingsAction(Request $request, WebserviceKeyFilters $filters): Response
+    public function saveSettingsAction(Request $request, WebserviceKeyFilters $filters)
     {
         $this->dispatchHook('actionAdminAdminWebserviceControllerPostProcessBefore', ['controller' => $this]);
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -239,25 +239,17 @@ class MetaController extends FrameworkBundleAdminController
      * @param MetaFilters $filters
      * @param Request $request
      *
-     * @return Response
+     * @return RedirectResponse
      */
-    public function processSetUpUrlsFormAction(MetaFilters $filters, Request $request)
+    public function processSetUpUrlsFormAction(MetaFilters $filters, Request $request): RedirectResponse
     {
-        $setUpUrlsForm = $this->processForm(
+        $this->processForm(
             $request,
             $this->getSetUpUrlsFormHandler(),
             'SetUpUrls'
         );
-        $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
-        $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
 
-        $urlSchemaForm = null;
-        if ($isRewriteSettingEnabled) {
-            $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
-        }
-
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->redirectToRoute('admin_metas_index');
     }
 
     /**
@@ -267,25 +259,17 @@ class MetaController extends FrameworkBundleAdminController
      * @param MetaFilters $filters
      * @param Request $request
      *
-     * @return Response
+     * @return RedirectResponse
      */
-    public function processShopUrlsFormAction(MetaFilters $filters, Request $request)
+    public function processShopUrlsFormAction(MetaFilters $filters, Request $request): RedirectResponse
     {
-        $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
-        $shopUrlsForm = $this->processForm(
+        $this->processForm(
             $request,
             $this->getShopUrlsFormHandler(),
             'ShopUrls'
         );
-        $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
 
-        $urlSchemaForm = null;
-        if ($isRewriteSettingEnabled) {
-            $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
-        }
-
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->redirectToRoute('admin_metas_index');
     }
 
     /**
@@ -295,21 +279,17 @@ class MetaController extends FrameworkBundleAdminController
      * @param MetaFilters $filters
      * @param Request $request
      *
-     * @return Response
+     * @return RedirectResponse
      */
-    public function processUrlSchemaFormAction(MetaFilters $filters, Request $request)
+    public function processUrlSchemaFormAction(MetaFilters $filters, Request $request): RedirectResponse
     {
-        $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
-        $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
-        $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
-
-        $urlSchemaForm = $this->processForm(
+        $this->processForm(
             $request,
             $this->getUrlSchemaFormHandler(),
             'UrlSchema'
         );
 
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->redirectToRoute('admin_metas_index');
     }
 
     /**
@@ -319,25 +299,17 @@ class MetaController extends FrameworkBundleAdminController
      * @param MetaFilters $filters
      * @param Request $request
      *
-     * @return Response
+     * @return RedirectResponse
      */
-    public function processSeoOptionsFormAction(MetaFilters $filters, Request $request)
+    public function processSeoOptionsFormAction(MetaFilters $filters, Request $request): RedirectResponse
     {
-        $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
-        $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
-        $seoOptionsForm = $this->processForm(
+        $this->processForm(
             $request,
             $this->getSeoOptionsFormHandler(),
             'SeoOptions'
         );
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
 
-        $urlSchemaForm = null;
-        if ($isRewriteSettingEnabled) {
-            $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
-        }
-
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->redirectToRoute('admin_metas_index');
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -241,7 +241,7 @@ class MetaController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
-    public function processSetUpUrlsFormAction(MetaFilters $filters, Request $request): RedirectResponse
+    public function processSetUpUrlsFormAction(MetaFilters $filters, Request $request)
     {
         $this->processForm(
             $request,
@@ -261,7 +261,7 @@ class MetaController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
-    public function processShopUrlsFormAction(MetaFilters $filters, Request $request): RedirectResponse
+    public function processShopUrlsFormAction(MetaFilters $filters, Request $request)
     {
         $this->processForm(
             $request,
@@ -281,7 +281,7 @@ class MetaController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
-    public function processUrlSchemaFormAction(MetaFilters $filters, Request $request): RedirectResponse
+    public function processUrlSchemaFormAction(MetaFilters $filters, Request $request)
     {
         $this->processForm(
             $request,
@@ -301,7 +301,7 @@ class MetaController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
-    public function processSeoOptionsFormAction(MetaFilters $filters, Request $request): RedirectResponse
+    public function processSeoOptionsFormAction(MetaFilters $filters, Request $request)
     {
         $this->processForm(
             $request,

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -239,17 +239,30 @@ class MetaController extends FrameworkBundleAdminController
      * @param MetaFilters $filters
      * @param Request $request
      *
-     * @return RedirectResponse
+     * @return Response|RedirectResponse
      */
     public function processSetUpUrlsFormAction(MetaFilters $filters, Request $request)
     {
-        $this->processForm(
-            $request,
-            $this->getSetUpUrlsFormHandler(),
-            'SetUpUrls'
-        );
+        $setUpUrlsForm = $this->processForm(
+                $request,
+                $this->getSetUpUrlsFormHandler(),
+                'SetUpUrls'
+            );
 
-        return $this->redirectToRoute('admin_metas_index');
+        if ($setUpUrlsForm instanceof RedirectResponse) {
+            return $setUpUrlsForm;
+        }
+
+        $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
+        $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
+        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
+
+        $urlSchemaForm = null;
+        if ($isRewriteSettingEnabled) {
+            $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
+        }
+
+        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**
@@ -259,17 +272,30 @@ class MetaController extends FrameworkBundleAdminController
      * @param MetaFilters $filters
      * @param Request $request
      *
-     * @return RedirectResponse
+     * @return Response|RedirectResponse
      */
     public function processShopUrlsFormAction(MetaFilters $filters, Request $request)
     {
-        $this->processForm(
-            $request,
-            $this->getShopUrlsFormHandler(),
-            'ShopUrls'
-        );
+        $shopUrlsForm = $this->processForm(
+                $request,
+                $this->getShopUrlsFormHandler(),
+                'ShopUrls'
+            );
 
-        return $this->redirectToRoute('admin_metas_index');
+        if ($shopUrlsForm instanceof RedirectResponse) {
+            return $shopUrlsForm;
+        }
+
+        $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
+        $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
+        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
+
+        $urlSchemaForm = null;
+        if ($isRewriteSettingEnabled) {
+            $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
+        }
+
+        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**
@@ -279,17 +305,25 @@ class MetaController extends FrameworkBundleAdminController
      * @param MetaFilters $filters
      * @param Request $request
      *
-     * @return RedirectResponse
+     * @return Response|RedirectResponse
      */
     public function processUrlSchemaFormAction(MetaFilters $filters, Request $request)
     {
-        $this->processForm(
-            $request,
-            $this->getUrlSchemaFormHandler(),
-            'UrlSchema'
-        );
+        $urlSchemaForm = $this->processForm(
+                $request,
+                $this->getUrlSchemaFormHandler(),
+                'UrlSchema'
+            );
 
-        return $this->redirectToRoute('admin_metas_index');
+        if ($urlSchemaForm instanceof RedirectResponse) {
+            return $urlSchemaForm;
+        }
+
+        $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
+        $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
+        $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
+
+        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**
@@ -299,17 +333,30 @@ class MetaController extends FrameworkBundleAdminController
      * @param MetaFilters $filters
      * @param Request $request
      *
-     * @return RedirectResponse
+     * @return Response|RedirectResponse
      */
     public function processSeoOptionsFormAction(MetaFilters $filters, Request $request)
     {
-        $this->processForm(
-            $request,
-            $this->getSeoOptionsFormHandler(),
-            'SeoOptions'
-        );
+        $seoOptionsForm = $this->processForm(
+                $request,
+                $this->getSeoOptionsFormHandler(),
+                'SeoOptions'
+            );
 
-        return $this->redirectToRoute('admin_metas_index');
+        if ($seoOptionsForm instanceof RedirectResponse) {
+            return $seoOptionsForm;
+        }
+
+        $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
+        $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
+        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
+
+        $urlSchemaForm = null;
+        if ($isRewriteSettingEnabled) {
+            $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
+        }
+
+        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**
@@ -439,7 +486,7 @@ class MetaController extends FrameworkBundleAdminController
      * @param FormHandlerInterface $formHandler
      * @param string $hookName
      *
-     * @return FormInterface
+     * @return FormInterface|RedirectResponse
      */
     protected function processForm(Request $request, FormHandlerInterface $formHandler, string $hookName)
     {
@@ -459,6 +506,8 @@ class MetaController extends FrameworkBundleAdminController
 
             if (0 === count($saveErrors)) {
                 $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_metas_index');
             } else {
                 $this->flashErrors($saveErrors);
             }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -243,14 +243,14 @@ class MetaController extends FrameworkBundleAdminController
      */
     public function processSetUpUrlsFormAction(MetaFilters $filters, Request $request)
     {
-        $setUpUrlsForm = $this->processForm(
-                $request,
-                $this->getSetUpUrlsFormHandler(),
-                'SetUpUrls'
-            );
+        $formProcessResult = $this->processForm(
+            $request,
+            $this->getSetUpUrlsFormHandler(),
+            'SetUpUrls'
+        );
 
-        if ($setUpUrlsForm instanceof RedirectResponse) {
-            return $setUpUrlsForm;
+        if ($formProcessResult instanceof RedirectResponse) {
+            return $formProcessResult;
         }
 
         $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
@@ -262,7 +262,7 @@ class MetaController extends FrameworkBundleAdminController
             $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
         }
 
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->renderForm($request, $filters, $formProcessResult, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**
@@ -276,14 +276,14 @@ class MetaController extends FrameworkBundleAdminController
      */
     public function processShopUrlsFormAction(MetaFilters $filters, Request $request)
     {
-        $shopUrlsForm = $this->processForm(
-                $request,
-                $this->getShopUrlsFormHandler(),
-                'ShopUrls'
-            );
+        $formProcessResult = $this->processForm(
+            $request,
+            $this->getShopUrlsFormHandler(),
+            'ShopUrls'
+        );
 
-        if ($shopUrlsForm instanceof RedirectResponse) {
-            return $shopUrlsForm;
+        if ($formProcessResult instanceof RedirectResponse) {
+            return $formProcessResult;
         }
 
         $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
@@ -295,7 +295,7 @@ class MetaController extends FrameworkBundleAdminController
             $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
         }
 
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->renderForm($request, $filters, $setUpUrlsForm, $formProcessResult, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**
@@ -309,21 +309,21 @@ class MetaController extends FrameworkBundleAdminController
      */
     public function processUrlSchemaFormAction(MetaFilters $filters, Request $request)
     {
-        $urlSchemaForm = $this->processForm(
-                $request,
-                $this->getUrlSchemaFormHandler(),
-                'UrlSchema'
-            );
+        $formProcessResult = $this->processForm(
+            $request,
+            $this->getUrlSchemaFormHandler(),
+            'UrlSchema'
+        );
 
-        if ($urlSchemaForm instanceof RedirectResponse) {
-            return $urlSchemaForm;
+        if ($formProcessResult instanceof RedirectResponse) {
+            return $formProcessResult;
         }
 
         $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
         $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
         $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
 
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $formProcessResult);
     }
 
     /**
@@ -337,14 +337,14 @@ class MetaController extends FrameworkBundleAdminController
      */
     public function processSeoOptionsFormAction(MetaFilters $filters, Request $request)
     {
-        $seoOptionsForm = $this->processForm(
-                $request,
-                $this->getSeoOptionsFormHandler(),
-                'SeoOptions'
-            );
+        $formProcessResult = $this->processForm(
+            $request,
+            $this->getSeoOptionsFormHandler(),
+            'SeoOptions'
+        );
 
-        if ($seoOptionsForm instanceof RedirectResponse) {
-            return $seoOptionsForm;
+        if ($formProcessResult instanceof RedirectResponse) {
+            return $formProcessResult;
         }
 
         $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
@@ -356,7 +356,7 @@ class MetaController extends FrameworkBundleAdminController
             $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
         }
 
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $formProcessResult, $urlSchemaForm);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -30,9 +30,9 @@ use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\MerchandiseReturnFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Class MerchandiseReturnController responsible for "Sell > Customer Service > Merchandise Returns" page
@@ -65,11 +65,11 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
 
             if (empty($errors)) {
                 $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_merchandise_returns_index');
             } else {
                 $this->flashErrors($errors);
             }
-
-            return $this->redirectToRoute('admin_merchandise_returns_index');
         }
 
         return $this->render('@PrestaShop/Admin/Sell/CustomerService/MerchandiseReturn/index.html.twig', [

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -32,6 +32,7 @@ use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Class MerchandiseReturnController responsible for "Sell > Customer Service > Merchandise Returns" page
@@ -49,7 +50,7 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
      * @param Request $request
      * @param MerchandiseReturnFilters $filters
      *
-     * @return Response
+     * @return Response|RedirectResponse
      */
     public function indexAction(Request $request, MerchandiseReturnFilters $filters): Response
     {
@@ -67,6 +68,8 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
             } else {
                 $this->flashErrors($errors);
             }
+
+            return $this->redirectToRoute('admin_merchandise_returns_index');
         }
 
         return $this->render('@PrestaShop/Admin/Sell/CustomerService/MerchandiseReturn/index.html.twig', [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR fixes the issue we had on some forms, when switching shop context after pushing the form. The fix implemented is to redirect to the page (GET url) after processing the form.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25674
| How to test?      | See issue #25674 
| Possible impacts? | I don't think so

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25833)
<!-- Reviewable:end -->
