### PR TITLE
Clean Back-office templates, part 4 - catalog

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/header.html.twig
@@ -24,13 +24,13 @@
  *#}
 <div class="product-header col-md-12">
   <div class="row justify-content-md-center">
-  {% if is_multishop_context %}
-    <div class="col-xxl-10">
-      <div class="alert alert-warning" role="alert">
-        <p class="alert-text">{{ 'You are in a multistore context: any modification will impact all your shops, or each shop of the active group.'|trans({}, 'Admin.Catalog.Notification') }}</p>
+    {% if is_multishop_context %}
+      <div class="col-xxl-10">
+        <div class="alert alert-warning" role="alert">
+          <p class="alert-text">{{ 'You are in a multistore context: any modification will impact all your shops, or each shop of the active group.'|trans({}, 'Admin.Catalog.Notification') }}</p>
+        </div>
       </div>
-    </div>
-  {% endif %}
+    {% endif %}
 
     <div class="col-xxl-10">
       <div class="row">
@@ -39,56 +39,43 @@
         </div>
         <div class="col-sm-7 col-md-2 form_step1_type_product">
           {{ form_widget(formType) }}
-          <span class="help-box pull-xs-right" data-toggle="popover"
-            data-content="{{ "Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?"|trans({}, 'Admin.Catalog.Help') }}"></span>
+          <span class="help-box pull-xs-right" data-toggle="popover" 
+          data-content="{{ "Is the product a pack (a combination of at least two existing products), a virtual product (downloadable file, service, etc.), or simply a standard, physical product?"|trans({}, 'Admin.Catalog.Help') }}"></span>
         </div>
         <div class="col-sm-2 col-md-1 form_switch_language">
           <div class="{{ languages|length == 1 ? 'hide' : '' }}">
             <select id="form_switch_language" class="custom-select">
               {% for language in languages %}
-                <option value="{{ language.iso_code }}" {% if default_language_iso == language.iso_code %}selected="selected"{% endif %}>{{ language.iso_code }}</option>
+                <option value="{{ language.iso_code }}" {% if default_language_iso == language.iso_code %} 
+                        selected="selected" {% endif %}>{{ language.iso_code }}</option>
               {% endfor %}
             </select>
           </div>
         </div>
         <div class="toolbar col-sm-3 col-md-2 text-md-right">
-          <a class="toolbar-button btn-sales" href="{{ stats_link }}" target="_blank" title="{{ 'Sales'|trans({}, 'Admin.Global') }}"
-            id="product_form_go_to_sales">
+          <a class="toolbar-button btn-sales" href="{{ stats_link }}" target="_blank" title="{{ 'Sales'|trans({}, 'Admin.Global') }}" id="product_form_go_to_sales">
             <i class="material-icons">assessment</i>
             <span class="title">{{ 'Sales'|trans({}, 'Admin.Global') }}</span>
           </a>
 
-          <a
-            class="toolbar-button btn-quicknav btn-sidebar"
-            href="#"
-            title="{{ 'Quick navigation'|trans({}, 'Admin.Global') }}"
-            data-toggle="sidebar"
-            data-target="#right-sidebar"
-            data-url="{{ path('admin_product_list', {limit: 'last', offset: 'last', view: 'quicknav'}) }}"
-            id="product_form_open_quicknav"
-          >
+          <a class="toolbar-button btn-quicknav btn-sidebar" href="#" title="{{ 'Quick navigation'|trans({}, 'Admin.Global') }}" 
+             data-toggle="sidebar" data-target="#right-sidebar" 
+             data-url="{{ path('admin_product_list', {limit: 'last', offset: 'last', view: 'quicknav'}) }}" id="product_form_open_quicknav">
             <i class="material-icons">list</i>
             <span class="title">{{ 'Product list'|trans({}, 'Admin.Catalog.Feature') }}</span>
           </a>
 
-          <a class="toolbar-button btn-help btn-sidebar" href="#"
-            title="{{ 'Help'|trans({}, 'Admin.Global') }}"
-            data-toggle="sidebar"
-            data-target="#right-sidebar"
-            data-url="{{ help_link }}"
-            id="product_form_open_help"
-          >
+          <a class="toolbar-button btn-help btn-sidebar" href="#" title="{{ 'Help'|trans({}, 'Admin.Global') }}" 
+             data-toggle="sidebar" data-target="#right-sidebar" 
+             data-url="{{ help_link }}" id="product_form_open_help">
             <i class="material-icons">help</i>
             <span class="title">{{ 'Help'|trans({}, 'Admin.Global') }}</span>
           </a>
         </div>
       </div>
-      <div class="row">
-        <div class="col-lg-12">
-          {{ form_errors(formName) }}
-          {{ form_errors(formType) }}
-        </div>
-      </div>
+      {{ form_errors(formName) }}
+      {{ form_errors(formType) }}
     </div>
   </div>
 </div>
+

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_categories.html.twig
@@ -23,8 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <h2>{{ "Categories"|trans({}, 'Admin.Catalog.Feature') }}
-  <span class="help-box" data-toggle="popover"
-    data-content="{{ "Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL. Disabled categories are written in italics."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+  <span class="help-box" 
+        data-toggle="popover"
+        data-content="{{ "Where should the product be available on your site? The main category is where the product appears by default: this is the category which is seen in the product page's URL. Disabled categories are written in italics."|trans({}, 'Admin.Catalog.Help') }}" >
+  </span>
 </h2>
 <div class="categories-tree js-categories-tree">
   <fieldset class="form-group">
@@ -49,8 +51,10 @@
 <div id="add-categories">
   <h2>
     {{ "Create a new category"|trans({}, 'Admin.Catalog.Feature') }}
-    <span class="help-box" data-toggle="popover"
-      data-content="{{ "If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).  A new category will not automatically appear in your shop's menu, please read the Help about it."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+    <span class="help-box" 
+          data-toggle="popover"
+          data-content="{{ "If you want to quickly create a new category, you can do it here. Don’t forget to then go to the Categories page to fill in the needed details (description, image, etc.).  A new category will not automatically appear in your shop's menu, please read the Help about it."|trans({}, 'Admin.Catalog.Help') }}" >
+    </span>
   </h2>
   <div id="add-categories-content" class="hide">
     <div id="form_step1_new_category" data-action="{{ path('admin_category_simple_add_form', {'id_product': productId }) }}">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
@@ -61,13 +61,13 @@
         <div class="btn-group btn-group-sm" role="group">
             <a href="#combination_form_{{ form.vars.value.id_product_attribute }}" class="btn btn-open tooltip-link btn-sm"><i class="material-icons">mode_edit</i></a>
         </div>
-        <div id="combination_form_{{ form.vars.value.id_product_attribute }}" data="{{ form.vars.value.id_product_attribute }}" class="combination-form hide row">
-            <div class="col-sm-12 nav">
+        <div id="combination_form_{{ form.vars.value.id_product_attribute }}" data="{{ form.vars.value.id_product_attribute }}" class="combination-form hide">
+            <div class="nav">
                 {# "Prev." is short for "Previous" #}
                 <a class="btn-sensitive prev"><i class="material-icons">keyboard_arrow_left</i> {{ 'Prev. combination'|trans({}, 'Admin.Catalog.Feature') }}</a>
                 <a class="next btn-sensitive">{{ 'Next combination'|trans({}, 'Admin.Catalog.Feature') }} <i class="material-icons">keyboard_arrow_right</i></a>
             </div>
-            <div class="panel col-md-12 p-2">
+            <div class="panel p-2">
                 <div class="float-left">
                     <button type="button" class="back-to-product btn btn-outline-secondary btn-back"><i class="material-icons">arrow_back</i> {{ 'Back to product'|trans({}, 'Admin.Catalog.Feature') }}</button>
                 </div>
@@ -99,8 +99,10 @@
                       <fieldset class="form-group">
                           <label class="form-control-label">
                             {{ form.attribute_minimal_quantity.vars.label }}
-                            <span class="help-box" data-toggle="popover"
-                              data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                            <span class="help-box" 
+                                  data-toggle="popover"
+                                  data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" >
+                            </span>
                           </label>
                           {{ form_errors(form.attribute_minimal_quantity) }}
                           {{ form_widget(form.attribute_minimal_quantity) }}
@@ -138,7 +140,11 @@
                       <div class="widget-checkbox-inline">
                         {{ form_errors(form.attribute_low_stock_alert) }}
                         {{ form_widget(form.attribute_low_stock_alert) }}
-                        <span class="help-box" data-toggle="popover" data-html="true" data-content="{{ "The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]"|trans({'[1]':'<a href=&quot;'~getAdminLink("AdminEmployees")~'&quot;>','[/1]':'</a>'}, 'Admin.Catalog.Help')|raw }}" ></span>
+                        <span class="help-box" 
+                              data-toggle="popover" 
+                              data-html="true" 
+                              data-content="{{ "The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]"|trans({'[1]':'<a href=&quot;'~getAdminLink("AdminEmployees")~'&quot;>','[/1]':'</a>'}, 'Admin.Catalog.Help')|raw }}" >
+                        </span>
                       </div>
                     </fieldset>
                   </div>
@@ -158,8 +164,10 @@
                         <fieldset class="form-group">
                             <label class="form-control-label">
                               {{ form.attribute_price.vars.label }}
-                              <span class="help-box" data-toggle="popover"
-                                data-content="{{ "Does this combination have a different price? Is it cheaper or more expensive than the default retail price?"|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                              <span class="help-box" 
+                                    data-toggle="popover"
+                                    data-content="{{ "Does this combination have a different price? Is it cheaper or more expensive than the default retail price?"|trans({}, 'Admin.Catalog.Help') }}" >
+                              </span>
                             </label>
                             {{ form_errors(form.attribute_price) }}
                             {{ form_widget(form.attribute_price) }}
@@ -189,8 +197,10 @@
                         <fieldset class="form-group">
                             <label class="form-control-label">
                               {{ form.attribute_unity.vars.label }}
-                              <span class="help-box" data-toggle="popover"
-                                data-content="{{ "Does this combination have a different price per unit?"|trans({}, 'Admin.Catalog.Feature') }}" ></span>
+                              <span class="help-box" 
+                                    data-toggle="popover"
+                                    data-content="{{ "Does this combination have a different price per unit?"|trans({}, 'Admin.Catalog.Feature') }}" >
+                              </span>
                             </label>
                             {{ form_errors(form.attribute_unity) }}
                             {{ form_widget(form.attribute_unity) }}
@@ -224,8 +234,10 @@
                         <fieldset class="form-group">
                             <label class="form-control-label">
                               {{ form.attribute_ean13.vars.label }}
-                              <span class="help-box" data-toggle="popover"
-                                data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                              <span class="help-box" 
+                                    data-toggle="popover"
+                                    data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'Admin.Catalog.Help') }}" >
+                              </span>
                             </label>
                             {{ form_errors(form.attribute_ean13) }}
                             {{ form_widget(form.attribute_ean13) }}
@@ -249,24 +261,17 @@
                 <h2 class="title">
                   {{ "Images"|trans({}, 'Admin.Catalog.Feature') }}
                 </h2>
-                <div class="row">
-                    <div class="col-md-12">
-                        <fieldset class="form-group js-combination-images">
-                            <label>
-                                <small class="form-control-label">{{ form.id_image_attr.vars.label }}</small>
-                                <small class="form-control-label number-of-images"></small>
-                            </label>
-                            {{ form_errors(form.id_image_attr) }}
-                            {{ form_widget(form.id_image_attr) }}
-                        </fieldset>
-                    </div>
-                </div>
 
-                <div class="row">
-                    <div class="col-md-12">
-                        {{ renderhook('displayAdminProductsCombinationBottom', { 'id_product': form.vars.value.id_product, 'id_product_attribute': form.vars.value.id_product_attribute }) }}
-                    </div>
-                </div>
+                <fieldset class="form-group js-combination-images">
+                    <label>
+                        <small class="form-control-label">{{ form.id_image_attr.vars.label }}</small>
+                        <small class="form-control-label number-of-images"></small>
+                    </label>
+                    {{ form_errors(form.id_image_attr) }}
+                    {{ form_widget(form.id_image_attr) }}
+                </fieldset>
+
+                {{ renderhook('displayAdminProductsCombinationBottom', { 'id_product': form.vars.value.id_product, 'id_product_attribute': form.vars.value.id_product_attribute }) }}
 
                 {{ form_widget(form.id_product_attribute) }}
             </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations.html.twig
@@ -54,24 +54,20 @@
     </div>
 
     <div id="combinations-bulk-form">
