### PR TITLE
Replace die() with an Exception in Module::getInstanceByName()

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1171,7 +1171,7 @@ abstract class ModuleCore implements ModuleInterface
     {
         if (!Validate::isModuleName($module_name)) {
             if (_PS_MODE_DEV_) {
-                throw new \Exception(Context::getContext()->getTranslator()->trans('%1$s is not a valid module name.', array(Tools::safeOutput($module_name)), 'Admin.Modules.Notification'));
+                throw new \Exception(Tools::displayError(Context::getContext()->getTranslator()->trans('%1$s is not a valid module name.', [Tools::safeOutput($module_name)], 'Admin.Modules.Notification')));               
             }
 
             return false;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1171,7 +1171,7 @@ abstract class ModuleCore implements ModuleInterface
     {
         if (!Validate::isModuleName($module_name)) {
             if (_PS_MODE_DEV_) {
-                throw new \Exception(Tools::displayError(Context::getContext()->getTranslator()->trans('%1$s is not a valid module name.', [Tools::safeOutput($module_name)], 'Admin.Modules.Notification')));               
+                throw new \InvalidArgumentException(Tools::displayError(Context::getContext()->getTranslator()->trans('%1$s is not a valid module name.', [Tools::safeOutput($module_name)], 'Admin.Modules.Notification')));
             }
 
             return false;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1171,7 +1171,7 @@ abstract class ModuleCore implements ModuleInterface
     {
         if (!Validate::isModuleName($module_name)) {
             if (_PS_MODE_DEV_) {
-                die(Tools::displayError(Context::getContext()->getTranslator()->trans('%1$s is not a valid module name.', [Tools::safeOutput($module_name)], 'Admin.Modules.Notification')));
+                throw new \Exception(Context::getContext()->getTranslator()->trans('%1$s is not a valid module name.', array(Tools::safeOutput($module_name)), 'Admin.Modules.Notification'));
             }
 
             return false;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1170,9 +1170,7 @@ abstract class ModuleCore implements ModuleInterface
     public static function getInstanceByName($module_name)
     {
         if (!Validate::isModuleName($module_name)) {
-            if (_PS_MODE_DEV_) {
-                throw new \InvalidArgumentException(Tools::displayError(Context::getContext()->getTranslator()->trans('%1$s is not a valid module name.', [Tools::safeOutput($module_name)], 'Admin.Modules.Notification')));
-            }
+            Tools::displayError(Context::getContext()->getTranslator()->trans('%1$s is not a valid module name.', array(Tools::safeOutput($module_name)), 'Admin.Modules.Notification'));
 
             return false;
         }


### PR DESCRIPTION
more developer friendly when $module_name is empty.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch           | develop
| Description      | Replace die() with an Exception in Module::getInstanceByName()
| Type             | improvement
| Category         | FO
| BC breaks        |  no
| Deprecations     |  no
| Fixed ticket     | Fixes #26113
| How to test      | Instanciate a Module Controller in command line or Admin context.
| Possible impacts | None I guess


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26114)
<!-- Reviewable:end -->
