### PR TITLE
Make Shop Parameters > Order Settings forms multistore compatible

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order-preferences/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order-preferences/index.ts
@@ -29,4 +29,10 @@ const {$} = window;
 
 $(() => {
   new TermsAndConditionsOptionHandler();
+
+  window.prestashop.component.initComponents(
+    [
+      'MultistoreConfigField',
+    ],
+  );
 });

--- a/src/Adapter/CMS/CMSDataProvider.php
+++ b/src/Adapter/CMS/CMSDataProvider.php
@@ -69,7 +69,7 @@ class CMSDataProvider
         $choices = [];
 
         foreach ($this->getCMSPages($languageId) as $cms) {
-            $choices[$cms['meta_title']] = $cms['id_cms'];
+            $choices[$cms['meta_title']] = (int) $cms['id_cms'];
         }
 
         return $choices;

--- a/src/Adapter/Order/GeneralConfiguration.php
+++ b/src/Adapter/Order/GeneralConfiguration.php
@@ -27,23 +27,13 @@
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 
 /**
  * General Settings configuration available in ShopParameters > Order Preferences.
  */
-class GeneralConfiguration implements DataConfigurationInterface
+class GeneralConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
-
-    public function __construct(Configuration $configuration)
-    {
-        $this->configuration = $configuration;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Adapter/Order/GeneralConfiguration.php
+++ b/src/Adapter/Order/GeneralConfiguration.php
@@ -58,15 +58,17 @@ class GeneralConfiguration extends AbstractMultistoreConfiguration
     public function updateConfiguration(array $configuration)
     {
         if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set('PS_FINAL_SUMMARY_ENABLED', $configuration['enable_final_summary']);
-            $this->configuration->set('PS_GUEST_CHECKOUT_ENABLED', $configuration['enable_guest_checkout']);
-            $this->configuration->set('PS_DISALLOW_HISTORY_REORDERING', $configuration['disable_reordering_option']);
-            $this->configuration->set('PS_PURCHASE_MINIMUM', $configuration['purchase_minimum_value']);
-            $this->configuration->set('PS_ORDER_RECALCULATE_SHIPPING', $configuration['recalculate_shipping_cost']);
-            $this->configuration->set('PS_ALLOW_MULTISHIPPING', $configuration['allow_multishipping']);
-            $this->configuration->set('PS_SHIP_WHEN_AVAILABLE', $configuration['allow_delayed_shipping']);
-            $this->configuration->set('PS_CONDITIONS', $configuration['enable_tos']);
-            $this->configuration->set('PS_CONDITIONS_CMS_ID', $configuration['tos_cms_id']);
+            $shopConstraint = $this->getShopConstraint();
+
+            $this->updateConfigurationValue('PS_FINAL_SUMMARY_ENABLED', 'enable_final_summary', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_GUEST_CHECKOUT_ENABLED', 'enable_guest_checkout', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_DISALLOW_HISTORY_REORDERING', 'disable_reordering_option', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_PURCHASE_MINIMUM', 'purchase_minimum_value', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_ORDER_RECALCULATE_SHIPPING', 'recalculate_shipping_cost', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_ALLOW_MULTISHIPPING', 'allow_multishipping', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_SHIP_WHEN_AVAILABLE', 'allow_delayed_shipping', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_CONDITIONS', 'enable_tos', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_CONDITIONS_CMS_ID', 'tos_cms_id', $configuration, $shopConstraint);
         }
 
         return [];

--- a/src/Adapter/Order/GeneralConfiguration.php
+++ b/src/Adapter/Order/GeneralConfiguration.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
-use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 
 /**

--- a/src/Adapter/Order/GeneralConfiguration.php
+++ b/src/Adapter/Order/GeneralConfiguration.php
@@ -60,12 +60,12 @@ class GeneralConfiguration extends AbstractMultistoreConfiguration
             'enable_final_summary' => (bool) $this->configuration->get('PS_FINAL_SUMMARY_ENABLED', false, $shopConstraint),
             'enable_guest_checkout' => (bool) $this->configuration->get('PS_GUEST_CHECKOUT_ENABLED', false, $shopConstraint),
             'disable_reordering_option' => (bool) $this->configuration->get('PS_DISALLOW_HISTORY_REORDERING', false, $shopConstraint),
-            'purchase_minimum_value' => (float) $this->configuration->get('PS_PURCHASE_MINIMUM', null, $shopConstraint),
+            'purchase_minimum_value' => (float) $this->configuration->get('PS_PURCHASE_MINIMUM', 0, $shopConstraint),
             'recalculate_shipping_cost' => (bool) $this->configuration->get('PS_ORDER_RECALCULATE_SHIPPING', false, $shopConstraint),
             'allow_multishipping' => (bool) $this->configuration->get('PS_ALLOW_MULTISHIPPING', false, $shopConstraint),
             'allow_delayed_shipping' => (bool) $this->configuration->get('PS_SHIP_WHEN_AVAILABLE', false, $shopConstraint),
             'enable_tos' => (bool) $this->configuration->get('PS_CONDITIONS', false, $shopConstraint),
-            'tos_cms_id' => (int) $this->configuration->get('PS_CONDITIONS_CMS_ID', null, $shopConstraint),
+            'tos_cms_id' => (int) $this->configuration->get('PS_CONDITIONS_CMS_ID', 0, $shopConstraint),
         ];
     }
 

--- a/src/Adapter/Order/GeneralConfiguration.php
+++ b/src/Adapter/Order/GeneralConfiguration.php
@@ -60,12 +60,12 @@ class GeneralConfiguration extends AbstractMultistoreConfiguration
             'enable_final_summary' => (bool) $this->configuration->get('PS_FINAL_SUMMARY_ENABLED', false, $shopConstraint),
             'enable_guest_checkout' => (bool) $this->configuration->get('PS_GUEST_CHECKOUT_ENABLED', false, $shopConstraint),
             'disable_reordering_option' => (bool) $this->configuration->get('PS_DISALLOW_HISTORY_REORDERING', false, $shopConstraint),
-            'purchase_minimum_value' => $this->configuration->get('PS_PURCHASE_MINIMUM', null, $shopConstraint),
+            'purchase_minimum_value' => (float) $this->configuration->get('PS_PURCHASE_MINIMUM', null, $shopConstraint),
             'recalculate_shipping_cost' => (bool) $this->configuration->get('PS_ORDER_RECALCULATE_SHIPPING', false, $shopConstraint),
             'allow_multishipping' => (bool) $this->configuration->get('PS_ALLOW_MULTISHIPPING', false, $shopConstraint),
             'allow_delayed_shipping' => (bool) $this->configuration->get('PS_SHIP_WHEN_AVAILABLE', false, $shopConstraint),
             'enable_tos' => (bool) $this->configuration->get('PS_CONDITIONS', false, $shopConstraint),
-            'tos_cms_id' => $this->configuration->get('PS_CONDITIONS_CMS_ID', null, $shopConstraint),
+            'tos_cms_id' => (int) $this->configuration->get('PS_CONDITIONS_CMS_ID', null, $shopConstraint),
         ];
     }
 

--- a/src/Adapter/Order/GeneralConfiguration.php
+++ b/src/Adapter/Order/GeneralConfiguration.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * General Settings configuration available in ShopParameters > Order Preferences.
@@ -34,20 +35,37 @@ use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 class GeneralConfiguration extends AbstractMultistoreConfiguration
 {
     /**
+     * @var array<int, string>
+     */
+    private const CONFIGURATION_FIELDS = [
+        'enable_final_summary',
+        'enable_guest_checkout',
+        'disable_reordering_option',
+        'purchase_minimum_value',
+        'recalculate_shipping_cost',
+        'allow_multishipping',
+        'allow_delayed_shipping',
+        'enable_tos',
+        'tos_cms_id',
+    ];
+
+    /**
      * {@inheritdoc}
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'enable_final_summary' => $this->configuration->getBoolean('PS_FINAL_SUMMARY_ENABLED'),
-            'enable_guest_checkout' => $this->configuration->getBoolean('PS_GUEST_CHECKOUT_ENABLED'),
-            'disable_reordering_option' => $this->configuration->getBoolean('PS_DISALLOW_HISTORY_REORDERING'),
-            'purchase_minimum_value' => $this->configuration->get('PS_PURCHASE_MINIMUM'),
-            'recalculate_shipping_cost' => $this->configuration->getBoolean('PS_ORDER_RECALCULATE_SHIPPING'),
-            'allow_multishipping' => $this->configuration->getBoolean('PS_ALLOW_MULTISHIPPING'),
-            'allow_delayed_shipping' => $this->configuration->getBoolean('PS_SHIP_WHEN_AVAILABLE'),
-            'enable_tos' => $this->configuration->getBoolean('PS_CONDITIONS'),
-            'tos_cms_id' => $this->configuration->get('PS_CONDITIONS_CMS_ID'),
+            'enable_final_summary' => (bool) $this->configuration->get('PS_FINAL_SUMMARY_ENABLED', false, $shopConstraint),
+            'enable_guest_checkout' => (bool) $this->configuration->get('PS_GUEST_CHECKOUT_ENABLED', false, $shopConstraint),
+            'disable_reordering_option' => (bool) $this->configuration->get('PS_DISALLOW_HISTORY_REORDERING', false, $shopConstraint),
+            'purchase_minimum_value' => $this->configuration->get('PS_PURCHASE_MINIMUM', null, $shopConstraint),
+            'recalculate_shipping_cost' => (bool) $this->configuration->get('PS_ORDER_RECALCULATE_SHIPPING', false, $shopConstraint),
+            'allow_multishipping' => (bool) $this->configuration->get('PS_ALLOW_MULTISHIPPING', false, $shopConstraint),
+            'allow_delayed_shipping' => (bool) $this->configuration->get('PS_SHIP_WHEN_AVAILABLE', false, $shopConstraint),
+            'enable_tos' => (bool) $this->configuration->get('PS_CONDITIONS', false, $shopConstraint),
+            'tos_cms_id' => $this->configuration->get('PS_CONDITIONS_CMS_ID', null, $shopConstraint),
         ];
     }
 
@@ -74,20 +92,22 @@ class GeneralConfiguration extends AbstractMultistoreConfiguration
     }
 
     /**
-     * {@inheritdoc}
+     * @return OptionsResolver
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        return isset(
-            $configuration['enable_final_summary'],
-            $configuration['enable_guest_checkout'],
-            $configuration['disable_reordering_option'],
-            $configuration['purchase_minimum_value'],
-            $configuration['recalculate_shipping_cost'],
-            $configuration['allow_multishipping'],
-            $configuration['allow_delayed_shipping'],
-            $configuration['enable_tos'],
-            $configuration['tos_cms_id']
-        );
+        $resolver = (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('enable_final_summary', 'bool')
+            ->setAllowedTypes('enable_guest_checkout', 'bool')
+            ->setAllowedTypes('disable_reordering_option', 'bool')
+            ->setAllowedTypes('purchase_minimum_value', 'float')
+            ->setAllowedTypes('recalculate_shipping_cost', 'bool')
+            ->setAllowedTypes('allow_multishipping', 'bool')
+            ->setAllowedTypes('allow_delayed_shipping', 'bool')
+            ->setAllowedTypes('enable_tos', 'bool')
+            ->setAllowedTypes('tos_cms_id', 'int');
+
+        return $resolver;
     }
 }

--- a/src/Adapter/Order/GiftOptionsConfiguration.php
+++ b/src/Adapter/Order/GiftOptionsConfiguration.php
@@ -53,10 +53,12 @@ class GiftOptionsConfiguration extends AbstractMultistoreConfiguration
     public function updateConfiguration(array $configuration)
     {
         if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set('PS_GIFT_WRAPPING', $configuration['enable_gift_wrapping']);
-            $this->configuration->set('PS_GIFT_WRAPPING_PRICE', $configuration['gift_wrapping_price']);
-            $this->configuration->set('PS_GIFT_WRAPPING_TAX_RULES_GROUP', $configuration['gift_wrapping_tax_rules_group']);
-            $this->configuration->set('PS_RECYCLABLE_PACK', $configuration['offer_recyclable_pack']);
+            $shopConstraint = $this->getShopConstraint();
+
+            $this->updateConfigurationValue('PS_GIFT_WRAPPING', 'enable_gift_wrapping', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_GIFT_WRAPPING_PRICE', 'gift_wrapping_price', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_GIFT_WRAPPING_TAX_RULES_GROUP', 'gift_wrapping_tax_rules_group', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_RECYCLABLE_PACK', 'offer_recyclable_pack', $configuration, $shopConstraint);
         }
 
         return [];

--- a/src/Adapter/Order/GiftOptionsConfiguration.php
+++ b/src/Adapter/Order/GiftOptionsConfiguration.php
@@ -27,23 +27,13 @@
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 
 /**
  * Gift Settings configuration available in ShopParameters > Order Preferences.
  */
-class GiftOptionsConfiguration implements DataConfigurationInterface
+class GiftOptionsConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
-
-    public function __construct(Configuration $configuration)
-    {
-        $this->configuration = $configuration;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Adapter/Order/GiftOptionsConfiguration.php
+++ b/src/Adapter/Order/GiftOptionsConfiguration.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
-use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 
 /**

--- a/src/Adapter/Order/GiftOptionsConfiguration.php
+++ b/src/Adapter/Order/GiftOptionsConfiguration.php
@@ -53,8 +53,8 @@ class GiftOptionsConfiguration extends AbstractMultistoreConfiguration
 
         return [
             'enable_gift_wrapping' => (bool) $this->configuration->get('PS_GIFT_WRAPPING', false, $shopConstraint),
-            'gift_wrapping_price' => (float) $this->configuration->get('PS_GIFT_WRAPPING_PRICE', null, $shopConstraint),
-            'gift_wrapping_tax_rules_group' => (int) $this->configuration->get('PS_GIFT_WRAPPING_TAX_RULES_GROUP', null, $shopConstraint),
+            'gift_wrapping_price' => (float) $this->configuration->get('PS_GIFT_WRAPPING_PRICE', 0, $shopConstraint),
+            'gift_wrapping_tax_rules_group' => (int) $this->configuration->get('PS_GIFT_WRAPPING_TAX_RULES_GROUP', 0, $shopConstraint),
             'offer_recyclable_pack' => (bool) $this->configuration->get('PS_RECYCLABLE_PACK', false, $shopConstraint),
         ];
     }

--- a/src/Adapter/Order/GiftOptionsConfiguration.php
+++ b/src/Adapter/Order/GiftOptionsConfiguration.php
@@ -53,8 +53,8 @@ class GiftOptionsConfiguration extends AbstractMultistoreConfiguration
 
         return [
             'enable_gift_wrapping' => (bool) $this->configuration->get('PS_GIFT_WRAPPING', false, $shopConstraint),
-            'gift_wrapping_price' => $this->configuration->get('PS_GIFT_WRAPPING_PRICE', null, $shopConstraint),
-            'gift_wrapping_tax_rules_group' => $this->configuration->get('PS_GIFT_WRAPPING_TAX_RULES_GROUP', null, $shopConstraint),
+            'gift_wrapping_price' => (float) $this->configuration->get('PS_GIFT_WRAPPING_PRICE', null, $shopConstraint),
+            'gift_wrapping_tax_rules_group' => (int) $this->configuration->get('PS_GIFT_WRAPPING_TAX_RULES_GROUP', null, $shopConstraint),
             'offer_recyclable_pack' => (bool) $this->configuration->get('PS_RECYCLABLE_PACK', false, $shopConstraint),
         ];
     }

--- a/src/Adapter/Order/GiftOptionsConfiguration.php
+++ b/src/Adapter/Order/GiftOptionsConfiguration.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Order;
 
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Gift Settings configuration available in ShopParameters > Order Preferences.
@@ -34,15 +35,27 @@ use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 class GiftOptionsConfiguration extends AbstractMultistoreConfiguration
 {
     /**
+     * @var array<int, string>
+     */
+    private const CONFIGURATION_FIELDS = [
+        'enable_gift_wrapping',
+        'gift_wrapping_price',
+        'gift_wrapping_tax_rules_group',
+        'offer_recyclable_pack',
+    ];
+
+    /**
      * {@inheritdoc}
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'enable_gift_wrapping' => $this->configuration->getBoolean('PS_GIFT_WRAPPING'),
-            'gift_wrapping_price' => $this->configuration->get('PS_GIFT_WRAPPING_PRICE'),
-            'gift_wrapping_tax_rules_group' => $this->configuration->get('PS_GIFT_WRAPPING_TAX_RULES_GROUP'),
-            'offer_recyclable_pack' => $this->configuration->getBoolean('PS_RECYCLABLE_PACK'),
+            'enable_gift_wrapping' => (bool) $this->configuration->get('PS_GIFT_WRAPPING', false, $shopConstraint),
+            'gift_wrapping_price' => $this->configuration->get('PS_GIFT_WRAPPING_PRICE', null, $shopConstraint),
+            'gift_wrapping_tax_rules_group' => $this->configuration->get('PS_GIFT_WRAPPING_TAX_RULES_GROUP', null, $shopConstraint),
+            'offer_recyclable_pack' => (bool) $this->configuration->get('PS_RECYCLABLE_PACK', false, $shopConstraint),
         ];
     }
 
@@ -64,15 +77,17 @@ class GiftOptionsConfiguration extends AbstractMultistoreConfiguration
     }
 
     /**
-     * {@inheritdoc}
+     * @return OptionsResolver
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        return isset(
-            $configuration['enable_gift_wrapping'],
-            $configuration['gift_wrapping_price'],
-            $configuration['gift_wrapping_tax_rules_group'],
-            $configuration['offer_recyclable_pack']
-        );
+        $resolver = (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('enable_gift_wrapping', 'bool')
+            ->setAllowedTypes('gift_wrapping_price', 'float')
+            ->setAllowedTypes('gift_wrapping_tax_rules_group', 'int')
+            ->setAllowedTypes('offer_recyclable_pack', 'bool');
+
+        return $resolver;
     }
 }

--- a/src/Adapter/Tax/TaxRuleDataProvider.php
+++ b/src/Adapter/Tax/TaxRuleDataProvider.php
@@ -122,7 +122,7 @@ class TaxRuleDataProvider
         $choices = [];
 
         foreach ($taxRulesGroups as $taxRulesGroup) {
-            $choices[$taxRulesGroup['name']] = $taxRulesGroup['id_tax_rules_group'];
+            $choices[$taxRulesGroup['name']] = (int) $taxRulesGroup['id_tax_rules_group'];
         }
 
         return $choices;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\OrderPreferences;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -77,16 +78,19 @@ class GeneralType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Enable final summary', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Display an overview of the addresses, shipping method and cart just before the order button (required in some European countries).', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_FINAL_SUMMARY_ENABLED',
             ])
             ->add('enable_guest_checkout', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Enable guest checkout', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Allow guest visitors to place an order without registering.', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_GUEST_CHECKOUT_ENABLED',
             ])
             ->add('disable_reordering_option', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Disable reordering option', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Disable the option to allow customers to reorder in one click from the order history page (required in some European countries).', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_DISALLOW_HISTORY_REORDERING',
             ])
             ->add('purchase_minimum_value', MoneyWithSuffixType::class, [
                 'required' => false,
@@ -94,11 +98,13 @@ class GeneralType extends TranslatorAwareType
                 'help' => $this->trans('Set to 0 to disable this feature.', 'Admin.Shopparameters.Help'),
                 'currency' => $currencyIsoCode,
                 'suffix' => $this->trans('(tax excl.)', 'Admin.Global'),
+                'multistore_configuration_key' => 'PS_PURCHASE_MINIMUM',
             ])
             ->add('recalculate_shipping_cost', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Recalculate shipping costs after editing the order', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Automatically updates the shipping costs when you edit an order.', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_ORDER_RECALCULATE_SHIPPING',
             ]);
 
         if ($isMultishippingEnabled) {
@@ -106,6 +112,7 @@ class GeneralType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Allow multishipping', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Allow the customer to ship orders to multiple addresses. This option will convert the customer\'s cart into one or more orders.', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_ALLOW_MULTISHIPPING',
             ]);
         }
 
@@ -114,11 +121,13 @@ class GeneralType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Delayed shipping', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('It allows you to delay shipping if your customers request it.', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_SHIP_WHEN_AVAILABLE',
             ])
             ->add('enable_tos', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Terms of service', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Require customers to accept or decline terms of service before processing an order.', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_CONDITIONS',
             ])
             ->add('tos_cms_id', ChoiceType::class, [
                 'required' => false,
@@ -126,6 +135,7 @@ class GeneralType extends TranslatorAwareType
                 'help' => $this->trans('Choose the page which contains your store\'s terms and conditions of use.', 'Admin.Shopparameters.Help'),
                 'placeholder' => $this->trans('None', 'Admin.Global'),
                 'choices' => $this->tosCmsChoices,
+                'multistore_configuration_key' => 'PS_CONDITIONS_CMS_ID',
             ]);
     }
 
@@ -145,5 +155,15 @@ class GeneralType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'order_preferences_general_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\OrderPreferences;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -78,6 +79,7 @@ class GiftOptionsType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Offer gift wrapping', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Suggest gift-wrapping to customers.', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_GIFT_WRAPPING',
             ])
             ->add('gift_wrapping_price', MoneyWithSuffixType::class, [
                 'required' => false,
@@ -85,6 +87,7 @@ class GiftOptionsType extends TranslatorAwareType
                 'help' => $this->trans('Set a price for gift wrapping.', 'Admin.Shopparameters.Help'),
                 'currency' => $currencyIsoCode,
                 'suffix' => $this->trans('(tax excl.)', 'Admin.Global'),
+                'multistore_configuration_key' => 'PS_GIFT_WRAPPING_PRICE',
             ]);
 
         if (!$atcpShipWrap) {
@@ -94,6 +97,7 @@ class GiftOptionsType extends TranslatorAwareType
                 'help' => $this->trans('Set a tax for gift wrapping.', 'Admin.Shopparameters.Help'),
                 'placeholder' => $this->trans('None', 'Admin.Global'),
                 'choices' => $this->taxChoices,
+                'multistore_configuration_key' => 'PS_GIFT_WRAPPING_TAX_RULES_GROUP',
             ]);
         }
 
@@ -101,6 +105,7 @@ class GiftOptionsType extends TranslatorAwareType
             'required' => false,
             'label' => $this->trans('Offer recycled packaging', 'Admin.Shopparameters.Feature'),
             'help' => $this->trans('Suggest recycled packaging to customer.', 'Admin.Shopparameters.Help'),
+            'multistore_configuration_key' => 'PS_RECYCLABLE_PACK',
         ]);
     }
 
@@ -120,5 +125,15 @@ class GiftOptionsType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'order_preferences_gift_options_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/order_preferences.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/order_preferences.yml
@@ -8,15 +8,15 @@ admin_order_preferences:
 
 admin_order_preferences_general_save:
   path: /general
-  methods: [PATCH, POST]
+  methods: [ PATCH, POST ]
   defaults:
-      _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderPreferencesController::processGeneralFormAction'
-      _legacy_controller: AdminOrderPreferences
-      _legacy_link: AdminOrderPreferences:update
+    _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderPreferencesController::processGeneralFormAction'
+    _legacy_controller: AdminOrderPreferences
+    _legacy_link: AdminOrderPreferences:update
 
 admin_order_preferences_gift_options_save:
   path: /gift-options
-  methods: [PATCH, POST]
+  methods: [ PATCH, POST ]
   defaults:
-      _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderPreferencesController::processGiftOptionsFormAction'
-      _legacy_controller: AdminOrderPreferences
+    _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderPreferencesController::processGiftOptionsFormAction'
+    _legacy_controller: AdminOrderPreferences

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/order_preferences.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/order_preferences.yml
@@ -8,15 +8,15 @@ admin_order_preferences:
 
 admin_order_preferences_general_save:
   path: /general
-  methods: [ POST ]
+  methods: [PATCH, POST]
   defaults:
-    _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderPreferencesController::processGeneralFormAction'
-    _legacy_controller: AdminOrderPreferences
-    _legacy_link: AdminOrderPreferences:update
+      _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderPreferencesController::processGeneralFormAction'
+      _legacy_controller: AdminOrderPreferences
+      _legacy_link: AdminOrderPreferences:update
 
 admin_order_preferences_gift_options_save:
   path: /gift-options
-  methods: [ POST ]
+  methods: [PATCH, POST]
   defaults:
-    _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderPreferencesController::processGiftOptionsFormAction'
-    _legacy_controller: AdminOrderPreferences
+      _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderPreferencesController::processGiftOptionsFormAction'
+      _legacy_controller: AdminOrderPreferences

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -47,6 +47,7 @@ services:
       - '@prestashop.adapter.debug_mode'
       - '@prestashop.adapter.legacy.configuration'
       - '%ps_config_dir%/defines.inc.php'
+      - '@prestashop.adapter.cache.clearer.class_index_cache_clearer'
 
   prestashop.adapter.optional_features.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\OptionalFeatures\OptionalFeaturesConfiguration'
@@ -67,7 +68,7 @@ services:
 
   prestashop.adapter.media_servers.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Media\MediaServerConfiguration'
-    arguments: ['@prestashop.adapter.legacy.configuration']
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]
 
   prestashop.adapter.caching.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Cache\CachingConfiguration'
@@ -93,23 +94,23 @@ services:
 
   prestashop.adapter.preferences.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Preferences\PreferencesConfiguration'
-    arguments: ['@prestashop.adapter.legacy.configuration']
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]
 
   prestashop.adapter.upload_quota.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Upload\UploadQuotaConfiguration'
-    arguments: ['@prestashop.adapter.legacy.configuration']
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]
 
   prestashop.adapter.notifications.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Admin\NotificationsConfiguration'
-    arguments: ['@prestashop.adapter.legacy.configuration']
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]
 
   prestashop.adapter.smarty_cache.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Smarty\SmartyCacheConfiguration'
-    arguments: ['@prestashop.adapter.legacy.configuration']
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]
 
   prestashop.adapter.logs.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Configuration\LogsConfiguration'
-    arguments: 
+    arguments:
       - '@prestashop.adapter.legacy.configuration'
       - '@translator'
       - '@prestashop.adapter.validate'
@@ -175,15 +176,15 @@ services:
 
   prestashop.adapter.geolocation_by_ip_address.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Geolocation\GeolocationByIpAddressConfiguration'
-    arguments: ['@prestashop.adapter.legacy.configuration']
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]
 
   prestashop.adapter.geolocation_ip_address_whitelist.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Geolocation\GeolocationIpAddressWhitelistConfiguration'
-    arguments: ['@prestashop.adapter.legacy.configuration']
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]
 
   prestashop.adapter.geolocation_options.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Geolocation\GeolocationOptionsConfiguration'
-    arguments: ['@prestashop.adapter.legacy.configuration']
+    arguments: [ '@prestashop.adapter.legacy.configuration' ]
 
   prestashop.adapter.payment_module_preferences.configuration:
     class: 'PrestaShop\PrestaShop\Core\Payment\PaymentModulePreferencesConfiguration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -31,11 +31,15 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Order\GeneralConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.adapter.order_gift.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Order\GiftOptionsConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.adapter.debug_mode.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Debug\DebugModeConfiguration'
@@ -43,7 +47,6 @@ services:
       - '@prestashop.adapter.debug_mode'
       - '@prestashop.adapter.legacy.configuration'
       - '%ps_config_dir%/defines.inc.php'
-      - '@prestashop.adapter.cache.clearer.class_index_cache_clearer'
 
   prestashop.adapter.optional_features.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\OptionalFeatures\OptionalFeaturesConfiguration'
@@ -64,7 +67,7 @@ services:
 
   prestashop.adapter.media_servers.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Media\MediaServerConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments: ['@prestashop.adapter.legacy.configuration']
 
   prestashop.adapter.caching.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Cache\CachingConfiguration'
@@ -90,23 +93,23 @@ services:
 
   prestashop.adapter.preferences.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Preferences\PreferencesConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments: ['@prestashop.adapter.legacy.configuration']
 
   prestashop.adapter.upload_quota.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Upload\UploadQuotaConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments: ['@prestashop.adapter.legacy.configuration']
 
   prestashop.adapter.notifications.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Admin\NotificationsConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments: ['@prestashop.adapter.legacy.configuration']
 
   prestashop.adapter.smarty_cache.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Smarty\SmartyCacheConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments: ['@prestashop.adapter.legacy.configuration']
 
   prestashop.adapter.logs.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Configuration\LogsConfiguration'
-    arguments:
+    arguments: 
       - '@prestashop.adapter.legacy.configuration'
       - '@translator'
       - '@prestashop.adapter.validate'
@@ -172,15 +175,15 @@ services:
 
   prestashop.adapter.geolocation_by_ip_address.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Geolocation\GeolocationByIpAddressConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments: ['@prestashop.adapter.legacy.configuration']
 
   prestashop.adapter.geolocation_ip_address_whitelist.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Geolocation\GeolocationIpAddressWhitelistConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments: ['@prestashop.adapter.legacy.configuration']
 
   prestashop.adapter.geolocation_options.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Geolocation\GeolocationOptionsConfiguration'
-    arguments: [ '@prestashop.adapter.legacy.configuration' ]
+    arguments: ['@prestashop.adapter.legacy.configuration']
 
   prestashop.adapter.payment_module_preferences.configuration:
     class: 'PrestaShop\PrestaShop\Core\Payment\PaymentModulePreferencesConfiguration'

--- a/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
+++ b/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Order;
+
+use PrestaShop\PrestaShop\Adapter\Order\GeneralConfiguration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Tests\TestCase\AbstractConfigurationTestCase;
+
+class GeneralConfigurationTest extends AbstractConfigurationTestCase
+{
+    private const SHOP_ID = 42;
+    private const MINIMUM_PURCHASE_VALUE = 3.0;
+    private const TOS_CMS_ID = 3;
+
+    /**
+     * @dataProvider provideShopConstraints
+     *
+     * @param ShopConstraint $shopConstraint
+     */
+    public function testGetConfiguration(ShopConstraint $shopConstraint): void
+    {
+        $generalConfiguration = new GeneralConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $this->mockShopConfiguration
+            ->method('getShopConstraint')
+            ->willReturn($shopConstraint);
+
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['PS_FINAL_SUMMARY_ENABLED', false, $shopConstraint, true],
+                    ['PS_GUEST_CHECKOUT_ENABLED', false, $shopConstraint, true],
+                    ['PS_DISALLOW_HISTORY_REORDERING', false, $shopConstraint, true],
+                    ['PS_PURCHASE_MINIMUM', null, $shopConstraint, self::MINIMUM_PURCHASE_VALUE],
+                    ['PS_ORDER_RECALCULATE_SHIPPING', false, $shopConstraint, true],
+                    ['PS_ALLOW_MULTISHIPPING', false, $shopConstraint, true],
+                    ['PS_SHIP_WHEN_AVAILABLE', false, $shopConstraint, true],
+                    ['PS_CONDITIONS', false, $shopConstraint, true],
+                    ['PS_CONDITIONS_CMS_ID', null, $shopConstraint, self::TOS_CMS_ID],
+                ]
+            );
+
+        $result = $generalConfiguration->getConfiguration();
+        $this->assertSame(
+            [
+                'enable_final_summary' => true,
+                'enable_guest_checkout' => true,
+                'disable_reordering_option' => true,
+                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+                'recalculate_shipping_cost' => true,
+                'allow_multishipping' => true,
+                'allow_delayed_shipping' => true,
+                'enable_tos' => true,
+                'tos_cms_id' => self::TOS_CMS_ID,
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidConfiguration
+     *
+     * @param string $exception
+     * @param array $values
+     */
+    public function testUpdateConfigurationWithInvalidConfiguration(string $exception, array $values): void
+    {
+        $generalConfiguration = new GeneralConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $this->expectException($exception);
+        $generalConfiguration->updateConfiguration($values);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideInvalidConfiguration(): array
+    {
+        return [
+            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            [InvalidOptionsException::class, [
+                'enable_final_summary' => 'wrong_type',
+                'enable_guest_checkout' => true,
+                'disable_reordering_option' => true,
+                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+                'recalculate_shipping_cost' => true,
+                'allow_multishipping' => true,
+                'allow_delayed_shipping' => true,
+                'enable_tos' => true,
+                'tos_cms_id' => self::TOS_CMS_ID,
+            ]],
+            [InvalidOptionsException::class, [
+                'enable_final_summary' => true,
+                'enable_guest_checkout' => 'wrong_type',
+                'disable_reordering_option' => true,
+                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+                'recalculate_shipping_cost' => true,
+                'allow_multishipping' => true,
+                'allow_delayed_shipping' => true,
+                'enable_tos' => true,
+                'tos_cms_id' => self::TOS_CMS_ID,
+            ]],
+            [InvalidOptionsException::class, [
+                'enable_final_summary' => true,
+                'enable_guest_checkout' => true,
+                'disable_reordering_option' => 'wrong_type',
+                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+                'recalculate_shipping_cost' => true,
+                'allow_multishipping' => true,
+                'allow_delayed_shipping' => true,
+                'enable_tos' => true,
+                'tos_cms_id' => self::TOS_CMS_ID,
+            ]],
+            [InvalidOptionsException::class, [
+                'enable_final_summary' => true,
+                'enable_guest_checkout' => true,
+                'disable_reordering_option' => true,
+                'purchase_minimum_value' => 'wrong_type',
+                'recalculate_shipping_cost' => true,
+                'allow_multishipping' => true,
+                'allow_delayed_shipping' => true,
+                'enable_tos' => true,
+                'tos_cms_id' => self::TOS_CMS_ID,
+            ]],
+            [InvalidOptionsException::class, [
+                'enable_final_summary' => true,
+                'enable_guest_checkout' => true,
+                'disable_reordering_option' => true,
+                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+                'recalculate_shipping_cost' => 'wrong_type',
+                'allow_multishipping' => true,
+                'allow_delayed_shipping' => true,
+                'enable_tos' => true,
+                'tos_cms_id' => self::TOS_CMS_ID,
+            ]],
+            [InvalidOptionsException::class, [
+                'enable_final_summary' => true,
+                'enable_guest_checkout' => true,
+                'disable_reordering_option' => true,
+                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+                'recalculate_shipping_cost' => true,
+                'allow_multishipping' => 'wrong_type',
+                'allow_delayed_shipping' => true,
+                'enable_tos' => true,
+                'tos_cms_id' => self::TOS_CMS_ID,
+            ]],
+            [InvalidOptionsException::class, [
+                'enable_final_summary' => true,
+                'enable_guest_checkout' => true,
+                'disable_reordering_option' => true,
+                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+                'recalculate_shipping_cost' => true,
+                'allow_multishipping' => true,
+                'allow_delayed_shipping' => 'wrong_type',
+                'enable_tos' => true,
+                'tos_cms_id' => self::TOS_CMS_ID,
+            ]],
+            [InvalidOptionsException::class, [
+                'enable_final_summary' => true,
+                'enable_guest_checkout' => true,
+                'disable_reordering_option' => true,
+                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+                'recalculate_shipping_cost' => true,
+                'allow_multishipping' => true,
+                'allow_delayed_shipping' => true,
+                'enable_tos' => 'wrong_type',
+                'tos_cms_id' => self::TOS_CMS_ID,
+            ]],
+            [InvalidOptionsException::class, [
+                'enable_final_summary' => true,
+                'enable_guest_checkout' => true,
+                'disable_reordering_option' => true,
+                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+                'recalculate_shipping_cost' => true,
+                'allow_multishipping' => true,
+                'allow_delayed_shipping' => true,
+                'enable_tos' => true,
+                'tos_cms_id' => 'wrong_type',
+            ]],
+        ];
+    }
+
+    public function testSuccessfulUpdate(): void
+    {
+        $generalConfiguration = new GeneralConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $res = $generalConfiguration->updateConfiguration([
+            'enable_final_summary' => true,
+            'enable_guest_checkout' => true,
+            'disable_reordering_option' => true,
+            'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
+            'recalculate_shipping_cost' => true,
+            'allow_multishipping' => true,
+            'allow_delayed_shipping' => true,
+            'enable_tos' => true,
+            'tos_cms_id' => self::TOS_CMS_ID,
+        ]);
+
+        $this->assertSame([], $res);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideShopConstraints(): array
+    {
+        return [
+            [ShopConstraint::shop(self::SHOP_ID)],
+            [ShopConstraint::shopGroup(self::SHOP_ID)],
+            [ShopConstraint::allShops()],
+        ];
+    }
+}

--- a/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
+++ b/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
@@ -37,8 +37,18 @@ use Tests\TestCase\AbstractConfigurationTestCase;
 class GeneralConfigurationTest extends AbstractConfigurationTestCase
 {
     private const SHOP_ID = 42;
-    private const MINIMUM_PURCHASE_VALUE = 3.0;
-    private const TOS_CMS_ID = 3;
+
+    private const VALID_CONFIGURATION = [
+        'enable_final_summary' => true,
+        'enable_guest_checkout' => true,
+        'disable_reordering_option' => true,
+        'purchase_minimum_value' => 3.0,
+        'recalculate_shipping_cost' => true,
+        'allow_multishipping' => true,
+        'allow_delayed_shipping' => true,
+        'enable_tos' => true,
+        'tos_cms_id' => 3,
+    ];
 
     /**
      * @dataProvider provideShopConstraints
@@ -47,7 +57,11 @@ class GeneralConfigurationTest extends AbstractConfigurationTestCase
      */
     public function testGetConfiguration(ShopConstraint $shopConstraint): void
     {
-        $generalConfiguration = new GeneralConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+        $generalConfiguration = new GeneralConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
 
         $this->mockShopConfiguration
             ->method('getShopConstraint')
@@ -60,30 +74,17 @@ class GeneralConfigurationTest extends AbstractConfigurationTestCase
                     ['PS_FINAL_SUMMARY_ENABLED', false, $shopConstraint, true],
                     ['PS_GUEST_CHECKOUT_ENABLED', false, $shopConstraint, true],
                     ['PS_DISALLOW_HISTORY_REORDERING', false, $shopConstraint, true],
-                    ['PS_PURCHASE_MINIMUM', null, $shopConstraint, self::MINIMUM_PURCHASE_VALUE],
+                    ['PS_PURCHASE_MINIMUM', 0, $shopConstraint, 3.0],
                     ['PS_ORDER_RECALCULATE_SHIPPING', false, $shopConstraint, true],
                     ['PS_ALLOW_MULTISHIPPING', false, $shopConstraint, true],
                     ['PS_SHIP_WHEN_AVAILABLE', false, $shopConstraint, true],
                     ['PS_CONDITIONS', false, $shopConstraint, true],
-                    ['PS_CONDITIONS_CMS_ID', null, $shopConstraint, self::TOS_CMS_ID],
+                    ['PS_CONDITIONS_CMS_ID', 0, $shopConstraint, 3],
                 ]
             );
 
         $result = $generalConfiguration->getConfiguration();
-        $this->assertSame(
-            [
-                'enable_final_summary' => true,
-                'enable_guest_checkout' => true,
-                'disable_reordering_option' => true,
-                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-                'recalculate_shipping_cost' => true,
-                'allow_multishipping' => true,
-                'allow_delayed_shipping' => true,
-                'enable_tos' => true,
-                'tos_cms_id' => self::TOS_CMS_ID,
-            ],
-            $result
-        );
+        $this->assertSame(self::VALID_CONFIGURATION, $result);
     }
 
     /**
@@ -94,7 +95,11 @@ class GeneralConfigurationTest extends AbstractConfigurationTestCase
      */
     public function testUpdateConfigurationWithInvalidConfiguration(string $exception, array $values): void
     {
-        $generalConfiguration = new GeneralConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+        $generalConfiguration = new GeneralConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
 
         $this->expectException($exception);
         $generalConfiguration->updateConfiguration($values);
@@ -107,123 +112,27 @@ class GeneralConfigurationTest extends AbstractConfigurationTestCase
     {
         return [
             [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
-            [InvalidOptionsException::class, [
-                'enable_final_summary' => 'wrong_type',
-                'enable_guest_checkout' => true,
-                'disable_reordering_option' => true,
-                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-                'recalculate_shipping_cost' => true,
-                'allow_multishipping' => true,
-                'allow_delayed_shipping' => true,
-                'enable_tos' => true,
-                'tos_cms_id' => self::TOS_CMS_ID,
-            ]],
-            [InvalidOptionsException::class, [
-                'enable_final_summary' => true,
-                'enable_guest_checkout' => 'wrong_type',
-                'disable_reordering_option' => true,
-                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-                'recalculate_shipping_cost' => true,
-                'allow_multishipping' => true,
-                'allow_delayed_shipping' => true,
-                'enable_tos' => true,
-                'tos_cms_id' => self::TOS_CMS_ID,
-            ]],
-            [InvalidOptionsException::class, [
-                'enable_final_summary' => true,
-                'enable_guest_checkout' => true,
-                'disable_reordering_option' => 'wrong_type',
-                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-                'recalculate_shipping_cost' => true,
-                'allow_multishipping' => true,
-                'allow_delayed_shipping' => true,
-                'enable_tos' => true,
-                'tos_cms_id' => self::TOS_CMS_ID,
-            ]],
-            [InvalidOptionsException::class, [
-                'enable_final_summary' => true,
-                'enable_guest_checkout' => true,
-                'disable_reordering_option' => true,
-                'purchase_minimum_value' => 'wrong_type',
-                'recalculate_shipping_cost' => true,
-                'allow_multishipping' => true,
-                'allow_delayed_shipping' => true,
-                'enable_tos' => true,
-                'tos_cms_id' => self::TOS_CMS_ID,
-            ]],
-            [InvalidOptionsException::class, [
-                'enable_final_summary' => true,
-                'enable_guest_checkout' => true,
-                'disable_reordering_option' => true,
-                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-                'recalculate_shipping_cost' => 'wrong_type',
-                'allow_multishipping' => true,
-                'allow_delayed_shipping' => true,
-                'enable_tos' => true,
-                'tos_cms_id' => self::TOS_CMS_ID,
-            ]],
-            [InvalidOptionsException::class, [
-                'enable_final_summary' => true,
-                'enable_guest_checkout' => true,
-                'disable_reordering_option' => true,
-                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-                'recalculate_shipping_cost' => true,
-                'allow_multishipping' => 'wrong_type',
-                'allow_delayed_shipping' => true,
-                'enable_tos' => true,
-                'tos_cms_id' => self::TOS_CMS_ID,
-            ]],
-            [InvalidOptionsException::class, [
-                'enable_final_summary' => true,
-                'enable_guest_checkout' => true,
-                'disable_reordering_option' => true,
-                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-                'recalculate_shipping_cost' => true,
-                'allow_multishipping' => true,
-                'allow_delayed_shipping' => 'wrong_type',
-                'enable_tos' => true,
-                'tos_cms_id' => self::TOS_CMS_ID,
-            ]],
-            [InvalidOptionsException::class, [
-                'enable_final_summary' => true,
-                'enable_guest_checkout' => true,
-                'disable_reordering_option' => true,
-                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-                'recalculate_shipping_cost' => true,
-                'allow_multishipping' => true,
-                'allow_delayed_shipping' => true,
-                'enable_tos' => 'wrong_type',
-                'tos_cms_id' => self::TOS_CMS_ID,
-            ]],
-            [InvalidOptionsException::class, [
-                'enable_final_summary' => true,
-                'enable_guest_checkout' => true,
-                'disable_reordering_option' => true,
-                'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-                'recalculate_shipping_cost' => true,
-                'allow_multishipping' => true,
-                'allow_delayed_shipping' => true,
-                'enable_tos' => true,
-                'tos_cms_id' => 'wrong_type',
-            ]],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_final_summary' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_guest_checkout' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['disable_reordering_option' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['purchase_minimum_value' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['recalculate_shipping_cost' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['allow_multishipping' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['allow_delayed_shipping' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_tos' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['tos_cms_id' => 'wrong_type'])],
         ];
     }
 
     public function testSuccessfulUpdate(): void
     {
-        $generalConfiguration = new GeneralConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+        $generalConfiguration = new GeneralConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
 
-        $res = $generalConfiguration->updateConfiguration([
-            'enable_final_summary' => true,
-            'enable_guest_checkout' => true,
-            'disable_reordering_option' => true,
-            'purchase_minimum_value' => self::MINIMUM_PURCHASE_VALUE,
-            'recalculate_shipping_cost' => true,
-            'allow_multishipping' => true,
-            'allow_delayed_shipping' => true,
-            'enable_tos' => true,
-            'tos_cms_id' => self::TOS_CMS_ID,
-        ]);
+        $res = $generalConfiguration->updateConfiguration(self::VALID_CONFIGURATION);
 
         $this->assertSame([], $res);
     }

--- a/tests/Unit/Adapter/Order/GiftOptionsConfigurationTest.php
+++ b/tests/Unit/Adapter/Order/GiftOptionsConfigurationTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Order;
+
+use PrestaShop\PrestaShop\Adapter\Order\GiftOptionsConfiguration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Tests\TestCase\AbstractConfigurationTestCase;
+
+class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
+{
+    private const SHOP_ID = 42;
+    private const GIFT_WRAPPING_PRICE = 3.0;
+    private const GIFT_WRAPPING_TAX_RULE_GROUP = 3;
+
+    /**
+     * @dataProvider provideShopConstraints
+     *
+     * @param ShopConstraint $shopConstraint
+     */
+    public function testGetConfiguration(ShopConstraint $shopConstraint): void
+    {
+        $giftOptionsConfiguration = new GiftOptionsConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $this->mockShopConfiguration
+            ->method('getShopConstraint')
+            ->willReturn($shopConstraint);
+
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['PS_GIFT_WRAPPING', false, $shopConstraint, true],
+                    ['PS_GIFT_WRAPPING_PRICE', null, $shopConstraint, self::GIFT_WRAPPING_PRICE],
+                    ['PS_GIFT_WRAPPING_TAX_RULES_GROUP', null, $shopConstraint, self::GIFT_WRAPPING_TAX_RULE_GROUP],
+                    ['PS_RECYCLABLE_PACK', false, $shopConstraint, true],
+                ]
+            );
+
+        $result = $giftOptionsConfiguration->getConfiguration();
+
+        $this->assertSame(
+            [
+                'enable_gift_wrapping' => true,
+                'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
+                'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
+                'offer_recyclable_pack' => true,
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidConfiguration
+     *
+     * @param string $exception
+     * @param array $values
+     */
+    public function testUpdateConfigurationWithInvalidConfiguration(string $exception, array $values): void
+    {
+        $giftOptionsConfiguration = new GiftOptionsConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $this->expectException($exception);
+        $giftOptionsConfiguration->updateConfiguration($values);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideInvalidConfiguration(): array
+    {
+        return [
+            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            [
+                InvalidOptionsException::class,
+                [
+                    'enable_gift_wrapping' => 'wrong_type',
+                    'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
+                    'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
+                    'offer_recyclable_pack' => true,
+                ],
+            ],
+            [
+                InvalidOptionsException::class,
+                [
+                    'enable_gift_wrapping' => true,
+                    'gift_wrapping_price' => 'wrong_type',
+                    'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
+                    'offer_recyclable_pack' => true,
+                ],
+            ],
+            [
+                InvalidOptionsException::class,
+                [
+                    'enable_gift_wrapping' => true,
+                    'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
+                    'gift_wrapping_tax_rules_group' => 'wrong_type',
+                    'offer_recyclable_pack' => true,
+                ],
+            ],
+            [
+                InvalidOptionsException::class,
+                [
+                    'enable_gift_wrapping' => true,
+                    'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
+                    'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
+                    'offer_recyclable_pack' => 'wrong_type',
+                ],
+            ],
+        ];
+    }
+
+    public function testSuccessfulUpdate(): void
+    {
+        $giftOptionsConfiguration = new GiftOptionsConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $res = $giftOptionsConfiguration->updateConfiguration([
+            'enable_gift_wrapping' => true,
+            'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
+            'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
+            'offer_recyclable_pack' => true,
+        ]);
+
+        $this->assertSame([], $res);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideShopConstraints(): array
+    {
+        return [
+            [ShopConstraint::shop(self::SHOP_ID)],
+            [ShopConstraint::shopGroup(self::SHOP_ID)],
+            [ShopConstraint::allShops()],
+        ];
+    }
+}

--- a/tests/Unit/Adapter/Order/GiftOptionsConfigurationTest.php
+++ b/tests/Unit/Adapter/Order/GiftOptionsConfigurationTest.php
@@ -37,8 +37,13 @@ use Tests\TestCase\AbstractConfigurationTestCase;
 class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
 {
     private const SHOP_ID = 42;
-    private const GIFT_WRAPPING_PRICE = 3.0;
-    private const GIFT_WRAPPING_TAX_RULE_GROUP = 3;
+
+    private const VALID_CONFIGURATION = [
+        'enable_gift_wrapping' => true,
+        'gift_wrapping_price' => 3.0,
+        'gift_wrapping_tax_rules_group' => 3,
+        'offer_recyclable_pack' => true,
+    ];
 
     /**
      * @dataProvider provideShopConstraints
@@ -47,7 +52,11 @@ class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
      */
     public function testGetConfiguration(ShopConstraint $shopConstraint): void
     {
-        $giftOptionsConfiguration = new GiftOptionsConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+        $giftOptionsConfiguration = new GiftOptionsConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
 
         $this->mockShopConfiguration
             ->method('getShopConstraint')
@@ -58,23 +67,14 @@ class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
             ->willReturnMap(
                 [
                     ['PS_GIFT_WRAPPING', false, $shopConstraint, true],
-                    ['PS_GIFT_WRAPPING_PRICE', null, $shopConstraint, self::GIFT_WRAPPING_PRICE],
-                    ['PS_GIFT_WRAPPING_TAX_RULES_GROUP', null, $shopConstraint, self::GIFT_WRAPPING_TAX_RULE_GROUP],
+                    ['PS_GIFT_WRAPPING_PRICE', 0, $shopConstraint, 3.0],
+                    ['PS_GIFT_WRAPPING_TAX_RULES_GROUP', 0, $shopConstraint, 3],
                     ['PS_RECYCLABLE_PACK', false, $shopConstraint, true],
                 ]
             );
 
         $result = $giftOptionsConfiguration->getConfiguration();
-
-        $this->assertSame(
-            [
-                'enable_gift_wrapping' => true,
-                'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
-                'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
-                'offer_recyclable_pack' => true,
-            ],
-            $result
-        );
+        $this->assertSame(self::VALID_CONFIGURATION, $result);
     }
 
     /**
@@ -85,7 +85,11 @@ class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
      */
     public function testUpdateConfigurationWithInvalidConfiguration(string $exception, array $values): void
     {
-        $giftOptionsConfiguration = new GiftOptionsConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+        $giftOptionsConfiguration = new GiftOptionsConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
 
         $this->expectException($exception);
         $giftOptionsConfiguration->updateConfiguration($values);
@@ -98,55 +102,22 @@ class GiftOptionsConfigurationTest extends AbstractConfigurationTestCase
     {
         return [
             [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
-            [
-                InvalidOptionsException::class,
-                [
-                    'enable_gift_wrapping' => 'wrong_type',
-                    'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
-                    'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
-                    'offer_recyclable_pack' => true,
-                ],
-            ],
-            [
-                InvalidOptionsException::class,
-                [
-                    'enable_gift_wrapping' => true,
-                    'gift_wrapping_price' => 'wrong_type',
-                    'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
-                    'offer_recyclable_pack' => true,
-                ],
-            ],
-            [
-                InvalidOptionsException::class,
-                [
-                    'enable_gift_wrapping' => true,
-                    'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
-                    'gift_wrapping_tax_rules_group' => 'wrong_type',
-                    'offer_recyclable_pack' => true,
-                ],
-            ],
-            [
-                InvalidOptionsException::class,
-                [
-                    'enable_gift_wrapping' => true,
-                    'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
-                    'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
-                    'offer_recyclable_pack' => 'wrong_type',
-                ],
-            ],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_gift_wrapping' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['gift_wrapping_price' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['gift_wrapping_tax_rules_group' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['offer_recyclable_pack' => 'wrong_type'])],
         ];
     }
 
     public function testSuccessfulUpdate(): void
     {
-        $giftOptionsConfiguration = new GiftOptionsConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+        $giftOptionsConfiguration = new GiftOptionsConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
 
-        $res = $giftOptionsConfiguration->updateConfiguration([
-            'enable_gift_wrapping' => true,
-            'gift_wrapping_price' => self::GIFT_WRAPPING_PRICE,
-            'gift_wrapping_tax_rules_group' => self::GIFT_WRAPPING_TAX_RULE_GROUP,
-            'offer_recyclable_pack' => true,
-        ]);
+        $res = $giftOptionsConfiguration->updateConfiguration(self::VALID_CONFIGURATION);
 
         $this->assertSame([], $res);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add multistore checkboxes/dropdowns on order settings page
| Type?             | new feature
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #19363. Fixes #19315.
| How to test?      | See issues
| Possible impacts? | -
| Sponsor company | @Creabilis
## BC BREAKS:

- `src/Adapter/Order/GeneralConfiguration.php` (constructor)
- `src/Adapter/Order/GiftOptionsConfiguration.php` (constructor)

These data configuration classes now extend `AbstractMultistoreConfiguration`, which implies those BC break.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25872)
<!-- Reviewable:end -->
