### PR TITLE
Fix time-val input buttons to change calendar date-range

### DIFF
--- a/admin-dev/themes/default/js/calendar.js
+++ b/admin-dev/themes/default/js/calendar.js
@@ -307,8 +307,8 @@ function setPreviousYear() {
   $('#date-end-compare').val(endDate.format($('#date-start').data('date-format')));
 }
 
-var datepickerStart;
-var datepickerEnd;
+let datepickerStart;
+let datepickerEnd;
 
 $(document).ready(() => {
   // Instanciate datepickers

--- a/admin-dev/themes/default/js/calendar.js
+++ b/admin-dev/themes/default/js/calendar.js
@@ -309,7 +309,7 @@ function setPreviousYear() {
 
 $(document).ready(() => {
   // Instanciate datepickers
-  const datepickerStart = $('.datepicker1').daterangepicker({
+  datepickerStart = $('.datepicker1').daterangepicker({
     dates: window.translated_dates,
     weekStart: 1,
     start: $('#date-start').val(),
@@ -320,7 +320,7 @@ $(document).ready(() => {
     }
   }).data('daterangepicker');
 
-  const datepickerEnd = $('.datepicker2').daterangepicker({
+  datepickerEnd = $('.datepicker2').daterangepicker({
     dates: window.translated_dates,
     weekStart: 1,
     start: $('#date-start').val(),

--- a/admin-dev/themes/default/js/calendar.js
+++ b/admin-dev/themes/default/js/calendar.js
@@ -307,6 +307,9 @@ function setPreviousYear() {
   $('#date-end-compare').val(endDate.format($('#date-start').data('date-format')));
 }
 
+var datepickerStart;
+var datepickerEnd;
+
 $(document).ready(() => {
   // Instanciate datepickers
   datepickerStart = $('.datepicker1').daterangepicker({

--- a/admin-dev/themes/default/js/calendar.js
+++ b/admin-dev/themes/default/js/calendar.js
@@ -402,9 +402,9 @@ $(document).ready(() => {
   });
 
   $('#compare-options').change(function () {
-    if (this.value === 1) setPreviousPeriod();
+    if (this.value == 1) setPreviousPeriod();
 
-    if (this.value === 2) setPreviousYear();
+    if (this.value == 2) setPreviousYear();
 
     datepickerStart.setStartCompare($('#date-start-compare').val());
     datepickerStart.setEndCompare($('#date-end-compare').val());
@@ -413,7 +413,7 @@ $(document).ready(() => {
     datepickerStart.setCompare(true);
     datepickerEnd.setCompare(true);
 
-    if (this.value === 3) $('#date-start-compare').focus();
+    if (this.value == 3) $('#date-start-compare').focus();
   });
 
   if ($('#datepicker-compare').attr('checked')) {

--- a/admin-dev/themes/default/js/calendar.js
+++ b/admin-dev/themes/default/js/calendar.js
@@ -402,9 +402,9 @@ $(document).ready(() => {
   });
 
   $('#compare-options').change(function () {
-    if (this.value == 1) setPreviousPeriod();
+    if (this.value === '1') setPreviousPeriod();
 
-    if (this.value == 2) setPreviousYear();
+    if (this.value === '2') setPreviousYear();
 
     datepickerStart.setStartCompare($('#date-start-compare').val());
     datepickerStart.setEndCompare($('#date-end-compare').val());
@@ -413,7 +413,7 @@ $(document).ready(() => {
     datepickerStart.setCompare(true);
     datepickerEnd.setCompare(true);
 
-    if (this.value == 3) $('#date-start-compare').focus();
+    if (this.value === '3') $('#date-start-compare').focus();
   });
 
   if ($('#datepicker-compare').attr('checked')) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Selecting a time-val button (day, month, year,...), doesn't change the calendar date-range and causes a jquery error.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25966
| How to test?      | Select a time-val button to change the calendar date-range.
| Possible impacts? | -

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26145)
<!-- Reviewable:end -->
