### PR TITLE
Fixes #26298 : product availability date differs between product page and cart page

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -740,6 +740,7 @@ class CartCore extends ObjectModel
                 product_attribute_shop.`price` AS price_attribute,
                 product_attribute_shop.`ecotax` AS ecotax_attr,
                 IF (IFNULL(pa.`reference`, \'\') = \'\', p.`reference`, pa.`reference`) AS reference,
+                IF (IFNULL(pa.`available_date`, \'\') = \'\', p.`available_date`, pa.`available_date`) AS available_date,
                 (p.`weight`+ IFNULL(product_attribute_shop.`weight`, pa.`weight`)) weight_attribute,
                 IF (IFNULL(pa.`ean13`, \'\') = \'\', p.`ean13`, pa.`ean13`) AS ean13,
                 IF (IFNULL(pa.`isbn`, \'\') = \'\', p.`isbn`, pa.`isbn`) AS isbn,


### PR DESCRIPTION
See https://github.com/PrestaShop/PrestaShop/issues/26298

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fetch the product combination availability date if there is one defined for the specific combination in the cart. Otherwise, keep default behavior : retrieve the product availability date.
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26298
| How to test?      | Follow steps to reproduce in #26298
| Possible impacts? | None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26299)
<!-- Reviewable:end -->
