### PR TITLE
Remove deprecated in Category and update code related to it

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -495,18 +495,6 @@ class CategoryCore extends ObjectModel
     }
 
     /**
-     * @param $categories
-     * @param $idCategory
-     * @param $n
-     *
-     * @deprecated 1.7.0
-     */
-    protected static function _subTree(&$categories, $idCategory, &$n)
-    {
-        self::subTree($categories, $idCategory, $n);
-    }
-
-    /**
      * @param array $categories
      * @param int $idCategory
      * @param int $n
@@ -872,18 +860,6 @@ class CategoryCore extends ObjectModel
         );
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
-    }
-
-    /**
-     * Get Shop ID.
-     *
-     * @return int
-     *
-     * @deprecated 1.7.0
-     */
-    public function getShopID()
-    {
-        return $this->id_shop;
     }
 
     /**
@@ -1904,15 +1880,6 @@ class CategoryCore extends ObjectModel
     }
 
     /**
-     * @see self::getUrlRewriteInformation()
-     * @deprecated 1.7.0
-     */
-    public static function getUrlRewriteInformations($idCategory)
-    {
-        return self::getUrlRewriteInformation($idCategory);
-    }
-
-    /**
      * Get URL Rewrite information.
      *
      * @param $idCategory
@@ -2097,15 +2064,6 @@ class CategoryCore extends ObjectModel
         }
 
         return $nbProductRecursive;
-    }
-
-    /**
-     * @see self::getCategoryInformation()
-     * @deprecated 1.7.0
-     */
-    public static function getCategoryInformations($idsCategory, $idLang = null)
-    {
-        return self::getCategoryInformation($idsCategory, $idLang);
     }
 
     /**

--- a/classes/helper/HelperTreeCategories.php
+++ b/classes/helper/HelperTreeCategories.php
@@ -143,7 +143,7 @@ class HelperTreeCategoriesCore extends TreeCore
                     }
                 }
 
-                $tree = Category::getCategoryInformations([$root_category], $lang);
+                $tree = Category::getCategoryInformation([$root_category], $lang);
 
                 $children = $this->fillTree($categories, $root_category);
 

--- a/tests/Resources/modules_tests/override/AdminProductsController.php
+++ b/tests/Resources/modules_tests/override/AdminProductsController.php
@@ -2726,10 +2726,10 @@ class AdminProductsController extends AdminProductsControllerCore
         $root = Category::getRootCategory();
         $default_category = $this->context->cookie->id_category_products_filter ? $this->context->cookie->id_category_products_filter : Context::getContext()->shop->id_category;
         if (!$product->id || !$product->isAssociatedToShop()) {
-            $selected_cat = Category::getCategoryInformations(Tools::getValue('categoryBox', [$default_category]), $this->default_form_language);
+            $selected_cat = Category::getCategoryInformation(Tools::getValue('categoryBox', [$default_category]), $this->default_form_language);
         } else {
             if (Tools::isSubmit('categoryBox')) {
-                $selected_cat = Category::getCategoryInformations(Tools::getValue('categoryBox', [$default_category]), $this->default_form_language);
+                $selected_cat = Category::getCategoryInformation(Tools::getValue('categoryBox', [$default_category]), $this->default_form_language);
             } else {
                 $selected_cat = Product::getProductCategoriesFull($product->id, $this->default_form_language);
             }

--- a/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -2834,10 +2834,10 @@ class AdminProductsController extends AdminProductsControllerCore
         $root = Category::getRootCategory();
         $default_category = $this->context->cookie->id_category_products_filter ? $this->context->cookie->id_category_products_filter : Context::getContext()->shop->id_category;
         if (!$product->id || !$product->isAssociatedToShop()) {
-            $selected_cat = Category::getCategoryInformations(Tools::getValue('categoryBox', [$default_category]), $this->default_form_language);
+            $selected_cat = Category::getCategoryInformation(Tools::getValue('categoryBox', [$default_category]), $this->default_form_language);
         } else {
             if (Tools::isSubmit('categoryBox')) {
-                $selected_cat = Category::getCategoryInformations(Tools::getValue('categoryBox', [$default_category]), $this->default_form_language);
+                $selected_cat = Category::getCategoryInformation(Tools::getValue('categoryBox', [$default_category]), $this->default_form_language);
             } else {
                 $selected_cat = Product::getProductCategoriesFull($product->id, $this->default_form_language);
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Category
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Category::_subTree()`
* Removed method : `Category::getShopID()`
* Removed method : `Category::getUrlRewriteInformations()`
* Removed method : `Category::getCategoryInformations()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26304)
<!-- Reviewable:end -->
