### PR TITLE
Disable sorting on customer discount vouchers

### DIFF
--- a/src/Core/Grid/Definition/Factory/CustomerDiscountGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerDiscountGridDefinitionFactory.php
@@ -72,6 +72,7 @@ final class CustomerDiscountGridDefinitionFactory extends AbstractGridDefinition
                     ->setName($this->trans('ID', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'id_cart_rule',
+                        'sortable' => false,
                     ])
             )
             ->add(
@@ -79,6 +80,7 @@ final class CustomerDiscountGridDefinitionFactory extends AbstractGridDefinition
                     ->setName($this->trans('Code', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'code',
+                        'sortable' => false,
                     ])
             )
             ->add(
@@ -86,6 +88,7 @@ final class CustomerDiscountGridDefinitionFactory extends AbstractGridDefinition
                     ->setName($this->trans('Name', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'name',
+                        'sortable' => false,
                     ])
             )
             ->add(
@@ -93,6 +96,7 @@ final class CustomerDiscountGridDefinitionFactory extends AbstractGridDefinition
                     ->setName($this->trans('Status', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'active',
+                        'sortable' => false,
                     ])
             )
             ->add(
@@ -100,6 +104,7 @@ final class CustomerDiscountGridDefinitionFactory extends AbstractGridDefinition
                     ->setName($this->trans('Qty available', [], 'Admin.Orderscustomers.Feature'))
                     ->setOptions([
                         'field' => 'quantity',
+                        'sortable' => false,
                     ])
             )
             ->add((new ActionColumn('actions'))


### PR DESCRIPTION
Disable sorting on customer discount vouchers, by adding in all fields `sortable` to false in `CustomerDiscountGridDefinitionFactory`

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Disable sorting on customer discount vouchers, by adding in all fields `sortable` to false in `CustomerDiscountGridDefinitionFactory`
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes a part of #26149
| How to test?      | To test this, you have to go on Customers > Customers > View a customer and see you can't sort the `Vouchers` table
| Possible impacts? | No


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26241)
<!-- Reviewable:end -->
