### PR TITLE
Refacto improper card markup on migrated pages

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -25,17 +25,17 @@
  */
 
 .form-horizontal {
-  .card-block {
-    justify-content: center;
+  .card-body {
     padding: 1.875rem $card-spacer-x;
-
-    &.row {
-      margin: 0; // used to override negative margins brought by .row
-    }
   }
 
-  .card-text {
-    @extend .col-sm-10;
+  .form-wrapper {
+    padding: 0 $spacer * 0.5;
+
+    @include media-breakpoint-up(sm) {
+      width: 83%;
+      margin: auto;
+    }
   }
 
   .form-group {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Backup/Blocks/options.html.twig
@@ -32,8 +32,8 @@
     <h3 class="card-header">
       <i class="material-icons">settings</i> {{ 'Backup options'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(backupForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_available_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_available_fields.html.twig
@@ -29,7 +29,7 @@
   <h3 class="card-header">
     <i class="material-icons">list</i> {{ 'Available fields'|trans }}
   </h3>
-  <div class="card-block">
+  <div class="card-body">
     <div class="js-available-field-template d-none"></div>
     {% include '@Common/HelpBox/helpbox.html.twig' with { "classes" : "js-available-field-popover-template d-none" } %}
     <div

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
@@ -33,94 +33,96 @@
     <i class="material-icons">import_export</i> {{ 'Import'|trans({}, 'Admin.Actions') }}
   </h3>
   <div class="card-body">
-    <div class="alert alert-info" role="alert">
-      <p class="alert-text">
-        {{ 'You can read information on import at:'|trans({}, 'Admin.Advparameters.Help') }}
-        <a href="{{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}" target="_blank" rel="noopener noreferrer nofollow">
-          {{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}
-        </a>
-      </p>
-      <p class="alert-text">
-        {{ 'Read more about the CSV format at:'|trans({}, 'Admin.Advparameters.Help') }}
-        <a href="{{ 'https://en.wikipedia.org/wiki/Comma-separated_values'|trans({}, 'Admin.Advparameters.Help') }}" target="_blank" rel="noopener noreferrer nofollow">
-          {{ 'https://en.wikipedia.org/wiki/Comma-separated_values'|trans({}, 'Admin.Advparameters.Help') }}
-        </a>
-      </p>
-    </div>
-
-    <hr>
-
-    <div class="form-group">
-      {{ form_row(importForm.entity) }}
-    </div>
-
-    <div class="alert alert-warning js-entity-alert" role="alert">
-      <ul>
-        <li>{{ 'Note that the Category import does not support having two categories with the same name.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
-        <li>{{ 'Note that you can have several products with the same reference.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
-      </ul>
-    </div>
-
-    <hr>
-
-    <div class="form-group hidden-xs-up">
-      {{ form_errors(importForm.csv) }}
-      {{ form_widget(importForm.csv, {'attr': {'class': 'js-import-file-input'}}) }}
-    </div>
-
-    <div class="form-group js-file-upload-form-group">
-      {{ form_label(importForm.file) }}
-      <div class="row">
-        <div class="col">
-          {{ form_errors(importForm.file) }}
-          {{ form_widget(importForm.file, {'attr': {'class': 'js-import-file', 'data-max-file-upload-size': maxFileUploadSize }}) }}
-        </div>
-        <div class="col">
-          <span>{{ 'or'|trans({}, 'Admin.Global') }}</span>
-          <button type="button"
-                  class="btn btn-outline-primary btn-sm js-from-files-history-btn"
-                  {% if importFileNames is empty %}disabled{% endif %}
-          >
-            <span class="badge badge-primary js-files-history-number">{{ importFileNames|length }}</span>
-            {{ 'Choose from history / FTP'|trans({}, 'Admin.Advparameters.Feature') }}
-          </button>
-        </div>
+    <div class="form-wrapper">
+      <div class="alert alert-info" role="alert">
+        <p class="alert-text">
+          {{ 'You can read information on import at:'|trans({}, 'Admin.Advparameters.Help') }}
+          <a href="{{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}" target="_blank" rel="noopener noreferrer nofollow">
+            {{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}
+          </a>
+        </p>
+        <p class="alert-text">
+          {{ 'Read more about the CSV format at:'|trans({}, 'Admin.Advparameters.Help') }}
+          <a href="{{ 'https://en.wikipedia.org/wiki/Comma-separated_values'|trans({}, 'Admin.Advparameters.Help') }}" target="_blank" rel="noopener noreferrer nofollow">
+            {{ 'https://en.wikipedia.org/wiki/Comma-separated_values'|trans({}, 'Admin.Advparameters.Help') }}
+          </a>
+        </p>
       </div>
-      <small class="form-text">{{ 'Allowed formats: .csv, .xls, .xlsx, .xlst, .ods, .ots'|trans({}, 'Admin.Advparameters.Help') }}</small>
-      <small class="form-text">{{ 'Only UTF-8 and ISO 8859-1 encodings are allowed'|trans({}, 'Admin.Advparameters.Help') }}</small>
-      <small class="form-text">{{ 'You can also upload your file via FTP to the following directory: %s .'|trans({'%s': importDirectory}, 'Admin.Advparameters.Help') }}</small>
+
+      <hr>
+
+      <div class="form-group">
+        {{ form_row(importForm.entity) }}
+      </div>
+
+      <div class="alert alert-warning js-entity-alert" role="alert">
+        <ul>
+          <li>{{ 'Note that the Category import does not support having two categories with the same name.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
+          <li>{{ 'Note that you can have several products with the same reference.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
+        </ul>
+      </div>
+
+      <hr>
+
+      <div class="form-group hidden-xs-up">
+        {{ form_errors(importForm.csv) }}
+        {{ form_widget(importForm.csv, {'attr': {'class': 'js-import-file-input'}}) }}
+      </div>
+
+      <div class="form-group js-file-upload-form-group">
+        {{ form_label(importForm.file) }}
+        <div class="row">
+          <div class="col">
+            {{ form_errors(importForm.file) }}
+            {{ form_widget(importForm.file, {'attr': {'class': 'js-import-file', 'data-max-file-upload-size': maxFileUploadSize }}) }}
+          </div>
+          <div class="col">
+            <span>{{ 'or'|trans({}, 'Admin.Global') }}</span>
+            <button type="button"
+                    class="btn btn-outline-primary btn-sm js-from-files-history-btn"
+                    {% if importFileNames is empty %}disabled{% endif %}
+            >
+              <span class="badge badge-primary js-files-history-number">{{ importFileNames|length }}</span>
+              {{ 'Choose from history / FTP'|trans({}, 'Admin.Advparameters.Feature') }}
+            </button>
+          </div>
+        </div>
+        <small class="form-text">{{ 'Allowed formats: .csv, .xls, .xlsx, .xlst, .ods, .ots'|trans({}, 'Admin.Advparameters.Help') }}</small>
+        <small class="form-text">{{ 'Only UTF-8 and ISO 8859-1 encodings are allowed'|trans({}, 'Admin.Advparameters.Help') }}</small>
+        <small class="form-text">{{ 'You can also upload your file via FTP to the following directory: %s .'|trans({'%s': importDirectory}, 'Admin.Advparameters.Help') }}</small>
+      </div>
+
+      <div class="alert alert-danger d-none js-import-file-error" role="alert">
+        <p class="alert-text">
+          <strong class="js-file-data"></strong>: <span class="js-error-message"></span>
+        </p>
+      </div>
+
+      <div class="alert alert-success d-none js-import-file-alert" role="alert">
+        <button type="button"
+                class="close btn btn-outline-secondary js-change-import-file-btn"
+                aria-label="{{ 'Change'|trans({}, 'Admin.Actions') }}"
+        >
+          <span aria-hidden="true"><i class="material-icons">edit</i></span>
+        </button>
+        <p class="alert-text js-import-file"></p>
+      </div>
+
+      {% block import_file_history_block %}
+        {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Blocks/import_file_history.html.twig' %}
+      {% endblock %}
+
+      <hr>
+      {{ form_row(importForm.iso_lang) }}
+      {{ form_row(importForm.separator) }}
+      {{ form_row(importForm.multiple_value_separator) }}
+      <hr>
+      {{ form_label(importForm.submitImportFile) }}
+
+      {# This is done so importForm.submitImportFile is not rendered, as it's defined via plain HTML instead #}
+      {% do importForm.submitImportFile.setRendered %}
+      {{ form_widget(importForm) }}
     </div>
-
-    <div class="alert alert-danger d-none js-import-file-error" role="alert">
-      <p class="alert-text">
-        <strong class="js-file-data"></strong>: <span class="js-error-message"></span>
-      </p>
-    </div>
-
-    <div class="alert alert-success d-none js-import-file-alert" role="alert">
-      <button type="button"
-              class="close btn btn-outline-secondary js-change-import-file-btn"
-              aria-label="{{ 'Change'|trans({}, 'Admin.Actions') }}"
-      >
-        <span aria-hidden="true"><i class="material-icons">edit</i></span>
-      </button>
-      <p class="alert-text js-import-file"></p>
-    </div>
-
-    {% block import_file_history_block %}
-      {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Blocks/import_file_history.html.twig' %}
-    {% endblock %}
-
-    <hr>
-    {{ form_row(importForm.iso_lang) }}
-    {{ form_row(importForm.separator) }}
-    {{ form_row(importForm.multiple_value_separator) }}
-    <hr>
-    {{ form_label(importForm.submitImportFile) }}
-
-    {# This is done so importForm.submitImportFile is not rendered, as it's defined via plain HTML instead #}
-    {% do importForm.submitImportFile.setRendered %}
-    {{ form_widget(importForm) }}
   </div>
   <div class="card-footer">
     <div class="d-flex justify-content-end">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
@@ -37,7 +37,7 @@
       <div class="alert alert-info" role="alert">
         <p class="alert-text">
           {{ 'You can read information on import at:'|trans({}, 'Admin.Advparameters.Help') }}
-          <a href="{{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}" target="_blank" rel="noopener noreferrer nofollow">
+          <a href="{{ 'https://docs.prestashop-project.org/1.7-documentation/user-guide/configuring-shop/advanced-parameters/import'|trans({}, 'Admin.Advparameters.Help') }}" target="_blank" rel="noopener noreferrer nofollow">
             {{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}
           </a>
         </p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_panel.html.twig
@@ -38,7 +38,7 @@
         <p class="alert-text">
           {{ 'You can read information on import at:'|trans({}, 'Admin.Advparameters.Help') }}
           <a href="{{ 'https://docs.prestashop-project.org/1.7-documentation/user-guide/configuring-shop/advanced-parameters/import'|trans({}, 'Admin.Advparameters.Help') }}" target="_blank" rel="noopener noreferrer nofollow">
-            {{ 'https://doc.prestashop.com/display/PS17/Import'|trans({}, 'Admin.Advparameters.Help') }}
+            {{ 'https://docs.prestashop-project.org/1.7-documentation/user-guide/configuring-shop/advanced-parameters/import'|trans({}, 'Admin.Advparameters.Help') }}
           </a>
         </p>
         <p class="alert-text">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_sample_files.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Blocks/import_sample_files.html.twig
@@ -31,7 +31,7 @@
         <i class="material-icons">file_download</i> {{ 'Download sample csv files'|trans({}, 'Admin.Advparameters.Feature') }}
     </h3>
 
-    <div class="card-block">
+    <div class="card-body">
         <div class="list-group">
             {{ ps.import_file_sample('Sample Categories file', 'categories_import') }}
             {{ ps.import_file_sample('Sample Products file', 'products_import') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
@@ -31,8 +31,8 @@
       <i class="material-icons">mail</i>
       {{ 'Email'|trans({}, 'Admin.Global') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_row(emailConfigurationForm.send_emails_to) }}
         {{ form_row(emailConfigurationForm.mail_method) }}
         <div class="js-smtp-configuration{% if emailConfigurationForm.mail_method.vars.value != smtpMailMethod %} d-none{% endif %}">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/test_email_sending.html.twig
@@ -32,8 +32,8 @@
       <i class="material-icons">settings</i>
       {{ 'Test your email configuration'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(testEmailSendingForm) }}
         <div class="alert alert-danger d-none js-test-email-errors" role="alert"></div>
         <div class="alert alert-success d-none js-test-email-success" role="alert">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -30,8 +30,8 @@
       <i class="material-icons">settings</i>
       {{ 'Employee options'|trans({}, 'Admin.Advparameters.Feature') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="form-group row">
           <label for="{{ employeeOptionsForm.password_change_time.vars.id }}" class="form-control-label">
             {{ 'Password regeneration'|trans({}, 'Admin.Advparameters.Feature') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -32,8 +32,8 @@
     <h3 class="card-header">
       {{ 'Employees'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_errors(employeeForm) }}
 
         {{ ps.form_group_row(employeeForm.firstname, {}, {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/FeatureFlag/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/FeatureFlag/index.html.twig
@@ -37,8 +37,8 @@
         {{ 'Experimental features'|trans }}
       </h3>
 
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           <div class="alert medium-alert alert-warning" role="alert">
             {{ 'Testing a feature before its official release can be exciting. However, you must be aware of the potential risks of such experiments:'|trans({}, 'Admin.Advparameters.Notification') }}
             <ul>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/ImportDataConfiguration/Blocks/import_data_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/ImportDataConfiguration/Blocks/import_data_configuration.html.twig
@@ -31,8 +31,8 @@
     <i class="material-icons">list</i>
     {{ 'Match your data'|trans }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
 
       <div class="alert alert-info" role="alert">
         <p class="alert-text">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig
@@ -28,7 +28,7 @@
     <i class="material-icons">warning</i>
     {{ 'Severity levels'|trans({}, 'Admin.Advparameters.Help') }}
   </h3>
-  <div class="card-block">
+  <div class="card-body">
     <div class="card-text">
       <p>{{ 'Meaning of severity levels:'|trans }}</p>
       <ol>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/index.html.twig
@@ -42,8 +42,8 @@
         <i class="material-icons">business_center</i>
         {{ 'Logs by email'|trans }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_widget(logsByEmailForm) }}
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig
@@ -31,8 +31,8 @@
     <i class="material-icons">group</i>
     {{ 'Profile'|trans({}, 'Admin.Advparameters.Feature') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_errors(profileForm) }}
 
       {{ ps.form_group_row(profileForm.name, {}, {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/db_tables_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/db_tables_panel.html.twig
@@ -31,7 +31,7 @@
       <h3 class="card-header">
           {{ 'List of MySQL Tables'|trans }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <div class="form-group">
           <select class="form-control js-db-tables-select"
                   title="{{ 'List of MySQL Tables'|trans }}"
@@ -61,7 +61,7 @@
       <h3 class="card-header">
           {{ 'List of attributes for this MySQL table'|trans }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <table class="table js-table-columns d-none" data-action-btn="{{ 'Add attribute to SQL query'|trans }}">
           <thead>
             <tr>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/form.html.twig
@@ -32,8 +32,8 @@
       <h3 class="card-header">
         {{ 'SQL query'|trans }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_widget(requestSqlForm) }}
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/settings_panel.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/Blocks/settings_panel.html.twig
@@ -32,8 +32,8 @@
         <i class="material-icons">settings</i>
         {{ 'Settings'|trans({}, 'Admin.Global') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(requestSqlSettingsForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/RequestSql/view.html.twig
@@ -36,7 +36,7 @@
           ({{ sqlRequestResult.rows|length }})
         </h3>
       </div>
-      <div class="card-block">
+      <div class="card-body">
         {% if sqlRequestResult.rows is not empty %}
           <div class="table-responsive">
             <table id="grid-table" class="table">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/Blocks/form.html.twig
@@ -31,8 +31,8 @@
     <h3 class="card-header">
       {{ 'Webservice Accounts'|trans({}, 'Admin.Advparameters.Feature') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_row(webserviceKeyForm.key) }}
         {{ form_row(webserviceKeyForm.description) }}
         {{ form_row(webserviceKeyForm.status) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Webservice/webservice_settings.html.twig
@@ -32,8 +32,8 @@
       <i class="material-icons">settings</i> {{ 'Configuration'|trans({}, 'Admin.Global') }}
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(webserviceConfigurationForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
@@ -89,9 +89,7 @@
       </h3>
       <div class="card-body">
         <div class="form-wrapper">
-          <div class="form-wrapper">
-            {{ form_widget(notificationsForm) }}
-          </div>
+          {{ form_widget(notificationsForm) }}
         </div>
       </div>
       <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/administration.html.twig
@@ -36,8 +36,8 @@
         <i class="material-icons">settings</i>
         {{ 'General'|trans({}, 'Admin.Global') }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_widget(generalForm) }}
         </div>
       </div>
@@ -57,8 +57,8 @@
         <i class="material-icons">file_upload</i>
         {{ 'Upload quota'|trans }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_widget(uploadQuotaForm) }}
         </div>
       </div>
@@ -87,9 +87,9 @@
               title="">
         </span>
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
-          <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
+          <div class="form-wrapper">
             {{ form_widget(notificationsForm) }}
           </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
@@ -39,8 +39,8 @@
         <i class="material-icons">business_center</i>
         {{ 'Smarty'|trans }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {% block perfs_form_smarty_cache_form %}
             {{ form_widget(smartyForm) }}
           {% endblock %}
@@ -62,8 +62,8 @@
         <i class="material-icons">bug_report</i>
         {{ 'Debug mode'|trans }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {% block perfs_form_debug_mode_form %}
             {{ form_widget(debugModeForm) }}
           {% endblock %}
@@ -94,8 +94,8 @@
               title="">
         </span>
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {% block perfs_form_optional_features_form %}
             {{ form_widget(optionalFeaturesForm) }}
           {% endblock %}
@@ -126,8 +126,8 @@
               title="">
         </span>
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {% block perfs_form_ccc_form %}
             {{ form_widget(combineCompressCacheForm) }}
           {% endblock %}
@@ -158,8 +158,8 @@
               title="">
         </span>
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {% block perfs_form_media_servers_form %}
             {{ form_widget(mediaServersForm) }}
           {% endblock %}
@@ -181,8 +181,8 @@
         <i class="material-icons">link</i>
         {{ 'Caching'|trans }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {% block perfs_form_caching_form %}
             {{ form_widget(cachingForm) }}
           {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -32,7 +32,7 @@
       <h3 class="card-header">
         <i class="material-icons">info_outline</i> {{ 'Configuration information'|trans }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <div class="card-text">
           <p>{{ 'This information must be provided when you report an issue on GitHub or on the forum.'|trans }}</p>
         </div>
@@ -43,7 +43,7 @@
       <h3 class="card-header">
         <i class="material-icons">info_outline</i> {{ 'Server information'|trans }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <div class="card-text">
           {% if system.uname is not empty %}
             <p>
@@ -76,7 +76,7 @@
       <h3 class="card-header">
         <i class="material-icons">info_outline</i> {{ 'Database information'|trans({}, 'Admin.Advparameters.Feature') }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <div class="card-text">
           <p>
             <strong>{{ 'MySQL version:'|trans }}</strong> {{ system.database.version }}
@@ -107,7 +107,7 @@
       <h3 class="card-header">
         <i class="material-icons">info_outline</i> {{ 'List of overrides'|trans({}, 'Admin.Advparameters.Feature') }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <div class="card-text">
           <ul>
             {% for override in system.overrides %}
@@ -123,7 +123,7 @@
       <h3 class="card-header">
         <i class="material-icons">info_outline</i> {{ 'Store information'|trans }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <div class="card-text">
           <p>
             <strong>{{ 'PrestaShop version:'|trans }}</strong> {{ system.shop.version }}
@@ -145,7 +145,7 @@
       <h3 class="card-header">
         <i class="material-icons">info_outline</i> {{ 'Mail configuration'|trans }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <div class="card-text">
           {% if system.isNativePHPmail %}
             <p>
@@ -189,7 +189,7 @@
       <h3 class="card-header">
         <i class="material-icons">info_outline</i> {{ 'Your information'|trans }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <div class="card-text">
           <p>
             <strong>{{ 'Your web browser:'|trans }}</strong> {{ userAgent }}
@@ -202,7 +202,7 @@
       <h3 class="card-header">
         <i class="material-icons">info_outline</i> {{ 'Check your configuration'|trans }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         <div class="card-text">
           {% if requirements.failRequired == false %}
             <p>
@@ -252,7 +252,7 @@
   <h3 class="card-header">
     <i class="material-icons">info_outline</i> {{ 'List of changed files'|trans }}
   </h3>
-  <div class="card-block">
+  <div class="card-body">
     <div class="card-text" id="changedFiles">
       <i class="material-icons">loop</i> {{ 'Checking files...'|trans({}, 'Admin.Advparameters.Notification') }}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -33,8 +33,8 @@
       <i class="material-icons">settings</i>
       {{ 'General'|trans({}, 'Admin.Global') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(generalForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
@@ -33,8 +33,8 @@
       <i class="material-icons">settings</i>
       {{ 'Products (general)'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="form-group row">
           {{ ps.label_with_help(('Catalog mode'|trans), ('Catalog mode disables the shopping cart on your store. Visitors will be able to browse your products catalog, but not buy them.'|trans({}, 'Admin.Shopparameters.Help'))) }}
           <div class="col-sm">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
@@ -32,8 +32,8 @@
       <i class="material-icons">shopping_basket</i>
       {{ 'Product page'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="form-group row">
           <label class="form-control-label">
             {{ 'Display available quantities on the product page'|trans }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
@@ -33,8 +33,8 @@
       <i class="material-icons">view_headline</i>
       {{ 'Pagination'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="form-group row">
           {{ ps.label_with_help(('Products per page'|trans), ('Number of products displayed per page. Default is 10.'|trans({}, 'Admin.Shopparameters.Help'))) }}
           <div class="col-sm">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
@@ -33,8 +33,8 @@
       <i class="material-icons">shop</i>
       {{ 'Products stock'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="form-group row">
           {{ ps.label_with_help(('Allow ordering of out-of-stock products'|trans), ('By default, the "%add_to_cart_label%" button is hidden when a product is unavailable. You can choose to have it displayed in all cases.'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help'))) }}
           <div class="col-sm">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Contact/Contacts/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Contact/Contacts/Blocks/form.html.twig
@@ -32,8 +32,8 @@
         <i class="material-icons">mail_outline</i>
         {{ 'Contacts'|trans({}, 'Admin.Shopparameters.Feature') }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_widget(contactForm) }}
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_general.html.twig
@@ -32,8 +32,8 @@
       <i class="material-icons">settings</i>
       {{ 'General'|trans({}, 'Admin.Global') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(generalForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderPreferences/Blocks/order_preferences_gift_options.html.twig
@@ -32,8 +32,8 @@
       <i class="material-icons">cake</i>
       {{ 'Gift options'|trans({}, 'Admin.Shopparameters.Feature') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(giftOptionsForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig
@@ -32,8 +32,8 @@
         <i class="material-icons">schedule</i>
         {{ 'Return statuses'|trans({}, 'Admin.Shopparameters.Feature') }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_errors(orderReturnStateForm) }}
 
           {{ ps.form_group_row(orderReturnStateForm.name, {}, {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig
@@ -32,8 +32,8 @@
         <i class="material-icons">schedule</i>
         {{ 'Order status'|trans({}, 'Admin.Shopparameters.Feature') }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_errors(orderStateForm) }}
 
           {{ ps.form_group_row(orderStateForm.name, {}, {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/form.html.twig
@@ -30,8 +30,8 @@
     <div class="card-header">
       {{ 'Meta tags'|trans({}, 'Admin.Shopparameters.Feature') }}
     </div>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_errors(metaForm) }}
 
         {{ ps.form_group_row(metaForm.page_name, {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/robots_file_generation.html.twig
@@ -32,8 +32,8 @@
     {{ 'Robots file generation'|trans }}
   </h3>
 
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       <div class="alert alert-info" role="alert">
         <div class="alert-text">
           {% set defaultDescription = 'Your robots.txt file MUST be in your website\'s root directory and nowhere else (e.g. http://www.example.com/robots.txt).'|trans({}, 'Admin.Shopparameters.Notification') %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/seo_options_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/seo_options_configuration.html.twig
@@ -31,8 +31,8 @@
     <h3 class="card-header">
       <i class="material-icons">settings</i> {{ 'SEO options'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(seoOptionsForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/set_up_urls_configuration.html.twig
@@ -31,8 +31,8 @@
     <h3 class="card-header">
       <i class="material-icons">settings</i> {{ 'Set up URLs'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(setUpUrlsForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/shop_urls_configuration.html.twig
@@ -35,8 +35,8 @@
         <i class="material-icons">settings</i>
         {{ cardHeaderLabel }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
 
           <div class="alert alert-info" role="alert">
             <div class="alert-text">
@@ -64,8 +64,8 @@
               title="">
         </span>
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_widget(shopUrlsForm) }}
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/Meta/Blocks/url_schema_configuration.html.twig
@@ -42,8 +42,8 @@
       >
       </span>
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(urlSchemaForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/TrafficSeo/SearchEngines/Blocks/form.html.twig
@@ -31,8 +31,8 @@
       {{ 'Referrer'|trans({}, 'Admin.Shopparameters.Feature') }}
     </div>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_errors(searchEngineForm) }}
 
         {% block search_engine_form_widget %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/maintenance.html.twig
@@ -35,8 +35,8 @@
         <i class="material-icons">business_center</i>
         {{ 'General'|trans({}, 'Admin.Global') }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_widget(generalForm) }}
           {{ form_rest(generalForm) }}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/preferences.html.twig
@@ -34,8 +34,8 @@
         <i class="material-icons">settings</i>
         {{ 'General'|trans({}, 'Admin.Global') }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {% if not app.request.isSecure() %}
             <div class="form-group row">
               <label class="form-control-label ">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/breadcrumb.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/breadcrumb.html.twig
@@ -25,7 +25,7 @@
 
 {% if cmsPageView.breadcrumb_tree is not empty %}
   <div class="card">
-    <div class="card-block">
+    <div class="card-body">
       <nav>
         <ol class="breadcrumb">
           {% for category in cmsPageView.breadcrumb_tree %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/category_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/category_form.html.twig
@@ -32,8 +32,8 @@
     <div class="card-header">
       {{ 'CMS Category'|trans({}, 'Admin.Design.Feature') }}
     </div>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(cmsPageCategoryForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -30,8 +30,8 @@
   <div class="card-header">
     {{ 'Page'|trans({}, 'Admin.Shopparameters.Feature') }}
   </div>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_widget(cmsPageForm) }}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig
@@ -32,8 +32,8 @@
     {{ 'Configuration'|trans({}, 'Admin.Global') }}
   </h3>
 
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       <div class="form-group row">
         {{ ps.label_with_help(
           ('Select your default email theme'|trans({}, 'Admin.Design.Feature')),

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
@@ -33,8 +33,8 @@
       {{ 'Generate emails'|trans({}, 'Admin.Design.Feature') }}
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
 
         <div class="form-group row">
           <label class="form-control-label">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
@@ -31,7 +31,7 @@
       {{ 'List %theme% layouts'|trans({'%theme%': mailTheme.name}, 'Admin.Design.Feature') }}
     </h3>
 
-    <div class="card-block">
+    <div class="card-body">
 
       <table class="grid-table table">
         <thead class="thead-default">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_themes.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_themes.html.twig
@@ -30,7 +30,7 @@
       {{ 'Email themes'|trans({}, 'Admin.Design.Feature') }}
     </h3>
 
-    <div class="card-block">
+    <div class="card-body">
 
       <table class="grid-table table">
         <thead class="thead-default">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
@@ -32,8 +32,8 @@
       {{ 'Translate emails'|trans({}, 'Admin.Actions') }}
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="form-group row">
           <label class="form-control-label">
             {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/multishop_switch.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/multishop_switch.html.twig
@@ -28,8 +28,8 @@
   <h3 class="card-header">
     {{ 'Multistore'|trans({}, 'Admin.Global') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ ps.multistore_switch(shopLogosForm, {
         'label': 'Multistore'|trans({}, 'Admin.Global'),
       }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/rtl_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/Blocks/rtl_configuration.html.twig
@@ -30,8 +30,8 @@
   <h3 class="card-header">
     {{ 'Adaptation to Right-to-Left languages'|trans({}, 'Admin.Design.Feature') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       <div class="alert alert-info">
         <p class="alert-text">
           {{ 'Be careful! Please check your theme in an RTL language before generating the RTL stylesheet: your theme could be already adapted to RTL.\nOnce you enable the "%generate_rtl_label%" option, any RTL-specific file that you might have added to your theme might be deleted by the created stylesheet.'|trans({'%generate_rtl_label%': 'Generate RTL stylesheet'|trans({}, 'Admin.Design.Feature')}, 'Admin.Design.Help') }}
@@ -50,8 +50,8 @@
 
   {% if isMultiShopFeatureUsed and isSingleShopContext %}
     <hr>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ ps.multistore_switch(shopLogosForm, {
           'label': 'Multistore'|trans({}, 'Admin.Global'),
         }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
@@ -51,8 +51,8 @@
           <i class="material-icons">file_copy</i>
           {{ 'Import from your computer'|trans({}, 'Admin.Design.Feature') }}
         </h3>
-        <div class="card-block row">
-          <div class="card-text">
+        <div class="card-body">
+          <div class="form-wrapper">
             {{ form_row(importThemeForm.import_from_computer) }}
           </div>
         </div>
@@ -73,8 +73,8 @@
           <i class="material-icons">file_copy</i>
           {{ 'Import from the web'|trans({}, 'Admin.Design.Feature') }}
         </h3>
-        <div class="card-block row">
-          <div class="card-text">
+        <div class="card-body">
+          <div class="form-wrapper">
             {{ form_row(importThemeForm.import_from_web) }}
           </div>
         </div>
@@ -95,8 +95,8 @@
           <i class="material-icons">file_copy</i>
           {{ 'Import from FTP'|trans({}, 'Admin.Design.Feature') }}
         </h3>
-        <div class="card-block row">
-          <div class="card-text">
+        <div class="card-body">
+          <div class="form-wrapper">
             {{ form_row(importThemeForm.import_from_ftp) }}
           </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -80,59 +80,60 @@
       <div class="card-header">
         {{ 'My theme for %name% shop'|trans({'%name%': shopName}, 'Admin.Design.Feature') }}
       </div>
-      <div class="card-body row">
+      <div class="card-body">
+        <div class="row">
+          {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
+            'themeName': currentlyUsedTheme.get('display_name'),
+            'themeVersion': currentlyUsedTheme.get('version'),
+            'themeAuthor': currentlyUsedTheme.get('author.name'),
+            'themeAuthorUrl': theme.get('author.url'),
+            'isActive': true
+          } %}
+            {% block image %}
+              <img src="{{ baseShopUrl }}{{ currentlyUsedTheme.get('preview') }}" alt="{{ currentlyUsedTheme.get('display_name') }}">
+            {% endblock %}
+            {% block button_container %}
+              <button class="btn action-button">
+                <i class="material-icons icon-current-theme">done</i>
+                {{ 'My current theme'|trans({}, 'Admin.Design.Feature') }}
+              </button>
+            {% endblock %}
+          {% endembed %}
 
-        {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
-          'themeName': currentlyUsedTheme.get('display_name'),
-          'themeVersion': currentlyUsedTheme.get('version'),
-          'themeAuthor': currentlyUsedTheme.get('author.name'),
-          'themeAuthorUrl': theme.get('author.url'),
-          'isActive': true
-        } %}
-          {% block image %}
-            <img src="{{ baseShopUrl }}{{ currentlyUsedTheme.get('preview') }}" alt="{{ currentlyUsedTheme.get('display_name') }}">
-          {% endblock %}
-          {% block button_container %}
-            <button class="btn action-button">
-              <i class="material-icons icon-current-theme">done</i>
-              {{ 'My current theme'|trans({}, 'Admin.Design.Feature') }}
-            </button>
-          {% endblock %}
-        {% endembed %}
-
-        {% if notUsedThemes is not empty %}
-          {% for theme in notUsedThemes %}
-            {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
-              'themeName': theme.get('display_name'),
-              'themeVersion': theme.get('version'),
-              'themeAuthor': theme.get('author.name'),
-              'themeAuthorUrl': theme.get('author.url'),
-              'isActive': false
-            }  %}
-              {% block image %}
-                <img src="{{ baseShopUrl }}{{ theme.get('preview') }}" alt="{{ theme.get('display_name') }}">
-              {% endblock %}
-              {% block button_container %}
-                <form action="{{ path('admin_themes_enable', {'themeName': theme.name}) }}" method="post" class="d-inline">
-                  <input type="hidden" name="token" value="{{ csrf_token('enable-theme') }}"/>
-                  <button type="button" class="btn action-button js-display-use-theme-modal" {{ (not isSingleShopContext) ? 'disabled' : '' }}>
-                    <i class="material-icons">
-                      present_to_all
-                    </i>
-                    <span>{{ 'Use this theme'|trans({}, 'Admin.Design.Feature') }}</span>
-                  </button>
-                </form>
-                <form action="{{ path('admin_themes_delete', {'themeName': theme.name}) }}" method="post" class="d-inline">
-                  <input type="hidden" name="token" value="{{ csrf_token('delete-theme') }}"/>
-                  <button type="button" class="btn delete-button js-display-delete-theme-modal">
-                    <i class="material-icons">
-                      delete
-                    </i>
-                  </button>
-                </form>
-              {% endblock %}
-            {% endembed %}
-          {% endfor %}
+          {% if notUsedThemes is not empty %}
+            {% for theme in notUsedThemes %}
+              {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
+                'themeName': theme.get('display_name'),
+                'themeVersion': theme.get('version'),
+                'themeAuthor': theme.get('author.name'),
+                'themeAuthorUrl': theme.get('author.url'),
+                'isActive': false
+              }  %}
+                {% block image %}
+                  <img src="{{ baseShopUrl }}{{ theme.get('preview') }}" alt="{{ theme.get('display_name') }}">
+                {% endblock %}
+                {% block button_container %}
+                  <form action="{{ path('admin_themes_enable', {'themeName': theme.name}) }}" method="post" class="d-inline">
+                    <input type="hidden" name="token" value="{{ csrf_token('enable-theme') }}"/>
+                    <button type="button" class="btn action-button js-display-use-theme-modal" {{ (not isSingleShopContext) ? 'disabled' : '' }}>
+                      <i class="material-icons">
+                        present_to_all
+                      </i>
+                      <span>{{ 'Use this theme'|trans({}, 'Admin.Design.Feature') }}</span>
+                    </button>
+                  </form>
+                  <form action="{{ path('admin_themes_delete', {'themeName': theme.name}) }}" method="post" class="d-inline">
+                    <input type="hidden" name="token" value="{{ csrf_token('delete-theme') }}"/>
+                    <button type="button" class="btn delete-button js-display-delete-theme-modal">
+                      <i class="material-icons">
+                        delete
+                      </i>
+                    </button>
+                  </form>
+                {% endblock %}
+              {% endembed %}
+            {% endfor %}
+          </div>
 
           {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/use_theme_modal.html.twig' %}
           {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/delete_theme_modal.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/exchange_rates.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/exchange_rates.html.twig
@@ -30,8 +30,8 @@
     <h3 class="card-header">
       {{ 'Exchange rate'|trans({}, 'Admin.International.Feature') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="form-group row">
           <label class="form-control-label" for="{{ exchangeRatesForm.live_exchange_rate.vars.id }}">
             {{ form_label(exchangeRatesForm.live_exchange_rate) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/Blocks/form.html.twig
@@ -56,8 +56,8 @@
       <div class="card-header">
         {{ 'Currencies'|trans({}, 'Admin.Global') }}
       </div>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_errors(currencyForm) }}
 
           {% if not currencyForm.vars.data.id is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig
@@ -31,8 +31,8 @@
     <h3 class="card-header">
       {{ 'Geolocation by IP address'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(geolocationByIpAddressForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig
@@ -42,8 +42,8 @@
       >
       </span>
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(geolocationIpAddressWhitelistForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig
@@ -42,8 +42,8 @@
       >
       </span>
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(geolocationOptionsForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/Blocks/form.html.twig
@@ -31,8 +31,8 @@
     <i class="material-icons">language</i>
     {{ 'Languages'|trans({}, 'Admin.Global') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_widget(languageForm) }}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig
@@ -32,8 +32,8 @@
       <i class="material-icons">settings</i> {{ 'Advanced'|trans({}, 'Admin.Global') }}
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(advancedForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/configuration.html.twig
@@ -32,8 +32,8 @@
       <i class="material-icons">settings</i> {{ 'Configuration'|trans({}, 'Admin.Global') }}
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">`
+    <div class="card-body">
+      <div class="form-wrapper">`
         {{ form_widget(configurationForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig
@@ -33,8 +33,8 @@
       <i class="material-icons">language</i> {{ 'Import a localization pack'|trans }}
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(localizationPackImportForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/Blocks/local_units.html.twig
@@ -32,8 +32,8 @@
       <i class="material-icons">language</i> {{ 'Local units'|trans }}
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(localUnitsForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/form.html.twig
@@ -31,8 +31,8 @@
     {{ 'Taxes'|trans({}, 'Admin.Global') }}
   </div>
 
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_errors(taxForm) }}
       {% block tax_form_widget %}
         {{ form_widget(taxForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/tax_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/Blocks/tax_options.html.twig
@@ -30,8 +30,8 @@
   <h3 class="card-header">
     {{ 'Tax options'|trans({}, 'Admin.International.Feature') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {% block tax_options_form_widget %}
         {{ form_widget(taxOptionsForm) }}
       {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig
@@ -44,8 +44,8 @@
     </span>
   </h3>
 
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_widget(addUpdateLanguageForm) }}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
@@ -35,8 +35,8 @@
       {{ 'Copy'|trans({}, 'Admin.Actions') }}
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="row">
           <div class="col-sm">
             <div class="alert alert-info" role="alert">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/export_language.html.twig
@@ -43,8 +43,8 @@
     >
     </span>
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_rest(exportCataloguesForm) }}
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig
@@ -45,8 +45,8 @@
       </span>
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(modifyTranslationsForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Zone/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Zone/Blocks/form.html.twig
@@ -31,8 +31,8 @@
       {{ 'Zones'|trans({}, 'Admin.International.Feature') }}
     </div>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_errors(zoneForm) }}
         {% block form_zone_widget %}
           {{ form_widget(zoneForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
@@ -40,7 +40,7 @@
         <i class="material-icons">credit_card</i>
         {{ 'Active payment'|trans }}
       </h3>
-      <div class="card-block">
+      <div class="card-body">
         {% include '@PrestaShop/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig' %}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig
@@ -32,8 +32,8 @@
       <i class="material-icons">local_shipping</i>
       {{ 'Carrier options'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(carrierOptionsForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
@@ -41,8 +41,8 @@
             title="">
       </span>
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ form_widget(handlingForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
@@ -36,7 +36,7 @@
   {% set column_default_xl_3 = 'col-xl-4' %}
 {% endif %}
 
-<div class="card card-block">
+<div class="card card-body">
   <h4><b>{{ 'Specific price conditions'|trans({}, 'Admin.Catalog.Feature') }}</b></h4>
   {{ form_errors(form) }}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Address/Blocks/form.html.twig
@@ -34,8 +34,8 @@
     {{ 'Addresses'|trans({}, 'Admin.Navigation.Menu') }}
   </div>
 
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_errors(addressForm) }}
 
       {% block customer_information %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig
@@ -33,8 +33,8 @@
         <i class="material-icons">attachment</i>
         {{ 'File'|trans({}, 'Admin.Global') }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_errors(attachmentForm) }}
           {{ form_widget(attachmentForm) }}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig
@@ -31,8 +31,8 @@
     <i class="material-icons">attach_money</i>
     {{ 'Catalog price rules'|trans({}, 'Admin.Catalog.Feature') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ ps.form_group_row(catalogPriceRuleForm.name, {}, {
         'label': 'Name'|trans({}, 'Admin.Global'),
       }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 <div class="card">
-  <div class="card-block">
+  <div class="card-body">
     <nav>
       <ol class="breadcrumb">
         {% for category in currentCategoryView.breadcrumb_tree %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -31,8 +31,8 @@
   <h3 class="card-header">
     {{ 'Category'|trans({}, 'Admin.Catalog.Feature') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_errors(categoryForm) }}
 
       {{ ps.form_group_row(categoryForm.name, {}, {

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/Blocks/form.html.twig
@@ -33,8 +33,8 @@
       {{ 'Feature'|trans({}, 'Admin.Catalog.Feature') }}
     </h3>
 
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ ps.form_group_row(featureForm.name, {}, {
           'label': 'Name'|trans({}, 'Admin.Global'),
           'help': 'Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>={}'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig
@@ -30,8 +30,8 @@
   <div class="card-header">
     {{ 'Addresses'|trans({}, 'Admin.Catalog.Feature') }}
   </div>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_row(addressForm.id_manufacturer) }}
       {{ form_row(addressForm.last_name) }}
       {{ form_row(addressForm.first_name) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig
@@ -31,8 +31,8 @@
     <i class="material-icons">star</i>
     {{ 'Brands'|trans({}, 'Admin.Catalog.Feature') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_row(manufacturerForm.name) }}
       {{ form_row(manufacturerForm.short_description) }}
       {{ form_row(manufacturerForm.description) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
@@ -40,7 +40,7 @@
       -
       <span>{{ combinationForm.vars.value.name }}</span>
     </div>
-    <div class="card-block row">
+    <div class="card-body">
       <div id="{{ combinationForm.vars.id }}">
         {{ form_row(combinationForm) }}
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig
@@ -31,8 +31,8 @@
     <i class="material-icons">local_shipping</i>
     {{ 'Suppliers'|trans({}, 'Admin.Global') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
 
       {{ form_row(supplierForm.name) }}
       {{ form_row(supplierForm.description) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/form.html.twig
@@ -34,8 +34,8 @@
         <i class="material-icons">person</i>
         {{ 'Customer'|trans({}, 'Admin.Global') }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           {{ form_widget(customerForm) }}
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/options.html.twig
@@ -30,8 +30,8 @@
     <h3 class="card-header">
       {{ 'Merchandise return (RMA) options'|trans({}, 'Admin.Orderscustomers.Feature') }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         {{ ps.form_group_row(merchandiseReturnsOptionsForm.enable_order_return, {}, {
           label: 'Enable returns'|trans({}, 'Admin.Orderscustomers.Feature'),
           help: 'Would you like to allow merchandise returns in your shop?'|trans({}, 'Admin.Orderscustomers.Help')

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/OrderMessage/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/OrderMessage/Blocks/form.html.twig
@@ -31,8 +31,8 @@
     <i class="material-icons">person</i>
     {{ 'Order messages'|trans({}, 'Admin.Orderscustomers.Feature') }}
   </h3>
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {{ form_errors(orderMessageForm) }}
       {% block order_message_form_widget %}
         {{ form_widget(orderMessageForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/credit_slip_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/credit_slip_options.html.twig
@@ -37,8 +37,8 @@
     <i class="material-icons">settings</i> {{ 'Credit slip options'|trans({}, 'Admin.Orderscustomers.Feature') }}
   </h3>
 
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {% block credit_slip_options_form %}
         {{ form_widget(creditSlipOptionsForm) }}
       {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/CreditSlip/Blocks/pdf_by_date.html.twig
@@ -36,8 +36,8 @@
     <i class="material-icons">date_range</i> {{ 'By date'|trans }}
   </h3>
 
-  <div class="card-block row">
-    <div class="card-text">
+  <div class="card-body">
+    <div class="form-wrapper">
       {% block credit_slip_pdf_by_date_form %}
         {{ form_widget(pdfByDateForm) }}
       {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig
@@ -37,8 +37,8 @@
         <i class="material-icons">print</i>
         {{ 'Print PDF'|trans }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           <div class="form-group row">
             {{ ps.label_with_help('From'|trans({}, 'Admin.Global'), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
             <div class="col-sm">
@@ -72,8 +72,8 @@
         <i class="material-icons">settings</i>
         {{ 'Delivery slip options'|trans }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           <div class="form-group row">
             {{ ps.label_with_help(('Delivery prefix'|trans), ('Prefix used for delivery slips.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
             <div class="col-sm">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_date.html.twig
@@ -33,8 +33,8 @@
       <i class="material-icons">date_range</i>
       {{ 'By date'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="form-group row">
           {{ ps.label_with_help(('From'|trans({}, 'Admin.Global')), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
           <div class="col-sm">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/generate_by_status.html.twig
@@ -36,8 +36,8 @@
         <i class="material-icons">schedule</i>
         {{ 'By order status'|trans }}
       </h3>
-      <div class="card-block row">
-        <div class="card-text">
+      <div class="card-body">
+        <div class="form-wrapper">
           <div class="form-group row">
             {{ ps.label_with_help(('Order statuses'|trans), ('You can also export orders which have not been charged yet.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
             <div class="col-sm">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig
@@ -33,8 +33,8 @@
       <i class="material-icons">settings</i>
       {{ 'Invoice options'|trans }}
     </h3>
-    <div class="card-block row">
-      <div class="card-text">
+    <div class="card-body">
+      <div class="form-wrapper">
         <div class="form-group row">
           {{ ps.label_with_help('Enable invoices'|trans, 'If enabled, your customers will receive an invoice for the purchase.'|trans({}, 'Admin.Orderscustomers.Help')) }}
           <div class="col-sm">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Markup inside card was wrongly used, card-block class doesn't exist, card-text is used to display text and nothing else, row were used without using col classes...
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25586.
| How to test?      | Check every files (you should find which page is associated to the file in the path of the file) and see if the card is not buggy (It's a bootstrap components with gray background, header, footer and content0
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25879)
<!-- Reviewable:end -->
