### PR TITLE
Remove _getPDO()

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -40,24 +40,6 @@ class DbPDOCore extends Db
     /**
      * Returns a new PDO object (database link).
      *
-     * @deprecated use getPDO
-     *
-     * @param string $host
-     * @param string $user
-     * @param string $password
-     * @param string $dbname
-     * @param int $timeout
-     *
-     * @return PDO
-     */
-    protected static function _getPDO($host, $user, $password, $dbname, $timeout = 5)
-    {
-        return static::getPDO($host, $user, $host, $dbname, $timeout);
-    }
-
-    /**
-     * Returns a new PDO object (database link).
-     *
      * @param string $host
      * @param string $user
      * @param string $password


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in DbPDO
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `DbPDO::_getPDO()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26317)
<!-- Reviewable:end -->
