### PR TITLE
Remove isPasswd() method

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -180,7 +180,7 @@ class CustomerCore extends ObjectModel
             'lastname' => ['type' => self::TYPE_STRING, 'validate' => 'isCustomerName', 'required' => true, 'size' => 255],
             'firstname' => ['type' => self::TYPE_STRING, 'validate' => 'isCustomerName', 'required' => true, 'size' => 255],
             'email' => ['type' => self::TYPE_STRING, 'validate' => 'isEmail', 'required' => true, 'size' => 255],
-            'passwd' => ['type' => self::TYPE_STRING, 'validate' => 'isPasswd', 'required' => true, 'size' => 255],
+            'passwd' => ['type' => self::TYPE_STRING, 'validate' => 'isPlaintextPassword', 'required' => true, 'size' => 255],
             'last_passwd_gen' => ['type' => self::TYPE_STRING, 'copy_post' => false],
             'id_gender' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId'],
             'birthday' => ['type' => self::TYPE_DATE, 'validate' => 'isBirthDate'],
@@ -1185,7 +1185,7 @@ class CustomerCore extends ObjectModel
         if (empty($password)) {
             $password = Tools::passwdGen(8, 'RANDOM');
         }
-        if (!Validate::isPasswd($password)) {
+        if (!Validate::isPlaintextPassword($password)) {
             return false;
         }
 

--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -117,7 +117,7 @@ class EmployeeCore extends ObjectModel
             'firstname' => ['type' => self::TYPE_STRING, 'validate' => 'isName', 'required' => true, 'size' => 255],
             'email' => ['type' => self::TYPE_STRING, 'validate' => 'isEmail', 'required' => true, 'size' => 255],
             'id_lang' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'required' => true],
-            'passwd' => ['type' => self::TYPE_STRING, 'validate' => 'isPasswd', 'required' => true, 'size' => 255],
+            'passwd' => ['type' => self::TYPE_STRING, 'validate' => 'isPlaintextPassword', 'required' => true, 'size' => 255],
             'last_passwd_gen' => ['type' => self::TYPE_STRING],
             'active' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'id_profile' => ['type' => self::TYPE_INT, 'validate' => 'isInt', 'required' => true],

--- a/classes/Referrer.php
+++ b/classes/Referrer.php
@@ -56,7 +56,7 @@ class ReferrerCore extends ObjectModel
         'primary' => 'id_referrer',
         'fields' => [
             'name' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 64],
-            'passwd' => ['type' => self::TYPE_STRING, 'validate' => 'isPasswd', 'size' => 255],
+            'passwd' => ['type' => self::TYPE_STRING, 'validate' => 'isPlaintextPassword', 'size' => 255],
             'http_referer_regexp' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 64],
             'request_uri_regexp' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 64],
             'http_referer_like' => ['type' => self::TYPE_STRING, 'validate' => 'isCleanHtml', 'size' => 64],

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -510,21 +510,6 @@ class ValidateCore
     }
 
     /**
-     * Check for password validity.
-     *
-     * @param string $passwd Password to validate
-     * @param int $size
-     *
-     * @return bool Validity is ok or not
-     *
-     * @deprecated 1.7.0
-     */
-    public static function isPasswd($passwd, $size = Validate::PASSWORD_LENGTH)
-    {
-        return self::isPlaintextPassword($passwd, $size);
-    }
-
-    /**
      * Check if plaintext password is valid
      * Size is limited by `password_hash()` (72 chars).
      *

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -142,7 +142,7 @@ class CustomerFormCore extends AbstractForm
 
         $passwordField = $this->getField('password');
         if ((!empty($passwordField->getValue()) || $this->passwordRequired)
-            && Validate::isPasswd($passwordField->getValue()) === false) {
+            && Validate::isPlaintextPassword($passwordField->getValue()) === false) {
             $passwordField->addError($this->translator->trans(
                 'Password must be between 5 and 72 characters long',
                 [],

--- a/classes/form/CustomerLoginFormatter.php
+++ b/classes/form/CustomerLoginFormatter.php
@@ -61,7 +61,7 @@ class CustomerLoginFormatterCore implements FormFormatterInterface
                     [],
                     'Shop.Forms.Labels'
                 ))
-                ->addConstraint('isPasswd'),
+                ->addConstraint('isPlaintextPassword'),
         ];
     }
 }

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -224,7 +224,7 @@ class AdminLoginControllerCore extends AdminController
 
         if (empty($passwd)) {
             $this->errors[] = $this->trans('The password field is blank.', [], 'Admin.Notifications.Error');
-        } elseif (!Validate::isPasswd($passwd)) {
+        } elseif (!Validate::isPlaintextPassword($passwd)) {
             $this->errors[] = $this->trans('Invalid password.', [], 'Admin.Notifications.Error');
         }
 
@@ -401,7 +401,7 @@ class AdminLoginControllerCore extends AdminController
         } elseif (!$reset_password) {
             // password (twice)
             $this->errors[] = $this->trans('The password is missing: please enter your new password.', [], 'Admin.Login.Notification');
-        } elseif (!Validate::isPasswd($reset_password)) {
+        } elseif (!Validate::isPlaintextPassword($reset_password)) {
             $this->errors[] = $this->trans('The password is not in a valid format.', [], 'Admin.Login.Notification');
         } elseif (!$reset_confirm) {
             $this->errors[] = $this->trans('The confirmation is empty: please fill in the password confirmation as well.', [], 'Admin.Login.Notification');

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -157,7 +157,7 @@ class PasswordControllerCore extends FrontController
                         $this->errors[] = $this->trans('The password and its confirmation do not match.', [], 'Shop.Notifications.Error');
                     }
 
-                    if (!Validate::isPasswd($passwd)) {
+                    if (!Validate::isPlaintextPassword($passwd)) {
                         $this->errors[] = $this->trans('The password is not in a valid format.', [], 'Shop.Notifications.Error');
                     }
                 }

--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -132,7 +132,7 @@ class Datas
         ],
         'admin_password' => [
             'name' => 'password',
-            'validate' => 'isPasswd',
+            'validate' => 'isPlaintextPassword',
             'default' => '0123456789',
         ],
         'admin_email' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Validate
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Validate::isPasswd()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26315)
<!-- Reviewable:end -->
