### PR TITLE
Remove deprecated into GroupReduction

### DIFF
--- a/classes/GroupReduction.php
+++ b/classes/GroupReduction.php
@@ -177,23 +177,6 @@ class GroupReductionCore extends ObjectModel
         );
     }
 
-    /**
-     * @deprecated 1.5.3.0
-     *
-     * @param int $id_category
-     *
-     * @return array|null
-     */
-    public static function getGroupByCategoryId($id_category)
-    {
-        Tools::displayAsDeprecated('Use GroupReduction::getGroupsByCategoryId($id_category)');
-
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
-			SELECT gr.`id_group` as id_group, gr.`reduction` as reduction, id_group_reduction
-			FROM `' . _DB_PREFIX_ . 'group_reduction` gr
-			WHERE `id_category` = ' . (int) $id_category, false);
-    }
-
     public static function getGroupsReductionByCategoryId($id_category)
     {
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
@@ -202,23 +185,6 @@ class GroupReductionCore extends ObjectModel
 			FROM `' . _DB_PREFIX_ . 'group_reduction` gr
 			WHERE `id_category` = ' . (int) $id_category
         );
-    }
-
-    /**
-     * @deprecated 1.5.3.0
-     *
-     * @param int $id_category
-     *
-     * @return array|null
-     */
-    public static function getGroupReductionByCategoryId($id_category)
-    {
-        Tools::displayAsDeprecated('Use GroupReduction::getGroupsByCategoryId($id_category)');
-
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow('
-			SELECT gr.`id_group_reduction` as id_group_reduction
-			FROM `' . _DB_PREFIX_ . 'group_reduction` gr
-			WHERE `id_category` = ' . (int) $id_category, false);
     }
 
     public static function setProductReduction($id_product, $id_group = null, $id_category = null, $reduction = null)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in GroupReduction
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `GroupReduction::getGroupByCategoryId()`
* Removed method : `GroupReduction::getGroupReductionByCategoryId()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26307)
<!-- Reviewable:end -->
