### PR TITLE
Respect country setting "Display tax label (e.g. "Tax incl.")" in cart and order confirmation page

### DIFF
--- a/classes/checkout/DeliveryOptionsFinder.php
+++ b/classes/checkout/DeliveryOptionsFinder.php
@@ -74,7 +74,7 @@ class DeliveryOptionsFinderCore
     {
         $delivery_option_list = $this->context->cart->getDeliveryOptionList();
         $include_taxes = !Product::getTaxCalculationMethod((int) $this->context->cart->id_customer) && (int) Configuration::get('PS_TAX');
-        $display_taxes_label = (Configuration::get('PS_TAX') && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'));
+        $display_taxes_label = (Configuration::get('PS_TAX') && $this->context->country->display_tax_label && !Configuration::get('AEUC_LABEL_TAX_INC_EXC'));
 
         $carriers_available = [];
 

--- a/themes/classic/templates/checkout/_partials/cart-summary-totals.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-summary-totals.tpl
@@ -36,7 +36,7 @@
       </div>
     {else}
       <div class="cart-summary-line cart-total">
-        <span class="label">{$cart.totals.total.label}&nbsp;{if $configuration.taxes_enabled}{$cart.labels.tax_short}{/if}</span>
+        <span class="label">{$cart.totals.total.label}&nbsp;{if $configuration.display_taxes_label && $configuration.taxes_enabled}{$cart.labels.tax_short}{/if}</span>
         <span class="value">{$cart.totals.total.value}</span>
       </div>
     {/if}

--- a/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/themes/classic/templates/checkout/_partials/order-confirmation-table.tpl
@@ -124,7 +124,7 @@
           </tr>
         {else}
           <tr class="total-value font-weight-bold">
-            <td><span class="text-uppercase">{$totals.total.label}&nbsp;{if $configuration.taxes_enabled}{$labels.tax_short}{/if}</span></td>
+            <td><span class="text-uppercase">{$totals.total.label}&nbsp;{if $configuration.taxes_enabled && $configuration.display_taxes_label}{$labels.tax_short}{/if}</span></td>
             <td>{$totals.total.value}</td>
           </tr>
         {/if}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Carrier price and cart summary total do not follow the country "show tax label" setting
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially Fixes #21484
| How to test?      | Mark at least one country as "Display tax label (e.g. "Tax incl.")" no in country settings. Add product to basket. Use the country with label no setting as the address. Check that "tax incl" text is not shown for carrier price on delivery step and cart summary total line on the right side of the process and on the total line on order confirmation page.
| Possible impacts? | Cart functionality and showing the label in different places of the process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25882)
<!-- Reviewable:end -->
