### PR TITLE
Fix bugs that occur in CI because of non-resilient code

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2423,20 +2423,22 @@ abstract class ModuleCore implements ModuleInterface
         if (Configuration::get('PS_SSL_ENABLED')) {
             $cache_array[] = (int) Tools::usingSecureMode();
         }
-        if (Shop::isFeatureActive()) {
+        if (isset($this->context->shop) && Shop::isFeatureActive()) {
             $cache_array[] = (int) $this->context->shop->id;
         }
         if (Group::isFeatureActive() && isset($this->context->customer)) {
             $cache_array[] = (int) Group::getCurrent()->id;
             $cache_array[] = implode('_', Customer::getGroupsStatic($this->context->customer->id));
         }
-        if (Language::isMultiLanguageActivated()) {
+        if (isset($this->context->language) && Language::isMultiLanguageActivated()) {
             $cache_array[] = (int) $this->context->language->id;
         }
-        if (Currency::isMultiCurrencyActivated()) {
+        if (isset($this->context->currency) && Currency::isMultiCurrencyActivated()) {
             $cache_array[] = (int) $this->context->currency->id;
         }
-        $cache_array[] = (int) $this->context->country->id;
+        if (isset($this->context->country)) {
+            $cache_array[] = (int) $this->context->country->id;
+        }
 
         return implode('|', $cache_array);
     }

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -66,7 +66,7 @@ class ModulePresenter implements PresenterInterface
         $attributes['picos'] = $this->addPicos($attributes);
         $attributes['price'] = $this->getModulePrice($attributes['price']);
         // Round to the nearest 0.5
-        $attributes['starsRate'] = str_replace('.', '', (string) (round($attributes['avgRate'] * 2) / 2));
+        $attributes['starsRate'] = str_replace('.', '', (string) (round(floatval($attributes['avgRate']) * 2) / 2));
 
         $moduleInstance = $module->getInstance();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix bugs that occur in CO because of non-resilient code This PR fixes two bugs:<br>- fix bug in Module.php when the currency is not in context, this usually happens locally even if the CI, weirdly, did not complain<br>- make code more resilient about `avgRate` from addons API, even if empty the code doesn't cause an error
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26036
| How to test?      | CI tests green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26047)
<!-- Reviewable:end -->
