### PR TITLE
Use `_PS_PRODUCT_IMG_DIR_`  instead of  `_PS_PROD_IMG_DIR_` to avoid confusion with `prod` and `dev` env.

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -87,8 +87,8 @@ class ImageCore extends ObjectModel
     public function __construct($id = null, $idLang = null)
     {
         parent::__construct($id, $idLang);
-        $this->image_dir = _PS_PROD_IMG_DIR_;
-        $this->source_index = _PS_PROD_IMG_DIR_ . 'index.php';
+        $this->image_dir = _PS_PRODUCT_IMG_DIR_;
+        $this->source_index = _PS_PRODUCT_IMG_DIR_ . 'index.php';
     }
 
     /**
@@ -389,16 +389,16 @@ class ImageCore extends ObjectModel
             if ($imageNew->add()) {
                 $newPath = $imageNew->getPathForCreation();
                 foreach ($imagesTypes as $imageType) {
-                    if (file_exists(_PS_PROD_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '.jpg')) {
+                    if (file_exists(_PS_PRODUCT_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '.jpg')) {
                         if (!Configuration::get('PS_LEGACY_IMAGES')) {
                             $imageNew->createImgFolder();
                         }
                         copy(
-                            _PS_PROD_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '.jpg',
+                            _PS_PRODUCT_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '.jpg',
                         $newPath . '-' . $imageType['name'] . '.jpg'
                         );
                         if (Configuration::get('WATERMARK_HASH')) {
-                            $oldImagePath = _PS_PROD_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '-' . Configuration::get('WATERMARK_HASH') . '.jpg';
+                            $oldImagePath = _PS_PRODUCT_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '-' . Configuration::get('WATERMARK_HASH') . '.jpg';
                             if (file_exists($oldImagePath)) {
                                 copy($oldImagePath, $newPath . '-' . $imageType['name'] . '-' . Configuration::get('WATERMARK_HASH') . '.jpg');
                             }
@@ -406,8 +406,8 @@ class ImageCore extends ObjectModel
                     }
                 }
 
-                if (file_exists(_PS_PROD_IMG_DIR_ . $imageOld->getExistingImgPath() . '.jpg')) {
-                    copy(_PS_PROD_IMG_DIR_ . $imageOld->getExistingImgPath() . '.jpg', $newPath . '.jpg');
+                if (file_exists(_PS_PRODUCT_IMG_DIR_ . $imageOld->getExistingImgPath() . '.jpg')) {
+                    copy(_PS_PRODUCT_IMG_DIR_ . $imageOld->getExistingImgPath() . '.jpg', $newPath . '.jpg');
                 }
 
                 Image::replaceAttributeImageAssociationId($combinationImages, (int) $imageOld->id, (int) $imageNew->id);
@@ -681,7 +681,7 @@ class ImageCore extends ObjectModel
         }
 
         if (!$this->existing_path) {
-            if (Configuration::get('PS_LEGACY_IMAGES') && file_exists(_PS_PROD_IMG_DIR_ . $this->id_product . '-' . $this->id . '.' . $this->image_format)) {
+            if (Configuration::get('PS_LEGACY_IMAGES') && file_exists(_PS_PRODUCT_IMG_DIR_ . $this->id_product . '-' . $this->id . '.' . $this->image_format)) {
                 $this->existing_path = $this->id_product . '-' . $this->id;
             } else {
                 $this->existing_path = $this->getImgPath();
@@ -720,16 +720,16 @@ class ImageCore extends ObjectModel
             return false;
         }
 
-        if (!file_exists(_PS_PROD_IMG_DIR_ . $this->getImgFolder())) {
+        if (!file_exists(_PS_PRODUCT_IMG_DIR_ . $this->getImgFolder())) {
             // Apparently sometimes mkdir cannot set the rights, and sometimes chmod can't. Trying both.
-            $success = @mkdir(_PS_PROD_IMG_DIR_ . $this->getImgFolder(), self::$access_rights, true);
-            $chmod = @chmod(_PS_PROD_IMG_DIR_ . $this->getImgFolder(), self::$access_rights);
+            $success = @mkdir(_PS_PRODUCT_IMG_DIR_ . $this->getImgFolder(), self::$access_rights, true);
+            $chmod = @chmod(_PS_PRODUCT_IMG_DIR_ . $this->getImgFolder(), self::$access_rights);
 
             // Create an index.php file in the new folder
             if (($success || $chmod)
-                && !file_exists(_PS_PROD_IMG_DIR_ . $this->getImgFolder() . 'index.php')
+                && !file_exists(_PS_PRODUCT_IMG_DIR_ . $this->getImgFolder() . 'index.php')
                 && file_exists($this->source_index)) {
-                return @copy($this->source_index, _PS_PROD_IMG_DIR_ . $this->getImgFolder() . 'index.php');
+                return @copy($this->source_index, _PS_PRODUCT_IMG_DIR_ . $this->getImgFolder() . 'index.php');
             }
         }
 
@@ -783,7 +783,7 @@ class ImageCore extends ObjectModel
         $startTime = time();
         $image = null;
         $tmpFolder = 'duplicates/';
-        foreach (scandir(_PS_PROD_IMG_DIR_, SCANDIR_SORT_NONE) as $file) {
+        foreach (scandir(_PS_PRODUCT_IMG_DIR_, SCANDIR_SORT_NONE) as $file) {
             // matches the base product image or the thumbnails
             if (preg_match('/^([0-9]+\-)([0-9]+)(\-(.*))?\.jpg$/', $file, $matches)) {
                 // don't recreate an image object for each image type
@@ -799,19 +799,19 @@ class ImageCore extends ObjectModel
 
                     // if there's already a file at the new image path, move it to a dump folder
                     // most likely the preexisting image is a demo image not linked to a product and it's ok to replace it
-                    $newPath = _PS_PROD_IMG_DIR_ . $image->getImgPath() . (isset($matches[3]) ? $matches[3] : '') . '.jpg';
+                    $newPath = _PS_PRODUCT_IMG_DIR_ . $image->getImgPath() . (isset($matches[3]) ? $matches[3] : '') . '.jpg';
                     if (file_exists($newPath)) {
-                        if (!file_exists(_PS_PROD_IMG_DIR_ . $tmpFolder)) {
-                            @mkdir(_PS_PROD_IMG_DIR_ . $tmpFolder, self::$access_rights);
-                            @chmod(_PS_PROD_IMG_DIR_ . $tmpFolder, self::$access_rights);
+                        if (!file_exists(_PS_PRODUCT_IMG_DIR_ . $tmpFolder)) {
+                            @mkdir(_PS_PRODUCT_IMG_DIR_ . $tmpFolder, self::$access_rights);
+                            @chmod(_PS_PRODUCT_IMG_DIR_ . $tmpFolder, self::$access_rights);
                         }
-                        $tmpPath = _PS_PROD_IMG_DIR_ . $tmpFolder . basename($file);
+                        $tmpPath = _PS_PRODUCT_IMG_DIR_ . $tmpFolder . basename($file);
                         if (!@rename($newPath, $tmpPath) || !file_exists($tmpPath)) {
                             return false;
                         }
                     }
                     // move the image
-                    if (!@rename(_PS_PROD_IMG_DIR_ . $file, $newPath) || !file_exists($newPath)) {
+                    if (!@rename(_PS_PRODUCT_IMG_DIR_ . $file, $newPath) || !file_exists($newPath)) {
                         return false;
                     }
                 }
@@ -831,7 +831,7 @@ class ImageCore extends ObjectModel
      */
     public static function testFileSystem()
     {
-        $folder1 = _PS_PROD_IMG_DIR_ . 'testfilesystem/';
+        $folder1 = _PS_PRODUCT_IMG_DIR_ . 'testfilesystem/';
         $testFolder = $folder1 . 'testsubfolder/';
         // check if folders are already existing from previous failed test
         if (file_exists($testFolder)) {
@@ -877,6 +877,6 @@ class ImageCore extends ObjectModel
             $this->createImgFolder();
         }
 
-        return _PS_PROD_IMG_DIR_ . $path;
+        return _PS_PRODUCT_IMG_DIR_ . $path;
     }
 }

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1006,9 +1006,9 @@ class LinkCore
         }
 
         // legacy mode or default image
