### PR TITLE
Not using href as a selector on order history page

### DIFF
--- a/tests/UI/campaigns/functional/FO/03_userAccount/08_orderHistory/01_reorderFromOrderList.js
+++ b/tests/UI/campaigns/functional/FO/03_userAccount/08_orderHistory/01_reorderFromOrderList.js
@@ -167,8 +167,7 @@ describe('FO - Account : Reorder from order list', async () => {
     it('should reorder the last order', async function () {
       await testContext.addContextItem(this, 'testIdentifier', 'reorderLastOrder', baseContext);
 
-      const lastOrderRowNumber = await foOrderHistoryPage.getNumberOfOrders(page);
-      await foOrderHistoryPage.clickOnReorderLink(page, lastOrderRowNumber);
+      await foOrderHistoryPage.clickOnReorderLink(page);
 
       const isCheckoutPage = await checkoutPage.isCheckoutPage(page);
       await expect(isCheckoutPage, 'Browser is not in checkout Page').to.be.true;

--- a/tests/UI/pages/FO/myAccount/orderHistory.js
+++ b/tests/UI/pages/FO/myAccount/orderHistory.js
@@ -21,8 +21,8 @@ class OrderHistory extends FOBasePage {
     this.ordersTableRows = `${this.ordersTable} tbody tr`;
     this.ordersTableRow = row => `${this.ordersTableRows}:nth-child(${row})`;
     this.orderTableColumn = (row, column) => `${this.ordersTableRow(row)} td:nth-child(${column})`;
-    this.reorderLink = id => `${this.ordersTable} td.order-actions a[href*='Reorder=&id_order=${id}']`;
-    this.detailsLink = row => `${this.ordersTableRow(row)} a[data-link-action='view-order-details']`;
+    this.reorderLink = row => `${this.ordersTableRow(row)} a.reorder-link`;
+    this.detailsLink = row => `${this.ordersTableRow(row)} a.view-order-details-link`;
   }
 
   /*
@@ -41,18 +41,18 @@ class OrderHistory extends FOBasePage {
   /**
    * Is reorder link visible
    * @param page {Page} Browser tab
-   * @param idOrder {Number} database id of the order
+   * @param orderRow {Number} Row on orders table
    * @returns {Promise<boolean>}
    */
-  isReorderLinkVisible(page, idOrder = 1) {
-    return this.elementVisible(page, this.reorderLink(idOrder), 1000);
+  isReorderLinkVisible(page, orderRow = 1) {
+    return this.elementVisible(page, this.reorderLink(orderRow), 1000);
   }
 
   /**
    *
    * Click on reorder link
    * @param page {Page} Browser tab
-   * @param orderRow {Number} row in orders table
+   * @param orderRow {Number} Row in orders table
    * @returns {Promise<void>}
    */
   async clickOnReorderLink(page, orderRow = 1) {

--- a/themes/classic/templates/customer/history.tpl
+++ b/themes/classic/templates/customer/history.tpl
@@ -67,11 +67,11 @@
               {/if}
             </td>
             <td class="text-sm-center order-actions">
-              <a href="{$order.details.details_url}" data-link-action="view-order-details">
+              <a class="view-order-details-link" href="{$order.details.details_url}" data-link-action="view-order-details">
                 {l s='Details' d='Shop.Theme.Customeraccount'}
               </a>
               {if $order.details.reorder_url}
-                <a href="{$order.details.reorder_url}">{l s='Reorder' d='Shop.Theme.Actions'}</a>
+                <a class="reorder-link" href="{$order.details.reorder_url}">{l s='Reorder' d='Shop.Theme.Actions'}</a>
               {/if}
             </td>
           </tr>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Not using href as a selector on order history page (following #25406)
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | no tests needed
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26416)
<!-- Reviewable:end -->
