### PR TITLE
Multistore - Orders > Delivery Slips - Add checkboxes

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/delivery/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/delivery/index.ts
@@ -30,3 +30,11 @@ const {$} = window;
 $(() => {
   new TranslatableInput();
 });
+
+$(() => {
+  window.prestashop.component.initComponents(
+    [
+      'MultistoreConfigField',
+    ],
+  );
+});

--- a/src/Adapter/Order/Delivery/SlipOptionsConfiguration.php
+++ b/src/Adapter/Order/Delivery/SlipOptionsConfiguration.php
@@ -26,27 +26,16 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Order\Delivery;
 
-use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 
 /**
  * This class manages Order delivery slip options configuration.
  */
-final class SlipOptionsConfiguration implements DataConfigurationInterface
+final class SlipOptionsConfiguration extends AbstractMultistoreConfiguration
 {
     public const PREFIX = 'PS_DELIVERY_PREFIX';
     public const NUMBER = 'PS_DELIVERY_NUMBER';
     public const ENABLE_PRODUCT_IMAGE = 'PS_PDF_IMG_DELIVERY';
-
-    /**
-     * @var Configuration
-     */
-    private $configuration;
-
-    public function __construct(Configuration $configuration)
-    {
-        $this->configuration = $configuration;
-    }
 
     /**
      * Returns configuration used to manage slip options in back office.
@@ -68,9 +57,9 @@ final class SlipOptionsConfiguration implements DataConfigurationInterface
     public function updateConfiguration(array $configuration)
     {
         if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set(self::PREFIX, $configuration['prefix']);
-            $this->configuration->set(self::NUMBER, $configuration['number']);
-            $this->configuration->set(self::ENABLE_PRODUCT_IMAGE, $configuration['enable_product_image']);
+            $this->updateConfigurationValue(self::PREFIX, 'prefix', $configuration, $this->getShopConstraint());
+            $this->updateConfigurationValue(self::NUMBER, 'number', $configuration, $this->getShopConstraint());
+            $this->updateConfigurationValue(self::ENABLE_PRODUCT_IMAGE, 'enable_product_image', $configuration, $this->getShopConstraint());
         }
 
         return [];

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -71,6 +71,16 @@ class SlipOptionsType extends MultistoreConfigurationType
 
     /**
      * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
+    }
+
+    /**
+     * {@inheritdoc}
      */
     public function getBlockPrefix()
     {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Sell\Order\Delivery;
 
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -36,7 +37,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * This form class generates the "Options" form in Delivery slips page.
  */
-class SlipOptionsType extends TranslatorAwareType
+class SlipOptionsType extends MultistoreConfigurationType
 {
     /**
      * {@inheritdoc}
@@ -49,15 +50,22 @@ class SlipOptionsType extends TranslatorAwareType
                 TranslatableType::class,
                 [
                     'type' => TextType::class,
+                    'multistore_configuration_key' => 'PS_DELIVERY_PREFIX',
                 ]
             )
             ->add(
                 'number',
-                FormType\NumberType::class
+                FormType\NumberType::class,
+                [
+                    'multistore_configuration_key' => 'PS_DELIVERY_NUMBER',
+                ]
             )
             ->add(
                 'enable_product_image',
-                SwitchType::class
+                SwitchType::class,
+                [
+                    'multistore_configuration_key' => 'PS_PDF_IMG_DELIVERY',
+                ]
             );
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Form\Admin\Sell\Order\Delivery;
 use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
-use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/delivery_slips.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/delivery_slips.yml
@@ -1,6 +1,6 @@
 admin_order_delivery_slip:
     path: /
-    methods:  [GET, POST]
+    methods:  [GET, PATCH,POST]
     defaults:
         _controller: PrestaShopBundle\Controller\Admin\Sell\Order\DeliveryController::slipAction
         _legacy_controller: AdminDeliverySlip

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -106,7 +106,7 @@ services:
 
     prestashop.adapter.logs.configuration:
         class: 'PrestaShop\PrestaShop\Adapter\Configuration\LogsConfiguration'
-        arguments: 
+        arguments:
             - '@prestashop.adapter.legacy.configuration'
             - '@translator'
             - '@prestashop.adapter.validate'
@@ -115,6 +115,8 @@ services:
         class: 'PrestaShop\PrestaShop\Adapter\Order\Delivery\SlipOptionsConfiguration'
         arguments:
             - '@prestashop.adapter.legacy.configuration'
+            - '@prestashop.adapter.shop.context'
+            - '@prestashop.adapter.multistore_feature'
 
     prestashop.adapter.order.delivery.slip.pdf.configuration:
         class: 'PrestaShop\PrestaShop\Adapter\Order\Delivery\SlipPdfConfiguration'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add multi store new behaviour on Delivery Slip Page , this PR need the implementation of https://github.com/PrestaShop/PrestaShop/pull/22139 to work properly
| Type?             | new feature 
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19383.
| How to test?      | Multistore - Checkbox should be visible on field slip_prefix on page Orders > Delivery Slips
| Possible impacts? | Change the way the data are saved with multistore


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25957)
<!-- Reviewable:end -->
