### PR TITLE
Remove deprecated getTheme() in Shop

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -496,18 +496,6 @@ class ShopCore extends ObjectModel
     }
 
     /**
-     * Get theme directory name.
-     *
-     * @return string $this->theme->theme_name
-     */
-    public function getTheme()
-    {
-        Tools::displayAsDeprecated('Please use $this->theme->getDirectory() instead');
-
-        return $this->theme->getDirectory();
-    }
-
-    /**
      * Get shop URI.
      *
      * @return string


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Shop
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Shop::getTheme()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26322)
<!-- Reviewable:end -->
