### PR TITLE
Replace Shudrum ArrayFinder by Symfony ArrayFinder in Theme

### DIFF
--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -42,14 +42,13 @@ class Theme implements AddonInterface
     /**
      * @param array $attributes Theme attributes
      * @param string|null $configurationCacheDirectory Default _PS_CACHE_DIR_
-     * @param string|null $themesDirectory Default _PS_ALL_THEMES_DIR_
+     * @param string $themesDirectory Default _PS_ALL_THEMES_DIR_
      */
-    public function __construct(array $attributes, $configurationCacheDirectory = null, $themesDirectory = null)
-    {
-        if (null === $themesDirectory) {
-            $themesDirectory = _PS_ALL_THEMES_DIR_;
-        }
-
+    public function __construct(
+        array $attributes,
+        ?string $configurationCacheDirectory = null,
+        string $themesDirectory = _PS_ALL_THEMES_DIR_
+    ) {
         if (isset($attributes['parent'])) {
             if (null === $configurationCacheDirectory) {
                 $configurationCacheDirectory = (new Configuration())->get('_PS_CACHE_DIR_');

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -41,8 +41,8 @@ class Theme implements AddonInterface
 
     /**
      * @param array $attributes Theme attributes
-     * @param string $configurationCacheDirectory Default _PS_CACHE_DIR_
-     * @param string $themesDirectory Default _PS_ALL_THEMES_DIR_
+     * @param string|null $configurationCacheDirectory Default _PS_CACHE_DIR_
+     * @param string|null $themesDirectory Default _PS_ALL_THEMES_DIR_
      */
     public function __construct(array $attributes, $configurationCacheDirectory = null, $themesDirectory = null)
     {

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -46,14 +46,15 @@ class Theme implements AddonInterface
      */
     public function __construct(array $attributes, $configurationCacheDirectory = null, $themesDirectory = null)
     {
-        if (null === $configurationCacheDirectory) {
-            $configurationCacheDirectory = (new Configuration())->get('_PS_CACHE_DIR_');
-        }
         if (null === $themesDirectory) {
             $themesDirectory = _PS_ALL_THEMES_DIR_;
         }
 
         if (isset($attributes['parent'])) {
+            if (null === $configurationCacheDirectory) {
+                $configurationCacheDirectory = (new Configuration())->get('_PS_CACHE_DIR_');
+            }
+
             $yamlParser = new YamlParser($configurationCacheDirectory);
             $parentAttributes = $yamlParser->parse($themesDirectory . '/' . $attributes['parent'] . '/config/theme.yml');
             $parentAttributes['preview'] = 'themes/' . $attributes['parent'] . '/preview.png';

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -29,18 +29,33 @@ namespace PrestaShop\PrestaShop\Core\Addon\Theme;
 use AbstractAssetManager;
 use Configuration;
 use PrestaShop\PrestaShop\Core\Addon\AddonInterface;
+use PrestaShop\PrestaShop\Core\Util\ArrayFinder;
 use PrestaShop\PrestaShop\Core\Util\File\YamlParser;
-use Shudrum\Component\ArrayFinder\ArrayFinder;
 
 class Theme implements AddonInterface
 {
+    /**
+     * @var ArrayFinder
+     */
     private $attributes;
 
-    public function __construct(array $attributes)
+    /**
+     * @param array $attributes Theme attributes
+     * @param string $configurationCacheDirectory Default _PS_CACHE_DIR_
+     * @param string $themesDirectory Default _PS_ALL_THEMES_DIR_
+     */
+    public function __construct(array $attributes, $configurationCacheDirectory = null, $themesDirectory = null)
     {
+        if (null === $configurationCacheDirectory) {
+            $configurationCacheDirectory = (new Configuration())->get('_PS_CACHE_DIR_');
+        }
+        if (null === $themesDirectory) {
+            $themesDirectory = _PS_ALL_THEMES_DIR_;
+        }
+
         if (isset($attributes['parent'])) {
-            $yamlParser = new YamlParser((new Configuration())->get('_PS_CACHE_DIR_'));
-            $parentAttributes = $yamlParser->parse(_PS_ALL_THEMES_DIR_ . '/' . $attributes['parent'] . '/config/theme.yml');
+            $yamlParser = new YamlParser($configurationCacheDirectory);
+            $parentAttributes = $yamlParser->parse($themesDirectory . '/' . $attributes['parent'] . '/config/theme.yml');
             $parentAttributes['preview'] = 'themes/' . $attributes['parent'] . '/preview.png';
             $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/') . '/';
             $attributes = array_merge($parentAttributes, $attributes);
@@ -48,7 +63,7 @@ class Theme implements AddonInterface
 
         $attributes['directory'] = rtrim($attributes['directory'], '/') . '/';
 
-        if (file_exists(_PS_ALL_THEMES_DIR_ . $attributes['name'] . '/preview.png')) {
+        if (file_exists($themesDirectory . $attributes['name'] . '/preview.png')) {
             $attributes['preview'] = 'themes/' . $attributes['name'] . '/preview.png';
         }
 

--- a/src/Core/Util/ArrayFinder.php
+++ b/src/Core/Util/ArrayFinder.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Util;
 
 use ArrayAccess;
 use Countable;
+use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
@@ -88,7 +89,12 @@ class ArrayFinder implements ArrayAccess, Countable
         }
         $path = $this->convertDotPathToArrayPath($path);
 
-        $value = $this->propertyAccessor->getValue($this->array, $path);
+        try {
+            $value = $this->propertyAccessor->getValue($this->array, $path);
+        } catch (UnexpectedTypeException $e) {
+            // If a value within the path is neither object nor array
+            return null;
+        }
 
         if (null !== $value) {
             return $value;

--- a/src/Core/Util/ArrayFinder.php
+++ b/src/Core/Util/ArrayFinder.php
@@ -208,6 +208,6 @@ class ArrayFinder implements ArrayAccess, Countable
         $expl = explode('.', $dotPath);
         $in = implode('][', $expl);
 
-        return '[' . $in . ']';
+        return str_replace('[]', '[0]', '[' . $in . ']');
     }
 }

--- a/tests/Unit/Core/Addon/Theme/ThemeTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeTest.php
@@ -46,7 +46,9 @@ class ThemeTest extends TestCase
                 'bar' => 'preston',
                 'directory' => 'a/',
             ],
-            '', '');
+            '',
+            ''
+        );
 
         $this->assertEquals('preston', $theme->get('bar'));
         $this->assertEquals('foo', $theme->get('name'));
@@ -83,7 +85,9 @@ class ThemeTest extends TestCase
                 'directory' => 'a/',
                 'theme_settings' => ['layouts' => 'z'],
             ],
-            '', '');
+            '',
+            ''
+        );
 
         $this->assertEquals('z', $theme->getPageLayouts());
     }
@@ -96,7 +100,9 @@ class ThemeTest extends TestCase
                 'directory' => 'a/',
                 'meta' => ['available_layouts' => 'z'],
             ],
-            '', '');
+            '',
+            ''
+        );
 
         $this->assertEquals('z', $theme->getAvailableLayouts());
     }
