### PR TITLE
Fix currency error

### DIFF
--- a/src/Adapter/Currency/CurrencyDataProvider.php
+++ b/src/Adapter/Currency/CurrencyDataProvider.php
@@ -89,7 +89,7 @@ class CurrencyDataProvider implements CurrencyDataProviderInterface
      */
     public function getCurrencyByIsoCode($isoCode, $idLang = null)
     {
-        $currencyId = Currency::getIdByIsoCode($isoCode, 0, false, true);
+        $currencyId = Currency::getIdByIsoCode($isoCode);
         if (!$currencyId) {
             return null;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Do no include deleted currencies. A deleted entry may mess up the currency in 1.7.7.8
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #26181
| How to test?      | Change a currency in an old version of PrestaShop. The shop was migrated from 1.2 -> 1.3 -> 1.4 -> 1.5 -> 1.6 -> 1.7.6 -> 1.7.7.8. E.g. changed the precision to 4. The old (deleted) precision will be used.
| Possible impacts? | It seem this has been changed earlier on. There was an option to include deleted entries but it has been removed. I wonder why the deleted entries were included.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26180)
<!-- Reviewable:end -->
