### PR TITLE
Avoid externally creating addresses not linked to any customer

### DIFF
--- a/classes/form/CustomerAddressPersister.php
+++ b/classes/form/CustomerAddressPersister.php
@@ -43,7 +43,7 @@ class CustomerAddressPersisterCore
 
     private function authorizeChange(Address $address, $token)
     {
-        if(!Validate::isLoadedObject($this->customer)) {
+        if (!Validate::isLoadedObject($this->customer)) {
             // No action allowed without a valid customer into the context
             return false;
         }

--- a/classes/form/CustomerAddressPersister.php
+++ b/classes/form/CustomerAddressPersister.php
@@ -43,6 +43,11 @@ class CustomerAddressPersisterCore
 
     private function authorizeChange(Address $address, $token)
     {
+        if(!Validate::isLoadedObject($this->customer)) {
+            // No action allowed without a valid customer into the context
+            return false;
+        }
+        
         if ($address->id_customer && (int) $address->id_customer !== (int) $this->customer->id) {
             // Can't touch anybody else's address
             return false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A possible bug is found in the CustomerAddressPersister that allows creating addresses externally. It could be tested using Postman or similar, just send the form body to address controller on a POST request and the persister will create a non-customer linked address (id_customer = 0). This bug could be critical if it is combined with some one like https://github.com/PrestaShop/PrestaShop/pull/16620
| Type?             | bug fix 
| Category?         | FO 
| Fixed ticket? | #25945
| BC breaks?        |  no
| Deprecations?     |  no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Description:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25944)
<!-- Reviewable:end -->