@@ -111,7 +117,9 @@ class ThemeTest extends TestCase
                     'default_layout' => 'm',
                     'layouts' => ['homepage' => 'o', 'checkout_page' => 'p'], ],
             ],
-            '', '');
+            '',
+            ''
+        );
 
         $this->assertEquals('o', $theme->getLayoutNameForPage('homepage'));
         $this->assertEquals('p', $theme->getLayoutNameForPage('checkout_page'));
@@ -138,7 +146,8 @@ class ThemeTest extends TestCase
                 ],
                 ],
             ],
-            '', ''
+            '',
+            ''
         );
 
         $this->assertEquals(

--- a/tests/Unit/Core/Addon/Theme/ThemeTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Addon\Theme;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
+
+class ThemeTest extends TestCase
+{
+    /**
+     * @var Theme
+     */
+    protected $theme;
+
+    public function testGetThemeAttributes(): void
+    {
+        $theme = new Theme(
+            [
+                'name' => 'foo',
+                'bar' => 'preston',
+                'directory' => 'a/',
+            ],
+            '', '');
+
+        $this->assertEquals('preston', $theme->get('bar'));
+        $this->assertEquals('foo', $theme->get('name'));
+        $this->assertEquals('a/', $theme->get('directory'));
+
+        $this->assertTrue($theme->has('bar'));
+        $this->assertTrue($theme->has('name'));
+        $this->assertTrue($theme->has('directory'));
+
+        $this->assertEquals('foo', $theme->getName());
+        $this->assertEquals('a/', $theme->getDirectory());
+    }
+
+    public function testGetAttributesFromThemeParent(): void
+    {
+        $theme = new Theme(
+            [
+                'name' => 'foo',
+                'parent' => 'fake-theme',
+                'directory' => 'a/',
+            ],
+            sys_get_temp_dir() . '/ThemeTest',
+            dirname(__DIR__, 4) . '/Resources/themes/'
+        );
+
+        $this->assertEquals('For testing purposes', $theme->get('display_name'));
+    }
+
+    public function testGetPageLayouts(): void
+    {
+        $theme = new Theme(
+            [
+                'name' => 'foo',
+                'directory' => 'a/',
+                'theme_settings' => ['layouts' => 'z'],
+            ],
+            '', '');
+
+        $this->assertEquals('z', $theme->getPageLayouts());
+    }
+
+    public function testGetAvailableLayouts(): void
+    {
+        $theme = new Theme(
+            [
+                'name' => 'foo',
+                'directory' => 'a/',
+                'meta' => ['available_layouts' => 'z'],
+            ],
+            '', '');
+
+        $this->assertEquals('z', $theme->getAvailableLayouts());
+    }
+
+    public function testGetLayoutNameForPage(): void
+    {
+        $theme = new Theme(
+            [
+                'name' => 'foo',
+                'directory' => 'a/',
+                'theme_settings' => [
+                    'default_layout' => 'm',
+                    'layouts' => ['homepage' => 'o', 'checkout_page' => 'p'], ],
+            ],
+            '', '');
+
+        $this->assertEquals('o', $theme->getLayoutNameForPage('homepage'));
+        $this->assertEquals('p', $theme->getLayoutNameForPage('checkout_page'));
+        $this->assertEquals('m', $theme->getLayoutNameForPage('not_exist'));
+    }
+
+    public function testGetPageSpecificCss(): void
+    {
+        $theme = new Theme(
+            [
+                'name' => 'foo',
+                'directory' => 'a/',
+                'assets' => ['css' => [
+                    'all' => [[
+                        'id' => 'custom-lib-style',
+                        'path' => 'assets/css/custom-lib.css',
+                    ]],
+                    'a' => [[
+                        'id' => 'product-style',
+                        'path' => 'assets/css/product.css',
+                        'media' => 'all',
+                        'priority' => 200,
+                    ]],
+                ],
+                ],
+            ],
+            '', ''
+        );
+
+        $this->assertEquals(
+            [
+                'css' => [
+                    [
+                        'id' => 'custom-lib-style',
+                        'path' => 'assets/css/custom-lib.css',
+                        'media' => 'all',
+                        'priority' => 50,
+                        'inline' => false,
+                    ],
+                    [
+                        'id' => 'product-style',
+                        'path' => 'assets/css/product.css',
+                        'media' => 'all',
+                        'priority' => 200,
+                        'inline' => false,
+                    ],
+                ],
+                'js' => [],
+            ], $theme->getPageSpecificAssets('a'));
+    }
+}

--- a/tests/Unit/Core/Util/ArrayFinderTest.php
+++ b/tests/Unit/Core/Util/ArrayFinderTest.php
@@ -245,4 +245,15 @@ class ArrayFinderTest extends TestCase
             (new ArrayFinder([]))->get('some.key', 'default value')
         );
     }