-        $theme = ((Shop::isFeatureActive() && file_exists(_PS_PROD_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . '-' . Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
+        $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . '-' . Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
         if (($psLegacyImages
-                && (file_exists(_PS_PROD_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . $theme . '.jpg')))
+                && (file_exists(_PS_PRODUCT_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . $theme . '.jpg')))
             || ($notDefault = strpos($ids, 'default') !== false)) {
             if ($this->allow == 1 && !$notDefault) {
                 $uriPath = __PS_BASE_URI__ . $ids . ($type ? '-' . $type : '') . $theme . '/' . $name . '.jpg';
@@ -1019,7 +1019,7 @@ class LinkCore
             // if ids if of the form id_product-id_image, we want to extract the id_image part
             $splitIds = explode('-', $ids);
             $idImage = (isset($splitIds[1]) ? $splitIds[1] : $splitIds[0]);
-            $theme = ((Shop::isFeatureActive() && file_exists(_PS_PROD_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . '-' . (int) Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
+            $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . '-' . (int) Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
             if ($this->allow == 1) {
                 $uriPath = __PS_BASE_URI__ . $idImage . ($type ? '-' . $type : '') . $theme . '/' . $name . '.jpg';
             } else {

--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -106,7 +106,7 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
             foreach ($order_details as &$order_detail) {
                 if ($order_detail['image'] != null) {
                     $name = 'product_mini_' . (int) $order_detail['product_id'] . (isset($order_detail['product_attribute_id']) ? '_' . (int) $order_detail['product_attribute_id'] : '') . '.jpg';
-                    $path = _PS_PROD_IMG_DIR_ . $order_detail['image']->getExistingImgPath() . '.jpg';
+                    $path = _PS_PRODUCT_IMG_DIR_ . $order_detail['image']->getExistingImgPath() . '.jpg';
 
                     $order_detail['image_tag'] = preg_replace(
                         '/\.*' . preg_quote(__PS_BASE_URI__, '/') . '/',

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -219,7 +219,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             foreach ($order_details as &$order_detail) {
                 if ($order_detail['image'] != null) {
                     $name = 'product_mini_' . (int) $order_detail['product_id'] . (isset($order_detail['product_attribute_id']) ? '_' . (int) $order_detail['product_attribute_id'] : '') . '.jpg';
-                    $path = _PS_PROD_IMG_DIR_ . $order_detail['image']->getExistingImgPath() . '.jpg';
+                    $path = _PS_PRODUCT_IMG_DIR_ . $order_detail['image']->getExistingImgPath() . '.jpg';
 
                     $order_detail['image_tag'] = preg_replace(
                         '/\.*' . preg_quote(__PS_BASE_URI__, '/') . '/',

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -659,7 +659,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 
     protected function manageProductImages()
     {
-        $this->manageDeclinatedImages(_PS_PROD_IMG_DIR_);
+        $this->manageDeclinatedImages(_PS_PRODUCT_IMG_DIR_);
     }
 
     protected function getCustomizations()
@@ -1140,18 +1140,18 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 
                     if ($this->imageType == 'products' && isset($image, $product)) {
                         $image = new Image($image->id);
-                        if (!(Configuration::get('PS_OLD_FILESYSTEM') && file_exists(_PS_PROD_IMG_DIR_ . $product->id . '-' . $image->id . '.jpg'))) {
+                        if (!(Configuration::get('PS_OLD_FILESYSTEM') && file_exists(_PS_PRODUCT_IMG_DIR_ . $product->id . '-' . $image->id . '.jpg'))) {
                             $image->createImgFolder();
                         }
 
                         if (!($tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !move_uploaded_file($file['tmp_name'], $tmp_name)) {
                             throw new WebserviceException('An error occurred during the image upload', [76, 400]);
-                        } elseif (!ImageManager::resize($tmp_name, _PS_PROD_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format)) {
+                        } elseif (!ImageManager::resize($tmp_name, _PS_PRODUCT_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format)) {
                             throw new WebserviceException('An error occurred while copying image', [76, 400]);
                         } else {
                             $images_types = ImageType::getImagesTypes('products');
                             foreach ($images_types as $imageType) {
-                                if (!ImageManager::resize($tmp_name, _PS_PROD_IMG_DIR_ . $image->getExistingImgPath() . '-' . stripslashes($imageType['name']) . '.' . $image->image_format, $imageType['width'], $imageType['height'], $image->image_format)) {
+                                if (!ImageManager::resize($tmp_name, _PS_PRODUCT_IMG_DIR_ . $image->getExistingImgPath() . '-' . stripslashes($imageType['name']) . '.' . $image->image_format, $imageType['width'], $imageType['height'], $image->image_format)) {
                                     $this->getWsObject()->errors[] = Context::getContext()->getTranslator()->trans('An error occurred while copying this image: %s', [stripslashes($imageType['name'])], 'Admin.Notifications.Error');
                                 }
                             }
@@ -1160,7 +1160,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 
                         Hook::exec('actionWatermark', ['id_image' => $image->id, 'id_product' => $image->id_product]);
 
-                        $this->imgToDisplay = _PS_PROD_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format;
+                        $this->imgToDisplay = _PS_PRODUCT_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format;
                         $this->objOutput->setFieldsToDisplay('full');
                         $this->output = $this->objOutput->renderEntity($image, 1);
                         $image_content = ['sqlId' => 'content', 'value' => base64_encode(file_get_contents($this->imgToDisplay)), 'encode' => 'base64'];

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -153,8 +153,8 @@ define('_PS_GENDERS_DIR_', _PS_IMG_DIR_.'genders/');
 define('_PS_LANG_IMG_DIR_', _PS_IMG_DIR_.'l/');
 define('_PS_MANU_IMG_DIR_', _PS_IMG_DIR_.'m/');
 define('_PS_ORDER_STATE_IMG_DIR_', _PS_IMG_DIR_.'os/');
-// _PS_PROD_IMG_DIR_ is deprecated since 1.7.8.1 version use _PS_PRODUCT_IMG_DIR_ instead
-define('_PS_PRODUCT_IMG_DIR_', _PS_IMG_DIR_.'p/');
+define('_PS_PRODUCT_IMG_DIR_', _PS_IMG_DIR_ . 'p/');
+// @deprecated since 1.7.8.1 version use _PS_PRODUCT_IMG_DIR_ instead
 define('_PS_PROD_IMG_DIR_', _PS_PRODUCT_IMG_DIR_);
 define('_PS_PROFILE_IMG_DIR_', _PS_IMG_DIR_.'pr/');
 define('_PS_SHIP_IMG_DIR_', _PS_IMG_DIR_.'s/');

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -153,7 +153,9 @@ define('_PS_GENDERS_DIR_', _PS_IMG_DIR_.'genders/');
 define('_PS_LANG_IMG_DIR_', _PS_IMG_DIR_.'l/');
 define('_PS_MANU_IMG_DIR_', _PS_IMG_DIR_.'m/');
 define('_PS_ORDER_STATE_IMG_DIR_', _PS_IMG_DIR_.'os/');
+// _PS_PROD_IMG_DIR_ is deprecated since 1.7.8.1 version use _PS_PRODUCT_IMG_DIR_ instead
 define('_PS_PROD_IMG_DIR_', _PS_IMG_DIR_.'p/');
+define('_PS_PRODUCT_IMG_DIR_', _PS_PROD_IMG_DIR_);
 define('_PS_PROFILE_IMG_DIR_', _PS_IMG_DIR_.'pr/');
 define('_PS_SHIP_IMG_DIR_', _PS_IMG_DIR_.'s/');
 define('_PS_STORE_IMG_DIR_', _PS_IMG_DIR_.'st/');

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -154,8 +154,8 @@ define('_PS_LANG_IMG_DIR_', _PS_IMG_DIR_.'l/');
 define('_PS_MANU_IMG_DIR_', _PS_IMG_DIR_.'m/');
 define('_PS_ORDER_STATE_IMG_DIR_', _PS_IMG_DIR_.'os/');
 // _PS_PROD_IMG_DIR_ is deprecated since 1.7.8.1 version use _PS_PRODUCT_IMG_DIR_ instead
-define('_PS_PROD_IMG_DIR_', _PS_IMG_DIR_.'p/');
-define('_PS_PRODUCT_IMG_DIR_', _PS_PROD_IMG_DIR_);
+define('_PS_PRODUCT_IMG_DIR_', _PS_IMG_DIR_.'p/');
+define('_PS_PROD_IMG_DIR_', _PS_PRODUCT_IMG_DIR_);
 define('_PS_PROFILE_IMG_DIR_', _PS_IMG_DIR_.'pr/');
 define('_PS_SHIP_IMG_DIR_', _PS_IMG_DIR_.'s/');
 define('_PS_STORE_IMG_DIR_', _PS_IMG_DIR_.'st/');

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -65,9 +65,9 @@ class AdminImagesControllerCore extends AdminController
             'stores' => ['title' => $this->trans('Stores', [], 'Admin.Global'), 'align' => 'center', 'type' => 'bool', 'callback' => 'printEntityActiveIcon', 'orderby' => false],
         ];
 
-        // No need to display the old image system migration tool except if product images are in _PS_PROD_IMG_DIR_
+        // No need to display the old image system migration tool except if product images are in _PS_PRODUCT_IMG_DIR_
         $this->display_move = false;
-        $dir = _PS_PROD_IMG_DIR_;
+        $dir = _PS_PRODUCT_IMG_DIR_;
         if (is_dir($dir)) {
             if ($dh = opendir($dir)) {
                 while (($file = readdir($dh)) !== false && $this->display_move == false) {
@@ -354,8 +354,8 @@ class AdminImagesControllerCore extends AdminController
     public function postProcess()
     {
         // When moving images, if duplicate images were found they are moved to a folder named duplicates/
-        if (file_exists(_PS_PROD_IMG_DIR_ . 'duplicates/')) {
-            $this->warnings[] = $this->trans('Duplicate images were found when moving the product images. This is likely caused by unused demonstration images. Please make sure that the folder %folder% only contains demonstration images, and then delete it.', ['%folder%' => _PS_PROD_IMG_DIR_ . 'duplicates/'], 'Admin.Design.Notification');
+        if (file_exists(_PS_PRODUCT_IMG_DIR_ . 'duplicates/')) {
+            $this->warnings[] = $this->trans('Duplicate images were found when moving the product images. This is likely caused by unused demonstration images. Please make sure that the folder %folder% only contains demonstration images, and then delete it.', ['%folder%' => _PS_PRODUCT_IMG_DIR_ . 'duplicates/'], 'Admin.Design.Notification');
         }
 
         if (Tools::isSubmit('submitRegenerate' . $this->table)) {
@@ -611,7 +611,7 @@ class AdminImagesControllerCore extends AdminController
             foreach ($languages as $language) {
                 $file = $dir . $language['iso_code'] . '.jpg';
                 if (!file_exists($file)) {
-                    $file = _PS_PROD_IMG_DIR_ . Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT')) . '.jpg';
+                    $file = _PS_PRODUCT_IMG_DIR_ . Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT')) . '.jpg';
                 }
                 if (!file_exists($dir . $language['iso_code'] . '-default-' . stripslashes($image_type['name']) . '.jpg')) {
                     if (!ImageManager::resize($file, $dir . $language['iso_code'] . '-default-' . stripslashes($image_type['name']) . '.jpg', (int) $image_type['width'], (int) $image_type['height'])) {
@@ -670,7 +670,7 @@ class AdminImagesControllerCore extends AdminController
             ['type' => 'categories', 'dir' => _PS_CAT_IMG_DIR_],
             ['type' => 'manufacturers', 'dir' => _PS_MANU_IMG_DIR_],
             ['type' => 'suppliers', 'dir' => _PS_SUPP_IMG_DIR_],
-            ['type' => 'products', 'dir' => _PS_PROD_IMG_DIR_],
+            ['type' => 'products', 'dir' => _PS_PRODUCT_IMG_DIR_],
             ['type' => 'stores', 'dir' => _PS_STORE_IMG_DIR_],
         ];
 

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -4520,9 +4520,9 @@ class AdminImportControllerCore extends AdminController
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_combination`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_image`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'pack`');
-                Image::deleteAllImages(_PS_PROD_IMG_DIR_);
-                if (!file_exists(_PS_PROD_IMG_DIR_)) {
-                    mkdir(_PS_PROD_IMG_DIR_);
+                Image::deleteAllImages(_PS_PRODUCT_IMG_DIR_);
+                if (!file_exists(_PS_PRODUCT_IMG_DIR_)) {
+                    mkdir(_PS_PRODUCT_IMG_DIR_);
                 }
 
                 break;

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1663,7 +1663,7 @@ class AdminProductsControllerCore extends AdminController
                 }
             }
         }
-        if (isset($image) && Validate::isLoadedObject($image) && !file_exists(_PS_PROD_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format)) {
+        if (isset($image) && Validate::isLoadedObject($image) && !file_exists(_PS_PRODUCT_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format)) {
             $image->delete();
         }
         if (count($this->errors)) {

--- a/images.inc.php
+++ b/images.inc.php
@@ -153,7 +153,7 @@ function deleteImage($id_item, $id_image = null)
     } else {
         // Product
 
-        $path = _PS_PROD_IMG_DIR_;
+        $path = _PS_PRODUCT_IMG_DIR_;
         $table = 'product';
         $image = new Image($id_image);
         $image->id_product = $id_item;

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -144,7 +144,7 @@ class ImageRetriever
         if (get_class($object) === 'Product') {
             $type = 'products';
             $getImageURL = 'getImageLink';
-            $root = _PS_PROD_IMG_DIR_;
+            $root = _PS_PRODUCT_IMG_DIR_;
             $imageFolderPath = implode(DIRECTORY_SEPARATOR, [
                 rtrim($root, DIRECTORY_SEPARATOR),
                 rtrim(Image::getImgFolderStatic($id_image), DIRECTORY_SEPARATOR),

--- a/src/Adapter/ImageManager.php
+++ b/src/Adapter/ImageManager.php
@@ -59,7 +59,7 @@ class ImageManager
      *
      * @return string The HTML < img > tag
      */
-    public function getThumbnailForListing($imageId, $imageType = 'jpg', $tableName = 'product', $imageDir = _PS_PROD_IMG_DIR_)
+    public function getThumbnailForListing($imageId, $imageType = 'jpg', $tableName = 'product', $imageDir = _PS_PRODUCT_IMG_DIR_)
     {
         $thumbPath = $this->getThumbnailTag($imageId, $imageType, $tableName, $imageDir);
 
@@ -79,7 +79,7 @@ class ImageManager
     {
         $imageType = 'jpg';
         $tableName = 'product';
-        $imageDir = _PS_PROD_IMG_DIR_;
+        $imageDir = _PS_PRODUCT_IMG_DIR_;
 
         $imagePath = $this->getImagePath($imageId, $imageType, $tableName, $imageDir);
         $thumbnailCachedImageName = $this->makeCachedImageName($imageId, $imageType, $tableName);

--- a/src/Adapter/Import/ImportEntityDeleter.php
+++ b/src/Adapter/Import/ImportEntityDeleter.php
@@ -244,7 +244,7 @@ final class ImportEntityDeleter implements ImportEntityDeleterInterface
 
         $this->truncateTablesIfExist($truncateIfExists);
 
-        $imgDir = $this->configuration->get('_PS_PROD_IMG_DIR_');
+        $imgDir = $this->configuration->get('_PS_PRODUCT_IMG_DIR_');
         $this->imageFileDeleter->deleteFromPath($imgDir, true, true);
     }
 

--- a/src/Adapter/Language/LanguageImageManager.php
+++ b/src/Adapter/Language/LanguageImageManager.php
@@ -62,7 +62,7 @@ class LanguageImageManager
     public const IMAGE_DIRECTORIES = [
         _PS_CAT_IMG_DIR_,
         _PS_MANU_IMG_DIR_,
-        _PS_PROD_IMG_DIR_,
+        _PS_PRODUCT_IMG_DIR_,
         _PS_SUPP_IMG_DIR_,
     ];
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -667,7 +667,7 @@ class Install extends AbstractInstall
         }
 
         $list = [
-            'products' => _PS_PROD_IMG_DIR_,
+            'products' => _PS_PRODUCT_IMG_DIR_,
             'categories' => _PS_CAT_IMG_DIR_,
             'manufacturers' => _PS_MANU_IMG_DIR_,
             'suppliers' => _PS_SUPP_IMG_DIR_,

--- a/src/PrestaShopBundle/Install/XmlLoader.php
+++ b/src/PrestaShopBundle/Install/XmlLoader.php
@@ -1446,7 +1446,7 @@ class XmlLoader
         }
 
         $backup_path = $this->img_path . 'p/';
-        $from_path = _PS_PROD_IMG_DIR_;
+        $from_path = _PS_PRODUCT_IMG_DIR_;
         if (!is_dir($backup_path) && !mkdir($backup_path)) {
             $this->setError(sprintf('Cannot create directory <i>%s</i>', $backup_path));
         }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -72,7 +72,7 @@ services:
   prestashop.adapter.product.image.product_image_filesystem_path_factory:
     class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
     arguments:
-      - !php/const _PS_PROD_IMG_DIR_
+      - !php/const _PS_PRODUCT_IMG_DIR_
       - !php/const _PS_TMP_IMG_DIR_
       - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
@@ -244,7 +244,7 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
         $directories = str_split((string) $imageId);
         $path = implode('/', $directories);
 
-        return _PS_PROD_IMG_DIR_ . $path;
+        return _PS_PRODUCT_IMG_DIR_ . $path;
     }
 
     /**
@@ -371,7 +371,7 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
     {
         $imageFolder = implode('/', str_split((string) $imageId));
 
-        return _PS_PROD_IMG_DIR_ . '/' . $imageFolder . '/' . $imageId . '.jpg';
+        return _PS_PRODUCT_IMG_DIR_ . '/' . $imageFolder . '/' . $imageId . '.jpg';
     }
 
     /**

--- a/tests/Resources/modules_tests/override/AdminProductsController.php
+++ b/tests/Resources/modules_tests/override/AdminProductsController.php
@@ -1485,7 +1485,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 }
             }
         }
-        if (isset($image) && Validate::isLoadedObject($image) && !file_exists(_PS_PROD_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format)) {
+        if (isset($image) && Validate::isLoadedObject($image) && !file_exists(_PS_PRODUCT_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format)) {
             $image->delete();
         }
         if (count($this->errors)) {

--- a/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -1471,7 +1471,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 }
             }
         }
-        if (isset($image) && Validate::isLoadedObject($image) && !file_exists(_PS_PROD_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format)) {
+        if (isset($image) && Validate::isLoadedObject($image) && !file_exists(_PS_PRODUCT_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format)) {
             $image->delete();
         }
         if (count($this->errors)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Use `_PS_PRODUCT_IMG_DIR_`  instead of  `_PS_PROD_IMG_DIR_` to avoid confusion with `prod` and `dev` env.
| Type?             | refacto 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | N/A
| How to test?      | Test green :)
| Possible impacts? | Check product images is work :)




### Deprecations

-  `_PS_PROD_IMG_DIR_` is now deprecated, use `_PS_PRODUCT_IMG_DIR_` instead

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26408)
<!-- Reviewable:end -->
