### PR TITLE
Clean Back-office templates, part 1 - common

### DIFF
--- a/admin-dev/themes/default/template/content.tpl
+++ b/admin-dev/themes/default/template/content.tpl
@@ -26,10 +26,6 @@
 {* ajaxBox allows*}
 <div id="ajaxBox" style="display:none"></div>
 
-<div class="row">
-	<div class="col-lg-12">
-		{if isset($content)}
-			{$content}
-		{/if}
-	</div>
-</div>
+{if isset($content)}
+	{$content}
+{/if}

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
@@ -25,24 +25,19 @@
 
 {% block grid_pagination %}
   {% if grid.data.records_total > 10 or grid.pagination.offset %}
-    <div class="row">
-      <div class="col-md-12">
-        {% set route_params = {} %}
+    {% set route_params = {} %}
 
-        {% for param_name, param_value in app.request.attributes.get('_route_params') %}
-          {% set route_params = route_params|merge({ (param_name) : (param_value) }) %}
-        {% endfor %}
+    {% for param_name, param_value in app.request.attributes.get('_route_params') %}
+      {% set route_params = route_params|merge({ (param_name) : (param_value) }) %}
+    {% endfor %}
 
-        {{ render(controller('PrestaShopBundle:Admin\\Common:pagination', {
-          'limit': grid.pagination.limit,
-          'offset': grid.pagination.offset,
-          'total': grid.data.records_total,
-          'prefix': grid.form_prefix,
-          'caller_route': app.request.attributes.get('_route'),
-          'caller_parameters': route_params
-        })) }}
-      </div>
-    </div>
+    {{ render(controller('PrestaShopBundle:Admin\\Common:pagination', {
+      'limit': grid.pagination.limit,
+      'offset': grid.pagination.offset,
+      'total': grid.data.records_total,
+      'prefix': grid.form_prefix,
+      'caller_route': app.request.attributes.get('_route'),
+      'caller_parameters': route_params
+    })) }}
   {% endif %}
 {% endblock %}
-

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/toggle.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/toggle.html.twig
@@ -33,9 +33,13 @@
     class="ps-switch ps-switch-sm ps-switch-nolabel ps-switch-center ps-togglable-row"
     data-toggle-url="{{ path(column.options.route, {(column.options.route_param_name) : id_primary_key})}}"
   >
-  <input type="radio" name="input-{{ column.options.route }}-{{ id_primary_key }}" id="input-false-{{ column.options.route }}-{{ id_primary_key }}" value="0" {% if not isValid %}checked{% endif %}>
+  <input type="radio" name="input-{{ column.options.route }}-{{ id_primary_key }}" 
+         id="input-false-{{ column.options.route }}-{{ id_primary_key }}" 
+         value="0" {% if not isValid %}checked{% endif %}>
       <label for="input-false-{{ column.options.route }}-{{ id_primary_key }}">Off</label>
-      <input type="radio" name="input-{{ column.options.route }}-{{ id_primary_key }}" id="input-true-{{ column.options.route }}-{{ id_primary_key }}" value="1" {% if isValid %}checked{% endif %}>
+      <input type="radio" name="input-{{ column.options.route }}-{{ id_primary_key }}" 
+             id="input-true-{{ column.options.route }}-{{ id_primary_key }}" 
+             value="1" {% if isValid %}checked{% endif %}>
       <label for="input-true-{{ column.options.route }}-{{ id_primary_key }}">On</label>
       <span class="slide-button"></span>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/grid.html.twig
@@ -23,38 +23,20 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<div class="row grid js-grid" id="{{ grid.id }}_grid" data-grid-id="{{ grid.id }}">
-  <div class="col-sm">
-    {% block grid_header_row %}
-      <div class="row">
-        {% block grid_bulk_actions_block %}
-          <div class="col-sm">
-            <div class="row">
-              <div class="col-sm">
-                {{ include('@PrestaShop/Admin/Common/Grid/Blocks/bulk_actions.html.twig', {'grid': grid}) }}
-              </div>
-            </div>
-          </div>
-        {% endblock %}
-      </div>
+<div class="grid js-grid" id="{{ grid.id }}_grid" data-grid-id="{{ grid.id }}">
+  {% block grid_header_row %}
+    {% block grid_bulk_actions_block %}
+      {{ include('@PrestaShop/Admin/Common/Grid/Blocks/bulk_actions.html.twig', {'grid': grid}) }}
     {% endblock %}
