### PR TITLE
In BackOffice, fixed mismatch between legacy and new theme for RTL languages

### DIFF
--- a/admin-dev/themes/default/public/theme.rtlfix
+++ b/admin-dev/themes/default/public/theme.rtlfix
@@ -35,6 +35,10 @@
 body.lang-fa, .lang-fa #content.bootstrap .panel .panel-heading a.btn, .lang-fa #content.bootstrap #dash_version .panel-heading a.btn, .lang-fa #content.bootstrap .message-item-initial .message-item-initial-body .panel-heading a.btn, .lang-fa #content.bootstrap .timeline .timeline-item .timeline-caption .timeline-panel .panel-heading a.btn, .lang-fa #notification .dropdown-menu .notifications .nav-tabs .nav-item .nav-link, .lang-fa .bootstrap .tooltip, .lang-fa .bootstrap .btn-group-action .btn, .lang-fa .bootstrap .page-head h2.page-title, .lang-fa .bootstrap .page-head h4.page-subtitle, .lang-fa .bootstrap #dashboard #dashproducts nav, .lang-fa .bootstrap #dashboard #dashtrends dt, .lang-fa .bootstrap #dashboard section > section header .small, .bootstrap h1, .lang-fa .bootstrap h2, .lang-fa .bootstrap h3, .lang-fa .bootstrap h4, .lang-fa .bootstrap h5, .lang-fa .bootstrap h6, .lang-fa .bootstrap .h1, .lang-fa .bootstrap .h2, .lang-fa .bootstrap .h3, .lang-fa .bootstrap .h4, .lang-fa .bootstrap .h5, .lang-fa .bootstrap .h6, .lang-fa #content.bootstrap .panel .panel-heading, .lang-fa #content.bootstrap #dash_version .panel-heading, .lang-fa #content.bootstrap .message-item-initial .message-item-initial-body .panel-heading, .lang-fa #content.bootstrap .timeline .timeline-item .timeline-caption .timeline-panel .panel-heading, .lang-fa .bootstrap #dashboard .tooltip-panel-heading, .lang-fa .bootstrap input[type="text"], .lang-fa .bootstrap input[type="search"], .lang-fa .bootstrap input[type="password"], .lang-fa .bootstrap input[type="email"], .lang-fa .bootstrap input[type="tel"], .lang-fa #content.bootstrap input, .lang-fa #content.bootstrap button, .lang-fa #content.bootstrap textarea, .lang-fa #content.bootstrap select {
   font-family: Vazir,Tahoma,Helvetica,Arial,sans-serif !important;
 }
