### PR TITLE
Update cssjanus 1.2 to 2.1, stop relying on PrestaShop fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "beberlei/doctrineextensions": "^1.0",
         "composer/ca-bundle": "^1.0",
         "composer/installers": "^1.0.21",
-        "cssjanus/cssjanus": "dev-patch-1",
+        "cssjanus/cssjanus": "^2.0",
         "curl/curl": "^2.3.2",
         "defuse/php-encryption": "^2.3.1",
         "doctrine/cache": "^2.0",
@@ -174,13 +174,6 @@
             "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php"
         ]
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/PrestaShop/php-cssjanus",
-            "canonical": false
-        }
-    ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d9ed50b33881e8eac7befb3e2e4d859",
+    "content-hash": "305692b69e58e468f5731adeda8c7016",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -509,25 +509,26 @@
         },
         {
             "name": "cssjanus/cssjanus",
-            "version": "dev-patch-1",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PrestaShop/php-cssjanus.git",
-                "reference": "7866b8a6f7ad8ba8c7f4eb9f87b084452a41d8e5"
+                "url": "https://github.com/cssjanus/php-cssjanus.git",
+                "reference": "de7483c0805750a6462b372eab55d022d555df02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/php-cssjanus/zipball/7866b8a6f7ad8ba8c7f4eb9f87b084452a41d8e5",
-                "reference": "7866b8a6f7ad8ba8c7f4eb9f87b084452a41d8e5",
+                "url": "https://api.github.com/repos/cssjanus/php-cssjanus/zipball/de7483c0805750a6462b372eab55d022d555df02",
+                "reference": "de7483c0805750a6462b372eab55d022d555df02",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4"
+                "php": ">=7.2.0"
             },
             "require-dev": {
-                "jakub-onderka/php-parallel-lint": "0.8.*",
-                "phpunit/phpunit": "4.8.*",
-                "squizlabs/php_codesniffer": "2.3.*"
+                "mediawiki/mediawiki-phan-config": "0.10.6",
+                "php-parallel-lint/php-parallel-lint": "^1.3.0",
+                "phpunit/phpunit": "^8.5.15",
+                "squizlabs/php_codesniffer": "^3.6.0"
             },
             "type": "library",
             "autoload": {
@@ -535,21 +536,27 @@
                     "": "src/"
                 }
             },
-            "scripts": {
-                "test": [
-                    "parallel-lint . --exclude vendor",
-                    "phpunit",
-                    "phpcs -p"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "Apache-2.0"
             ],
+            "authors": [
+                {
+                    "name": "Roan Kattouw"
+                },
+                {
+                    "name": "Trevor Parscal"
+                },
+                {
+                    "name": "Timo Tijhof"
+                }
+            ],
             "description": "Convert CSS stylesheets between left-to-right and right-to-left.",
             "support": {
-                "source": "https://github.com/PrestaShop/php-cssjanus/tree/patch-1"
+                "issues": "https://github.com/cssjanus/php-cssjanus/issues",
+                "source": "https://github.com/cssjanus/php-cssjanus/tree/v2.1.0"
             },
-            "time": "2018-01-08T09:57:29+00:00"
+            "time": "2021-09-09T17:58:26+00:00"
         },
         {
             "name": "curl/curl",
@@ -12372,7 +12379,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "cssjanus/cssjanus": 20,
         "phake/phake": 0
     },
     "prefer-stable": true,

--- a/tests/Unit/Core/Localization/RTL/StylesheetGeneratorTest.php
+++ b/tests/Unit/Core/Localization/RTL/StylesheetGeneratorTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Localization\RTL;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Localization\RTL\StylesheetGenerator;
+use Symfony\Component\Filesystem\Filesystem;
+
+class StylesheetGeneratorTest extends TestCase
+{
+    private const RTL_INPUT_FILENAME = 'rtl_input.css';
+    private const RTL_INPUT_FILENAME_WITH_SUFFIX = 'rtl_input_rtl.css';
+    private const RTL_OUTPUT_FILENAME = 'rtl_output.css';
+
+    /**
+     * @var Filesystem
+     */
+    protected $filesystem;
+
+    /** @var string */
+    protected $cssSamplesDirectory;
+    /** @var string */
+    protected $sandboxDirectory;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->sandboxDirectory = sys_get_temp_dir() . '/StylesheetGeneratorTest';
+        $this->cssSamplesDirectory = __DIR__ . '/../../../Resources/assets/css';
+
+        $this->filesystem->mkdir($this->sandboxDirectory);
+        $this->filesystem->copy(
+            $this->cssSamplesDirectory . '/' . self::RTL_INPUT_FILENAME,
+            $this->sandboxDirectory . '/' . self::RTL_INPUT_FILENAME
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->filesystem->remove($this->sandboxDirectory . '/' . self::RTL_INPUT_FILENAME);
+        $this->filesystem->remove($this->sandboxDirectory . '/' . self::RTL_INPUT_FILENAME_WITH_SUFFIX);
+    }
+
+    public function test()
+    {
+        $generator = new StylesheetGenerator();
+        $generator->generateInDirectory($this->sandboxDirectory);
+
+        $expectedCssFileContent = file_get_contents($this->cssSamplesDirectory . '/' . self::RTL_OUTPUT_FILENAME);
+        $generatedCssFileContent = file_get_contents($this->sandboxDirectory . '/' . self::RTL_INPUT_FILENAME_WITH_SUFFIX);
+
+        $this->assertEquals($expectedCssFileContent, $generatedCssFileContent);
+    }
+}

