### PR TITLE
Allowing to set different image ratio on product miniature, minor code refacto

### DIFF
--- a/themes/classic/_dev/css/components/featuredproducts.scss
+++ b/themes/classic/_dev/css/components/featuredproducts.scss
@@ -94,13 +94,10 @@ $product-description-height: 70px;
 
       img {
         position: relative;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
         max-width: 100%;
-        max-height: 100%;
+        height: auto;
         margin: auto;
+        display: block;
       }
     }
   }

--- a/themes/classic/_dev/css/components/featuredproducts.scss
+++ b/themes/classic/_dev/css/components/featuredproducts.scss
@@ -138,9 +138,9 @@ $product-description-height: 70px;
 
   .highlighted-informations {
     position: absolute;
+    top: 100%;
     z-index: 2;
     width: $thumbnail-size;
-    top: 100%;
     height: auto;
     padding: 0.625rem 0;
     text-align: center;

--- a/themes/classic/_dev/css/components/featuredproducts.scss
+++ b/themes/classic/_dev/css/components/featuredproducts.scss
@@ -3,17 +3,45 @@ $product-description-height: 70px;
 
 #products,
 .featured-products,
-.product-accessories,
-.product-miniature {
+.product-accessories {
   .products {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
   }
 
+  .products-section-title {
+    margin: 2.5rem 0;
+    font-weight: 500;
+    text-align: center;
+  }
+
+  .all-product-link {
+    margin-top: 1.5rem;
+    margin-bottom: 1.5rem;
+    clear: both;
+    font-weight: 500;
+    color: $gray;
+
+    @at-root .lang-rtl & {
+      .material-icons {
+        transform: rotate(-180deg);
+      }
+    }
+  }
+}
+
+.product-miniature {
   .product {
     display: flex;
     justify-content: center;
+    padding: 0;
+    margin: 0 0.8125rem;
+
+    @at-root .page-index &, .page-search & {
+      width: 25%;
+      min-width: 250px;
+    }
   }
 
   .product-thumbnail {
@@ -38,16 +66,14 @@ $product-description-height: 70px;
     &:hover,
     &:focus {
       .highlighted-informations {
-        top: calc(250px - 4.4rem);
-        bottom: 5.5rem;
+        top: calc(100% - 4.4rem);
 
         &::after {
           opacity: 1;
         }
 
         &.no-variants {
-          top: calc(250px - 2.5rem);
-          bottom: 2.2rem;
+          top: calc(100% - 2.5rem);
         }
       }
 
@@ -79,12 +105,6 @@ $product-description-height: 70px;
     }
   }
 
-  .products-section-title {
-    margin: 2.5rem 0;
-    font-weight: 500;
-    text-align: center;
-  }
-
   .product-title {
     margin-top: 0.7rem;
     text-align: center;
@@ -111,17 +131,21 @@ $product-description-height: 70px;
     background: $white;
   }
 
+  .thumbnail-top {
+    position: relative;
+    overflow: hidden;
+  }
+
   .highlighted-informations {
     position: absolute;
-    top: $thumbnail-size;
-    bottom: 1.25rem;
     z-index: 2;
     width: $thumbnail-size;
+    top: 100%;
     height: auto;
-    padding-top: 0.625rem;
+    padding: 0.625rem 0;
     text-align: center;
     background: $white;
-    transition: top 0.3s, bottom 0.3s;
+    transition: 0.3s;
 
     .quick-view {
       font-size: $base-font-size;
@@ -144,16 +168,14 @@ $product-description-height: 70px;
     background: $white;
   }
 
-  .product-miniature {
-    .product-flags {
-      li.product-flag {
-        min-width: 3.125rem;
-        min-height: 1.875rem;
-        font-weight: 600;
+  .product-flags {
+    li.product-flag {
+      min-width: 3.125rem;
+      min-height: 1.875rem;
+      font-weight: 600;
 
-        &.online-only {
-          top: 13.1rem;
-        }
+      &.online-only {
+        top: 13.1rem;
       }
     }
   }
@@ -175,20 +197,6 @@ $product-description-height: 70px;
     bottom: 0.5rem;
     font-weight: 700;
     color: $gray;
-  }
-
-  .all-product-link {
-    margin-top: 1.5rem;
-    margin-bottom: 1.5rem;
-    clear: both;
-    font-weight: 500;
-    color: $gray;
-
-    @at-root .lang-rtl & {
-      .material-icons {
-        transform: rotate(-180deg);
-      }
-    }
   }
 }
 

--- a/themes/classic/_dev/css/components/featuredproducts.scss
+++ b/themes/classic/_dev/css/components/featuredproducts.scss
@@ -94,10 +94,10 @@ $product-description-height: 70px;
 
       img {
         position: relative;
+        display: block;
         max-width: 100%;
         height: auto;
         margin: auto;
-        display: block;
       }
     }
   }

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -46,6 +46,7 @@
                 loading="lazy"
                 width="{$urls.no_picture_image.bySize.home_default.width}"
                 height="{$urls.no_picture_image.bySize.home_default.height}"
+                alt="{l s='No product image' d='Shop.Theme.Global'}"
               />
             </a>
           {/if}

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -26,30 +26,45 @@
 <div class="product{if !empty($productClasses)} {$productClasses}{/if}">
   <article class="product-miniature js-product-miniature" data-id-product="{$product.id_product}" data-id-product-attribute="{$product.id_product_attribute}">
     <div class="thumbnail-container">
-      {block name='product_thumbnail'}
-        {if $product.cover}
-          <a href="{$product.url}" class="thumbnail product-thumbnail">
-            <img
-              class="img-fluid"
-              src="{$product.cover.bySize.home_default.url}"
-              alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
-              loading="lazy"
-              data-full-size-image-url="{$product.cover.large.url}"
-              width="250"
-              height="250"
-            />
-          </a>
-        {else}
-          <a href="{$product.url}" class="thumbnail product-thumbnail">
-            <img
-              src="{$urls.no_picture_image.bySize.home_default.url}"
-              loading="lazy"
-              width="250"
-              height="250"
-            />
-          </a>
-        {/if}
-      {/block}
+      <div class="thumbnail-top">
+        {block name='product_thumbnail'}
+          {if $product.cover}
+            <a href="{$product.url}" class="thumbnail product-thumbnail">
+              <img
+                src="{$product.cover.bySize.home_default.url}"
+                alt="{if !empty($product.cover.legend)}{$product.cover.legend}{else}{$product.name|truncate:30:'...'}{/if}"
+                loading="lazy"
+                data-full-size-image-url="{$product.cover.large.url}"
+                width="{$product.cover.bySize.home_default.width}"
+                height="{$product.cover.bySize.home_default.height}"
+              />
+            </a>
+          {else}
+            <a href="{$product.url}" class="thumbnail product-thumbnail">
+              <img
+                src="{$urls.no_picture_image.bySize.home_default.url}"
+                loading="lazy"
+                width="{$urls.no_picture_image.bySize.home_default.width}"
+                height="{$urls.no_picture_image.bySize.home_default.height}"
+              />
+            </a>
+          {/if}
+        {/block}
+
+        <div class="highlighted-informations{if !$product.main_variants} no-variants{/if} hidden-sm-down">
+          {block name='quick_view'}
+            <a class="quick-view js-quick-view" href="#" data-link-action="quickview">
+              <i class="material-icons search">&#xE8B6;</i> {l s='Quick view' d='Shop.Theme.Actions'}
+            </a>
+          {/block}
+
+          {block name='product_variants'}
+            {if $product.main_variants}
+              {include file='catalog/_partials/variant-links.tpl' variants=$product.main_variants}
+            {/if}
+          {/block}
+        </div>
+      </div>
 
       <div class="product-description">
         {block name='product_name'}
@@ -98,20 +113,6 @@
       </div>
 
       {include file='catalog/_partials/product-flags.tpl'}
-
-      <div class="highlighted-informations{if !$product.main_variants} no-variants{/if} hidden-sm-down">
-        {block name='quick_view'}
-          <a class="quick-view js-quick-view" href="#" data-link-action="quickview">
-            <i class="material-icons search">&#xE8B6;</i> {l s='Quick view' d='Shop.Theme.Actions'}
-          </a>
-        {/block}
-
-        {block name='product_variants'}
-          {if $product.main_variants}
-            {include file='catalog/_partials/variant-links.tpl' variants=$product.main_variants}
-          {/if}
-        {/block}
-      </div>
     </div>
   </article>
 </div>

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -46,7 +46,6 @@
                 loading="lazy"
                 width="{$urls.no_picture_image.bySize.home_default.width}"
                 height="{$urls.no_picture_image.bySize.home_default.height}"
-                alt="{l s='No product image' d='Shop.Theme.Global'}"
               />
             </a>
           {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This changes allow us to change image ration on listing (other that 250x250px) and set proper width/height attribute on img tag to reduce CLS. 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     |  no
| Fixed ticket?     | Fixes #25849
| How to test?      | Follow steps in issue
| Possible impacts? | I am not sure if there is native module that override listing styles for its needs? 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25855)
<!-- Reviewable:end -->
