### PR TITLE
Fix old deleted customization fields copied after duplicating a product

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5327,6 +5327,7 @@ class ProductCore extends ObjectModel
             SELECT `id_customization_field`, `type`, `required`
             FROM `' . _DB_PREFIX_ . 'customization_field`
             WHERE `id_product` = ' . (int) $product_id . '
+            AND `is_deleted` = 0
             ORDER BY `id_customization_field`')) === false) {
             return false;
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | After duplicating a product, an old deleted customization field is copied to the new product.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/18086
| How to test?      | Follow scenario described in the issue
| Possible impacts? | --

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26415)
<!-- Reviewable:end -->
