### PR TITLE
Clean Back-office templates, part 3 - improve

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/breadcrumb.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/breadcrumb.html.twig
@@ -24,30 +24,25 @@
  *#}
 
 {% if cmsPageView.breadcrumb_tree is not empty %}
-  <div class="row">
-    <div class="col">
-      <div class="card">
-        <div class="card-block">
-          <nav>
-            <ol class="breadcrumb">
-              {% for category in cmsPageView.breadcrumb_tree %}
-                <li class="breadcrumb-item">
-                  {% set cmsPageRouteParameters = {} %}
+  <div class="card">
+    <div class="card-block">
+      <nav>
+        <ol class="breadcrumb">
+          {% for category in cmsPageView.breadcrumb_tree %}
+            <li class="breadcrumb-item">
+              {% set cmsPageRouteParameters = {} %}
 
-                  {% if category.cmsPageCategoryId.value != cmsPageView.root_category_id %}
-                    {% set cmsPageRouteParameters = {'id_cms_category' : category.cmsPageCategoryId.value} %}
-                  {% endif %}
+              {% if category.cmsPageCategoryId.value != cmsPageView.root_category_id %}
+                {% set cmsPageRouteParameters = {'id_cms_category' : category.cmsPageCategoryId.value} %}
+              {% endif %}
 
-                  <a href="{{ path('admin_cms_pages_index', cmsPageRouteParameters) }}">
-                    {{ category.name }}
-                  </a>
-                </li>
-              {% endfor %}
-            </ol>
-          </nav>
-        </div>
-      </div>
+              <a href="{{ path('admin_cms_pages_index', cmsPageRouteParameters) }}">
+                {{ category.name }}
+              </a>
+            </li>
+          {% endfor %}
+        </ol>
+      </nav>
     </div>
   </div>
 {% endif %}
-

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/add.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/create_category.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/create_category.html.twig
@@ -25,15 +25,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
-          'cmsPageCategoryForm': cmsPageCategoryForm,
-          'cmsCategoryParentId': app.request.query.get('id_cms_category')
-        })
-      }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
+      'cmsPageCategoryForm': cmsPageCategoryForm,
+      'cmsCategoryParentId': app.request.query.get('id_cms_category')
+    })
+  }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit.html.twig
@@ -26,12 +26,8 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
-      <span class="js-preview-url" data-preview-url="{{ previewUrl }}"></span>
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/form.html.twig', {}) }}
+  <span class="js-preview-url" data-preview-url="{{ previewUrl }}"></span>
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit_category.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/edit_category.html.twig
@@ -26,15 +26,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
-          'cmsPageCategoryForm': cmsPageCategoryForm,
-          'cmsCategoryParentId': cmsCategoryParentId
-        })
-      }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/Design/Cms/Blocks/category_form.html.twig', {
+      'cmsPageCategoryForm': cmsPageCategoryForm,
+      'cmsCategoryParentId': cmsCategoryParentId
+    })
+  }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/index.html.twig
@@ -41,37 +41,24 @@
 
 {% block content %}
 
-  <div class="row">
-    <div class="col-sm">
-      {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/showcase_card.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/showcase_card.html.twig' %}
 
   {% block cms_page_category_breadcrumb %}
     {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/breadcrumb.html.twig' %}
   {% endblock %}
 
   {% block cms_category_grid %}
-    <div class="row">
-      <div class="col">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cmsCategoryGrid} %}
-
-            {% block grid_panel_footer %}
-              {% if app.request.query.get('id_cms_category') and app.request.query.get('id_cms_category') != cmsPageView.root_category_id %}
-                {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/listing_panel_footer.html.twig' %}
-              {% endif %}
-            {% endblock %}
-        {% endembed %}
-      </div>
-    </div>
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cmsCategoryGrid} %}
+      {% block grid_panel_footer %}
+        {% if app.request.query.get('id_cms_category') and app.request.query.get('id_cms_category') != cmsPageView.root_category_id %}
+          {% include '@PrestaShop/Admin/Improve/Design/Cms/Blocks/listing_panel_footer.html.twig' %}
+        {% endif %}
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 
   {% block cms_grid %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cmsGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cmsGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/configuration_form.html.twig
@@ -25,41 +25,35 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block mailThemeConfigurationFormBlock %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      {{ form_start(mailThemeConfigurationForm, {'action': path('admin_mail_theme_save_configuration')}) }}
-      <div class="card">
-        <h3 class="card-header">
-          <i class="material-icons">settings</i> {{ 'Configuration'|trans({}, 'Admin.Global') }}
-        </h3>
+{{ form_start(mailThemeConfigurationForm, {'action': path('admin_mail_theme_save_configuration')}) }}
+<div class="card">
+  <h3 class="card-header">
+    <i class="material-icons">settings</i>
+    {{ 'Configuration'|trans({}, 'Admin.Global') }}
+  </h3>
 
-        <div class="card-block row">
-          <div class="card-text">
-
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ ps.label_with_help(
-                  ('Select your default email theme'|trans({}, 'Admin.Design.Feature')),
-                  ('This won\'t regenerate email templates, it only sets the default email theme for future generation (when a language is installed for example).'|trans({}, 'Admin.Design.Help'))
-                ) }}
-              </label>
-              <div class="col-sm">
-                {{ form_errors(mailThemeConfigurationForm.defaultTheme) }}
-                {{ form_widget(mailThemeConfigurationForm.defaultTheme) }}
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            <button class="btn btn-primary" id="save-configuration-form">
-              <span>{{ 'Save'|trans({}, 'Admin.Actions') }}</span>
-            </button>
-          </div>
+  <div class="card-block row">
+    <div class="card-text">
+      <div class="form-group row">
+        {{ ps.label_with_help(
+          ('Select your default email theme'|trans({}, 'Admin.Design.Feature')),
+          ('This won\'t regenerate email templates, it only sets the default email theme for future generation (when a language is installed for example).'|trans({}, 'Admin.Design.Help'))
+        ) }}
+        <div class="col-sm">
+          {{ form_errors(mailThemeConfigurationForm.defaultTheme) }}
+          {{ form_widget(mailThemeConfigurationForm.defaultTheme) }}
         </div>
       </div>
-      {{ form_end(mailThemeConfigurationForm) }}
     </div>
   </div>
+
+  <div class="card-footer">
+    <div class="d-flex justify-content-end">
+      <button class="btn btn-primary" id="save-configuration-form">
+        <span>{{ 'Save'|trans({}, 'Admin.Actions') }}</span>
+      </button>
+    </div>
+  </div>
+</div>
+{{ form_end(mailThemeConfigurationForm) }}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/generate_mails_form.html.twig
@@ -25,77 +25,74 @@
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
 {% block generateMailsFormBlock %}
-<div class="row justify-content-center">
-  <div class="col-xl-12">
-    {{ form_start(generateMailsForm, {'action': path('admin_mail_theme_generate')}) }}
-    <div class="card">
-      <h3 class="card-header">
-        <i class="material-icons">email</i> {{ 'Generate emails'|trans({}, 'Admin.Design.Feature') }}
-      </h3>
 
-      <div class="card-block row">
-        <div class="card-text">
+  {{ form_start(generateMailsForm, {'action': path('admin_mail_theme_generate')}) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">email</i>
+      {{ 'Generate emails'|trans({}, 'Admin.Design.Feature') }}
+    </h3>
 
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Select your email theme'|trans({}, 'Admin.Design.Feature') }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(generateMailsForm.mailTheme) }}
-              {{ form_widget(generateMailsForm.mailTheme) }}
-            </div>
+    <div class="card-block row">
+      <div class="card-text">
+
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Select your email theme'|trans({}, 'Admin.Design.Feature') }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(generateMailsForm.mailTheme) }}
+            {{ form_widget(generateMailsForm.mailTheme) }}
           </div>
+        </div>
 
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(generateMailsForm.language) }}
-              {{ form_widget(generateMailsForm.language) }}
-            </div>
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(generateMailsForm.language) }}
+            {{ form_widget(generateMailsForm.language) }}
           </div>
+        </div>
 
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ ps.label_with_help(
-                ('Select the theme you want to overwrite'|trans({}, 'Admin.Design.Feature')),
-              ('PrestaShop\'s email templates are stored in the "mails" folder, but they can be overridden by your current theme\'s own "mails" folder. Using this option enables to overwrite emails from your current theme.'|trans({}, 'Admin.Design.Help'))
-              ) }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(generateMailsForm.theme) }}
-              {{ form_widget(generateMailsForm.theme) }}
-              {% if generateMailsForm.theme.vars.disabled %}
+        <div class="form-group row">
+          {{ ps.label_with_help(
+            ('Select the theme you want to overwrite'|trans({}, 'Admin.Design.Feature')),
+            ('PrestaShop\'s email templates are stored in the "mails" folder, but they can be overridden by your current theme\'s own "mails" folder. Using this option enables to overwrite emails from your current theme.'|trans({}, 'Admin.Design.Help'))
+          ) }}
+          <div class="col-sm">
+            {{ form_errors(generateMailsForm.theme) }}
+            {{ form_widget(generateMailsForm.theme) }}
+            {% if generateMailsForm.theme.vars.disabled %}
               <small class="form-text">{{ 'No emails were detected in any theme folder so this field is disabled.'|trans({}, 'Admin.Design.Help') }}</small>
-              {% endif %}
-            </div>
+            {% endif %}
           </div>
+        </div>
 
-          <div class="form-group row">
-            {{ ps.label_with_help(
-              ('Overwrite templates'|trans({}, 'Admin.Design.Feature')),
+        <div class="form-group row">
+          {{ ps.label_with_help(
+            ('Overwrite templates'|trans({}, 'Admin.Design.Feature')),
             ('By default, existing email template files are not modified to avoid deleting any modification you may have done. Enable this option to force the overwrite.'|trans({}, 'Admin.Design.Help'))
-            ) }}
-            <div class="col-sm">
-              {{ form_errors(generateMailsForm.overwrite) }}
-              {{ form_widget(generateMailsForm.overwrite) }}
-            </div>
+          ) }}
+          <div class="col-sm">
+            {{ form_errors(generateMailsForm.overwrite) }}
+            {{ form_widget(generateMailsForm.overwrite) }}
           </div>
-
         </div>
-      </div>
 
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary">
-            <i class="material-icons">email</i>
-            <span>{{ 'Generate emails'|trans({}, 'Admin.Actions') }}</span>
-          </button>
-        </div>
       </div>
     </div>
-    {{ form_end(generateMailsForm) }}
+
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary">
+          <i class="material-icons">email</i>
+          <span>{{ 'Generate emails'|trans({}, 'Admin.Actions') }}</span>
+        </button>
+      </div>
+    </div>
   </div>