--- a/tests/Unit/Core/Localization/RTL/StylesheetGeneratorTest.php
+++ b/tests/Unit/Core/Localization/RTL/StylesheetGeneratorTest.php
@@ -55,7 +55,7 @@ class StylesheetGeneratorTest extends TestCase
     {
         $this->filesystem = new Filesystem();
         $this->sandboxDirectory = sys_get_temp_dir() . '/StylesheetGeneratorTest';
-        $this->cssSamplesDirectory = __DIR__ . '/../../../Resources/assets/css';
+        $this->cssSamplesDirectory = dirname(__DIR__, 3) . '/Resources/assets/css';
 
         $this->filesystem->mkdir($this->sandboxDirectory);
         $this->filesystem->copy(
@@ -70,7 +70,7 @@ class StylesheetGeneratorTest extends TestCase
         $this->filesystem->remove($this->sandboxDirectory . '/' . self::RTL_INPUT_FILENAME_WITH_SUFFIX);
     }
 
-    public function test()
+    public function testGeneration(): void
     {
         $generator = new StylesheetGenerator();
         $generator->generateInDirectory($this->sandboxDirectory);

--- a/tests/Unit/Resources/assets/css/rtl_input.css
+++ b/tests/Unit/Resources/assets/css/rtl_input.css
@@ -1,0 +1,15 @@
+.fooa { left: 10px; }
+.foob { right:-1.5em; }
+.fooc { padding: .25em 15px 0pt 0ex; }
+.food { padding: 1.1px 4.4px 3.3px 2.2px; }
+.fooe { padding: 1px 4px 3px 2px !important; }
+.food { float: left !important; }
+.foof { text-shadow: -1px 2px 3px red; }
+.foog { border-color: red #f00 hsl(0, 100%, 50%) hsla(0, 100%, 50%, 0.5); }
+.fooh { border-top-left-radius: 0; }
+.fooi { background: url(/foo/bar.png) no-repeat left top; }
+.fooj { background: #000 url(/foo/bar.png) no-repeat 77% 40%; }
+.fook { background: url(/foo/bar-ltr_left.png);right:10px; direction: ltr }
+/* @noflip */ div { float: left; } div { float: right; }
+.fool .left .bar #myid { width: 0; }
+body { direction: ltr; }

--- a/tests/Unit/Resources/assets/css/rtl_output.css
+++ b/tests/Unit/Resources/assets/css/rtl_output.css
@@ -1,0 +1,15 @@
+.fooa { right: 10px; }
+.foob { left:-1.5em; }
+.fooc { padding: .25em 0ex 0pt 15px; }
+.food { padding: 1.1px 2.2px 3.3px 4.4px; }
+.fooe { padding: 1px 2px 3px 4px !important; }
+.food { float: right !important; }
+.foof { text-shadow: 1px 2px 3px red; }
+.foog { border-color: red hsla(0, 100%, 50%, 0.5) hsl(0, 100%, 50%) #f00; }
+.fooh { border-top-right-radius: 0; }
+.fooi { background: url(/foo/bar.png) no-repeat right top; }
+.fooj { background: #000 url(/foo/bar.png) no-repeat 23% 40%; }
+.fook { background: url(/foo/bar-ltr_left.png);left:10px; direction: rtl }
+/* @noflip */ div { float: left; } div { float: left; }
+.fool .left .bar #myid { width: 0; }
+body { direction: rtl; }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25845
| How to test?      | CI should be valid
| Possible impacts? | Only PrestaShop\PrestaShop\Core\Localization\RTL\StylesheetGenerator could be modified

## Description

In 2018, PrestaShop forked https://github.com/cssjanus/php-cssjanus on https://github.com/PrestaShop/php-cssjanus .

This was because of an issue related to https://github.com/cssjanus/php-cssjanus/issues/14. Details on @eternoendless post: https://github.com/cssjanus/php-cssjanus/pull/13#issuecomment-355574605

This bug has been solved in latest php-cssjanus versions.

This PR has 2 steps, 2 commits:

1. The first commit adds a unit test for the PrestaShop class StylesheetGenerator. This is the only class that relies on CSSJanus, and it uses CSSJanus to convert CSS from LTR to RTL.

The unit test fetches a CSS sample file `rtl_input.css` that I built using CSSJanus test samples, and runs `StylesheetGenerator::generateInDirectory()` to generate a `rtl_input_rtl.css` that is the RTL version of the input.

2. The second commits stops relying on our fork, and update CSSJanus from 1.2.0 to 2.1.0 .

The unit test added above verifies that the behavior of StylesheetGenerator is equivalent to before.

## BC Break

CSSJanus Composer dependency version update: from 1.2 to 2.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25847)
<!-- Reviewable:end -->
