### PR TITLE
Fetch and set logo image size inside template

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1635,7 +1635,7 @@ class FrontControllerCore extends Controller
         return [
             'src' => ($this->getTemplateVarUrls()['img_ps_url'] ?? _PS_IMG_) . $logoFileName,
             'width' => $logoWidth,
-            'height' => $logoHeight
+            'height' => $logoHeight,
         ];
     }
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1621,7 +1621,7 @@ class FrontControllerCore extends Controller
     /**
      * Get the shop logo with its dimensions
      *
-     * @return array
+     * @return array<string, string|int>
      */
     public function getShopLogo(): array
     {
@@ -1630,7 +1630,13 @@ class FrontControllerCore extends Controller
         }
 
         $logoFileName = Configuration::get('PS_LOGO');
-        list($logoWidth, $logoHeight) = getimagesize(_PS_IMG_DIR_ . $logoFileName);
+        $logoFileDir = _PS_IMG_DIR_ . $logoFileName;
+
+        if (!file_exists($logoFileDir)) {
+            return [];
+        }
+
+        list($logoWidth, $logoHeight) = getimagesize($logoFileDir);
 
         return [
             'src' => ($this->getTemplateVarUrls()['img_ps_url'] ?? _PS_IMG_) . $logoFileName,

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1618,6 +1618,26 @@ class FrontControllerCore extends Controller
         return $cust;
     }
 
+    public function getShopLogo(): array
+    {
+        $logoData = [];
+        $urls = $this->getTemplateVarUrls();
+        $psImageUrl = $urls['img_ps_url'] ?? _PS_IMG_;
+        $logoDir = _PS_IMG_DIR_;
+
+        if (Configuration::hasKey('PS_LOGO')) {
+            $logoFileName = Configuration::get('PS_LOGO');
+            $logoFileDir = $logoDir . $logoFileName;
+            $logoSizes = getimagesize($logoFileDir);
+
+            $logoData['src'] = $psImageUrl . $logoFileName;
+            $logoData['width'] = $logoSizes[0];
+            $logoData['height'] = $logoSizes[1];
+        }
+
+        return $logoData;
+    }
+
     public function getTemplateVarShop()
     {
         $address = $this->context->shop->getAddress();
@@ -1634,7 +1654,7 @@ class FrontControllerCore extends Controller
             'long' => Configuration::get('PS_STORES_CENTER_LONG'),
             'lat' => Configuration::get('PS_STORES_CENTER_LAT'),
 
-            'logo' => Configuration::hasKey('PS_LOGO') ? $psImageUrl . Configuration::get('PS_LOGO') : '',
+            'logo' => $this->getShopLogo(),
             'stores_icon' => Configuration::hasKey('PS_STORES_ICON') ? $psImageUrl . Configuration::get('PS_STORES_ICON') : '',
             'favicon' => Configuration::hasKey('PS_FAVICON') ? $psImageUrl . Configuration::get('PS_FAVICON') : '',
             'favicon_update_time' => Configuration::get('PS_IMG_UPDATE_TIME'),

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1618,24 +1618,25 @@ class FrontControllerCore extends Controller
         return $cust;
     }
 
