### PR TITLE
Fix object model partial update

### DIFF
--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationDetailsHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationDetailsHandler.php
@@ -107,6 +107,7 @@ final class UpdateCombinationDetailsHandler implements UpdateCombinationDetailsH
 
         if (null !== $command->getWeight()) {
             $combination->weight = (float) (string) $command->getWeight();
+            $updatableProperties[] = 'weight';
         }
 
         return $updatableProperties;

--- a/tests/Integration/Classes/ObjectModelTest.php
+++ b/tests/Integration/Classes/ObjectModelTest.php
@@ -105,7 +105,7 @@ class ObjectModelTest extends TestCase
         $this->assertNotNull($newObject->id);
         // Only the id field is filled, the identified primary key should also be updated
         // $this->assertNotNull($object->id_testable_object);
-        $createdId = $newObject->id;
+        $createdId = (int) $newObject->id;
 
         $multiLangObject = new TestableObjectModel($createdId);
         $this->assertEquals($createdId, $multiLangObject->id);
@@ -113,6 +113,51 @@ class ObjectModelTest extends TestCase
         $this->assertEquals($quantity, $multiLangObject->quantity);
         $this->assertTrue((bool) $multiLangObject->enabled);
         $this->assertEquals($localizedNames, $multiLangObject->name);
