### PR TITLE
Refactor on AbstractMultistoreConfiguration class + unit tests + integration tests

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -123,7 +123,7 @@ class ConfigurationCore extends ObjectModel
      *
      * @return int Configuration key ID
      */
-    public static function getIdByNameFromGivenContext(string $key, int $idShopGroup = null, int $idShop = null): int
+    public static function getIdByNameFromGivenContext(string $key, ?int $idShopGroup, ?int $idShop): int
     {
         $sql = 'SELECT `' . bqSQL(self::$definition['primary']) . '`
                 FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -607,7 +607,7 @@ class ConfigurationCore extends ObjectModel
 
         $configurationId = Configuration::getIdByName($key, $idShopGroup, $idShop);
 
-        self::deleteMultiShopConfigurationByKey($key, $configurationId, $idShopGroup, $idShop);
+        self::deleteById($configurationId);
     }
 
     /**
@@ -616,9 +616,14 @@ class ConfigurationCore extends ObjectModel
      * @param int|null $idShopGroup
      * @param int|null $idShop
      */
-    public static function deleteMultiShopConfigurationByKey($key, ?int $configurationId, ?int $idShopGroup, ?int $idShop): void
+    public static function deleteFromGivenContext($key, ?int $idShopGroup, ?int $idShop): void
     {
-        $configurationId = $configurationId ?: Configuration::getIdByNameFromGivenContext($key, $idShopGroup, $idShop);
+        $configurationId = Configuration::getIdByNameFromGivenContext($key, $idShopGroup, $idShop);
+        self::deleteById($configurationId);
+    }
+
+    public static function deleteById(int $configurationId): void
+    {
         Db::getInstance()->execute('
         DELETE FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`
         WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . (int) $configurationId);

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -113,6 +113,18 @@ class ConfigurationCore extends ObjectModel
             $idShopGroup = Shop::getContextShopGroupID(true);
         }
 
+        return self::getIdByNameFromGivenContext($key, $idShopGroup, $idShop);
+    }
+
+    /**
+     * @param $key
+     * @param null $idShopGroup
+     * @param null $idShop
+     *
+     * @return int Configuration key ID
+     */
+    public static function getIdByNameFromGivenContext($key, $idShopGroup = null, $idShop = null)
+    {
         $sql = 'SELECT `' . bqSQL(self::$definition['primary']) . '`
                 FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`
                 WHERE name = \'' . pSQL($key) . '\'
@@ -593,13 +605,26 @@ class ConfigurationCore extends ObjectModel
             $idShop = Shop::getContextShopID(true);
         }
 
-        $id = Configuration::getIdByName($key, $idShopGroup, $idShop);
+        $configurationId = Configuration::getIdByName($key, $idShopGroup, $idShop);
+
+        self::deleteFromGivenContext($key, $configurationId, $idShopGroup, $idShop);
+    }
+
+    /**
+     * @param mixed $key
+     * @param int|null $configurationId
+     * @param int|null $idShopGroup
+     * @param int|null $idShop
+     */
+    public static function deleteFromGivenContext($key, int $configurationId = null, int $idShopGroup = null, int $idShop = null)
+    {
+        $configurationId = $configurationId ?: Configuration::getIdByNameFromGivenContext($key, $idShopGroup, $idShop);
         Db::getInstance()->execute('
         DELETE FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`
-        WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . (int) $id);
+        WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . (int) $configurationId);
         Db::getInstance()->execute('
         DELETE FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '_lang`
-        WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . (int) $id);
+        WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . (int) $configurationId);
 
         self::$_cache = null;
         self::$_new_cache_shop = null;

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -117,9 +117,9 @@ class ConfigurationCore extends ObjectModel
     }
 
     /**
-     * @param $key
-     * @param null $idShopGroup
-     * @param null $idShop
+     * @param string $key
+     * @param int $idShopGroup
+     * @param int $idShop
      *
      * @return int Configuration key ID
      */

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -148,11 +148,7 @@ class ConfigurationCore extends ObjectModel
      */
     public static function clearConfigurationCacheForTesting()
     {
-        self::$_cache = null;
-        self::$_new_cache_shop = null;
-        self::$_new_cache_group = null;
-        self::$_new_cache_global = null;
-        self::$_initialized = false;
+        self::resetStaticCache();
     }
 
     /**

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -144,12 +144,24 @@ class ConfigurationCore extends ObjectModel
     }
 
     /**
+     * @deprecated 8.0.0 Use resetStaticCache method instead.
+     */
+    public static function clearConfigurationCacheForTesting()
+    {
+        self::$_cache = null;
+        self::$_new_cache_shop = null;
+        self::$_new_cache_group = null;
+        self::$_new_cache_global = null;
+        self::$_initialized = false;
+    }
+
+    /**
      * WARNING: For testing only. Do NOT rely on this method, it may be removed at any time.
      *
      * @todo Delegate static calls from Configuration to an instance
      * of a class to be created.
      */
-    public static function clearConfigurationCacheForTesting()
+    public static function resetStaticCache()
     {
         self::$_cache = null;
         self::$_new_cache_shop = null;

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -611,11 +611,11 @@ class ConfigurationCore extends ObjectModel
     }
 
     /**
-     * @param mixed $key
+     * @param string $key
      * @param int|null $idShopGroup
      * @param int|null $idShop
      */
