### PR TITLE
Fix CLI install

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -1020,7 +1020,7 @@ class ShopCore extends ObjectModel
     /**
      * Get current ID of shop if context is CONTEXT_SHOP.
      *
-     * @return int
+     * @return int|null
      */
     public static function getContextShopID($null_value_without_multishop = false)
     {
@@ -1046,7 +1046,7 @@ class ShopCore extends ObjectModel
     /**
      * Get current ID of shop group if context is CONTEXT_SHOP or CONTEXT_GROUP.
      *
-     * @return int
+     * @return int|null
      */
     public static function getContextShopGroupID($null_value_without_multishop = false)
     {

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -67,6 +67,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         // Clean all cache values
         Cache::clean('*');
 
+        Configuration::set('PS_SHOP_DEFAULT', 1);
         Shop::initialize();
         Context::getContext()->shop = new Shop(1);
         Shop::setContext(Shop::CONTEXT_SHOP, 1);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | When installing PrestaShop in CLI in a subfolder (`--base_uri=/subfolder`), the installer throw an exception. This PR aims to fix this.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25959
| How to test?      | Try to install PrestaShop in CLI with the `--base_uri` option:`php install-dev/index_cli.php --base_uri=/subfolder`, no exception should be thrown
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25982)
<!-- Reviewable:end -->
