### PR TITLE
Trigger a deprecated when using a hook alias and correctly handle errors

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -79,16 +79,6 @@ class HookCore extends ObjectModel
     ];
 
     /**
-     * @deprecated 1.5.0
-     */
-    protected static $_hook_modules_cache = null;
-
-    /**
-     * @deprecated 1.5.0
-     */
-    protected static $_hook_modules_cache_exec = null;
-
-    /**
      * List of all deprecated hooks.
      *
      * @var array
@@ -243,25 +233,6 @@ class HookCore extends ObjectModel
         }
 
         return Cache::retrieve($cache_id);
-    }
-
-    /**
-     * Returns a list of hook names, indexed by lower case alias.
-     *
-     * @since 1.5.0
-     *
-     * @return array Array of hookAlias => hookName
-     *
-     * @deprecated Since 1.7.1.0
-     */
-    public static function getHookAliasList()
-    {
-        @trigger_error(
-            __FUNCTION__ . ' is deprecated since version 1.7.1.0.',
-            E_USER_DEPRECATED
-        );
-
-        return static::getCanonicalHookNames();
     }
 
     /**
@@ -443,38 +414,6 @@ class HookCore extends ObjectModel
     }
 
     /**
-     * This function exists for retro compatibility only. Do not use!
-     *
-     * - If the provided hook name is an alias, it returns the canonical name of the aliased hook.
-     * - If the hook name is not an alias, but it has a know alias, then it will return that.
-     * - If the hook does not have an alias, it will return an empty string.
-     *
-     * @since 1.5.0
-     *
-     * @param string $hookName Hook name
-     *
-     * @return int|string Hook ID
-     *
-     * @deprecated 1.7.1.0
-     */
-    public static function getRetroHookName($hookName)
-    {
-        $hookNamesByAlias = static::getCanonicalHookNames();
-        if (isset($hookNamesByAlias[strtolower($hookName)])) {
-            // return the canonical name (?)
-            return $hookNamesByAlias[strtolower($hookName)];
-        }
-
-        $alias = array_search($hookName, $hookNamesByAlias);
-        if ($alias === false) {
-            return '';
-        }
-
-        // return the alias
-        return $alias;
-    }
-
-    /**
      * Get list of all registered hooks with modules, indexed by hook id and module id
      *
      * @since 1.5.0
@@ -513,9 +452,6 @@ class HookCore extends ObjectModel
             ];
         }
         Cache::store($cache_id, $list);
-
-        // @todo remove this in 1.6, we keep it in 1.5 for retrocompatibility
-        Hook::$_hook_modules_cache = $list;
 
         return $list;
     }
@@ -731,10 +667,13 @@ class HookCore extends ObjectModel
 
         // add modules that are registered to aliases of this hook
         $aliases = Hook::getHookAliasesFor($hookName);
+
         if (!empty($aliases)) {
             $alreadyIncludedModuleIds = array_column($modulesToInvoke, 'id_module');
+
             foreach ($aliases as $alias) {
                 $hookAlias = strtolower($alias);
+
                 if (isset($allHookRegistrations[$hookAlias])) {
                     foreach ($allHookRegistrations[$hookAlias] as $registeredAlias) {
                         if (!in_array($registeredAlias['id_module'], $alreadyIncludedModuleIds)) {
@@ -820,11 +759,6 @@ class HookCore extends ObjectModel
             return ($array_return) ? [] : false;
         }
 
-        if (array_key_exists($hook_name, static::$deprecated_hooks)) {
-            $deprecVersion = static::$deprecated_hooks[$hook_name]['from'] ?? _PS_VERSION_;
-            Tools::displayAsDeprecated('The hook ' . $hook_name . ' is deprecated in PrestaShop v.' . $deprecVersion);
-        }
-
         // Store list of executed hooks on this page
         Hook::$executed_hooks[$id_hook] = $hook_name;
 
@@ -873,6 +807,15 @@ class HookCore extends ObjectModel
             } else {
                 // the module is registered to an alias
                 $registeredHookName = static::getNameById($hookRegistration['id_hook']);
+                trigger_error(
+                    sprintf(
+                        'The hook "%s" is deprecated, please use "%s" instead in module "%s".',
+                        $registeredHookName,
+                        $hook_name,
+                        $hookRegistration['module']
+                    ),
+                    E_USER_DEPRECATED
+                );
             }
 
             // Check permissions
@@ -1199,8 +1142,6 @@ class HookCore extends ObjectModel
 
         if ($useCache) {
             Cache::store($cache_id, $allHookRegistrations);
-            // @todo remove this in 1.6, we keep it in 1.5 for backward compatibility
-            static::$_hook_modules_cache_exec = $allHookRegistrations;
         }
 
         return $allHookRegistrations;

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -188,7 +188,7 @@ abstract class ControllerCore
         );
 
         /* @phpstan-ignore-next-line */
