### PR TITLE
Remove deprecated code in CmsCategory

### DIFF
--- a/classes/CMSCategory.php
+++ b/classes/CMSCategory.php
@@ -583,30 +583,6 @@ class CMSCategoryCore extends ObjectModel
     }
 
     /**
-     * Retrieve CMSCategory by name and parent CMSCategory id.
-     *
-     * @param int $id_lang Language ID
-     * @param string $CMSCategory_name Searched CMSCategory name
-     * @param int $id_parent_CMSCategory parent CMSCategory ID
-     *
-     * @return array Corresponding CMSCategory
-     *
-     * @deprecated 1.5.3.0
-     */
-    public static function searchByNameAndParentCMSCategoryId($id_lang, $CMSCategory_name, $id_parent_CMSCategory)
-    {
-        Tools::displayAsDeprecated();
-
-        return Db::getInstance()->getRow('
-		SELECT c.*, cl.*
-	    FROM `' . _DB_PREFIX_ . 'cms_category` c
-	    LEFT JOIN `' . _DB_PREFIX_ . 'cms_category_lang` cl ON (c.`id_cms_category` = cl.`id_cms_category` AND `id_lang` = ' . (int) $id_lang . ')
-	    WHERE `name` = \'' . pSQL($CMSCategory_name) . '\'
-		AND c.`id_cms_category` != 1
-		AND c.`id_parent` = ' . (int) $id_parent_CMSCategory);
-    }
-
-    /**
      * Get Each parent CMSCategory of this CMSCategory until the root CMSCategory.
      *
      * @param int $id_lang Language ID


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in CmsCategory
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `CmsCategory::searchByNameAndParentCMSCategoryId()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26305)
<!-- Reviewable:end -->