+  {% endblock %}
 
-    {% block grid_table_row %}
-      <div class="row">
-        <div class="col-sm">
-          {{ include('@PrestaShop/Admin/Common/Grid/Blocks/table.html.twig', {'grid': grid}) }}
-        </div>
-      </div>
-    {% endblock %}
+  {% block grid_table_row %}
+    {{ include('@PrestaShop/Admin/Common/Grid/Blocks/table.html.twig', {'grid': grid}) }}
+  {% endblock %}
 
-    {% block grid_footer_row %}
-      <div class="row">
-        <div class="col">
-          {{ include('@PrestaShop/Admin/Common/Grid/Blocks/pagination.html.twig', {'grid': grid}) }}
-        </div>
-      </div>
-    {% endblock %}
-  </div>
+  {% block grid_footer_row %}
+    {{ include('@PrestaShop/Admin/Common/Grid/Blocks/pagination.html.twig', {'grid': grid}) }}
+  {% endblock %}
 </div>
 
 {% block grid_extra_content %}{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
@@ -26,7 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}"/>
 {% endblock %}
 
 {% block title %}
@@ -35,47 +35,45 @@
 
 {% block body %}
   <div class="container">
-    <div class="row mt-5">
-      <div class="col">
-        <div class="card">
-          <div class="card-body text-center">
-            <img class="img-responsive"
-                 src="{{ asset('themes/new-theme/img/error/500.svg') }}"
-                 alt="{{ 'Oops... looks like an unexpected error occurred'|trans({}, 'Admin.Notifications.Error') }}"
-            >
+    <div class="mt-5">
+      <div class="card">
+        <div class="card-body text-center">
+          <img class="img-responsive" 
+               src="{{ asset('themes/new-theme/img/error/500.svg') }}" 
+               alt="{{ 'Oops... looks like an unexpected error occurred'|trans({}, 'Admin.Notifications.Error') }}">
 
-            <div class="mt-3">
-              <p class="error-header">
-                {{ 'Oops... looks like an unexpected error occurred'|trans({}, 'Admin.Notifications.Error') }}
-              </p>
+          <div class="mt-3">
+            <p class="error-header">
+              {{ 'Oops... looks like an unexpected error occurred'|trans({}, 'Admin.Notifications.Error') }}
+            </p>
 
