### PR TITLE
Easily override default value for primary user on docker

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -3,8 +3,6 @@ FROM prestashop/prestashop-git:latest
 # To run files with the same group as your primary user
 ARG GROUP_ID
 ARG USER_ID
-RUN echo $GROUP_ID
-RUN echo $USER_ID
 
 RUN groupmod -g $GROUP_ID www-data \
   && usermod -u $USER_ID -g $GROUP_ID www-data

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,11 +1,16 @@
 FROM prestashop/prestashop-git:latest
 
 # To run files with the same group as your primary user
-RUN groupmod -g 1000 www-data \
-  && usermod -u 1000 -g 1000 www-data
+ARG GROUP_ID
+ARG USER_ID
+RUN echo $GROUP_ID
+RUN echo $USER_ID
 
-COPY /wait-for-it.sh /tmp/
-COPY /docker_run_git.sh /tmp/
+RUN groupmod -g $GROUP_ID www-data \
+  && usermod -u $USER_ID -g $GROUP_ID www-data
+
+COPY .docker/wait-for-it.sh /tmp/
+COPY .docker/docker_run_git.sh /tmp/
 
 RUN mkdir -p /var/www/.npm
 RUN chown -R www-data:www-data /var/www/.npm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,12 @@ services:
       MYSQL_DATABASE: prestashop
     restart: always
   prestashop-git:
-    build: .docker
+    build:
+      dockerfile: .docker/Dockerfile
+      context: .
+      args:
+        - USER_ID=${USER_ID:-1000}
+        - GROUP_ID=${GROUP_ID:-1000}
     environment:
       DISABLE_MAKE: ${DISABLE_MAKE:-0}
       PS_INSTALL_AUTO: ${PS_INSTALL_AUTO:-1}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Primary user is not always 1000 (1001 for me), so we can now override this without changing it on DockerFile
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | `USER_ID=$(id -u) GROUP_ID=$(id -g) docker-compose up --build --force-recreate` => PrestaShop is build directly.
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25949)
<!-- Reviewable:end -->