+
+        $defaultLangObject = new TestableObjectModel($createdId, $this->defaultLanguageId);
+        $this->assertEquals($localizedNames[$this->defaultLanguageId], $defaultLangObject->name);
+
+        $secondLangObject = new TestableObjectModel($createdId, $this->secondLanguageId);
+        $this->assertEquals($localizedNames[$this->secondLanguageId], $secondLangObject->name);
+    }
+
+    public function testUpdate(): void
+    {
+        $quantity = 42;
+        $localizedNames = [
+            $this->defaultLanguageId => 'Default name',
+            $this->secondLanguageId => 'Second name',
+        ];
+
+        $newObject = new TestableObjectModel();
+        $newObject->quantity = $quantity;
+        $newObject->enabled = true;
+        $newObject->name = $localizedNames;
+
+        $this->assertTrue((bool) $newObject->add());
+        $this->assertNotNull($newObject->id);
+        $createdId = (int) $newObject->id;
+
+        $newLocalizedNames = [
+            $this->defaultLanguageId => 'New Default name',
+            $this->secondLanguageId => 'New Second name',
+        ];
+        $newObject->enabled = false;
+        $newObject->quantity = 51;
+        $newObject->name = $newLocalizedNames;
+        $this->assertTrue((bool) $newObject->update());
+
+        $multiLangObject = new TestableObjectModel($createdId);
+        $this->assertEquals($createdId, $multiLangObject->id);
+        $this->assertEquals($createdId, $multiLangObject->id_testable_object);
+        $this->assertEquals(51, $multiLangObject->quantity);
+        $this->assertFalse((bool) $multiLangObject->enabled);
+        $this->assertEquals($newLocalizedNames, $multiLangObject->name);
+
+        $multiLangObject->quantity = $quantity;
+        $multiLangObject->enabled = true;
+        $multiLangObject->name = $localizedNames;
+        $this->assertTrue((bool) $multiLangObject->update());
 
         $defaultLangObject = new TestableObjectModel($createdId, $this->defaultLanguageId);
         $this->assertEquals($localizedNames[$this->defaultLanguageId], $defaultLangObject->name);

--- a/tests/Integration/Classes/ObjectModelTest.php
+++ b/tests/Integration/Classes/ObjectModelTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Classes;
+
+use Configuration;
+use Db;
+use ObjectModel;
+use Language;
+use PHPUnit\Framework\TestCase;
+use Shop;
+
+class ObjectModelTest extends TestCase
+{
+    /**
+     * @var int
+     */
+    protected $defaultLanguageId;
+
+    /**
+     * @var int
+     */
+    protected $secondLanguageId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->installTestableObjectTables();;
+        $this->installLanguages();
+    }
+
+    protected function installTestableObjectTables(): void
+    {
+        $testableObjectSqlFile = dirname(__DIR__, 2) . '/Resources/sql/install_testable_object.sql';
+        $sqlRequest = file_get_contents($testableObjectSqlFile);
+        $sqlRequest = preg_replace('/PREFIX_/', _DB_PREFIX_, $sqlRequest);
+
+        $dbCollation = Db::getInstance()->getValue('SELECT @@collation_database');
+        $allowedCollations = ['utf8mb4_general_ci', 'utf8mb4_unicode_ci'];
+        $collateReplacement = (empty($dbCollation) || !in_array($dbCollation, $allowedCollations)) ? '' : 'COLLATE ' . $dbCollation;
+        $sqlRequest = preg_replace('/COLLATION/', $collateReplacement, $sqlRequest);
+
+        $sqlRequest = preg_replace('/ENGINE_TYPE/', _MYSQL_ENGINE_, $sqlRequest);
+
+        $db = Db::getInstance();
+        $db->execute($sqlRequest);
+    }
+
+    protected function installLanguages(): void
+    {
+        $this->defaultLanguageId = (int) Configuration::get('PS_LANG_DEFAULT');
+        $this->secondLanguageId = (int) Language::getIdByIso('fr');
+        if ($this->secondLanguageId) {
+            return;
+        }
+
+        $language = new Language();
+        $language->name = 'fr';
+        $language->iso_code = 'fr';
+        $language->locale = 'fr-FR';
+        $language->language_code = 'fr-FR';
+        $language->add();
+        $this->secondLanguageId = (int) $language->id;
+    }
+
+    public function testAdd(): void
+    {
+        $quantity = 42;
+        $localizedNames = [
+            $this->defaultLanguageId => 'Default name',
+            $this->secondLanguageId => 'Second name',
+        ];
+
+        $newObject = new TestableObjectModel();
+        $newObject->quantity = $quantity;
+        $newObject->enabled = true;
+        $newObject->name = $localizedNames;
+
+        $this->assertTrue((bool) $newObject->add());
+        $this->assertNotNull($newObject->id);
+        // Only the id field is filled, the identified primary key should also be updated
+        // $this->assertNotNull($object->id_testable_object);
+        $createdId = $newObject->id;
+
+        $multiLangObject = new TestableObjectModel($createdId);
+        $this->assertEquals($createdId, $multiLangObject->id);
+        $this->assertEquals($createdId, $multiLangObject->id_testable_object);
+        $this->assertEquals($quantity, $multiLangObject->quantity);
+        $this->assertTrue((bool) $multiLangObject->enabled);
+        $this->assertEquals($localizedNames, $multiLangObject->name);
+
+        $defaultLangObject = new TestableObjectModel($createdId, $this->defaultLanguageId);
+        $this->assertEquals($localizedNames[$this->defaultLanguageId], $defaultLangObject->name);
+
+        $secondLangObject = new TestableObjectModel($createdId, $this->secondLanguageId);
+        $this->assertEquals($localizedNames[$this->secondLanguageId], $secondLangObject->name);
+    }
+}
+
+class TestableObjectModel extends ObjectModel {
+    /**
+     * @var int
+     */
+    public $id_testable_object;
+
+    /**
+     * This field is multilang and multi shop
+     *
+     * @var string|string[]
+     */
+    public $name;
+
+    /**
+     * This field is global to all shops
+     *
+     * @var int
+     */
+    public $quantity;
+
+    /**
+     * This field is multishop
+     *
+     * @var bool
+     */
+    public $enabled;
+
+    public static $definition = [
+        'table' => 'testable_object',
+        'primary' => 'id_testable_object',
+        'multilang' => true,
+        'multilang_shop' => true,
+        'fields' => [
+            // Classic fields
+            'quantity' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedFloat'],
+            // Multi lang fields
+            'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCatalogName', 'required' => false, 'size' => 128],
+            // Shop fields
+            'enabled' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
+        ]
+    ];
+
+    public function __construct($id = null, $id_lang = null, $id_shop = null)
+    {
+        Shop::addTableAssociation('testable_object', ['type' => 'shop']);
+        parent::__construct($id, $id_lang, $id_shop);
+    }
+}

