### PR TITLE
Dashboard - Correct display of the titles with panel-heading when the screen is reduced

### DIFF
--- a/admin-dev/themes/default/scss/partials/_content.scss
+++ b/admin-dev/themes/default/scss/partials/_content.scss
@@ -86,7 +86,6 @@ body {
       font-weight: 600;
       color: $main-color;
       text-overflow: ellipsis;
-      white-space: nowrap;
 
       > .btn-group {
         margin-top: -7px;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When we resize the window to 320px => some titles are NOK, related to this PR: https://github.com/PrestaShop/dashproducts/pull/34#issuecomment-947667498
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/dashproducts/pull/34#issuecomment-947667498
| How to test?      | Go to dashboard page and resize the window to 320 px => no titles panel-heading are well displayed
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26371)
<!-- Reviewable:end -->
