### PR TITLE
Properly copy property content instead of the whole directory when copying it into gcloud

### DIFF
--- a/.github/workflows/cron_nightly.yml
+++ b/.github/workflows/cron_nightly.yml
@@ -59,7 +59,7 @@ jobs:
               && cd -
 
       -   name: Upload to Google Cloud Storage (GCS)
-          run: gsutil cp -r "/tmp/ps-release" gs://prestashop-core-nightly
+          run: gsutil cp -r "/tmp/ps-release/**" gs://prestashop-core-nightly
 
       -   name: Stop the instance if started
           run: gcloud compute instances stop --zone $GC_ZONE "${GC_INSTANCE_NAME}-${INSTANCE_TYPE}"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Copy the /tmp/ps-release content instead of the whole directory for nightly builds
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need QA
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26138)
<!-- Reviewable:end -->
