### PR TITLE
Fix_display_panel-heading_dashboard_page

### DIFF
--- a/admin-dev/themes/default/scss/partials/_content.scss
+++ b/admin-dev/themes/default/scss/partials/_content.scss
@@ -86,7 +86,6 @@ body {
       font-weight: 600;
       color: $main-color;
       text-overflow: ellipsis;
-      white-space: nowrap;
 
       > .btn-group {
         margin-top: -7px;

--- a/admin-dev/themes/default/scss/partials/_forms.scss
+++ b/admin-dev/themes/default/scss/partials/_forms.scss
@@ -295,6 +295,7 @@ input[type="color"]:hover,
   .translatable-field {
     .btn.dropdown-toggle {
       height: $input-height-base;
+      white-space: nowrap;
     }
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | When we resize the window to 320px => some titles are NOK, related to this PR: https://github.com/PrestaShop/dashproducts/pull/34#issuecomment-947667498
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/dashproducts/pull/34#issuecomment-947667498
| How to test?      | Go to dashboard page and resize the window to 320 px => no titles panel-heading are well displayed
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26371)
<!-- Reviewable:end -->
