### PR TITLE
Remove getJqueryPath() method

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -289,62 +289,6 @@ class MediaCore
     }
 
     /**
-     * return jquery path.
-     *
-     * @param mixed $version
-     *
-     * @return array
-     *
-     * @deprecated 1.7.7 jQuery is always included, this method should no longer be used
-     */
-    public static function getJqueryPath($version = null, $folder = null, $minifier = true)
-    {
-        @trigger_error(
-            'Media::getJqueryPath() is deprecated since version 1.7.7.0, jquery is always included',
-            E_USER_DEPRECATED
-        );
-        $addNoConflict = false;
-        if ($version === null) {
-            $version = _PS_JQUERY_VERSION_;
-        } //set default version
-        elseif (preg_match('/^([0-9\.]+)$/Ui', $version)) {
-            $addNoConflict = true;
-        } else {
-            return false;
-        }
-
-        if ($folder === null) {
-            $folder = _PS_JS_DIR_ . 'jquery/';
-        } //set default folder
-        //check if file exist
-        $file = $folder . 'jquery-' . $version . ($minifier ? '.min.js' : '.js');
-
-        // remove PS_BASE_URI on _PS_ROOT_DIR_ for the following
-        $urlData = parse_url($file);
-        $fileUri = _PS_ROOT_DIR_ . Tools::str_replace_once(__PS_BASE_URI__, DIRECTORY_SEPARATOR, $urlData['path']);
-        $fileUriHostMode = _PS_CORE_DIR_ . Tools::str_replace_once(__PS_BASE_URI__, DIRECTORY_SEPARATOR, $urlData['path']);
-        // check if js files exists, if not try to load query from ajax.googleapis.com
-
-        $return = [];
-
-        if (@filemtime($fileUri) || (defined('_PS_HOST_MODE_') && @filemtime($fileUriHostMode))) {
-            $return[] = Media::getJSPath($file);
-        } else {
-            $return[] = Media::getJSPath(Tools::getCurrentUrlProtocolPrefix() . 'ajax.googleapis.com/ajax/libs/jquery/' . $version . '/jquery' . ($minifier ? '.min.js' : '.js'));
-        }
-
-        if ($addNoConflict) {
-            $return[] = Media::getJSPath(Context::getContext()->shop->getBaseURL(true, false) . _PS_JS_DIR_ . 'jquery/jquery.noConflict.php?version=' . $version);
-        }
-
-        // added jQuery migrate for compatibility with new version of jQuery
-        // will be removed when using latest version of jQuery
-        $return[] = Media::getJSPath(_PS_JS_DIR_ . 'jquery/jquery-migrate-1.2.1.min.js');
-
-        return $return;
-    }
-
-    /**
      * return jqueryUI component path.
      *
      * @param mixed $component

--- a/tests/Integration/Classes/MediaTest.php
+++ b/tests/Integration/Classes/MediaTest.php
@@ -34,17 +34,6 @@ use PHPUnit\Framework\TestCase;
 
 class MediaTest extends TestCase
 {
-    public function testCorrectJQueryNoConflictURL(): void
-    {
-        $domain = Configuration::get('PS_SHOP_DOMAIN');
-        $this->assertTrue(
-            in_array(
-                'http://' . $domain . __PS_BASE_URI__ . 'js/jquery/jquery.noConflict.php?version=1.11',
-                Media::getJqueryPath('1.11')
-            )
-        );
-    }
-
     public function providerCSSInputs(): iterable
     {
         yield ['http://wwww.google.com/images/nav_logo.png', '', 'http://wwww.google.com/images/nav_logo.png', false];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Media
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Media::getJqueryPath()`
* Removed method : `MediaTest::testCorrectJQueryNoConflictURL()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26310)
<!-- Reviewable:end -->
