### PR TITLE
Be able to instantiate PDF renderer with different language than in Context

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -593,6 +593,7 @@ abstract class PaymentModuleCore extends Module
                             $order_invoice_list = $order->getInvoicesCollection();
                             Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => $order_invoice_list]);
                             $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty, 'P', $orderLanguage);
+                            $file_attachment = [];
                             $file_attachment['content'] = $pdf->render(false);
                             $file_attachment['name'] = Configuration::get('PS_INVOICE_PREFIX', (int) $order->id_lang, null, $order->id_shop) . sprintf('%06d', $order->invoice_number) . '.pdf';
                             $file_attachment['mime'] = 'application/pdf';

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -590,19 +590,14 @@ abstract class PaymentModuleCore extends Module
 
                         // Join PDF invoice
                         if ((int) Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
-                            $currentLanguage = $this->context->language;
-                            $this->context->language = $orderLanguage;
-                            $this->context->getTranslator()->setLocale($orderLanguage->locale);
                             $order_invoice_list = $order->getInvoicesCollection();
                             Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => $order_invoice_list]);
-                            $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty);
-                            $file_attachement['content'] = $pdf->render(false);
-                            $file_attachement['name'] = Configuration::get('PS_INVOICE_PREFIX', (int) $order->id_lang, null, $order->id_shop) . sprintf('%06d', $order->invoice_number) . '.pdf';
-                            $file_attachement['mime'] = 'application/pdf';
-                            $this->context->language = $currentLanguage;
-                            $this->context->getTranslator()->setLocale($currentLanguage->locale);
+                            $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty, 'P', $orderLanguage);
+                            $file_attachment['content'] = $pdf->render(false);
+                            $file_attachment['name'] = Configuration::get('PS_INVOICE_PREFIX', (int) $order->id_lang, null, $order->id_shop) . sprintf('%06d', $order->invoice_number) . '.pdf';
+                            $file_attachment['mime'] = 'application/pdf';
                         } else {
-                            $file_attachement = null;
+                            $file_attachment = null;
                         }
 
                         if (self::DEBUG_MODE) {
@@ -685,7 +680,7 @@ abstract class PaymentModuleCore extends Module
                                 $this->context->customer->firstname . ' ' . $this->context->customer->lastname,
                                 null,
                                 null,
-                                $file_attachement,
+                                $file_attachment,
                                 null,
                                 _PS_MAIL_DIR_,
                                 false,

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -72,7 +72,7 @@ class PDFCore
      * @param string $orientation
      * @param Language $language
      */
-    public function __construct($objects, $template, $smarty, $orientation = 'P', $language = null)
+    public function __construct($objects, $template, $smarty, $orientation = 'P', Language $language = null)
     {
         $this->pdf_renderer = new PDFGenerator((bool) Configuration::get('PS_PDF_USE_CACHE'), $orientation, $language);
         $this->template = $template;

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -70,6 +70,7 @@ class PDFCore
      * @param string $template
      * @param Smarty $smarty
      * @param string $orientation
+     * @param Language $language
      */
     public function __construct($objects, $template, $smarty, $orientation = 'P', $language = null)
     {

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -71,9 +71,9 @@ class PDFCore
      * @param Smarty $smarty
      * @param string $orientation
      */
-    public function __construct($objects, $template, $smarty, $orientation = 'P')
+    public function __construct($objects, $template, $smarty, $orientation = 'P', $language = null)
     {
-        $this->pdf_renderer = new PDFGenerator((bool) Configuration::get('PS_PDF_USE_CACHE'), $orientation);
+        $this->pdf_renderer = new PDFGenerator((bool) Configuration::get('PS_PDF_USE_CACHE'), $orientation, $language);
         $this->template = $template;
 
         /*
@@ -129,7 +129,6 @@ class PDFCore
     public function render($display = true)
     {
         $render = false;
-        $this->pdf_renderer->setFontForLang(Context::getContext()->language->iso_code);
         foreach ($this->objects as $object) {
             $this->pdf_renderer->startPageGroup();
             $template = $this->getTemplateObject($object);

--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -98,7 +98,7 @@ class PDFGeneratorCore extends TCPDF
      * @param string $orientation
      * @param Language $language
      */
-    public function __construct($use_cache = false, $orientation = 'P', $language = null)
+    public function __construct($use_cache = false, $orientation = 'P', Language $language = null)
     {
         parent::__construct($orientation, 'mm', 'A4', true, 'UTF-8', $use_cache, false);
         if ($language === null) {

--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -96,6 +96,7 @@ class PDFGeneratorCore extends TCPDF
     /**
      * @param bool $use_cache
      * @param string $orientation
+     * @param Language $language
      */
     public function __construct($use_cache = false, $orientation = 'P', $language = null)
     {

--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -97,10 +97,14 @@ class PDFGeneratorCore extends TCPDF
      * @param bool $use_cache
      * @param string $orientation
      */
-    public function __construct($use_cache = false, $orientation = 'P')
+    public function __construct($use_cache = false, $orientation = 'P', $language = null)
     {
         parent::__construct($orientation, 'mm', 'A4', true, 'UTF-8', $use_cache, false);
-        $this->setRTL(Context::getContext()->language->is_rtl);
+        if ($language === null) {
+            $language = Context::getContext()->language;
+        }
+        $this->setRTL($language->is_rtl);
+        $this->setFontForLang($language->iso_code);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There was some smelly code that switched context language to generate a PDF. You can now generate PDFs in desired language configuration, if it's missing, it will still take the context config.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | Yes, for overrides - If somebody overrides PDFGenerator and does not have the third parameter in constructor.
| Deprecations?     | no
| Fixed ticket?     | - 
| How to test?      | Make an order and see that PDF generates fine.
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26234)
<!-- Reviewable:end -->