--- a/tests/Integration/Classes/ObjectModelTest.php
+++ b/tests/Integration/Classes/ObjectModelTest.php
@@ -67,102 +67,12 @@ class ObjectModelTest extends TestCase
     {
         parent::setUp();
 
+        // Because if process isolation we cannot rely on setupBeforeClass because it is called on each run, so we have
+        // to initialize our test data during setup which implies checking at each time if the fixtures data have been
+        // created or not
         $this->installTestableObjectTables();
         $this->installLanguages();
         $this->installShops();
-    }
-
-    private function installTestableObjectTables(): void
-    {
-        $testableObjectSqlFile = dirname(__DIR__, 2) . '/Resources/sql/install_testable_object.sql';
-        $sqlRequest = file_get_contents($testableObjectSqlFile);
-        $sqlRequest = preg_replace('/PREFIX_/', _DB_PREFIX_, $sqlRequest);
-
-        $dbCollation = Db::getInstance()->getValue('SELECT @@collation_database');
-        $allowedCollations = ['utf8mb4_general_ci', 'utf8mb4_unicode_ci'];
-        $collateReplacement = (empty($dbCollation) || !in_array($dbCollation, $allowedCollations)) ? '' : 'COLLATE ' . $dbCollation;
-        $sqlRequest = preg_replace('/COLLATION/', $collateReplacement, $sqlRequest);
-
-        $sqlRequest = preg_replace('/ENGINE_TYPE/', _MYSQL_ENGINE_, $sqlRequest);
-
-        $db = Db::getInstance();
-        $db->execute($sqlRequest);
-    }
-
-    private function installLanguages(): void
-    {
-        $this->defaultLanguageId = (int) Configuration::get('PS_LANG_DEFAULT');
-        $this->secondLanguageId = (int) Language::getIdByIso('fr');
-        if ($this->secondLanguageId) {
-            $this->cleanUndesiredLanguages();
-
-            return;
-        }
-
-        $language = new Language();
-        $language->name = 'fr';
-        $language->iso_code = 'fr';
-        $language->locale = 'fr-FR';
-        $language->language_code = 'fr-FR';
-        $language->add();
-        $this->secondLanguageId = (int) $language->id;
-        $this->cleanUndesiredLanguages();
-    }
-
-    private function installShops(): void
-    {
-        $this->defaultShopId = (int) Configuration::get('PS_SHOP_DEFAULT');
-        $this->secondShopId = Shop::getIdByName('Shop 2');
-        if ($this->secondShopId) {
-            $this->cleanUndesiredShops();
-
-            return;
-        }
-
-        $shop = new Shop();
-        $shop->name = 'Shop 2';
-        $shop->id_category = 1;
-        $shop->id_shop_group = 1;
-        $shop->domain = Configuration::get('PS_SHOP_DOMAIN');
-        $shop->physical_uri = '/';
-        $shop->add();
-        $this->secondShopId = (int) $shop->id;
-        $this->cleanUndesiredShops();
-    }
-
-    /**
-     * We need to remove extra languages because they would mess with the expected content,
-     * but we don't want to use DatabaseDump::restoredDB because all the tests are process
-     * isolated and it would be dumped on each test which would take too long.
-     */
-    private function cleanUndesiredLanguages(): void
-    {
-        // Clean undesired languages
-        $db = Db::getInstance();
-        $db->execute(sprintf(
-            'DELETE FROM %slang WHERE id_lang != %d AND id_lang != %d',
-            _DB_PREFIX_,
-            $this->defaultLanguageId,
-            $this->secondLanguageId
-        ));
-        Language::resetCache();
-    }
-
-    /**
-     * We need to remove extra shops because they would mess with the expected content,
-     * but we don't want to use DatabaseDump::restoredDB because all the tests are process
-     * isolated and it would be dumped on each test which would take too long.
-     */
-    private function cleanUndesiredShops(): void
-    {
-        // Clean undesired shops
-        $db = Db::getInstance();
-        $db->execute(sprintf(
-            'DELETE FROM %sshop WHERE id_shop != %d AND id_shop != %d',
-            _DB_PREFIX_,
-            $this->defaultShopId,
-            $this->secondShopId
-        ));
     }
 
     public function testAdd(): void