+    /**
+     * Get the shop logo with its dimensions
+     *
+     * @return array
+     */
     public function getShopLogo(): array
     {
-        $logoData = [];
-        $urls = $this->getTemplateVarUrls();
-        $psImageUrl = $urls['img_ps_url'] ?? _PS_IMG_;
-        $logoDir = _PS_IMG_DIR_;
-
-        if (Configuration::hasKey('PS_LOGO')) {
-            $logoFileName = Configuration::get('PS_LOGO');
-            $logoFileDir = $logoDir . $logoFileName;
-            $logoSizes = getimagesize($logoFileDir);
-
-            $logoData['src'] = $psImageUrl . $logoFileName;
-            $logoData['width'] = $logoSizes[0];
-            $logoData['height'] = $logoSizes[1];
+        if (!Configuration::hasKey('PS_LOGO')) {
+            return [];
         }
 
-        return $logoData;
+        $logoFileName = Configuration::get('PS_LOGO');
+        list($logoWidth, $logoHeight) = getimagesize(_PS_IMG_DIR_ . $logoFileName);
+
+        return [
+            'src' => ($this->getTemplateVarUrls()['img_ps_url'] ?? _PS_IMG_) . $logoFileName,
+            'width' => $logoWidth,
+            'height' => $logoHeight
+        ];
     }
 
     public function getTemplateVarShop()

--- a/themes/classic/templates/_partials/header.tpl
+++ b/themes/classic/templates/_partials/header.tpl
@@ -54,22 +54,32 @@
   </nav>
 {/block}
 
+{function renderLogo}
+  <a href="{$urls.pages.index}">
+    <img
+      class="logo img-fluid"
+      src="{$shop.logo.src}"
+      alt="{$shop.name}"
+      loading="lazy"
+      width="{$shop.logo.width}"
+      height="{$shop.logo.height}">
+  </a>
+{/function}
+
 {block name='header_top'}
   <div class="header-top">
     <div class="container">
        <div class="row">
         <div class="col-md-2 hidden-sm-down" id="_desktop_logo">
+          {if $shop.logo}
             {if $page.page_name == 'index'}
               <h1>
-                <a href="{$urls.pages.index}">
-                  <img class="logo img-responsive" src="{$shop.logo}" alt="{$shop.name}" loading="lazy" width="100" height="28">
-                </a>
+                {renderLogo}
               </h1>
             {else}
-                <a href="{$urls.pages.index}">
-                  <img class="logo img-responsive" src="{$shop.logo}" alt="{$shop.name}" loading="lazy" width="100" height="28">
-                </a>
+              {renderLogo}
             {/if}
+          {/if}
         </div>
         <div class="header-top-right col-md-10 col-sm-12 position-static">
           {hook h='displayTop'}

--- a/themes/classic/templates/_partials/microdata/head-jsonld.tpl
+++ b/themes/classic/templates/_partials/microdata/head-jsonld.tpl
@@ -28,10 +28,12 @@
     "@type": "Organization",
     "name" : "{$shop.name}",
     "url" : "{$urls.pages.index}",
-    "logo": {
-      "@type": "ImageObject",
-      "url":"{$shop.logo}"
-    }
+    {if $shop.logo}
+      "logo": {
+        "@type": "ImageObject",
+        "url":"{$shop.logo.src}"
+      }
+    {/if}
   }
 </script>
 
@@ -55,10 +57,12 @@
       "@context": "https://schema.org",
       "@type": "WebSite",
       "url" : "{$urls.pages.index}",
-      "image": {
-        "@type": "ImageObject",
-        "url":"{$shop.logo}"
-      },
+      {if $shop.logo}
+        "image": {
+          "@type": "ImageObject",
+          "url":"{$shop.logo.src}"
+        },
+      {/if}
       "potentialAction": {
         "@type": "SearchAction",
         "target": "{'--search_term_string--'|str_replace:'{search_term_string}':$link->getPageLink('search',true,null,['search_query'=>'--search_term_string--'])}",

--- a/themes/classic/templates/checkout/_partials/header.tpl
+++ b/themes/classic/templates/checkout/_partials/header.tpl
@@ -28,7 +28,13 @@
       <div class="row">
         <div class="col-md-6 hidden-sm-down" id="_desktop_logo">
           <a href="{$urls.pages.index}">
-            <img class="logo img-responsive" src="{$shop.logo}" alt="{$shop.name} {l s='logo' d='Shop.Theme.Global'}" loading="lazy">
+            <img
+              class="logo img-fluid"
+              src="{$shop.logo.src}"
+              alt="{$shop.name}"
+              loading="lazy"
+              width="{$shop.logo.width}"
+              height="{$shop.logo.height}">
           </a>
         </div>
         <div class="col-md-6 text-xs-right hidden-sm-down">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Instead of setting width and height fixed for shop logo, we are fetching it size and set proper width and height values. It required to adjust json-ld where logo was fetched from `$shop.logo`. <br>  We are changing `$shop.logo` variable from `string` to `array` and it is breaking change. Themes and module that are using `$shop.logo` as src logo will have to change it to `$shop.logo.src`. 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  yes
| Deprecations?     |  no
| Fixed ticket?     | Fixes #25853
| How to test?      | Follow instruction inside issue.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25857)
<!-- Reviewable:end -->
