### PR TITLE
Create CommandAccessor component which will be used by the command builders services

### DIFF
--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessor.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessor.php
@@ -158,6 +158,8 @@ class CommandAccessor
                 return (bool) $value;
             case CommandField::TYPE_INT:
                 return (int) $value;
+            case CommandField::TYPE_ARRAY:
+                return (array) $value;
             default:
                 return $value;
         }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessor.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessor.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor;
 
-use PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -105,7 +104,7 @@ class CommandAccessor
      * Check if the data has a mapping checkbox to modify all shops for the tested field, if so use the allShopsCommand
      *
      * @param array $data
-     * @param string $dataPath
+     * @param PropertyPath $dataPath
      * @param mixed $shopCommand
      * @param mixed|null $allShopsCommand
      *
@@ -113,7 +112,7 @@ class CommandAccessor
      */
     private function getAppropriateCommand(
         array $data,
-        string $dataPath,
+        PropertyPath $dataPath,
         $shopCommand,
         $allShopsCommand
     ) {
@@ -121,17 +120,17 @@ class CommandAccessor
             return $shopCommand;
         }
 
-        $propertyPath = new PropertyPath($dataPath);
-        $lastElement = $propertyPath->getElement($propertyPath->getLength() - 1);
-        $multiShopName = ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX . $lastElement;
+        $lastElement = $dataPath->getElement($dataPath->getLength() - 1);
+        $multiShopName = $this->config->getMultiShopPrefix() . $lastElement;
 
         // Replace last element
