### PR TITLE
Move dashboard right column elements into a hook

### DIFF
--- a/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
@@ -87,34 +87,8 @@
 		<div class="col-md-4 col-lg-3" id="hookDashboardZoneOne">
 			{$hookDashboardZoneOne}
 		</div>
-		<div class="col-md-8 col-lg-7" id="hookDashboardZoneTwo">
+		<div class="col-md-8 col-lg-9" id="hookDashboardZoneTwo">
 			{$hookDashboardZoneTwo}
-			<div id="dashaddons" class="row-margin-bottom">
-				<a href="https://addons.prestashop.com/en/209-dashboards?utm_source=back-office&amp;utm_medium=dashboard&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" target="_blank" rel="noopener noreferrer nofollow">
-					<i class="icon-plus"></i> {l s='Add more dashboard modules' d='Admin.Dashboard.Feature'}
-				</a>
-			</div>
-		</div>
-		<div class="col-md-12 col-lg-2">
-			<section class="dash_news panel">
-				<h3><i class="icon-rss"></i> {l s='PrestaShop News' d='Admin.Dashboard.Feature'}</h3>
-				<div class="dash_news_content"></div>
-				<div class="text-center"><h4><a href="http://www.prestashop.com/blog/" onclick="return !window.open(this.href);">{l s='Find more news' d='Admin.Dashboard.Feature'}</a></h4></div>
-			</section>
-			<section id="dash_version" class="visible-lg">
-				<iframe style="overflow:hidden;border:none" src="{$new_version_url|escape:'html':'UTF-8'}" ></iframe>
-			</section>
-			<section class="dash_links panel">
-				<h3><i class="icon-link"></i> {l s="We stay by your side!" d='Admin.Dashboard.Feature'}</h3>
-					<dl>
-						<dt><a href="{$help_center_link}" target="_blank" rel="noopener noreferrer nofollow">{l s="Help Center" d='Admin.Global'}</a></dt>
-						<dd>{l s="Documentation, support, experts, training... PrestaShop and all of its community are here to guide you" d='Admin.Dashboard.Feature'}</dd>
-					</dl>
-					<dl>
-						<dt><a href="https://addons.prestashop.com?utm_source=back-office&amp;utm_medium=links&amp;utm_campaign=addons-{$lang_iso}&amp;utm_content=download17" target="_blank" rel="noopener noreferrer nofollow">{l s="PrestaShop Marketplace" d='Admin.Dashboard.Feature'}</a></dt>
-						<dd>{l s="Traffic, conversion rate, customer loyalty... Increase your sales with all of the PrestaShop modules and themes" d='Admin.Dashboard.Feature'}</dd>
-					</dl>
-			</section>
 		</div>
 	</div>
 </div>

--- a/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/dashboard/helpers/view/view.tpl
@@ -87,8 +87,13 @@
 		<div class="col-md-4 col-lg-3" id="hookDashboardZoneOne">
 			{$hookDashboardZoneOne}
 		</div>
-		<div class="col-md-8 col-lg-9" id="hookDashboardZoneTwo">
+		<div class="col-md-8 col-lg-{if $hookDashboardZoneThree}7{else}9{/if}" id="hookDashboardZoneTwo">
 			{$hookDashboardZoneTwo}
 		</div>
+    {if $hookDashboardZoneThree}
+      <div class="col-md-12 col-lg-2" id="hookDashboardZoneThree">
+          {$hookDashboardZoneThree}
+      </div>
+    {/if}
 	</div>
 </div>

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -299,6 +299,7 @@ class AdminDashboardControllerCore extends AdminController
             'date_to' => $this->context->employee->stats_date_to,
             'hookDashboardZoneOne' => Hook::exec('dashboardZoneOne', $params),
             'hookDashboardZoneTwo' => Hook::exec('dashboardZoneTwo', $params),
