### PR TITLE
Do not use virtual cart for saving quantity in stock

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -752,9 +752,13 @@ class OrderDetailCore extends ObjectModel
         $this->product_weight = $product['id_product_attribute'] ? (float) $product['weight_attribute'] : (float) $product['weight'];
         $this->id_warehouse = $id_warehouse;
 
-        $product_quantity = (int) Product::getQuantity($this->product_id, $this->product_attribute_id);
-        $this->product_quantity_in_stock = ($product_quantity - (int) $product['cart_quantity'] < 0) ?
-            $product_quantity : (int) $product['cart_quantity'];
+        // We get the real quantity of the product in stock and save how much of the ordered quantity was in stock
+        $product_quantity_in_stock = (int) Product::getQuantity($this->product_id, $this->product_attribute_id);
+        
+        // Ordered 3 pcs, in stock 10 pcs, result is 3
+        // Ordered 3 pcs, in stock 1 pcs, result is 1
+        $this->product_quantity_in_stock = ($product_quantity_in_stock - (int) $product['cart_quantity'] < 0) ?
+            $product_quantity_in_stock : (int) $product['cart_quantity'];
 
         $this->setVirtualProductInformation($product);
         $this->checkProductStock($product, $id_order_state);

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -754,7 +754,7 @@ class OrderDetailCore extends ObjectModel
 
         // We get the real quantity of the product in stock and save how much of the ordered quantity was in stock
         $product_quantity_in_stock = (int) Product::getQuantity($this->product_id, $this->product_attribute_id);
-        
+
         // Ordered 3 pcs, in stock 10 pcs, result is 3
         // Ordered 3 pcs, in stock 1 pcs, result is 1
         $this->product_quantity_in_stock = ($product_quantity_in_stock - (int) $product['cart_quantity'] < 0) ?

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -752,7 +752,7 @@ class OrderDetailCore extends ObjectModel
         $this->product_weight = $product['id_product_attribute'] ? (float) $product['weight_attribute'] : (float) $product['weight'];
         $this->id_warehouse = $id_warehouse;
 
-        $product_quantity = (int) Product::getQuantity($this->product_id, $this->product_attribute_id, null, $cart);
+        $product_quantity = (int) Product::getQuantity($this->product_id, $this->product_attribute_id);
         $this->product_quantity_in_stock = ($product_quantity - (int) $product['cart_quantity'] < 0) ?
             $product_quantity : (int) $product['cart_quantity'];
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | **product_quantity_in_stock** in OrderDetail table should save data about how many pieces of the product were in stock at the time of ordering. This behavior was broken (by accident) in non-related PR on 27 Feb 2018. We should not use virtual cart in this case.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #16840
| How to test?      | See below
| Possible impacts? | -

**How to test:**
- Make Product A with quantity 0, Product B with quantity 1, Product C with quantity 2.
- Order all of them.
- Go to **ps_order_detail** in database and see that **product_quantity** contains amount of ordered products and **product_quantity_in_stock** properly contains the quantity of items in stock, at the time of your order.
- It will be the same behavior as till 1.7.2.

![Výstřižek](https://user-images.githubusercontent.com/6097524/135873268-c659a739-b2a3-4dc2-9280-322b9eabbf73.JPG)

**PR that broke the behavior:**
https://github.com/PrestaShop/PrestaShop/commit/64e6f9e1d4068bd1ebab78c089e08d16c928fcd9 - OrderDetail.php

**Changes:**
- I do not use virtual cart (that subtracts items in cart from the amount) for this purpose. We need real amount in stock.
- I renamed a variables and added comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26075)
<!-- Reviewable:end -->
