### PR TITLE
Fixed modal content when bulk delete combinations

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -358,4 +358,5 @@
 "tax excl.": "tax excl."|trans({}, 'Admin.Catalog.Feature'),
 "You can't create pack product with variations. Are you sure to disable variations ? they will all be deleted.": "A pack of products can't have combinations."|trans({}, "Admin.Catalog.Notification") ~ ' ' ~ js_translatable['Are you sure to disable variations ? they will all be deleted'],
 "You can't create virtual product with variations. Are you sure to disable variations ? they will all be deleted.": "A virtual product can't have combinations."|trans({}, "Admin.Catalog.Notification") ~ ' ' ~ js_translatable['Are you sure to disable variations ? they will all be deleted'],
+"Are you sure you want to delete the selected item(s)?": "Are you sure you want to delete the selected item(s)?"|trans({}, 'Admin.Global'),
 }|merge(js_translatable) %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixed modal content when bulk delete combinations
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25901
| How to test?      | Cf. #25901
| Possible impacts? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25904)
<!-- Reviewable:end -->