-        if (_PS_MODE_DEV_ && $this->controller_type == 'admin') {
+        if (_PS_MODE_DEV_ && $this->controller_type == 'admin' && !($this instanceof AdminLegacyLayoutControllerCore)) {
             set_error_handler([__CLASS__, 'myErrorHandler']);
         }
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -28,7 +28,6 @@ use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
-use Symfony\Component\Debug\Debug;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\IpUtils;
 
@@ -301,9 +300,6 @@ class FrontControllerCore extends Controller
         self::$initialized = true;
 
         parent::init();
-
-        // enable Symfony error handler if debug mode enabled
-        $this->initDebugguer();
 
         // If current URL use SSL, set it true (used a lot for module redirect)
         if (Tools::usingSecureMode()) {
@@ -1982,13 +1978,6 @@ class FrontControllerCore extends Controller
         $form->setAction($this->getCurrentURL());
 
         return $form;
-    }
-
-    private function initDebugguer()
-    {
-        if (true === _PS_MODE_DEV_) {
-            Debug::enable();
-        }
     }
 
     /**

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2436,9 +2436,7 @@ abstract class ModuleCore implements ModuleInterface
             return Hook::isDisplayHookName($hook_name);
         }
 
-        $retro_hook_name = Hook::getRetroHookName($hook_name);
-
-        return is_callable([$this, 'hook' . ucfirst($hook_name)]) || is_callable([$this, 'hook' . ucfirst($retro_hook_name)]);
+        return is_callable([$this, 'hook' . ucfirst($hook_name)]);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -194,7 +194,7 @@
         "git-hook-install": "@php .github/contrib/install.php",
         "git-hook-uninstall": "@php .github/contrib/uninstall.php",
         "integration-behaviour-tests": [
-            "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml  --format progress --no-snippets --strict"
+            "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml --format progress --no-snippets --strict"
         ],
         "integration-tests": [
             "@composer create-test-db",

--- a/composer.lock
+++ b/composer.lock
@@ -5508,16 +5508,16 @@
         },
         {
             "name": "prestashop/pagesnotfound",
-            "version": "v2.0.0",
+            "version": "v2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/pagesnotfound.git",
-                "reference": "8707d8184f0c6678a95c64b957aec6053ed069ef"
+                "reference": "b0a8ebdbf733128b6cf0454c41ea2a6edfa4c0cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/pagesnotfound/zipball/8707d8184f0c6678a95c64b957aec6053ed069ef",
-                "reference": "8707d8184f0c6678a95c64b957aec6053ed069ef",
+                "url": "https://api.github.com/repos/PrestaShop/pagesnotfound/zipball/b0a8ebdbf733128b6cf0454c41ea2a6edfa4c0cc",
+                "reference": "b0a8ebdbf733128b6cf0454c41ea2a6edfa4c0cc",
                 "shasum": ""
             },
             "require": {
@@ -5526,7 +5526,7 @@
             "type": "prestashop-module",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "AFL - Academic Free License (AFL 3.0)"
+                "AFL-3.0"
             ],
             "authors": [
                 {
@@ -5537,9 +5537,9 @@
             "description": "PrestaShop module pagesnotfound",
             "homepage": "https://github.com/PrestaShop/pagesnotfound",
             "support": {
-                "source": "https://github.com/PrestaShop/pagesnotfound/tree/dev"
+                "source": "https://github.com/PrestaShop/pagesnotfound/tree/v2.0.1"
             },
-            "time": "2017-02-20T11:14:52+00:00"
+            "time": "2021-12-15T08:48:59+00:00"
         },
         {
             "name": "prestashop/php-dev-tools",
@@ -6589,16 +6589,16 @@
         },
         {
             "name": "prestashop/ps_shoppingcart",
-            "version": "v2.0.4",
+            "version": "v2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_shoppingcart.git",
-                "reference": "b168cfcaf15724a17d7bbc862b2347730f79daa4"
+                "reference": "114e39589e84536af46cc344e05c0e8bc37355e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_shoppingcart/zipball/b168cfcaf15724a17d7bbc862b2347730f79daa4",
-                "reference": "b168cfcaf15724a17d7bbc862b2347730f79daa4",
+                "url": "https://api.github.com/repos/PrestaShop/ps_shoppingcart/zipball/114e39589e84536af46cc344e05c0e8bc37355e3",
+                "reference": "114e39589e84536af46cc344e05c0e8bc37355e3",
                 "shasum": ""
             },
             "require": {
@@ -6627,9 +6627,9 @@
             "description": "PrestaShop module ps_shoppingcart",
             "homepage": "https://github.com/PrestaShop/ps_shoppingcart",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_shoppingcart/tree/v2.0.4"
+                "source": "https://github.com/PrestaShop/ps_shoppingcart/tree/v2.0.5"
             },
-            "time": "2021-01-07T15:52:21+00:00"
+            "time": "2021-12-15T08:46:24+00:00"
         },
         {
             "name": "prestashop/ps_socialfollow",
@@ -6786,16 +6786,16 @@
         },
         {
             "name": "prestashop/ps_viewedproduct",
-            "version": "v1.2.1",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_viewedproduct.git",
-                "reference": "1a7078c46d423414b9d703daea15a0f6fd8268b0"
+                "reference": "2ea78388b13a49c18ce409870f32a44e88934456"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_viewedproduct/zipball/1a7078c46d423414b9d703daea15a0f6fd8268b0",
-                "reference": "1a7078c46d423414b9d703daea15a0f6fd8268b0",
+                "url": "https://api.github.com/repos/PrestaShop/ps_viewedproduct/zipball/2ea78388b13a49c18ce409870f32a44e88934456",
+                "reference": "2ea78388b13a49c18ce409870f32a44e88934456",
                 "shasum": ""
             },
             "require": {
@@ -6804,7 +6804,7 @@
             "type": "prestashop-module",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "AFL - Academic Free License (AFL 3.0)"
+                "AFL-3.0"
             ],
             "authors": [
                 {
@@ -6815,9 +6815,9 @@
             "description": "PrestaShop - Viewed Products",
             "homepage": "https://github.com/PrestaShop/ps_viewedproduct",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_viewedproduct/tree/master"
+                "source": "https://github.com/PrestaShop/ps_viewedproduct/tree/v1.2.2"
             },
-            "time": "2019-02-06T10:45:05+00:00"
+            "time": "2021-10-26T14:04:09+00:00"
         },
         {
             "name": "prestashop/ps_wirepayment",

--- a/composer.lock
+++ b/composer.lock
@@ -6276,22 +6276,31 @@
         },
         {
             "name": "prestashop/ps_featuredproducts",
-            "version": "v2.1.0",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_featuredproducts.git",
-                "reference": "a175279ce8fce9669fa1b22c5a13be86c4c1c334"
+                "reference": "693d106181eaaea14358ad035fe7166106b9a1a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_featuredproducts/zipball/a175279ce8fce9669fa1b22c5a13be86c4c1c334",
-                "reference": "a175279ce8fce9669fa1b22c5a13be86c4c1c334",
+                "url": "https://api.github.com/repos/PrestaShop/ps_featuredproducts/zipball/693d106181eaaea14358ad035fe7166106b9a1a4",
+                "reference": "693d106181eaaea14358ad035fe7166106b9a1a4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
+            "require-dev": {
+                "prestashop/php-dev-tools": "^3.4"
+            },
             "type": "prestashop-module",
+            "autoload": {
+                "classmap": [
+                    "ps_featuredproducts.php"
+                ],
+                "exclude-from-classmap": []
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "AFL-3.0"
@@ -6305,9 +6314,9 @@
             "description": "PrestaShop - Featured products",
             "homepage": "https://github.com/PrestaShop/ps_featuredproducts",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_featuredproducts/tree/v2.1.0"
+                "source": "https://github.com/PrestaShop/ps_featuredproducts/tree/v2.1.1"
             },
-            "time": "2020-07-22T16:21:40+00:00"
+            "time": "2021-12-10T13:44:29+00:00"
         },
         {
             "name": "prestashop/ps_imageslider",
@@ -12533,5 +12542,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -6276,16 +6276,16 @@
         },
         {
             "name": "prestashop/ps_featuredproducts",
-            "version": "v2.1.1",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/ps_featuredproducts.git",
-                "reference": "693d106181eaaea14358ad035fe7166106b9a1a4"
+                "reference": "44e6567bd0419537d61389741c7e68ef90d8caf3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/ps_featuredproducts/zipball/693d106181eaaea14358ad035fe7166106b9a1a4",
-                "reference": "693d106181eaaea14358ad035fe7166106b9a1a4",
+                "url": "https://api.github.com/repos/PrestaShop/ps_featuredproducts/zipball/44e6567bd0419537d61389741c7e68ef90d8caf3",
+                "reference": "44e6567bd0419537d61389741c7e68ef90d8caf3",
                 "shasum": ""
             },
             "require": {
@@ -6314,9 +6314,9 @@
             "description": "PrestaShop - Featured products",
             "homepage": "https://github.com/PrestaShop/ps_featuredproducts",
             "support": {
-                "source": "https://github.com/PrestaShop/ps_featuredproducts/tree/v2.1.1"
+                "source": "https://github.com/PrestaShop/ps_featuredproducts/tree/v2.1.2"
             },
-            "time": "2021-12-10T13:44:29+00:00"
+            "time": "2021-12-14T09:04:39+00:00"
         },
         {
             "name": "prestashop/ps_imageslider",

--- a/src/Adapter/HookManager.php
+++ b/src/Adapter/HookManager.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter;
 
+use Exception;
 use Hook;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -78,10 +79,22 @@ class HookManager
         } else {
             try {
                 return Hook::exec($hook_name, $hook_args, $id_module, $array_return, $check_exceptions, $use_push, $id_shop);
-            } catch (\Exception $e) {
-                $logger = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\LegacyLogger');
-                $environment = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\Environment');
-                $logger->error(sprintf('Exception on hook %s for module %s. %s', $hook_name, $id_module, $e->getMessage()), ['object_type' => 'Module', 'object_id' => $id_module, 'allow_duplicate' => true]);
+            } catch (Exception $e) {
+                $logger = ServiceLocator::get(LegacyLogger::class);
+                $environment = ServiceLocator::get(Environment::class);
+                $logger->error(
+                    sprintf(
+                        'Exception on hook %s for module %s. %s',
+                        $hook_name,
+                        $id_module,
+                        $e->getMessage()
+                    ),
+                    [
+                        'object_type' => 'Module',
+                        'object_id' => $id_module,
+                        'allow_duplicate' => true,
+                    ]
+                );
                 if ($environment->isDebug()) {
                     throw new CoreException($e->getMessage(), $e->getCode(), $e);
                 }

--- a/src/Adapter/LegacyHookSubscriber.php
+++ b/src/Adapter/LegacyHookSubscriber.php
@@ -120,7 +120,12 @@ class LegacyHookSubscriber implements EventSubscriberInterface
         $moduleId = (int) $ids[1];
         list($event, $hookName) = $args;
 
-        $content = Hook::exec($hookName, $event->getHookParameters(), $moduleId, ($event instanceof RenderingHookEvent));
+        $content = Hook::exec(
+            $hookName,
+            $event->getHookParameters(),
+            $moduleId,
+            ($event instanceof RenderingHookEvent)
+        );
 
         if (
             $event instanceof RenderingHookEvent

--- a/tests-legacy/phpunit-endpoints.xml
+++ b/tests-legacy/phpunit-endpoints.xml
@@ -1,16 +1,11 @@
-<phpunit stopOnFailure="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="true"
->
-    <php>
-        <env name="_PS_IN_TEST_" value="1"/>
-    </php>
+<phpunit processIsolation="true">
+  <php>
+    <env name="_PS_IN_TEST_" value="1"/>
+  </php>
 
-    <testsuites>
-        <testsuite name="Endpoints">
-            <directory>Endpoints</directory>
-        </testsuite>
-    </testsuites>
+  <testsuites>
+    <testsuite name="Endpoints">
+      <directory>Endpoints</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Integration/phpunit.xml
+++ b/tests/Integration/phpunit.xml
@@ -1,15 +1,15 @@
-<phpunit bootstrap="bootstrap.php"
-         stopOnFailure="true"
-         processIsolation="true"
->
-    <!-- process isolation is required since the introduction of GenerateMailTemplatesCommandTest file -->
-    <php>
-      <env name="KERNEL_CLASS" value="AppKernel" />
-      <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-    </php>
-    <testsuites>
-        <testsuite name="Integration">
-            <directory>.</directory>
-        </testsuite>
-    </testsuites>
+<phpunit
+    bootstrap="bootstrap.php"
+    convertDeprecationsToExceptions="false"
+    processIsolation="true">
+  <!-- process isolation is required since the introduction of GenerateMailTemplatesCommandTest file -->
+  <php>
+    <env name="KERNEL_CLASS" value="AppKernel" />
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+  </php>
+  <testsuites>
+    <testsuite name="Integration">
+      <directory>.</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/Unit/phpunit.xml
+++ b/tests/Unit/phpunit.xml
@@ -1,20 +1,19 @@
-<phpunit bootstrap="bootstrap.php"
-         stopOnFailure="true"
-         backupGlobals="true"
->
+<phpunit
+    bootstrap="bootstrap.php"
+    backupGlobals="true">
   <php>
     <server name="KERNEL_CLASS" value="AppKernel" />
   </php>
-    <testsuites>
-        <testsuite name="Unit">
-            <directory>.</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">../../src</directory>
-            <directory suffix=".php">../../classes</directory>
-            <directory suffix=".php">../../controllers</directory>
-        </whitelist>
-    </filter>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory>.</directory>
+    </testsuite>
+  </testsuites>
+  <filter>
+    <whitelist>
+      <directory suffix=".php">../../src</directory>
+      <directory suffix=".php">../../classes</directory>
+      <directory suffix=".php">../../controllers</directory>
+    </whitelist>
+  </filter>
 </phpunit>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Also, remove init debug in front as we don't have Symfony profiler, it hides a lot of possible errors. Plus, only use php_errors when using a controller that's not AdminLegacylayoutControllerCore.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | yes
| Fixed ticket?   | Fixes #26411
| How to test?      | No need QA
| Possible impacts? | The front and the back are now correctly handle "trigger_error" calls, a lot of changes will have to be made :sweat_smile: 


### BC breaks

- `Hook::getHookAliasList` is no longer available
- `Hook::getRetroHookName` is no longer available

### Deprecated

- The usage of hook aliases now trigger a deprecated message 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26267)
<!-- Reviewable:end -->
