### PR TITLE
Console command for config

### DIFF
--- a/.github/workflows/phpstan/return-types-for-new-class-methods-rule-exclusion-list.php
+++ b/.github/workflows/phpstan/return-types-for-new-class-methods-rule-exclusion-list.php
@@ -4483,6 +4483,7 @@ $baseline = [
     'PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface::get',
     'PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface::set',
     'PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface::has',
+    'PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface::remove',
     'PrestaShop\PrestaShop\Core\Domain\ValueObject\Email::__construct',
     'PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException::__construct',
     'PrestaShop\PrestaShop\Core\Domain\Order\Payment\ValueObject\OrderPaymentId::__construct',

--- a/.github/workflows/phpstan/type-hint-for-new-class-methods-rule-exclusion-list.php
+++ b/.github/workflows/phpstan/type-hint-for-new-class-methods-rule-exclusion-list.php
@@ -1454,6 +1454,7 @@ $baseline = [
 'PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface::get',
 'PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface::set',
 'PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface::has',
+'PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface::remove',
 'PrestaShop\PrestaShop\Core\Domain\Order\Invoice\ValueObject\OrderInvoiceId::__construct',
 'PrestaShop\PrestaShop\Core\Domain\ValueObject\Email::__construct',
 'PrestaShop\PrestaShop\Core\Domain\ValueObject\Email::assertEmailIsNotEmpty',

--- a/src/Core/Domain/Configuration/ShopConfigurationInterface.php
+++ b/src/Core/Domain/Configuration/ShopConfigurationInterface.php
@@ -58,4 +58,18 @@ interface ShopConfigurationInterface extends ConfigurationInterface
      * @return bool
      */
     public function has($key, ShopConstraint $shopConstraint = null);
+
+    /**
+     * @param string $key
+     *
+     * @return ShopConfigurationInterface
+     */
+    public function remove($key);
+
+    /**
+     * Get all configuration keys
+     *
+     * @return array
+     */
+    public function keys();
 }

--- a/src/PrestaShopBundle/Command/ConfigCommand.php
+++ b/src/PrestaShopBundle/Command/ConfigCommand.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Command;
+
+use Exception;
+use PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider;
+use PrestaShop\PrestaShop\Adapter\LegacyContextLoader;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Validate;
+
+class ConfigCommand extends Command
+{
+    // return values
+    public const STATUS_OK = 0;
+    public const STATUS_INVALID_ACTION = 1;
+    public const STATUS_VALUE_REQUIRED = 2;
+    public const STATUS_FAILED_SET = 3;
+    public const STATUS_FAILED_REMOVE = 4;
+    public const STATUS_INVALID_OPTIONS = 5;
+    public const STATUS_FAILED_SHOPCONSTRAINT = 6;
+    public const STATUS_LANG_REQUIRED = 7;
+    public const STATUS_NOT_IMPLEMENTED = 8;
+    public const STATUS_ERROR = 9;
+
+    private $allowedActions = [
+        'get',
+        'set',
+        'remove',
+    ];
+
+    /**
+     * @var SymfonyStyle
+     */
+    protected $io;
+
+    /**
+     * @var InputInterface
+     */
+    protected $input;
+
+    /**
+     * @var ShopConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
+     * @var LanguageDataProvider
+     */
+    private $languageDataProvider;
+
+    /**
+     * @var string|null
+     */
+    private $action;
+
+    /**
+     * @var int|null
+     */
+    private $idLang;
+
+    public function __construct(
+        LegacyContextLoader $legacyContextLoader,
+        ShopConfigurationInterface $configuration,
+        LanguageDataProvider $languageDataProvider
+    ) {
+        parent::__construct();
+        $legacyContextLoader->loadGenericContext();
+        $this->configuration = $configuration;
+        $this->languageDataProvider = $languageDataProvider;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('prestashop:config')
+            ->setDescription('Manage your configuration via command line')
+            ->addArgument('action', InputArgument::REQUIRED, sprintf('Action to execute (Allowed actions: %s).', implode(' / ', $this->allowedActions)))
+            ->addArgument('key', InputArgument::REQUIRED, 'Configuration key. like PS_LANG_DEFAULT')
+            ->addOption('value', 'val', InputArgument::OPTIONAL, 'value to set', null)
+            ->addOption('lang', 'l', InputArgument::OPTIONAL, 'in this language. this can be either language id or ISO 3166-2 alpha-2 (en, fr, fi...)', null)
+            ->addOption('shopGroupId', 'g', InputArgument::OPTIONAL, 'in this shop group (if no shop group or shop options are given defaults to allShops)', null)
+            ->addOption('shopId', 's', InputArgument::OPTIONAL, 'in this shop (if no shop group or shop options are given defaults to allShops)', null)
+            ;
+    }
+
+    protected function init(): void
+    {
+        // check our action
+        $action = $this->input->getArgument('action');
+        if (!in_array($action, $this->allowedActions)) {
+            $msg = sprintf('Unknown configuration action. It must be one of these values: %s', implode(' / ', $this->allowedActions));
+            throw new Exception($msg, self::STATUS_INVALID_ACTION);
+        }
+
+        $this->action = $action;
+
+        $this->initShopConstraint();
+
+        $this->initLanguage();
+    }
+
+    /**
+     * init possible shopconstraints
+     */
+    private function initShopConstraint(): void
+    {
+        if ($this->input->getOption('shopId') && $this->input->getOption('shopGroupId')) {
+            throw new Exception('Both shopId and shopGroupId cannot be defined', self::STATUS_INVALID_OPTIONS);
+        }
+        // init shopConstraint
+        try {
+            if ($this->input->getOption('shopGroupId')) {
+                $this->shopConstraint = ShopConstraint::shopGroup((int) $this->input->getOption('shopGroupId'));
+            } elseif ($this->input->getOption('shopId')) {
+                $this->shopConstraint = ShopConstraint::shop((int) $this->input->getOption('shopId'));
+            } else {
+                $this->shopConstraint = ShopConstraint::allShops();
+            }
+        } catch (Exception $e) {
+            $msg = sprintf('Failed initializing ShopConstraint: %s', $e->getMessage());
+            throw new Exception($msg, self::STATUS_FAILED_SHOPCONSTRAINT);
+        }
+    }
+
+    /**
+     * initialize language if the option was given
+     */
+    private function initLanguage(): void
+    {
+        $inputlang = $this->input->getOption('lang');
+        if (!$inputlang) {
+            return;
+        }
+
+        // all languages
+        $onlyActive = true;
+        $onlyShopId = null;
+        if (null !== $this->shopConstraint->getShopId()) {
+            $onlyShopId = $this->shopConstraint->getShopId()->getValue();
+        }
+        $languages = $this->languageDataProvider->getLanguages($onlyActive, $onlyShopId);
+
+        $found = current(array_filter($languages, function (array $item) use ($inputlang) {
+            $key = is_numeric($inputlang) ? 'id_lang' : 'iso_code';
+
+            return isset($item[$key]) && $inputlang == $item[$key];
+        }));
+
+        if (!$found) {
+            throw new Exception('Invalid language', self::STATUS_INVALID_OPTIONS);
+        }
+
+        $this->idLang = (int) $found['id_lang'];
+    }
+
+    /**
+     * Get and print out one configuration value
+     */
+    private function get(): void
+    {
+        $key = $this->input->getArgument('key');
+
+        if (!Validate::isConfigName($key)) {
+            throw new Exception('"' . $key . '" is not a valid configuration key', self::STATUS_INVALID_OPTIONS);
+        }
+
+        $value = $this->configuration->get($key, null, $this->shopConstraint);
+
+        // non language values will be just strings
+        // but for language dependant values the response is an array
+        if (is_array($value)) {
+            if (!$this->idLang) {
+                $msg = sprintf('%s is language dependant, --lang option is required', $key);
+                throw new Exception($msg, self::STATUS_LANG_REQUIRED);
+            }
+            $value = $value[$this->idLang];
+        }
+
+        $this->io->success(sprintf('%s=%s', $key, $value));
+    }
+
+    /**
+     * Set and print out one configuration value
+     */
+    private function set(): void
+    {
+        $key = $this->input->getArgument('key');
+
+        if (!Validate::isConfigName($key)) {
+            throw new Exception('"' . $key . '" is not a valid configuration key', self::STATUS_INVALID_OPTIONS);
+        }
+
+        $newvalue = $this->input->getOption('value');
+
+        // new value is required for set
+        if (null === $newvalue) {
+            throw new Exception('Value required for action "set"', self::STATUS_VALUE_REQUIRED);
+        }
+
+        // make the value language array if lang is set
+        if (null !== $this->idLang) {
+            $newvalue = [
+                $this->idLang => $newvalue,
+            ];
+        }
+
+        // set the value
+        try {
+            $this->configuration->set($key, $newvalue, $this->shopConstraint);
+        } catch (Exception $e) {
+            $msg = sprintf('Failed setting value: %s', $e->getMessage());
+            throw new Exception($msg, self::STATUS_FAILED_SET);
+        }
+
+        // and show a result by getting the value which prints it out
+        $this->get();
+    }
+
+    /**
+     * Remove one configuration value
+     */
+    private function remove(): void
+    {
+        $key = $this->input->getArgument('key');
+
+        try {
+            // remove does not support removing only one language, use default
+            // lang if not defined
+            if (!$this->idLang) {
+                $this->idLang = $this->configuration->get('PS_LANG_DEFAULT');
+            }
+            // this will give the user at least some backup
+            $this->get();
+            $this->configuration->remove($key);
+        } catch (Exception $e) {
+            $msg = sprintf('Failed removing: %s. Original message: %s', $key, $e->getMessage());
+            throw new Exception($msg, self::STATUS_FAILED_REMOVE);
+        }
+
+        $this->io->success(sprintf('%s removed', $key));
+    }
+
+    /**
+     * Main execute. Calls the method defined by action
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->io = new SymfonyStyle($input, $output);
+        $this->input = $input;
+
+        try {
+            $this->init();
+            $this->{$this->action}();
+        } catch (Exception $e) {
+            $this->io->error($e->getMessage());
+
+            return $e->getCode();
+        }
+
+        return self::STATUS_OK;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
@@ -53,3 +53,11 @@ services:
       - '@prestashop.adapter.legacy_context_loader'
     tags:
       - 'console.command'
+
+  PrestaShopBundle\Command\ConfigCommand:
+    arguments:
+      - '@prestashop.adapter.legacy_context_loader'
+      - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.data_provider.language'
+    tags:
+      - 'console.command'

--- a/tests/Unit/PrestaShopBundle/Command/ConfigCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/Command/ConfigCommandTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider;
+use PrestaShop\PrestaShop\Adapter\LegacyContextLoader;
+use PrestaShopBundle\Command\ConfigCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ConfigCommandTest extends TestCase
+{
+    public function testGet(): void
+    {
+        $commandTester = $this->getCommandTester();
+
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'get', 'key' => 'CONFIG_TEST']));
+        $this->assertStringContainsString('CONFIG_TEST=', $commandTester->getDisplay());
+
+        // language specific
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'get', 'key' => 'PS_INVOICE_PREFIX', '--lang' => 'en']));
+        $this->assertEquals(ConfigCommand::STATUS_INVALID_OPTIONS, $commandTester->execute(['action' => 'get', 'key' => 'PS_INVOICE_PREFIX', '--lang' => 'fr']));
+        $this->assertStringContainsString('Invalid language', $commandTester->getDisplay());
+        // lang with shop
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'get', 'key' => 'PS_INVOICE_PREFIX', '--lang' => 'en', '--shopId' => '1']));
+
+        // for one shop
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'get', 'key' => 'CONFIG_TEST', '--shopId' => '1']));
+        $this->assertStringContainsString('CONFIG_TEST=', $commandTester->getDisplay());
+
+        // for shop group
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'get', 'key' => 'CONFIG_TEST', '--shopGroupId' => '1']));
+        $this->assertStringContainsString('CONFIG_TEST=', $commandTester->getDisplay());
+
+        // invalid shop / shopgroup / both set
+        $this->assertEquals(ConfigCommand::STATUS_FAILED_SHOPCONSTRAINT, $commandTester->execute(['action' => 'get', 'key' => 'CONFIG_TEST', '--shopId' => '-1']));
+        $this->assertEquals(ConfigCommand::STATUS_FAILED_SHOPCONSTRAINT, $commandTester->execute(['action' => 'get', 'key' => 'CONFIG_TEST', '--shopGroupId' => '-1']));
+        $this->assertEquals(ConfigCommand::STATUS_INVALID_OPTIONS, $commandTester->execute(['action' => 'get', 'key' => 'CONFIG_TEST', '--shopId' => '1', '--shopGroupId' => '1']));
+
+        // invalid key
+        $this->assertEquals(ConfigCommand::STATUS_INVALID_OPTIONS, $commandTester->execute(['action' => 'get', 'key' => 'INVALID KEY AS IT HAS SPACES']));
+        $this->assertStringContainsString('is not a valid configuration key', $commandTester->getDisplay());
+    }
+
+    public function testSet(): void
+    {
+        $commandTester = $this->getCommandTester();
+
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'set', 'key' => 'CONFIG_TEST', '--value' => 'testing']));
+        $this->assertStringContainsString('CONFIG_TEST=', $commandTester->getDisplay());
+
+        // with language
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'set', 'key' => 'CONFIG_TEST', '--value' => 'testing', '--lang' => 'en']));
+        $this->assertStringContainsString('CONFIG_TEST=', $commandTester->getDisplay());
+
+        // missing value
+        $this->assertEquals(ConfigCommand::STATUS_VALUE_REQUIRED, $commandTester->execute(['action' => 'set', 'key' => 'CONFIG_TEST']));
+        $this->assertStringContainsString('Value required', $commandTester->getDisplay());
+
+        // invalid key
+        $this->assertEquals(ConfigCommand::STATUS_INVALID_OPTIONS, $commandTester->execute(['action' => 'set', 'key' => 'INVALID KEY']));
+        $this->assertStringContainsString('is not a valid configuration key', $commandTester->getDisplay());
+    }
+
+    public function testRemove(): void
+    {
+        $commandTester = $this->getCommandTester();
+
+        // remove before set
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'remove', 'key' => 'CONFIG_TEST_TO_BE_REMOVED']));
+
+        // set and remove
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'set', 'key' => 'CONFIG_TEST_TO_BE_REMOVED', '--value' => 'testing']));
+        $this->assertStringContainsString('CONFIG_TEST_TO_BE_REMOVED=', $commandTester->getDisplay());
+        $this->assertEquals(ConfigCommand::STATUS_OK, $commandTester->execute(['action' => 'remove', 'key' => 'CONFIG_TEST_TO_BE_REMOVED']));
+        $this->assertStringContainsString('OK', $commandTester->getDisplay());
+    }
+
+    public function testExceptionsInvalidAction(): void
+    {
+        $commandTester = $this->getCommandTester();
+        $this->assertEquals(ConfigCommand::STATUS_INVALID_ACTION, $commandTester->execute(['action' => 'invalidaction', 'key' => 'CONFIG_TEST']));
+        $this->assertStringContainsString('Unknown configuration action', $commandTester->getDisplay());
+    }
+
+    public function testExceptionsMissingKey(): void
+    {
+        $commandTester = $this->getCommandTester();
+        $this->expectException(\RuntimeException::class);
+        $this->assertEquals(ConfigCommand::STATUS_INVALID_ACTION, $commandTester->execute(['action' => 'get']));
+    }
+
+    public function testExceptionsMissingEverything(): void
+    {
+        $commandTester = $this->getCommandTester();
+
+        $this->expectException(\RuntimeException::class);
+        $commandTester->execute([]);
+    }
+
+    protected function getCommandTester(): CommandTester
+    {
+        $command = new ConfigCommand(
+            $this->mockLegacyContextLoader(),
+            $this->mockConfiguration(),
+            $this->mockLanguageDataProvider()
+        );
+
+        return new CommandTester($command);
+    }
+
+    protected function mockLegacyContextLoader(): LegacyContextLoader
+    {
+        $legacyContextLoaderMock = $this->getMockBuilder(LegacyContextLoader::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $legacyContextLoaderMock;
+    }
+
+    protected function mockConfiguration(): Configuration
+    {
+        $configurationMock = $this->getMockBuilder(Configuration::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $configurationMock;
+    }
+
+    protected function mockLanguageDataProvider(): LanguageDataProvider
+    {
+        $languageDataProviderMock = $this->getMockBuilder(LanguageDataProvider::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $languageDataProviderMock->method('getLanguages')->willReturn($this->getMockLanguageData());
+
+        return $languageDataProviderMock;
+    }
+
+    private function getMockLanguageData(): array
+    {
+        return [
+            0 => [
+                'id_lang' => '1',
+                'name' => 'English (English)',
+                'active' => '1',
+                'iso_code' => 'en',
+                'language_code' => 'en-us',
+                'locale' => 'en-US',
+                'date_format_lite' => 'm/d/Y',
+                'date_format_full' => 'm/d/Y H:i:s',
+                'is_rtl' => '0',
+                'id_shop' => '1',
+                'shops' => [
+                    1 => true,
+                ],
+            ],
+            1 => [
+                'id_lang' => '2',
+                'name' => 'Suomi (Finnish)',
+                'active' => '1',
+                'iso_code' => 'fi',
+                'language_code' => 'fi-fi',
+                'locale' => 'fi-FI',
+                'date_format_lite' => 'Y-m-d',
+                'date_format_full' => 'Y-m-d H:i:s',
+                'is_rtl' => '0',
+                'id_shop' => '1',
+                'shops' => [
+                    1 => true,
+                ],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Adds console command for managing config values `bin/console prestashop:config`
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26211
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | None

This pr adds a new console command for setting up shops configuration values programmatically.

### Examples:

#### Set mailcather smtp settings for dev shop without ever going to bo

```bash
root@4475312d9f82:/var/www/html# bin/console prestashop:config set PS_MAIL_SERVER --value "my-mailcatcher-container-name"
PS_MAIL_SERVER="my-mailcatcher-container-name"
root@4475312d9f82:/var/www/html# bin/console prestashop:config set PS_MAIL_SMTP_PORT --value 1025
PS_MAIL_SMTP_PORT="1025"
```

#### check a setting value
```bash
root@4475312d9f82:/var/www/html# bin/console prestashop:config get PS_LOGS_EMAIL_RECEIVERS
PS_LOGS_EMAIL_RECEIVERS="demo@prestashop.com"
```

#### language support
```bash
root@4475312d9f82:/var/www/html# bin/console prestashop:config get PS_INVOICE_PREFIX
                                                              
  PS_INVOICE_PREFIX is language dependant, language required  
                                                              
root@4475312d9f82:/var/www/html# bin/console prestashop:config get PS_INVOICE_PREFIX --lang en
PS_INVOICE_PREFIX="#IN"
root@4475312d9f82:/var/www/html# bin/console prestashop:config set PS_INVOICE_PREFIX --lang fi --value "#ON"
PS_INVOICE_PREFIX="#ON"
root@4475312d9f82:/var/www/html# bin/console prestashop:config get PS_INVOICE_PREFIX --lang en
PS_INVOICE_PREFIX="#IN"
root@4475312d9f82:/var/www/html# bin/console prestashop:config get PS_INVOICE_PREFIX --lang fi
PS_INVOICE_PREFIX="#ON"
```

### all arguments and options as reported by console --help

```bash
root@4475312d9f82:/var/www/html# bin/console prestashop:config --help
Description:
  Manage your configuration via command line

Usage:
  prestashop:config [options] [--] <action> <key>

Arguments:
  action                         Action to execute (Allowed actions: get / set / delete).
  key                            Configuration key

Options:
  -l, --lang=LANG                in this language. this can be either language id or ISO 3166-2 alpha-2 (en, fr, fi...)
  -g, --shopGroupId=SHOPGROUPID  in this shop group (if no shop group or shop options are given defaults to allShops)
  -s, --shopId=SHOPID            in this shop (if no shop group or shop options are given defaults to allShops)
  -h, --help                     Display this help message
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi                     Force ANSI output
      --no-ansi                  Disable ANSI output
  -n, --no-interaction           Do not ask any interactive question
  -e, --env=ENV                  The Environment name. [default: "dev"]
      --no-debug                 Switches off debug mode.
  -val, --value=VALUE            value to set
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

```

### testing

I'm not sure if console commands can be tested easily? if someone knows please let me know and I can try to add tests also.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26183)
<!-- Reviewable:end -->
