### PR TITLE
Footer from next invoice shown on invoice when exporting multiple invoices (i.e. invoices by date range)

### DIFF
--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -150,9 +150,9 @@ class PDFCore
             $this->pdf_renderer->createPagination($template->getPagination());
             $this->pdf_renderer->createContent($template->getContent());
             $this->pdf_renderer->writePage();
-	    // The footer must be added after adding the page, or TCPDF will
-	    // add the footer for the next page from on the last page of this
-	    // page group, which could mean the wrong store info is rendered.
+            // The footer must be added after adding the page, or TCPDF will
+            // add the footer for the next page from on the last page of this
+            // page group, which could mean the wrong store info is rendered.
             $this->pdf_renderer->createFooter($template->getFooter());
             $render = true;
 

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -147,10 +147,13 @@ class PDFCore
             $template->assignHookData($object);
 
             $this->pdf_renderer->createHeader($template->getHeader());
-            $this->pdf_renderer->createFooter($template->getFooter());
             $this->pdf_renderer->createPagination($template->getPagination());
             $this->pdf_renderer->createContent($template->getContent());
             $this->pdf_renderer->writePage();
+	    // The footer must be added after adding the page, or TCPDF will
+	    // add the footer for the next page from on the last page of this
+	    // page group, which could mean the wrong store info is rendered.
+            $this->pdf_renderer->createFooter($template->getFooter());
             $render = true;
 
             unset($template);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When exporting multiple invoices (i.e. invoices by date range), the footer of the following invoice is shown on the current invoice erroneously. This meant that in a multi-store environment, the wrong store details could be output on the invoice footer, which can create a compliance issue, especially if different tax information should be displayed. The issue resolves around the use of TCPDF, where the footer needs to be output after AddPage, otherwise the last page of a page group will end up having the footer of the next page group.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26067
| How to test?      | 1. In a multi-store environment -- set up multiple stores with different data, such that the footers on invoices would differ depending on which store items were ordered from 2. Place and invoice a mixture of orders - switch between stores when placing orders 3. Export orders using the invoices by date range functionality 4. Where invoices switch between stores, the footer should always be relative to the store the invoice is from
| Possible impacts? | Individual invoicing (no issues seen in testing so far though), any other PDF generation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26068)
<!-- Reviewable:end -->
