### PR TITLE
Hide order confirmation when order is not valid

### DIFF
--- a/themes/classic/templates/checkout/order-confirmation.tpl
+++ b/themes/classic/templates/checkout/order-confirmation.tpl
@@ -5,28 +5,31 @@
       <div class="card-block">
         <div class="row">
           <div class="col-md-12">
+          
+            {if $order.details.is_valid}
+                {block name='order_confirmation_header'}
+                    <h3 class="h1 card-title">
+                        <i
+                            class="material-icons rtl-no-flip done">&#xE876;</i>{l s='Your order is confirmed' d='Shop.Theme.Checkout'}
+                    </h3>
+                {/block}
 
-            {block name='order_confirmation_header'}
-              <h3 class="h1 card-title">
-                <i class="material-icons rtl-no-flip done">&#xE876;</i>{l s='Your order is confirmed' d='Shop.Theme.Checkout'}
-              </h3>
-            {/block}
-
-            <p>
-              {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $customer.email]}
-              {if $order.details.invoice_url}
-                {* [1][/1] is for a HTML tag. *}
-                {l
-                  s='You can also [1]download your invoice[/1]'
-                  d='Shop.Theme.Checkout'
-                  sprintf=[
-                    '[1]' => "<a href='{$order.details.invoice_url}'>",
-                    '[/1]' => "</a>"
-                  ]
-                }
-              {/if}
-            </p>
-
+                <p>
+                    {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $customer.email]}
+                    {if $order.details.invoice_url}
+                        {* [1][/1] is for a HTML tag. *}
+                        {l
+                      s='You can also [1]download your invoice[/1]'
+                      d='Shop.Theme.Checkout'
+                      sprintf=[
+                        '[1]' => "<a href='{$order.details.invoice_url}'>",
+                        '[/1]' => "</a>"
+                        ]
+                        }
+                    {/if}
+                </p>
+            {/if}
+            
             {block name='hook_order_confirmation'}
               {$HOOK_ORDER_CONFIRMATION nofilter}
             {/block}


### PR DESCRIPTION
When payment error happen, the order confirmation message still displayed.
fix: Hide order confirmation message when order is not valid.
Seem also related to #9997

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  1.7.8.x
| Description?      | For the classic theme
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9997.
| How to test?      | Make a payment with error through a payment gateway (CB,VISA...).
| Possible impacts? | Nothing except the view of the order confirmation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25918)
<!-- Reviewable:end -->
