### PR TITLE
Fix language dropdown when resizing window  in attribute creation page

### DIFF
--- a/admin-dev/themes/default/scss/partials/_forms.scss
+++ b/admin-dev/themes/default/scss/partials/_forms.scss
@@ -295,6 +295,7 @@ input[type="color"]:hover,
   .translatable-field {
     .btn.dropdown-toggle {
       height: $input-height-base;
+      white-space: nowrap;
     }
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | when we resize the window the language dropdown is not well displayed
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26252
| How to test?      | resize the window the language dropdown should be well displayed
| Possible impacts? | /


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26328)
<!-- Reviewable:end -->
