### PR TITLE
Remove getExentedMessage()

### DIFF
--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -207,16 +207,6 @@ class PrestaShopExceptionCore extends Exception
     }
 
     /**
-     * @deprecated 1.5.5
-     */
-    protected function getExentedMessage($html = true)
-    {
-        Tools::displayAsDeprecated('Use getExtendedMessage instead');
-
-        return $this->getExtendedMessage($html);
-    }
-
-    /**
      * Return the content of the Exception.
      *
      * @return string content of the exception


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in PrestaShopException
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `PrestaShopException::getExentedMessage()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26318)
<!-- Reviewable:end -->
