### PR TITLE
Respect display_taxes_label in ps_shoppingcart classic theme template

### DIFF
--- a/themes/classic/modules/ps_shoppingcart/modal.tpl
+++ b/themes/classic/modules/ps_shoppingcart/modal.tpl
@@ -77,10 +77,10 @@
               {/if}
 
               {if !$configuration.display_prices_tax_incl && $configuration.taxes_enabled}
-                <p><span>{$cart.totals.total.label}&nbsp;{$cart.labels.tax_short}</span>&nbsp;<span>{$cart.totals.total.value}</span></p>
+                <p><span>{$cart.totals.total.label}{if $configuration.display_taxes_label}&nbsp;{$cart.labels.tax_short}{/if}</span>&nbsp;<span>{$cart.totals.total.value}</span></p>
                 <p class="product-total"><span class="label">{$cart.totals.total_including_tax.label}</span>&nbsp;<span class="value">{$cart.totals.total_including_tax.value}</span></p>
               {else}
-                <p class="product-total"><span class="label">{$cart.totals.total.label}&nbsp;{if $configuration.taxes_enabled}{$cart.labels.tax_short}{/if}</span>&nbsp;<span class="value">{$cart.totals.total.value}</span></p>
+                <p class="product-total"><span class="label">{$cart.totals.total.label}&nbsp;{if $configuration.taxes_enabled && $configuration.display_taxes_label}{$cart.labels.tax_short}{/if}</span>&nbsp;<span class="value">{$cart.totals.total.value}</span></p>
               {/if}
 
               {if $cart.subtotals.tax}


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | respect display_taxes_label in the modal view of ps_shoppingcart. The modal template is overwritten in classic theme so this fixes the classic theme. Looks like the original modal doesn't even show the taxes label so it is actually not affected.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26236.
| How to test?      | BO>Locations>Countries>Edit countries<br />Display tax label (e.g. "Tax incl.") > No<br />FO>product page>Add to the cart<br />Check that the "inc tax" text is not shown on the Total row.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26242)
<!-- Reviewable:end -->