+            'hookDashboardZoneThree' => Hook::exec('dashboardZoneThree', $params),
             'action' => '#',
             'warning' => $this->getWarningDomainName(),
             'dashboard_use_push' => Configuration::get('PS_DASHBOARD_USE_PUSH'),

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -23,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 
 class AdminDashboardControllerCore extends AdminController
 {

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -23,7 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
 class AdminDashboardControllerCore extends AdminController
 {
     public function __construct()

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -294,9 +294,6 @@ class AdminDashboardControllerCore extends AdminController
             'date_to' => $this->context->employee->stats_date_to,
         ];
 
-        $moduleManagerBuilder = ModuleManagerBuilder::getInstance();
-        $moduleManager = $moduleManagerBuilder->build();
-
         $this->tpl_view_vars = [
             'date_from' => $this->context->employee->stats_date_from,
             'date_to' => $this->context->employee->stats_date_to,
@@ -304,14 +301,12 @@ class AdminDashboardControllerCore extends AdminController
             'hookDashboardZoneTwo' => Hook::exec('dashboardZoneTwo', $params),
             'action' => '#',
             'warning' => $this->getWarningDomainName(),
-            'new_version_url' => Tools::getCurrentUrlProtocolPrefix() . _PS_API_DOMAIN_ . '/version/check_version.php?v=' . _PS_VERSION_ . '&lang=' . $this->context->language->iso_code . '&autoupgrade=' . (int) ($moduleManager->isInstalled('autoupgrade') && $moduleManager->isEnabled('autoupgrade')) . '&hosted_mode=' . (int) defined('_PS_HOST_MODE_'),
             'dashboard_use_push' => Configuration::get('PS_DASHBOARD_USE_PUSH'),
             'calendar' => $calendar_helper->generate(),
             'PS_DASHBOARD_SIMULATION' => Configuration::get('PS_DASHBOARD_SIMULATION'),
             'datepickerFrom' => Tools::getValue('datepickerFrom', $this->context->employee->stats_date_from),
             'datepickerTo' => Tools::getValue('datepickerTo', $this->context->employee->stats_date_to),
             'preselect_date_range' => Tools::getValue('preselectDateRange', $this->context->employee->preselect_date_range),
-            'help_center_link' => $this->getHelpCenterLink($this->context->language->iso_code),
         ];
 
         return parent::renderView();
@@ -476,28 +471,5 @@ class AdminDashboardControllerCore extends AdminController
         }
 
         die(json_encode($return));
-    }
-
-    /**
-     * Returns the Help center link for the provided locale
-     *
-     * @param string $languageCode 2-letter locale code
-     *
-     * @return string
-     */
-    private function getHelpCenterLink($languageCode)
-    {
-        $links = [
-            'fr' => 'https://www.prestashop.com/fr/contact?utm_source=back-office&utm_medium=links&utm_campaign=help-center-fr&utm_content=download17',
-            'en' => 'https://www.prestashop.com/en/contact?utm_source=back-office&utm_medium=links&utm_campaign=help-center-en&utm_content=download17',
-            'es' => 'https://www.prestashop.com/es/contacto?utm_source=back-office&utm_medium=links&utm_campaign=help-center-es&utm_content=download17',
-            'de' => 'https://www.prestashop.com/de/kontakt?utm_source=back-office&utm_medium=links&utm_campaign=help-center-de&utm_content=download17',
-            'it' => 'https://www.prestashop.com/it/contatti?utm_source=back-office&utm_medium=links&utm_campaign=help-center-it&utm_content=download17',
-            'nl' => 'https://www.prestashop.com/nl/contacteer-ons?utm_source=back-office&utm_medium=links&utm_campaign=help-center-nl&utm_content=download17',
-            'pt' => 'https://www.prestashop.com/pt/contato?utm_source=back-office&utm_medium=links&utm_campaign=help-center-pt&utm_content=download17',
-            'pl' => 'https://www.prestashop.com/pl/kontakt?utm_source=back-office&utm_medium=links&utm_campaign=help-center-pl&utm_content=download17',
-        ];
-
-        return isset($links[$languageCode]) ? $links[$languageCode] : $links['en'];
     }
 }

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3525,5 +3525,10 @@
       <title>Payment options Presenter</title>
       <description>This hook is called before payment options are presented</description>
     </hook>
+    <hook id="dashboardZoneThree">
+      <name>dashboardZoneThree</name>
+      <title>Dashboard column three</title>
+      <description>This hook is displayed in the third column of the dashboard</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Replace data and links to addons on the Dashboard by hook that can display a third column.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25030 
| How to test?      | In the dashboard, right column and link at the bottom of the middle column should be deleted. If `ps_mbo` of this [PR](https://github.com/PrestaShopCorp/ps_mbo/pull/114) is installed, they must be back again.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26239)
<!-- Reviewable:end -->
