### PR TITLE
Remove deprecated methods in Language

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -584,16 +584,6 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     }
 
     /**
-     * @deprecated 1.6.1.1 Use Tools::deleteDirectory($dir) instead
-     *
-     * @param string $dir is the path of the directory to delete
-     */
-    public static function recurseDeleteDir($dir)
-    {
-        return Tools::deleteDirectory($dir);
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function delete()
@@ -1148,19 +1138,6 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         return true;
     }
 
-    /**
-     * @deprecated Since 1.7.7, use LanguageImageManager
-     */
-    protected static function _copyNoneFlag($id)
-    {
-        @trigger_error(
-            __FUNCTION__ . 'is deprecated since version 1.7.7. Use ' . LanguageImageManager::class . ' instead.',
-            E_USER_DEPRECATED
-        );
-
-        return true;
-    }
-
     public static function isInstalled($iso_code)
     {
         if (static::$_cache_language_installation === null) {
@@ -1346,22 +1323,6 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         }
 
         return true;
-    }
-
-    /**
-     * @param array $lang_pack
-     * @param array $errors
-     *
-     * @deprecated This method is deprecated since 1.7.6.0 use GenerateThemeMailsCommand instead
-     */
-    public static function installEmailsLanguagePack($lang_pack, &$errors = [])
-    {
-        @trigger_error(
-            'Language::installEmailsLanguagePack() is deprecated since version 1.7.6.0 Use GenerateThemeMailsCommand instead.',
-            E_USER_DEPRECATED
-        );
-
-        static::generateEmailsLanguagePack($lang_pack, $errors, true);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Language
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Language::recurseDeleteDir()`
* Removed method : `Language::_copyNoneFlag()`
* Removed method : `Language::installEmailsLanguagePack()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26309)
<!-- Reviewable:end -->
