### PR TITLE
Order addresses by alias on checkout

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -790,7 +790,8 @@ class CustomerCore extends ObjectModel
                         `id_lang` = ' . (int) $idLang . '
                         AND `id_customer` = ' . (int) $this->id . '
                         AND a.`deleted` = 0
-                        AND a.`active` = 1';
+                        AND a.`active` = 1
+                    ORDER BY a.`alias`';
 
         if (null !== $idAddress) {
             $sql .= ' AND a.`id_address` = ' . (int) $idAddress;


### PR DESCRIPTION
Add an order by in the getSimpleAddressSql method, to render addresses ordered by alias

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Versions: 1.7.6, 1.7.7, 1.7.8. <br> Addresses send to checkout step address was not ordered by aliases
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #21437.
| How to test?      | Follow steps from #21437: Make sure you have 2 addresses or more for your customer account. <br> Make an order with the first address. <br> Then do another order, but at the address selection step, edit the first address (used in the last order), push the form, you'll see that the addresses selectors are not reversed. <br>
| Possible impacts? | Addresses will also be ordered in Address listing in My Account


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26200)
<!-- Reviewable:end -->
