### PR TITLE
Remove formatProductAndVoucherForEmail() in PaymentModule

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -753,20 +753,6 @@ abstract class PaymentModuleCore extends Module
     }
 
     /**
-     * @deprecated 1.6.0.7
-     *
-     * @param mixed $content
-     *
-     * @return mixed
-     */
-    public function formatProductAndVoucherForEmail($content)
-    {
-        Tools::displayAsDeprecated('Use $content instead');
-
-        return $content;
-    }
-
-    /**
      * @param Address $the_address that needs to be txt formatted
      *
      * @return string the txt formatted address block


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in PaymentModule
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `PaymentModule::formatProductAndVoucherForEmail()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26311)
<!-- Reviewable:end -->
