### PR TITLE
Deleting extra parameter

### DIFF
--- a/classes/checkout/CheckoutSession.php
+++ b/classes/checkout/CheckoutSession.php
@@ -70,8 +70,7 @@ class CheckoutSessionCore
     public function getCustomerAddressesCount()
     {
         return count($this->getCustomer()->getSimpleAddresses(
-            $this->context->language->id,
-            true // no cache
+            $this->context->language->id
         ));
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  In method getCustomerAddressesCount of class CheckoutSession, the call of method getSimpleAddresses from class Customer has a wrong number of parameters
| Type?             |  refacto 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26212
| How to test?      | Check the method getSimpleAddresses in class Customer -> Only one argument<br>Compare with its call in method getCustomerAddressesCount of class CheckoutSession -> 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26268)
<!-- Reviewable:end -->
