### PR TITLE
Remove useless mod php5 check

### DIFF
--- a/img/.htaccess
+++ b/img/.htaccess
@@ -1,7 +1,3 @@
-<IfModule mod_php5.c>
-    php_flag engine off
-</IfModule>
-
 # Apache 2.2
 <IfModule !mod_authz_core.c>
     Order deny,allow

--- a/upload/.htaccess
+++ b/upload/.htaccess
@@ -2,9 +2,6 @@
     RemoveHandler .php .phtml .php3 .php4 .php5
     RemoveType .php .phtml .php3 .php4 .php5
 </IfModule>
-<IfModule mod_php5.c>
-    php_flag engine off
-</IfModule>
 
 <IfModule mod_headers.c>
   Header set Content-Disposition "Attachment"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The check for apache php mod has no reason to live. First, the php5mod is no longer accepted, then the php_flag will remove the usage of the index.php in these directories. Also, the php_flag / php_admin_flag is only available in apache with php mod, it's not working with FPM
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need QA
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26189)
<!-- Reviewable:end -->
