### PR TITLE
Remove deprecated param into Alias constructor

### DIFF
--- a/classes/Alias.php
+++ b/classes/Alias.php
@@ -52,14 +52,9 @@ class AliasCore extends ObjectModel
      * @param int|null $id Alias ID
      * @param string|null $alias Alias
      * @param string|null $search Search string
-     * @param int|null $idLang Language ID
      */
-    public function __construct($id = null, $alias = null, $search = null, $idLang = null)
+    public function __construct($id = null, $alias = null, $search = null)
     {
-        if ($idLang !== null) {
-            Tools::displayParameterAsDeprecated('idLang');
-        }
-
         $this->def = Alias::getDefinition($this);
         $this->setDefinitionRetrocompatibility();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Alias
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed param : `$idLang`, in `Alias::__construct()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26301)
<!-- Reviewable:end -->
