### PR TITLE
Fixed Modern email theme for RTL languages

### DIFF
--- a/mails/themes/modern/components/footer.html.twig
+++ b/mails/themes/modern/components/footer.html.twig
@@ -28,7 +28,7 @@
                class="" style="vertical-align:top;width:604px;"
             >
           <![endif]-->
-                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <div class="footer mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                             <tr>
                               <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">

--- a/mails/themes/modern/components/header.html.twig
+++ b/mails/themes/modern/components/header.html.twig
@@ -28,7 +28,7 @@
                class="" style="vertical-align:top;width:554px;"
             >
           <![endif]-->
-                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                        <div class="header mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                             <tr>
                               <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">

--- a/mails/themes/modern/components/layout.html.twig
+++ b/mails/themes/modern/components/layout.html.twig
@@ -55,6 +55,24 @@
         </style>
         <![endif]-->
   <style type="text/css">
+  {% if languageIsRTL|default(false) %}
+    div {
+      direction: rtl !important;
+      text-align: right !important;
+    }
+    
+    .header td table {
+      margin: 0 auto;
+    }
+    
+    .mj-column-px-25 {
+      float: right;
+    }
+    
+    .footer div {
+      text-align: center !important;
+    }
+  {% endif %}
   </style>
   <style type="text/css">
     .shadow {

--- a/mails/themes/modern/components/layout.html.twig
+++ b/mails/themes/modern/components/layout.html.twig
@@ -54,7 +54,8 @@
           .mj-outlook-group-fix { width:100% !important; }
         </style>
         <![endif]-->
-  {% if languageIsRTL|default(false) %}<style type="text/css">
+  <style type="text/css">
+  {% if languageIsRTL|default(false) %}
     div {
       direction: rtl !important;
       text-align: right !important;

--- a/mails/themes/modern/components/layout.html.twig
+++ b/mails/themes/modern/components/layout.html.twig
@@ -54,8 +54,7 @@
           .mj-outlook-group-fix { width:100% !important; }
         </style>
         <![endif]-->
-  <style type="text/css">
-  {% if languageIsRTL|default(false) %}
+  {% if languageIsRTL|default(false) %}<style type="text/css">
     div {
       direction: rtl !important;
       text-align: right !important;
@@ -72,8 +71,7 @@
     .footer div {
       text-align: center !important;
     }
-  {% endif %}
-  </style>
+  </style>{% endif %}
   <style type="text/css">
     .shadow {
       box-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.1);

--- a/mails/themes/modern/components/layout.html.twig
+++ b/mails/themes/modern/components/layout.html.twig
@@ -72,8 +72,7 @@
     .footer div {
       text-align: center !important;
     }
-  </style>{% endif %}
-  <style type="text/css">
+  {% endif %}
     .shadow {
       box-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.1);
     }

--- a/mails/themes/modern/components/order_layout.html.twig
+++ b/mails/themes/modern/components/order_layout.html.twig
@@ -55,6 +55,24 @@
         </style>
         <![endif]-->
   <style type="text/css">
+  {% if languageIsRTL|default(false) %}
+    div {
+      direction: rtl !important;
+      text-align: right !important;
+    }
+    
+    .header td table {
+      margin: 0 auto;
+    }
+    
+    .mj-column-px-25 {
+      float: right;
+    }
+    
+    .footer div {
+      text-align: center !important;
+    }
+  {% endif %}
   </style>
   <style type="text/css">
     .shadow {

--- a/mails/themes/modern/components/order_layout.html.twig
+++ b/mails/themes/modern/components/order_layout.html.twig
@@ -54,7 +54,8 @@
           .mj-outlook-group-fix { width:100% !important; }
         </style>
         <![endif]-->
-  {% if languageIsRTL|default(false) %}<style type="text/css">
+  <style type="text/css">
+  {% if languageIsRTL|default(false) %}
     div {
       direction: rtl !important;
       text-align: right !important;

--- a/mails/themes/modern/components/order_layout.html.twig
+++ b/mails/themes/modern/components/order_layout.html.twig
@@ -54,8 +54,7 @@
           .mj-outlook-group-fix { width:100% !important; }
         </style>
         <![endif]-->
-  <style type="text/css">
-  {% if languageIsRTL|default(false) %}
+  {% if languageIsRTL|default(false) %}<style type="text/css">
     div {
       direction: rtl !important;
       text-align: right !important;
@@ -72,8 +71,7 @@
     .footer div {
       text-align: center !important;
     }
-  {% endif %}
-  </style>
+  </style>{% endif %}
   <style type="text/css">
     .shadow {
       box-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.1);

--- a/mails/themes/modern/components/order_layout.html.twig
+++ b/mails/themes/modern/components/order_layout.html.twig
@@ -72,8 +72,7 @@
     .footer div {
       text-align: center !important;
     }
-  </style>{% endif %}
-  <style type="text/css">
+  {% endif %}
     .shadow {
       box-shadow: 0 20px 30px 0 rgba(0, 0, 0, 0.1);
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes text align and text direction in Modern email template for RTL languages.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26177
| How to test?      | Email template must be regenerate base on Modern theme and a RTL language.
| Possible impacts? | -

**Screenshots**

Generated email template:

<img src="https://user-images.githubusercontent.com/85633460/138106905-aa29820f-c6ee-4323-b571-99455f96c14b.png" width="600"/>

Expected email template:

<img src="https://user-images.githubusercontent.com/85633460/138106941-0ae75c86-23f1-49b5-8b02-876e2e91ff50.png" width="600"/>



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26340)
<!-- Reviewable:end -->
