### PR TITLE
Repair sorting on block address in customer view

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/customer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.ts
@@ -70,6 +70,7 @@ $(() => {
 
   const customerAddressesGrid = new Grid('customer_address');
   customerAddressesGrid.addExtension(new SubmitRowActionExtension());
+  customerAddressesGrid.addExtension(new SortingExtension());
   customerAddressesGrid.addExtension(new LinkRowActionExtension());
 
   const showcaseCard = new ShowcaseCard('customersShowcaseCard');

--- a/src/Core/Grid/Data/Factory/CustomerAddressGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerAddressGridDataFactoryDecorator.php
@@ -29,8 +29,6 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
-use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
-use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 
 /**
@@ -59,50 +57,10 @@ final class CustomerAddressGridDataFactoryDecorator implements GridDataFactoryIn
     {
         $customerData = $this->customerAddressDoctrineGridDataFactory->getData($searchCriteria);
 
-        $customerRecords = $this->applyModifications($customerData->getRecords());
-
         return new GridData(
-            $customerRecords,
+            $customerData->getRecords(),
             $customerData->getRecordsTotal(),
             $customerData->getQuery()
         );
-    }
-
-    /**
-     * @param RecordCollectionInterface $addresses
-     *
-     * @return RecordCollection
-     */
-    private function applyModifications(RecordCollectionInterface $addresses)
-    {
-        $modifiedAddresses = [];
-
-        foreach ($addresses as $address) {
-            if (empty($address['company'])) {
-                $address['company'] = '--';
-            }
-
-            $address['full_name'] = sprintf('%s %s', $address['firstname'], $address['lastname']);
-
-            $address['full_address'] = sprintf(
-                '%s %s %s %s',
-                $address['address1'],
-                $address['address2'],
-                $address['postcode'],
-                $address['city']
-            );
-
-            if (!empty($address['phone'])) {
-                $address['phone_number'] = $address['phone'];
-            } elseif (!empty($address['phone_mobile'])) {
-                $address['phone_number'] = $address['phone_mobile'];
-            } else {
-                $address['phone_number'] = '--';
-            }
-
-            $modifiedAddresses[] = $address;
-        }
-
-        return new RecordCollection($modifiedAddresses);
     }
 }

--- a/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
@@ -98,7 +98,6 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
                     ->setName($this->trans('Name', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'full_name',
-                        'sortable' => false,
                     ])
             )
             ->add(

--- a/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
@@ -98,6 +98,7 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
                     ->setName($this->trans('Name', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'full_name',
+                        'sortable' => false,
                     ])
             )
             ->add(
@@ -105,6 +106,7 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
                     ->setName($this->trans('Address', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'full_address',
+                        'sortable' => false,
                     ])
             )
             ->add(
@@ -119,6 +121,7 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
                     ->setName($this->trans('Phone number(s)', [], 'Admin.Orderscustomers.Feature'))
                     ->setOptions([
                         'field' => 'phone_number',
+                        'sortable' => false,
                     ])
             )
             ->add((new ActionColumn('actions'))

--- a/src/Core/Grid/Query/CustomerAddressQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerAddressQueryBuilder.php
@@ -80,8 +80,20 @@ final class CustomerAddressQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
 
         $qb
-            ->select('a.`id_address`, a.`firstname`, a.`lastname`, a.`address1`, a.`address2`, a.`postcode`, ' .
-                'a.`city`, a.`company`, a.`phone`, a.`phone_mobile`'
+            ->select(
+                'a.`id_address`,
+                CONCAT(a.`firstname`, " ", a.`lastname`) AS full_name,
+                CONCAT(a.`address1`, " ", a.`address2`, " ", a.`postcode`, " ", a.`city`) AS full_address,
+                IF(
+                  a.`company` IS NULL or a.`company` = "",
+                  "--",
+                  a.`company`
+                ) AS company,
+                IF(
+                  a.`phone` IS NULL or a.`phone` = "",
+                  IF(a.`phone_mobile` IS NULL or a.`phone_mobile` = "", "--",  a.`phone_mobile`),
+                  a.`phone`
+                ) AS phone_number'
             )
             ->addSelect('cl.`name` as country_name')
         ;


### PR DESCRIPTION
Add `SortingExtension`on address grid, then add `CustomerAddressFilters` on viewAction, and finally disable some sort because they are not possible with the generic request

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add `SortingExtension`on address grid, then add `CustomerAddressFilters` on viewAction, and finally disable some sort because they are not possible with the generic request
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes a part of #26149
| How to test?      | To test this, you have to go on Customers > Customers > View a customer and try to filter addresses, with id, name, company or country
| Possible impacts? | No


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26220)
<!-- Reviewable:end -->