-    public static function deleteFromGivenContext($key, ?int $idShopGroup, ?int $idShop): void
+    public static function deleteFromGivenContext(string $key, ?int $idShopGroup, ?int $idShop): void
     {
         $configurationId = Configuration::getIdByNameFromGivenContext($key, $idShopGroup, $idShop);
         self::deleteById($configurationId);

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -612,7 +612,6 @@ class ConfigurationCore extends ObjectModel
 
     /**
      * @param mixed $key
-     * @param int|null $configurationId
      * @param int|null $idShopGroup
      * @param int|null $idShop
      */
@@ -626,10 +625,10 @@ class ConfigurationCore extends ObjectModel
     {
         Db::getInstance()->execute('
         DELETE FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`
-        WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . (int) $configurationId);
+        WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . $configurationId);
         Db::getInstance()->execute('
         DELETE FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '_lang`
-        WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . (int) $configurationId);
+        WHERE `' . bqSQL(self::$definition['primary']) . '` = ' . $configurationId);
 
         self::$_cache = null;
         self::$_new_cache_shop = null;

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -607,7 +607,7 @@ class ConfigurationCore extends ObjectModel
 
         $configurationId = Configuration::getIdByName($key, $idShopGroup, $idShop);
 
-        self::deleteFromGivenContext($key, $configurationId, $idShopGroup, $idShop);
+        self::deleteMultiShopConfigurationByKey($key, $configurationId, $idShopGroup, $idShop);
     }
 
     /**
@@ -616,7 +616,7 @@ class ConfigurationCore extends ObjectModel
      * @param int|null $idShopGroup
      * @param int|null $idShop
      */
-    public static function deleteFromGivenContext($key, int $configurationId = null, int $idShopGroup = null, int $idShop = null)
+    public static function deleteMultiShopConfigurationByKey($key, ?int $configurationId, ?int $idShopGroup, ?int $idShop): void
     {
         $configurationId = $configurationId ?: Configuration::getIdByNameFromGivenContext($key, $idShopGroup, $idShop);
         Db::getInstance()->execute('

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -118,8 +118,8 @@ class ConfigurationCore extends ObjectModel
 
     /**
      * @param string $key
-     * @param int $idShopGroup
-     * @param int $idShop
+     * @param int|null $idShopGroup
+     * @param int|null $idShop
      *
      * @return int Configuration key ID
      */

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -123,7 +123,7 @@ class ConfigurationCore extends ObjectModel
      *
      * @return int Configuration key ID
      */
-    public static function getIdByNameFromGivenContext($key, $idShopGroup = null, $idShop = null)
+    public static function getIdByNameFromGivenContext(string $key, int $idShopGroup = null, int $idShop = null): int
     {
         $sql = 'SELECT `' . bqSQL(self::$definition['primary']) . '`
                 FROM `' . _DB_PREFIX_ . bqSQL(self::$definition['table']) . '`

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -999,6 +999,7 @@ class ShopCore extends ObjectModel
     {
         self::$context = null;
         self::$feature_active = null;
+        self::$context_id_shop = null;
     }
 
     /**

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -103,6 +103,9 @@ class ShopCore extends ObjectModel
     /** @var int ID shop group in the current context (will be empty if context is CONTEXT_ALL) */
     protected static $context_id_shop_group;
 
+    /** @var bool is multistore activated */
+    protected static $feature_active;
+
     /** @var Theme * */
     public $theme;
 
@@ -995,6 +998,7 @@ class ShopCore extends ObjectModel
     public static function resetContext()
     {
         self::$context = null;
+        self::$feature_active = null;
     }
 
     /**
@@ -1153,14 +1157,12 @@ class ShopCore extends ObjectModel
      */
     public static function isFeatureActive()
     {
-        static $feature_active = null;
-
-        if ($feature_active === null) {
-            $feature_active = (bool) Db::getInstance()->getValue('SELECT value FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"')
+        if (self::$feature_active === null) {
+            self::$feature_active = (bool) Db::getInstance()->getValue('SELECT value FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"')
                 && (Db::getInstance()->getValue('SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'shop') > 1);
         }
 
-        return $feature_active;
+        return self::$feature_active;
     }
 
     public function copyShopData($old_id, $tables_import = false, $deleted = false)

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -103,7 +103,7 @@ class ShopCore extends ObjectModel
     /** @var int ID shop group in the current context (will be empty if context is CONTEXT_ALL) */
     protected static $context_id_shop_group;
 
-    /** @var bool is multistore activated */
+    /** @var bool|null is multistore activated */
     protected static $feature_active;
 
     /** @var Theme * */

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1157,8 +1157,8 @@ class ShopCore extends ObjectModel
      */
     public static function isFeatureActive()
     {
-        if (self::$feature_active === null) {
-            self::$feature_active = (bool) Db::getInstance()->getValue('SELECT value FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"')
+        if (static::$feature_active === null) {
+            static::$feature_active = (bool) Db::getInstance()->getValue('SELECT value FROM `' . _DB_PREFIX_ . 'configuration` WHERE `name` = "PS_MULTISHOP_FEATURE_ACTIVE"')
                 && (Db::getInstance()->getValue('SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'shop') > 1);
         }
 

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1162,7 +1162,7 @@ class ShopCore extends ObjectModel
                 && (Db::getInstance()->getValue('SELECT COUNT(*) FROM ' . _DB_PREFIX_ . 'shop') > 1);
         }
 
-        return self::$feature_active;
+        return static::$feature_active;
     }
 
     public function copyShopData($old_id, $tables_import = false, $deleted = false)

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -395,6 +395,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
     /**
      * @param string $key
      * @param ShopConstraint $shopConstraint
+     *
      * @throws ShopException
      */
     public function deleteFromContext(string $key, ShopConstraint $shopConstraint): void

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -401,8 +401,9 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
         $shopId = $shopConstraint->getShopId();
         $shopGroupId = $shopConstraint->getShopGroupId();
 
-        ConfigurationLegacy::deleteFromContext(
+        ConfigurationLegacy::deleteFromGivenContext(
             $key,
+            null,
             !empty($shopGroupId) ? $shopGroupId->getValue() : null,
             !empty($shopId) ? $shopId->getValue() : null
         );

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -401,7 +401,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
     {
         if ($shopConstraint->forAllShops()) {
             throw new ShopException(
-                'Configuration values cannot be deleted for all shop context',
+                sprintf('This method can not be used for all shops, if you want to completely delete a configuration use %s:: remove() instead', static::class),
             );
         }
 

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -401,9 +401,8 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
         $shopId = $shopConstraint->getShopId();
         $shopGroupId = $shopConstraint->getShopGroupId();
 
-        ConfigurationLegacy::deleteMultiShopConfigurationByKey(
+        ConfigurationLegacy::deleteFromGivenContext(
             $key,
-            null,
             !empty($shopGroupId) ? $shopGroupId->getValue() : null,
             !empty($shopId) ? $shopId->getValue() : null
         );

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -401,7 +401,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
     {
         if ($shopConstraint->forAllShops()) {
             throw new ShopException(
-                sprintf('This method can not be used for all shops, if you want to completely delete a configuration use %s:: remove() instead', static::class),
+                sprintf('This method can not be used for all shops, if you want to completely delete a configuration use %s::remove() instead', static::class),
             );
         }
 

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -401,7 +401,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
     {
         if ($shopConstraint->forAllShops()) {
             throw new ShopException(
-                sprintf('This method can not be used for all shops, if you want to completely delete a configuration use %s::remove() instead', static::class),
+                sprintf('This method can not be used for all shops, if you want to completely delete a configuration use %s::remove() instead', static::class)
             );
         }
 

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -395,9 +395,16 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
     /**
      * @param string $key
      * @param ShopConstraint $shopConstraint
+     * @throws ShopException
      */
     public function deleteFromContext(string $key, ShopConstraint $shopConstraint): void
     {
+        if ($shopConstraint->forAllShops()) {
+            throw new ShopException(
+                'Configuration values cannot be deleted for all shop context',
+            );
+        }
+
         $shopId = $shopConstraint->getShopId();
         $shopGroupId = $shopConstraint->getShopGroupId();
 

--- a/src/Adapter/Configuration.php
+++ b/src/Adapter/Configuration.php
@@ -401,7 +401,7 @@ class Configuration extends ParameterBag implements ShopConfigurationInterface
         $shopId = $shopConstraint->getShopId();
         $shopGroupId = $shopConstraint->getShopGroupId();
 
-        ConfigurationLegacy::deleteFromGivenContext(
+        ConfigurationLegacy::deleteMultiShopConfigurationByKey(
             $key,
             null,
             !empty($shopGroupId) ? $shopGroupId->getValue() : null,

--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -37,7 +37,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
     /**
      * @var array<int, string>
      */
-    private $fields = ['enable_shop', 'maintenance_ip', 'maintenance_text'];
+    const CONFIGURATION_FIELDS = ['enable_shop', 'maintenance_ip', 'maintenance_text'];
 
     /**
      * {@inheritdoc}
@@ -75,7 +75,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
     protected function buildResolver(): OptionsResolver
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefined($this->fields);
+        $resolver->setDefined(self::CONFIGURATION_FIELDS);
         $resolver->setAllowedTypes('enable_shop', 'bool');
         $resolver->setAllowedTypes('maintenance_ip', 'string');
         $resolver->setAllowedTypes('maintenance_text', 'array');

--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Shop;
 
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
-use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * This class loads and saves data configuration for the Maintenance page.
@@ -37,17 +37,19 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
     /**
      * @var array<int, string>
      */
-    private $fields = ['enable_shop', 'maintenance_ip', 'maintenance_text'];
+    protected $fields = ['enable_shop', 'maintenance_ip', 'maintenance_text'];
 
     /**
      * {@inheritdoc}
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
             'enable_shop' => $this->configuration->getBoolean('PS_SHOP_ENABLE'),
-            'maintenance_ip' => $this->configuration->get('PS_MAINTENANCE_IP'),
-            'maintenance_text' => $this->configuration->get('PS_MAINTENANCE_TEXT'),
+            'maintenance_ip' => $this->configuration->get('PS_MAINTENANCE_IP', null, $shopConstraint),
+            'maintenance_text' => $this->configuration->get('PS_MAINTENANCE_TEXT', null, $shopConstraint),
         ];
     }
 
@@ -68,24 +70,16 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
     }
 
     /**
-     * @param array $configurationInputValues
-     *
-     * @return bool
+     * @return OptionsResolver
      */
-    public function validateConfiguration(array $configurationInputValues)
+    protected function buildResolver(): OptionsResolver
     {
-        // add multistore fields in list of expected fields
-        foreach ($this->fields as $value) {
-            $this->fields[] = MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . $value;
-        }
+        $resolver = new OptionsResolver();
+        $resolver->setDefined($this->fields);
+        $resolver->setAllowedTypes('enable_shop', 'bool');
+        $resolver->setAllowedTypes('maintenance_ip', 'string');
+        $resolver->setAllowedTypes('maintenance_text', 'array');
 
-        // check all given fields are expected
-        foreach ($configurationInputValues as $key => $value) {
-            if (!in_array($key, $this->fields)) {
-                return false;
-            }
-        }
-
-        return true;
+        return $resolver;
     }
 }

--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -37,7 +37,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
     /**
      * @var array<int, string>
      */
-    const CONFIGURATION_FIELDS = ['enable_shop', 'maintenance_ip', 'maintenance_text'];
+    private const CONFIGURATION_FIELDS = ['enable_shop', 'maintenance_ip', 'maintenance_text'];
 
     /**
      * {@inheritdoc}
@@ -47,7 +47,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
         $shopConstraint = $this->getShopConstraint();
 
         return [
-            'enable_shop' => $this->configuration->getBoolean('PS_SHOP_ENABLE'),
+            'enable_shop' => (bool) $this->configuration->get('PS_SHOP_ENABLE'),
             'maintenance_ip' => $this->configuration->get('PS_MAINTENANCE_IP', null, $shopConstraint),
             'maintenance_text' => $this->configuration->get('PS_MAINTENANCE_TEXT', null, $shopConstraint),
         ];

--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -47,7 +47,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
         $shopConstraint = $this->getShopConstraint();
 
         return [
-            'enable_shop' => (bool) $this->configuration->get('PS_SHOP_ENABLE'),
+            'enable_shop' => (bool) $this->configuration->get('PS_SHOP_ENABLE', false, $shopConstraint),
             'maintenance_ip' => $this->configuration->get('PS_MAINTENANCE_IP', null, $shopConstraint),
             'maintenance_text' => $this->configuration->get('PS_MAINTENANCE_TEXT', null, $shopConstraint),
         ];

--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -37,7 +37,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
     /**
      * @var array<int, string>
      */
-    protected $fields = ['enable_shop', 'maintenance_ip', 'maintenance_text'];
+    private $fields = ['enable_shop', 'maintenance_ip', 'maintenance_text'];
 
     /**
      * {@inheritdoc}

--- a/src/Core/Configuration/AbstractMultistoreConfiguration.php
+++ b/src/Core/Configuration/AbstractMultistoreConfiguration.php
@@ -120,7 +120,7 @@ abstract class AbstractMultistoreConfiguration implements DataConfigurationInter
         $resolver = $this->buildResolver();
         $definedOptions = $fields = $resolver->getDefinedOptions();
 
-        if (!$this->shopContext->isAllShopContext()) {
+        if (!$this->multistoreFeature->isUsed() || !$this->shopContext->isAllShopContext()) {
             // add multistore fields in list of defined fields
             foreach ($definedOptions as $value) {
                 $fields[] = MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . $value;

--- a/src/Core/Configuration/AbstractMultistoreConfiguration.php
+++ b/src/Core/Configuration/AbstractMultistoreConfiguration.php
@@ -109,7 +109,7 @@ abstract class AbstractMultistoreConfiguration implements DataConfigurationInter
      * - Only defined configuration fields exist
      * - In single or group shop context, multistore fields are added to the list of defined fields, so that no error
      * is triggered because of additional checkboxes
-     * - In all shop context, all fields must be there
+     * - In all shop context, all fields are required
      *
      * @param array $configurationInputValues
      *

--- a/src/Core/Configuration/AbstractMultistoreConfiguration.php
+++ b/src/Core/Configuration/AbstractMultistoreConfiguration.php
@@ -120,7 +120,7 @@ abstract class AbstractMultistoreConfiguration implements DataConfigurationInter
         $resolver = $this->buildResolver();
         $definedOptions = $fields = $resolver->getDefinedOptions();
 
-        if (!$this->multistoreFeature->isUsed() || !$this->shopContext->isAllShopContext()) {
+        if ($this->multistoreFeature->isUsed() && !$this->shopContext->isAllShopContext()) {
             // add multistore fields in list of defined fields
             foreach ($definedOptions as $value) {
                 $fields[] = MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . $value;

--- a/src/Core/Configuration/AbstractMultistoreConfiguration.php
+++ b/src/Core/Configuration/AbstractMultistoreConfiguration.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 abstract class AbstractMultistoreConfiguration implements DataConfigurationInterface
 {
@@ -64,6 +65,8 @@ abstract class AbstractMultistoreConfiguration implements DataConfigurationInter
         $this->shopContext = $shopContext;
         $this->multistoreFeature = $multistoreFeature;
     }
+
+    abstract protected function buildResolver(): OptionsResolver;
 
     /**
      * @return ShopConstraint|null
@@ -99,5 +102,38 @@ abstract class AbstractMultistoreConfiguration implements DataConfigurationInter
         } else {
             $this->configuration->set($configurationKey, $input[$fieldName], $shopConstraint, $options);
         }
+    }
+
+    /**
+     * This method checks that:
+     * - Only defined configuration fields exist
+     * - In single or group shop context, multistore fields are added to the list of defined fields, so that no error
+     * is triggered because of additional checkboxes
+     * - In all shop context, all fields must be there
+     *
+     * @param array $configurationInputValues
+     *
+     * @return bool
+     */
+    public function validateConfiguration(array $configurationInputValues): bool
+    {
+        $resolver = $this->buildResolver();
+        $definedOptions = $fields = $resolver->getDefinedOptions();
+
+        if (!$this->shopContext->isAllShopContext()) {
+            // add multistore fields in list of defined fields
+            foreach ($definedOptions as $value) {
+                $fields[] = MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . $value;
+            }
+            $resolver->setDefined($fields);
+        } else {
+            // all fields are mandatory in all shop context. (not in single or group shop context because fields
+            // can be disabled with checkboxes)
+            $resolver->setRequired($definedOptions);
+        }
+
+        $resolver->resolve($configurationInputValues);
+
+        return true;
     }
 }

--- a/src/Core/Configuration/AbstractMultistoreConfiguration.php
+++ b/src/Core/Configuration/AbstractMultistoreConfiguration.php
@@ -87,7 +87,7 @@ abstract class AbstractMultistoreConfiguration implements DataConfigurationInter
      * @param ShopConstraint|null $shopConstraint
      * @param array $options<int, string> Options @deprecated Will be removed in next major
      */
-    public function updateConfigurationValue(string $configurationKey, string $fieldName, array $input, ?ShopConstraint $shopConstraint, array $options = []): void
+    protected function updateConfigurationValue(string $configurationKey, string $fieldName, array $input, ?ShopConstraint $shopConstraint, array $options = []): void
     {
         if (!array_key_exists($fieldName, $input)) {
             return;

--- a/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
+++ b/src/Core/Domain/Shop/ValueObject/ShopConstraint.php
@@ -124,6 +124,14 @@ class ShopConstraint
     /**
      * @return bool
      */
+    public function forAllShops(): bool
+    {
+        return null === $this->shopId && null === $this->shopGroupId;
+    }
+
+    /**
+     * @return bool
+     */
     public function isStrict(): bool
     {
         return $this->strict;

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -79,7 +79,7 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
      * @param array $data
      * @param array $checkList
      */
-    public function testUpdate(ShopConstraint $shopConstraint, array $data, array $checkList)
+    public function testUpdate(ShopConstraint $shopConstraint, array $data, array $checkList): void
     {
         $testedObject = $this->getConfiguration($shopConstraint);
         $testedObject->updateConfiguration($data);

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -79,13 +79,13 @@ class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
      */
     public function testUpdate(ShopConstraint $shopConstraint, array $data, array $checkList): void
     {
-        $testedObject = $this->getConfiguration($shopConstraint);
+        $testedObject = $this->getDummyMultistoreConfiguration($shopConstraint);
         $testedObject->updateConfiguration($data);
 
         LegacyConfiguration::resetStaticCache();
 
         foreach ($checkList as $expectedValues) {
-            $testedObject = $this->getConfiguration($expectedValues[0]);
+            $testedObject = $this->getDummyMultistoreConfiguration($expectedValues[0]);
             Shop::resetContext();
             $testResults = $testedObject->getConfiguration();
             foreach ($expectedValues[1] as $key => $value) {

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -86,7 +86,6 @@ class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
 
         foreach ($checkList as $expectedValues) {
             $testedObject = $this->getDummyMultistoreConfiguration($expectedValues[0]);
-            Shop::resetContext();
             $testResults = $testedObject->getConfiguration();
             foreach ($expectedValues[1] as $key => $value) {
                 $this->assertTrue($value === $testResults[$key]);

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Core\Configuration;
 
+use Configuration as LegacyConfiguration;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
@@ -148,6 +149,20 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
         $newShop->deleted = false;
         $newShop->add();
         $this->newShop = $newShop;
+        Shop::resetContext();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        // remove previously created shop
+        $newShopId = Shop::getIdByName('test_shop_2');
+        $newShop = new Shop($newShopId);
+        $newShop->delete();
+
+        // disable multistore
+        LegacyConfiguration::set('PS_MULTISHOP_FEATURE_ACTIVE', 0);
+
+        // reset shop context
         Shop::resetContext();
     }
 }

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -160,7 +160,7 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
         $newShop->delete();
 
         // disable multistore
-        LegacyConfiguration::set('PS_MULTISHOP_FEATURE_ACTIVE', 0);
+        LegacyConfiguration::deleteByName('PS_MULTISHOP_FEATURE_ACTIVE');
 
         // reset shop context
         Shop::resetContext();

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -76,10 +76,6 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
      */
     public function testUpdate(?ShopConstraint $shopConstraint): void
     {
-        if (null === $shopConstraint) {
-            $shopConstraint = ShopConstraint::shop((int) $this->newShop->id);
-        }
-
         // we mock the shop context so that its `getShopConstraint` method returns the ShopConstraint from our provider
         $this->shopContext = $this->createShopContextMock();
         $this->shopContext

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -99,7 +99,7 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
         }
 
         $res = $testedObject->getConfiguration();
-        $this->assertSame(true, (bool) $res['test_conf_1']);
+        $this->assertSame(true, $res['test_conf_1']);
         $this->assertSame('string_result', $res['test_conf_2']);
 
         if ($isAllShopContext) {
@@ -112,7 +112,7 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
         $testedObject->updateConfiguration(['test_conf_1' => false]);
         $testedObject->updateConfiguration(['test_conf_2' => 'string_result_not_saved']);
         $res = $testedObject->getConfiguration();
-        $this->assertSame(true, (bool) $res['test_conf_1']);
+        $this->assertSame(true, $res['test_conf_1']);
         $this->assertSame('string_result', $res['test_conf_2']);
     }
 

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Core\Configuration;
+
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
+use Shop;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Tests\Resources\DummyMultistoreConfiguration;
+
+class AbstractMultistoreConfigurationTest extends KernelTestCase
+{
+    /**
+     * @var Configuration
+     */
+    protected $legacyConfiguration;
+
+    /**
+     * @var Context
+     */
+    protected $shopContext;
+
+    /**
+     * @var FeatureInterface
+     */
+    protected $multistoreFeature;
+
+    /**
+     * @var Shop
+     */
+    protected $newShop;
+
+    public function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = self::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+        $this->legacyConfiguration = self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration');
+        $this->initMultistore();
+        $this->multistoreFeature = self::$kernel->getContainer()->get('prestashop.adapter.multistore_feature');
+    }
+
+    /**
+     * @dataProvider provideShopConstraints
+     */
+    public function testUpdate(?ShopConstraint $shopConstraint): void
+    {
+        if (null === $shopConstraint) {
+            $shopConstraint = ShopConstraint::shop((int) $this->newShop->id);
+        }
+
+        // we mock the shop context so that its `getShopConstraint` method returns the ShopConstraint from our provider
+        $this->shopContext = $this->createShopContextMock();
+        $this->shopContext
+            ->method('getShopConstraint')
+            ->willReturn($shopConstraint);
+
+        $testedObject = new DummyMultistoreConfiguration(
+            $this->legacyConfiguration,
+            $this->shopContext,
+            $this->multistoreFeature
+        );
+
+        // test with multistore checkboxes, data should be saved for current context
+        $testedObject->updateConfiguration(['test_conf_1' => true, MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . 'test_conf_1' => true]);
+        $testedObject->updateConfiguration(['test_conf_2' => 'string_result', MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . 'test_conf_2' => true]);
+        $res = $testedObject->getConfiguration();
+        $this->assertSame(true, $res['test_conf_1']);
+        $this->assertSame('string_result', $res['test_conf_2']);
+
+        // test without multistore checkboxes, previously saved data should be removed for current context
+        $testedObject->updateConfiguration(['test_conf_1' => true]);
+        $testedObject->updateConfiguration(['test_conf_2' => 'string_result']);
+        $res = $testedObject->getConfiguration();
+        $this->assertSame(null, $res['test_conf_1']);
+        $this->assertSame(null, $res['test_conf_2']);
+
+        // test wrong data (should get related exception)
+        $this->expectException(UndefinedOptionsException::class);
+        $testedObject->updateConfiguration(['undefined_element' => true, MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . 'test_conf_1' => true]);
+        $this->expectException(InvalidOptionsException::class);
+        $testedObject->updateConfiguration(['test_conf_1' => 'wrong value type', MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX . 'test_conf_1' => true]);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideShopConstraints(): array
+    {
+        return [
+            [ShopConstraint::allShops()],
+            [ShopConstraint::shopGroup(1)],
+            [ShopConstraint::shop(1)],
+        ];
+    }
+
+    /**
+     * @return ShopContext
+     */
+    protected function createShopContextMock(): Context
+    {
+        return $this->getMockBuilder(Context::class)
+            ->setMethods(['getContextShopGroup', 'getContextShopID', 'isAllShopContext', 'getShopConstraint'])
+            ->getMock();
+    }
+
+    private function initMultistore(): void
+    {
+        // activate multistore
+        $this->legacyConfiguration->set('PS_MULTISHOP_FEATURE_ACTIVE', 1);
+        $newShop = new Shop();
+        $newShop->active = true;
+        $newShop->id_category = 2;
+        $newShop->name = 'test_shop_2';
+        $newShop->id_shop_group = 1;
+        $newShop->color = 'red';
+        $newShop->theme_name = 'classic';
+        $newShop->deleted = false;
+        $newShop->add();
+        $this->newShop = $newShop;
+        Shop::resetContext();
+    }
+}

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -84,7 +84,7 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
         $testedObject = $this->getConfiguration($shopConstraint);
         $testedObject->updateConfiguration($data);
 
-        LegacyConfiguration::clearConfigurationCacheForTesting();
+        LegacyConfiguration::resetStaticCache();
 
         foreach ($checkList as $expectedValues) {
             $testedObject = $this->getConfiguration($expectedValues[0]);

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -79,7 +79,7 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
      */
     public function testUpdate(ShopConstraint $shopConstraint, bool $isAllShopContext): void
     {
-        $testedObject = $this->getTestableObject($shopConstraint, $isAllShopContext);
+        $testedObject = $this->getConfiguration($shopConstraint, $isAllShopContext);
 
         if ($isAllShopContext) {
             // in all shop we test without multistore checkboxes (it would throw an exception, this is tested elsewhere)
@@ -124,7 +124,7 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
      */
     public function testUndefinedOptionsException(ShopConstraint $shopConstraint, bool $isAllShopContext): void
     {
-        $testedObject = $this->getTestableObject($shopConstraint, $isAllShopContext);
+        $testedObject = $this->getConfiguration($shopConstraint, $isAllShopContext);
         $this->expectException(UndefinedOptionsException::class);
 
         if ($isAllShopContext) {
@@ -144,7 +144,7 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
      */
     public function testInvalidOptionsException(ShopConstraint $shopConstraint, bool $isAllShopContext): void
     {
-        $testedObject = $this->getTestableObject($shopConstraint, $isAllShopContext);
+        $testedObject = $this->getConfiguration($shopConstraint, $isAllShopContext);
         $this->expectException(InvalidOptionsException::class);
         $confValues = [
             'test_conf_1' => 'wrong value type',
@@ -164,7 +164,7 @@ class AbstractMultistoreConfigurationTest extends KernelTestCase
      *
      * @return DummyMultistoreConfiguration
      */
-    private function getTestableObject(ShopConstraint $shopConstraint, bool $isAllShopContext): DummyMultistoreConfiguration
+    private function getConfiguration(ShopConstraint $shopConstraint, bool $isAllShopContext): DummyMultistoreConfiguration
     {
         // we mock the shop context so that its `getShopConstraint` method returns the ShopConstraint from our provider
         $this->shopContext = $this->createShopContextMock();

--- a/tests/Integration/Utility/ContextMocker.php
+++ b/tests/Integration/Utility/ContextMocker.php
@@ -87,7 +87,7 @@ class ContextMocker
         // need to reset loooot of things
         Product::flushPriceCache();
         SpecificPrice::flushCache();
-        Configuration::clearConfigurationCacheForTesting();
+        Configuration::resetStaticCache();
         Configuration::loadConfiguration();
         Cache::clear();
         Cart::resetStaticCache();

--- a/tests/Resources/DummyMultistoreConfiguration.php
+++ b/tests/Resources/DummyMultistoreConfiguration.php
@@ -75,4 +75,10 @@ class DummyMultistoreConfiguration extends AbstractMultistoreConfiguration
 
         return $resolver;
     }
+
+    // wrapper public method to test the protected "updateConfigurationValue" method in unit tests
+    public function dummyUpdateConfigurationValue($fieldName, $inputValues, $shopConstraint)
+    {
+        $this->updateConfigurationValue('PS_CONF_KEY', $fieldName, $inputValues, $shopConstraint);
+    }
 }

--- a/tests/Resources/DummyMultistoreConfiguration.php
+++ b/tests/Resources/DummyMultistoreConfiguration.php
@@ -41,7 +41,7 @@ class DummyMultistoreConfiguration extends AbstractMultistoreConfiguration
         $shopConstraint = $this->getShopConstraint();
 
         return [
-            'test_conf_1' => $this->configuration->get('TEST_CONF_1', null, $shopConstraint),
+            'test_conf_1' => (bool) $this->configuration->get('TEST_CONF_1', null, $shopConstraint),
             'test_conf_2' => $this->configuration->get('TEST_CONF_2', null, $shopConstraint),
         ];
     }

--- a/tests/Resources/DummyMultistoreConfiguration.php
+++ b/tests/Resources/DummyMultistoreConfiguration.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Resources;
+
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class DummyMultistoreConfiguration extends AbstractMultistoreConfiguration
+{
+    public function getConfiguration()
+    {
+        $shopConstraint = $this->getShopConstraint();
+
+        return [
+            'test_conf_1' => $this->configuration->get('TEST_CONF_1', null, $shopConstraint),
+            'test_conf_2' => $this->configuration->get('TEST_CONF_2', null, $shopConstraint),
+        ];
+    }
+
+    public function updateConfiguration(array $configurationInputValues)
+    {
+        if ($this->validateConfiguration($configurationInputValues)) {
+            $shopConstraint = $this->getShopConstraint();
+
+            $this->updateConfigurationValue('TEST_CONF_1', 'test_conf_1', $configurationInputValues, $shopConstraint);
+            $this->updateConfigurationValue('TEST_CONF_2', 'test_conf_2', $configurationInputValues, $shopConstraint);
+        }
+
+        return [];
+    }
+
+    public function buildResolver(): OptionsResolver
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefined(['test_conf_1', 'test_conf_2']);
+        $resolver->setAllowedTypes('test_conf_1', 'bool');
+        $resolver->setAllowedTypes('test_conf_2', 'string');
+
+        return $resolver;
+    }
+}

--- a/tests/Resources/DummyMultistoreConfiguration.php
+++ b/tests/Resources/DummyMultistoreConfiguration.php
@@ -33,7 +33,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class DummyMultistoreConfiguration extends AbstractMultistoreConfiguration
 {
-    public function getConfiguration()
+    /**
+     * @return array
+     */
+    public function getConfiguration(): array
     {
         $shopConstraint = $this->getShopConstraint();
 
@@ -43,7 +46,12 @@ class DummyMultistoreConfiguration extends AbstractMultistoreConfiguration
         ];
     }
 
-    public function updateConfiguration(array $configurationInputValues)
+    /**
+     * @param array $configurationInputValues
+     *
+     * @return array
+     */
+    public function updateConfiguration(array $configurationInputValues): array
     {
         if ($this->validateConfiguration($configurationInputValues)) {
             $shopConstraint = $this->getShopConstraint();
@@ -55,6 +63,9 @@ class DummyMultistoreConfiguration extends AbstractMultistoreConfiguration
         return [];
     }
 
+    /**
+     * @return OptionsResolver
+     */
     public function buildResolver(): OptionsResolver
     {
         $resolver = new OptionsResolver();

--- a/tests/TestCase/AbstractConfigurationTestCase.php
+++ b/tests/TestCase/AbstractConfigurationTestCase.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\TestCase;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Shop\Context as ShopContext;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+
+abstract class AbstractConfigurationTestCase extends TestCase
+{
+    /**
+     * @var Configuration
+     */
+    protected $mockConfiguration;
+
+    /**
+     * @var ShopContext
+     */
+    protected $mockShopConfiguration;
+
+    /**
+     * @var FeatureInterface
+     */
+    protected $mockMultistoreFeature;
+
+    protected function setUp(): void
+    {
+        $this->mockConfiguration = $this->createConfigurationMock();
+        $this->mockShopConfiguration = $this->createShopContextMock();
+        $this->mockMultistoreFeature = $this->createMultistoreFeatureMock();
+    }
+
+    /**
+     * @return Configuration
+     */
+    protected function createConfigurationMock(): Configuration
+    {
+        return $this->getMockBuilder(Configuration::class)
+            ->setMethods(['get', 'getBoolean', 'set'])
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return ShopContext
+     */
+    protected function createShopContextMock(): ShopContext
+    {
+        return $this->getMockBuilder(ShopContext::class)
+            ->setMethods(['getContextShopGroup', 'getContextShopID', 'isAllShopContext', 'getShopConstraint'])
+            ->getMock();
+    }
+
+    /**
+     * @return FeatureInterface
+     */
+    protected function createMultistoreFeatureMock(): FeatureInterface
+    {
+        return $this->getMockForAbstractClass(FeatureInterface::class);
+    }
+}

--- a/tests/TestCase/AbstractConfigurationTestCase.php
+++ b/tests/TestCase/AbstractConfigurationTestCase.php
@@ -103,7 +103,7 @@ abstract class AbstractConfigurationTestCase extends KernelTestCase
 
         $this->shopContext
             ->method('isAllShopContext')
-            ->willReturn($isAllShopContext);
+            ->willReturn($shopConstraint->forAllShops());
 
         return new DummyMultistoreConfiguration(
             $this->legacyConfigurationAdapter,

--- a/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
+++ b/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Preferences;
+
+use PrestaShop\PrestaShop\Adapter\Shop\MaintenanceConfiguration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Tests\TestCase\AbstractConfigurationTestCase;
+
+class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
+{
+    /**
+     * @var PreferencesConfiguration
+     */
+    private $maintenanceConfiguration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->maintenanceConfiguration = new MaintenanceConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+    }
+
+    /**
+     * @dataProvider provideShopConstraints
+     */
+    public function testGetConfiguration(ShopConstraint $shopConstraint): void
+    {
+        $this->mockShopConfiguration
+            ->method('getShopConstraint')
+            ->willReturn($shopConstraint);
+
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['PS_MAINTENANCE_IP', null, $shopConstraint, 'test'],
+                    ['PS_MAINTENANCE_IP', null, null, null],
+                    ['PS_MAINTENANCE_TEXT', null, $shopConstraint, 'test'],
+                    ['PS_MAINTENANCE_TEXT', null, null, null],
+                ]
+            );
+
+        $this->mockConfiguration
+            ->method('getBoolean')
+            ->willReturnMap(
+                [
+                    ['PS_SHOP_ENABLE', false, true],
+                ]
+            );
+
+        $result = $this->maintenanceConfiguration->getConfiguration();
+        $this->assertSame(
+            [
+                'enable_shop' => true,
+                'maintenance_ip' => 'test',
+                'maintenance_text' => 'test',
+            ],
+            $result
+        );
+    }
+
+    public function testUpdateConfigurationWithInvalidConfiguration(): void
+    {
+        $this->expectException(UndefinedOptionsException::class);
+        $this->maintenanceConfiguration->updateConfiguration(['does_not_exist' => 'does_not_exist']);
+        $this->expectException(InvalidOptionsException::class);
+        $this->maintenanceConfiguration->updateConfiguration(['enable_shop' => 'wrong_type']);
+        $this->expectException(InvalidOptionsException::class);
+        $this->maintenanceConfiguration->updateConfiguration(['maintenance_text' => ['wrong_type']]);
+        $this->expectException(InvalidOptionsException::class);
+        $this->maintenanceConfiguration->updateConfiguration(['maintenance_text' => 'wrong_type']);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideShopConstraints(): array
+    {
+        return [
+            [ShopConstraint::shop(2)],
+            [ShopConstraint::shopGroup(2)],
+            [ShopConstraint::allShops()],
+        ];
+    }
+}

--- a/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
+++ b/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
@@ -93,7 +93,7 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
         $this->expectException(InvalidOptionsException::class);
         $this->maintenanceConfiguration->updateConfiguration(['enable_shop' => 'wrong_type']);
         $this->expectException(InvalidOptionsException::class);
-        $this->maintenanceConfiguration->updateConfiguration(['maintenance_text' => ['wrong_type']]);
+        $this->maintenanceConfiguration->updateConfiguration(['maintenance_ip' => ['wrong_type']]);
         $this->expectException(InvalidOptionsException::class);
         $this->maintenanceConfiguration->updateConfiguration(['maintenance_text' => 'wrong_type']);
     }

--- a/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
-use Symfony\Component\OptionsResolver\OptionsResolver;
+use Tests\Resources\DummyMultistoreConfiguration;
 use Tests\TestCase\AbstractConfigurationTestCase;
 
 class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
@@ -125,33 +125,11 @@ class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
         int $shopGroupId = 1,
         int $shopId = 1
     ): AbstractMultistoreConfiguration {
-        return new class($this->createShopConfigurationMock($expectedCalledMethod), $this->createMultistoreContextMock($isAllShopContext, $shopGroupId, $shopId), $this->getMultistoreFeatureMock($isMultistoreUsed)) extends AbstractMultistoreConfiguration {
-            public function getConfiguration()
-            {
-                return [];
-            }
-
-            public function validateConfiguration(array $configuration): bool
-            {
-                return true;
-            }
-
-            public function updateConfiguration(array $configuration)
-            {
-                return [];
-            }
-
-            public function buildResolver(): OptionsResolver
-            {
-                return new OptionsResolver();
-            }
-
-            // wrapper public method to test the protected "updateConfigurationValue" method
-            public function dummyUpdateConfigurationValue($fieldName, $inputValues, $shopConstraint)
-            {
-                $this->updateConfigurationValue('PS_CONF_KEY', $fieldName, $inputValues, $shopConstraint);
-            }
-        };
+        return new DummyMultistoreConfiguration(
+            $this->createShopConfigurationMock($expectedCalledMethod),
+            $this->createMultistoreContextMock($isAllShopContext, $shopGroupId, $shopId),
+            $this->getMultistoreFeatureMock($isMultistoreUsed)
+        );
     }
 
     /**

--- a/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -27,7 +27,6 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Configuration as ShopConfiguration;
 use PrestaShop\PrestaShop\Adapter\Shop\Context as ShopContext;
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
@@ -35,8 +34,9 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Tests\TestCase\AbstractConfigurationTestCase;
 
-class AbstractMultistoreConfigurationTest extends TestCase
+class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
 {
     /**
      * @dataProvider provideForGetShopConstraint

--- a/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -91,7 +91,7 @@ class AbstractMultistoreConfigurationTest extends TestCase
     {
         // this will test that inside the `UpdateConfigurationValue` method, the right update method will be called depending on situation
         $abstractMultistoreConfiguration = $this->getTestableClass(false, $expectedMethodToBeCalled, $isMultistoreUsed);
-        $abstractMultistoreConfiguration->updateConfigurationValue('PS_CONF_KEY', $fieldName, $inputValues, $this->getShopConstraintMock());
+        $abstractMultistoreConfiguration->dummyUpdateConfigurationValue($fieldName, $inputValues, $this->getShopConstraintMock());
     }
 
     /**
@@ -144,6 +144,12 @@ class AbstractMultistoreConfigurationTest extends TestCase
             public function buildResolver(): OptionsResolver
             {
                 return new OptionsResolver();
+            }
+
+            // wrapper public method to test the protected "updateConfigurationValue" method
+            public function dummyUpdateConfigurationValue($fieldName, $inputValues, $shopConstraint)
+            {
+                $this->updateConfigurationValue('PS_CONF_KEY', $fieldName, $inputValues, $shopConstraint);
             }
         };
     }

--- a/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AbstractMultistoreConfigurationTest extends TestCase
 {
@@ -138,6 +139,11 @@ class AbstractMultistoreConfigurationTest extends TestCase
             public function updateConfiguration(array $configuration)
             {
                 return [];
+            }
+
+            public function buildResolver(): OptionsResolver
+            {
+                return new OptionsResolver();
             }
         };
     }

--- a/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Unit/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -130,7 +130,7 @@ class AbstractMultistoreConfigurationTest extends TestCase
                 return [];
             }
 
-            public function validateConfiguration(array $configuration)
+            public function validateConfiguration(array $configuration): bool
             {
                 return true;
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In configuration classes (ex: MaintenanceConfiguration), this PR moves `validateConfiguration` method into `AbstractMultistoreConfiguration` and defines a new mandatory abstract method `buildResolver` 
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | #26240
| How to test?      | Maintenance configuration page still works in multistore
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

**:notebook: BC Breaks :** 

- Added method `buildResolver` to `AbstractMultistoreConfiguration` class
- Changed scope of the method `updateConfigurationValue` in `AbstractMultistoreConfiguration` class in protected

**This PR does several things:**

1/ A small refactor impacting classes extending `AbstractMultistoreConfiguration`, it:

- Abstracts common validation processes into `AbstractMultistoreConfiguration`
- Enforces the use Symfony's `OptionsResolver` for data validation, by making the `buildResolver` method mandatory and returning an `OptionsResolver`

This was motivated by the lack of concrete usage for the mandatory `validateConfiguration` method, using the OptionsResolver is cleaner than chaining meaningless calls of `isset`  on configuration fields.

2/ Unit tests for the `MaintenanceConfiguration` class

3/ Integration tests for `AbstractMultistoreConfiguration` class (via PHPUnit)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25956)
<!-- Reviewable:end -->
