### PR TITLE
Provide modules with information how much a quantity changed

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -625,6 +625,8 @@ class StockAvailableCore extends ObjectModel
                     'id_product' => $id_product,
                     'id_product_attribute' => $id_product_attribute,
                     'quantity' => $stock_available->quantity,
+                    'delta_quantity' => $deltaQuantity ?? null,
+                    'id_shop' => $id_shop,
                 ]
             );
         }

--- a/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
+++ b/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
@@ -28,8 +28,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Stock\Update;
 
-use Hook;
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository;
@@ -84,19 +84,24 @@ class ProductStockUpdater
      */
     private $advancedStockEnabled;
 
+    /** @var HookManager */
+    private $hookManager;
+
     /**
      * @param StockManager $stockManager
      * @param ProductMultiShopRepository $productRepository
      * @param StockAvailableMultiShopRepository $stockAvailableRepository
      * @param MovementReasonRepository $movementReasonRepository
      * @param Configuration $configuration
+     * @param HookManager $hookManager
      */
     public function __construct(
         StockManager $stockManager,
         ProductMultiShopRepository $productRepository,
         StockAvailableMultiShopRepository $stockAvailableRepository,
         MovementReasonRepository $movementReasonRepository,
-        Configuration $configuration
+        Configuration $configuration,
+        HookManager $hookManager
     ) {
         $this->stockManager = $stockManager;
         $this->productRepository = $productRepository;
@@ -104,6 +109,7 @@ class ProductStockUpdater
         $this->movementReasonRepository = $movementReasonRepository;
         $this->configuration = $configuration;
         $this->advancedStockEnabled = $this->configuration->getBoolean('PS_ADVANCED_STOCK_MANAGEMENT');
+        $this->hookManager = $hookManager;
     }
 
     /**
@@ -311,7 +317,7 @@ class ProductStockUpdater
             ]
         );
 
-        Hook::exec(
+        $this->hookManager->exec(
             'actionUpdateQuantity',
             [
                 'id_product' => $stockAvailable->id_product,

--- a/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
+++ b/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Stock\Update;
 
+use Hook;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository;
@@ -306,6 +307,17 @@ class ProductStockUpdater
             $stockModification->getDeltaQuantity(),
             [
                 'id_stock_mvt_reason' => $stockModification->getMovementReasonId()->getValue(),
+                'id_shop' => (int) $stockAvailable->id_shop,
+            ]
+        );
+
+        Hook::exec(
+            'actionUpdateQuantity',
+            [
+                'id_product' => $stockAvailable->id_product,
+                'id_product_attribute' => $stockAvailable->id_product_attribute,
+                'quantity' => $stockAvailable->quantity,
+                'delta_quantity' => $stockModification->getDeltaQuantity(),
                 'id_shop' => (int) $stockAvailable->id_shop,
             ]
         );

--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -191,6 +191,7 @@ class StockManager
                 'id_product_attribute' => $id_product_attribute,
                 'quantity' => $stockAvailable->quantity,
                 'delta_quantity' => $delta_quantity,
+                'id_shop' => $id_shop,
             ]
         );
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
@@ -56,3 +56,4 @@ services:
       - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
       - '@prestashop.adapter.product.stock.repository.movement_reason_repository'
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.hook.manager'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allows modules to know how much the quantity has changed during update. Not only the new number.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially fixes #25981
| How to test?      | Test using ps_qualityassurance and see that correct increments/decrements are provided in delta_quantity
| Possible impacts? | -

I named the parameter the same as in other parts of PS: https://github.com/PrestaShop/PrestaShop/blob/ad181f7fb89dea67dfebba779a6440854baa6d5b/src/Core/Stock/StockManager.php#L193