### PR TITLE
Remove deprecated into ImageType

### DIFF
--- a/classes/ImageType.php
+++ b/classes/ImageType.php
@@ -171,22 +171,6 @@ class ImageTypeCore extends ObjectModel
     /**
      * Get formatted name.
      *
-     * @deprecated 1.7.0.0 Use ImageType::getFormattedName($name) instead
-     *
-     * @param string $name
-     *
-     * @return string
-     */
-    public static function getFormatedName($name)
-    {
-        Tools::displayAsDeprecated('Please use ImageType::getFormattedName($name) instead');
-
-        return self::getFormattedName($name);
-    }
-
-    /**
-     * Get formatted name.
-     *
      * @param string $name
      *
      * @return string


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in ImageType
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `ImageType::getFormatedName()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26308)
<!-- Reviewable:end -->
