### PR TITLE
Remove deprecated in Configuration

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -255,14 +255,6 @@ class ConfigurationCore extends ObjectModel
     }
 
     /**
-     * @deprecated use Configuration::getConfigInMultipleLangs() instead
-     */
-    public static function getInt($key, $idShopGroup = null, $idShop = null)
-    {
-        return self::getConfigInMultipleLangs($key, $idShopGroup, $idShop);
-    }
-
-    /**
      * Get a single configuration value (in multiple languages).
      *
      * @param string $key Configuration Key


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Configuration
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes. Like ps_banner that use it's as now (https://github.com/PrestaShop/ps_banner/pull/39)
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Configuration::getInt()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26306)
<!-- Reviewable:end -->