@@ -173,17 +83,21 @@ class ObjectModelTest extends TestCase
             $this->secondLanguageId => 'Second name',
         ];
 
+        // First add the object with specified data (mix of common, multishop, multilang fields)
         $newObject = new TestableObjectModel();
         $newObject->quantity = $quantity;
         $newObject->enabled = true;
         $newObject->name = $localizedNames;
 
+        // Then check that the object is correctly added and its ID was generated
         $this->assertTrue((bool) $newObject->add());
         $this->assertNotNull($newObject->id);
-        // Only the id field is filled, the identified primary key should also be updated
-        // $this->assertNotNull($object->id_testable_object);
+        // Only the id field is filled, the identified primary key (id_testable_object) should also be updated,
+        // but the add method doesn't update it (it would be a nice, and simple, improvement)
         $createdId = (int) $newObject->id;
 
+        // Then get the object from DB without specifying the lang ID so that multilang values are returned, check that
+        // the saved data matches the initial inputs
         $multiLangObject = new TestableObjectModel($createdId);
         $this->assertEquals($createdId, $multiLangObject->id);
         $this->assertEquals($createdId, $multiLangObject->id_testable_object);
@@ -191,6 +105,7 @@ class ObjectModelTest extends TestCase
         $this->assertTrue((bool) $multiLangObject->enabled);
         $this->assertEquals($localizedNames, $multiLangObject->name);
 
+        // Finally, fetch the object with a specified langId the multilang field is now a simple string
         $defaultLangObject = new TestableObjectModel($createdId, $this->defaultLanguageId);
         $this->assertEquals($localizedNames[$this->defaultLanguageId], $defaultLangObject->name);
 
@@ -206,6 +121,7 @@ class ObjectModelTest extends TestCase
             $this->secondLanguageId => 'Second name',
         ];
 
+        // To check update we must first create a instance to be modified later
         $newObject = new TestableObjectModel();
         $newObject->quantity = $quantity;
         $newObject->enabled = true;
@@ -215,6 +131,7 @@ class ObjectModelTest extends TestCase
         $this->assertNotNull($newObject->id);
         $createdId = (int) $newObject->id;
 
+        // Now that the instance is created in DB we update its content and perform an update
         $newLocalizedNames = [
             $this->defaultLanguageId => 'New Default name',
             $this->secondLanguageId => 'New Second name',
@@ -224,6 +141,8 @@ class ObjectModelTest extends TestCase
         $newObject->name = $newLocalizedNames;
         $this->assertTrue((bool) $newObject->update());
 
+        // Then we fetch the object (in multilang) and check that the data in DB matches the updated values (not the
+        // initial ones)
         $multiLangObject = new TestableObjectModel($createdId);
         $this->assertEquals($createdId, $multiLangObject->id);
         $this->assertEquals($createdId, $multiLangObject->id_testable_object);
@@ -231,6 +150,8 @@ class ObjectModelTest extends TestCase
         $this->assertFalse((bool) $multiLangObject->enabled);
         $this->assertEquals($newLocalizedNames, $multiLangObject->name);
 
+        // Then we set back the initial data and update the object again (just to check that multiple object instances
+        // do update the same table row appropriately)
         $multiLangObject->quantity = $quantity;
         $multiLangObject->enabled = true;
         $multiLangObject->name = $localizedNames;
@@ -253,20 +174,25 @@ class ObjectModelTest extends TestCase
      */
     public function testPartialUpdate(array $initialProperties, array $updatedProperties, array $fieldsToUpdate, array $expectedProperties): void
     {
+        // First create the initial object in DB
         $newObject = new TestableObjectModel();
         $this->applyModifications($newObject, $initialProperties);
         $this->assertTrue((bool) $newObject->add());
         $this->assertNotNull($newObject->id);
         $createdId = (int) $newObject->id;
 
+        // Then fetch the created object and apply the modifications
         $objectToUpdate = new TestableObjectModel($createdId);
         $this->applyModifications($objectToUpdate, $updatedProperties);
         if (isset($fieldsToUpdate['name'])) {
             $fieldsToUpdate['name'] = $this->convertLocalizedValue($fieldsToUpdate['name']);
         }
+
+        // We set the fields to be updated. They may not match the whole fields, that's the point of partial update
         $objectToUpdate->setFieldsToUpdate($fieldsToUpdate);
         $this->assertTrue((bool) $objectToUpdate->update());
 
+        // Finally, check that the object in DB matches the expected values (only some fields should have been updated)
         $updatedObject = new TestableObjectModel($createdId);
         $this->checkObjectFields($updatedObject, $expectedProperties);
     }
@@ -290,6 +216,7 @@ class ObjectModelTest extends TestCase
             'name' => $localizedNames,
         ];
 
