### PR TITLE
Add actionPresentPaymentOptions hook

### DIFF
--- a/classes/checkout/PaymentOptionsFinder.php
+++ b/classes/checkout/PaymentOptionsFinder.php
@@ -81,7 +81,7 @@ class PaymentOptionsFinderCore extends HookFinder
 
         $find = $free ? $this->findFree() : $this->find();
 
-        return array_map(function (array $options) use (&$id) {
+        $paymentOptions = array_map(function (array $options) use (&$id) {
             return array_map(function (PaymentOption $option) use (&$id) {
                 ++$id;
                 $formattedOption = $option->toArray();
@@ -98,5 +98,11 @@ class PaymentOptionsFinderCore extends HookFinder
                 return $formattedOption;
             }, $options);
         }, $find);
+
+        Hook::exec('actionPresentPaymentOptions',
+            ['paymentOptions' => &$paymentOptions]
+        );
+
+        return $paymentOptions;
     }
 }

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3520,5 +3520,10 @@
       <title>Cart summary top</title>
       <description>This hook allows you to display new elements in top of cart summary</description>
     </hook>
+    <hook id="actionPresentPaymentOptions">
+      <name>actionPresentPaymentOptions</name>
+      <title>Payment options Presenter</title>
+      <description>This hook is called before payment options are presented</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/upgrade/sql/1.7.9.0.sql
+++ b/install-dev/upgrade/sql/1.7.9.0.sql
@@ -10,5 +10,6 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionValidateOrderAfter', 'New Order', 'This hook is called after validating an order by core', '1'),
   (NULL, 'actionAdminOrdersTrackingNumberUpdate', 'After setting the tracking number for the order', 'This hook allows you to execute code after the unique tracking number for the order was added', '1'),
-  (NULL, 'displayBackOfficeEmployeeMenu', 'Administration menu', 'This hook is displayed in the employee menu', '1')
+  (NULL, 'displayBackOfficeEmployeeMenu', 'Administration menu', 'This hook is displayed in the employee menu', '1'),
+  (NULL, 'actionPresentPaymentOptions', 'Payment options Presenter', 'This hook is called before payment options are presented', '1')
 ;

--- a/install-dev/upgrade/sql/1.7.9.0.sql
+++ b/install-dev/upgrade/sql/1.7.9.0.sql
@@ -10,6 +10,5 @@ INSERT INTO `PREFIX_configuration` (`name`, `value`, `date_add`, `date_upd`) VAL
 INSERT IGNORE INTO `PREFIX_hook` (`id_hook`, `name`, `title`, `description`, `position`) VALUES
   (NULL, 'actionValidateOrderAfter', 'New Order', 'This hook is called after validating an order by core', '1'),
   (NULL, 'actionAdminOrdersTrackingNumberUpdate', 'After setting the tracking number for the order', 'This hook allows you to execute code after the unique tracking number for the order was added', '1'),
-  (NULL, 'displayBackOfficeEmployeeMenu', 'Administration menu', 'This hook is displayed in the employee menu', '1'),
-  (NULL, 'actionPresentPaymentOptions', 'Payment options Presenter', 'This hook is called before payment options are presented', '1')
+  (NULL, 'displayBackOfficeEmployeeMenu', 'Administration menu', 'This hook is displayed in the employee menu', '1')
 ;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add the actionPresentPaymentOptions like other presenter (Cart, Product, Order, ...).
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You can have a module hooked on actionPresentPaymentOptions and see that params having the $paymentOptions array in it.
| Possible impacts? | Nothing, it will just add possibility to unset some payments methods by a module.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26259)
<!-- Reviewable:end -->
