### PR TITLE
Remove deprecated methods/params into Cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4908,20 +4908,13 @@ class CartCore extends ObjectModel
      * Are all products of the Cart in stock?
      *
      * @param bool $ignore_virtual Ignore virtual products
-     * @param bool $exclusive (DEPRECATED) If true, the validation is exclusive : it must be present product in stock and out of stock
      *
      * @since 1.5.0
      *
      * @return bool False if not all products in the cart are in stock
      */
-    public function isAllProductsInStock($ignoreVirtual = false, $exclusive = false)
+    public function isAllProductsInStock($ignoreVirtual = false)
     {
-        if (func_num_args() > 1) {
-            @trigger_error(
-                '$exclusive parameter is deprecated since version 1.7.3.2 and will be removed in the next major version.',
-                E_USER_DEPRECATED
-            );
-        }
         $productOutOfStock = 0;
         $productInStock = 0;
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1399,36 +1399,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Check if the Cart contains the given Product (Attribute).
-     *
-     * @deprecated 1.7.3.1
-     * @see Cart::getProductQuantity()
-     *
-     * @param int $id_product Product ID
-     * @param int $id_product_attribute ProductAttribute ID
-     * @param int $id_customization Customization ID
-     * @param int $id_address_delivery Delivery Address ID
-     *
-     * @return array|bool Whether the Cart contains the Product
-     *                    Result comes directly from the database
-     */
-    public function containsProduct($id_product, $id_product_attribute = 0, $id_customization = 0, $id_address_delivery = 0)
-    {
-        $result = $this->getProductQuantity(
-            $id_product,
-            $id_product_attribute,
-            $id_customization,
-            $id_address_delivery
-        );
-
-        if (empty($result['quantity'])) {
-            return false;
-        }
-
-        return ['quantity' => $result['quantity']];
-    }
-
-    /**
      * Update Product quantity.
      *
      * @param int $quantity Quantity to add (or substract)

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3832,22 +3832,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * @deprecated 1.5.0
-     *
-     * @param CartRule $obj
-     *
-     * @return bool|string
-     */
-    public function checkDiscountValidity($obj, $discounts, $order_total, $products, $check_cart_discount = false)
-    {
-        Tools::displayAsDeprecated();
-        $context = Context::getContext()->cloneContext();
-        $context->cart = $this;
-
-        return $obj->checkValidity($context);
-    }
-
-    /**
      * Return useful information about the cart for display purpose.
      * Products are splitted between paid ones and gift
      * Gift price and shipping (if shipping is free) are removed from Discounts

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3422,16 +3422,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * @deprecated 1.5.0, use Cart->getPackageShippingCost()
-     */
-    public function getOrderShippingCost($id_carrier = null, $use_tax = true, Country $default_country = null, $product_list = null)
-    {
-        Tools::displayAsDeprecated('Use Cart->getPackageShippingCost()');
-
-        return $this->getPackageShippingCost((int) $id_carrier, $use_tax, $default_country, $product_list);
-    }
-
-    /**
      * Return package shipping cost.
      *
      * @param int $id_carrier Carrier ID (default : current carrier)

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4192,21 +4192,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * @deprecated 1.5.5.0
-     *
-     * @param int $id_product Product ID
-     * @param int $index Customization field identifier as id_customization_field in table customization_field
-     *
-     * @return bool
-     */
-    public function deletePictureToProduct($id_product, $index)
-    {
-        Tools::displayAsDeprecated('Use deleteCustomizationToProduct() instead');
-
-        return $this->deleteCustomizationToProduct($id_product, (int) $index);
-    }
-
-    /**
      * Remove a customer's customization.
      *
      * @param int $id_product Product ID

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3122,68 +3122,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Get all deliveries options available for the current cart formatted like Carriers::getCarriersForOrder
-     * This method was wrote for retrocompatibility with 1.4 theme
-     * New theme need to use Cart::getDeliveryOptionList() to generate carriers option in the checkout process.
-     *
-     * @since 1.5.0
-     * @deprecated 1.7.0
-     *
-     * @param Country $default_country Default Country
-     * @param bool $flush Force flushing cache
-     *
-     * @return array
-     */
-    public function simulateCarriersOutput(Country $default_country = null, $flush = false)
-    {
-        $delivery_option_list = $this->getDeliveryOptionList($default_country, $flush);
-
-        // This method cannot work if there is multiple address delivery
-        if (count($delivery_option_list) > 1 || empty($delivery_option_list)) {
-            return [];
-        }
-
-        $carriers = [];
-        foreach (reset($delivery_option_list) as $key => $option) {
-            $price = $option['total_price_with_tax'];
-            $price_tax_exc = $option['total_price_without_tax'];
-            $name = $img = $delay = '';
-
-            if ($option['unique_carrier']) {
-                $carrier = reset($option['carrier_list']);
-                if (isset($carrier['instance'])) {
-                    $name = $carrier['instance']->name;
-                    $delay = $carrier['instance']->delay;
-                    $delay = isset($delay[Context::getContext()->language->id]) ?
-                        $delay[Context::getContext()->language->id] : $delay[(int) Configuration::get('PS_LANG_DEFAULT')];
-                }
-                if (isset($carrier['logo'])) {
-                    $img = $carrier['logo'];
-                }
-            } else {
-                $nameList = [];
-                foreach ($option['carrier_list'] as $carrier) {
-                    $nameList[] = $carrier['instance']->name;
-                }
-                $name = implode(' -', $nameList);
-                $img = ''; // No images if multiple carriers
-                $delay = '';
-            }
-            $carriers[] = [
-                'name' => $name,
-                'img' => $img,
-                'delay' => $delay,
-                'price' => $price,
-                'price_tax_exc' => $price_tax_exc,
-                'id_carrier' => Cart::intifier($key), // Need to translate to an integer for retrocompatibility reason, in 1.4 template we used intval
-                'is_module' => false,
-            ];
-        }
-
-        return $carriers;
-    }
-
-    /**
      * Simulate output of selected Carrier.
      *
      * @param bool $use_cache Use cache

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4970,41 +4970,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Execute hook displayCarrierList (extraCarrier) and merge them into the $array.
-     *
-     * @deprecated since 1.7.6.0.
-     * @see https://github.com/PrestaShop/PrestaShop/issues/10979
-     *
-     * @param array $array
-     */
-    public static function addExtraCarriers(&$array)
-    {
-        @trigger_error(
-            __FUNCTION__ . 'is deprecated since version 1.7.6.0 and will be removed in the next major version.',
-            E_USER_DEPRECATED
-        );
-
-        $first = true;
-        $hook_extracarrier_addr = [];
-        foreach (Context::getContext()->cart->getAddressCollection() as $address) {
-            $hook = Hook::exec('displayCarrierList', ['address' => $address]);
-            $hook_extracarrier_addr[$address->id] = $hook;
-
-            if ($first) {
-                $array = array_merge(
-                    $array,
-                    ['HOOK_EXTRACARRIER' => $hook]
-                );
-                $first = false;
-            }
-            $array = array_merge(
-                $array,
-                ['HOOK_EXTRACARRIER_ADDR' => $hook_extracarrier_addr]
-            );
-        }
-    }
-
-    /**
      * Get all the IDs of the delivery Addresses without Carriers.
      *
      * @param bool $return_collection Returns sa collection

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -181,8 +181,6 @@ class CartCore extends ObjectModel
     const ONLY_SHIPPING = 5;
     const ONLY_WRAPPING = 6;
 
-    /** @deprecated since 1.7 **/
-    const ONLY_PRODUCTS_WITHOUT_SHIPPING = 7;
     const ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING = 8;
 
     private const DEFAULT_ATTRIBUTES_KEYS = ['attributes' => '', 'attributes_small' => ''];
@@ -2050,7 +2048,6 @@ class CartCore extends ObjectModel
      *                  - Cart::BOTH_WITHOUT_SHIPPING
      *                  - Cart::ONLY_SHIPPING
      *                  - Cart::ONLY_WRAPPING
-     *                  - Cart::ONLY_PRODUCTS_WITHOUT_SHIPPING
      *                  - Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING
      * @param array $products
      * @param int $id_carrier
@@ -2071,11 +2068,6 @@ class CartCore extends ObjectModel
     ) {
         if ((int) $id_carrier <= 0) {
             $id_carrier = null;
-        }
-
-        // deprecated type
-        if ($type == Cart::ONLY_PRODUCTS_WITHOUT_SHIPPING) {
-            $type = Cart::ONLY_PRODUCTS;
         }
 
         // check type

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -409,36 +409,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Calculate average Tax rate in Cart, as a percentage.
-     *
-     * @deprecated since version 1.7.6. Use $cart->getAverageProductsTaxRate() instead.
-     *
-     * @param mixed $cart Cart ID or Cart Object
-     *
-     * @return float Average Tax used in Cart (eg. 20.0 for 20% average rate)
-     */
-    public static function getTaxesAverageUsed($cart)
-    {
-        @trigger_error(
-            'Cart::getTaxesAverageUsed() is deprecated since version 1.7.6. Use $cart->getAverageProductsTaxRate() instead.',
-            E_USER_DEPRECATED
-        );
-
-        if (!is_object($cart)) {
-            $cart = new Cart((int) $cart);
-        }
-        if (!Validate::isLoadedObject($cart)) {
-            die(Tools::displayError());
-        }
-
-        if (!Configuration::get('PS_TAX')) {
-            return 0;
-        }
-
-        return $cart->getAverageProductsTaxRate() * 100;
-    }
-
-    /**
      * Returns the average Tax rate for all products in the cart, as a multiplier.
      *
      * The arguments are optional and only serve as return values in case caller needs the details.

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -764,7 +764,8 @@ class OrderCore extends ObjectModel
 
     public function getTaxesAverageUsed()
     {
-        return Cart::getTaxesAverageUsed((int) $this->id_cart);
+        $cart = new Cart((int) $this->id_cart);
+        return $cart->getAverageProductsTaxRate() * 100;
     }
 
     /**

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -547,7 +547,7 @@ class CartPresenter implements PresenterInterface
         $cartVouchers = $cart->getCartRules();
         $vouchers = [];
 
-        $cartHasTax = null === $cart->id ? false : $cart::getTaxesAverageUsed($cart);
+        $cartHasTax = null === $cart->id ? false : $cart->getAverageProductsTaxRate() * 100;
         $freeShippingAlreadySet = false;
         foreach ($cartVouchers as $cartVoucher) {
             $vouchers[$cartVoucher['id_cart_rule']]['id_cart_rule'] = $cartVoucher['id_cart_rule'];

--- a/tests/Integration/Utility/CartOld.php
+++ b/tests/Integration/Utility/CartOld.php
@@ -51,7 +51,6 @@ class CartOld extends Cart
      *                  - Cart::BOTH_WITHOUT_SHIPPING
      *                  - Cart::ONLY_SHIPPING
      *                  - Cart::ONLY_WRAPPING
-     *                  - Cart::ONLY_PRODUCTS_WITHOUT_SHIPPING
      *                  - Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING
      * @param array $products
      * @param int $id_carrier
@@ -87,7 +86,6 @@ class CartOld extends Cart
             Cart::BOTH_WITHOUT_SHIPPING,
             Cart::ONLY_SHIPPING,
             Cart::ONLY_WRAPPING,
-            Cart::ONLY_PRODUCTS_WITHOUT_SHIPPING,
             Cart::ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING,
         ];
 
@@ -128,10 +126,6 @@ class CartOld extends Cart
 
         if ($type == Cart::ONLY_SHIPPING) {
             return $shipping_fees;
-        }
-
-        if ($type == Cart::ONLY_PRODUCTS_WITHOUT_SHIPPING) {
-            $type = Cart::ONLY_PRODUCTS;
         }
 
         $param_product = true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Cart
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed const : `Cart::ONLY_PRODUCTS_WITHOUT_SHIPPING`
* Removed method : `Cart::getTaxesAverageUsed()`
* Removed method : `Cart::containsProduct()`
* Removed method : `Cart::simulateCarriersOutput()`
* Removed method : `Cart::getOrderShippingCost()`
* Removed method : `Cart::checkDiscountValidity()`
* Removed method : `Cart::deletePictureToProduct()`
* Removed method : `Cart::addExtraCarriers()`
* Removed parameters : `$exclusive`, in `Cart::isAllProductsInStock()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26302)
<!-- Reviewable:end -->
