### PR TITLE
Remove deprecated methods into taxes related classes

### DIFF
--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -228,30 +228,6 @@ class TaxCore extends ObjectModel
     }
 
     /**
-     * Return the product tax rate using the tax rules system.
-     *
-     * @param int $id_product
-     * @param int $id_country
-     * @param int $id_state
-     * @param string $zipcode
-     *
-     * @return Tax
-     *
-     * @deprecated since 1.5
-     */
-    public static function getProductTaxRateViaRules($id_product, $id_country, $id_state, $zipcode)
-    {
-        Tools::displayAsDeprecated();
-
-        if (!isset(self::$_product_tax_via_rules[$id_product . '-' . $id_country . '-' . $id_state . '-' . $zipcode])) {
-            $tax_rate = TaxRulesGroup::getTaxesRate((int) Product::getIdTaxRulesGroupByIdProduct((int) $id_product), (int) $id_country, (int) $id_state, $zipcode);
-            self::$_product_tax_via_rules[$id_product . '-' . $id_country . '-' . $zipcode] = $tax_rate;
-        }
-
-        return self::$_product_tax_via_rules[$id_product . '-' . $id_country . '-' . $zipcode];
-    }
-
-    /**
      * Returns the product tax rate.
      *
      * @param int $id_product

--- a/classes/tax/TaxRule.php
+++ b/classes/tax/TaxRule.php
@@ -112,16 +112,6 @@ class TaxRuleCore extends ObjectModel
     }
 
     /**
-     * @deprecated since 1.5
-     */
-    public static function deleteTaxRuleByIdCounty($id_county)
-    {
-        Tools::displayAsDeprecated();
-
-        return true;
-    }
-
-    /**
      * @param int $id_tax
      *
      * @return bool

--- a/classes/tax/TaxRulesGroup.php
+++ b/classes/tax/TaxRulesGroup.php
@@ -264,30 +264,4 @@ class TaxRulesGroupCore extends ObjectModel
 		WHERE `id_tax_rules_group` = ' . (int) $this->id
         );
     }
-
-    /**
-     * @deprecated since 1.5
-     */
-    public static function getTaxesRate($id_tax_rules_group, $id_country, $id_state, $zipcode)
-    {
-        Tools::displayAsDeprecated();
-        $rate = 0;
-        foreach (TaxRulesGroup::getTaxes($id_tax_rules_group, $id_country, $id_state, $zipcode) as $tax) {
-            $rate += (float) $tax->rate;
-        }
-
-        return $rate;
-    }
-
-    /**
-     * Return taxes associated to this para.
-     *
-     * @deprecated since 1.5
-     */
-    public static function getTaxes($id_tax_rules_group, $id_country, $id_state, $id_county)
-    {
-        Tools::displayAsDeprecated();
-
-        return [];
-    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Tax related classes
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Tax::getProductTaxRateViaRules()`
* Removed method : `TaxRule::deleteTaxRuleByIdCounty()`
* Removed method : `TaxRulesGroup::getTaxesRate()`
* Removed method : `TaxRulesGroup::getTaxes()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26324)
<!-- Reviewable:end -->
