### PR TITLE
Remove deprecated methods into Uploader

### DIFF
--- a/classes/Uploader.php
+++ b/classes/Uploader.php
@@ -208,7 +208,7 @@ class UploaderCore
             $this->setSavePath(_PS_UPLOAD_DIR_);
         }
 
-        return $this->_normalizeDirectory($this->_save_path);
+        return $this->normalizeDirectory($this->_save_path);
     }
 
     /**
@@ -385,19 +385,6 @@ class UploaderCore
      *
      * @return int
      *
-     * @deprecated 1.7.0
-     */
-    protected function _getFileSize($filePath, $clearStatCache = false)
-    {
-        return $this->getFileSize($filePath, $clearStatCache);
-    }
-
-    /**
-     * @param string $filePath
-     * @param bool $clearStatCache
-     *
-     * @return int
-     *
      * @since 1.7.0
      */
     protected function getFileSize($filePath, $clearStatCache = false)
@@ -414,35 +401,11 @@ class UploaderCore
      *
      * @return string
      *
-     * @deprecated 1.7.0
-     */
-    protected function _getServerVars($var)
-    {
-        return $this->getServerVars($var);
-    }
-
-    /**
-     * @param $var
-     *
-     * @return string
-     *
      * @since 1.7.0
      */
     protected function getServerVars($var)
     {
         return isset($_SERVER[$var]) ? $_SERVER[$var] : '';
-    }
-
-    /**
-     * @param $directory
-     *
-     * @return string
-     *
-     * @deprecated 1.7.0
-     */
-    protected function _normalizeDirectory($directory)
-    {
-        return $this->normalizeDirectory($directory);
     }
 
     /**

--- a/classes/helper/HelperImageUploader.php
+++ b/classes/helper/HelperImageUploader.php
@@ -32,7 +32,7 @@ class HelperImageUploaderCore extends HelperUploader
 
     public function getSavePath()
     {
-        return $this->_normalizeDirectory(_PS_TMP_IMG_DIR_);
+        return $this->normalizeDirectory(_PS_TMP_IMG_DIR_);
     }
 
     public function getFilePath($file_name = null)
@@ -49,13 +49,13 @@ class HelperImageUploaderCore extends HelperUploader
 
         $upload_max_filesize = Tools::convertBytes(ini_get('upload_max_filesize'));
 
-        if ($post_max_size && ($this->_getServerVars('CONTENT_LENGTH') > $post_max_size)) {
+        if ($post_max_size && ($this->getServerVars('CONTENT_LENGTH') > $post_max_size)) {
             $file['error'] = Context::getContext()->getTranslator()->trans('The uploaded file exceeds the post_max_size directive in php.ini', [], 'Admin.Notifications.Error');
 
             return false;
         }
 
-        if ($upload_max_filesize && ($this->_getServerVars('CONTENT_LENGTH') > $upload_max_filesize)) {
+        if ($upload_max_filesize && ($this->getServerVars('CONTENT_LENGTH') > $upload_max_filesize)) {
             $file['error'] = Context::getContext()->getTranslator()->trans('The uploaded file exceeds the upload_max_filesize directive in php.ini', [], 'Admin.Notifications.Error');
 
             return false;

--- a/classes/helper/HelperUploader.php
+++ b/classes/helper/HelperUploader.php
@@ -190,7 +190,7 @@ class HelperUploaderCore extends Uploader
             $this->_template_directory = self::DEFAULT_TEMPLATE_DIRECTORY;
         }
 
-        return $this->_normalizeDirectory($this->_template_directory);
+        return $this->normalizeDirectory($this->_template_directory);
     }
 
     public function getTemplateFile($template)
@@ -200,22 +200,22 @@ class HelperUploaderCore extends Uploader
         }
 
         if ($this->getContext()->controller instanceof ModuleAdminController
-            && file_exists($this->_normalizeDirectory($this->getContext()->controller->getTemplatePath()) . $this->getTemplateDirectory() . $template)
+            && file_exists($this->normalizeDirectory($this->getContext()->controller->getTemplatePath()) . $this->getTemplateDirectory() . $template)
         ) {
-            return $this->_normalizeDirectory($this->getContext()->controller->getTemplatePath())
+            return $this->normalizeDirectory($this->getContext()->controller->getTemplatePath())
                 . $this->getTemplateDirectory() . $template;
         } elseif ($this->getContext()->controller instanceof AdminController && isset($controller_name)
-            && file_exists($this->_normalizeDirectory($this->getContext()->smarty->getTemplateDir(0)) . 'controllers'
+            && file_exists($this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0)) . 'controllers'
                 . DIRECTORY_SEPARATOR . $controller_name . DIRECTORY_SEPARATOR . $this->getTemplateDirectory() . $template)) {
-            return $this->_normalizeDirectory($this->getContext()->smarty->getTemplateDir(0)) . 'controllers'
+            return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0)) . 'controllers'
                 . DIRECTORY_SEPARATOR . $controller_name . DIRECTORY_SEPARATOR . $this->getTemplateDirectory() . $template;
-        } elseif (file_exists($this->_normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
+        } elseif (file_exists($this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
                 . $this->getTemplateDirectory() . $template)) {
-            return $this->_normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
+            return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(1))
                     . $this->getTemplateDirectory() . $template;
-        } elseif (file_exists($this->_normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
+        } elseif (file_exists($this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
                 . $this->getTemplateDirectory() . $template)) {
-            return $this->_normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
+            return $this->normalizeDirectory($this->getContext()->smarty->getTemplateDir(0))
                 . $this->getTemplateDirectory() . $template;
         } else {
             return $this->getTemplateDirectory() . $template;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Upload
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Uploader::_getFileSize()`
* Removed method : `Uploader::_getServerVars()`
* Removed method : `Uploader::_normalizeDirectory()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26314)
<!-- Reviewable:end -->
