### PR TITLE
Unify reporting of query types

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -181,6 +181,7 @@ class CategoryControllerCore extends ProductListingFrontController
     {
         $query = new ProductSearchQuery();
         $query
+            ->setQueryType('category')
             ->setIdCategory($this->category->id)
             ->setSortOrder(new SortOrder('product', Tools::getProductsOrder('by'), Tools::getProductsOrder('way')));
 

--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -106,6 +106,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
     {
         $query = new ProductSearchQuery();
         $query
+            ->setQueryType('manufacturer')
             ->setIdManufacturer($this->manufacturer->id)
             ->setSortOrder(new SortOrder('product', Tools::getProductsOrder('by'), Tools::getProductsOrder('way')));
 

--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -87,6 +87,7 @@ class SearchControllerCore extends ProductListingFrontController
     {
         $query = new ProductSearchQuery();
         $query
+            ->setQueryType('search')
             ->setSortOrder(new SortOrder('product', 'position', 'desc'))
             ->setSearchString($this->search_string)
             ->setSearchTag($this->search_tag);

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -107,6 +107,7 @@ class SupplierControllerCore extends ProductListingFrontController
     {
         $query = new ProductSearchQuery();
         $query
+            ->setQueryType('supplier')
             ->setIdSupplier($this->supplier->id)
             ->setSortOrder(new SortOrder('product', 'position', 'asc'));
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I added controller names to every product listing controller queries. It will be easier for filtering modules (faceted search) to determine where the query is coming from. PricesDrop, BestSales, NewProducts already had it filled in.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | You can test in faceted search module for example. See below.
| Possible impacts? | - 

### How to test
- You can test it in faceted search.
- `Open up \modules\ps_facetedsearch\src\Hook\ProductSearch.php` and add `dump($query);` to the beginning of `productSearchProvider` function.
- Then open all pages there are in PS - category, manufacturer, supplier, search, prices drop, best sales, new products and see that there is a query type everywhere. 
- Before, there was only a category id or search term. Much better if we can use just one property to see where are we at. :-)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26285)
<!-- Reviewable:end -->