-</div>
+  {{ form_end(generateMailsForm) }}
+
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_theme_layouts.html.twig
@@ -24,98 +24,95 @@
  *#}
 
 {% block generateMailsFormBlock %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div class="card">
-        <h3 class="card-header">
-          <i class="material-icons">email</i> {{ 'List %theme% layouts'|trans({'%theme%': mailTheme.name}, 'Admin.Design.Feature') }}
-        </h3>
 
-        <div class="card-block">
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">email</i>
+      {{ 'List %theme% layouts'|trans({'%theme%': mailTheme.name}, 'Admin.Design.Feature') }}
+    </h3>
 
-            <table class="grid-table table">
-              <thead class="thead-default">
-                <tr class="column-headers">
-                  <th scope="col">
-                    {{ 'Name'|trans({}, 'Admin.Global') }}
-                  </th>
-                  <th scope="col">
-                    {{ 'Module'|trans({}, 'Admin.Global') }}
-                  </th>
-                  <th scope="col">
-                    <div class="grid-actions-header-text">
-                      {{ 'Actions'|trans({}, 'Admin.Global') }}
+    <div class="card-block">
+
+      <table class="grid-table table">
+        <thead class="thead-default">
+          <tr class="column-headers">
+            <th scope="col">
+              {{ 'Name'|trans({}, 'Admin.Global') }}
+            </th>
+            <th scope="col">
+              {{ 'Module'|trans({}, 'Admin.Global') }}
+            </th>
+            <th scope="col">
+              <div class="grid-actions-header-text">
+                {{ 'Actions'|trans({}, 'Admin.Global') }}
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for mailLayout in mailTheme.layouts %}
+            <tr>
+              <td class="data-type">
+                {{ mailLayout.name }}
+              </td>
+              <td class="data-type">
+                {{ mailLayout.moduleName }}
+              </td>
+              <td class="action-type">
+                {% if mailLayout.moduleName is empty %}
+                  {% set previewUrl = path('admin_mail_theme_preview_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
+                  {% set rawUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
+                  {% set txtUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'txt'}) %}
+                  {% set mailUrl = path('admin_mail_theme_send_test_mail', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name}) %}
+                {% else %}
+                  {% set previewUrl = path('admin_mail_theme_preview_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
+                  {% set rawUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
+                  {% set txtUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'txt'}) %}
+                  {% set mailUrl = path('admin_mail_theme_send_test_module_mail', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name}) %}
+                {% endif %}
+
+                <div class="btn-group-action text-right">
+                  <div class="btn-group">
+                    <a target="_blank" class="btn tooltip-link dropdown-item" href="{{ previewUrl }}">
+                      <i class="material-icons">http</i>
+                    </a>
+
+                    <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate"
+                       data-toggle="dropdown" 
+                       aria-haspopup="true" 
+                       aria-expanded="false">
+                    </a>
+                    <div class="dropdown-menu dropdown-menu-right">
+                      <a target="_blank" class="btn tooltip-link dropdown-item raw-html-link" href="{{ rawUrl }}">
+                        <i class="material-icons">code</i>
+                        {{ 'Raw HTML'|trans({}, 'Admin.Design.Feature') }}
+                      </a>
+                      <a target="_blank" class="btn tooltip-link dropdown-item raw-text-link" href="{{ txtUrl }}">
+                        <i class="material-icons">subject</i>
+                        {{ 'Text'|trans({}, 'Admin.Design.Feature') }}
+                      </a>
+                      <a class="btn tooltip-link dropdown-item" href="{{ mailUrl }}">
+                        <i class="material-icons">email</i>
+                        {{ 'Send a test email'|trans({}, 'Admin.Advparameters.Feature') }}
+                      </a>
                     </div>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for mailLayout in mailTheme.layouts %}
-                  <tr>
-                    <td class="data-type">
-                      {{ mailLayout.name }}
-                    </td>
-                    <td class="data-type">
-                      {{ mailLayout.moduleName }}
-                    </td>
-                    <td class="action-type">
-                      {% if mailLayout.moduleName is empty %}
-                        {% set previewUrl = path('admin_mail_theme_preview_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
-                        {% set rawUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'html'}) %}
-                        {% set txtUrl = path('admin_mail_theme_raw_layout', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name, type: 'txt'}) %}
-                        {% set mailUrl = path('admin_mail_theme_send_test_mail', {locale: app.request.locale, theme: mailTheme.name, layout: mailLayout.name}) %}
-                      {% else %}
-                        {% set previewUrl = path('admin_mail_theme_preview_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
-                        {% set rawUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'html'}) %}
-                        {% set txtUrl = path('admin_mail_theme_raw_module_layout', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name, type: 'txt'}) %}
-                        {% set mailUrl = path('admin_mail_theme_send_test_module_mail', {locale: app.request.locale, theme: mailTheme.name, module: mailLayout.moduleName, layout: mailLayout.name}) %}
-                      {% endif %}
+                  </div>
+                </div>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
 
-                      <div class="btn-group-action text-right">
-                        <div class="btn-group">
-                          <a target="_blank" class="btn tooltip-link dropdown-item" href="{{ previewUrl }}">
-                            <i class="material-icons">http</i>
-                          </a>
-
-                          <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate"
-                             data-toggle="dropdown"
-                             aria-haspopup="true"
-                             aria-expanded="false"
-                          >
-                          </a>
-
-                          <div class="dropdown-menu dropdown-menu-right">
-                            <a target="_blank" class="btn tooltip-link dropdown-item raw-html-link" href="{{ rawUrl }}">
-                              <i class="material-icons">code</i>
-                              {{ 'Raw HTML'|trans({}, 'Admin.Design.Feature') }}
-                            </a>
-                            <a target="_blank" class="btn tooltip-link dropdown-item raw-text-link" href="{{ txtUrl }}">
-                              <i class="material-icons">subject</i>
-                              {{ 'Text'|trans({}, 'Admin.Design.Feature') }}
-                            </a>
-                            <a class="btn tooltip-link dropdown-item" href="{{ mailUrl }}">
-                              <i class="material-icons">email</i>
-                              {{ 'Send a test email'|trans({}, 'Admin.Advparameters.Feature') }}
-                            </a>
-                          </div>
-                        </div>
-                      </div>
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-
-        </div>
-
-        <div class="card-footer">
-          <a href="{{ path('admin_mail_theme_index', params|default({})) }}" class="btn btn-outline-secondary" id="back-to-configuration-link">
-            <i class="material-icons">arrow_back</i>
-            {{ 'Back to configuration'|trans({}, 'Admin.Actions') }}
-          </a>
-        </div>
-
-      </div>
     </div>
+
+    <div class="card-footer">
+      <a href="{{ path('admin_mail_theme_index', params|default({})) }}" class="btn btn-outline-secondary" id="back-to-configuration-link">
+        <i class="material-icons">arrow_back</i>
+        {{ 'Back to configuration'|trans({}, 'Admin.Actions') }}
+      </a>
+    </div>
+
   </div>
+
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_themes.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/list_mail_themes.html.twig
@@ -24,48 +24,45 @@
  *#}
 
 {% block generateMailsFormBlock %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div class="card">
-        <h3 class="card-header">
-          <i class="material-icons">email</i> {{ 'Email themes'|trans({}, 'Admin.Design.Feature') }}
-        </h3>
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">email</i>
+      {{ 'Email themes'|trans({}, 'Admin.Design.Feature') }}
+    </h3>
 
-        <div class="card-block">
+    <div class="card-block">
 
-            <table class="grid-table table">
-              <thead class="thead-default">
-                <tr class="column-headers">
-                  <th scope="col">
-                    {{ 'Name'|trans({}, 'Admin.Global') }}
-                  </th>
-                  <th scope="col">
-                    <div class="grid-actions-header-text">
-                      {{ 'Actions'|trans({}, 'Admin.Global') }}
-                    </div>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for theme in mailThemes %}
-                  <tr>
-                    <td class="data-type column-name">
-                      {{ theme.name }}
-                    </td>
-                    <td class="action-type">
-                      <div class="btn-group-action text-right">
-                        <a class="btn tooltip-link preview-link" href="{{ path('admin_mail_theme_preview', {'theme': theme.name}) }}">
-                          <i class="material-icons">search</i>
-                        </a>
-                      </div>
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
+      <table class="grid-table table">
+        <thead class="thead-default">
+          <tr class="column-headers">
+            <th scope="col">
+              {{ 'Name'|trans({}, 'Admin.Global') }}
+            </th>
+            <th scope="col">
+              <div class="grid-actions-header-text">
+                {{ 'Actions'|trans({}, 'Admin.Global') }}
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for theme in mailThemes %}
+            <tr>
+              <td class="data-type column-name">
+                {{ theme.name }}
+              </td>
+              <td class="action-type">
+                <div class="btn-group-action text-right">
+                  <a class="btn tooltip-link preview-link" href="{{ path('admin_mail_theme_preview', {'theme': theme.name}) }}">
+                    <i class="material-icons">search</i>
+                  </a>
+                </div>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
 
-        </div>
-      </div>
     </div>
   </div>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/MailTheme/Blocks/translate_mails_body_form.html.twig
@@ -24,38 +24,37 @@
  *#}
 
 {% block translateMailsBodyFormBlock %}
-<div class="row justify-content-center">
-  <div class="col-xl-12">
-    {{ form_start(translateMailsBodyForm, {'action': path('admin_mail_theme_translate_body')}) }}
-    <div class="card">
-      <h3 class="card-header">
-        <i class="material-icons">email</i> {{ 'Translate emails'|trans({}, 'Admin.Actions') }}
-      </h3>
 
-      <div class="card-block row">
-        <div class="card-text">
-          <div class="form-group row">
-            <label class="form-control-label">
-              {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
-            </label>
-            <div class="col-sm">
-              {{ form_errors(translateMailsBodyForm.language) }}
-              {{ form_widget(translateMailsBodyForm.language) }}
-            </div>
+  {{ form_start(translateMailsBodyForm, {'action': path('admin_mail_theme_translate_body')}) }}
+  <div class="card">
+    <h3 class="card-header">
+      <i class="material-icons">email</i>
+      {{ 'Translate emails'|trans({}, 'Admin.Actions') }}
+    </h3>
+
+    <div class="card-block row">
+      <div class="card-text">
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Select your language'|trans({}, 'Admin.International.Feature') }}
+          </label>
+          <div class="col-sm">
+            {{ form_errors(translateMailsBodyForm.language) }}
+            {{ form_widget(translateMailsBodyForm.language) }}
           </div>
         </div>
       </div>
+    </div>
 
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          <button class="btn btn-primary">
-            <i class="material-icons">email</i>
-            <span>{{ 'Translate emails'|trans({}, 'Admin.Actions') }}</span>
-          </button>
-        </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary">
+          <i class="material-icons">email</i>
+          <span>{{ 'Translate emails'|trans({}, 'Admin.Actions') }}</span>
+        </button>
       </div>
     </div>
-    {{ form_end(translateMailsBodyForm) }}
   </div>
-</div>
+  {{ form_end(translateMailsBodyForm) }}
+
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/customize_page_layouts.html.twig
@@ -26,49 +26,45 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col-12">
-      {{ form_start(pageLayoutCustomizationForm) }}
-        <div class="row justify-content-center">
-          <div class="col-xl-10">
-            <div class="card">
-              <h3 class="card-header">
-                <i class="material-icons">settings</i>
-                {{ 'Choose layouts'|trans({}, 'Admin.Actions') }}
-              </h3>
-              <div class="card-body">
-                <table class="table">
-                  <thead>
-                    <tr>
-                      <th>{{ 'Page'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Description'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Layout'|trans({}, 'Admin.Global') }}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for customizablePage in pages %}
-                      <tr>
-                        <td>{{ customizablePage.title|default(customizablePage.page) }}</td>
-                        <td>{{ customizablePage.description }}</td>
-                        <td>{{ form_widget(pageLayoutCustomizationForm['layouts'][customizablePage.page]) }}</td>
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
+  {{ form_start(pageLayoutCustomizationForm) }}
+  <div class="row justify-content-center">
+    <div class="col-xl-10">
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">settings</i>
+          {{ 'Choose layouts'|trans({}, 'Admin.Actions') }}
+        </h3>
+        <div class="card-body">
+          <table class="table">
+            <thead>
+              <tr>
+                <th>{{ 'Page'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Description'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Layout'|trans({}, 'Admin.Global') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for customizablePage in pages %}
+                <tr>
+                  <td>{{ customizablePage.title|default(customizablePage.page) }}</td>
+                  <td>{{ customizablePage.description }}</td>
+                  <td>{{ form_widget(pageLayoutCustomizationForm['layouts'][customizablePage.page]) }}</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
 
-                {% block page_layout_customization_form_rest %}
-                  {{ form_rest(pageLayoutCustomizationForm) }}
-                {% endblock %}
-              </div>
-              <div class="card-footer">
-                <div class="d-flex justify-content-end">
-                  <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-                </div>
-              </div>
-            </div>
+          {% block page_layout_customization_form_rest %}
+            {{ form_rest(pageLayoutCustomizationForm) }}
+          {% endblock %}
+        </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
           </div>
         </div>
-      {{ form_end(pageLayoutCustomizationForm) }}
+      </div>
     </div>
   </div>
+  {{ form_end(pageLayoutCustomizationForm) }}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/import.html.twig
@@ -41,83 +41,81 @@
 } %}
 
 {% block content %}
