### PR TITLE
Fix for issue with customizable products returns

### DIFF
--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -67,9 +67,9 @@ class OrderReturnCore extends ObjectModel
         /* Classic product return */
         if ($order_detail_list) {
             foreach ($order_detail_list as $key => $order_detail) {
-                $orderdetail = new OrderDetail((int) $order_detail);
-                $id_customization = $orderdetail->id_customization;
                 if ($qty = (int) $product_qty_list[$key]) {
+                    $orderdetail = new OrderDetail((int) $order_detail);
+                    $id_customization = $orderdetail->id_customization;
                     Db::getInstance()->insert('order_return_detail', ['id_order_return' => (int) $this->id, 'id_order_detail' => (int) $order_detail, 'product_quantity' => $qty, 'id_customization' => (int) $id_customization]);
                 }
             }

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -67,8 +67,10 @@ class OrderReturnCore extends ObjectModel
         /* Classic product return */
         if ($order_detail_list) {
             foreach ($order_detail_list as $key => $order_detail) {
+                $orderdetail = new OrderDetail($order_detail);
+                $id_customization = $orderdetail->id_customization;
                 if ($qty = (int) $product_qty_list[$key]) {
-                    Db::getInstance()->insert('order_return_detail', ['id_order_return' => (int) $this->id, 'id_order_detail' => (int) $order_detail, 'product_quantity' => $qty, 'id_customization' => 0]);
+                    Db::getInstance()->insert('order_return_detail', ['id_order_return' => (int) $this->id, 'id_order_detail' => (int) $order_detail, 'product_quantity' => $qty, 'id_customization' => (int) $id_customization]);
                 }
             }
         }

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -67,7 +67,7 @@ class OrderReturnCore extends ObjectModel
         /* Classic product return */
         if ($order_detail_list) {
             foreach ($order_detail_list as $key => $order_detail) {
-                $orderdetail = new OrderDetail($order_detail);
+                $orderdetail = new OrderDetail((int) $order_detail);
                 $id_customization = $orderdetail->id_customization;
                 if ($qty = (int) $product_qty_list[$key]) {
                     Db::getInstance()->insert('order_return_detail', ['id_order_return' => (int) $this->id, 'id_order_detail' => (int) $order_detail, 'product_quantity' => $qty, 'id_customization' => (int) $id_customization]);

--- a/themes/classic/templates/customer/_partials/order-detail-return.tpl
+++ b/themes/classic/templates/customer/_partials/order-detail-return.tpl
@@ -40,17 +40,9 @@
         {foreach from=$order.products item=product name=products}
           <tr>
             <td>
-              {if !$product.customizations}
-                <span id="_desktop_product_line_{$product.id_order_detail}">
+              <span id="_desktop_product_line_{$product.id_order_detail}">
                 <input type="checkbox" id="cb_{$product.id_order_detail}" name="ids_order_detail[{$product.id_order_detail}]" value="{$product.id_order_detail}">
               </span>
-              {else}
-                {foreach $product.customizations  as $customization}
-                  <span id="_desktop_product_customization_line_{$product.id_order_detail}_{$customization.id_customization}">
-                  <input type="checkbox" id="cb_{$product.id_order_detail}" name="customization_ids[{$product.id_order_detail}][]" value="{$customization.id_customization}">
-                </span>
-                {/foreach}
-              {/if}
             </td>
             <td>
               <strong>{$product.name}</strong><br/>
@@ -103,37 +95,21 @@
               {/if}
             </td>
             <td class="qty">
-              {if !$product.customizations}
-                <div class="current">
-                  {$product.quantity}
+              <div class="current">
+                {$product.quantity}
+              </div>
+              {if $product.quantity > $product.qty_returned}
+                <div class="select" id="_desktop_return_qty_{$product.id_order_detail}">
+                  <select name="order_qte_input[{$product.id_order_detail}]" class="form-control form-control-select">
+                    {section name=quantity start=1 loop=$product.quantity+1-$product.qty_returned}
+                      <option value="{$smarty.section.quantity.index}">{$smarty.section.quantity.index}</option>
+                    {/section}
+                  </select>
+                  {if $product.customizations}
+                    <input type="hidden" value="1" name="customization_qty_input[{$customization.id_customization}]" />
+                  {/if}
                 </div>
-                {if $product.quantity > $product.qty_returned}
-                  <div class="select" id="_desktop_return_qty_{$product.id_order_detail}">
-                    <select name="order_qte_input[{$product.id_order_detail}]" class="form-control form-control-select">
-                      {section name=quantity start=1 loop=$product.quantity+1-$product.qty_returned}
-                        <option value="{$smarty.section.quantity.index}">{$smarty.section.quantity.index}</option>
-                      {/section}
-                    </select>
-                  </div>
                 {/if}
-              {else}
-                {foreach $product.customizations as $customization}
-                  <div class="current">
-                    {$customization.quantity}
-                  </div>
-                  <div class="select" id="_desktop_return_qty_{$product.id_order_detail}_{$customization.id_customization}">
-                    <select
-                      name="customization_qty_input[{$customization.id_customization}]"
-                      class="form-control form-control-select"
-                    >
-                      {section name=quantity start=1 loop=$customization.quantity+1}
-                        <option value="{$smarty.section.quantity.index}">{$smarty.section.quantity.index}</option>
-                      {/section}
-                    </select>
-                  </div>
-                {/foreach}
-                <div class="clearfix"></div>
-              {/if}
             </td>
             <td class="text-xs-right">{$product.qty_returned}</td>
             <td class="text-xs-right">{$product.price}</td>


### PR DESCRIPTION
Remove all special code in template for customized order rows.
Add id_customization value on return detail for all rows.
This part of the code was having lots of legacy code from the time when customized order rows where connected to a single order row. Now when every new version of the customized product is a new order row, there is really no need to have special code for customized products as you can return these as any other order row. 
I made a small change to the OrderReturn class to keep id_customization on the the return_details table.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9579.
| How to test?      | Make returns of customized products.
| Possible impacts? | Return handling


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26347)
<!-- Reviewable:end -->