-      <div class="row">
-        <div class="col-md-12">
-          <p
-            class="form-control bulk-action"
-            data-toggle="collapse"
-            href="#bulk-combinations-container"
-            aria-expanded="false"
-            aria-controls="bulk-combinations-container"
-          >
-            {# First tag [1] is number of combinations selected. Second tag [2] is the total of combinations available. #}
-            <strong>{{ 'Bulk actions ([1]/[2] combination(s) selected)'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<span class="js-bulk-combinations">0</span>', '[2]': '<span id="js-bulk-combinations-total">' ~ combinations_count ~ '</span>' })|raw }}</strong>
-            <i class="material-icons float-right">keyboard_arrow_down</i>
-          </p>
-        </div>
-        <div class="col-md-12 collapse js-collapse" id="bulk-combinations-container">
-          <div class="border p-3">
-            {{ include('@Product/ProductPage/Forms/form_combinations_bulk.html.twig', { 'form': form_combination_bulk }) }}
-          </div>
+      <p
+        class="form-control bulk-action"
+        data-toggle="collapse"
+        href="#bulk-combinations-container"
+        aria-expanded="false"
+        aria-controls="bulk-combinations-container"
+      >
+        {# First tag [1] is number of combinations selected. Second tag [2] is the total of combinations available. #}
+        <strong>{{ 'Bulk actions ([1]/[2] combination(s) selected)'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<span class="js-bulk-combinations">0</span>', '[2]': '<span id="js-bulk-combinations-total">' ~ combinations_count ~ '</span>' })|raw }}</strong>
+        <i class="material-icons float-right">keyboard_arrow_down</i>
+      </p>
+      <div class="collapse js-collapse" id="bulk-combinations-container">
+        <div class="border p-3">
+          {{ include('@Product/ProductPage/Forms/form_combinations_bulk.html.twig', { 'form': form_combination_bulk }) }}
         </div>
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig
@@ -75,7 +75,10 @@
 
   <div class="col-lg-4 col-md-3 col-sm-6">
     <label class="form-control-label">{{ form.low_stock_threshold.vars.label }}
-      <span class="help-box" data-toggle="popover" data-content="{{ 'You can increase or decrease low stock levels in bulk. You cannot disable them in bulk: you have to do it on a per-combination basis.'|trans({}, 'Admin.Catalog.Feature') }}" ></span>
+      <span class="help-box" 
+            data-toggle="popover" 
+            data-content="{{ 'You can increase or decrease low stock levels in bulk. You cannot disable them in bulk: you have to do it on a per-combination basis.'|trans({}, 'Admin.Catalog.Feature') }}" >
+      </span>
     </label>
     {{ form_errors(form.low_stock_threshold) }}
     {{ form_widget(form.low_stock_threshold) }}
@@ -85,7 +88,10 @@
     <div class="widget-checkbox-inline">
       {{ form_errors(form.low_stock_alert) }}
       {{ form_widget(form.low_stock_alert) }}
-      <span class="help-box" data-toggle="popover" data-content="{{ 'The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to Advanced Parameters > Team'|trans({}, 'Admin.Catalog.Feature') }}" ></span>
+      <span class="help-box" 
+            data-toggle="popover" 
+            data-content="{{ 'The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to Advanced Parameters > Team'|trans({}, 'Admin.Catalog.Feature') }}" >
+      </span>
     </div>
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_feature.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_feature.html.twig
@@ -23,13 +23,13 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div class="row product-feature">
-    <div class="col-lg-12 col-xl-4">
+    <div class="col-xl-4">
         <fieldset class="form-group mb-0">
             <label class="form-control-label">{{ form.feature.vars.label }}</label>
             {{ form_widget(form.feature) }}
         </fieldset>
     </div>
-    <div class="col-lg-12 col-xl-4">
+    <div class="col-xl-4">
         <fieldset class="form-group mb-0">
             <label class="form-control-label">{{ form.value.vars.label }}</label>
             {{ form_widget(form.value) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_related_products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_related_products.html.twig
@@ -22,11 +22,10 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<div  id="related-title" class="row">
-  <div class="col-md-12">
-    <h2>{{ "Related product"|trans({}, 'Admin.Catalog.Feature') }}</h2>
-  </div>
+<div id="related-title">
+  <h2>{{ "Related product"|trans({}, 'Admin.Catalog.Feature') }}</h2>
 </div>
+
 <div id="related-content" class="row {{ form.vars.value.data|length == 0 ? 'hide':'' }}">
   <div class="col-xl-8 col-lg-11">
     <fieldset class="form-group">
@@ -39,10 +38,7 @@
       </fieldset>
   </div>
 </div>
-<div class="row">
-  <div class="col-md-4">
-    <button type="button" class="btn btn-outline-primary sensitive open {{ form.vars.value.data|length > 0 ? 'hide':'' }}" id="add-related-product-button">
-      <i class="material-icons">add_circle</i> {{ 'Add a related product'|trans({}, 'Admin.Catalog.Feature') }}
-    </button>
-  </div>
-</div>
+
+<button type="button" class="btn btn-outline-primary sensitive open {{ form.vars.value.data|length > 0 ? 'hide':'' }}" id="add-related-product-button">
+  <i class="material-icons">add_circle</i> {{ 'Add a related product'|trans({}, 'Admin.Catalog.Feature') }}
+</button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
@@ -22,114 +22,116 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-<div class="col-md-12">
 
-  <h2>{{ 'Search Engine Optimization'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-  <p class="subtitle">{{ 'Improve your ranking and how your product page will appear in search engines results.'|trans({}, 'Admin.Catalog.Feature') }}</p>
+<h2>{{ 'Search Engine Optimization'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+<p class="subtitle">{{ 'Improve your ranking and how your product page will appear in search engines results.'|trans({}, 'Admin.Catalog.Feature') }}</p>
 
-  {% block product_catalog_tool_serp %}
-    <p>{{ "Here is a preview of your search engine result, play with it!"|trans({}, 'Admin.Catalog.Feature') }}</p>
-    {# Div targetted by the SERP component in VueJs. It displays a Google search result preview. #}
-    <div id="serp-app"></div>
-  {% endblock %}
+{% block product_catalog_tool_serp %}
+  <p>{{ "Here is a preview of your search engine result, play with it!"|trans({}, 'Admin.Catalog.Feature') }}</p>
+  {# Div targetted by the SERP component in VueJs. It displays a Google search result preview. #}
+  <div id="serp-app"></div>
+{% endblock %}
 
-  <div class="row">
-    <div class="col-md-9">
-      <fieldset class="form-group">
-        {{ form_label(seoForm.meta_title) }}
-        {{ form_errors(seoForm.meta_title) }}
-        {{ form_widget(seoForm.meta_title) }}
-      </fieldset>
-    </div>
+<div class="row">
+  <div class="col-md-9">
+    <fieldset class="form-group">
+      {{ form_label(seoForm.meta_title) }}
+      {{ form_errors(seoForm.meta_title) }}
+      {{ form_widget(seoForm.meta_title) }}
+    </fieldset>
   </div>
-
-  <div class="row">
-    <div class="col-md-9">
-      <fieldset class="form-group">
-        {{ form_label(seoForm.meta_description) }}
-        {{ form_errors(seoForm.meta_description) }}
-        {{ form_widget(seoForm.meta_description) }}
-      </fieldset>
-    </div>
-  </div>
-  <fieldset class="form-group">
-    <label class="form-control-label">
-      {{ seoForm.link_rewrite.vars.label }}
-      <span class="help-box" data-toggle="popover"
-        data-content="{{ "This is the human-readable URL, as generated from the product's name. You can change it if you want."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-    </label>
-    {{ form_errors(seoForm.link_rewrite) }}
-    <div class="row">
-      <div class="col-md-7">
-        {{ form_widget(seoForm.link_rewrite) }}
-      </div>
-      <div class="col-md-2">
-        <button type="button" class="btn btn-block btn-outline-secondary" id="seo-url-regenerate">{{ 'Reset URL'|trans({}, 'Admin.Catalog.Feature') }}</button>
-      </div>
-    </div>
-  </fieldset>
-
-  <div class="row">
-    <div class="col-md-9">
-      <div class="alert alert-info" role="alert">
-        <p class="alert-text">
-          {% if configuration('PS_REWRITING_SETTINGS') == 0 %}
-            <strong>{{ 'Friendly URLs are currently disabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
-            {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
-          {% else %}
-            <strong>{{ 'Friendly URLs are currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
-            {{ 'To disable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
-          {% endif %}
-        </p>
-        <p class="alert-text">
-          {% if configuration('PS_FORCE_FRIENDLY_PRODUCT') == 1 %}
-            <strong>{{ 'The "Force update of friendly URL" option is currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
-            {# "It" refers to the option "Force update of friendly URL" #}
-            {{ 'To disable it, go to [1]Product Settings[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminPPreferences") ~ '#configuration_fieldset_products">', '[/1]': '</a>'})|raw }}
-          {% endif %}
-        </p>
-      </div>
-    </div>
-  </div>
-
-  <h2 class="mt-4">
-    {{ 'Redirection page'|trans({}, 'Admin.Catalog.Feature') }}
-    <span class="help-box" data-toggle="popover"
-      data-content="{{ "When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-  </h2>
-
-  <div class="row">
-
-    <div class="col-md-4">
-      <fieldset class="form-group">
-        <label class="form-control-label">{{ seoForm.redirect_type.vars.label }}</label>
-        {{ form_errors(seoForm.redirect_type) }}
-        {{ form_widget(seoForm.redirect_type) }}
-      </fieldset>
-    </div>
-
-    <div class="col-md-5" id="id-product-redirected">
-      <fieldset class="form-group">
-        <label class="form-control-label">{{ seoForm.id_type_redirected.vars.label }}</label>
-        {{ form_errors(seoForm.id_type_redirected) }}
-        {{ form_widget(seoForm.id_type_redirected) }}
-      </fieldset>
-
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-9">
-      <div class="alert alert-info" role="alert">
-        <p class="alert-text">
-          {{ 'No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.'|trans({}, 'Admin.Catalog.Help') }}<br>
-          {{ 'Permanent redirection (301) = Permanently display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}<br>
-          {{ 'Temporary redirection (302) = Temporarily display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}
-        </p>
-      </div>
-    </div>
-  </div>
-
-  {{ form_rest(seoForm) }}
-
-  {{ renderhook('displayAdminProductsSeoStepBottom', { 'id_product': productId }) }}
 </div>
+
+<div class="row">
+  <div class="col-md-9">
+    <fieldset class="form-group">
+      {{ form_label(seoForm.meta_description) }}
+      {{ form_errors(seoForm.meta_description) }}
+      {{ form_widget(seoForm.meta_description) }}
+    </fieldset>
+  </div>
+</div>
+<fieldset class="form-group">
+  <label class="form-control-label">
+    {{ seoForm.link_rewrite.vars.label }}
+    <span class="help-box" 
+          data-toggle="popover"
+          data-content="{{ "This is the human-readable URL, as generated from the product's name. You can change it if you want."|trans({}, 'Admin.Catalog.Help') }}" >
+    </span>
+  </label>
+  {{ form_errors(seoForm.link_rewrite) }}
+  <div class="row">
+    <div class="col-md-7">
+      {{ form_widget(seoForm.link_rewrite) }}
+    </div>
+    <div class="col-md-2">
+      <button type="button" class="btn btn-block btn-outline-secondary" id="seo-url-regenerate">{{ 'Reset URL'|trans({}, 'Admin.Catalog.Feature') }}</button>
+    </div>
+  </div>
+</fieldset>
+
+<div class="row">
+  <div class="col-md-9">
+    <div class="alert alert-info" role="alert">
+      <p class="alert-text">
+        {% if configuration('PS_REWRITING_SETTINGS') == 0 %}
+          <strong>{{ 'Friendly URLs are currently disabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
+          {{ 'To enable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
+        {% else %}
+          <strong>{{ 'Friendly URLs are currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
+          {{ 'To disable it, go to [1]SEO and URLs[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminMeta") ~ '#meta_fieldset_general">', '[/1]': '</a>'})|raw }}
+        {% endif %}
+      </p>
+      <p class="alert-text">
+        {% if configuration('PS_FORCE_FRIENDLY_PRODUCT') == 1 %}
+          <strong>{{ 'The "Force update of friendly URL" option is currently enabled.'|trans({}, 'Admin.Catalog.Notification') }}</strong>
+          {# "It" refers to the option "Force update of friendly URL" #}
+          {{ 'To disable it, go to [1]Product Settings[/1]'|trans({}, 'Admin.Catalog.Notification')|replace({'[1]': '<a href="' ~ getAdminLink("AdminPPreferences") ~ '#configuration_fieldset_products">', '[/1]': '</a>'})|raw }}
+        {% endif %}
+      </p>
+    </div>
+  </div>
+</div>
+
+<h2 class="mt-4">
+  {{ 'Redirection page'|trans({}, 'Admin.Catalog.Feature') }}
+  <span class="help-box" 
+        data-toggle="popover"
+        data-content="{{ "When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name."|trans({}, 'Admin.Catalog.Help') }}" >
+  </span>
+</h2>
+
+<div class="row">
+
+  <div class="col-md-4">
+    <fieldset class="form-group">
+      <label class="form-control-label">{{ seoForm.redirect_type.vars.label }}</label>
+      {{ form_errors(seoForm.redirect_type) }}
+      {{ form_widget(seoForm.redirect_type) }}
+    </fieldset>
+  </div>
+
+  <div class="col-md-5" id="id-product-redirected">
+    <fieldset class="form-group">
+      <label class="form-control-label">{{ seoForm.id_type_redirected.vars.label }}</label>
+      {{ form_errors(seoForm.id_type_redirected) }}
+      {{ form_widget(seoForm.id_type_redirected) }}
+    </fieldset>
+
+  </div>
+</div>
+<div class="row">
+  <div class="col-md-9">
+    <div class="alert alert-info" role="alert">
+      <p class="alert-text">
+        {{ 'No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'Permanent redirection (301) = Permanently display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'Temporary redirection (302) = Temporarily display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}
+      </p>
+    </div>
+  </div>
+</div>
+
+{{ form_rest(seoForm) }}
+
+{{ renderhook('displayAdminProductsSeoStepBottom', { 'id_product': productId }) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
@@ -82,8 +82,10 @@
   <div class="form-group">
     <h2>
       {{ form.additional_delivery_times.vars.label }}
-      <span class="help-box" data-toggle="popover"
-        data-content="{{ "Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+      <span class="help-box" 
+            data-toggle="popover"
+            data-content="{{ "Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws."|trans({}, 'Admin.Catalog.Help') }}" >
+      </span>
     </h2>
     <div class="row">
        <div class="col-md-12" {% if block('widget_container_attributes') is defined %} {{ block('widget_container_attributes') }} {% endif %}>
@@ -123,8 +125,10 @@
   <div class="form-group">
     <h2>
       {{ form.additional_shipping_cost.vars.label }}
-      <span class="help-box" data-toggle="popover"
-        data-content="{{ "If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+      <span class="help-box" 
+            data-toggle="popover"
+            data-content="{{ "If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping."|trans({}, 'Admin.Catalog.Help') }}" >
+      </span>
     </h2>
     <label class="form-control-label">{{ 'Does this product incur additional shipping costs?'|trans({}, 'Admin.Catalog.Feature') }}</label>
     <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_choice.html.twig
@@ -25,21 +25,19 @@
 {% if form.suppliers|length > 0 %}
   <div id="form_step6_suppliers_custom_fields">
     <h2>{{ form.suppliers.vars.label }}</h2>
-    <div class="row mb-1">
-      <div class="col-md-12">
-        <div class="alert expandable-alert alert-info" role="alert">
-          <button type="button" class="read-more btn-link" data-toggle="collapse" data-target="#suppliersInfo" aria-expanded="false" aria-controls="collapseDanger">
-            {{ 'Read more'|trans({}, 'Admin.Actions')|raw }}
-          </button>
-          <p class="alert-text">
-            {{ 'This interface allows you to specify the suppliers of the current product and its combinations, if any.'|trans({}, 'Admin.Catalog.Help')|raw }}<br>
-            {{ 'You can specify supplier references according to previously associated suppliers.'|trans({}, 'Admin.Catalog.Help')|raw }}
+    <div class="mb-1">
+      <div class="alert expandable-alert alert-info" role="alert">
+        <button type="button" class="read-more btn-link" data-toggle="collapse" data-target="#suppliersInfo" aria-expanded="false" aria-controls="collapseDanger">
+          {{ 'Read more'|trans({}, 'Admin.Actions')|raw }}
+        </button>
+        <p class="alert-text">
+          {{ 'This interface allows you to specify the suppliers of the current product and its combinations, if any.'|trans({}, 'Admin.Catalog.Help')|raw }}<br>
+          {{ 'You can specify supplier references according to previously associated suppliers.'|trans({}, 'Admin.Catalog.Help')|raw }}
+        </p>
+        <div class="alert-more collapse" id="suppliersInfo">
+          <p>
+            {{ 'When using the advanced stock management tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.'|trans({}, 'Admin.Catalog.Help')|raw }}
           </p>
-          <div class="alert-more collapse" id="suppliersInfo">
-            <p>
-              {{ 'When using the advanced stock management tool (see Shop Parameters > Products settings), the values you define (price, references) will be used in supply orders.'|trans({}, 'Admin.Catalog.Help')|raw }}
-            </p>
-          </div>
         </div>
       </div>
     </div>
@@ -50,18 +48,18 @@
           {{ form_errors(form.suppliers) }}
           <table class="table" id="form_step6_suppliers">
             <thead class="thead-default">
-            <tr>
-              <th width="70%">{{ 'Choose the suppliers associated with this product'|trans({}, 'Admin.Catalog.Feature') }}</th>
-              <th width="30%">{{ 'Default supplier'|trans({}, 'Admin.Catalog.Feature') }}</th>
-            </tr>
+              <tr>
+                <th width="70%">{{ 'Choose the suppliers associated with this product'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th width="30%">{{ 'Default supplier'|trans({}, 'Admin.Catalog.Feature') }}</th>
+              </tr>
             </thead>
             <tbody>
-            {% for key, supplier in form.suppliers %}
-              <tr>
-                <td>{{ form_widget(supplier) }}</td>
-                <td>{{ form_widget(form.default_supplier[key]) }}</td>
-              </tr>
-            {% endfor %}
+              {% for key, supplier in form.suppliers %}
+                <tr>
+                  <td>{{ form_widget(supplier) }}</td>
+                  <td>{{ form_widget(form.default_supplier[key]) }}</td>
+                </tr>
+              {% endfor %}
             </tbody>
           </table>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_supplier_combination.html.twig
@@ -24,27 +24,25 @@
  *#}
 {% if suppliers|length > 0 %}
   <h4>{{ 'Supplier reference(s)'|trans({}, 'Admin.Catalog.Feature') }}</h4>
-  <div class="row">
-    <div class="col-md-12">
-      <div class="alert alert-info" role="alert">
-        <p class="alert-text">
-          {{ 'You can specify product reference(s) for each associated supplier. Click "%save_label%" after changing selected suppliers to display the associated product references.'|trans({'%save_label%': 'Save'|trans({}, 'Admin.Actions')}, 'Admin.Catalog.Help')|raw }}
-        </p>
-      </div>
-    </div>
+  <div class="alert alert-info" role="alert">
+    <p class="alert-text">
+      {{ 'You can specify product reference(s) for each associated supplier. Click "%save_label%" after changing selected suppliers to display the associated product references.'|trans({'%save_label%': 'Save'|trans({}, 'Admin.Actions')}, 'Admin.Catalog.Help')|raw }}
+    </p>
   </div>
 {% endif %}
 
 {% for supplierId in suppliers %}
   {% set collectionName = 'supplier_combination_' ~ supplierId %}
   <div class="panel panel-default">
-    <div class="panel-heading"><strong>{{ form[collectionName].vars.label }}</strong></div>
+    <div class="panel-heading">
+      <strong>{{ form[collectionName].vars.label }}</strong>
+    </div>
     <div class="panel-body" id="supplier_combination_{{ supplierId }}">
       <div>
         {{ form_errors(form[collectionName]) }}
         <table class="table">
           <thead class="thead-default">
-            <tr >
+            <tr>
               <th width="30%">{{ 'Product name'|trans({}, 'Admin.Catalog.Feature') }}</th>
               <th width="30%">{{ 'Supplier reference'|trans({}, 'Admin.Catalog.Feature') }}</th>
               <th width="20%">{{ 'Cost price (tax excl.)'|trans({}, 'Admin.Catalog.Feature') }}</th>
@@ -52,18 +50,18 @@
             </tr>
           </thead>
           <tbody>
-          {% for supplier_combination in form[collectionName] %}
-            <tr>
-              <td>{{ supplier_combination.vars.value.label }}</td>
-              <td>{{ form_widget(supplier_combination.supplier_reference) }}</td>
-              <td>{{ form_widget(supplier_combination.product_price) }}</td>
-              <td>
-                {{ form_widget(supplier_combination.product_price_currency) }}
-                {{ form_widget(supplier_combination.id_product_attribute) }}
-                {{ form_widget(supplier_combination.supplier_id) }}
-              </td>
-            </tr>
-          {% endfor %}
+            {% for supplier_combination in form[collectionName] %}
+              <tr>
+                <td>{{ supplier_combination.vars.value.label }}</td>
+                <td>{{ form_widget(supplier_combination.supplier_reference) }}</td>
+                <td>{{ form_widget(supplier_combination.product_price) }}</td>
+                <td>
+                  {{ form_widget(supplier_combination.product_price_currency) }}
+                  {{ form_widget(supplier_combination.id_product_attribute) }}
+                  {{ form_widget(supplier_combination.supplier_id) }}
+                </td>
+              </tr>
+            {% endfor %}
           </tbody>
         </table>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/combinations.html.twig
@@ -23,181 +23,181 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane" id="step3">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
+  <div class="container-fluid">
+
+    <div id="quantities" style="{% if has_combinations or formDependsOnStocks.vars.value != "0" %}display: none;{% endif %}">
+      <h2>{{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+      <fieldset class="form-group">
         <div class="row">
-
-          <div class="col-md-12">
-
-            <div id="quantities" style="{% if has_combinations or formDependsOnStocks.vars.value != "0" %}display: none;{% endif %}">
-              <h2>{{ 'Quantities'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-              <fieldset class="form-group">
-                <div class="row">
-                  {% if configuration('PS_STOCK_MANAGEMENT') %}
-                    <div class="col-md-4">
-                      <label class="form-control-label">{{ formStockQuantity.vars.label }}</label>
-                      {{ form_errors(formStockQuantity) }}
-                      {{ form_widget(formStockQuantity) }}
-                    </div>
-                  {% endif %}
-                  <div class="col-md-4">
-                    <label class="form-control-label">
-                      {{ formStockMinimalQuantity.vars.label }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    </label>
-                    {{ form_errors(formStockMinimalQuantity) }}
-                    {{ form_widget(formStockMinimalQuantity) }}
-                  </div>
-                </div>
-              </fieldset>
-
-              <h2>{{ 'Stock'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-              <fieldset class="form-group">
-                <div class="row">
-                  <div class="col-md-4">
-                    <label class="form-control-label">{{ formLocation.vars.label }}</label>
-                    {{ form_errors(formLocation) }}
-                    {{ form_widget(formLocation) }}
-                  </div>
-                </div>
-                <div class="row">
-                  <div class="col-md-4">
-                    <label class="form-control-label">{{ formLowStockThreshold.vars.label }}</label>
-                    {{ form_errors(formLowStockThreshold) }}
-                    {{ form_widget(formLowStockThreshold) }}
-                  </div>
-                  <div class="col-md-8">
-                    <label class="form-control-label">&nbsp;</label>
-                    <div class="widget-checkbox-inline">
-                      {{ form_errors(formLowStockAlert) }}
-                      {{ form_widget(formLowStockAlert) }}
-                      <span class="help-box" data-toggle="popover" data-html="true" data-content="{{ "The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]"|trans({'[1]':'<a href=&quot;'~getAdminLink("AdminEmployees")~'&quot;>','[/1]':'</a>'}, 'Admin.Catalog.Help')|raw }}" ></span>
-                    </div>
-                  </div>
-                </div>
-              </fieldset>
+          {% if configuration('PS_STOCK_MANAGEMENT') %}
+            <div class="col-md-4">
+              <label class="form-control-label">{{ formStockQuantity.vars.label }}</label>
+              {{ form_errors(formStockQuantity) }}
+              {{ form_widget(formStockQuantity) }}
             </div>
+          {% endif %}
+          <div class="col-md-4">
+            <label class="form-control-label">
+              {{ formStockMinimalQuantity.vars.label }}
+              <span class="help-box" data-toggle="popover"
+                data-content="{{ "The minimum quantity required to buy this product (set to 1 to disable this feature). E.g.: if set to 3, customers will be able to purchase the product only if they take at least 3 in quantity."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+            </label>
+            {{ form_errors(formStockMinimalQuantity) }}
+            {{ form_widget(formStockMinimalQuantity) }}
+          </div>
+        </div>
+      </fieldset>
 
-            <div id="virtual_product" data-action="{{ path('admin_product_virtual_save_action', { 'idProduct': productId }) }}" data-action-remove="{{ path('admin_product_virtual_remove_action', {'idProduct': productId }) }}">
+      <h2>{{ 'Stock'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+      <fieldset class="form-group">
+        <div class="row">
+          <div class="col-md-4">
+            <label class="form-control-label">{{ formLocation.vars.label }}</label>
+            {{ form_errors(formLocation) }}
+            {{ form_widget(formLocation) }}
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-md-4">
+            <label class="form-control-label">{{ formLowStockThreshold.vars.label }}</label>
+            {{ form_errors(formLowStockThreshold) }}
+            {{ form_widget(formLowStockThreshold) }}
+          </div>
+          <div class="col-md-8">
+            <label class="form-control-label">&nbsp;</label>
+            <div class="widget-checkbox-inline">
+              {{ form_errors(formLowStockAlert) }}
+              {{ form_widget(formLowStockAlert) }}
+              <span class="help-box" 
+                    data-toggle="popover" 
+                    data-html="true" 
+                    data-content="{{ "The email will be sent to all the users who have the right to run the stock page. To modify the permissions, go to [1]Advanced Parameters > Team[/1]"|trans({'[1]':'<a href=&quot;'~getAdminLink("AdminEmployees")~'&quot;>','[/1]':'</a>'}, 'Admin.Catalog.Help')|raw }}">
+              </span>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+    </div>
 
-              <div class="row">
-                <div class="col-md-4">
-                  <h2>{{ formVirtualProduct.vars.label }}</h2>
-                </div>
-                <div class="col-md-8">
-                  <fieldset class="form-group">
-                    {{ form_widget(formVirtualProduct.is_virtual_file) }}
-                  </fieldset>
-                </div>
+    <div id="virtual_product" 
+         data-action="{{ path('admin_product_virtual_save_action', { 'idProduct': productId }) }}" 
+         data-action-remove="{{ path('admin_product_virtual_remove_action', {'idProduct': productId }) }}">
+        
+      <h2>{{ formVirtualProduct.vars.label }}</h2>
+      <fieldset class="form-group">
+        {{ form_widget(formVirtualProduct.is_virtual_file) }}
+      </fieldset>
+
+      <div class="row">
+        <div class="col-md-8">
+          <div id="virtual_product_content" class="bg-light p-3">
+            <div class="row">
+              {{ form_errors(formVirtualProduct) }}
+              <div class="col-md-12">
+                <fieldset class="form-group">
+                  <label class="form-control-label">
+                    {{ formVirtualProduct.file.vars.label }}
+                    <span class="help-box" data-toggle="popover"
+                      data-content="{{ "Upload a file from your computer (%maxUploadSize% max.)"|trans({'%maxUploadSize%': max_upload_size}, 'Admin.Catalog.Help') }}" ></span>
+                  </label>
+                  <div id="form_step3_virtual_product_file_input" class="{{ formVirtualProduct.vars.value.filename is defined ? 'hide' : 'show' }}">
+                    {{ form_widget(formVirtualProduct.file) }}
+                  </div>
+                  <div id="form_step3_virtual_product_file_details" class="{{ formVirtualProduct.vars.value.filename is defined ? 'show' : 'hide' }}">
+                    <a href="{{ formVirtualProduct.vars.value.file_download_link is defined ? formVirtualProduct.vars.value.file_download_link : '' }}" class="btn btn-default btn-sm download">{{ 'Download file'|trans({}, 'Admin.Actions') }}</a>
+                    <a href="{{ path('admin_product_virtual_remove_file_action', {'idProduct': productId}) }}" class="btn btn-danger btn-sm delete">{{ 'Delete this file'|trans({}, 'Admin.Actions') }}</a>
+                  </div>
+                </fieldset>
               </div>
-
-              <div id="virtual_product_content" class="row col-md-8">
-                {{ form_errors(formVirtualProduct) }}
-                <div class="col-md-12">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">
-                      {{ formVirtualProduct.file.vars.label }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "Upload a file from your computer (%maxUploadSize% max.)"|trans({'%maxUploadSize%': max_upload_size}, 'Admin.Catalog.Help') }}" ></span>
-                    </label>
-                    <div id="form_step3_virtual_product_file_input" class="{{ formVirtualProduct.vars.value.filename is defined ? 'hide' : 'show' }}">
-                      {{ form_widget(formVirtualProduct.file) }}
-                    </div>
-                    <div id="form_step3_virtual_product_file_details" class="{{ formVirtualProduct.vars.value.filename is defined ? 'show' : 'hide' }}">
-                      <a href="{{ formVirtualProduct.vars.value.file_download_link is defined ? formVirtualProduct.vars.value.file_download_link : '' }}" class="btn btn-default btn-sm download">{{ 'Download file'|trans({}, 'Admin.Actions') }}</a>
-                      <a href="{{ path('admin_product_virtual_remove_file_action', {'idProduct': productId}) }}" class="btn btn-danger btn-sm delete">{{ 'Delete this file'|trans({}, 'Admin.Actions') }}</a>
-                    </div>
-                  </fieldset>
-                </div>
-                <div class="col-md-6">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">
-                      {{ formVirtualProduct.name.vars.label }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "The full filename with its extension (e.g. Book.pdf)"|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    </label>
-                    {{ form_errors(formVirtualProduct.name) }}
-                    {{ form_widget(formVirtualProduct.name) }}
-                  </fieldset>
-                </div>
-                <div class="col-md-6">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">
-                      {{ formVirtualProduct.nb_downloadable.vars.label }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "Number of downloads allowed per customer. Set to 0 for unlimited downloads."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    </label>
-                    {{ form_errors(formVirtualProduct.nb_downloadable) }}
-                    {{ form_widget(formVirtualProduct.nb_downloadable) }}
-                  </fieldset>
-                </div>
-                <div class="col-md-6">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">
-                      {{ formVirtualProduct.expiration_date.vars.label }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    </label>
-                    {{ form_errors(formVirtualProduct.expiration_date) }}
-                    {{ form_widget(formVirtualProduct.expiration_date) }}
-                  </fieldset>
-                </div>
-                <div class="col-md-6">
-                  <fieldset class="form-group">
-                    <label class="form-control-label">
-                      {{ formVirtualProduct.nb_days.vars.label }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "Number of days this file can be accessed by customers. Set to zero for unlimited access."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    </label>
-                    {{ form_errors(formVirtualProduct.nb_days) }}
-                    {{ form_widget(formVirtualProduct.nb_days) }}
-                  </fieldset>
-                </div>
-                <div class="col-md-12">
-                  {{ form_widget(formVirtualProduct.save) }}
-                </div>
+              <div class="col-md-6">
+                <fieldset class="form-group">
+                  <label class="form-control-label">
+                    {{ formVirtualProduct.name.vars.label }}
+                    <span class="help-box" data-toggle="popover"
+                      data-content="{{ "The full filename with its extension (e.g. Book.pdf)"|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                  </label>
+                  {{ form_errors(formVirtualProduct.name) }}
+                  {{ form_widget(formVirtualProduct.name) }}
+                </fieldset>
+              </div>
+              <div class="col-md-6">
+                <fieldset class="form-group">
+                  <label class="form-control-label">
+                    {{ formVirtualProduct.nb_downloadable.vars.label }}
+                    <span class="help-box" data-toggle="popover"
+                      data-content="{{ "Number of downloads allowed per customer. Set to 0 for unlimited downloads."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                  </label>
+                  {{ form_errors(formVirtualProduct.nb_downloadable) }}
+                  {{ form_widget(formVirtualProduct.nb_downloadable) }}
+                </fieldset>
+              </div>
+              <div class="col-md-6">
+                <fieldset class="form-group">
+                  <label class="form-control-label">
+                    {{ formVirtualProduct.expiration_date.vars.label }}
+                    <span class="help-box" data-toggle="popover"
+                      data-content="{{ "If set, the file will not be downloadable after this date. Leave blank if you do not wish to attach an expiration date."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                  </label>
+                  {{ form_errors(formVirtualProduct.expiration_date) }}
+                  {{ form_widget(formVirtualProduct.expiration_date) }}
+                </fieldset>
+              </div>
+              <div class="col-md-6">
+                <fieldset class="form-group">
+                  <label class="form-control-label">
+                    {{ formVirtualProduct.nb_days.vars.label }}
+                    <span class="help-box" data-toggle="popover"
+                      data-content="{{ "Number of days this file can be accessed by customers. Set to zero for unlimited access."|trans({}, 'Admin.Catalog.Help') }}" ></span>
+                  </label>
+                  {{ form_errors(formVirtualProduct.nb_days) }}
+                  {{ form_widget(formVirtualProduct.nb_days) }}
+                </fieldset>
+              </div>
+              <div class="col-md-12">
+                {{ form_widget(formVirtualProduct.save) }}
               </div>
             </div>
-
-            {% if asm_globally_activated and formType.vars.value != "2" %}
-              <div class="form-group" id="asm_quantity_management">
-                <label class="col-sm-2 control-label" for="form_step3_advanced_stock_management"></label>
-                <div class="col-sm-10">
-                  {{ form_errors(formAdvancedStockManagement) }}
-                  {{ form_widget(formAdvancedStockManagement) }}
-                  {% if form.step1.type_product.vars.value == "1" %}
-                    {{ 'When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.'|trans({}, 'Admin.Catalog.Notification') }}
-                  {% endif %}
-                </div>
-              </div>
-              <div class="form-group" id="depends_on_stock_div" style="{% if not(formAdvancedStockManagement.vars.checked) %}display: none;{% endif %}">
-                <label class="col-sm-2 control-label" for="form_step3_depends_on_stock"></label>
-                <div class="col-sm-10">
-                  {{ form_errors(formDependsOnStocks) }}
-                  {{ form_widget(formDependsOnStocks) }}
-                </div>
-              </div>
-            {% endif %}
-            {% if configuration('PS_STOCK_MANAGEMENT') %}
-              <div id="pack_stock_type">
-                <h2>{{ formPackStockType.vars.label }}</h2>
-                <div class="row col-md-4">
-                  <fieldset class="form-group">
-                    {{ form_errors(formPackStockType) }}
-                    {{ form_widget(formPackStockType) }}
-                  </fieldset>
-                </div>
-              </div>
-            {% endif %}
-            {{ include('@Product/ProductPage/Forms/form_combinations.html.twig', {'form': formStep3, 'form_combination_bulk': formCombinations}) }}
-
-            {{ renderhook('displayAdminProductsQuantitiesStepBottom', { 'id_product': productId }) }}
-
           </div>
         </div>
       </div>
+
     </div>
+
+    {% if asm_globally_activated and formType.vars.value != "2" %}
+      <div class="form-group" id="asm_quantity_management">
+        <label class="col-sm-2 control-label" for="form_step3_advanced_stock_management"></label>
+        <div class="col-sm-10">
+          {{ form_errors(formAdvancedStockManagement) }}
+          {{ form_widget(formAdvancedStockManagement) }}
+          {% if form.step1.type_product.vars.value == "1" %}
+            {{ 'When enabling advanced stock management for a pack, please make sure it is also enabled for its product(s) – if you choose to decrement product quantities.'|trans({}, 'Admin.Catalog.Notification') }}
+          {% endif %}
+        </div>
+      </div>
+      <div class="form-group" id="depends_on_stock_div" style="{% if not(formAdvancedStockManagement.vars.checked) %}display: none;{% endif %}">
+        <label class="col-sm-2 control-label" for="form_step3_depends_on_stock"></label>
+        <div class="col-sm-10">
+          {{ form_errors(formDependsOnStocks) }}
+          {{ form_widget(formDependsOnStocks) }}
+        </div>
+      </div>
+    {% endif %}
+    {% if configuration('PS_STOCK_MANAGEMENT') %}
+      <div id="pack_stock_type">
+        <h2>{{ formPackStockType.vars.label }}</h2>
+        <div class="row">
+          <div class="col-md-4">
+            <fieldset class="form-group">
+              {{ form_errors(formPackStockType) }}
+              {{ form_widget(formPackStockType) }}
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    {{ include('@Product/ProductPage/Forms/form_combinations.html.twig', {'form': formStep3, 'form_combination_bulk': formCombinations}) }}
+
+    {{ renderhook('displayAdminProductsQuantitiesStepBottom', { 'id_product': productId }) }}
+
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/essentials.html.twig
@@ -23,247 +23,253 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane active" id="step1">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
-        <div class="row">
+  <div class="container-fluid">
+    <div
+      class="row">
 
-          {# LEFT #}
-          <div class="col-md-9 left-column">
+      {# LEFT #}
+      <div class="col-md-9 left-column">
 
-            <div id="js_form_step1_inputPackItems">
-              {{ form_errors(formPackItems) }}
-              {{ form_widget(formPackItems) }}
+        <div id="js_form_step1_inputPackItems">
+          {{ form_errors(formPackItems) }}
+          {{ form_widget(formPackItems) }}
+        </div>
+
+        <div id="product-images-container" class="mb-4">
+          <div id="product-images-dropzone" class="panel dropzone ui-sortable col-md-12" 
+               url-upload="{{ path('admin_product_image_upload', {'idProduct': productId}) }}" 
+               url-position="{{ path('admin_product_image_positions') }}" 
+               data-max-size="{{ configuration('PS_LIMIT_UPLOAD_IMAGE_VALUE') }}">
+            <div id="product-images-dropzone-error" class="text-danger"></div>
+            <div class="dz-default dz-message openfilemanager">
+              <i class="material-icons">add_a_photo</i><br/>
+              {{js_translatable['Drop images here']}}<br/>
+              <a>{{js_translatable['or select files']}}</a><br/>
+              <small>
+                {{js_translatable['files recommandations']}}<br/>
+                {{js_translatable['files recommandations2']}}
+              </small>
             </div>
-
-            <div id="product-images-container" class="mb-4">
-              <div id="product-images-dropzone" class="panel dropzone ui-sortable col-md-12"
-                  url-upload="{{ path('admin_product_image_upload', {'idProduct': productId}) }}"
-                  url-position="{{ path('admin_product_image_positions') }}"
-                  data-max-size="{{ configuration('PS_LIMIT_UPLOAD_IMAGE_VALUE') }}"
-              >
-                <div id="product-images-dropzone-error" class="text-danger"></div>
-                <div class="dz-default dz-message openfilemanager">
-                    <i class="material-icons">add_a_photo</i><br/>
-                    {{js_translatable['Drop images here']}}<br/>
-                    <a>{{js_translatable['or select files']}}</a><br/>
-                    <small>
-                        {{js_translatable['files recommandations']}}<br/>
-                        {{js_translatable['files recommandations2']}}
-                    </small>
+            {% if images is defined %}
+              {% if editable %}
+                <div class="dz-preview disabled openfilemanager">
+                  <div>
+                    <span>+</span>
+                  </div>
                 </div>
-                {% if images is defined %}
-                    {% if editable %}
-                        <div class="dz-preview disabled openfilemanager">
-                            <div><span>+</span></div>
-                        </div>
-                    {% endif %}
-                  {% for image in images %}
-                    <div class="dz-preview dz-processing dz-image-preview dz-complete ui-sortable-handle"
-                        data-id="{{ image.id }}"
-                        url-delete="{{ path('admin_product_image_delete', {'idImage': image.id}) }}"
-                        url-update="{{ path('admin_product_image_form', {'idImage': image.id}) }}"
-                    >
-                      <div class="dz-image bg" style="background-image: url('{{ image.base_image_url }}-home_default.{{ image.format }}');"></div>
-                      <div class="dz-details">
-                        <div class="dz-size"><span data-dz-size=""></span></div>
-                        <div class="dz-filename"><span data-dz-name=""></span></div>
-                      </div>
-                      <div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress="" style="width: 100%;"></span></div>
-                      <div class="dz-error-message"><span data-dz-errormessage=""></span></div>
-                      <div class="dz-success-mark"></div>
-                      <div class="dz-error-mark"></div>
-                      {% if image.cover %}
-                        <div class="iscover">{{ 'Cover'|trans({}, 'Admin.Catalog.Feature') }}</div>
-                      {% endif %}
+              {% endif %}
+              {% for image in images %}
+                <div class="dz-preview dz-processing dz-image-preview dz-complete ui-sortable-handle" data-id="{{ image.id }}" 
+                     url-delete="{{ path('admin_product_image_delete', {'idImage': image.id}) }}" 
+                     url-update="{{ path('admin_product_image_form', {'idImage': image.id}) }}">
+                  <div class="dz-image bg" style="background-image: url('{{ image.base_image_url }}-home_default.{{ image.format }}');"></div>
+                  <div class="dz-details">
+                    <div class="dz-size">
+                      <span data-dz-size=""></span>
                     </div>
-                  {% endfor %}
-                {% endif %}
-              </div>
-              <div id="product-images-form-container" class="col-md-4">
-                <div id="product-images-form"></div>
-              </div>
-              <div class="dropzone-expander text-sm-center col-md-12">
-                <span class="expand">{{ 'View all images'|trans({}, 'Admin.Catalog.Feature') }}</span>
-                <span class="compress">{{ 'View less'|trans({}, 'Admin.Catalog.Feature') }}</span>
-              </div>
-
-            </div>
-
-            <div class="summary-description-container">
-              <h2>{{ 'Summary'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-              <div id="description_short" class="mb-3">
-                {{ form_widget(formShortDescription) }}
-              </div>
-
-              <h2>{{ 'Description'|trans({}, 'Admin.Global') }}</h2>
-              <div id="description" class="mb-3">
-                {{ form_widget(formDescription) }}
-              </div>
-            </div>
-
-            {{ renderhook('displayAdminProductsMainStepLeftColumnMiddle', { 'id_product': productId }) }}
-
-            <div id="features" class="mb-3">
-              <div id="features-content" class="content {{ formFeatures|length == 0 ? 'hide':'' }}">
-                <h2>{{ 'Features'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                {{ form_errors(formFeatures) }}
-                <div
-                  class="feature-collection nostyle"
-                  data-prototype="{% apply escape %}
-                    {{ include('@Product/ProductPage/Forms/form_feature.html.twig', { 'form': formFeatures.vars.prototype }) }}
-                  {% endapply %}"
-                >
-                  {% for feature in formFeatures %}
-                    {{ include('@Product/ProductPage/Forms/form_feature.html.twig', { 'form': feature }) }}
-                  {% endfor %}
+                    <div class="dz-filename">
+                      <span data-dz-name=""></span>
+                    </div>
+                  </div>
+                  <div class="dz-progress">
+                    <span class="dz-upload" data-dz-uploadprogress="" style="width: 100%;"></span>
+                  </div>
+                  <div class="dz-error-message">
+                    <span data-dz-errormessage=""></span>
+                  </div>
+                  <div class="dz-success-mark"></div>
+                  <div class="dz-error-mark"></div>
+                  {% if image.cover %}
+                    <div class="iscover">{{ 'Cover'|trans({}, 'Admin.Catalog.Feature') }}</div>
+                  {% endif %}
                 </div>
-              </div>
-              <div class="row">
-                <div class="col-md-4">
-                  <button type="button" class="btn btn-outline-primary sensitive add" id="add_feature_button"><i class="material-icons">add_circle</i> {{ 'Add a feature'|trans({}, 'Admin.Catalog.Feature') }}</button>
-                </div>
-              </div>
-            </div>
-
-            <div id="manufacturer" class="mb-3">
-              {{ include('@Product/ProductPage/Forms/form_manufacturer.html.twig', { 'form': formManufacturer }) }}
-            </div>
-
-            <div id="related-product" class="mb-3">
-              {{ include('@Product/ProductPage/Forms/form_related_products.html.twig', { 'form': formRelatedProducts }) }}
-            </div>
-
-            {{ renderhook('displayAdminProductsMainStepLeftColumnBottom', { 'id_product': productId }) }}
-
+              {% endfor %}
+            {% endif %}
+          </div>
+          <div id="product-images-form-container" class="col-md-4">
+            <div id="product-images-form"></div>
+          </div>
+          <div class="dropzone-expander text-sm-center col-md-12">
+            <span class="expand">{{ 'View all images'|trans({}, 'Admin.Catalog.Feature') }}</span>
+            <span class="compress">{{ 'View less'|trans({}, 'Admin.Catalog.Feature') }}</span>
           </div>
 
-          {# RIGHT #}
-          <div class="col-md-3 right-column">
+        </div>
 
-              <div class="row">
-                <div class="col-md-12">
+        <div class="summary-description-container">
+          <h2>{{ 'Summary'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+          <div id="description_short" class="mb-3">
+            {{ form_widget(formShortDescription) }}
+          </div>
 
-                  {% if is_combination_active %}
-                    <div class="form-group mb-3" id="show_variations_selector">
-                      <h2>
-                        {{ "Combinations"|trans({}, 'Admin.Catalog.Feature') }}
-                        <span class="help-box" data-toggle="popover"
-                          data-content="{{ "Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?"|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                      </h2>
-                      <div class="radio">
-                        <label>
-                          <input type="radio" name="show_variations" value="0" {% if not has_combinations %}checked="checked"{% endif %}>
-                          {{ "Simple product"|trans({}, 'Admin.Catalog.Feature') }}
-                        </label>
-                      </div>
-                      <div class="radio">
-                        <label>
-                          <input type="radio" name="show_variations" value="1" {% if has_combinations %}checked="checked"{% endif %}>
-                          {{ "Product with combinations"|trans({}, 'Admin.Catalog.Feature') }}
-                        </label>
-                        <div id="product_type_combinations_shortcut">
-                          <span class="small font-secondary">
-                            {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                            {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  {% endif %}
-
-                  <div class="form-group mb-4">
-                    <h2>
-                      {{ "Reference"|trans({}, 'Admin.Catalog.Feature') }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "Your reference code for this product. Allowed special characters: .-_#\."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    </h2>
-                    {{ form_errors(formReference) }}
-                    <div class="row">
-                      <div class="col-xl-12 col-lg-12" id="product_reference_field">
-                          {{ form_widget(formReference) }}
-                      </div>
-                    </div>
-                  </div>
-
-                  {% if configuration('PS_STOCK_MANAGEMENT') %}
-                    <div class="form-group mb-4" id="product_qty_0_shortcut_div">
-                      <h2>
-                        {{ "Quantity"|trans({}, 'Admin.Catalog.Feature') }}
-                        <span class="help-box" data-toggle="popover"
-                          data-content="{{ "How many products should be available for sale?"|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                      </h2>
-                      {{ form_errors(formQuantityShortcut) }}
-                      <div class="row">
-                        <div class="col-xl-6 col-lg-12">
-                          {{ form_widget(formQuantityShortcut) }}
-                        </div>
-                      </div>
-                      <span class="small font-secondary">
-                        {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                        {{ "Advanced settings in [1][2]Quantities[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
-                      </span>
-                    </div>
-                  {% endif %}
-
-                  <div class="form-group mb-4">
-                    <h2>
-                      {{ "Price"|trans({}, 'Admin.Global') }}
-                      <span class="help-box" data-toggle="popover"
-                        data-content="{{ "This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                    </h2>
-                    <div class="row">
-                      <div class="col-md-6">
-                        <label class="form-control-label">{{ "Tax excluded"|trans({}, 'Admin.Catalog.Feature') }}</label>
-                        {{ form_widget(formPriceShortcut) }}
-                        {{ form_errors(formPriceShortcut) }}
-                      </div>
-                      <div class="col-md-6 col-offset-md-1">
-                        <label class="form-control-label">{{ "Tax included"|trans({}, 'Admin.Catalog.Feature') }}</label>
-                        {{ form_widget(formPriceShortcutTTC) }}
-                        {{ form_errors(formPriceShortcutTTC) }}
-                      </div>
-                      <div class="col-md-12 mt-1">
-                        <label class="form-control-label">{{ "Tax rule"|trans({}, 'Admin.Catalog.Feature') }}</label>
-                        {{ render(
-                            controller('PrestaShopBundle:Admin/Common:renderField', {
-                              'formName': 'step2',
-                              'formType': 'PrestaShopBundle\\Form\\Admin\\Product\\ProductPrice',
-                              'fieldName': 'id_tax_rules_group',
-                              'fieldData' : form.step2.id_tax_rules_group.vars.value
-                              }
-                            )
-                          )
-                        }}
-                      </div>
-                      <div class="col-md-12">
-                        <span class="small font-secondary">
-                          {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
-                          {{ "Advanced settings in [1][2]Pricing[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step2" onclick="$(\'a[href=\\\'#step2\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
-                        </span>
-                      </div>
-                    </div>
-                    <div class="row hide">
-                      <div class="col-md-12">
-                        <label>{{ "Tax rule"|trans({}, 'Admin.Catalog.Feature') }}</label>
-                      </div>
-                      <div class="clearfix"></div>
-                      <div class="col-md-11" id="tax_rule_shortcut">
-                      </div>
-                      <a href="#" onclick="$(this).parent().hide()">&times;</a>
-                    </div>
-                  </div>
-
-                  <div class="form-group mb-4" id="categories">
-                    {{ include('@Product/ProductPage/Forms/form_categories.html.twig', { 'form': formCategories, 'productId': productId }) }}
-                  </div>
-
-                  {{ renderhook('displayAdminProductsMainStepRightColumnBottom', { 'id_product': productId }) }}
-
-                </div>
-              </div>
+          <h2>{{ 'Description'|trans({}, 'Admin.Global') }}</h2>
+          <div id="description" class="mb-3">
+            {{ form_widget(formDescription) }}
           </div>
         </div>
+
+        {{ renderhook('displayAdminProductsMainStepLeftColumnMiddle', { 'id_product': productId }) }}
+
+        <div id="features" class="mb-3">
+          <div id="features-content" class="content {{ formFeatures|length == 0 ? 'hide':'' }}">
+            <h2>{{ 'Features'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+            {{ form_errors(formFeatures) }}
+            <div class="feature-collection nostyle" data-prototype="{% apply escape %} {{ include('@Product/ProductPage/Forms/form_feature.html.twig', { 'form': formFeatures.vars.prototype }) }} {% endapply %}">
+              {% for feature in formFeatures %}
+                {{ include('@Product/ProductPage/Forms/form_feature.html.twig', { 'form': feature }) }}
+              {% endfor %}
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-4">
+              <button type="button" class="btn btn-outline-primary sensitive add" id="add_feature_button">
+                <i class="material-icons">add_circle</i>
+                {{ 'Add a feature'|trans({}, 'Admin.Catalog.Feature') }}</button>
+            </div>
+          </div>
+        </div>
+
+        <div id="manufacturer" class="mb-3">
+          {{ include('@Product/ProductPage/Forms/form_manufacturer.html.twig', { 'form': formManufacturer }) }}
+        </div>
+
+        <div id="related-product" class="mb-3">
+          {{ include('@Product/ProductPage/Forms/form_related_products.html.twig', { 'form': formRelatedProducts }) }}
+        </div>
+
+        {{ renderhook('displayAdminProductsMainStepLeftColumnBottom', { 'id_product': productId }) }}
+
+      </div>
+
+      {# RIGHT #}
+      <div class="col-md-3 right-column">
+
+        {% if is_combination_active %}
+          <div class="form-group mb-3" id="show_variations_selector">
+            <h2>
+              {{ "Combinations"|trans({}, 'Admin.Catalog.Feature') }}
+              <span class="help-box" 
+                    data-toggle="popover" 
+                    data-content="{{ "Combinations are the different variations of a product, with attributes like its size, weight or color taking different values. Does your product require combinations?"|trans({}, 'Admin.Catalog.Help') }}">
+              </span>
+            </h2>
+            <div class="radio">
+              <label>
+                <input type="radio" name="show_variations" value="0" {% if not has_combinations %} checked="checked" {% endif %}>
+                {{ "Simple product"|trans({}, 'Admin.Catalog.Feature') }}
+              </label>
+            </div>
+            <div class="radio">
+              <label>
+                <input type="radio" name="show_variations" value="1" {% if has_combinations %} checked="checked" {% endif %}>
+                {{ "Product with combinations"|trans({}, 'Admin.Catalog.Feature') }}
+              </label>
+              <div id="product_type_combinations_shortcut">
+                <span
+                  class="small font-secondary">
+                  {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
+                  {{ "Advanced settings in [1][2]Combinations[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+                </span>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+
+        <div class="form-group mb-4">
+          <h2>
+            {{ "Reference"|trans({}, 'Admin.Catalog.Feature') }}
+            <span class="help-box" 
+                  data-toggle="popover" 
+                  data-content="{{ "Your reference code for this product. Allowed special characters: .-_#\."|trans({}, 'Admin.Catalog.Help') }}">
+            </span>
+          </h2>
+          {{ form_errors(formReference) }}
+          <div class="row">
+            <div class="col-lg-12" id="product_reference_field">
+              {{ form_widget(formReference) }}
+            </div>
+          </div>
+        </div>
+
+        {% if configuration('PS_STOCK_MANAGEMENT') %}
+          <div class="form-group mb-4" id="product_qty_0_shortcut_div">
+            <h2>
+              {{ "Quantity"|trans({}, 'Admin.Catalog.Feature') }}
+              <span class="help-box" 
+                    data-toggle="popover" 
+                    data-content="{{ "How many products should be available for sale?"|trans({}, 'Admin.Catalog.Help') }}">
+              </span>
+            </h2>
+            {{ form_errors(formQuantityShortcut) }}
+            <div class="row">
+              <div class="col-xl-6 col-lg-12">
+                {{ form_widget(formQuantityShortcut) }}
+              </div>
+            </div>
+            <span
+              class="small font-secondary">
+              {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
+              {{ "Advanced settings in [1][2]Quantities[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step3" onclick="$(\'a[href=\\\'#step3\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+            </span>
+          </div>
+        {% endif %}
+
+        <div class="form-group mb-4">
+          <h2>
+            {{ "Price"|trans({}, 'Admin.Global') }}
+            <span class="help-box" 
+                  data-toggle="popover" 
+                  data-content="{{ "This is the retail price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'Admin.Catalog.Help') }}">
+            </span>
+          </h2>
+          <div class="row">
+            <div class="col-md-6">
+              <label class="form-control-label">{{ "Tax excluded"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              {{ form_widget(formPriceShortcut) }}
+              {{ form_errors(formPriceShortcut) }}
+            </div>
+            <div class="col-md-6 col-offset-md-1">
+              <label class="form-control-label">{{ "Tax included"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              {{ form_widget(formPriceShortcutTTC) }}
+              {{ form_errors(formPriceShortcutTTC) }}
+            </div>
+            <div class="col-md-12 mt-1">
+              <label class="form-control-label">{{ "Tax rule"|trans({}, 'Admin.Catalog.Feature') }}</label>
+              {{ render(
+                      controller('PrestaShopBundle:Admin/Common:renderField', {
+                        'formName': 'step2',
+                        'formType': 'PrestaShopBundle\\Form\\Admin\\Product\\ProductPrice',
+                        'fieldName': 'id_tax_rules_group',
+                        'fieldData' : form.step2.id_tax_rules_group.vars.value
+                        }
+                      )
+                    )
+                  }}
+            </div>
+            <div class="col-md-12">
+              <span
+                class="small font-secondary">
+                {# First tag [1][/1] is for a HTML link. Second tag [2] is an icon (no closing tag needed). #}
+                {{ "Advanced settings in [1][2]Pricing[/1]"|trans({}, 'Admin.Catalog.Help')|replace({'[1]': '<a href="#tab-step2" onclick="$(\'a[href=\\\'#step2\\\']\').click();" class="btn sensitive px-0">', '[/1]': '</a>', '[2]': '<i class="material-icons">open_in_new</i>'})|raw }}
+              </span>
+            </div>
+          </div>
+          <div class="row hide">
+            <div class="col-md-12">
+              <label>{{ "Tax rule"|trans({}, 'Admin.Catalog.Feature') }}</label>
+            </div>
+            <div class="clearfix"></div>
+            <div class="col-md-11" id="tax_rule_shortcut"></div>
+            <a href="#" onclick="$(this).parent().hide()">&times;</a>
+          </div>
+        </div>
+
+        <div class="form-group mb-4" id="categories">
+          {{ include('@Product/ProductPage/Forms/form_categories.html.twig', { 'form': formCategories, 'productId': productId }) }}
+        </div>
+
+        {{ renderhook('displayAdminProductsMainStepRightColumnBottom', { 'id_product': productId }) }}
+
       </div>
     </div>
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/options.html.twig
@@ -23,208 +23,192 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane" id="step6">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
+  <div class="container-fluid">
+
+    {{ renderhook('displayAdminProductsOptionsStepTop', { 'id_product': productId }) }}
+
+    <h2>{{ 'Visibility'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+    <p class="subtitle">{{ 'Where do you want your product to appear?'|trans({}, 'Admin.Catalog.Feature') }}</p>
+
+    <div class="row">
+      <div class="col-md-4 form-group">
+        {{ form_errors(optionsForm.visibility) }}
+        {{ form_widget(optionsForm.visibility) }}
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-7 form-group">
+        {{ form_errors(optionsForm.display_options) }}
         <div class="row">
-
-          <div class="col-md-12">
-
-            {{ renderhook('displayAdminProductsOptionsStepTop', { 'id_product': productId }) }}
-
-            <div class="row">
-              <div class="col-md-12">
-                <h2>{{ 'Visibility'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                <p class="subtitle">{{ 'Where do you want your product to appear?'|trans({}, 'Admin.Catalog.Feature') }}</p>
-              </div>
-            </div>
-
-            <div class="row">
-              <div class="col-md-4 form-group">
-                {{ form_errors(optionsForm.visibility) }}
-                {{ form_widget(optionsForm.visibility) }}
-              </div>
-            </div>
-
-            <div class="row">
-              <div class="col-md-7 form-group">
-                  {{ form_errors(optionsForm.display_options) }}
-                  <div class="row">
-                    <div class="col-md-4 js-available-for-order">
-                      {{ form_widget(optionsForm.display_options.available_for_order) }}
-                    </div>
-                    <div class="col-md-3 js-show-price">
-                      {{ form_widget(optionsForm.display_options.show_price) }}
-                    </div>
-                    <div class="col-md-5">
-                      {{ form_widget(optionsForm.display_options.online_only) }}
-                    </div>
-                  </div>
-              </div>
-            </div>
-            <div class="row form-group">
-              <div class="col-md-8">
-                <label class="form-control-label">{{ 'Tags'|trans({}, 'Admin.Catalog.Feature') }}</label>
-                {{ form_errors(optionsForm.tags) }}
-                {{ form_widget(optionsForm.tags) }}
-                <div class="alert expandable-alert alert-info mt-3" role="alert">
-                  <p class="alert-text">{{ 'Tags are meant to help your customers find your products via the search bar.'|trans({}, 'Admin.Catalog.Help')|raw }}</p>
-                  <div class="alert-more collapse" id="tagsInfo">
-                    <p>
-                      {{ 'Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.'|trans({}, 'Admin.Catalog.Help')|raw }}<br>
-                      {{ 'You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.'|trans({}, 'Admin.Catalog.Help')|
+          <div class="col-md-4 js-available-for-order">
+            {{ form_widget(optionsForm.display_options.available_for_order) }}
+          </div>
+          <div class="col-md-3 js-show-price">
+            {{ form_widget(optionsForm.display_options.show_price) }}
+          </div>
+          <div class="col-md-5">
+            {{ form_widget(optionsForm.display_options.online_only) }}
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row form-group">
+      <div class="col-md-8">
+        <label class="form-control-label">{{ 'Tags'|trans({}, 'Admin.Catalog.Feature') }}</label>
+        {{ form_errors(optionsForm.tags) }}
+        {{ form_widget(optionsForm.tags) }}
+        <div class="alert expandable-alert alert-info mt-3" role="alert">
+          <p class="alert-text">{{ 'Tags are meant to help your customers find your products via the search bar.'|trans({}, 'Admin.Catalog.Help')|raw }}</p>
+          <div class="alert-more collapse" id="tagsInfo">
+            <p>
+              {{ 'Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.'|trans({}, 'Admin.Catalog.Help')|raw }}<br>
+              {{ 'You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.'|trans({}, 'Admin.Catalog.Help')|
                       replace({
                         '[1]' : '<a href="'~ getAdminLink("AdminSearchConf") ~'" target="_blank">',
                         '[/1]' : '</a>'
                       })|raw
                       }}
-                    </p>
-                  </div>
-                 <div class="read-more-container">
-                   <button type="button" class="read-more btn-link" data-toggle="collapse" data-target="#tagsInfo" aria-expanded="false" aria-controls="collapseDanger">
-                      {{ 'Read more'|trans({}, 'Admin.Actions')|raw }}
-                    </button>
-                 </div>
-                </div>
-              </div>
-            </div>
-
-            <div class="row">
-              <div class="col-md-12">
-                <h2>{{ 'Condition & References'|trans({}, 'Admin.Catalog.Feature')|raw }}</h2>
-              </div>
-            </div>
-
-            <div class="row">
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.condition.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.condition) }}
-                {{ form_widget(optionsForm.condition) }}
-              </fieldset>
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">&nbsp;</label>
-                {{ form_widget(optionsForm.show_condition) }}
-              </fieldset>
-            </div>
-            <div class="row">
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.isbn.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "ISBN is used internationally to identify books and their various editions."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.isbn) }}
-                {{ form_widget(optionsForm.isbn) }}
-              </fieldset>
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.ean13.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.ean13) }}
-                {{ form_widget(optionsForm.ean13) }}
-              </fieldset>
-            </div>
-            <div class="row">
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.upc.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.upc) }}
-                {{ form_widget(optionsForm.upc) }}
-              </fieldset>
-              <fieldset class="col-md-4 form-group">
-                <label class="form-control-label">
-                  {{ optionsForm.mpn.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                        data-content="{{ "MPN is used internationally to identify the Manufacturer Part Number."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                {{ form_errors(optionsForm.mpn) }}
-                {{ form_widget(optionsForm.mpn) }}
-              </fieldset>
-            </div>
-
-            <div class="row">
-              <div class="col-md-12">
-                <div id="custom_fields" class="mt-3">
-                  <h2>{{ optionsForm.custom_fields.vars.label }}</h2>
-                  <p class="subtitle">{{ 'Customers can personalize the product by entering some text or by providing custom image files.'|trans({}, 'Admin.Catalog.Feature') }}</p>
-                  {{ form_errors(optionsForm.custom_fields) }}
-                  <ul class="customFieldCollection nostyle" data-prototype="
-                              {% apply escape %}
-                              {{ include('@Product/ProductPage/Forms/form_custom_fields.html.twig', { 'form': optionsForm.custom_fields.vars.prototype }) }}
-                              {% endapply %}">
-                    {% for field in optionsForm.custom_fields %}
-                      <li>
-                        {{ include('@Product/ProductPage/Forms/form_custom_fields.html.twig', { 'form': field }) }}
-                      </li>
-                    {% endfor %}
-                  </ul>
-                  <a href="#" class="btn btn-outline-secondary add">
-                    <i class="material-icons">add_circle</i>
-                    {{ 'Add a customization field'|trans({}, 'Admin.Catalog.Feature') }}
-                  </a>
-                </div>
-              </div>
-            </div>
-
-            <div class="row mt-4">
-              <div class="col-md-8">
-                <h2>{{ 'Attached files'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                <p class="subtitle">{{ 'Select the files (instructions, documentation, recipes, etc.) your customers can directly download on this product page.'|trans({}, 'Admin.Catalog.Feature') }} <br/> {{ 'Need to browse all files? Go to [1]Catalog > Files[/1]'|trans({'[1]':'<a href="'~getAdminLink("AdminAttachments")~'">','[/1]':'</a>'}, 'Admin.Catalog.Feature')|raw }} </p>
-                {{ form_widget(optionsForm.attachments) }}
-              </div>
-            </div>
-            <div class="row mt-3">
-              <div class="col-md-8">
-                <a
-                  class="btn btn-outline-secondary mb-3"
-                  href="#collapsedForm"
-                  data-toggle="collapse"
-                  aria-expanded="false"
-                  aria-controls="collapsedForm"
-                >
-                  <i class="material-icons">add_circle</i>
-                  {{ 'Attach a new file'|trans({}, 'Admin.Catalog.Feature') }}
-                </a>
-                <fieldset class="form-group collapse" id="collapsedForm">
-                  {{ form_errors(optionsForm.attachment_product) }}
-                  <div id="form_step6_attachment_product" data-action="{{ optionsForm.attachment_product.vars.attr['data-action'] }}">
-                    <div class="form-group">{{ form_widget(optionsForm.attachment_product.file) }}</div>
-                    <div class="form-group">{{ form_widget(optionsForm.attachment_product.name) }}</div>
-                    <div class="form-group">{{ form_widget(optionsForm.attachment_product.description) }}</div>
-                    <div class="form-group">
-                      {{ form_widget(optionsForm.attachment_product.add) }}
-                      {{ form_widget(optionsForm.attachment_product.cancel) }}
-                    </div>
-                  </div>
-                </fieldset>
-              </div>
-            </div>
-
-            <div class="row mt-3">
-              <div class="col-md-8" id="supplier_collection">
-                {{ include('@Product/ProductPage/Forms/form_supplier_choice.html.twig', { 'form': optionsForm }) }}
-              </div>
-            </div>
-            <div class="row">
-              <div id="supplier_combination_collection" class="col-md-12" data-url="{{ path('admin_supplier_refresh_product_supplier_combination_form', { 'idProduct': productId, 'supplierIds': 1}) }}">
-                {{ include('@Product/ProductPage/Forms/form_supplier_combination.html.twig', { 'suppliers': optionsForm.suppliers.vars.value, 'form': optionsForm }) }}
-              </div>
-            </div>
-
-            {{ renderhook('displayAdminProductsOptionsStepBottom', { 'id_product': productId }) }}
-
+            </p>
+          </div>
+          <div class="read-more-container">
+            <button type="button" class="read-more btn-link" data-toggle="collapse" data-target="#tagsInfo" aria-expanded="false" aria-controls="collapseDanger">
+              {{ 'Read more'|trans({}, 'Admin.Actions')|raw }}
+            </button>
           </div>
         </div>
       </div>
     </div>
+
+    <h2>{{ 'Condition & References'|trans({}, 'Admin.Catalog.Feature')|raw }}</h2>
+
+    <div class="row">
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.condition.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.condition) }}
+        {{ form_widget(optionsForm.condition) }}
+      </fieldset>
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">&nbsp;</label>
+        {{ form_widget(optionsForm.show_condition) }}
+      </fieldset>
+    </div>
+    <div class="row">
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.isbn.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "ISBN is used internationally to identify books and their various editions."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.isbn) }}
+        {{ form_widget(optionsForm.isbn) }}
+      </fieldset>
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.ean13.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "This type of product code is specific to Europe and Japan, but is widely used internationally. It is a superset of the UPC code: all products marked with an EAN will be accepted in North America."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.ean13) }}
+        {{ form_widget(optionsForm.ean13) }}
+      </fieldset>
+    </div>
+    <div class="row">
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.upc.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "This type of product code is widely used in the United States, Canada, the United Kingdom, Australia, New Zealand and in other countries."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.upc) }}
+        {{ form_widget(optionsForm.upc) }}
+      </fieldset>
+      <fieldset class="col-md-4 form-group">
+        <label class="form-control-label">
+          {{ optionsForm.mpn.vars.label }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "MPN is used internationally to identify the Manufacturer Part Number."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </label>
+        {{ form_errors(optionsForm.mpn) }}
+        {{ form_widget(optionsForm.mpn) }}
+      </fieldset>
+    </div>
+
+    <div id="custom_fields" class="mt-3">
+      <h2>{{ optionsForm.custom_fields.vars.label }}</h2>
+      <p class="subtitle">{{ 'Customers can personalize the product by entering some text or by providing custom image files.'|trans({}, 'Admin.Catalog.Feature') }}</p>
+      {{ form_errors(optionsForm.custom_fields) }}
+      <ul class="customFieldCollection nostyle" data-prototype="
+        {% apply escape %}
+          {{ include('@Product/ProductPage/Forms/form_custom_fields.html.twig', { 'form': optionsForm.custom_fields.vars.prototype }) }}
+        {% endapply %}">
+        {% for field in optionsForm.custom_fields %}
+          <li>
+            {{ include('@Product/ProductPage/Forms/form_custom_fields.html.twig', { 'form': field }) }}
+          </li>
+        {% endfor %}
+      </ul>
+      <a href="#" class="btn btn-outline-secondary add">
+        <i class="material-icons">add_circle</i>
+        {{ 'Add a customization field'|trans({}, 'Admin.Catalog.Feature') }}
+      </a>
+    </div>
+
+    <div class="row mt-4">
+      <div class="col-md-8">
+        <h2>{{ 'Attached files'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+        <p class="subtitle">{{ 'Select the files (instructions, documentation, recipes, etc.) your customers can directly download on this product page.'|trans({}, 'Admin.Catalog.Feature') }}
+          <br/>
+          {{ 'Need to browse all files? Go to [1]Catalog > Files[/1]'|trans({'[1]':'<a href="'~getAdminLink("AdminAttachments")~'">','[/1]':'</a>'}, 'Admin.Catalog.Feature')|raw }}
+        </p>
+        {{ form_widget(optionsForm.attachments) }}
+      </div>
+    </div>
+    <div class="row mt-3">
+      <div class="col-md-8">
+        <a class="btn btn-outline-secondary mb-3" href="#collapsedForm" data-toggle="collapse" aria-expanded="false" aria-controls="collapsedForm">
+          <i class="material-icons">add_circle</i>
+          {{ 'Attach a new file'|trans({}, 'Admin.Catalog.Feature') }}
+        </a>
+        <fieldset class="form-group collapse" id="collapsedForm">
+          {{ form_errors(optionsForm.attachment_product) }}
+          <div id="form_step6_attachment_product" data-action="{{ optionsForm.attachment_product.vars.attr['data-action'] }}">
+            <div class="form-group">{{ form_widget(optionsForm.attachment_product.file) }}</div>
+            <div class="form-group">{{ form_widget(optionsForm.attachment_product.name) }}</div>
+            <div class="form-group">{{ form_widget(optionsForm.attachment_product.description) }}</div>
+            <div class="form-group">
+              {{ form_widget(optionsForm.attachment_product.add) }}
+              {{ form_widget(optionsForm.attachment_product.cancel) }}
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    </div>
+
+    <div class="row mt-3">
+      <div class="col-md-8" id="supplier_collection">
+        {{ include('@Product/ProductPage/Forms/form_supplier_choice.html.twig', { 'form': optionsForm }) }}
+      </div>
+    </div>
+    <div id="supplier_combination_collection" data-url="{{ path('admin_supplier_refresh_product_supplier_combination_form', { 'idProduct': productId, 'supplierIds': 1}) }}">
+      {{ include('@Product/ProductPage/Forms/form_supplier_combination.html.twig', { 'suppliers': optionsForm.suppliers.vars.value, 'form': optionsForm }) }}
+    </div>
+
+    {{ renderhook('displayAdminProductsOptionsStepBottom', { 'id_product': productId }) }}
+
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/pricing.html.twig
@@ -23,204 +23,192 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane" id="step2">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
-        <div class="row">
+  <div class="container-fluid">
 
-          <div class="col-md-12">
-            <h2>{{ 'Retail price'|trans({}, 'Admin.Catalog.Feature') }}
-              <span class="help-box" data-toggle="popover"
-                data-content="{{ "This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-            </h2>
-          </div>
+    <h2>{{ 'Retail price'|trans({}, 'Admin.Catalog.Feature') }}
+      <span class="help-box" 
+            data-toggle="popover" 
+            data-content="{{ "This is the price at which you intend to sell this product to your customers. The tax included price will change according to the tax rule you select."|trans({}, 'Admin.Catalog.Help') }}">
+      </span>
+    </h2>
 
-          <div class="col-md-12 form-group">
-            <div class="row">
+    <div class="form-group">
+      <div class="row">
 
-              <div class="col-xl-2 col-lg-3">
-                <label class="form-control-label">{{ pricingForm.price.vars.label }}</label>
-                {{ form_errors(pricingForm.price) }}
-                {{ form_widget(pricingForm.price) }}
-              </div>
-              <div class="col-xl-2 col-lg-3">
-                <label class="form-control-label">{{ pricingForm.price_ttc.vars.label }}</label>
-                {{ form_errors(pricingForm.price_ttc) }}
-                {{ form_widget(pricingForm.price_ttc) }}
-              </div>
+        <div class="col-xl-2 col-lg-3">
+          <label class="form-control-label">{{ pricingForm.price.vars.label }}</label>
+          {{ form_errors(pricingForm.price) }}
+          {{ form_widget(pricingForm.price) }}
+        </div>
+        <div class="col-xl-2 col-lg-3">
+          <label class="form-control-label">{{ pricingForm.price_ttc.vars.label }}</label>
+          {{ form_errors(pricingForm.price_ttc) }}
+          {{ form_widget(pricingForm.price_ttc) }}
+        </div>
 
-              <div class="col-xl-4 col-lg-6 mx-auto">
-                <label class="form-control-label">
-                  {{ pricingForm.unit_price.vars.label }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "Some products can be purchased by unit (per bottle, per pound, etc.),  and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </label>
-                <div class="row">
-                  <div class="col-md-6">
-                    {{ form_errors(pricingForm.unit_price) }}
-                    {{ form_widget(pricingForm.unit_price) }}
-                  </div>
-                  <div class="col-md-6">
-                    {{ form_errors(pricingForm.unity) }}
-                    {{ form_widget(pricingForm.unity) }}
-                  </div>
-                </div>
-              </div>
-              <div class="col-md-2 col-md-offset-1 {% if configuration('PS_USE_ECOTAX') != 1 %}hide{% endif %}">
-                <label class="form-control-label">{{ pricingForm.ecotax.vars.label }}</label>
-                {{ form_errors(pricingForm.ecotax) }}
-                {{ form_widget(pricingForm.ecotax) }}
-              </div>
+        <div class="col-xl-4 col-lg-6 mx-auto">
+          <label class="form-control-label">
+            {{ pricingForm.unit_price.vars.label }}
+            <span class="help-box" 
+                  data-toggle="popover" 
+                  data-content="{{ "Some products can be purchased by unit (per bottle, per pound, etc.), and this is the price for one unit. For instance, if you’re selling fabrics, it would be the price per meter."|trans({}, 'Admin.Catalog.Help') }}">
+            </span>
+          </label>
+          <div class="row">
+            <div class="col-md-6">
+              {{ form_errors(pricingForm.unit_price) }}
+              {{ form_widget(pricingForm.unit_price) }}
+            </div>
+            <div class="col-md-6">
+              {{ form_errors(pricingForm.unity) }}
+              {{ form_widget(pricingForm.unity) }}
             </div>
           </div>
-
-          <div class="col-md-12">
-            <div class="row form-group">
-              <div class="col-md-4">
-                <label class="form-control-label">{{ pricingForm.id_tax_rules_group.vars.label }}</label>
-                {{ form_errors(pricingForm.id_tax_rules_group) }}
-                {{ form_widget(pricingForm.id_tax_rules_group) }}
-              </div>
-              <div class="col-md-8">
-                <label class="form-control-label">&nbsp;</label>
-                <a class="form-control-static external-link" href="{{ getAdminLink("AdminTaxes") }}" target="_blank">
-                  {{ 'Manage tax rules'|trans({}, 'Admin.Catalog.Feature') }}
-                </a>
-              </div>
-              <div class="col-md-12 pt-1">
-                {{ form_widget(pricingForm.on_sale) }}
-              </div>
-              <div class="col-md-12">
-                <div class="row">
-                  <div class="col-xl-5 col-lg-12">
-                    <div class="alert alert-info mt-2" role="alert">
-                      <p class="alert-text">
-                        {{ 'Final retail price: [1][2][/2] tax incl.[/1] / [3][/3] tax excl.'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<strong>', '[/1]': '</strong>', '[2]': '<span id="final_retail_price_ti">', '[/2]': '</span>', '[3]': '<span id="final_retail_price_te">', '[/3]': '</span>', })|raw }}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="col-md-12">
-            <div class="row mb-3">
-              <div class="col-md-12">
-                <h2>
-                  {{ 'Cost price'|trans({}, 'Admin.Catalog.Feature') }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </h2>
-              </div>
-              <div class="col-xl-2 col-lg-3 form-group">
-                <label class="form-control-label">{{ pricingForm.wholesale_price.vars.label|raw }}</label>
-                {{ form_errors(pricingForm.wholesale_price) }}
-                {{ form_widget(pricingForm.wholesale_price) }}
-              </div>
-            </div>
-          </div>
-
-          <div class="col-md-12">
-            <div class="row mb-3">
-              <div class="col-md-12">
-                <h2>
-                  {{ 'Specific prices'|trans({}, 'Admin.Catalog.Feature') }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "You can set specific prices for customers belonging to different groups, different countries, etc."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </h2>
-              </div>
-              <div class="col-md-12">
-                <div id="specific-price" class="mb-2">
-                  <a id="js-open-create-specific-price-form" class="btn btn-outline-primary mb-3" data-toggle="collapse" href="#specific_price_form" aria-expanded="false">
-                    <i class="material-icons">add_circle</i>
-                    {{ 'Add a specific price'|trans({}, 'Admin.Catalog.Feature') }}
-                  </a>
-                  <div class="collapse" id="specific_price_form" data-action="{{ path('admin_specific_price_add') }}">
-                      {{ include('@Product/ProductPage/Forms/form_specific_price.html.twig', {'form': pricingForm.specific_price, 'is_multishop_context': is_multishop_context}) }}
-                  </div>
-                  <table
-                      id="js-specific-price-list"
-                      class="table hide seo-table"
-                      data-listing-url="{{ path('admin_specific_price_list', { 'idProduct': 1 }) }}"
-                      data-action-delete="{{ path('admin_delete_specific_price', { 'idSpecificPrice': 1 }) }}"
-                      data-action-edit="{{ path('admin_get_specific_price_update_form', { 'idSpecificPrice': 1 }) }}">
-                    <thead class="thead-default">
-                    <tr>
-                      <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Rule'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th>{{ 'Combination'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th>{{ 'Currency'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Country'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Group'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Customer'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'Fixed price'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th>{{ 'Impact'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th>{{ 'Period'|trans({}, 'Admin.Global') }}</th>
-                      <th>{{ 'From'|trans({}, 'Admin.Catalog.Feature') }}</th>
-                      <th></th>
-                      <th></th>
-                    </tr>
-                    </thead>
-                    <tbody></tbody>
-                  </table>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div>
-            {{ include('@Product/ProductPage/Forms/form_edit_specific_price_modal.html.twig') }}
-          </div>
-
-
-          <div class="col-md-12">
-            <div class="row">
-              <div class="col-md-12">
-                <h2>
-                  {{ 'Priority management'|trans({}, 'Admin.Catalog.Feature') }}
-                  <span class="help-box" data-toggle="popover"
-                    data-content="{{ "Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first."|trans({}, 'Admin.Catalog.Help') }}" ></span>
-                </h2>
-              </div>
-              <div class="col-md-3">
-                <fieldset class="form-group">
-                  <label>{{ 'Priorities'|trans({}, 'Admin.Catalog.Feature') }}</label>
-                  {{ form_errors(pricingForm.specificPricePriority_0) }}
-                  {{ form_widget(pricingForm.specificPricePriority_0) }}
-                </fieldset>
-              </div>
-              <div class="col-md-3">
-                <fieldset class="form-group">
-                  <label>&nbsp;</label>
-                  {{ form_errors(pricingForm.specificPricePriority_1) }}
-                  {{ form_widget(pricingForm.specificPricePriority_1) }}
-                </fieldset>
-              </div>
-              <div class="col-md-3">
-                <fieldset class="form-group">
-                  <label>&nbsp;</label>
-                  {{ form_errors(pricingForm.specificPricePriority_2) }}
-                  {{ form_widget(pricingForm.specificPricePriority_2) }}
-                </fieldset>
-              </div>
-              <div class="col-md-3">
-                <fieldset class="form-group">
-                  <label>&nbsp;</label>
-                  {{ form_errors(pricingForm.specificPricePriority_3) }}
-                  {{ form_widget(pricingForm.specificPricePriority_3) }}
-                </fieldset>
-              </div>
-              <div class="col-md-12">
-                {{ form_widget(pricingForm.specificPricePriorityToAll) }}
-              </div>
-            </div>
-          </div>
-
-          {{ renderhook('displayAdminProductsPriceStepBottom', { 'id_product': productId }) }}
-
+        </div>
+        <div class="col-md-2 col-md-offset-1 {% if configuration('PS_USE_ECOTAX') != 1 %}hide{% endif %}">
+          <label class="form-control-label">{{ pricingForm.ecotax.vars.label }}</label>
+          {{ form_errors(pricingForm.ecotax) }}
+          {{ form_widget(pricingForm.ecotax) }}
         </div>
       </div>
     </div>
+
+    <div class="row form-group">
+      <div class="col-md-4">
+        <label class="form-control-label">{{ pricingForm.id_tax_rules_group.vars.label }}</label>
+        {{ form_errors(pricingForm.id_tax_rules_group) }}
+        {{ form_widget(pricingForm.id_tax_rules_group) }}
+      </div>
+      <div class="col-md-8">
+        <label class="form-control-label">&nbsp;</label>
+        <a class="form-control-static external-link" href="{{ getAdminLink("AdminTaxes") }}" target="_blank">
+          {{ 'Manage tax rules'|trans({}, 'Admin.Catalog.Feature') }}
+        </a>
+      </div>
+      <div class="col-md-12 pt-1">
+        {{ form_widget(pricingForm.on_sale) }}
+      </div>
+      <div class="col-md-12">
+        <div class="row">
+          <div class="col-xl-5 col-lg-12">
+            <div class="alert alert-info mt-2" role="alert">
+              <p class="alert-text">
+                {{ 'Final retail price: [1][2][/2] tax incl.[/1] / [3][/3] tax excl.'|trans({}, 'Admin.Catalog.Feature')|replace({ '[1]': '<strong>', '[/1]': '</strong>', '[2]': '<span id="final_retail_price_ti">', '[/2]': '</span>', '[3]': '<span id="final_retail_price_te">', '[/3]': '</span>', })|raw }}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-md-12">
+        <h2>
+          {{ 'Cost price'|trans({}, 'Admin.Catalog.Feature') }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </h2>
+      </div>
+      <div class="col-xl-2 col-lg-3 form-group">
+        <label class="form-control-label">{{ pricingForm.wholesale_price.vars.label|raw }}</label>
+        {{ form_errors(pricingForm.wholesale_price) }}
+        {{ form_widget(pricingForm.wholesale_price) }}
+      </div>
+    </div>
+
+    <div class="row mb-3">
+      <div class="col-md-12">
+        <h2>
+          {{ 'Specific prices'|trans({}, 'Admin.Catalog.Feature') }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "You can set specific prices for customers belonging to different groups, different countries, etc."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </h2>
+      </div>
+      <div class="col-md-12">
+        <div id="specific-price" class="mb-2">
+          <a id="js-open-create-specific-price-form" class="btn btn-outline-primary mb-3" data-toggle="collapse" href="#specific_price_form" aria-expanded="false">
+            <i class="material-icons">add_circle</i>
+            {{ 'Add a specific price'|trans({}, 'Admin.Catalog.Feature') }}
+          </a>
+          <div class="collapse" id="specific_price_form" data-action="{{ path('admin_specific_price_add') }}">
+            {{ include('@Product/ProductPage/Forms/form_specific_price.html.twig', {'form': pricingForm.specific_price, 'is_multishop_context': is_multishop_context}) }}
+          </div>
+          <table id="js-specific-price-list" class="table hide seo-table" data-listing-url="{{ path('admin_specific_price_list', { 'idProduct': 1 }) }}" data-action-delete="{{ path('admin_delete_specific_price', { 'idSpecificPrice': 1 }) }}" data-action-edit="{{ path('admin_get_specific_price_update_form', { 'idSpecificPrice': 1 }) }}">
+            <thead class="thead-default">
+              <tr>
+                <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Rule'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th>{{ 'Combination'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th>{{ 'Currency'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Country'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Group'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Customer'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'Fixed price'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th>{{ 'Impact'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th>{{ 'Period'|trans({}, 'Admin.Global') }}</th>
+                <th>{{ 'From'|trans({}, 'Admin.Catalog.Feature') }}</th>
+                <th></th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      {{ include('@Product/ProductPage/Forms/form_edit_specific_price_modal.html.twig') }}
+    </div>
+
+    <div class="row">
+      <div class="col-md-12">
+        <h2>
+          {{ 'Priority management'|trans({}, 'Admin.Catalog.Feature') }}
+          <span class="help-box" 
+                data-toggle="popover" 
+                data-content="{{ "Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first."|trans({}, 'Admin.Catalog.Help') }}">
+          </span>
+        </h2>
+      </div>
+      <div class="col-md-3">
+        <fieldset class="form-group">
+          <label>{{ 'Priorities'|trans({}, 'Admin.Catalog.Feature') }}</label>
+          {{ form_errors(pricingForm.specificPricePriority_0) }}
+          {{ form_widget(pricingForm.specificPricePriority_0) }}
+        </fieldset>
+      </div>
+      <div class="col-md-3">
+        <fieldset class="form-group">
+          <label>&nbsp;</label>
+          {{ form_errors(pricingForm.specificPricePriority_1) }}
+          {{ form_widget(pricingForm.specificPricePriority_1) }}
+        </fieldset>
+      </div>
+      <div class="col-md-3">
+        <fieldset class="form-group">
+          <label>&nbsp;</label>
+          {{ form_errors(pricingForm.specificPricePriority_2) }}
+          {{ form_widget(pricingForm.specificPricePriority_2) }}
+        </fieldset>
+      </div>
+      <div class="col-md-3">
+        <fieldset class="form-group">
+          <label>&nbsp;</label>
+          {{ form_errors(pricingForm.specificPricePriority_3) }}
+          {{ form_widget(pricingForm.specificPricePriority_3) }}
+        </fieldset>
+      </div>
+      <div class="col-md-12">
+        {{ form_widget(pricingForm.specificPricePriorityToAll) }}
+      </div>
+    </div>
+
+    {{ renderhook('displayAdminProductsPriceStepBottom', { 'id_product': productId }) }}
+
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Panels/seo.html.twig
@@ -23,17 +23,11 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <div role="tabpanel" class="form-contenttab tab-pane" id="step5">
-  <div class="row">
-    <div class="col-md-12">
-      <div class="container-fluid">
-        <div class="row">
-          {{ include('@Product/ProductPage/Forms/form_seo.html.twig', {
-            'seoForm' : seoForm,
-            'productId': productId
-            })
-          }}
-        </div>
-      </div>
-    </div>
+  <div class="container-fluid">
+    {{ include('@Product/ProductPage/Forms/form_seo.html.twig', {
+      'seoForm' : seoForm,
+      'productId': productId
+      })
+    }}
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -113,8 +113,6 @@
         {# PANEL SHIPPING #}
         {% block product_panel_shipping %}
           <div role="tabpanel" class="form-contenttab tab-pane" id="step4">
-            <div class="row">
-              <div class="col-md-12">
                 <div class="container-fluid">
                   <div class="row">
                     {{ include('@Product/ProductPage/Forms/form_shipping.html.twig', {
@@ -126,8 +124,6 @@
                     }) }}
                   </div>
                 </div>
-              </div>
-            </div>
           </div>
         {% endblock %}
 
@@ -160,93 +156,73 @@
         {% block product_panel_modules %}
           {% if hooksarraycontent(hooks) is not empty %}
             <div role="tabpanel" class="form-contenttab tab-pane" id="hooks">
-              <div class="row">
-                <div class="col-md-12">
-                  <div class="container-fluid">
-                    <div class="row">
-
-                      {# LEFT #}
-                      <div class="col-md-12">
-                        <div class="row module-selection" style="display: none;">
-                          <div class="col-md-12 col-lg-7">
-                            {% for module in hooks %}
-                              <div class="module-render-container module-{{ module.attributes.name }}">
-                                <div>
-                                  <img class="top-logo" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
-                                  <h2 class="text-ellipsis module-name-grid">
-                                    {{ module.attributes.displayName }}
-                                  </h2>
-                                  <div class="text-ellipsis small-text module-version">
-                                    {{ module.attributes.version }} by {{ module.attributes.author }}
-                                  </div>
-                                </div>
-                                <div class="small no-padding">
-                                  {{ module.attributes.description }}
-                                </div>
-                              </div>
-                            {% endfor %}
-                          </div>
-                          <div class="col-md-12 col-lg-5">
-                            <h2>{{ 'Module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                            <select class="modules-list-select" data-toggle="select2">
-                              {% for module in hooks %}
-                                <option value="module-{{ module.attributes.name }}">{{ module.attributes.displayName }}</option>
-                              {% endfor %}
-                            </select>
-                          </div>
+              <div class="container-fluid">
+                <div class="row module-selection" style="display: none;">
+                  <div class="col-lg-7">
+                    {% for module in hooks %}
+                      <div class="module-render-container module-{{ module.attributes.name }}">
+                        <div>
+                          <img class="top-logo" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
+                          <h2 class="text-ellipsis module-name-grid">{{ module.attributes.displayName }}</h2>
+                          <div class="text-ellipsis small-text module-version">{{ module.attributes.version }} by {{ module.attributes.author }}</div>
                         </div>
-
-                        <div class="module-render-container all-modules">
-                          <p>
-                            <h2>{{ 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
-                            {{ 'These modules are relative to the product page of your shop.'|trans({}, 'Admin.Catalog.Feature') }}<br />
-                            {{ 'To manage all your modules go to the [1]Installed module page[/1]'|trans({}, 'Admin.Catalog.Feature')|replace({'[1]': '<a href="' ~ path("admin_module_manage") ~ '">', '[/1]': '</a>'})|raw }}
-                          </p>
-                          <div class="row">
-                            {% for module in hooks %}
-                              <div class="col-md-12 col-lg-6 col-xl-4">
-                                <div class="module-item-wrapper-grid">
-                                  <div class="module-item-heading-grid">
-                                    <img class="module-logo-thumb-grid" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
-                                    <h3 class="text-ellipsis module-name-grid">
-                                      {{ module.attributes.displayName }}
-                                    </h3>
-                                    <div class="text-ellipsis small-text module-version-author-grid">
-                                      {{ module.attributes.version }} by {{ module.attributes.author }}
-                                    </div>
-                                  </div>
-                                  <div class="module-quick-description-grid small no-padding">
-                                    {{ module.attributes.description }}
-                                  </div>
-                                  <div class="module-container">
-                                    <div class="module-quick-action-grid clearfix">
-                                      <button class="modules-list-button btn btn-outline-primary pull-xs-right" data-target="module-{{ module.id }}">
-                                        {{ 'Configure'|trans({}, 'Admin.Actions') }}
-                                      </button>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            {% endfor %}
-                          </div>
+                        <div class="small no-padding">
+                          {{ module.attributes.description }}
                         </div>
-
-                        {% for module in hooks %}
-                          <div
-                            id="module_{{ module.id }}"
-                            class="module-render-container module-{{ module.attributes.name }}"
-                            style="display: none;"
-                          >
-                            <div>
-                              {{ module.content|raw }}
-                            </div>
-                          </div>
-                        {% endfor %}
                       </div>
-
-                    </div>
+                    {% endfor %}
+                  </div>
+                  <div class="col-lg-5">
+                    <h2>{{ 'Module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+                    <select class="modules-list-select" data-toggle="select2">
+                      {% for module in hooks %}
+                        <option value="module-{{ module.attributes.name }}">{{ module.attributes.displayName }}</option>
+                      {% endfor %}
+                    </select>
                   </div>
                 </div>
+
+                <div class="module-render-container all-modules">
+                  <div>
+                    <h2>{{ 'Choose a module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+                    <p>{{ 'These modules are relative to the product page of your shop.'|trans({}, 'Admin.Catalog.Feature') }}<br />
+                    {{ 'To manage all your modules go to the [1]Installed module page[/1]'|trans({}, 'Admin.Catalog.Feature')|replace({'[1]': '<a href="' ~ path("admin_module_manage") ~ '">', '[/1]': '</a>'})|raw }}</p>
+                  </div>
+                  <div class="row">
+                    {% for module in hooks %}
+                      <div class="col-lg-6 col-xl-4">
+                        <div class="module-item-wrapper-grid">
+                          <div class="module-item-heading-grid">
+                            <img class="module-logo-thumb-grid" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">
+                            <h3 class="text-ellipsis module-name-grid">
+                              {{ module.attributes.displayName }}
+                            </h3>
+                            <div class="text-ellipsis small-text module-version-author-grid">
+                              {{ module.attributes.version }} by {{ module.attributes.author }}
+                            </div>
+                          </div>
+                          <div class="module-quick-description-grid small no-padding">
+                            {{ module.attributes.description }}
+                          </div>
+                          <div class="module-container">
+                            <div class="module-quick-action-grid clearfix">
+                              <button class="modules-list-button btn btn-outline-primary pull-xs-right" data-target="module-{{ module.id }}">
+                                {{ 'Configure'|trans({}, 'Admin.Actions') }}
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    {% endfor %}
+                  </div>
+                </div>
+
+                {% for module in hooks %}
+                  <div id="module_{{ module.id }}" class="module-render-container module-{{ module.attributes.name }}" style="display: none;">
+                    <div>{{ module.content|raw }}</div>
+                  </div>
+                {% endfor %}
+
               </div>
             </div>
           {% endif %}
@@ -298,7 +274,6 @@
   {{ parent() }}
 
   <script src="{{ asset('themes/new-theme/public/catalog_product.bundle.js') }}"></script>
-
   <script src="{{ asset('themes/default/js/bundle/product/product-manufacturer.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/product/product-related.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/product/product-category-tags.js') }}"></script>
@@ -308,9 +283,7 @@
   <script src="{{ asset('themes/default/js/bundle/module/module_card.js') }}"></script>
   <script src="{{ asset('themes/default/js/bundle/modal-confirmation.js') }}"></script>
   <script src="{{ asset('themes/new-theme/public/product_page.bundle.js') }}"></script>
-
   <script src="{{ asset('themes/default/js/bundle/product/form.js') }}"></script>
-
   <script src="{{ asset('../js/tiny_mce/tiny_mce.js') }}"></script>
   <script src="{{ asset('../js/admin/tinymce.inc.js') }}"></script>
   <script src="{{ asset('../js/admin/tinymce_loader.js') }}"></script>

--- a/src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/ProductImage/form.html.twig
@@ -25,10 +25,10 @@
 <button type="button" class="float-right close" onclick="formImagesProduct.close()"><i class="material-icons">close</i></button>
 
 <div class="row">
-    <div class="col-lg-12 col-xl-7">
+    <div class="col-xl-7">
       {{ form_widget(form.cover) }}
     </div>
-    <div class="col-lg-12 col-xl-4">
+    <div class="col-xl-4">
         <a href="{{ image.base_image_url }}.{{ image.format }}" class="btn btn-link btn-sm open-image" target="_blank">
           <i class="material-icons">zoom_in</i> {{ 'Zoom'|trans({}, 'Admin.Catalog.Feature') }}
         </a>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/add.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig' with {'attachmentId': attachmentId} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Attachment/Blocks/form.html.twig' with {'attachmentId': attachmentId} %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attachment/index.html.twig
@@ -27,11 +27,7 @@
 
 {% block content %}
   {% block attachments_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attachmentGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attachmentGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attribute/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Attribute/index.html.twig
@@ -35,21 +35,16 @@
 
 {% block content %}
   {% block attributes_listing %}
-    <div class="row">
-      <div class="col">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attributeGrid} %}
-          {% block grid_panel_footer %}
-            <div class="card-footer">
-              <a href="{{ path('admin_attribute_groups_index') }}"
-                 class="btn btn-outline-secondary">
-                <i class="material-icons">arrow_back</i>
-                {{ 'Back to list'|trans({}, 'Admin.Actions') }}
-              </a>
-            </div>
-          {% endblock %}
-        {% endembed %}
-      </div>
-    </div>
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attributeGrid} %}
+      {% block grid_panel_footer %}
+        <div class="card-footer">
+          <a href="{{ path('admin_attribute_groups_index') }}" class="btn btn-outline-secondary">
+            <i class="material-icons">arrow_back</i>
+            {{ 'Back to list'|trans({}, 'Admin.Actions') }}
+          </a>
+        </div>
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/AttributeGroup/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/AttributeGroup/index.html.twig
@@ -36,19 +36,11 @@
 {% block content %}
 
   {% block attribute_group_showcase_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/AttributeGroup/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/AttributeGroup/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% block attributes_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attributeGroupGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': attributeGroupGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CartRule/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CartRule/index.html.twig
@@ -27,11 +27,7 @@
 
 {% block content %}
   {% block cart_rule_listing %}
-    <div class="row">
-      <div class="col-12">
-        {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cartRuleGrid} %}
-      </div>
-    </div>
+    {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': cartRuleGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/create.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/edit.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/index.html.twig
@@ -36,11 +36,7 @@
 
 {% block content %}
   {% block catalog_price_rule_listing %}
-    <div class="row">
-      <div class="col-12">
-        {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': catalogPriceRuleGrid} %}
-      </div>
-    </div>
+    {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': catalogPriceRuleGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_block.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_block.html.twig
@@ -25,39 +25,31 @@
 
 {% if isDeleteSubmitted %}
   {{ form_start(deleteCategoriesForm) }}
-    <div class="col-md-12">
-      <div class="card">
-        <h3 class="card-header">
-          {{ 'What do you want to do with the products associated with this category?'|trans({}, 'Admin.Catalog.Notification') }}
-        </h3>
-        <div class="card-body">
-          <div class="row">
-            <div class="col">
-                <div class="form-group mb-0">
-                  {{ form_widget(deleteCategoriesForm.delete_mode) }}
-                </div>
-                <div class="d-none">
-                  {{ form_widget(deleteCategoriesForm.categories_to_delete) }}
-                </div>
-            </div>
-          </div>
+  <div class="col-md-12">
+    <div class="card">
+      <h3 class="card-header">
+        {{ 'What do you want to do with the products associated with this category?'|trans({}, 'Admin.Catalog.Notification') }}
+      </h3>
+      <div class="card-body">
+        <div class="form-group mb-0">
+          {{ form_widget(deleteCategoriesForm.delete_mode) }}
         </div>
-        <div class="card-footer">
-          <a class="btn btn-secondary btn-sm"
-             href="{{ path('admin_categories_index') }}"
-          >
-            <i class="material-icons">cancel</i>
-            {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-          </a>
-
-          <button class="btn btn-danger btn-sm"
-                  type="submit"
-          >
-            <i class="material-icons">delete</i>
-            {{ 'Delete'|trans({}, 'Admin.Actions') }}
-          </button>
+        <div class="d-none">
+          {{ form_widget(deleteCategoriesForm.categories_to_delete) }}
         </div>
       </div>
+      <div class="card-footer">
+        <a class="btn btn-secondary btn-sm" href="{{ path('admin_categories_index') }}">
+          <i class="material-icons">cancel</i>
+          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+        </a>
+
+        <button class="btn btn-danger btn-sm" type="submit">
+          <i class="material-icons">delete</i>
+          {{ 'Delete'|trans({}, 'Admin.Actions') }}
+        </button>
+      </div>
     </div>
+  </div>
   {{ form_end(deleteCategoriesForm) }}
 {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/create.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/create_root.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/create_root.html.twig
@@ -28,11 +28,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {'categoryForm': rootCategoryForm} %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {'categoryForm': rootCategoryForm} %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/edit.html.twig
@@ -28,16 +28,12 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
-        'categoryForm': editCategoryForm,
-        'thumbnailImage': editableCategory.thumbnailImage,
-        'coverImage': editableCategory.coverImage,
-        'menuThumbnailImages': editableCategory.menuThumbnailImages,
-      } %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
+    'categoryForm': editCategoryForm,
+    'thumbnailImage': editableCategory.thumbnailImage,
+    'coverImage': editableCategory.coverImage,
+    'menuThumbnailImages': editableCategory.menuThumbnailImages,
+  } %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/edit_root.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/edit_root.html.twig
@@ -28,16 +28,12 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
-        'categoryForm': editRootCategoryForm,
-        'thumbnailImage': editableCategory.thumbnailImage,
-        'coverImage': editableCategory.coverImage,
-        'menuThumbnailImages': editableCategory.menuThumbnailImages,
-      } %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/form.html.twig' with {
+    'categoryForm': editRootCategoryForm,
+    'thumbnailImage': editableCategory.thumbnailImage,
+    'coverImage': editableCategory.coverImage,
+    'menuThumbnailImages': editableCategory.menuThumbnailImages,
+  } %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/index.html.twig
@@ -31,50 +31,34 @@
 
 {% block content %}
   {% block category_showcase_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% block categories_kpis %}
-    <div class="row">
-      <div class="col">
-        <div class="card card-kpis">
-          <div class="row">
-            {{ render(controller(
+    <div class="card card-kpis">
+      <div class="row">
+        {{ render(controller(
               'PrestaShopBundle:Admin\\Common:renderKpiRow',
               { 'kpiRow': categoriesKpi }
             )) }}
-          </div>
-        </div>
       </div>
     </div>
   {% endblock %}
 
   {% block categories_breadcrumb %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/breadcrumb.html.twig' %}
   {% endblock %}
 
   {% block categories_listing %}
-    <div class="row">
-      <div class="col">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': categoriesGrid} %}
-          {% block grid_panel_footer %}
-            {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/listing_panel_footer.html.twig' %}
-          {% endblock %}
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': categoriesGrid} %}
+      {% block grid_panel_footer %}
+        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/listing_panel_footer.html.twig' %}
+      {% endblock %}
 
-          {% block grid_panel_extra_content %}
-            {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig' %}
-          {% endblock %}
-        {% endembed %}
-      </div>
-    </div>
+      {% block grid_panel_extra_content %}
+        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig' %}
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/create.html.twig
@@ -31,14 +31,10 @@
   {% if showDisabledFeatureWarning is defined and showDisabledFeatureWarning %}
     {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig' %}
   {% else %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
-          featureId: null,
-          featureForm: featureForm
-        } %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
+      featureId: null,
+      featureForm: featureForm
+    } %}
   {% endif %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/edit.html.twig
@@ -31,14 +31,10 @@
   {% if showDisabledFeatureWarning is defined and showDisabledFeatureWarning %}
     {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig' %}
   {% else %}
-    <div class="row justify-content-center">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
-          featureId: editableFeature.featureId.getValue,
-          featureForm: featureForm
-        } %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
+      featureId: editableFeature.featureId.getValue,
+      featureForm: featureForm
+    } %}
   {% endif %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Address/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Address/create.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Address/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Address/edit.html.twig
@@ -26,11 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Address/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/View/addresses.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/View/addresses.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<div class="card">
+<div class="card" data-role="addresses-card">
   <h3 class="card-header">
     {{ 'Addresses'|trans({}, 'Admin.Global') }}
     ({{ viewableManufacturer.manufacturerAddresses|length }})

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/add.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/edit.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/index.html.twig
@@ -44,19 +44,11 @@
 {% block content %}
   {% block manufacturers_listing %}
     {{ ps.infotip(settingsTipMessage, true) }}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerGrid} %}
   {% endblock %}
 
   {% block manufacturers_address_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerAddressGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': manufacturerAddressGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/view.html.twig
@@ -26,16 +26,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/View/addresses.html.twig' %}
-    </div>
-  </div>
 
-  <div class="row mt-3">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/View/products.html.twig' %}
-    </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/View/addresses.html.twig' %}
+
+  <div class="mt-3">
+    {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/Blocks/View/products.html.twig' %}
   </div>
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Monitoring/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Monitoring/index.html.twig
@@ -27,87 +27,55 @@
 
 {% block content %}
   {% block monitoring_showcase_card %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Sell/Catalog/Monitoring/Blocks/showcase_card.html.twig' %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Sell/Catalog/Monitoring/Blocks/showcase_card.html.twig' %}
   {% endblock %}
 
   {% block empty_categories_listing %}
-    <div class="row">
-      <div class="col">
-        {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': emptyCategoryGrid} %}
+    {% embed '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': emptyCategoryGrid} %}
 
-          {% block grid_panel_body %}
-            <div class="card-body">
-              <div class="alert alert-info">
-                <div class="alert-text">
-                  {{ 'An empty category is a category that has no product directly associated to it. An empty category may however contain products through its subcategories.'|trans({}, 'Admin.Catalog.Help') }}
-                </div>
-              </div>
-              {% block grid_view_block %}
-                {{ include('@PrestaShop/Admin/Common/Grid/grid.html.twig', {'grid': emptyCategoryGrid }) }}
-              {% endblock %}
+      {% block grid_panel_body %}
+        <div class="card-body">
+          <div class="alert alert-info">
+            <div class="alert-text">
+              {{ 'An empty category is a category that has no product directly associated to it. An empty category may however contain products through its subcategories.'|trans({}, 'Admin.Catalog.Help') }}
             </div>
+          </div>
+          {% block grid_view_block %}
+            {{ include('@PrestaShop/Admin/Common/Grid/grid.html.twig', {'grid': emptyCategoryGrid }) }}
           {% endblock %}
+        </div>
+      {% endblock %}
 
-          {% block grid_panel_extra_content %}
-            {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig'
+      {% block grid_panel_extra_content %}
+        {% include '@PrestaShop/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig'
               with {'deleteCategoriesForm': deleteCategoryForm }
             %}
-          {% endblock %}
-        {% endembed %}
-      </div>
-    </div>
+      {% endblock %}
+    {% endembed %}
   {% endblock %}
 
   {% block no_qty_product_with_combinations_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': noQtyProductWithCombinationGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': noQtyProductWithCombinationGrid} %}
   {% endblock %}
 
   {% block no_qty_product_without_combinations_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': noQtyProductWithoutCombinationGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': noQtyProductWithoutCombinationGrid} %}
   {% endblock %}
 
   {% block disabled_product_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': disabledProductGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': disabledProductGrid} %}
   {% endblock %}
 
   {% block product_without_image_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutImageGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutImageGrid} %}
   {% endblock %}
 
   {% block product_without_description_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutDescriptionGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutDescriptionGrid} %}
   {% endblock %}
 
   {% block product_without_price_listing %}
-    <div class="row">
-      <div class="col">
-        {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutPriceGrid} %}
-      </div>
-    </div>
+    {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': productWithoutPriceGrid} %}
   {% endblock %}
 
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-content.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 <div class="row module-selection d-none">
-  <div class="col-md-12 col-lg-7">
+  <div class="col-lg-7">
     {% for module in extraModules %}
       <div class="module-render-container module-{{ module.attributes.name }}">
         <div>
@@ -43,7 +43,7 @@
     {% endfor %}
   </div>
 
-  <div class="col-md-12 col-lg-5">
+  <div class="col-lg-5">
     <h2>{{ 'Module to configure'|trans({}, 'Admin.Catalog.Feature') }}</h2>
     <select class="modules-list-select" data-toggle="select2">
       {% for module in extraModules %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/modules-preview.html.twig
@@ -32,7 +32,7 @@
 
   <div class="row">
     {% for module in extraModules %}
-      <div class="col-md-12 col-lg-6 col-xl-4">
+      <div class="col-lg-6 col-xl-4">
         <div class="module-item-wrapper-grid">
           <div class="module-item-heading-grid">
             <img class="module-logo-thumb-grid" src="{{ module.attributes.img }}" alt="{{ module.attributes.displayName }}">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
@@ -32,23 +32,20 @@
 {% endblock %}
 
 {% block content %}
-<div class="row justify-content-center">
-  <div class="col-sm-12">
-    {{ form_start(combinationForm, {'attr': {'class': 'form-horizontal combination-page', 'novalidate': 'novalidate'}}) }}
-    <div class="card">
-      <div class="card-header">
-        {{ 'Combination details'|trans({}, 'Admin.Catalog.Feature') }} -
-        <span>{{ combinationForm.vars.value.name }}</span>
-      </div>
-      <div class="card-block row">
-        <div id="{{ combinationForm.vars.id }}">
-          {{ form_row(combinationForm) }}
-        </div>
+  {{ form_start(combinationForm, {'attr': {'class': 'form-horizontal combination-page', 'novalidate': 'novalidate'}}) }}
+  <div class="card">
+    <div class="card-header">
+      {{ 'Combination details'|trans({}, 'Admin.Catalog.Feature') }}
+      -
+      <span>{{ combinationForm.vars.value.name }}</span>
+    </div>
+    <div class="card-block row">
+      <div id="{{ combinationForm.vars.id }}">
+        {{ form_row(combinationForm) }}
       </div>
     </div>
-    {{ form_end(combinationForm) }}
   </div>
-</div>
+  {{ form_end(combinationForm) }}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/features.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/features.html.twig
@@ -32,14 +32,14 @@
 
 {%- block feature_value_row -%}
   <div class="form-group row product-feature">
-    <div class="col-lg-12 col-xl-3">
+    <div class="col-xl-3">
       <fieldset class="form-group mb-0">
         <label class="form-control-label">{{ form.feature_id.vars.label }}</label>
         {{ form_widget(form.feature_id) }}
         {{ form_errors(form.feature_id) }}
       </fieldset>
     </div>
-    <div class="col-lg-12 col-xl-4">
+    <div class="col-xl-4">
       <fieldset class="form-group mb-0">
         <label class="form-control-label">{{ form.feature_value_id.vars.label }}</label>
         {{ form_widget(form.feature_value_id) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/add.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/add.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/edit.html.twig
@@ -29,11 +29,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row justify-content-center">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/index.html.twig
@@ -39,11 +39,7 @@
 {% block content %}
   {% block supplier_grid %}
     {{ ps.infotip(settingsTipMessage, true) }}
-    <div class="row">
-      <div class="col">
-        {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': supplierGrid} %}
-      </div>
-    </div>
+    {% include'@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': supplierGrid} %}
   {% endblock %}
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/view.html.twig
@@ -26,9 +26,5 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  <div class="row">
-    <div class="col">
-      {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/View/products.html.twig' %}
-    </div>
-  </div>
+  {% include '@PrestaShop/Admin/Sell/Catalog/Suppliers/Blocks/View/products.html.twig' %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
@@ -29,18 +29,13 @@
 {% endblock %}
 
 {% block content %}
-
     {% if is_shop_context %}
         <div id="stock-app"></div>
-
     {% else %}
-        <div class="col-md-12">
-            <div class="alert alert-danger" role="alert">
-                <p class="alert-text">{{ 'You can\'t manage your stock in this shop context: select a shop instead of a group of shops.'|trans({}, 'Admin.Catalog.Notification') }}</p>
-            </div>
+        <div class="alert alert-danger" role="alert">
+            <p class="alert-text">{{ 'You can\'t manage your stock in this shop context: select a shop instead of a group of shops.'|trans({}, 'Admin.Catalog.Notification') }}</p>
         </div>
     {% endif %}
-
 {% endblock %}
 
 {% block javascripts %}

--- a/tests/UI/pages/BO/catalog/brands/view.js
+++ b/tests/UI/pages/BO/catalog/brands/view.js
@@ -16,7 +16,7 @@ class ViewBrand extends BOBasePage {
 
     // Selectors
     this.contentDiv = 'div.content-div';
-    this.addressesGrid = `${this.contentDiv} > div.row > div > div.row:nth-of-type(2)`;
+    this.addressesGrid = 'div[data-role=addresses-card]';
     this.addressesGridHeader = `${this.addressesGrid} h3.card-header`;
     this.addressesTableBody = `${this.addressesGrid} .card-body table tbody`;
     this.addressesTableRow = row => `${this.addressesTableBody} tr:nth-of-type(${row})`;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | This PR should be considered as a BC because of lot of HTML structure changes and they might be used by a module or anything else, but it's acceptable. The optimizations are only within the files itself, so it does not matter if anyone uses the old version in any form in their modules.
| Deprecations?     | no
| How to test?      | Go through Catalog section BO and see if nothing is broken by this PR. There should be no visible change.
| Possible impacts? | No bad impacts. :-)

### Description
- I went through all templates and removed 99% of unneeded boostrap code like `<div class="row"><div class="col">XXX</div></div>`. It will reduce render depth and complexity by several layers - easier to navigate, debug CSS, maybe faster to render on slower PCs.
- I fixed all places where somebody used single quotations or no quotations at all.
- I fixed all places where somebody combined row and column in same element, this is not allowed.
- I fixed all places where somebody used syntax line col-sm-12 col-md-12 or col-md-12 col-lg-6. The first one is not needed.
- Small fixes here and there - removed some container classes, fixed module position page responsivity a bit, fixed virtual product block responsivity etc...
It should produce no BC breaks, unless some 3rd party module was targetting some classes they shouldn't have OR they targeted it by child or parent.

### Templates concerned
Product/CatalogPage
Product/ProductPage
Product/ProductPage/Panels
Sell/Catalog/Attachment
Sell/Catalog/Attribute
Sell/Catalog/AttributeGroup
Sell/Catalog/CartRule
Sell/Catalog/CatalogPriceRule
Sell/Catalog/Categories
Sell/Catalog/Features
Sell/Catalog/Manufacturer
Sell/Catalog/Manufacturer/Address
Sell/Catalog/Monitoring
Sell/Catalog/Product/Combination
Sell/Catalog/Product
Sell/Catalog/Suppliers
Stock
ProductImage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26063)
<!-- Reviewable:end -->