-  <div class="row">
-    <div class="col">
-      {{ form_start(importThemeForm) }}
-      {{ form_errors(importThemeForm) }}
-      <div class="row justify-content-center">
-        <div class="col-xl-10">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">file_copy</i>
-              {{ 'Import from your computer'|trans({}, 'Admin.Design.Feature') }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {{ form_row(importThemeForm.import_from_computer) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">
-                  <i class="material-icons">cloud_upload</i>
-                  {{ 'Save'|trans({}, 'Admin.Actions') }}
-                </button>
-              </div>
-            </div>
+
+  {{ form_start(importThemeForm) }}
+  {{ form_errors(importThemeForm) }}
+  <div class="row justify-content-center">
+    <div class="col-xl-10">
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">file_copy</i>
+          {{ 'Import from your computer'|trans({}, 'Admin.Design.Feature') }}
+        </h3>
+        <div class="card-block row">
+          <div class="card-text">
+            {{ form_row(importThemeForm.import_from_computer) }}
           </div>
         </div>
-
-        <div class="col-xl-10">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">file_copy</i>
-              {{ 'Import from the web'|trans({}, 'Admin.Design.Feature') }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {{ form_row(importThemeForm.import_from_web) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">
-                  <i class="material-icons">cloud_upload</i>
-                  {{ 'Save'|trans({}, 'Admin.Actions') }}
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-xl-10">
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">file_copy</i>
-              {{ 'Import from FTP'|trans({}, 'Admin.Design.Feature') }}
-            </h3>
-            <div class="card-block row">
-              <div class="card-text">
-                {{ form_row(importThemeForm.import_from_ftp) }}
-              </div>
-            </div>
-            <div class="card-footer">
-              <div class="d-flex justify-content-end">
-                <button class="btn btn-primary">
-                  <i class="material-icons">cloud_upload</i>
-                  {{ 'Save'|trans({}, 'Admin.Actions') }}
-                </button>
-              </div>
-            </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button class="btn btn-primary">
+              <i class="material-icons">cloud_upload</i>
+              {{ 'Save'|trans({}, 'Admin.Actions') }}
+            </button>
           </div>
         </div>
       </div>
+    </div>
 
-      {% block import_theme_form_rest %}
-        {{ form_rest(importThemeForm) }}
-      {% endblock %}
+    <div class="col-xl-10">
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">file_copy</i>
+          {{ 'Import from the web'|trans({}, 'Admin.Design.Feature') }}
+        </h3>
+        <div class="card-block row">
+          <div class="card-text">
+            {{ form_row(importThemeForm.import_from_web) }}
+          </div>
+        </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button class="btn btn-primary">
+              <i class="material-icons">cloud_upload</i>
+              {{ 'Save'|trans({}, 'Admin.Actions') }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
 
-      {{ form_end(importThemeForm) }}
+    <div class="col-xl-10">
+      <div class="card">
+        <h3 class="card-header">
+          <i class="material-icons">file_copy</i>
+          {{ 'Import from FTP'|trans({}, 'Admin.Design.Feature') }}
+        </h3>
+        <div class="card-block row">
+          <div class="card-text">
+            {{ form_row(importThemeForm.import_from_ftp) }}
+          </div>
+        </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            <button class="btn btn-primary">
+              <i class="material-icons">cloud_upload</i>
+              {{ 'Save'|trans({}, 'Admin.Actions') }}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
+
+  {% block import_theme_form_rest %}
+    {{ form_rest(importThemeForm) }}
+  {% endblock %}
+
+  {{ form_end(importThemeForm) }}
+
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -41,126 +41,124 @@
 
 {% block content %}
   <div id="themes-logo-page">
-    <div class="row">
-      <div class="col">
 
-        {% if not isSingleShopContext %}
-          <div class="alert alert-info">
-            <p class="alert-text">
-              {{ 'You must select a shop from the above list if you wish to choose a theme.'|trans({}, 'Admin.Design.Help') }}
-            </p>
-          </div>
-        {% endif %}
 
-        {% if isInstalledRtlLanguage %}
-          {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/rtl_configuration.html.twig' %}
-        {% endif %}
+    {% if not isSingleShopContext %}
+      <div class="alert alert-info">
+        <p class="alert-text">
+          {{ 'You must select a shop from the above list if you wish to choose a theme.'|trans({}, 'Admin.Design.Help') }}
+        </p>
+      </div>
+    {% endif %}
 
-        {{ form_start(shopLogosForm, {'action': path('admin_themes_upload_logos')}) }}
-          {% if not isInstalledRtlLanguage and isSingleShopContext and isMultiShopFeatureUsed %}
-            {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/multishop_switch.html.twig' %}
-          {% endif %}
-          <div class="card">
-            <div class="card-header">
-              {{ 'Logo'|trans({}, 'Admin.Global') }}
-            </div>
-            <div class="card-body logo-configuration-card-body">
-              {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/logo_configuration.html.twig' %}
-            </div>
-            <div class="card-footer">
-              <button class="btn btn-primary float-right">
-                {{ 'Save'|trans({}, 'Admin.Actions') }}
-              </button>
-              <div class="clearfix">&nbsp;</div>
-            </div>
-          </div>
-          {{ form_rest(shopLogosForm) }}
-        {{ form_end(shopLogosForm) }}
+    {% if isInstalledRtlLanguage %}
+      {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/rtl_configuration.html.twig' %}
+    {% endif %}
 
-        <div class="card">
-          <div class="card-header">
-            {{ 'My theme for %name% shop'|trans({'%name%': shopName}, 'Admin.Design.Feature') }}
-          </div>
-          <div class="card-body row">
-
-            {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
-              'themeName': currentlyUsedTheme.get('display_name'),
-              'themeVersion': currentlyUsedTheme.get('version'),
-              'themeAuthor': currentlyUsedTheme.get('author.name'),
-              'themeAuthorUrl': theme.get('author.url'),
-              'isActive': true
-              } %}
-              {% block image %}
-                <img src="{{ baseShopUrl }}{{ currentlyUsedTheme.get('preview') }}" alt="{{ currentlyUsedTheme.get('display_name')   }}">
-              {% endblock %}
-              {% block button_container %}
-                <button class="btn action-button">
-                  <i class="material-icons icon-current-theme">done</i>
-                  {{ 'My current theme'|trans({}, 'Admin.Design.Feature') }}
-                </button>
-              {% endblock %}
-            {% endembed %}
-
-            {% if notUsedThemes is not empty %}
-              {% for theme in notUsedThemes %}
-                {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
-                  'themeName': theme.get('display_name'),
-                  'themeVersion': theme.get('version'),
-                  'themeAuthor': theme.get('author.name'),
-                  'themeAuthorUrl': theme.get('author.url'),
-                  'isActive': false
-                  }  %}
-                  {% block image %}
-                    <img src="{{ baseShopUrl }}{{ theme.get('preview') }}" alt="{{ theme.get('display_name') }}">
-                  {% endblock %}
-                  {% block button_container %}
-                    <form action="{{ path('admin_themes_enable', {'themeName': theme.name}) }}" method="post" class="d-inline">
-                      <input type="hidden" name="token" value="{{ csrf_token('enable-theme') }}" />
-                      <button type="button" class="btn action-button js-display-use-theme-modal" {{ (not isSingleShopContext) ? 'disabled' : '' }}>
-                        <i class="material-icons">
-                          present_to_all
-                        </i>
-                        <span>{{ 'Use this theme'|trans({}, 'Admin.Design.Feature') }}</span>
-                      </button>
-                    </form>
-                    <form action="{{ path('admin_themes_delete', {'themeName': theme.name}) }}" method="post" class="d-inline">
-                      <input type="hidden" name="token" value="{{ csrf_token('delete-theme') }}" />
-                      <button type="button" class="btn delete-button js-display-delete-theme-modal">
-                        <i class="material-icons">
-                          delete
-                        </i>
-                      </button>
-                    </form>
-                  {% endblock %}
-                {% endembed %}
-              {% endfor %}
-
-              {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/use_theme_modal.html.twig' %}
-              {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/delete_theme_modal.html.twig' %}
-            {% endif %}
-
-            {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_catalog_card.html.twig' %}
-              {% block image %}
-                <img src="{{ asset('themes/new-theme/public/pages/themes/icon_themes.png') }}" alt="{{ 'Visit the theme catalog'|trans({}, 'Admin.Design.Feature') }}">
-              {% endblock %}
-
-              {% block description %}
-                {{ 'Explore more than a thousand themes'|trans({}, 'Admin.Design.Feature') }}
-              {% endblock %}
-
-              {% block button_container %}
-                <a class="btn btn-primary" href="{{ themeCatalogUrl }}" target="_blank">
-                  {{ 'Visit the theme catalog'|trans({}, 'Admin.Design.Feature') }}
-                </a>
-              {% endblock %}
-
-            {% endembed %}
-
-            {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/layouts_configuration.html.twig' %}
-          </div>
-        </div>
+    {{ form_start(shopLogosForm, {'action': path('admin_themes_upload_logos')}) }}
+    {% if not isInstalledRtlLanguage and isSingleShopContext and isMultiShopFeatureUsed %}
+      {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/multishop_switch.html.twig' %}
+    {% endif %}
+    <div class="card">
+      <div class="card-header">
+        {{ 'Logo'|trans({}, 'Admin.Global') }}
+      </div>
+      <div class="card-body logo-configuration-card-body">
+        {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/logo_configuration.html.twig' %}
+      </div>
+      <div class="card-footer">
+        <button class="btn btn-primary float-right">
+          {{ 'Save'|trans({}, 'Admin.Actions') }}
+        </button>
+        <div class="clearfix">&nbsp;</div>
       </div>
     </div>
+    {{ form_rest(shopLogosForm) }}
+    {{ form_end(shopLogosForm) }}
+
+    <div class="card">
+      <div class="card-header">
+        {{ 'My theme for %name% shop'|trans({'%name%': shopName}, 'Admin.Design.Feature') }}
+      </div>
+      <div class="card-body row">
+
+        {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
+          'themeName': currentlyUsedTheme.get('display_name'),
+          'themeVersion': currentlyUsedTheme.get('version'),
+          'themeAuthor': currentlyUsedTheme.get('author.name'),
+          'themeAuthorUrl': theme.get('author.url'),
+          'isActive': true
+        } %}
+          {% block image %}
+            <img src="{{ baseShopUrl }}{{ currentlyUsedTheme.get('preview') }}" alt="{{ currentlyUsedTheme.get('display_name') }}">
+          {% endblock %}
+          {% block button_container %}
+            <button class="btn action-button">
+              <i class="material-icons icon-current-theme">done</i>
+              {{ 'My current theme'|trans({}, 'Admin.Design.Feature') }}
+            </button>
+          {% endblock %}
+        {% endembed %}
+
+        {% if notUsedThemes is not empty %}
+          {% for theme in notUsedThemes %}
+            {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_card.html.twig' with {
+              'themeName': theme.get('display_name'),
+              'themeVersion': theme.get('version'),
+              'themeAuthor': theme.get('author.name'),
+              'themeAuthorUrl': theme.get('author.url'),
+              'isActive': false
+            }  %}
+              {% block image %}
+                <img src="{{ baseShopUrl }}{{ theme.get('preview') }}" alt="{{ theme.get('display_name') }}">
+              {% endblock %}
+              {% block button_container %}
+                <form action="{{ path('admin_themes_enable', {'themeName': theme.name}) }}" method="post" class="d-inline">
+                  <input type="hidden" name="token" value="{{ csrf_token('enable-theme') }}"/>
+                  <button type="button" class="btn action-button js-display-use-theme-modal" {{ (not isSingleShopContext) ? 'disabled' : '' }}>
+                    <i class="material-icons">
+                      present_to_all
+                    </i>
+                    <span>{{ 'Use this theme'|trans({}, 'Admin.Design.Feature') }}</span>
+                  </button>
+                </form>
+                <form action="{{ path('admin_themes_delete', {'themeName': theme.name}) }}" method="post" class="d-inline">
+                  <input type="hidden" name="token" value="{{ csrf_token('delete-theme') }}"/>
+                  <button type="button" class="btn delete-button js-display-delete-theme-modal">
+                    <i class="material-icons">
+                      delete
+                    </i>
+                  </button>
+                </form>
+              {% endblock %}
+            {% endembed %}
+          {% endfor %}
+
+          {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/use_theme_modal.html.twig' %}
+          {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/delete_theme_modal.html.twig' %}
+        {% endif %}
+
+        {% embed '@PrestaShop/Admin/Improve/Design/Theme/Blocks/Partials/theme_catalog_card.html.twig' %}
+          {% block image %}
+            <img src="{{ asset('themes/new-theme/public/pages/themes/icon_themes.png') }}" alt="{{ 'Visit the theme catalog'|trans({}, 'Admin.Design.Feature') }}">
+          {% endblock %}
+
+          {% block description %}
+            {{ 'Explore more than a thousand themes'|trans({}, 'Admin.Design.Feature') }}
+          {% endblock %}
+
+          {% block button_container %}
+            <a class="btn btn-primary" href="{{ themeCatalogUrl }}" target="_blank">
+              {{ 'Visit the theme catalog'|trans({}, 'Admin.Design.Feature') }}
+            </a>
+          {% endblock %}
+
+        {% endembed %}
+
+        {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/layouts_configuration.html.twig' %}
+      </div>
+    </div>
+
   </div>
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/positions.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/positions.html.twig
@@ -26,34 +26,58 @@
 {% trans_default_domain "Admin.Design.Feature" %}
 
 {% block content %}
-  <div class="row m-0">
+  <div class="row">
     {% if not canMove %}
       <p class="alert alert-warning alert-can-move">
         {{ 'If you want to order/move the following data, please select a shop from the shop list.' | trans({}, 'Admin.Design.Notification') }}
       </p>
     {% endif %}
 
-    <div class="card col-9">
-      <div class="card-body">
-        <div class="card">
-          <form class="mt-2" id="position-filters">
-            <div class="container">
-              <div class="row">
-                <div class="row col-md-12 col-lg-6">
-                  <label class="form-control-label col-4 text-left mt-1">{{ 'Show' | trans({}, 'Admin.Actions') }}</label>
-                  <div class="col-8">
+    <div class="col-md-3">
+      <div class="card" id="modules-position-selection-panel">
+        <h3 class="card-header">
+          <i class="material-icons">check</i>
+          {{ 'Selection' | trans({}, 'Admin.Global') }}</h3>
+        <div class="card-body">
+          <p>
+            <span id="modules-position-single-selection">{{ '1 module selected' | trans }}</span>
+            <span id="modules-position-multiple-selection">
+              <span id="modules-position-selection-count"></span>
+              {{ 'modules selected' | trans({}, 'Admin.Design.Feature') }}
+            </span>
+          </p>
+          <div>
+            <button class="btn btn-primary">
+              <i class="icon-remove"></i>
+              {{ 'Unhook the selection' | trans }}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-md-9 order-md-first">
+      <div class="card card-body">
+        <div class="card bg-light p-3">
+          <form id="position-filters">
+            <div class="row">
+              <div class="col-lg-6 mb-2">
+                <div class="row align-items-center">
+                  <label class="form-control-label col-md-4 text-left text-lg-center">{{ 'Show' | trans({}, 'Admin.Actions') }}</label>
+                  <div class="col-md-8">
                     <select id="show-modules" class="filter">
                       <option value="all">{{ 'All modules' | trans }}&nbsp;</option>
                       {% for module in modules %}
-                        <option value="{{ module.id }}"{% if selectedModule == module.id %} selected="selected"{% endif %}>{{ module.displayName }}</option>
+                        <option value="{{ module.id }}" {% if selectedModule == module.id %} selected="selected" {% endif %}>{{ module.displayName }}</option>
                       {% endfor %}
                     </select>
                   </div>
                 </div>
+              </div>
 
-                <div class="row col-md-12 col-lg-6">
-                  <label class="form-control-label col-5 text-center mt-1">{{ 'Search for a hook' | trans }}</label>
-                  <div class="input-group col-7">
+              <div class="col-lg-6 mb-2">
+                <div class="row align-items-center">
+                  <label class="form-control-label col-md-4 text-left text-lg-center">{{ 'Search for a hook' | trans }}</label>
+                  <div class="input-group col-md-8">
                     <div class="input-group-prepend">
                       <div class="input-group-text">
                         <i class="material-icons">search</i>
@@ -65,42 +89,45 @@
               </div>
             </div>
 
-            <div class="container mt-3">
-              <div class="row">
-                <div class="col-lg-12">
-                  <p class="checkbox">
-                    <label class="form-control-label" for="hook-position">
-                      <input type="checkbox" id="hook-position" />
-                      <label class="selectbox" for="hook-position"><i class="material-icons done">done</i></label>
-                      {{ 'Display non-positionable hooks' | trans }}
-                    </label>
-                  </p>
-                </div>
-              </div>
-            </div>
+            <p class="checkbox mt-3 mb-0">
+              <label class="form-control-label" for="hook-position">
+                <input type="checkbox" id="hook-position"/>
+                <label class="selectbox" for="hook-position">
+                  <i class="material-icons done">done</i>
+                </label>
+                {{ 'Display non-positionable hooks' | trans }}
+              </label>
+            </p>
           </form>
         </div>
 
-        <form id="module-positions-form" method="post" action="{{ path('admin_modules_positions_unhook') }}" data-update-url="{{ path('api_improve_design_positions_update') }}" data-togglestatus-url="{{ path('admin_modules_positions_toggle_status') }}">
+        <form id="module-positions-form" method="post" 
+              action="{{ path('admin_modules_positions_unhook') }}" 
+              data-update-url="{{ path('api_improve_design_positions_update') }}" 
+              data-togglestatus-url="{{ path('admin_modules_positions_toggle_status') }}">
           {% for hook in hooks %}
-            <section class="hook-panel{% if not hook['position'] %} hook-position{% endif %}"{% if not hook['position'] %} style="display:none;"{% endif %}>
+            <section class="hook-panel{% if not hook['position'] %} hook-position{% endif %}" {% if not hook['position'] %} style="display:none;" {% endif %}>
               <a name="{{ hook['name'] }}"></a>
               <header class="hook-panel-header">
                 <span class="hook-status">
-                   <input
-                      class="switch-input-md hook-switch-action"
-                      data-toggle="switch"
-                      data-hook-id="{{ hook['id_hook'] }}"
-                      type="checkbox"
-                      value="{{ hook['active'] }}"
-                      {{ hook['active'] ? 'checked="checked"' : '' }}
-                    />
+                  <input class="switch-input-md hook-switch-action" 
+                         data-toggle="switch" 
+                         data-hook-id="{{ hook['id_hook'] }}" 
+                         type="checkbox" 
+                         value="{{ hook['active'] }}" 
+                         {{ hook['active'] ? 'checked="checked"' : '' }}
+                  />
                 </span>
                 <span class="hook-name">{{ hook['name'] }}</span>
                 <label class="badge badge-pill float-right">
                   {% if hook['modules_count'] and canMove %}
-                    <input type="checkbox" class="hook-checker" id="Ghook{{ hook['id_hook'] }}" data-hook-id="{{ hook['id_hook'] }}" />
-                    <label class="selectbox" for="Ghook{{ hook['id_hook'] }}"><i class="material-icons done">done</i></label>
+                    <input type="checkbox" class="hook-checker" 
+                           id="Ghook{{ hook['id_hook'] }}" 
+                           data-hook-id="{{ hook['id_hook'] }}"
+                    />
+                    <label class="selectbox" for="Ghook{{ hook['id_hook'] }}">
+                      <i class="material-icons done">done</i>
+                    </label>
                   {% endif %}
 
                   {{ hook['modules_count'] }}
@@ -117,17 +144,24 @@
                   <ul class="list-unstyled{% if hook['modules_count'] > 1 %} sortable{% endif %}">
                     {% for module in hook['modules']|filter(module => modules[module['id_module']] is defined) %}
                       {% set moduleInstance = modules[module['id_module']] %}
-                      <li id="{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}"
-                        class="module-position-{{ moduleInstance.id }} module-item{% if canMove and hook['modules_count'] >= 2 %} draggable{% endif %}">
+                      <li id="{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}" 
+                          class="module-position-{{ moduleInstance.id }} module-item{% if canMove and hook['modules_count'] >= 2 %} draggable{% endif %}">
 
                         <div class="module-column-select">
                           <i class="material-icons drag_indicator">drag_indicator</i>
-                          <input type="checkbox" id="selecterbox{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}" data-hook-id="{{ hook['id_hook'] }}" class="modules-position-checkbox hook{{ hook['id_hook'] }}" name="unhooks[]" value="{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}"/>
-                          <label class="selectbox" for="selecterbox{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}"><i class="material-icons done">done</i></label>
+                          <input type="checkbox" id="selecterbox{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}" 
+                                 data-hook-id="{{ hook['id_hook'] }}" 
+                                 class="modules-position-checkbox hook{{ hook['id_hook'] }}" 
+                                 name="unhooks[]" 
+                                 value="{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}"
+                          />
+                          <label class="selectbox" for="selecterbox{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}">
+                            <i class="material-icons done">done</i>
+                          </label>
                         </div>
 
                         <div class="module-column-icon">
-                          <img src="{{ asset('../modules/' ~ moduleInstance.name ~ '/logo.png') }}" alt="{{ moduleInstance.displayName| escape }}" />
+                          <img src="{{ asset('../modules/' ~ moduleInstance.name ~ '/logo.png') }}" alt="{{ moduleInstance.displayName| escape }}"/>
                         </div>
 
                         <div class="module-column-infos">
@@ -144,7 +178,8 @@
                         </div>
 
                         {% if not selectedModule and hook['modules_count'] > 1 %}
-                          <div class="btn-toolbar text-center module-column-position{% if canMove and hook['modules_count'] >= 2 %} dragHandle{% endif %}" id="td_{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}">
+                          <div class="btn-toolbar text-center module-column-position{% if canMove and hook['modules_count'] >= 2 %} dragHandle{% endif %}" 
+                               id="td_{{ hook['id_hook'] ~ '_' ~ moduleInstance.id }}">
                             <div class="btn-group">
                               <span class="index-position">{{ loop.index }}</span>
                             </div>
@@ -162,13 +197,17 @@
                               {% set linkParams = linkParams|merge({'show_modules': selectedModule}) %}
                             {% endif %}
 
-                            <a class="btn tooltip-link" href="{{ getAdminLink('AdminModulesPositions', true, linkParams) }}" aria-label="{{ 'Edit' | trans({}, 'Admin.Actions') }}" title="{{ 'Edit' | trans({}, 'Admin.Actions') }}">
+                            <a class="btn tooltip-link" href="{{ getAdminLink('AdminModulesPositions', true, linkParams) }}" 
+                               aria-label="{{ 'Edit' | trans({}, 'Admin.Actions') }}" title="{{ 'Edit' | trans({}, 'Admin.Actions') }}">
                               <i class="material-icons">edit</i>
                             </a>
 
-                            <a class="btn tooltip-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-reference="parent">
+                            <a class="btn tooltip-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split" 
+                               data-toggle="dropdown" 
+                               aria-haspopup="true" 
+                               aria-expanded="false" 
+                               data-reference="parent">
                             </a>
-
                             <div class="dropdown-menu">
                               <a class="dropdown-item" href="{{ path('admin_modules_positions_unhook', {moduleId: moduleInstance.id, hookId: hook['id_hook']}) }}">
                                 <i class="material-icons">indeterminate_check_box</i>
@@ -196,23 +235,6 @@
             </button>
           </div>
         </form>
-      </div>
-    </div>
-
-    <div class="col-3">
-      <div class="card" id="modules-position-selection-panel">
-        <h3 class="card-header"><i class="material-icons">checked</i> {{ 'Selection' | trans({}, 'Admin.Global') }}</h3>
-        <div class="card-body">
-          <p>
-            <span id="modules-position-single-selection">{{ '1 module selected' | trans }}</span>
-            <span id="modules-position-multiple-selection">
-              <span id="modules-position-selection-count"></span> {{ 'modules selected' | trans({}, 'Admin.Design.Feature') }}
-            </span>
-          </p>
-          <div class="text-center">
-            <button class="btn btn-primary"><i class="icon-remove"></i> {{ 'Unhook the selection' | trans }}</button>
-          </div>
-        </div>
       </div>
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/create.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Currency/Blocks/form.html.twig', {'currencyForm': currencyForm, 'languages': []}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Currency/Blocks/form.html.twig', {'currencyForm': currencyForm, 'languages': []}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Currency/Blocks/form.html.twig', {'currencyForm': currencyForm, 'languages': languages}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Currency/Blocks/form.html.twig', {'currencyForm': currencyForm, 'languages': languages}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Currency/index.html.twig
@@ -36,11 +36,7 @@
 
 {% block content %}
 
-  <div class="row">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': currencyGrid }) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Common/Grid/grid_panel.html.twig', {'grid': currencyGrid }) }}
 
   {% block exchange_rates_block %}
     <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Geolocation/index.html.twig
@@ -28,36 +28,26 @@
 
 {% block content %}
   {% if not geolocationDatabaseAvailable %}
-    <div class="row">
-      <div class="col">
-        <div class="alert alert-warning" role="alert">
-          <span class="alert-text">
-            {{ 'Since December 30, 2019, you need to register for a [1]MaxMind[/1] account to get a license key to be able to download the geolocation data. Once downloaded, extract the data using Winrar or Gzip into the /app/Resources/geoip/ directory.'|trans({'[1]': '<a href="https://dev.maxmind.com/geoip/geoip2/geolite2" target="_blank">', '[/1]': '<a/>'}, 'Admin.Notifications.Warning')|raw }}
-          </span>
-        </div>
-      </div>
+
+    <div class="alert alert-warning" role="alert">
+      <span class="alert-text">
+        {{ 'Since December 30, 2019, you need to register for a [1]MaxMind[/1] account to get a license key to be able to download the geolocation data. Once downloaded, extract the data using Winrar or Gzip into the /app/Resources/geoip/ directory.'|trans({'[1]': '<a href="https://dev.maxmind.com/geoip/geoip2/geolite2" target="_blank">', '[/1]': '<a/>'}, 'Admin.Notifications.Warning')|raw }}
+      </span>
     </div>
+
   {% endif %}
 
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      {{ form_start(geolocationByIpAddressForm, {'action': path('admin_geolocation_by_ip_address_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig' %}
-      {{ form_end(geolocationByIpAddressForm) }}
-    </div>
+  {{ form_start(geolocationByIpAddressForm, {'action': path('admin_geolocation_by_ip_address_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_by_ip_address.html.twig' %}
+  {{ form_end(geolocationByIpAddressForm) }}
 
-    <div class="col-xl-12">
-      {{ form_start(geolocationOptionsForm, {'action': path('admin_geolocation_options_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig' %}
-      {{ form_end(geolocationOptionsForm) }}
-    </div>
+  {{ form_start(geolocationOptionsForm, {'action': path('admin_geolocation_options_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_options.html.twig' %}
+  {{ form_end(geolocationOptionsForm) }}
 
-    <div class="col-xl-12">
-      {{ form_start(geolocationIpAddressWhitelistForm, {'action': path('admin_geolocation_whitelist_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig' %}
-      {{ form_end(geolocationIpAddressWhitelistForm) }}
-    </div>
-  </div>
+  {{ form_start(geolocationIpAddressWhitelistForm, {'action': path('admin_geolocation_whitelist_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Geolocation/Blocks/geolocation_ip_address_whitelist.html.twig' %}
+  {{ form_end(geolocationIpAddressWhitelistForm) }}
 
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/create.html.twig
@@ -28,11 +28,7 @@
 {% set layoutTitle = 'Add new'|trans({}, 'Admin.Actions') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Improve/International/Language/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Improve/International/Language/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/edit.html.twig
@@ -28,11 +28,7 @@
 {% set layoutTitle = 'Edit: %value%'|trans({'%value%': editableLanguage.name}, 'Admin.Catalog.Feature') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Improve/International/Language/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Improve/International/Language/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Language/index.html.twig
@@ -37,26 +37,20 @@
 
 {% block content %}
   {% include '@PrestaShop/Admin/Common/multistore-infotip.html.twig' %}
-  <div class="row">
-    <div class="col">
-      <div class="alert alert-warning" role="alert">
-        <p class="alert-text">{{ 'When you delete a language, all related translations in the database will be deleted.'|trans({}, 'Admin.International.Notification') }}</p>
-      </div>
 
-      {% if not isHtaccessFileWriter %}
-        <div class="alert alert-info" role="alert">
-          <p class="alert-text">{{ 'Your .htaccess file must be writable.'|trans({}, 'Admin.International.Notification') }}</p>
-        </div>
-      {% endif %}
-    </div>
+  <div class="alert alert-warning" role="alert">
+    <p class="alert-text">{{ 'When you delete a language, all related translations in the database will be deleted.'|trans({}, 'Admin.International.Notification') }}</p>
   </div>
 
-  {% block language_listing %}
-    <div class="row">
-      <div class="col-sm">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with { 'grid': languageGrid } %}
-      </div>
+  {% if not isHtaccessFileWriter %}
+    <div class="alert alert-info" role="alert">
+      <p class="alert-text">{{ 'Your .htaccess file must be writable.'|trans({}, 'Admin.International.Notification') }}</p>
     </div>
+  {% endif %}
+
+
+  {% block language_listing %}
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with { 'grid': languageGrid } %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Localization/index.html.twig
@@ -27,31 +27,19 @@
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/import_localization_pack_block.html.twig' %}
 
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      {{ form_start(configurationForm, {'action': path('admin_localization_configuration_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/configuration.html.twig' %}
-      {{ form_end(configurationForm) }}
-    </div>
+  {{ form_start(configurationForm, {'action': path('admin_localization_configuration_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/configuration.html.twig' %}
+  {{ form_end(configurationForm) }}
 
-    <div class="col-xl-12">
-      {{ form_start(localUnitsForm, {'action': path('admin_localization_local_units_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/local_units.html.twig' %}
-      {{ form_end(localUnitsForm) }}
-    </div>
+  {{ form_start(localUnitsForm, {'action': path('admin_localization_local_units_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/local_units.html.twig' %}
+  {{ form_end(localUnitsForm) }}
 
-    <div class="col-xl-12">
-      {{ form_start(advancedForm, {'action': path('admin_localization_advanced_save')}) }}
-        {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig' %}
-      {{ form_end(advancedForm) }}
-    </div>
-  </div>
+  {{ form_start(advancedForm, {'action': path('admin_localization_advanced_save')}) }}
+  {% include '@PrestaShop/Admin/Improve/International/Localization/Blocks/advanced_configuration.html.twig' %}
+  {{ form_end(advancedForm) }}
 
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/create.html.twig
@@ -27,11 +27,7 @@
 
 {% block content %}
   {% include '@PrestaShop/Admin/Common/multistore-infotip.html.twig' %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/edit.html.twig
@@ -28,11 +28,7 @@
 {% set layoutTitle = 'Edit: %value%'|trans({'%value%': taxName}, 'Admin.Actions') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Tax/Blocks/form.html.twig', {'taxForm': taxForm}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Tax/index.html.twig
@@ -36,12 +36,8 @@
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col-lg-12">
-      {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': taxGrid} %}
-      {% include '@PrestaShop/Admin/Improve/International/Tax/Blocks/tax_options.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': taxGrid} %}
+  {% include '@PrestaShop/Admin/Improve/International/Tax/Blocks/tax_options.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/index.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col-lg-12">
-      {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': taxRulesGroupGrid} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': taxRulesGroupGrid} %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/Blocks/copy_language.html.twig
@@ -31,7 +31,8 @@
 
   <div class="card">
     <h3 class="card-header">
-      <i class="material-icons">file_copy</i> {{ 'Copy'|trans({}, 'Admin.Actions') }}
+      <i class="material-icons">file_copy</i>
+      {{ 'Copy'|trans({}, 'Admin.Actions') }}
     </h3>
 
     <div class="card-block row">
@@ -48,9 +49,7 @@
           </div>
         </div>
         <div class="form-group row">
-          <label class="form-control-label">
-            {{ form_label(copyLanguageForm.from_language) }}
-          </label>
+          {{ form_label(copyLanguageForm.from_language) }}
           <div class="col-sm">
             <div class="input-group">
               {{ form_errors(copyLanguageForm.from_language) }}
@@ -66,9 +65,7 @@
         </div>
 
         <div class="form-group row">
-          <label class="form-control-label">
-            {{ form_label(copyLanguageForm.to_language) }}
-          </label>
+          {{ form_label(copyLanguageForm.to_language) }}
           <div class="col-sm">
             <div class="input-group">
               {{ form_errors(copyLanguageForm.to_language) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -27,36 +27,20 @@
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div class="card card-kpis">
-        {% block translations_kpis_row %}
-          <div class="row">
-            {{ render(controller(
-              'PrestaShopBundle:Admin\\Common:renderKpiRow',
-              { 'kpiRow': kpiRow }
-            )) }}
-          </div>
-        {% endblock %}
-      </div>
-    </div>
-
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig' %}
-    </div>
-
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig' %}
-    </div>
-
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/export_language.html.twig' %}
-    </div>
-
-    <div class="col-xl-12">
-      {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/copy_language.html.twig' %}
-    </div>
+  <div class="card card-kpis">
+    {% block translations_kpis_row %}
+      {{ render(controller(
+        'PrestaShopBundle:Admin\\Common:renderKpiRow',
+        { 'kpiRow': kpiRow }
+      )) }}
+    {% endblock %}
   </div>
+
+  {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig' %}
+  {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig' %}
+  {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/export_language.html.twig' %}
+  {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/copy_language.html.twig' %}
+
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Zone/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Zone/create.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Zone/Blocks/form.html.twig') }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Zone/Blocks/form.html.twig') }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Zone/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Zone/edit.html.twig
@@ -28,11 +28,7 @@
 {% set layoutTitle = 'Edit: %value%'|trans({'%value%': zoneName}, 'Admin.Actions') %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {{ include('@PrestaShop/Admin/Improve/International/Zone/Blocks/form.html.twig', {'zoneForm': zoneForm}) }}
-    </div>
-  </div>
+  {{ include('@PrestaShop/Admin/Improve/International/Zone/Blocks/form.html.twig', {'zoneForm': zoneForm}) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig
@@ -29,12 +29,12 @@
   <div class="module-item-list">
   {% for module in paymentModules %}
     <div class="row module-item-wrapper-list border-bottom mb-sm-3">
-      <div class="col-12 col-sm-2 col-md-1 col-lg-1">
+      <div class="col-sm-2 col-md-1 col-lg-1">
         <div class="module-logo-thumb-list text-center">
           <img src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}"/>
         </div>
       </div>
-      <div class="col-12 col-sm-6 col-md-8 col-lg-9 pl-0">
+      <div class="col-sm-6 col-md-8 col-lg-9 pl-0">
         <p class="mb-0">
           {{ module.attributes.displayName|raw }}
           <span class="text-muted">
@@ -46,7 +46,7 @@
         </p>
       </div>
       {% if module.attributes.is_configurable %}
-      <div class="col-12 col-sm-4 col-md-3 col-lg-2 mb-3">
+      <div class="col-sm-4 col-md-3 col-lg-2 mb-3">
         <div class="text-center">
           <a href="{{ path('admin_module_configure_action', {'module_name': module.attributes.name}) }}"
              class="btn btn-primary-reverse btn-outline-primary light-button"

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/PaymentMethods/payment_methods.html.twig
@@ -26,41 +26,27 @@
 {% trans_default_domain 'Admin.Payment.Feature' %}
 
 {% block content %}
-  <div class="container">
-
-    {% if paymentModules|length < 2 %}
-      <div class="card-block row alert-block">
-        <div class="card-text">
-          <div class="row">
-            <div class="col-sm">
-              <div class="alert alert-info" role="alert">
-                <div class="alert-text">
-                  {{ 'We recommend providing at least two different payment methods. Only one payment method could be problematic if this option cannot be used by a customer because it will prevent him/her from ordering.'|trans({}, 'Admin.Payment.Notification') }}
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    {% endif %}
-
-    <div class="row">
-      <div class="col">
-        {% if isSingleShopContext %}
-          <div class="card">
-            <h3 class="card-header">
-              <i class="material-icons">credit_card</i> {{ 'Active payment'|trans }}
-            </h3>
-            <div class="card-block">
-              {% include '@PrestaShop/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig' %}
-            </div>
-          </div>
-        {% else %}
-          <div class="alert alert-warning" role="alert">
-            <p class="alert-text">{{ 'You have more than one shop and must select one to configure payment.'|trans({}, 'Admin.Payment.Notification') }}</p>
-          </div>
-        {% endif %}
+  {% if paymentModules|length < 2 %}
+    <div class="alert alert-info" role="alert">
+      <div class="alert-text">
+        {{ 'We recommend providing at least two different payment methods. Only one payment method could be problematic if this option cannot be used by a customer because it will prevent him/her from ordering.'|trans({}, 'Admin.Payment.Notification') }}
       </div>
     </div>
-  </div>
+  {% endif %}
+
+  {% if isSingleShopContext %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">credit_card</i>
+        {{ 'Active payment'|trans }}
+      </h3>
+      <div class="card-block">
+        {% include '@PrestaShop/Admin/Improve/Payment/PaymentMethods/Blocks/payment_modules_list.html.twig' %}
+      </div>
+    </div>
+  {% else %}
+    <div class="alert alert-warning" role="alert">
+      <p class="alert-text">{{ 'You have more than one shop and must select one to configure payment.'|trans({}, 'Admin.Payment.Notification') }}</p>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/payment_preferences.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Payment/Preferences/payment_preferences.html.twig
@@ -27,35 +27,31 @@
 
 {% block content %}
   <div class="container">
-    <div class="row">
-      <div class="col">
-        {% if not isSingleShopContext %}
-          <div class="alert alert-warning" role="alert">
-            <p class="alert-text">
-              {{ 'Note that this page is available in a single shop context only. Switch context to work on it.'|trans({}, 'Admin.Notifications.Info') }}
-            </p>
-          </div>
-        {% elseif paymentModulesCount == 0 %}
-          <div class="alert alert-warning" role="alert">
-            <p class="alert-text">
-              {{ 'No payment module installed'|trans({}, 'Admin.Payment.Notification') }}
-            </p>
-          </div>
-        {% else %}
-          <div class="alert alert-info" role="alert">
-            <p class="alert-text">
-              {{ 'This is where you decide what payment modules are available for different variations like your customers\' currency, group, and country.'|trans({}, 'Admin.Payment.Help') }}
-            </p>
-            <p class="alert-text">
-              {{ 'A check mark indicates you want the payment module available.'|trans({}, 'Admin.Payment.Help') }}
-              {{ 'If it is not checked then this means that the payment module is disabled.'|trans({}, 'Admin.Payment.Help') }}
-            </p>
-          </div>
-
-          {% include '@PrestaShop/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig' %}
-        {% endif %}
+    {% if not isSingleShopContext %}
+      <div class="alert alert-warning" role="alert">
+        <p class="alert-text">
+          {{ 'Note that this page is available in a single shop context only. Switch context to work on it.'|trans({}, 'Admin.Notifications.Info') }}
+        </p>
       </div>
-    </div>
+    {% elseif paymentModulesCount == 0 %}
+      <div class="alert alert-warning" role="alert">
+        <p class="alert-text">
+          {{ 'No payment module installed'|trans({}, 'Admin.Payment.Notification') }}
+        </p>
+      </div>
+    {% else %}
+      <div class="alert alert-info" role="alert">
+        <p class="alert-text">
+          {{ 'This is where you decide what payment modules are available for different variations like your customers\' currency, group, and country.'|trans({}, 'Admin.Payment.Help') }}
+        </p>
+        <p class="alert-text">
+          {{ 'A check mark indicates you want the payment module available.'|trans({}, 'Admin.Payment.Help') }}
+          {{ 'If it is not checked then this means that the payment module is disabled.'|trans({}, 'Admin.Payment.Help') }}
+        </p>
+      </div>
+
+      {% include '@PrestaShop/Admin/Improve/Payment/Preferences/Blocks/payment_preferences_form_block.html.twig' %}
+    {% endif %}
   </div>
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Carriers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Carriers/index.html.twig
@@ -27,19 +27,11 @@
 
 {% block content %}
   {% block carrier_showcase_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Improve/Shipping/Carriers/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Improve/Shipping/Carriers/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% include '@PrestaShop/Admin/Improve/Shipping/Carriers/Blocks/information_block.html.twig' %}
-  <div class="row">
-    <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': carrierGrid} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': carrierGrid} %}
 
   {# Recommended modules will be attached to here. #}
   <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_carrier_options.html.twig
@@ -27,22 +27,19 @@
 {% form_theme carrierOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block shipping_preferences_carrier_options %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div id="carrier-options" class="card">
-        <h3 class="card-header">
-          <i class="material-icons">local_shipping</i> {{ 'Carrier options'|trans }}
-        </h3>
-        <div class="card-block row">
-          <div class="card-text">
-            {{ form_widget(carrierOptionsForm) }}
-          </div>
-        </div>
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            <button class="btn btn-primary" id="save-carrier-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-          </div>
-        </div>
+  <div id="carrier-options" class="card">
+    <h3 class="card-header">
+      <i class="material-icons">local_shipping</i>
+      {{ 'Carrier options'|trans }}
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(carrierOptionsForm) }}
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" id="save-carrier-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
       </div>
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Shipping/Preferences/Blocks/shipping_preferences_handling.html.twig
@@ -27,33 +27,28 @@
 {% form_theme handlingForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block shipping_preferences_handling %}
-  <div class="row justify-content-center">
-    <div class="col-xl-12">
-      <div id="handling" class="card">
-        <h3 class="card-header">
-          <i class="material-icons">filter_none</i> {{ 'Handling'|trans }}
+  <div id="handling" class="card">
+    <h3 class="card-header">
+      <i class="material-icons">filter_none</i>
+      {{ 'Handling'|trans }}
 
-          <span
-            class="help-box"
-            data-container="body"
-            data-toggle="popover"
-            data-trigger="hover"
-            data-placement="right"
-            data-content="{{ 'If you set these parameters to 0, they will be disabled.'|trans({}, 'Admin.Shipping.Help') }} {{ 'Coupons are not taken into account when calculating free shipping.'|trans({}, 'Admin.Shipping.Help') }}"
-            title=""
-          >
-          </span>
-        </h3>
-        <div class="card-block row">
-          <div class="card-text">
-            {{ form_widget(handlingForm) }}
-          </div>
-        </div>
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-          </div>
-        </div>
+      <span class="help-box" 
+            data-container="body" 
+            data-toggle="popover" 
+            data-trigger="hover" 
+            data-placement="right" 
+            data-content="{{ 'If you set these parameters to 0, they will be disabled.'|trans({}, 'Admin.Shipping.Help') }} {{ 'Coupons are not taken into account when calculating free shipping.'|trans({}, 'Admin.Shipping.Help') }}" 
+            title="">
+      </span>
+    </h3>
+    <div class="card-block row">
+      <div class="card-text">
+        {{ form_widget(handlingForm) }}
+      </div>
+    </div>
+    <div class="card-footer">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
       </div>
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
@@ -33,7 +33,7 @@
 
 {% else %}
 
-    <form class='{{classes_form|default() }}' method="post" action="{{ url }}">
+    <form class="{{classes_form|default() }}" method="post" action="{{ url }}">
       <button type="submit" class="{{ classes }} module_action_menu_{{ action }}" data-confirm_modal="module-modal-confirm-{{ name }}-{{ action }}">
         {{ displayAction }}
       </button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_grid.html.twig
@@ -25,7 +25,7 @@
 {% set isModuleActive = module.database.active %}
 
 <div
-  class="module-item module-item-grid col-md-12 col-lg-6 col-xl-3 {% if origin == 'manage' and isModuleActive == '0' %}module-item-grid-isNotActive{% endif %}"
+  class="module-item module-item-grid col-lg-6 col-xl-3 {% if origin == 'manage' and isModuleActive == '0' %}module-item-grid-isNotActive{% endif %}"
   data-id="{{ module.attributes.id }}"
   data-name="{{ module.attributes.displayName }}"
   data-scoring="{{ module.attributes.avgRate }}"

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_grid_addons.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_grid_addons.html.twig
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<div class="module-addons-item-grid col-md-12 col-lg-6 col-xl-3">
+<div class="module-addons-item-grid col-lg-6 col-xl-3">
   <div class="module-addons-item-wrapper-grid">
     <span class="module-icon-addons-exit-grid">
       <img src="{{ asset('themes/default/img/preston.png') }}" alt="{{ 'Exit to PrestaShop Addons Marketplace'|trans({}, 'Admin.Modules.Feature') }}" />

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -44,13 +44,13 @@
 >
   <div class="container-fluid">
     <div class="module-item-wrapper-list row">
-      <div class="col-sm-12 col-md-12 col-lg-1 text-sm-center">
+      <div class="col-lg-1 text-sm-center">
         <div class="module-logo-thumb-list">
           <img src="{{ module.attributes.img }}" class="text-md-center" alt="{{ module.attributes.displayName }}"/>
         </div>
       </div>
-      <div class="col-md-12 col-lg-11 row">
-        <div class="col-sm-12 col-md-10 col-lg-11">
+      <div class="col-lg-11 row">
+        <div class="col-md-10 col-lg-11">
           <h3
             class="text-ellipsis module-name-list"
             data-toggle="pstooltip"
@@ -65,7 +65,7 @@
             {% endif %}
           </h3>
         </div>
-        <div class="col-sm-12 col-md-2">
+        <div class="col-md-2">
           <div class="text-ellipsis small-text">
             {% block addon_version %}
               {% if module.attributes.productType == "service" %}
@@ -79,9 +79,9 @@
             {% if module.attributes.urls.upgrade is defined %}
                 <span class="badge badge-success my-1">{{ 'Upgrade available'|trans({}, 'Admin.Modules.Feature') }}</span>
             {% endif %}
-          </div>          
+          </div>
         </div>
-        <div class="col-sm-12 col-md-8 col-lg-7">
+        <div class="col-md-8 col-lg-7">
           {% block addon_description %}
             {{ module.attributes.description|raw }}
             {% if module.attributes.description|length > 0 and module.attributes.description|length < module.attributes.fullDescription|length %}
@@ -94,7 +94,7 @@
             </span>
           {% endblock %}
         </div>
-        <div class="col-sm-12 col-md-12 col-lg-3 text-md-right">
+        <div class="col-lg-3 text-md-right">
           {% block module_actions %}
             {% if requireBulkActions is defined and requireBulkActions == true %}
               <div class="module-checkbox-bulk-list md-checkbox">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_loader.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_loader.html.twig
@@ -24,36 +24,32 @@
  *#}
 {#Simulate a bunch of module card #}
 <div class="module-placeholders-wrapper row">
-    {% for i in 0..8 %}
-
-      <div class="timeline-item col-xl-3 col-lg-6 col-md-12 col-sm-12">
-        <div class="timeline-item-wrapper">
-            <div class="animated-background">
-              <div class="background-masker header-top"></div>
-              <div class="background-masker header-left"></div>
-              <div class="background-masker header-right"></div>
-              <div class="background-masker header-bottom"></div>
-              <div class="background-masker subheader-left"></div>
-              <div class="background-masker subheader-right"></div>
-              <div class="background-masker subheader-bottom"></div>
-              <div class="background-masker content-top"></div>
-              <div class="background-masker content-first-end"></div>
-              <div class="background-masker content-second-line"></div>
-              <div class="background-masker content-second-end"></div>
-              <div class="background-masker content-third-line"></div>
-              <div class="background-masker content-third-end"></div>
-            </div>
-          </div>
+  {% for i in 0..8 %}
+    <div class="timeline-item col-lg-6 col-xl-3">
+      <div class="timeline-item-wrapper">
+        <div class="animated-background">
+          <div class="background-masker header-top"></div>
+          <div class="background-masker header-left"></div>
+          <div class="background-masker header-right"></div>
+          <div class="background-masker header-bottom"></div>
+          <div class="background-masker subheader-left"></div>
+          <div class="background-masker subheader-right"></div>
+          <div class="background-masker subheader-bottom"></div>
+          <div class="background-masker content-top"></div>
+          <div class="background-masker content-first-end"></div>
+          <div class="background-masker content-second-line"></div>
+          <div class="background-masker content-second-end"></div>
+          <div class="background-masker content-third-line"></div>
+          <div class="background-masker content-third-end"></div>
+        </div>
       </div>
-
-    {% endfor %}
+    </div>
+  {% endfor %}
 </div>
 
-<div class="module-placeholders-failure row">
-      <div class="module-placeholders-failure-wrapper col-md-12">
-          <div class='module-placeholders-failure-msg'>
-          </div>
-          <button id='module-placeholders-failure-retry' type="button" class="btn btn-primary">{{ 'Try again'|trans({}, 'Admin.Actions') }}</button>
-      </div>
-
+<div class="module-placeholders-failure">
+  <div class="module-placeholders-failure-wrapper">
+    <div class="module-placeholders-failure-msg"></div>
+    <button id="module-placeholders-failure-retry" type="button" class="btn btn-primary">{{ 'Try again'|trans({}, 'Admin.Actions') }}</button>
+  </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm.html.twig
@@ -45,73 +45,60 @@
                 <span aria-hidden="true">&times;</span>
               </button>
             </div>
-            <div class="modal-body row">
-              <div class="col-md-12">
-                <p>
-                  {% if module_action == 'disable' %}
-                    {{ "You are about to disable %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
-                    <br>
-                    <br>
-                    {{ "Your current settings will be saved, but the module will no longer be active."|trans({}, 'Admin.Modules.Notification') }}
-                  {% endif %}
-                  {% if module_action == 'uninstall' %}
-                    {{ "You are about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
-                    <br>
-                    {{ module.attributes.confirmUninstall }}
-                    <br>
-                    <br>
-                    {{ "This will disable the module and delete all its files. For good."|trans({}, 'Admin.Modules.Notification') }}
-                    <br>
-                    <label>
-                      <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
-                    </label>
-                    <br>
-                    <span class="italic red">
-                      {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
-                    </span>
-                  {% endif %}
-                  {% if module_action == 'reset' %}
-                    {{ "You're about to reset %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
-                    <br>
-                    <br>
-                    {{ "This will restore the defaults settings."|trans({}, 'Admin.Modules.Notification') }}
-                    <br>
-                    <span class="italic red">
-                      {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
-                    </span>
-                  {% endif %}
-                </p>
-              </div>
+            <div class="modal-body">
+              <p>
+                {% if module_action == 'disable' %}
+                  {{ "You are about to disable %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
+                  <br>
+                  <br>
+                  {{ "Your current settings will be saved, but the module will no longer be active."|trans({}, 'Admin.Modules.Notification') }}
+                {% endif %}
+                {% if module_action == 'uninstall' %}
+                  {{ "You are about to uninstall %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
+                  <br>
+                  {{ module.attributes.confirmUninstall }}
+                  <br>
+                  <br>
+                  {{ "This will disable the module and delete all its files. For good."|trans({}, 'Admin.Modules.Notification') }}
+                  <br>
+                  <label>
+                    <input type="checkbox" id="force_deletion" name="force_deletion" data-tech-name="{{module.attributes.name}}">
+                    {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
+                  </label>
+                  <br>
+                  <span class="italic red">
+                    {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
+                  </span>
+                {% endif %}
+                {% if module_action == 'reset' %}
+                  {{ "You're about to reset %moduleName% module."|trans({'%moduleName%': module.attributes.displayName}, 'Admin.Modules.Notification') }}
+                  <br>
+                  <br>
+                  {{ "This will restore the defaults settings."|trans({}, 'Admin.Modules.Notification') }}
+                  <br>
+                  <span class="italic red">
+                    {{ "This action cannot be undone."|trans({}, 'Admin.Modules.Notification') }}
+                  </span>
+                {% endif %}
+              </p>
             </div>
             <div class="modal-footer">
-              <input type="button" class="btn btn-outline-secondary" data-dismiss="modal" value="{{ "Cancel"|trans({}, 'Admin.Actions') }}" />
+              <input type="button" class="btn btn-outline-secondary" data-dismiss="modal" value="{{ "Cancel"|trans({}, 'Admin.Actions') }}"/>
               {% if module_action == 'disable' %}
-                <a
-                  class="btn btn-primary uppercase module_action_modal_{{ module_action }}"
-                  href="{{ module_url }}"
-                  data-dismiss="modal"
-                  data-tech-name="{{module.attributes.name}}"
-                >
+                <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}" href="{{ module_url }}" 
+                data-dismiss="modal" data-tech-name="{{module.attributes.name}}">
                   {{ "Yes, disable it"|trans({}, 'Admin.Modules.Feature') }}
                 </a>
               {% endif %}
               {% if module_action == 'uninstall' %}
-                <a
-                  class="btn btn-primary uppercase module_action_modal_{{ module_action }}"
-                  href="{{ module_url }}"
-                  data-dismiss="modal"
-                  data-tech-name="{{module.attributes.name}}"
-                >
+                <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}" href="{{ module_url }}" 
+                data-dismiss="modal" data-tech-name="{{module.attributes.name}}">
                   {{ "Yes, uninstall it"|trans({}, 'Admin.Modules.Feature') }}
                 </a>
               {% endif %}
               {% if module_action == 'reset' %}
-                <a
-                  class="btn btn-primary uppercase module_action_modal_{{ module_action }}"
-                  href="{{ module_url }}"
-                  data-dismiss="modal"
-                  data-tech-name="{{module.attributes.name}}"
-                >
+                <a class="btn btn-primary uppercase module_action_modal_{{ module_action }}" href="{{ module_url }}" 
+                data-dismiss="modal" data-tech-name="{{module.attributes.name}}">
                   {{ "Yes, reset it"|trans({}, 'Admin.Modules.Feature') }}
                 </a>
               {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_confirm_bulk_action.html.twig
@@ -31,26 +31,23 @@
         <button type="button" class="close" data-dismiss="modal">&times;</button>
       </div>
       <div class="modal-body">
-          <div class="row">
-              <div class="col-md-12">
-                  <p>
-                    {{ "You are about to [1] the following modules:"|trans({}, 'Admin.Modules.Notification')|replace({'[1]' : '<span id="module-modal-bulk-confirm-action-name">[Module Action]</span>'})|raw }}
-                  </p>
-                  <p id="module-modal-bulk-confirm-list">
-                      [Module List Up To 10 Max]
-                  </p>
+        <p>
+          {{ "You are about to [1] the following modules:"|trans({}, 'Admin.Modules.Notification')|replace({'[1]' : '<span id="module-modal-bulk-confirm-action-name">[Module Action]</span>'})|raw }}
+        </p>
+        <p id="module-modal-bulk-confirm-list">
+          [Module List Up To 10 Max]
+        </p>
 
-                  <div id="module-modal-bulk-checkbox">
-                    <label>
-                      <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion"> {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
-                    </label>
-                  </div>
-              </div>
-          </div>
+        <div id="module-modal-bulk-checkbox">
+          <label>
+            <input type="checkbox" id="force_bulk_deletion" name="force_bulk_deletion">
+            {{ "Optional: delete module folder after uninstall."|trans({}, 'Admin.Modules.Feature') }}
+          </label>
+        </div>
       </div>
       <div class="modal-footer">
-          <input type="button" class="btn btn-outline-secondary uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
-          <button class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules.Feature') }}</button>
+        <input type="button" class="btn btn-outline-secondary uppercase" data-dismiss="modal" value="{{ 'Cancel'|trans({}, 'Admin.Actions') }}">
+        <button class="btn btn-primary uppercase" data-dismiss="modal" id="module-modal-confirm-bulk-ack">{{ 'Yes, I want to do it'|trans({}, 'Admin.Modules.Feature') }}</button>
       </div>
 
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
@@ -23,68 +23,59 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div id="module-modal-import" class="modal modal-vcenter fade" role="dialog" data-backdrop="static" data-keyboard="false">
-    <div class="modal-dialog">
-        <!-- Modal content-->
-        <div class="modal-content">
-            <div class="modal-header">
-                <h4 class="modal-title module-modal-title">{{ 'Upload a module'|trans({}, 'Admin.Modules.Feature') }}</h4>
-                <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
+  <div class="modal-dialog">
+    <!-- Modal content-->
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title module-modal-title">{{ 'Upload a module'|trans({}, 'Admin.Modules.Feature') }}</h4>
+        <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
+      </div>
+      <div class="modal-body">
+        {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') %}
+          <div class="alert alert-danger" role="alert">
+            <p class="alert-text">
+              {{ errorMessage }}
+            </p>
+          </div>
+        {% else %}
+          <form action="#" class="dropzone" id="importDropzone">
+            <div class="module-import-start">
+              <i class="module-import-start-icon material-icons">cloud_upload</i><br/>
+              <p class="module-import-start-main-text">
+                {{ 'Drop your module archive here or [1]select file[/1]'|trans({}, 'Admin.Modules.Feature')|replace({'[1]' : '<a href="#" class="module-import-start-select-manual">', '[/1]' : '</a>'})|raw }}
+              </p>
+              <p class="module-import-start-footer-text">
+                {{ 'Please upload one file at a time, .zip or tarball format (.tar, .tar.gz or .tgz).'|trans({}, 'Admin.Modules.Help') }}
+                {{ 'Your module will be installed right after that.'|trans({}, 'Admin.Modules.Help') }}
+              </p>
             </div>
-            <div class="modal-body">
-                {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') %}
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="alert alert-danger" role="alert">
-                                <p class="alert-text">
-                                    {{ errorMessage }}
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                {% else %}
-                    <div class="row">
-                        <div class="col-md-12">
-                            <form action="#" class="dropzone" id="importDropzone">
-                                <div class="module-import-start">
-                                    <i class="module-import-start-icon material-icons">cloud_upload</i><br/>
-                                    <p class=module-import-start-main-text>
-                                        {{ 'Drop your module archive here or [1]select file[/1]'|trans({}, 'Admin.Modules.Feature')|replace({'[1]' : '<a href="#" class="module-import-start-select-manual">', '[/1]' : '</a>'})|raw }}
-                                    </p>
-                                    <p class=module-import-start-footer-text>
-                                        {{ 'Please upload one file at a time, .zip or tarball format (.tar, .tar.gz or .tgz).'|trans({}, 'Admin.Modules.Help') }}
-                                        {{ 'Your module will be installed right after that.'|trans({}, 'Admin.Modules.Help') }}
-                                    </p>
-                                </div>
-                                <div class='module-import-processing'>
-                                    <!-- Loader -->
-                                    <div class="spinner"></div>
-                                    <p class=module-import-processing-main-text>{{ 'Installing module...'|trans({}, 'Admin.Modules.Notification') }}</p>
-                                    <p class=module-import-processing-footer-text>
-                                        {{ "It will close as soon as the module is installed. It won't be long!"|trans({}, 'Admin.Modules.Notification') }}
-                                    </p>
-                                </div>
-                                <div class='module-import-success'>
-                                    <i class="module-import-success-icon material-icons">done</i><br/>
-                                    <p class='module-import-success-msg'>{{ 'Module installed!'|trans({}, 'Admin.Modules.Notification') }}</p>
-                                    <p class="module-import-success-details"></p>
-                                    <a class="module-import-success-configure btn btn-primary-reverse btn-outline-primary light-button" href='#'>{{ 'Configure'|trans({}, 'Admin.Actions') }}</a>
-                                </div>
-                                <div class='module-import-failure'>
-                                    <i class="module-import-failure-icon material-icons">error</i><br/>
-                                    <p class='module-import-failure-msg'>{{ 'Oops... Upload failed.'|trans({}, 'Admin.Modules.Notification') }}</p>
-                                    <a href="#" class="module-import-failure-details-action">{{ 'What happened?'|trans({}, 'Admin.Modules.Help') }}</a>
-                                    <div class='module-import-failure-details'></div>
-                                    <a class="module-import-failure-retry btn btn-tertiary" href='#'>{{ 'Try again'|trans({}, 'Admin.Actions') }}</a>
-                                </div>
-                                <div class='module-import-confirm'>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                {% endif %}
+            <div
+              class="module-import-processing">
+              <!-- Loader -->
+              <div class="spinner"></div>
+              <p class="module-import-processing-main-text">{{ 'Installing module...'|trans({}, 'Admin.Modules.Notification') }}</p>
+              <p class="module-import-processing-footer-text">
+                {{ "It will close as soon as the module is installed. It won't be long!"|trans({}, 'Admin.Modules.Notification') }}
+              </p>
             </div>
-            <div class="modal-footer">
+            <div class="module-import-success">
+              <i class="module-import-success-icon material-icons">done</i><br/>
+              <p class="module-import-success-msg">{{ 'Module installed!'|trans({}, 'Admin.Modules.Notification') }}</p>
+              <p class="module-import-success-details"></p>
+              <a class="module-import-success-configure btn btn-primary-reverse btn-outline-primary light-button" href="#">{{ 'Configure'|trans({}, 'Admin.Actions') }}</a>
             </div>
-        </div>
+            <div class="module-import-failure">
+              <i class="module-import-failure-icon material-icons">error</i><br/>
+              <p class="module-import-failure-msg">{{ 'Oops... Upload failed.'|trans({}, 'Admin.Modules.Notification') }}</p>
+              <a href="#" class="module-import-failure-details-action">{{ 'What happened?'|trans({}, 'Admin.Modules.Help') }}</a>
+              <div class="module-import-failure-details"></div>
+              <a class="module-import-failure-retry btn btn-tertiary" href="#">{{ 'Try again'|trans({}, 'Admin.Actions') }}</a>
+            </div>
+            <div class="module-import-confirm"></div>
+          </form>
+        {% endif %}
+      </div>
+      <div class="modal-footer"></div>
     </div>
+  </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -38,7 +38,8 @@
   ats.features,
   ats.badges is defined and ats.badges|length > 0 ? ats.badges : false
 %}
-<div class="modal-dialog module-modal-dialog">
+<div
+  class="modal-dialog module-modal-dialog">
   <!-- Modal content-->
   <div class="modal-content module-modal-content no-padding">
     <div class="modal-header module-modal-header">
@@ -69,12 +70,13 @@
       </button>
     </div>
 
-    <div class="modal-body row module-modal-body">
-      <div class="col-md-12 module-big-cover">
+    <div class="modal-body module-modal-body">
+      <div class="module-big-cover">
         <img src="{% if cover.big is defined %}{{ cover.big }}{% else %}{{ notFoundImg }}{% endif %}"/>
       </div>
-      <div class="col-md-12 module-menu-readmore">
-        <nav class="navbar navbar-light">
+      <div class="module-menu-readmore">
+        <nav
+          class="navbar navbar-light">
           {# tab list #}
           <ul class="nav nav-pills">
             <li class="nav-item">
@@ -108,7 +110,8 @@
             {# end tab list #}
           </ul>
         </nav>
-        <div class="tab-content">
+        <div
+          class="tab-content">
           {# tab content list #}
           <div id="overview-{{ name }}" class="tab-pane fade in active show">
             <p class="module-readmore-tab-content">

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/see_more.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/see_more.html.twig
@@ -22,13 +22,11 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<div class="col-12">
-  <p class="text-center">
-    <button type="button" class="btn btn-link see-more" data-category="{{ id }}">
-      {{ 'See more' | trans({}, 'Admin.Actions') }}
-    </button>
-    <button type="button" class="btn btn-link see-less d-none" data-category="{{ id }}">
-      {{ 'See less' | trans({}, 'Admin.Actions') }}
-    </button>
-  </p>
-</div>
+<p class="text-center">
+  <button type="button" class="btn btn-link see-more" data-category="{{ id }}">
+    {{ 'See more' | trans({}, 'Admin.Actions') }}
+  </button>
+  <button type="button" class="btn btn-link see-less d-none" data-category="{{ id }}">
+    {{ 'See less' | trans({}, 'Admin.Actions') }}
+  </button>
+</p>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/tab-modules-list.html.twig
@@ -24,47 +24,45 @@
  *#}
 {% set modulesListShouldBeDisplayed = (modulesList is defined and modulesList is not empty) %}
 {% if modulesListShouldBeDisplayed == true %}
-  <div class="row row-margin-bottom">
-  <div class="col-lg-12">
+  <div class="row-margin-bottom">
     <ul class="nav nav-pills">
       {% if modulesList.notInstalled|length > 0 %}
-      <li class="active">
-        <a href="#tab_modules_list_not_installed" data-toggle="tab">
-          {{ 'Not Installed'|trans({}) }}
-        </a>
-      </li>
+        <li class="active">
+          <a href="#tab_modules_list_not_installed" data-toggle="tab">
+            {{ 'Not Installed'|trans({}) }}
+          </a>
+        </li>
       {% endif %}
 
       {% if modulesList.installed|length > 0 %}
-        <li {% if modulesList.notInstalled|length == 0 %}class="active"{% endif %}>
-        <a href="#tab_modules_list_installed" data-toggle="tab">
-          {{ 'Installed'|trans({}) }}
-        </a>
+        <li {% if modulesList.notInstalled|length == 0 %} class="active" {% endif %}>
+          <a href="#tab_modules_list_installed" data-toggle="tab">
+            {{ 'Installed'|trans({}) }}
+          </a>
         </li>
       {% endif %}
     </ul>
   </div>
-</div>
-<div id="modules_list_container_content" class="tab-content modal-content-overflow">
-  {% if modulesList.notInstalled is defined and modulesList.notInstalled is not empty %}
-  <div class="tab-pane active" id="tab_modules_list_not_installed">
-    <table id="tab_modules_list_not_installed" class="table">
-      {% for module in modulesList.notInstalled %}
-        {{ include('@PrestaShop/Admin/Module/Includes/tab-module-line.html.twig',{'module': module}) }}
-      {% endfor %}
-    </table>
+  <div id="modules_list_container_content" class="tab-content modal-content-overflow">
+    {% if modulesList.notInstalled is defined and modulesList.notInstalled is not empty %}
+      <div class="tab-pane active" id="tab_modules_list_not_installed">
+        <table id="tab_modules_list_not_installed" class="table">
+          {% for module in modulesList.notInstalled %}
+            {{ include('@PrestaShop/Admin/Module/Includes/tab-module-line.html.twig',{'module': module}) }}
+          {% endfor %}
+        </table>
+      </div>
+    {% endif %}
+    {% if modulesList.installed|length > 0 %}
+      <div class="tab-pane {% if modulesList.notInstalled|length == 0 %}active{% endif %}" id="tab_modules_list_installed">
+        <table id="tab_modules_list_installed" class="table">
+          {% for module in modulesList.installed %}
+            {{ include('@PrestaShop/Admin/Module/Includes/tab-module-line.html.twig',{'module': module}) }}
+          {% endfor %}
+        </table>
+      </div>
+    {% endif %}
   </div>
-  {% endif %}
-  {% if modulesList.installed|length > 0 %}
-  <div class="tab-pane {% if modulesList.notInstalled|length == 0 %}active{% endif %}" id="tab_modules_list_installed">
-    <table id="tab_modules_list_installed" class="table">
-      {% for module in modulesList.installed %}
-        {{ include('@PrestaShop/Admin/Module/Includes/tab-module-line.html.twig',{'module': module}) }}
-      {% endfor %}
-    </table>
-  </div>
-  {% endif %}
-</div>
 {% endif %}
 <div class="alert alert-addons row-margin-top" role="alert">
   <p class="alert-text">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | This PR should be considered as a BC because of lot of HTML structure changes and they might be used by a module or anything else, but it's acceptable. The optimizations are only within the files itself, so it does not matter if anyone uses the old version in any form in their modules.
| Deprecations?     | no
| How to test?      | Go through Improve section in BO and see if nothing is broken by this PR. There should be no visible change.
| Possible impacts? | No bad impacts. :-)

### Description
- I went through all templates and removed 99% of unneeded boostrap code like `<div class="row"><div class="col">XXX</div></div>`. It will reduce render depth and complexity by several layers - easier to navigate, debug CSS, maybe faster to render on slower PCs.
- I fixed all places where somebody used single quotations or no quotations at all.
- I fixed all places where somebody combined row and column in same element, this is not allowed.
- I fixed all places where somebody used syntax line col-sm-12 col-md-12 or col-md-12 col-lg-6. The first one is not needed.
- Small fixes here and there - removed some container classes, fixed module position page responsivity a bit, fixed virtual product block responsivity etc...
It should produce no BC breaks, unless some 3rd party module was targetting some classes they shouldn't have OR they targeted it by child or parent.

### Visible fixes
I fixed the responsivity of module positions page a bit. The modules itself still need to be improved, but at least the basic layout is correct now. The card on the right switches position to the top on mobile.

![module_desktop](https://user-images.githubusercontent.com/6097524/136042133-7aebec7e-0202-4c59-89f3-29445f69a114.JPG)
![module_mobile](https://user-images.githubusercontent.com/6097524/136042142-37372d2d-4c12-4577-817b-d2be18c76754.JPG)

### Templates concerned
Improve/Design
Improve/Design/Cms
Improve/Design/MailTheme
Improve/Design/Theme
Improve/International/Currency
Improve/International/Geolocation
Improve/International/Language
Improve/International/Localization
Improve/International/Tax
Improve/International/TaxRulesGroup
Improve/International/Translations
Improve/International/Zone
Improve/Payment/PaymentMethods
Improve/Payment/Preferences
Improve/Shipping/Carriers
Improve/Shipping/Preferences
Module
Module/Includes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26062)
<!-- Reviewable:end -->