+
+    public function testArrayAccessNullNode(): void
+    {
+        $arrayFinder = new ArrayFinder([
+            'z' => 'x',
+            'y' => null,
+        ]);
+        $this->assertNull($arrayFinder->get('y'));
+        $this->assertNull($arrayFinder->get('y.a'));
+        $this->assertNull($arrayFinder->get('y.a.b'));
+    }
 }

--- a/tests/Unit/Core/Util/ArrayFinderTest.php
+++ b/tests/Unit/Core/Util/ArrayFinderTest.php
@@ -246,7 +246,7 @@ class ArrayFinderTest extends TestCase
         );
     }
 
-    public function testArrayAccessNullNode(): void
+    public function testGetNullNode(): void
     {
         $arrayFinder = new ArrayFinder([
             'z' => 'x',
@@ -255,5 +255,16 @@ class ArrayFinderTest extends TestCase
         $this->assertNull($arrayFinder->get('y'));
         $this->assertNull($arrayFinder->get('y.a'));
         $this->assertNull($arrayFinder->get('y.a.b'));
+    }
+
+    public function testGetEmptyNode(): void
+    {
+        $arrayFinder = new ArrayFinder([
+            'z' => 'x',
+            'foo' => ['bar' => []],
+        ]);
+        $this->assertNull($arrayFinder->get('y.'));
+        $this->assertNull($arrayFinder->get('z.'));
+        $this->assertNull($arrayFinder->get('foo.bar.'));
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Replace Shudrum ArrayFinder usage by Symfony ArrayFinder in Theme. See details below.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to https://github.com/PrestaShop/PrestaShop/issues/19243
| How to test?      | CI is green
| Possible impacts? | Theme class is loaded in multiple places in the software. The main place is the Theme BO page.

# Description

## Objective and process

In order to replace Shudrum ArrayFinder usage by Symfony ArrayFinder in Theme.php, I applied the standard refactoring process:

1. Use dependency injection inside Theme.php in order to make it possible to isolate it
2. Write unit tests for current implementation
3. Modify Theme.php
4. Verify changes did not break behavior thanks to unit tests

#### About Theme testability and dependency injection

I now inject the cache directory and the theme directory inside the Theme class. However this class is important for PrestaShop, so I don't think I can introduce a BC break by adding mandatory parameters for the class to be instanciated. This is why I add a backward compatibility layer by making new arguments optional, and using previous implementation as fallback.

## Improvements for ArrayFinder

The UI tests found two bugs!

First one happens when Symfony PropertyAccessor fails when trying to access node `a.b.c` of an array is `a` is the key for null ⬇️ 
```
$array = ['a' => null];
```

Shudrum Arrayfinder behavior was to return null in such a case, so I modified the Symfony ArrayFinder to follow the same. A phpunit test has been added to validate the behavior https://github.com/PrestaShop/PrestaShop/pull/25937/commits/62087d3d80585c3a27005aa0b44ba5cabd881e43

Second one happens when PrestaShop attempts to access a "not finished" path like `theme.assets.css.` (nothing after the last dot). Symfony ArrayFinder was crashing when running in this usecase.

I modified the Symfony ArrayFinder to return null in such a case, as this is the behavior of Shudrum ArrayFinder. A phpunit test has been added to validate the behavior https://github.com/PrestaShop/PrestaShop/pull/25937/commits/b5722ac2711fdcea6cb521c0a333bb5b4825f28a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25937)
<!-- Reviewable:end -->