-        if (($pos = strrpos($dataPath, $lastElement)) !== false) {
-            $dataPath = substr_replace($dataPath, $multiShopName, $pos, strlen($lastElement));
+        $stringPath = (string) $dataPath;
+        if (($pos = strrpos($stringPath, $lastElement)) !== false) {
+            $stringPath = substr_replace($stringPath, $multiShopName, $pos, strlen($lastElement));
         }
 
         try {
-            $modifyAll = $this->propertyAccessor->getValue($data, $dataPath);
+            $modifyAll = $this->propertyAccessor->getValue($data, $stringPath);
 
             return $modifyAll ? $allShopsCommand : $shopCommand;
         } catch (NoSuchIndexException | NoSuchPropertyException $e) {

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessor.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessor.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor;
+
+use PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension;
+use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyAccess\PropertyPath;
+
+/**
+ * This class is inspired from the PropertyAccessor component from Symfony but it's centered around
+ * prefilling command objects based on a config and the data available in the flattened form data array.
+ */
+class CommandAccessor
+{
+    /**
+     * @var CommandAccessorConfig
+     */
+    private $config;
+
+    /**
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    public function __construct(CommandAccessorConfig $config)
+    {
+        $this->config = $config;
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->enableExceptionOnInvalidIndex()
+            ->enableExceptionOnInvalidPropertyPath()
+            ->disableMagicCall()
+            ->getPropertyAccessor()
+        ;
+    }
+
+    /**
+     * @param array $data
+     * @param mixed $shopCommand
+     * @param mixed|null $allShopsCommand
+     *
+     * @return array
+     */
+    public function buildCommands(
+        array $data,
+        $shopCommand,
+        $allShopsCommand = null
+    ): array {
+        $modifiedCommands = [];
+        foreach ($this->config->getFields() as $commandField) {
+            try {
+                $value = $this->propertyAccessor->getValue($data, $commandField->getDataPath());
+                $castedValue = $this->castValue($value, $commandField->getType());
+                $command = $this->getAppropriateCommand($data, $commandField->getDataPath(), $shopCommand, $allShopsCommand);
+                $this->propertyAccessor->setValue($command, $commandField->getCommandSetter(), $castedValue);
+                if (!in_array($command, $modifiedCommands)) {
+                    $modifiedCommands[] = $command;
+                }
+            } catch (NoSuchIndexException $e) {
+                // Data has no value for this field
+            }
+        }
+
+        // Make sure the order of returned commands is always consistent (single shop comes first)
+        $commands = [];
+        if (in_array($shopCommand, $modifiedCommands)) {
+            $commands[] = $shopCommand;
+        }
+        if (in_array($allShopsCommand, $modifiedCommands)) {
+            $commands[] = $allShopsCommand;
+        }
+
+        return $commands;
+    }
+
+    /**
+     * Check if the data has a mapping checkbox to modify all shops for the tested field, if so use the allShopsCommand
+     *
+     * @param array $data
+     * @param string $dataPath
+     * @param mixed $shopCommand
+     * @param mixed|null $allShopsCommand
+     *
+     * @return mixed
+     */
+    private function getAppropriateCommand(
+        array $data,
+        string $dataPath,
+        $shopCommand,
+        $allShopsCommand
+    ) {
+        if (null === $allShopsCommand) {
+            return $shopCommand;
+        }
+
+        $propertyPath = new PropertyPath($dataPath);
+        $lastElement = $propertyPath->getElement($propertyPath->getLength() - 1);
+        $multiShopName = ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX . $lastElement;
+
+        // Replace last element
+        if (($pos = strrpos($dataPath, $lastElement)) !== false) {
+            $dataPath = substr_replace($dataPath, $multiShopName, $pos, strlen($lastElement));
+        }
+
+        try {
+            $modifyAll = $this->propertyAccessor->getValue($data, $dataPath);
+
+            return $modifyAll ? $allShopsCommand : $shopCommand;
+        } catch (NoSuchIndexException | NoSuchPropertyException $e) {
+            return $shopCommand;
+        }
+    }
+
+    /**
+     * @param mixed $value
+     * @param string $type
+     *
+     * @return bool|int|mixed|string
+     */
+    private function castValue($value, string $type)
+    {
+        switch ($type) {
+            case CommandField::TYPE_STRING:
+                return (string) $value;
+            case CommandField::TYPE_BOOL:
+                return (bool) $value;
+            case CommandField::TYPE_INT:
+                return (int) $value;
+            default:
+                return $value;
+        }
+    }
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessor.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessor.php
@@ -32,7 +32,6 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
-use Symfony\Component\PropertyAccess\PropertyPath;
 
 /**
  * This class is inspired from the PropertyAccessor component from Symfony, but it's centered around
@@ -82,7 +81,8 @@ class CommandAccessor
             try {
                 $value = $this->propertyAccessor->getValue($data, $commandField->getDataPath());
                 $castedValue = $this->castValue($value, $commandField->getType());
-                $command = $this->getAppropriateCommand($data, $commandField->getDataPath(), $singleStoreCommand, $allStoresCommand);
+
+                $command = $this->getAppropriateCommand($data, $commandField, $singleStoreCommand, $allStoresCommand);
                 $this->propertyAccessor->setValue($command, $commandField->getCommandSetter(), $castedValue);
                 if (!in_array($command, $modifiedCommands)) {
                     $modifiedCommands[] = $command;
@@ -108,7 +108,7 @@ class CommandAccessor
      * Check if the data has a mapping checkbox to modify all stores for the tested field, if so use the allStoresCommand
      *
      * @param array $data
-     * @param PropertyPath $dataPath
+     * @param CommandField $commandField
      * @param mixed $singleStoreCommand
      * @param mixed|null $allStoresCommand
      *
@@ -116,14 +116,15 @@ class CommandAccessor
      */
     private function getAppropriateCommand(
         array $data,
-        PropertyPath $dataPath,
+        CommandField $commandField,
         $singleStoreCommand,
         $allStoresCommand
     ) {
-        if (null === $allStoresCommand) {
+        if (null === $allStoresCommand || !$commandField->isMultistoreField()) {
             return $singleStoreCommand;
         }
 
+        $dataPath = $commandField->getDataPath();
         $lastElement = $dataPath->getElement($dataPath->getLength() - 1);
         $modifyAllNamePrefix = $this->config->getModifyAllNamePrefix() . $lastElement;
 

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
@@ -74,7 +74,29 @@ class CommandAccessorConfig
         $this->fields[] = new CommandField(
             $propertyPath,
             $commandSetter,
-            $propertyType
+            $propertyType,
+            false
+        );
+
+        return $this;
+    }
+
+    /**
+     * @param string $propertyPath
+     * @param string $commandSetter
+     * @param string $propertyType
+     *
+     * @return $this
+     *
+     * @throws InvalidCommandFieldTypeException
+     */
+    public function addMultiStoreField(string $propertyPath, string $commandSetter, string $propertyType): self
+    {
+        $this->fields[] = new CommandField(
+            $propertyPath,
+            $commandSetter,
+            $propertyType,
+            true
         );
 
         return $this;

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
@@ -111,7 +111,7 @@ class CommandAccessorConfig
     }
 
     /**
-     * @return CommandField[]
+     * @return array<int, CommandField>
      */
     public function getFields(): array
     {

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
@@ -31,9 +31,22 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Acce
 class CommandAccessorConfig
 {
     /**
+     * @var string
+     */
+    private $multiShopPrefix;
+
+    /**
      * @var CommandField[]
      */
     private $fields = [];
+
+    /**
+     * @param string $multiShopPrefix
+     */
+    public function __construct(string $multiShopPrefix)
+    {
+        $this->multiShopPrefix = $multiShopPrefix;
+    }
 
     public function addField(string $propertyPath, string $commandSetter, string $propertyType): self
     {
@@ -44,6 +57,14 @@ class CommandAccessorConfig
         );
 
         return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMultiShopPrefix(): string
+    {
+        return $this->multiShopPrefix;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor;
+
+class CommandAccessorConfig
+{
+    /**
+     * @var CommandField[]
+     */
+    private $fields = [];
+
+    public function addField(string $propertyPath, string $commandSetter, string $propertyType): self
+    {
+        $this->fields[] = new CommandField(
+            $propertyPath,
+            $commandSetter,
+            $propertyType
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return CommandField[]
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorConfig.php
@@ -28,12 +28,24 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor;
 
+/**
+ * Config that gives information to the CommandAccessor component to correctly check the data and prefill the command
+ * object, each data property is associated to a setter in the command and its appropriate type for casting. Example:
+ *
+ * $config = new CommandAccessorConfig('modify_all_');
+ * $config
+ *     ->addField('[name]', 'setName', CommandField::TYPE_STRING)
+ *     ->addField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
+ *     ->addField('[_number]', 'setCount', CommandField::TYPE_INT)
+ *     ->addField('[parent][children]', 'setChildren', CommandField::TYPE_ARRAY)
+ * ;
+ */
 class CommandAccessorConfig
 {
     /**
      * @var string
      */
-    private $multiShopPrefix;
+    private $modifyAllNamePrefix;
 
     /**
      * @var CommandField[]
@@ -41,13 +53,22 @@ class CommandAccessorConfig
     private $fields = [];
 
     /**
-     * @param string $multiShopPrefix
+     * @param string $modifyAllNamePrefix
      */
-    public function __construct(string $multiShopPrefix)
+    public function __construct(string $modifyAllNamePrefix = '')
     {
-        $this->multiShopPrefix = $multiShopPrefix;
+        $this->modifyAllNamePrefix = $modifyAllNamePrefix;
     }
 
+    /**
+     * @param string $propertyPath
+     * @param string $commandSetter
+     * @param string $propertyType
+     *
+     * @return $this
+     *
+     * @throws InvalidCommandFieldTypeException
+     */
     public function addField(string $propertyPath, string $commandSetter, string $propertyType): self
     {
         $this->fields[] = new CommandField(
@@ -62,9 +83,9 @@ class CommandAccessorConfig
     /**
      * @return string
      */
-    public function getMultiShopPrefix(): string
+    public function getModifyAllNamePrefix(): string
     {
-        return $this->multiShopPrefix;
+        return $this->modifyAllNamePrefix;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandField.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandField.php
@@ -28,20 +28,24 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor;
 
+use Symfony\Component\PropertyAccess\PropertyPath;
+
 class CommandField
 {
     public const TYPE_STRING = 'string';
     public const TYPE_BOOL = 'bool';
     public const TYPE_INT = 'int';
+    public const TYPE_ARRAY = 'array';
 
     public const ACCEPTED_TYPES = [
         self::TYPE_STRING,
         self::TYPE_BOOL,
         self::TYPE_INT,
+        self::TYPE_ARRAY,
     ];
 
     /**
-     * @var string
+     * @var PropertyPath
      */
     private $dataPath;
 
@@ -75,15 +79,15 @@ class CommandField
             ));
         }
 
-        $this->dataPath = $dataPath;
+        $this->dataPath = new PropertyPath($dataPath);
         $this->commandSetter = $commandSetter;
         $this->type = $type;
     }
 
     /**
-     * @return string
+     * @return PropertyPath
      */
-    public function getDataPath(): string
+    public function getDataPath(): PropertyPath
     {
         return $this->dataPath;
     }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandField.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandField.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor;
+
+class CommandField
+{
+    public const TYPE_STRING = 'string';
+    public const TYPE_BOOL = 'bool';
+    public const TYPE_INT = 'int';
+
+    public const ACCEPTED_TYPES = [
+        self::TYPE_STRING,
+        self::TYPE_BOOL,
+        self::TYPE_INT,
+    ];
+
+    /**
+     * @var string
+     */
+    private $dataPath;
+
+    /**
+     * @var string
+     */
+    private $commandSetter;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @param string $dataPath
+     * @param string $commandSetter
+     * @param string $type
+     *
+     * @throws InvalidCommandFieldTypeException
+     */
+    public function __construct(
+        string $dataPath,
+        string $commandSetter,
+        string $type
+    ) {
+        if (!in_array($type, self::ACCEPTED_TYPES)) {
+            throw new InvalidCommandFieldTypeException(sprintf(
+                'Invalid type "%s" used, only accepted values are: %s',
+                $type,
+                implode(',', self::ACCEPTED_TYPES)
+            ));
+        }
+
+        $this->dataPath = $dataPath;
+        $this->commandSetter = $commandSetter;
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDataPath(): string
+    {
+        return $this->dataPath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCommandSetter(): string
+    {
+        return $this->commandSetter;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandField.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandField.php
@@ -60,6 +60,11 @@ class CommandField
     private $type;
 
     /**
+     * @var bool
+     */
+    private $multistoreField;
+
+    /**
      * @param string $dataPath
      * @param string $commandSetter
      * @param string $type
@@ -69,7 +74,8 @@ class CommandField
     public function __construct(
         string $dataPath,
         string $commandSetter,
-        string $type
+        string $type,
+        bool $multistoreField
     ) {
         if (!in_array($type, self::ACCEPTED_TYPES)) {
             throw new InvalidCommandFieldTypeException(sprintf(
@@ -82,6 +88,7 @@ class CommandField
         $this->dataPath = new PropertyPath($dataPath);
         $this->commandSetter = $commandSetter;
         $this->type = $type;
+        $this->multistoreField = $multistoreField;
     }
 
     /**
@@ -106,5 +113,13 @@ class CommandField
     public function getType(): string
     {
         return $this->type;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isMultistoreField(): bool
+    {
+        return $this->multistoreField;
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/InvalidCommandFieldTypeException.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/InvalidCommandFieldTypeException.php
@@ -30,6 +30,9 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Acce
 
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 
+/**
+ * Thorwn when trying to create a CommandField with invalid type.
+ */
 class InvalidCommandFieldTypeException extends CoreException
 {
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/InvalidCommandFieldTypeException.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/InvalidCommandFieldTypeException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor;
+
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+class InvalidCommandFieldTypeException extends CoreException
+{
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/InvalidCommandFieldTypeException.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Accessor/InvalidCommandFieldTypeException.php
@@ -31,7 +31,7 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Acce
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 
 /**
- * Thorwn when trying to create a CommandField with invalid type.
+ * Thrown when trying to create a CommandField with invalid type.
  */
 class InvalidCommandFieldTypeException extends CoreException
 {

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorTest.php
@@ -1,0 +1,367 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Accessor;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor\CommandAccessor;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor\CommandAccessorConfig;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor\CommandField;
+
+class CommandAccessorTest extends TestCase
+{
+    private const MULTI_SHOP_PREFIX = 'multi_shop_';
+    private const SHOP_ID = 1;
+
+    /**
+     * @dataProvider getSingleCommandParameters
+     *
+     * @param CommandAccessorConfig $config
+     * @param array $data
+     * @param array $expectedCommands
+     */
+    public function testBuildSingleCommand(
+        CommandAccessorConfig $config,
+        array $data,
+        array $expectedCommands
+    ): void {
+        $accessor = new CommandAccessor($config);
+        $command = new CommandAccessorTestCommand(ShopConstraint::shop(self::SHOP_ID));
+        $commands = $accessor->buildCommands($data, $command);
+        $this->assertEquals($expectedCommands, $commands);
+    }
+
+    public function getSingleCommandParameters(): iterable
+    {
+        $config = new CommandAccessorConfig(self::MULTI_SHOP_PREFIX);
+        $config
+            ->addField('[name]', 'setName', CommandField::TYPE_STRING)
+            ->addField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
+            ->addField('[_number]', 'setCount', CommandField::TYPE_INT)
+            ->addField('[parent][children]', 'setChildren', CommandField::TYPE_ARRAY)
+        ;
+        $children = [
+            'bob',
+            'steve',
+        ];
+
+        $command = new CommandAccessorTestCommand(ShopConstraint::shop(self::SHOP_ID));
+        $command
+            ->setName('toto')
+            ->setIsValid(true)
+            ->setCount(42)
+            ->setChildren($children)
+        ;
+
+        yield [
+            $config,
+            [
+                'name' => 'toto',
+                'command' => [
+                    'isValid' => true,
+                ],
+                '_number' => 42,
+                'parent' => [
+                    'children' => $children,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new CommandAccessorTestCommand(ShopConstraint::shop(self::SHOP_ID));
+        $command
+            ->setName('toto')
+            ->setIsValid(false)
+        ;
+
+        yield [
+            $config,
+            [
+                'name' => 'toto',
+                'command' => [
+                    'isValid' => false,
+                ],
+                'unknown' => 45,
+            ],
+            [$command],
+        ];
+    }
+
+    /**
+     * @dataProvider getMultiShopCommandsParameters
+     *
+     * @param CommandAccessorConfig $config
+     * @param array $data
+     * @param array $expectedCommands
+     */
+    public function testBuildMultiShopCommands(
+        CommandAccessorConfig $config,
+        array $data,
+        array $expectedCommands
+    ): void {
+        $accessor = new CommandAccessor($config);
+        $command = new CommandAccessorTestCommand(ShopConstraint::shop(self::SHOP_ID));
+        $allShopsCommand = new CommandAccessorTestCommand(ShopConstraint::allShops());
+        $commands = $accessor->buildCommands($data, $command, $allShopsCommand);
+        $this->assertEquals($expectedCommands, $commands);
+    }
+
+    public function getMultiShopCommandsParameters(): iterable
+    {
+        $config = new CommandAccessorConfig(self::MULTI_SHOP_PREFIX);
+        $config
+            ->addField('[name]', 'setName', CommandField::TYPE_STRING)
+            ->addField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
+            ->addField('[_number]', 'setCount', CommandField::TYPE_INT)
+            ->addField('[parent][children]', 'setChildren', CommandField::TYPE_ARRAY)
+        ;
+        $children = [
+            'bob',
+            'steve',
+        ];
+
+        $command = new CommandAccessorTestCommand(ShopConstraint::shop(self::SHOP_ID));
+        $command
+            ->setName('toto')
+            ->setIsValid(true)
+            ->setCount(42)
+            ->setChildren($children)
+        ;
+
+        yield [
+            $config,
+            [
+                'name' => 'toto',
+                'command' => [
+                    'isValid' => true,
+                ],
+                '_number' => 42,
+                'parent' => [
+                    'children' => $children,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new CommandAccessorTestCommand(ShopConstraint::shop(self::SHOP_ID));
+        $command
+            ->setName('toto')
+            ->setIsValid(false)
+        ;
+
+        $allShopsCommand = new CommandAccessorTestCommand(ShopConstraint::allShops());
+        $allShopsCommand
+            ->setCount(42)
+            ->setChildren($children)
+        ;
+
+        yield [
+            $config,
+            [
+                'name' => 'toto',
+                'command' => [
+                    'isValid' => false,
+                ],
+                '_number' => 42,
+                self::MULTI_SHOP_PREFIX . '_number' => true,
+                'parent' => [
+                    'children' => $children,
+                    self::MULTI_SHOP_PREFIX . 'children' => true,
+                ],
+            ],
+            [$command, $allShopsCommand],
+        ];
+
+        yield [
+            $config,
+            [
+                '_number' => 42,
+                self::MULTI_SHOP_PREFIX . '_number' => true,
+                'parent' => [
+                    'children' => $children,
+                    self::MULTI_SHOP_PREFIX . 'children' => true,
+                ],
+            ],
+            [$allShopsCommand],
+        ];
+
+        $command = new CommandAccessorTestCommand(ShopConstraint::shop(self::SHOP_ID));
+        $command
+            ->setName('toto')
+            ->setCount(42)
+            ->setIsValid(false)
+        ;
+
+        $allShopsCommand = new CommandAccessorTestCommand(ShopConstraint::allShops());
+        $allShopsCommand
+            ->setChildren($children)
+        ;
+
+        yield [
+            $config,
+            [
+                'name' => 'toto',
+                'command' => [
+                    'isValid' => false,
+                ],
+                '_number' => 42,
+                self::MULTI_SHOP_PREFIX . '_number' => false,
+                'parent' => [
+                    'children' => $children,
+                    self::MULTI_SHOP_PREFIX . 'children' => true,
+                ],
+            ],
+            [$command, $allShopsCommand],
+        ];
+    }
+}
+
+class CommandAccessorTestCommand
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var bool
+     */
+    private $isValid;
+
+    /**
+     * @var int
+     */
+    private $count;
+
+    /**
+     * @var array
+     */
+    private $children;
+
+    /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
+     * @param ShopConstraint $shopConstraint
+     */
+    public function __construct(ShopConstraint $shopConstraint)
+    {
+        $this->shopConstraint = $shopConstraint;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return static
+     */
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isValid(): bool
+    {
+        return $this->isValid;
+    }
+
+    /**
+     * @param bool $isValid
+     *
+     * @return static
+     */
+    public function setIsValid(bool $isValid): self
+    {
+        $this->isValid = $isValid;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+
+    /**
+     * @param int $count
+     *
+     * @return static
+     */
+    public function setCount(int $count): self
+    {
+        $this->count = $count;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    /**
+     * @param array $children
+     *
+     * @return static
+     */
+    public function setChildren(array $children): self
+    {
+        $this->children = $children;
+
+        return $this;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandAccessorTest.php
@@ -36,7 +36,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor\C
 
 class CommandAccessorTest extends TestCase
 {
-    private const MULTI_SHOP_PREFIX = 'multi_shop_';
+    private const MULTI_STORE_PREFIX = 'multi_store_';
     private const SHOP_ID = 1;
 
     /**
@@ -59,7 +59,7 @@ class CommandAccessorTest extends TestCase
 
     public function getSingleCommandParameters(): iterable
     {
-        $config = new CommandAccessorConfig(self::MULTI_SHOP_PREFIX);
+        $config = new CommandAccessorConfig(self::MULTI_STORE_PREFIX);
         $config
             ->addField('[name]', 'setName', CommandField::TYPE_STRING)
             ->addField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
@@ -134,7 +134,7 @@ class CommandAccessorTest extends TestCase
 
     public function getMultiShopCommandsParameters(): iterable
     {
-        $config = new CommandAccessorConfig(self::MULTI_SHOP_PREFIX);
+        $config = new CommandAccessorConfig(self::MULTI_STORE_PREFIX);
         $config
             ->addField('[name]', 'setName', CommandField::TYPE_STRING)
             ->addField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
@@ -189,10 +189,10 @@ class CommandAccessorTest extends TestCase
                     'isValid' => false,
                 ],
                 '_number' => 42,
-                self::MULTI_SHOP_PREFIX . '_number' => true,
+                self::MULTI_STORE_PREFIX . '_number' => true,
                 'parent' => [
                     'children' => $children,
-                    self::MULTI_SHOP_PREFIX . 'children' => true,
+                    self::MULTI_STORE_PREFIX . 'children' => true,
                 ],
             ],
             [$command, $allShopsCommand],
@@ -202,10 +202,10 @@ class CommandAccessorTest extends TestCase
             $config,
             [
                 '_number' => 42,
-                self::MULTI_SHOP_PREFIX . '_number' => true,
+                self::MULTI_STORE_PREFIX . '_number' => true,
                 'parent' => [
                     'children' => $children,
-                    self::MULTI_SHOP_PREFIX . 'children' => true,
+                    self::MULTI_STORE_PREFIX . 'children' => true,
                 ],
             ],
             [$allShopsCommand],
@@ -231,10 +231,10 @@ class CommandAccessorTest extends TestCase
                     'isValid' => false,
                 ],
                 '_number' => 42,
-                self::MULTI_SHOP_PREFIX . '_number' => false,
+                self::MULTI_STORE_PREFIX . '_number' => false,
                 'parent' => [
                     'children' => $children,
-                    self::MULTI_SHOP_PREFIX . 'children' => true,
+                    self::MULTI_STORE_PREFIX . 'children' => true,
                 ],
             ],
             [$command, $allShopsCommand],

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandFieldTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandFieldTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Accessor;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor\CommandField;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Accessor\InvalidCommandFieldTypeException;
+use Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException;
+
+class CommandFieldTest extends TestCase
+{
+    /**
+     * @dataProvider getValidParameters
+     *
+     * @param string $dataPath
+     * @param string $commandSetter
+     * @param string $type
+     */
+    public function testValidConstructors(string $dataPath, string $commandSetter, string $type): void
+    {
+        $field = new CommandField($dataPath, $commandSetter, $type);
+        $this->assertNotNull($field);
+        $this->assertEquals($dataPath, $field->getDataPath());
+        $this->assertEquals($commandSetter, $field->getCommandSetter());
+        $this->assertEquals($type, $field->getType());
+    }
+
+    public function getValidParameters(): iterable
+    {
+        yield [
+            '[form_data][my_field]',
+            'setMyField',
+            CommandField::TYPE_STRING,
+        ];
+
+        yield [
+            'form_data.my_field',
+            'setMyField',
+            CommandField::TYPE_BOOL,
+        ];
+
+        yield [
+            'my_field',
+            'setMyField',
+            CommandField::TYPE_INT,
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidParameters
+     *
+     * @param string $dataPath
+     * @param string $commandSetter
+     * @param string $type
+     * @param string $expectedException
+     */
+    public function testInvalidConstructors(string $dataPath, string $commandSetter, string $type, string $expectedException): void
+    {
+        $this->expectException($expectedException);
+        new CommandField($dataPath, $commandSetter, $type);
+    }
+
+    public function getInvalidParameters(): iterable
+    {
+        yield [
+            '[form_data][my_field]',
+            'setMyField',
+            'invalid',
+            InvalidCommandFieldTypeException::class,
+        ];
+
+        yield [
+            '',
+            'setMyField',
+            CommandField::TYPE_INT,
+            InvalidPropertyPathException::class,
+        ];
+
+        yield [
+            '[form_data.objectField',
+            'setMyField',
+            CommandField::TYPE_INT,
+            InvalidPropertyPathException::class,
+        ];
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandFieldTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Accessor/CommandFieldTest.php
@@ -41,14 +41,16 @@ class CommandFieldTest extends TestCase
      * @param string $dataPath
      * @param string $commandSetter
      * @param string $type
+     * @param bool $isMultistoreField
      */
-    public function testValidConstructors(string $dataPath, string $commandSetter, string $type): void
+    public function testValidConstructors(string $dataPath, string $commandSetter, string $type, bool $isMultistoreField): void
     {
-        $field = new CommandField($dataPath, $commandSetter, $type);
+        $field = new CommandField($dataPath, $commandSetter, $type, $isMultistoreField);
         $this->assertNotNull($field);
         $this->assertEquals($dataPath, $field->getDataPath());
         $this->assertEquals($commandSetter, $field->getCommandSetter());
         $this->assertEquals($type, $field->getType());
+        $this->assertEquals($isMultistoreField, $field->isMultistoreField());
     }
 
     public function getValidParameters(): iterable
@@ -57,18 +59,21 @@ class CommandFieldTest extends TestCase
             '[form_data][my_field]',
             'setMyField',
             CommandField::TYPE_STRING,
+            true,
         ];
 
         yield [
             'form_data.my_field',
             'setMyField',
             CommandField::TYPE_BOOL,
+            false,
         ];
 
         yield [
             'my_field',
             'setMyField',
             CommandField::TYPE_INT,
+            true,
         ];
     }
 
@@ -78,12 +83,13 @@ class CommandFieldTest extends TestCase
      * @param string $dataPath
      * @param string $commandSetter
      * @param string $type
+     * @param bool $isMultistoreField
      * @param string $expectedException
      */
-    public function testInvalidConstructors(string $dataPath, string $commandSetter, string $type, string $expectedException): void
+    public function testInvalidConstructors(string $dataPath, string $commandSetter, string $type, bool $isMultistoreField, string $expectedException): void
     {
         $this->expectException($expectedException);
-        new CommandField($dataPath, $commandSetter, $type);
+        new CommandField($dataPath, $commandSetter, $type, $isMultistoreField);
     }
 
     public function getInvalidParameters(): iterable
@@ -92,6 +98,7 @@ class CommandFieldTest extends TestCase
             '[form_data][my_field]',
             'setMyField',
             'invalid',
+            true,
             InvalidCommandFieldTypeException::class,
         ];
 
@@ -99,6 +106,7 @@ class CommandFieldTest extends TestCase
             '',
             'setMyField',
             CommandField::TYPE_INT,
+            false,
             InvalidPropertyPathException::class,
         ];
 
@@ -106,6 +114,7 @@ class CommandFieldTest extends TestCase
             '[form_data.objectField',
             'setMyField',
             CommandField::TYPE_INT,
+            true,
             InvalidPropertyPathException::class,
         ];
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The command builders are all very simple and naive for now, the purpose of the CommandAccessor component is to have a generic component that can help build the commands The component will be used in builders services, most importantly the component can build the command for multishop context
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | The component is unit tested, CI green will be enough for this PR
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26086)
<!-- Reviewable:end -->
