### PR TITLE
Fix update qty of cart when qty is set to 0 on front-office

### DIFF
--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -194,8 +194,8 @@ $(document).ready(() => {
         let dataset;
 
         if ($target && $target.dataset) {
-        // eslint-disable-next-line
-        dataset = $target.dataset;
+          // eslint-disable-next-line prefer-destructuring
+          dataset = $target.dataset;
         } else {
           dataset = resp;
         }

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -194,8 +194,8 @@ $(document).ready(() => {
         let dataset;
 
         if ($target && $target.dataset) {
-          // eslint-disable-next-line
-          dataset = $target.dataset;
+        // eslint-disable-next-line
+        dataset = $target.dataset;
         } else {
           dataset = resp;
         }
@@ -258,12 +258,16 @@ $(document).ready(() => {
   $body.on('focusout keyup', productLineInCartSelector, (event) => {
     if (event.type === 'keyup') {
       if (event.keyCode === 13) {
+        isUpdateOperation = true;
         updateProductQuantityInCart(event);
       }
+
       return false;
     }
 
-    updateProductQuantityInCart(event);
+    if (!isUpdateOperation) {
+      updateProductQuantityInCart(event);
+    }
 
     return false;
   });

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -247,8 +247,13 @@ $(document).ready(() => {
       return;
     }
 
-    $target.attr('value', targetValue);
-    sendUpdateQuantityInCartRequest(updateQuantityInCartUrl, getRequestData(qty), $target);
+    if (targetValue === '0') {
+      console.log($target.closest('[data-link-action="delete-from-cart"]'));
+      $target.closest('.product-line-actions').find('[data-link-action="delete-from-cart"]').click();
+    } else {
+      $target.attr('value', targetValue);
+      sendUpdateQuantityInCartRequest(updateQuantityInCartUrl, getRequestData(qty), $target);
+    }
   }
 
   $body.on('focusout keyup', productLineInCartSelector, (event) => {

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -256,7 +256,6 @@ $(document).ready(() => {
   }
 
   $body.on('focusout keyup', productLineInCartSelector, (event) => {
-    isUpdateOperation = false;
     if (event.type === 'keyup') {
       if (event.keyCode === 13) {
         isUpdateOperation = true;

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -248,7 +248,6 @@ $(document).ready(() => {
     }
 
     if (targetValue === '0') {
-      console.log($target.closest('[data-link-action="delete-from-cart"]'));
       $target.closest('.product-line-actions').find('[data-link-action="delete-from-cart"]').click();
     } else {
       $target.attr('value', targetValue);

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -256,6 +256,7 @@ $(document).ready(() => {
   }
 
   $body.on('focusout keyup', productLineInCartSelector, (event) => {
+    isUpdateOperation = false;
     if (event.type === 'keyup') {
       if (event.keyCode === 13) {
         isUpdateOperation = true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When you update the product qty to 0 with the keyboard, product is having a strange behavior
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25470.
| How to test?      | Add a product to the cart, update the qty to 10 manually by typing it and press enter, it should be fine, update, do the same thing but with 0 => the product should be removed
| Possible impacts? | Cart qty update


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25883)
<!-- Reviewable:end -->
