### PR TITLE
Fix display of address format in Countries page

### DIFF
--- a/admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl
@@ -26,7 +26,7 @@
 
 {block name="field"}
 	{if $input.type == 'address_layout'}
-		<div class="col-lg-9">
+		<div class="col-lg-8">
 			<div class="form-group">
 				<div class="col-lg-4">
 					<textarea id="ordered_fields" name="address_layout" style="height:150px;">{$input.address_layout}</textarea>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x 
| Description?      | Address format should be centered like the other elements. Tabs and buttons should be on one line.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26342.
| How to test?      | Check that the display of "Address format" in Countries page is ok.
| Possible impacts? | /
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26253)
<!-- Reviewable:end -->