-              {% if exception %}
-                <div class="mx-auto">
-                  <p class="mb-0">{{ exception.message }}</p>
-                  <p class="mb-0">[{{ exception.class }} {{ exception.code }}]</p>
-                </div>
-              {% endif %}
-
-              <div class="mt-4">
-                <form action="{{ path('admin_errors_enable_debug_mode') }}" method="post" class="d-inline">
-                  <input type="hidden" name="_redirect_url" value="{{ app.request.requestUri }}">
-
-                  <button class="btn btn-outline-secondary" type="submit">
-                    {{ 'Enable debug mode'|trans({}, 'Admin.Actions') }}
-                  </button>
-                </form>
-                <button class="btn btn-primary js-go-back-btn ml-3" type="button">
-                  {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
-                </button>
+            {% if exception %}
+              <div class="mx-auto">
+                <p class="mb-0">{{ exception.message }}</p>
+                <p class="mb-0">[{{ exception.class }}
+                  {{ exception.code }}]</p>
               </div>
+            {% endif %}
 
-              <p class="mt-3">
-                <a href="{{ documentation_link('debug_mode') }}" target="_blank">
-                  {{ 'Learn more about debug mode'|trans({}, 'Admin.Actions') }}
-                  <i class="material-icons">arrow_right_alt</i>
-                </a>
-              </p>
+            <div class="mt-4">
+              <form action="{{ path('admin_errors_enable_debug_mode') }}" method="post" class="d-inline">
+                <input type="hidden" name="_redirect_url" value="{{ app.request.requestUri }}">
+
+                <button class="btn btn-outline-secondary" type="submit">
+                  {{ 'Enable debug mode'|trans({}, 'Admin.Actions') }}
+                </button>
+              </form>
+              <button class="btn btn-primary js-go-back-btn ml-3" type="button">
+                {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
+              </button>
             </div>
+
+            <p class="mt-3">
+              <a href="{{ documentation_link('debug_mode') }}" target="_blank">
+                {{ 'Learn more about debug mode'|trans({}, 'Admin.Actions') }}
+                <i class="material-icons">arrow_right_alt</i>
+              </a>
+            </p>
           </div>
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
@@ -26,7 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}"/>
 {% endblock %}
 
 {% block title %}
@@ -35,55 +35,51 @@
 
 {% block body %}
   <div class="container">
-    <div class="row mt-5">
-      <div class="col">
-        <div class="card">
-          <div class="card-body text-center">
-            <img class="img-responsive"
-                 src="{{ asset('themes/new-theme/img/error/500.svg') }}"
-                 alt="{{ 'The object cannot be loaded (or found).'|trans({}, 'Admin.Notifications.Error') }}"
-            >
+    <div class="mt-5">
+      <div class="card">
+        <div class="card-body text-center">
+          <img class="img-responsive" src="{{ asset('themes/new-theme/img/error/500.svg') }}" alt="{{ 'The object cannot be loaded (or found).'|trans({}, 'Admin.Notifications.Error') }}">
 
-            <div class="mt-3">
-              <p class="error-header">
-                {{ 'The object cannot be loaded (or found).'|trans({}, 'Admin.Notifications.Error') }}
-              </p>
+          <div class="mt-3">
+            <p class="error-header">
+              {{ 'The object cannot be loaded (or found).'|trans({}, 'Admin.Notifications.Error') }}
+            </p>
 
-              {% if exception is defined and exception %}
-                <div class="mx-auto">
-                  <p class="mb-0">{{ exception.message }}</p>
-                  {% if exception.class is defined or exception.code is defined %}
-                    <p class="mb-0">[{{ exception.class|default('Exception') }} {{ exception.code|default(0) }}]</p>
-                  {% endif %}
-                </div>
-              {% endif %}
-
-              {% if errorMessage is defined %}
-                <div class="mx-auto">
-                  <p class="mb-0">{{ errorMessage }}</p>
-                </div>
-              {% endif %}
-
-              <div class="mt-4">
-                <form action="{{ path('admin_errors_enable_debug_mode') }}" method="post" class="d-inline">
-                  <input type="hidden" name="_redirect_url" value="{{ app.request.requestUri }}">
-
-                  <button class="btn btn-outline-secondary" type="submit">
-                    {{ 'Enable debug mode'|trans({}, 'Admin.Actions') }}
-                  </button>
-                </form>
-                <button class="btn btn-primary js-go-back-btn ml-3" type="button">
-                  {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
-                </button>
+            {% if exception is defined and exception %}
+              <div class="mx-auto">
+                <p class="mb-0">{{ exception.message }}</p>
+                {% if exception.class is defined or exception.code is defined %}
+                  <p class="mb-0">[{{ exception.class|default('Exception') }}
+                    {{ exception.code|default(0) }}]</p>
+                {% endif %}
               </div>
+            {% endif %}
 
-              <p class="mt-3">
-                <a href="{{ documentation_link('debug_mode') }}" target="_blank">
-                  {{ 'Learn more about debug mode'|trans({}, 'Admin.Actions') }}
-                  <i class="material-icons">arrow_right_alt</i>
-                </a>
-              </p>
+            {% if errorMessage is defined %}
+              <div class="mx-auto">
+                <p class="mb-0">{{ errorMessage }}</p>
+              </div>
+            {% endif %}
+
+            <div class="mt-4">
+              <form action="{{ path('admin_errors_enable_debug_mode') }}" method="post" class="d-inline">
+                <input type="hidden" name="_redirect_url" value="{{ app.request.requestUri }}">
+
+                <button class="btn btn-outline-secondary" type="submit">
+                  {{ 'Enable debug mode'|trans({}, 'Admin.Actions') }}
+                </button>
+              </form>
+              <button class="btn btn-primary js-go-back-btn ml-3" type="button">
+                {{ 'Back to previous page'|trans({}, 'Admin.Actions') }}
+              </button>
             </div>
+
+            <p class="mt-3">
+              <a href="{{ documentation_link('debug_mode') }}" target="_blank">
+                {{ 'Learn more about debug mode'|trans({}, 'Admin.Actions') }}
+                <i class="material-icons">arrow_right_alt</i>
+              </a>
+            </p>
           </div>
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -827,7 +827,7 @@
 
 {% block form_hint %}
   {% if hint %}
-    <div class="row col-lg hint-box">
+    <div class="hint-box">
       <div class="alert alert-info">{{ hint|raw }}</div>
     </div>
   {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
@@ -166,7 +166,6 @@
 {%- block number_widget -%}
   {# type="number" doesn't work with floats #}
   {%- set type = type|default('text') -%}
-
   {{ block('form_widget_simple') }}
 {%- endblock number_widget -%}
 
@@ -315,7 +314,10 @@
     {% set form_method = "POST" %}
   {%- endif -%}
   <form name="{{ name }}"
-        method="{{ form_method|lower }}" action="{{ action }}"{% for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}{% if multipart %} enctype="multipart/form-data"{% endif %}>
+        method="{{ form_method|lower }}" 
+        action="{{ action }}"
+        {% for attrname, attrvalue in attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}
+        {% if multipart %} enctype="multipart/form-data"{% endif %}>
   {%- if form_method != method -%}
     <input type="hidden" name="_method" value="{{ method }}"/>
   {%- endif -%}

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -88,7 +88,8 @@
 
 {# Show link to import file sample #}
 {% macro import_file_sample(label, filename) %}
-    <a id="download-sample-{{ filename }}-file-link" class="list-group-item list-group-item-action" href="{{ path('admin_import_sample_download', {'sampleName': filename}) }}">
+    <a id="download-sample-{{ filename }}-file-link" class="list-group-item list-group-item-action" 
+       href="{{ path('admin_import_sample_download', {'sampleName': filename}) }}">
         {{ label|trans({}, 'Admin.Advparameters.Feature') }}
     </a>
 {% endmacro %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | This PR should be considered as a BC because of lot of HTML structure changes and they might be used by a module or anything else, but it's acceptable. The optimizations are only within the files itself, so it does not matter if anyone uses the old version in any form in their modules.
| Deprecations?     | no
| How to test?      | Briefly go through pages that implement Grids (like order list) and see if nothing is broken by this PR. There should be no visible change.
| Possible impacts? | No bad impacts. :-)

### Description
- I went through all templates and removed 99% of unneeded boostrap code like `<div class="row"><div class="col">XXX</div></div>`. It will reduce render depth and complexity by several layers - easier to navigate, debug CSS, maybe faster to render on slower PCs.
- I fixed all places where somebody used single quotations or no quotations at all.
- I fixed all places where somebody combined row and column in same element, this is not allowed.
- I fixed all places where somebody used syntax line col-sm-12 col-md-12 or col-md-12 col-lg-6. The first one is not needed.
- Small fixes here and there - removed some container classes, fixed module position page responsivity a bit, fixed virtual product block responsivity etc...
It should produce no BC breaks, unless some 3rd party module was targetting some classes they shouldn't have OR they targeted it by child or parent.

### Templates concerned
Legacy wrapper
Common
Common/Grid
Exception

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26060)
<!-- Reviewable:end -->
