### PR TITLE
Fix product_quantity_in_stock

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -753,8 +753,7 @@ class OrderDetailCore extends ObjectModel
         $this->id_warehouse = $id_warehouse;
 
         $product_quantity = (int) Product::getQuantity($this->product_id, $this->product_attribute_id, null, $cart);
-        $this->product_quantity_in_stock = ($product_quantity - (int) $product['cart_quantity'] < 0) ?
-            $product_quantity : (int) $product['cart_quantity'];
+        $this->product_quantity_in_stock = $product_quantity;
 
         $this->setVirtualProductInformation($product);
         $this->checkProductStock($product, $id_order_state);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | fix product_quantity_in_stock : it now takes vitual stock at the moment of the order.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/16840
| How to test?      | Reproduce orders I've mentioned in the issue : it should be 10 - ordered quantity
| Possible impacts? | check packs


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26074)
<!-- Reviewable:end -->
