### PR TITLE
Remove deprecated in AddressFormat

### DIFF
--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -640,18 +640,6 @@ class AddressFormatCore extends ObjectModel
     }
 
     /**
-     * @param int $idCountry
-     *
-     * @return false|string|null
-     *
-     * @deprecated 1.7.0
-     */
-    protected function _getFormatDB($idCountry)
-    {
-        return self::getFormatDB($idCountry);
-    }
-
-    /**
      * Get Address format from DB.
      *
      * @param int $idCountry Country ID


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in AddressFormat
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `AddressFormat::_getFormatDB()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26300)
<!-- Reviewable:end -->
