### PR TITLE
Fix display of Category discount page

### DIFF
--- a/admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl
@@ -127,7 +127,7 @@
 		}
 		</script>
 
-		<div class="col-lg-9">
+		<div class="col-lg-8">
 			<a class="btn btn-default" href="#group_discount_category_fancybox" id="group_discount_category">{l s='Add a category discount' d='Admin.Shopparameters.Feature'}</a>
 			<table class="table" id="group_discount_category_table">
 				{foreach $input['values'] key=key item=category }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The "Category discount" part is misaligned when you edit a customer group.
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #26348.
| How to test?      | Check that The "Category discount" part is well displayed .
| Possible impacts? | /
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26253)
<!-- Reviewable:end -->