### PR TITLE
Fix SQL query in OrderQueryBuilder

### DIFF
--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -116,13 +116,8 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $qb = $this->getBaseQueryBuilder($searchCriteria->getFilters());
-        if (isset($searchCriteria->getFilters()['new'])) {
-            $this->addNewCustomerField($qb->addSelect('o.id_order as o_id_order'));
-            $qb = $this->applyNewCustomerFilter($qb, $searchCriteria->getFilters());
-            $qb->select('count(o_id_order)');
-        } else {
-            $qb->select('count(o.id_order)');
-        }
+        $qb = $this->applyNewCustomerFilter($qb, $searchCriteria->getFilters());
+        $qb->select('count(o.id_order)');
 
         return $qb;
     }
@@ -233,20 +228,27 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
     }
 
     /**
-     * @param QueryBuilder $qb
+     * return the subquery defining if a customer is new or not
      */
-    private function addNewCustomerField(QueryBuilder $qb)
+    private function getNewCustomerSubSelect(): string
     {
-        $newCustomerSubSelect = $this->connection
+        return $this->connection
             ->createQueryBuilder()
-            ->select('so.id_order')
+            ->select('IF(count(so.id_order) > 0, 0, 1)')
             ->from($this->dbPrefix . 'orders', 'so')
             ->where('so.id_customer = o.id_customer')
             ->andWhere('so.id_order < o.id_order')
             ->setMaxResults(1)
+            ->getSQL()
         ;
+    }
 
-        $qb->addSelect('IF ((' . $newCustomerSubSelect->getSQL() . ') > 0, 0, 1) AS new');
+    /**
+     * @param QueryBuilder $qb
+     */
+    private function addNewCustomerField(QueryBuilder $qb)
+    {
+        $qb->addSelect('(' . $this->getNewCustomerSubSelect() . ') AS new');
     }
 
     /**
@@ -269,11 +271,8 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
             return $qb;
         }
 
-        $builder = $this->connection
-            ->createQueryBuilder()
-            ->select('*')
-            ->from('(' . $qb->getSQL() . ') tmp_table')
-            ->andWhere('new = :new')
+        $builder = $qb
+            ->andWhere('(' . $this->getNewCustomerSubSelect() . ') = :new')
             ->setParameter('new', $filters['new'])
         ;
 

--- a/src/Core/Grid/Query/OrderQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderQueryBuilder.php
@@ -228,7 +228,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
     }
 
     /**
-     * return the subquery defining if a customer is new or not
+     * Returns the subquery defining if a customer is new or not
      */
     private function getNewCustomerSubSelect(): string
     {
@@ -246,7 +246,7 @@ final class OrderQueryBuilder implements DoctrineQueryBuilderInterface
     /**
      * @param QueryBuilder $qb
      */
-    private function addNewCustomerField(QueryBuilder $qb)
+    private function addNewCustomerField(QueryBuilder $qb): void
     {
         $qb->addSelect('(' . $this->getNewCustomerSubSelect() . ') AS new');
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Because of the way the SQL query was made in OrderQueryBuilder, it threw an exception when trying to extend the form. This PR solves the issue by changing the way the SQL query is made.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24911
| How to test?      | See Below
| Possible impacts? | 

### How to test

Create new table `app_order_table` with `id_order`
![image](https://user-images.githubusercontent.com/16067358/138904529-f6c4d729-779d-4beb-85e3-427af06eaab3.png)

Install the module [ps_qualityassurance](https://github.com/PrestaShop/ps_qualityassurance), add two hooks:

`actionOrderGridQueryBuilderModifier` with this content:
```php
$searchQueryBuilder = $params['search_query_builder'];
$countQueryBuilder = $params['count_query_builder'];

    $searchCriteria = $params['search_criteria'];

    $searchQueryBuilder->addSelect(
        'app.`id_order` IS NOT NULL AS `from_app`'
    );

    $searchQueryBuilder->leftJoin(
        'o',
        '`app_order_table`',
        'app',
        'app.`id_order` = o.`id_order`'
    );
	$countQueryBuilder->leftJoin(
        'o',
        '`app_order_table`',
        'app',
        'app.`id_order` = o.`id_order`'
    );

    if ('from_app' === $searchCriteria->getOrderBy()) {
        $searchQueryBuilder->orderBy('app.`id_order`', $searchCriteria->getOrderWay());
    }

    foreach ($searchCriteria->getFilters() as $filterName => $filterValue) {
        if ('from_app' === $filterName) {
            $searchQueryBuilder
              ->andWhere('app.`id_order` IS ' . ($filterValue ? 'NOT' : '') . ' NULL');
          $countQueryBuilder
              ->andWhere('app.`id_order` IS ' . ($filterValue ? 'NOT' : '') . ' NULL');
        }
    }
```

and `actionOrderGridDefinitionModifier` with this content:
```php
$definition = $params['definition'];

    $definition->getColumns()->addAfter(
        'date_add',
        (new PrestaShop\PrestaShop\Core\Grid\Column\Type\BooleanColumn('from_app'))
            ->setName($this->l('App order'))
            ->setOptions([
                'field' => 'from_app',
                'true_name' => $this->trans('Yes', [], 'Admin.Global'),
                'false_name' => $this->trans('No', [], 'Admin.Global'),
                'clickable' => true,
            ])
    );

    $definition->getFilters()->add(
        (new PrestaShop\PrestaShop\Core\Grid\Filter\Filter('from_app', PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType::class))
        ->setTypeOptions([
            'required' => false,
        ])    
        ->setAssociatedColumn('from_app')
    );
```

Now, go on the page Order and try to change the filter `new client`. An exception should happen without this PR.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26221)
<!-- Reviewable:end -->