+/* Fix Material Icons mirroring for RTL language */
+.menu-collapse .material-icons {
+  transform: scaleX(-1);
+}
 .rtl-flip:not(.rtl-no-flip) {
   -moz-transform: scaleX(-1);
   -o-transform: scaleX(-1);

--- a/admin-dev/themes/default/public/theme.rtlfix
+++ b/admin-dev/themes/default/public/theme.rtlfix
@@ -1,34 +1,39 @@
+/*
+ * Vazir is a Persian/Arabic font
+ * https://github.com/rastikerdar/vazir-font
+ */
 @font-face {
-  font-family: Vazir;
-  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.eot');
-  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.eot?#iefix') format('embedded-opentype'),
-       url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.woff') format('woff'),
-       url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir.ttf') format('truetype');
-  font-weight: normal;
+    font-family: Vazir;
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.eot');
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.eot?#iefix') format('embedded-opentype'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.woff2') format('woff2'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.woff') format('woff'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
 }
-
 @font-face {
-  font-family: Vazir;
-  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045523/vazir_v18.0.0/Vazir-Bold.eot');
-  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522045523/vazir_v18.0.0/Vazir-Bold.eot?#iefix') format('embedded-opentype'),
-       url('https://res.cloudinary.com/ipresta/raw/upload/v1522045380/vazir_v18.0.0/Vazir.woff') format('woff'),
-       url('https://res.cloudinary.com/ipresta/raw/upload/v1522045523/vazir_v18.0.0/Vazir-Bold.ttf') format('truetype');
-  font-weight: bold;
+    font-family: Vazir;
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.eot');
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.eot?#iefix') format('embedded-opentype'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.woff2') format('woff2'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.woff') format('woff'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.ttf') format('truetype');
+    font-weight: bold;
+    font-style: normal;
 }
-
 @font-face {
-  font-family: Vazir;
-  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.eot');
-  src: url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.eot?#iefix') format('embedded-opentype'),
-       url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.woff') format('woff'),
-       url('https://res.cloudinary.com/ipresta/raw/upload/v1522044764/vazir_v18.0.0/Vazir-Light.ttf') format('truetype');
-  font-weight: 300;
+    font-family: Vazir;
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.eot');
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.eot?#iefix') format('embedded-opentype'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.woff2') format('woff2'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.woff') format('woff'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.ttf') format('truetype');
+    font-weight: 300;
+    font-style: normal;
 }
-.bootstrap body.lang-fa, body.lang-fa, .lang-fa #content.bootstrap .panel .panel-heading a.btn, .lang-fa #content.bootstrap #dash_version .panel-heading a.btn, .lang-fa #content.bootstrap .message-item-initial .message-item-initial-body .panel-heading a.btn, .lang-fa #content.bootstrap .timeline .timeline-item .timeline-caption .timeline-panel .panel-heading a.btn, .lang-fa #notification .dropdown-menu .notifications .nav-tabs .nav-item .nav-link, .lang-fa .bootstrap .tooltip, .lang-fa .bootstrap .btn-group-action .btn, .lang-fa .bootstrap .page-head h2.page-title, .lang-fa .bootstrap .page-head h4.page-subtitle, .lang-fa .bootstrap #dashboard section > section header .small, .lang-fa .bootstrap #login-panel #shop_name, .bootstrap #login-panel #reset_name, .bootstrap #login-panel #reset_confirm_name, .bootstrap #login-panel #forgot_name, .bootstrap #login-panel #forgot_confirm_name, .bootstrap h1, .lang-fa .bootstrap h2, .lang-fa .bootstrap h3, .lang-fa .bootstrap h4, .lang-fa .bootstrap h5, .lang-fa .bootstrap h6, .lang-fa .bootstrap .h1, .lang-fa .bootstrap .h2, .lang-fa .bootstrap .h3, .lang-fa .bootstrap .h4, .lang-fa .bootstrap .h5, .lang-fa .bootstrap .h6, .lang-fa #content.bootstrap .panel .panel-heading, .lang-fa #content.bootstrap #dash_version .panel-heading, .lang-fa #content.bootstrap .message-item-initial .message-item-initial-body .panel-heading, .lang-fa #content.bootstrap .timeline .timeline-item .timeline-caption .timeline-panel .panel-heading, .bootstrap .nav-tabs li a, .bootstrap .list-empty .list-empty-msg, .bootstrap #dashboard #dashtrends dt, .bootstrap #dashboard #dashproducts nav, .lang-fa .bootstrap #dashboard .tooltip-panel-heading {
-  font-family:"Vazir",Helvetica,Arial,sans-serif;
-}
-.lang-fa .bootstrap input[type="text"], .lang-fa .bootstrap input[type="search"], .lang-fa .bootstrap input[type="password"], .lang-fa .bootstrap input[type="email"], .lang-fa .bootstrap input[type="tel"] {
-  font-family:"Vazir",Helvetica,Arial,sans-serif !important;
+body.lang-fa, .lang-fa #content.bootstrap .panel .panel-heading a.btn, .lang-fa #content.bootstrap #dash_version .panel-heading a.btn, .lang-fa #content.bootstrap .message-item-initial .message-item-initial-body .panel-heading a.btn, .lang-fa #content.bootstrap .timeline .timeline-item .timeline-caption .timeline-panel .panel-heading a.btn, .lang-fa #notification .dropdown-menu .notifications .nav-tabs .nav-item .nav-link, .lang-fa .bootstrap .tooltip, .lang-fa .bootstrap .btn-group-action .btn, .lang-fa .bootstrap .page-head h2.page-title, .lang-fa .bootstrap .page-head h4.page-subtitle, .lang-fa .bootstrap #dashboard #dashproducts nav, .lang-fa .bootstrap #dashboard #dashtrends dt, .lang-fa .bootstrap #dashboard section > section header .small, .bootstrap h1, .lang-fa .bootstrap h2, .lang-fa .bootstrap h3, .lang-fa .bootstrap h4, .lang-fa .bootstrap h5, .lang-fa .bootstrap h6, .lang-fa .bootstrap .h1, .lang-fa .bootstrap .h2, .lang-fa .bootstrap .h3, .lang-fa .bootstrap .h4, .lang-fa .bootstrap .h5, .lang-fa .bootstrap .h6, .lang-fa #content.bootstrap .panel .panel-heading, .lang-fa #content.bootstrap #dash_version .panel-heading, .lang-fa #content.bootstrap .message-item-initial .message-item-initial-body .panel-heading, .lang-fa #content.bootstrap .timeline .timeline-item .timeline-caption .timeline-panel .panel-heading, .lang-fa .bootstrap #dashboard .tooltip-panel-heading, .lang-fa .bootstrap input[type="text"], .lang-fa .bootstrap input[type="search"], .lang-fa .bootstrap input[type="password"], .lang-fa .bootstrap input[type="email"], .lang-fa .bootstrap input[type="tel"], .lang-fa #content.bootstrap input, .lang-fa #content.bootstrap button, .lang-fa #content.bootstrap textarea, .lang-fa #content.bootstrap select {
+  font-family: Vazir,Tahoma,Helvetica,Arial,sans-serif !important;
 }
 .rtl-flip:not(.rtl-no-flip) {
   -moz-transform: scaleX(-1);

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -41,6 +41,11 @@ body.lang-rtl .float-right {
 body.lang-rtl .float-left {
     float: right !important;
 }
+/* Fix dropdown menu text overflow */
+.dropdown-menu.show {
+  right: 0px;
+  left: auto !important;
+}
 /* Fix arrow direction in categories list */
 ul.category-tree .more > .checkbox:before, ul.category-tree .more > .radio:before, .material-choice-tree-container ul.choice-tree .collapsed > .checkbox:before, .material-choice-tree-container ul.choice-tree .collapsed > .radio:before {
   content: "\E5CB";

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -42,7 +42,7 @@ body.lang-rtl .float-left {
     float: right !important;
 }
 /* Fix dropdown menu text overflow */
-.dropdown-menu.show {
+.dropdown-menu[x-placement="bottom-start"].show {
   right: 0px;
   left: auto !important;
 }

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -1,3 +1,80 @@
+/*
+ * Vazir is a Persian/Arabic font
+ * https://github.com/rastikerdar/vazir-font
+ */
+@font-face {
+    font-family: Vazir;
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.eot');
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.eot?#iefix') format('embedded-opentype'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.woff2') format('woff2'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.woff') format('woff'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Regular.ttf') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+@font-face {
+    font-family: Vazir;
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.eot');
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.eot?#iefix') format('embedded-opentype'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.woff2') format('woff2'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.woff') format('woff'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Bold.ttf') format('truetype');
+    font-weight: bold;
+    font-style: normal;
+}
+@font-face {
+    font-family: Vazir;
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.eot');
+    src: url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.eot?#iefix') format('embedded-opentype'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.woff2') format('woff2'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.woff') format('woff'),
+         url('https://cdn.jsdelivr.net/gh/rastikerdar/vazir-font@v30.1.0/dist/Vazir-Light.ttf') format('truetype');
+    font-weight: 300;
+    font-style: normal;
+}
+body.lang-fa, .lang-fa h1, .lang-fa h2, .lang-fa .modal-title, .lang-fa h3, .lang-fa h4, .lang-fa h5, .lang-fa h6, .lang-fa .h1, .lang-fa .h2, .lang-fa .h3, .lang-fa .h4, .lang-fa .h5, .lang-fa .h6, .lang-fa .tooltip, .lang-fa .popover, .lang-fa .module-search-result-title {
+  font-family: Vazir,Tahoma,Helvetica,Arial,sans-serif !important;
+}
+body.lang-rtl .float-right {
+    float: left !important;
+}
+body.lang-rtl .float-left {
+    float: right !important;
+}
+/* Fix arrow direction in categories list */
+ul.category-tree .more > .checkbox:before, ul.category-tree .more > .radio:before, .material-choice-tree-container ul.choice-tree .collapsed > .checkbox:before, .material-choice-tree-container ul.choice-tree .collapsed > .radio:before {
+  content: "\E5CB";
+}
+/* Fix arrow direction for tooltip */
+.popover .arrow {
+  transform: scaleX(1) !important;
+}
+/* Fix menu placement for TinyMCE */
+.mce-window, .mce-menu {
+  right: auto !important;
+  left: 0;
+}
+/* Fix page navigation arrows */
+.page-item.previous.next .page-link:after, .page-item.next.next .page-link:after {
+  content: "\E314";
+}
+.page-item.previous.previous .page-link:after, .page-item.next.previous .page-link:after {
+  content: "\E315";
+}
+/* Fix attributes list in product page */
+#attributes-list .attribute-group .attributes .attribute .js-attribute-checkbox + .attribute-label .pretty-checkbox {
+  float: right !important;
+  margin-left: 0.4375rem;
+  margin-right: 0 !important;
+}
+/* Fix categories list in product page */
+.product-page .category-tree-overflow ul.category-tree .category-tree-inputs {
+  padding: 0 1.25rem 0 0 !important;
+}
+.product-page .category-tree-overflow ul.category-tree ul {
+  padding-left: 0 !important;
+  padding-right: 0.75rem;
+}
 @keyframes showcase-img-appearance-rtl {
   from {
     -webkit-transform: translate(-20px) translateX(-1);

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -41,6 +41,23 @@ body.lang-rtl .float-right {
 body.lang-rtl .float-left {
     float: right !important;
 }
+/* Fix Material Icons mirroring for RTL language */
+.next .material-icons,
+.prev .material-icons,
+.btn-back .material-icons,
+.order-navigation-right .material-icons,
+.order-navigation-left .material-icons,
+.order-preview-content .btn .material-icons,
+.configure-link .material-icons,
+.menu-collapse .material-icons {
+  transform: scaleX(-1);
+}
+/* Fix flexible space for navigation buttons */
+.product-page .combination-form .next,
+.order-navigation {
+  margin-right: auto;
+  margin-left: 0 !important;
+}
 /* Fix dropdown menu text overflow */
 .dropdown-menu[x-placement="bottom-start"].show {
   right: 0px;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixes RTL problems in BO (Arrow directions, TinyMCE menu, Categories list, Attributes list and Page navigation). Upgrade Persian language font-face and matching between legacy and new theme.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26017
| How to test?      | The Admin language for the font-face testing must be set to Persian. Other fixes also are visible in Arabic languages.
| Possible impacts? | -

#### Modifications made:

1. All BO pages has matched font-face for Persian language.
2. BO > Catalog > Categories > Select a category
2.1. The "more" icon in category-list section has correct direction.
3. BO > Catalog > Products > Select a product
3.1. Checkbox in attributes-list section placed in right direction.
3.2. Dropdown menu in TinyMCE editor placed in correct position.
4. BO > Catalog > Products
4.1. Page navigation items (next and previous icons) has correct direction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26147)
<!-- Reviewable:end -->
