### PR TITLE
Allow OrderStates changes to send emails located in modules

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -571,7 +571,7 @@ class OrderHistoryCore extends ObjectModel
                     null,
                     $file_attachement,
                     null,
-                    $result['module_name'] ? _PS_MODULE_DIR_ . $result['module_name'] . '/mails/' : _PS_MAIL_DIR_ ,
+                    $result['module_name'] ? _PS_MODULE_DIR_ . $result['module_name'] . '/mails/' : _PS_MAIL_DIR_,
                     false,
                     (int) $order->id_shop
                 )) {

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -571,7 +571,7 @@ class OrderHistoryCore extends ObjectModel
                     null,
                     $file_attachement,
                     null,
-                    _PS_MAIL_DIR_,
+                    $result['module_name'] ? _PS_MODULE_DIR_ . $result['module_name'] . '/mails/' : _PS_MAIL_DIR_ ,
                     false,
                     (int) $order->id_shop
                 )) {


### PR DESCRIPTION
With this change, now emails located inside modules can be sent if they are referenced in the OrderState.
### Before
You have a module with a custom email template located in /modules/my_module/mails/en/my_email.html
You create a new OrderState having $order_state->name = "New State" send_email = true, template = my_email, module_name = my_module, if you try to send an email when changing the order status to "New State", the email won't be sent, you will have an error:  Error - The following e-mail template is missing: my_email
### Now
You repeat the same steps, but the email gets sent correctly


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?          | develop
| Description?      |  Allow to send emails referenced in Modules using custom OrderStates.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Repeat the steps indicated in the description.
| Possible impacts? | It shouldn't impact anyting else. Ideally, the "templates" field shown when editing an OrderState should also include the templates located inside the modules as well. This isn't included in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25861)
<!-- Reviewable:end -->
