### PR TITLE
Fix disabled attribute on checkout on classic

### DIFF
--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -111,6 +111,7 @@ class Payment {
     } else {
       this.showConfirmation();
       $(`${this.confirmationSelector} button`).toggleClass('disabled', !show);
+      $(`${this.confirmationSelector} button`).attr('disabled', !show);
 
       if (show) {
         $(this.conditionAlertSelector).hide();

--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -111,6 +111,7 @@ class Payment {
     } else {
       this.showConfirmation();
       $(`${this.confirmationSelector} button`).toggleClass('disabled', !show);
+      // We keep in order to be retro compatible with older themes
       $(`${this.confirmationSelector} button`).attr('disabled', !show);
 
       if (show) {

--- a/themes/_core/js/checkout-payment.js
+++ b/themes/_core/js/checkout-payment.js
@@ -111,7 +111,7 @@ class Payment {
     } else {
       this.showConfirmation();
       $(`${this.confirmationSelector} button`).toggleClass('disabled', !show);
-      // We keep in order to be retro compatible with older themes
+      // Next line provides backward compatibility for Classic Theme < 1.7.8
       $(`${this.confirmationSelector} button`).attr('disabled', !show);
 
       if (show) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The button is disabled even if everything is fine at the last step of checkout
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26274.
| How to test?      | See issue, keep in mind that you need to have an 1.7.7, then upgrade to 1.7.8 in order to reproduce the bug (and then test it)
| Possible impacts? | Checkout on FO


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26289)
<!-- Reviewable:end -->
