### PR TITLE
[BO] Fix Modern email theme for RTL languages

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1661,7 +1661,8 @@ class FrontControllerCore extends Controller
             'long' => Configuration::get('PS_STORES_CENTER_LONG'),
             'lat' => Configuration::get('PS_STORES_CENTER_LAT'),
 
-            'logo' => $this->getShopLogo(),
+            'logo' => Configuration::hasKey('PS_LOGO') ? $psImageUrl . Configuration::get('PS_LOGO') : '',
+            'logo_details' => $this->getShopLogo(),
             'stores_icon' => Configuration::hasKey('PS_STORES_ICON') ? $psImageUrl . Configuration::get('PS_STORES_ICON') : '',
             'favicon' => Configuration::hasKey('PS_FAVICON') ? $psImageUrl . Configuration::get('PS_FAVICON') : '',
             'favicon_update_time' => Configuration::get('PS_IMG_UPDATE_TIME'),

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -93,7 +93,6 @@ class AdminLegacyLayoutControllerCore extends AdminController
         $controllers = [
             'AdminFeatureFlag',
             'AdminLanguages',
-            'AdminPerformance',
             'AdminProfiles',
             'AdminSpecificPriceRule',
             'AdminStatuses',

--- a/mails/themes/modern/components/footer.html.twig
+++ b/mails/themes/modern/components/footer.html.twig
@@ -28,7 +28,7 @@
                class="" style="vertical-align:top;width:604px;"
             >
           <![endif]-->
-                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <div class="footer mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                             <tr>
                               <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">

--- a/mails/themes/modern/components/header.html.twig
+++ b/mails/themes/modern/components/header.html.twig
@@ -28,7 +28,7 @@
                class="" style="vertical-align:top;width:554px;"
             >
           <![endif]-->
-                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <div class="header mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                             <tr>
                               <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">

--- a/mails/themes/modern/components/layout.html.twig
+++ b/mails/themes/modern/components/layout.html.twig
@@ -55,6 +55,24 @@
         </style>
         <![endif]-->
   <style type="text/css">
+  {% if languageIsRTL|default(false) %}
+    div {
+      direction: rtl !important;
+      text-align: right !important;
+    }
+    
+    .header td table {
+      margin: 0 auto;
+    }
+    
+    .mj-column-px-25 {
+      float: right;
+    }
+    
+    .footer div {
+      text-align: center !important;
+    }
+  {% endif %}
   </style>
   <style type="text/css">
     .shadow {

--- a/mails/themes/modern/components/order_layout.html.twig
+++ b/mails/themes/modern/components/order_layout.html.twig
@@ -55,6 +55,24 @@
         </style>
         <![endif]-->
   <style type="text/css">
+  {% if languageIsRTL|default(false) %}
+    div {
+      direction: rtl !important;
+      text-align: right !important;
+    }
+    
+    .header td table {
+      margin: 0 auto;
+    }
+    
+    .mj-column-px-25 {
+      float: right;
+    }
+    
+    .footer div {
+      text-align: center !important;
+    }
+  {% endif %}
   </style>
   <style type="text/css">
     .shadow {

--- a/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/CustomerDiscountGridDataFactory.php
@@ -72,11 +72,19 @@ final class CustomerDiscountGridDataFactory implements GridDataFactoryInterface
             false
         );
 
+        $numDiscounts = count($discounts);
+
+        $discounts = array_slice(
+            $discounts,
+            (int) $searchCriteria->getOffset(),
+            (int) $searchCriteria->getLimit()
+        );
+
         $records = new RecordCollection($discounts);
 
         return new GridData(
             $records,
-            $records->count()
+            $numDiscounts
         );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
@@ -84,11 +84,6 @@ class PerformanceController extends FrameworkBundleAdminController
             'cachingForm' => $cachingForm->createView(),
             'memcacheForm' => $memcacheForm->createView(),
             'servers' => $this->get('prestashop.adapter.memcache_server.manager')->getServers(),
-            'multistoreInfoTip' => $this->trans(
-                'Note that this page is available in all shops context only, this is why your context has just switched.',
-                'Admin.Notifications.Info'
-            ),
-            'multistoreIsUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -258,11 +258,17 @@ class CustomerController extends AbstractAdminController
      *
      * @param int $customerId
      * @param Request $request
+     * @param CustomerDiscountFilters $customerDiscountFilters
+     * @param CustomerAddressFilters $customerAddressFilters
      *
      * @return Response
      */
-    public function viewAction($customerId, Request $request)
-    {
+    public function viewAction(
+        $customerId,
+        Request $request,
+        CustomerDiscountFilters $customerDiscountFilters,
+        CustomerAddressFilters $customerAddressFilters
+    ) {
         try {
             /** @var ViewableCustomer $customerInformation */
             $customerInformation = $this->getQueryBus()->handle(new GetCustomerForViewing((int) $customerId));
@@ -291,7 +297,7 @@ class CustomerController extends AbstractAdminController
             'filters' => [
                 'id_customer' => $customerId,
             ],
-        ]);
+        ] + $customerDiscountFilters->all());
         $customerDiscountGrid = $customerDiscountGridFactory->getGrid($customerDiscountFilters);
 
         $customerAddressGridFactory = $this->get('prestashop.core.grid.factory.customer.address');
@@ -299,7 +305,7 @@ class CustomerController extends AbstractAdminController
             'filters' => [
                 'id_customer' => $customerId,
             ],
-        ]);
+        ] + $customerAddressFilters->all());
         $customerAddressGrid = $customerAddressGridFactory->getGrid($customerAddressFilters);
 
         if ($request->query->has('conf')) {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/performance.html.twig
@@ -33,7 +33,6 @@
 {% form_theme cachingForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {% block content %}
-  {% if multistoreIsUsed %}{{ ps.infotip(multistoreInfoTip, true) }}{% endif %}
   {{ form_start(smartyForm, {attr : {class: 'form'}, action: path('admin_performance_smarty_save') }) }}
     <div class="row justify-content-center">
       {% block perfs_form_smarty_cache %}

--- a/themes/classic/templates/_partials/header.tpl
+++ b/themes/classic/templates/_partials/header.tpl
@@ -54,24 +54,12 @@
   </nav>
 {/block}
 
-{function renderLogo}
-  <a href="{$urls.pages.index}">
-    <img
-      class="logo img-fluid"
-      src="{$shop.logo.src}"
-      alt="{$shop.name}"
-      loading="lazy"
-      width="{$shop.logo.width}"
-      height="{$shop.logo.height}">
-  </a>
-{/function}
-
 {block name='header_top'}
   <div class="header-top">
     <div class="container">
        <div class="row">
         <div class="col-md-2 hidden-sm-down" id="_desktop_logo">
-          {if $shop.logo}
+          {if $shop.logo_details}
             {if $page.page_name == 'index'}
               <h1>
                 {renderLogo}

--- a/themes/classic/templates/_partials/helpers.tpl
+++ b/themes/classic/templates/_partials/helpers.tpl
@@ -1,0 +1,36 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+ 
+{function renderLogo}
+  <a href="{$urls.pages.index}">
+    <img
+      class="logo img-fluid"
+      src="{$shop.logo_details.src}"
+      alt="{$shop.name}"
+      loading="lazy"
+      width="{$shop.logo_details.width}"
+      height="{$shop.logo_details.height}">
+  </a>
+{/function}

--- a/themes/classic/templates/_partials/microdata/head-jsonld.tpl
+++ b/themes/classic/templates/_partials/microdata/head-jsonld.tpl
@@ -28,10 +28,10 @@
     "@type": "Organization",
     "name" : "{$shop.name}",
     "url" : "{$urls.pages.index}",
-    {if $shop.logo}
+    {if $shop.logo_details}
       "logo": {
         "@type": "ImageObject",
-        "url":"{$shop.logo.src}"
+        "url":"{$shop.logo_details.src}"
       }
     {/if}
   }
@@ -57,10 +57,10 @@
       "@context": "https://schema.org",
       "@type": "WebSite",
       "url" : "{$urls.pages.index}",
-      {if $shop.logo}
+      {if $shop.logo_details}
         "image": {
           "@type": "ImageObject",
-          "url":"{$shop.logo.src}"
+          "url":"{$shop.logo_details.src}"
         },
       {/if}
       "potentialAction": {

--- a/themes/classic/templates/checkout/_partials/header.tpl
+++ b/themes/classic/templates/checkout/_partials/header.tpl
@@ -27,15 +27,7 @@
     <div class="container">
       <div class="row">
         <div class="col-md-6 hidden-sm-down" id="_desktop_logo">
-          <a href="{$urls.pages.index}">
-            <img
-              class="logo img-fluid"
-              src="{$shop.logo.src}"
-              alt="{$shop.name}"
-              loading="lazy"
-              width="{$shop.logo.width}"
-              height="{$shop.logo.height}">
-          </a>
+            {renderLogo}
         </div>
         <div class="col-md-6 text-xs-right hidden-sm-down">
           {hook h='displayNav1'}

--- a/themes/classic/templates/layouts/layout-both-columns.tpl
+++ b/themes/classic/templates/layouts/layout-both-columns.tpl
@@ -22,6 +22,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
+
+{include file='_partials/helpers.tpl'}
+
 <!doctype html>
 <html lang="{$language.locale}">
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixes text align and text direction in Modern email template for RTL languages.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26177
| How to test?      | Email template must be regenerate base on Modern theme and a RTL language.
| Possible impacts? | -

**Screenshots**

❌ Generated email template:

<img src="https://user-images.githubusercontent.com/85633460/136664939-c1a22423-14a0-4a0b-9c5d-ea999fed05c3.png" width="550"/>

✔ Expected email template:

<img src="https://user-images.githubusercontent.com/85633460/136664943-cfe111b3-2af2-41b8-928e-9fb50522ebf7.png" width="550"/>

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26331)
<!-- Reviewable:end -->
