### PR TITLE
Remove duplicate actionCategoryUpdate call on toggling category display status

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -278,19 +278,6 @@ class CategoryCore extends ObjectModel
     }
 
     /**
-     * Toggles the `active` flag.
-     *
-     * @return bool Indicates whether the status was successfully toggled
-     */
-    public function toggleStatus()
-    {
-        $result = parent::toggleStatus();
-        Hook::exec('actionCategoryUpdate', ['category' => $this]);
-
-        return $result;
-    }
-
-    /**
      * Recursive scan of subcategories.
      *
      * @param int $maxDepth Maximum depth of the tree (i.e. 2 => 3 levels depth)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix actionCategoryUpdate hook triggering twice on toggling category display status.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25870
| How to test?      | See issue for testing
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25995)
<!-- Reviewable:end -->