+        // First test updates all the fields (but explicitly register them for update)
         yield [
             $initialValues,
             [
@@ -403,7 +330,10 @@ class ObjectModelTest extends TestCase
      */
     public function testMultiShopUpdate(array $initialProperties, array $initialShops, array $multiShopValues, array $expectedMultiShopValues): void
     {
+        // First create the initial object
         $newObject = new TestableObjectModel();
+
+        // Define the shop associated to the entity based on the parameter
         $initialShopIds = [];
         if (in_array(static::DEFAULT_SHOP_PLACEHOLDER, $initialShops)) {
             $initialShopIds[] = $this->defaultShopId;
@@ -412,19 +342,25 @@ class ObjectModelTest extends TestCase
             $initialShopIds[] = $this->secondShopId;
         }
         $newObject->id_shop_list = $initialShopIds;
+
+        // Set the object's fields based on the input parameters and add the object to DB
         $this->applyModifications($newObject, $initialProperties);
         $this->assertTrue((bool) $newObject->add());
         $this->assertNotNull($newObject->id);
         $createdId = (int) $newObject->id;
 
+        // Now we update the values for different shops
         foreach ($multiShopValues as $shopId => $updateValues) {
             $shopId = $shopId === static::DEFAULT_SHOP_PLACEHOLDER ? $this->defaultShopId : $this->secondShopId;
+            // Fetch the object with specified shopId, then apply modifications
             $objectToUpdate = new TestableObjectModel($createdId, null, $shopId);
+            // We force this field so that only one shop is updated
             $objectToUpdate->id_shop_list = [$shopId];
             $this->applyModifications($objectToUpdate, $updateValues);
             $this->assertTrue((bool) $objectToUpdate->update());
         }
 
+        // Finally, we fetch the object for each shop separately and check that the values match the expected data
         foreach ($expectedMultiShopValues as $shopId => $expectedValues) {
             $shopId = $shopId === static::DEFAULT_SHOP_PLACEHOLDER ? $this->defaultShopId : $this->secondShopId;
             $updatedObject = new TestableObjectModel($createdId, null, $shopId);
@@ -450,6 +386,7 @@ class ObjectModelTest extends TestCase
             'name' => $localizedNames,
         ];
 
+        // Object is created in both shops, both shops are modified the same way
         yield [
             $initialValues,
             [self::DEFAULT_SHOP_PLACEHOLDER, self::SECOND_SHOP_PLACEHOLDER],
@@ -473,6 +410,7 @@ class ObjectModelTest extends TestCase
             ],
         ];
 
+        // Object is create for both shops, one shop has enabled modified the other one its name
         yield [
             $initialValues,
             [self::DEFAULT_SHOP_PLACEHOLDER, self::SECOND_SHOP_PLACEHOLDER],
@@ -513,7 +451,10 @@ class ObjectModelTest extends TestCase
         array $multiShopFieldsToUpdate,
         array $expectedMultiShopValues
     ): void {
+        // First create the initial object
         $newObject = new TestableObjectModel();
+
+        // Define the shop associated to the entity based on the parameter
         $initialShopIds = [];
         if (in_array(static::DEFAULT_SHOP_PLACEHOLDER, $initialShops)) {
             $initialShopIds[] = $this->defaultShopId;
@@ -522,24 +463,34 @@ class ObjectModelTest extends TestCase
             $initialShopIds[] = $this->secondShopId;
         }
         $newObject->id_shop_list = $initialShopIds;
+
+        // Set the object's fields based on the input parameters and add the object to DB
         $this->applyModifications($newObject, $initialProperties);
         $this->assertTrue((bool) $newObject->add());
         $this->assertNotNull($newObject->id);
         $createdId = (int) $newObject->id;
 
+        // Now we update the values for different shops
         foreach ($multiShopValues as $shopId => $updateValues) {
             $fieldsToUpdate = $multiShopFieldsToUpdate[$shopId];
             $shopId = $shopId === static::DEFAULT_SHOP_PLACEHOLDER ? $this->defaultShopId : $this->secondShopId;
+            // Fetch the object with specified shopId
             $objectToUpdate = new TestableObjectModel($createdId, null, $shopId);
+            // We force this field so that only one shop is updated
             $objectToUpdate->id_shop_list = [$shopId];
+
+            // Apply modifications on multiple fields
             $this->applyModifications($objectToUpdate, $updateValues);
             if (isset($fieldsToUpdate['name'])) {
                 $fieldsToUpdate['name'] = $this->convertLocalizedValue($fieldsToUpdate['name']);
             }
+
+            // But limit the update to specific fields
             $objectToUpdate->setFieldsToUpdate($fieldsToUpdate);
             $this->assertTrue((bool) $objectToUpdate->update());
         }
 
+        // Finally, we fetch the object for each shop separately and check that the values match the expected data
         foreach ($expectedMultiShopValues as $shopId => $expectedValues) {
             $shopId = $shopId === static::DEFAULT_SHOP_PLACEHOLDER ? $this->defaultShopId : $this->secondShopId;
             $updatedObject = new TestableObjectModel($createdId, null, $shopId);
@@ -565,9 +516,13 @@ class ObjectModelTest extends TestCase
             'name' => $localizedNames,
         ];
 
+        // Object is added to both shops, update enabled only via partial update on both shops
         yield [
+            // Initial values for creation
             $initialValues,
+            // List of associated shops
             [self::DEFAULT_SHOP_PLACEHOLDER, self::SECOND_SHOP_PLACEHOLDER],
+            // Modifications on the object
             [
                 self::DEFAULT_SHOP_PLACEHOLDER => [
                     'enabled' => false,
@@ -576,6 +531,7 @@ class ObjectModelTest extends TestCase
                     'enabled' => false,
                 ],
             ],
+            // Define which field are registered for partial update
             [
                 self::DEFAULT_SHOP_PLACEHOLDER => [
                     'enabled' => true,
@@ -584,6 +540,7 @@ class ObjectModelTest extends TestCase
                     'enabled' => true,
                 ],
             ],
+            // Expected values after partial update
             [
                 self::DEFAULT_SHOP_PLACEHOLDER => [
                     'enabled' => 0,
@@ -596,6 +553,9 @@ class ObjectModelTest extends TestCase
             ],
         ];
 
+        // Object is added on both shops, both shop have their name and enabled modified But name is partially updated
+        // for default shop only (both languages), while enabled is partially updated for second shop only The other
+        // fields should not be modified
         yield [
             $initialValues,
             [self::DEFAULT_SHOP_PLACEHOLDER, self::SECOND_SHOP_PLACEHOLDER],
@@ -674,5 +634,102 @@ class ObjectModelTest extends TestCase
         }
 
         return $localizedValue;
+    }
+
+    /*
+     * Following are fixtures installation functions
+     */
+
+    private function installTestableObjectTables(): void
+    {
+        $testableObjectSqlFile = dirname(__DIR__, 2) . '/Resources/sql/install_testable_object.sql';
+        $sqlRequest = file_get_contents($testableObjectSqlFile);
+        $sqlRequest = preg_replace('/PREFIX_/', _DB_PREFIX_, $sqlRequest);
+
+        $dbCollation = Db::getInstance()->getValue('SELECT @@collation_database');
+        $allowedCollations = ['utf8mb4_general_ci', 'utf8mb4_unicode_ci'];
+        $collateReplacement = (empty($dbCollation) || !in_array($dbCollation, $allowedCollations)) ? '' : 'COLLATE ' . $dbCollation;
+        $sqlRequest = preg_replace('/COLLATION/', $collateReplacement, $sqlRequest);
+
+        $sqlRequest = preg_replace('/ENGINE_TYPE/', _MYSQL_ENGINE_, $sqlRequest);
+
+        $db = Db::getInstance();
+        $db->execute($sqlRequest);
+    }
+
+    private function installLanguages(): void
+    {
+        $this->defaultLanguageId = (int) Configuration::get('PS_LANG_DEFAULT');
+        $this->secondLanguageId = (int) Language::getIdByIso('fr');
+        if ($this->secondLanguageId) {
+            $this->cleanUndesiredLanguages();
+
+            return;
+        }
+
+        $language = new Language();
+        $language->name = 'fr';
+        $language->iso_code = 'fr';
+        $language->locale = 'fr-FR';
+        $language->language_code = 'fr-FR';
+        $language->add();
+        $this->secondLanguageId = (int) $language->id;
+        $this->cleanUndesiredLanguages();
+    }
+
+    private function installShops(): void
+    {
+        $this->defaultShopId = (int) Configuration::get('PS_SHOP_DEFAULT');
+        $this->secondShopId = Shop::getIdByName('Shop 2');
+        if ($this->secondShopId) {
+            $this->cleanUndesiredShops();
+
+            return;
+        }
+
+        $shop = new Shop();
+        $shop->name = 'Shop 2';
+        $shop->id_category = 1;
+        $shop->id_shop_group = 1;
+        $shop->domain = Configuration::get('PS_SHOP_DOMAIN');
+        $shop->physical_uri = '/';
+        $shop->add();
+        $this->secondShopId = (int) $shop->id;
+        $this->cleanUndesiredShops();
+    }
+
+    /**
+     * We need to remove extra languages because they would mess with the expected content,
+     * but we don't want to use DatabaseDump::restoredDB because all the tests are process
+     * isolated and it would be dumped on each test which would take too long.
+     */
+    private function cleanUndesiredLanguages(): void
+    {
+        // Clean undesired languages
+        $db = Db::getInstance();
+        $db->execute(sprintf(
+            'DELETE FROM %slang WHERE id_lang != %d AND id_lang != %d',
+            _DB_PREFIX_,
+            $this->defaultLanguageId,
+            $this->secondLanguageId
+        ));
+        Language::resetCache();
+    }
+
+    /**
+     * We need to remove extra shops because they would mess with the expected content,
+     * but we don't want to use DatabaseDump::restoredDB because all the tests are process
+     * isolated and it would be dumped on each test which would take too long.
+     */
+    private function cleanUndesiredShops(): void
+    {
+        // Clean undesired shops
+        $db = Db::getInstance();
+        $db->execute(sprintf(
+            'DELETE FROM %sshop WHERE id_shop != %d AND id_shop != %d',
+            _DB_PREFIX_,
+            $this->defaultShopId,
+            $this->secondShopId
+        ));
     }
 }

--- a/tests/Resources/classes/TestableObjectModel.php
+++ b/tests/Resources/classes/TestableObjectModel.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Resources\classes;
+
+use ObjectModel;
+use Shop;
+
+class TestableObjectModel extends ObjectModel
+{
+    /**
+     * @var int
+     */
+    public $id_testable_object;
+
+    /**
+     * This field is multilang and multi shop
+     *
+     * @var string|string[]
+     */
+    public $name;
+
+    /**
+     * This field is global to all shops
+     *
+     * @var int
+     */
+    public $quantity;
+
+    /**
+     * This field is multishop
+     *
+     * @var bool
+     */
+    public $enabled;
+
+    public static $definition = [
+        'table' => 'testable_object',
+        'primary' => 'id_testable_object',
+        'multilang' => true,
+        'multilang_shop' => true,
+        'fields' => [
+            // Classic fields
+            'quantity' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedFloat'],
+            // Multi lang fields
+            'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCatalogName', 'required' => false, 'size' => 128],
+            // Shop fields
+            'enabled' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
+        ],
+    ];
+
+    public function __construct($id = null, $id_lang = null, $id_shop = null)
+    {
+        Shop::addTableAssociation('testable_object', ['type' => 'shop']);
+        Shop::addTableAssociation('testable_object_lang', ['type' => 'fk_shop']);
+        parent::__construct($id, $id_lang, $id_shop);
+    }
+}

--- a/tests/Resources/sql/install_testable_object.sql
+++ b/tests/Resources/sql/install_testable_object.sql
@@ -23,3 +23,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_testable_object_shop` (
   PRIMARY KEY (`id_testable_object`, `id_shop`),
   KEY `id_shop` (`id_shop`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
+
+TRUNCATE `PREFIX_testable_object_shop`;
+TRUNCATE `PREFIX_testable_object_lang`;
+TRUNCATE `PREFIX_testable_object`;

--- a/tests/Resources/sql/install_testable_object.sql
+++ b/tests/Resources/sql/install_testable_object.sql
@@ -1,0 +1,25 @@
+/* Testable object */
+CREATE TABLE IF NOT EXISTS `PREFIX_testable_object` (
+  `id_testable_object` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `quantity` int(10) unsigned NOT NULL DEFAULT '0',
+  `enabled` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id_testable_object`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
+
+/* Localized Testable object */
+CREATE TABLE IF NOT EXISTS `PREFIX_testable_object_lang` (
+  `id_testable_object` int(10) unsigned NOT NULL,
+  `id_lang` int(10) unsigned NOT NULL,
+  `id_shop` int(10) unsigned NOT NULL DEFAULT '1',
+  `name` varchar(128) NOT NULL,
+  PRIMARY KEY (`id_testable_object`, `id_shop`, `id_lang`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
+
+/* Association between a Testable object and a shop */
+CREATE TABLE IF NOT EXISTS `PREFIX_testable_object_shop` (
+  `id_testable_object` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `id_shop` INT(11) UNSIGNED NOT NULL,
+  `enabled` tinyint(1) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id_testable_object`, `id_shop`),
+  KEY `id_shop` (`id_shop`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR fixes the management of partial updates, along the way the feature became buggy and didn't work anymore. This PR fixes the behaviour for classic fields, multi lang fields and multishop fields.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #13007
| How to test?      | This is a technical modification, which is hard to test by QA That is why some integration tests were added to validate the fix The tests were added before the fix to highlight the behaviours that didn't work (see this build https://github.com/jolelievre/PrestaShop/runs/3623175580) Then the fix was cherry-picked from this PR #25464 where it was initially fixed So no QA is needed only CI green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25913)
<!-- Reviewable:end -->

### Description

This modification is important because it appears the whole "partial update of an ObjectModel" feature has been buggy for quite a while now. I went through the history of this code and found these consecutive modifications:

https://github.com/PrestaShop/PrestaShop/commit/009e190263a2b4d904d084b0bea5a02a2c235fdb
https://github.com/PrestaShop/PrestaShop/commit/84d1e57ad968bb6fd81ba22ac6e4ef40d5efbeee
https://github.com/PrestaShop/PrestaShop/commit/07c3ee5dd1ddc1b091fc0700249d5d5def6ca7cd (https://github.com/PrestaShop/PrestaShop/pull/2452)

I think the code got harder and harder to understand and some features were lost along the way, the initial purpose of `update_fields` is to filter the fields that need to be updated, so basically if the `update_fields` is defined and the field is not inside the array we skip it so it's not updated

Although there are a few complex use cases:

For multilang values, the `updated_fields` must be check based on the `$id_lang` of course

For multishop values:

- any multishop value should only be updated in the `_shop` table not in the original one
- in the Product case this check was not correctly done, since most fields are duplicated it resulted in updating the column in both the `product` table AND the `product_shop` table
- there is an exception though when the multishop field is defined with `'shop' => 'both'` then the value must be updated in both tables (this is only used for `Combination` and `Image`)

But the way the `both` feature was handled broke the feature because the condition `!empty($data['shop']) && $data['shop'] != 'both'` is not correct, the purpose is to detect when `'shop' => true` but since `'both'` is considered truthy the condition is never met even when `'shop' => true` That's why a strict non equality is required here.
