### PR TITLE
Fix Gift message bug if clicking fast

### DIFF
--- a/themes/classic/_dev/js/checkout.js
+++ b/themes/classic/_dev/js/checkout.js
@@ -46,7 +46,7 @@ function setUpCheckout() {
   });
 
   $(prestashop.themeSelectors.checkout.giftCheckbox).on('click', () => {
-    $('#gift').collapse('toggle');
+    $('#gift').slideToggle();
   });
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Gift message bug if clicking fast, collapse issue
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26044.
| How to test?      | Enable gift wrapping. Add something to cart, go to checkout, delivery step. Click on gift wrapping checkbox very fast, and you can get it to a state where the checkbox is checked, but the gift message is hidden, or reverse.
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26392)
<!-- Reviewable:end -->
