### PR TITLE
Fix duplication of specific prices that apply to a single combination

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -400,6 +400,14 @@ class ProductCore extends ObjectModel
     protected static $_combinations = [];
 
     /**
+     * Associations between the ids of base combinations and their duplicates.
+     * Used for duplicating specific prices when duplicating a product.
+     *
+     * @var array
+     */
+    protected static $_combination_associations = [];
+
+    /**
      * @deprecated Since 1.5.6.1
      *
      * @var array
@@ -4964,6 +4972,7 @@ class ProductCore extends ObjectModel
             $return &= $combination->save();
 
             $id_product_attribute_new = (int) $combination->id;
+            self::$_combination_associations[$id_product_attribute_old] = $id_product_attribute_new;
 
             if ($result_images = Product::_getAttributeImageAssociations($id_product_attribute_old)) {
                 $combination_images['old'][$id_product_attribute_old] = $result_images;
@@ -5363,7 +5372,7 @@ class ProductCore extends ObjectModel
     {
         foreach (SpecificPrice::getIdsByProductId((int) $old_product_id) as $data) {
             $specific_price = new SpecificPrice((int) $data['id_specific_price']);
-            if (!$specific_price->duplicate((int) $product_id)) {
+            if (!$specific_price->duplicate((int) $product_id, self::$_combination_associations)) {
                 return false;
             }
         }

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -213,11 +213,11 @@ class SpecificPriceCore extends ObjectModel
     public static function getIdsByProductId($id_product, $id_product_attribute = false, $id_cart = 0)
     {
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-			SELECT `id_specific_price`
-			FROM `' . _DB_PREFIX_ . 'specific_price`
-			WHERE `id_product` = ' . (int) $id_product .
+            SELECT `id_specific_price`
+            FROM `' . _DB_PREFIX_ . 'specific_price`
+            WHERE `id_product` = ' . (int) $id_product .
             ($id_product_attribute !== false ? ' AND id_product_attribute = ' . (int) $id_product_attribute : '') . '
-			AND id_cart = ' . (int) $id_cart);
+            AND id_cart = ' . (int) $id_cart);
     }
 
     /**

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -215,9 +215,9 @@ class SpecificPriceCore extends ObjectModel
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 			SELECT `id_specific_price`
 			FROM `' . _DB_PREFIX_ . 'specific_price`
-			WHERE `id_product` = ' . (int) $id_product . '
-			AND id_product_attribute=' . (int) $id_product_attribute . '
-			AND id_cart=' . (int) $id_cart);
+			WHERE `id_product` = ' . (int) $id_product .
+            ($id_product_attribute !== false ? ' AND id_product_attribute = ' . (int) $id_product_attribute : '') . '
+			AND id_cart = ' . (int) $id_cart);
     }
 
     /**
@@ -716,13 +716,17 @@ class SpecificPriceCore extends ObjectModel
      * Duplicate a product.
      *
      * @param bool|int $id_product The product ID to duplicate, false when duplicating the current product
+     * @param array $combination_associations Associations between the ids of base combinations and their duplicates
      *
      * @return bool
      */
-    public function duplicate($id_product = false)
+    public function duplicate($id_product = false, array $combination_associations = []): bool
     {
         if ($id_product) {
             $this->id_product = (int) $id_product;
+        }
+        if ($this->id_product_attribute && isset($combination_associations[$this->id_product_attribute])) {
+            $this->id_product_attribute = (int) $combination_associations[$this->id_product_attribute];
         }
         unset($this->id);
         // specific price row may already have been created for catalog specific price rule

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -122,29 +122,6 @@ Feature: Duplicate product from Back Office (BO).
       | includes tax    | true   |
       | from quantity   | 1      |
     Then product "product1" should have 1 specific prices
-    When I add product product_with_combinations with following information:
-      | name[en-US] | Jar of sand  |
-      | type        | combinations |
-    And I generate combinations for product product_with_combinations using following attributes:
-      | Color | [Red,Blue] |
-    Then product "product_with_combinations" should have following combinations:
-      | id reference                   | combination name | reference | attributes    | impact on price | quantity | is default |
-      | product_with_combinationsRed   | Color - Red      |           | [Color:Red]   | 0               | 0        | true       |
-      | product_with_combinationsBlue  | Color - Blue     |           | [Color:Blue]  | 0               | 0        | false      |
-    When I add a specific price specific_price1 to product product_with_combinations with following details:
-      | price           | 123.00                       |
-      | combination     | product_with_combinationsRed |
-      | reduction type  | amount                       |
-      | reduction value | 0.00                         |
-      | includes tax    | true                         |
-      | from quantity   | 1                            |
-    And I add a specific price specific_price2 to product product_with_combinations with following details:
-      | price           | 0.00   |
-      | reduction type  | amount |
-      | reduction value | 5.00   |
-      | includes tax    | true   |
-      | from quantity   | 1      |
-    Then product "product_with_combinations" should have 2 specific prices
 
   Scenario: I duplicate product
 #todo: add specific prices & priorities, test combinations, packs
@@ -241,6 +218,29 @@ Feature: Duplicate product from Back Office (BO).
 #@todo: add tests for other type of products Pack, Virtual, Combinations
 
   Scenario: I duplicate product with combinations
+    When I add product product_with_combinations with following information:
+      | name[en-US] | Jar of sand  |
+      | type        | combinations |
+    And I generate combinations for product product_with_combinations using following attributes:
+      | Color | [Red,Blue] |
+    Then product "product_with_combinations" should have following combinations:
+      | id reference                   | combination name | reference | attributes    | impact on price | quantity | is default |
+      | product_with_combinationsRed   | Color - Red      |           | [Color:Red]   | 0               | 0        | true       |
+      | product_with_combinationsBlue  | Color - Blue     |           | [Color:Blue]  | 0               | 0        | false      |
+    When I add a specific price specific_price1 to product product_with_combinations with following details:
+      | price           | 123.00                       |
+      | combination     | product_with_combinationsRed |
+      | reduction type  | amount                       |
+      | reduction value | 0.00                         |
+      | includes tax    | true                         |
+      | from quantity   | 1                            |
+    And I add a specific price specific_price2 to product product_with_combinations with following details:
+      | price           | 0.00   |
+      | reduction type  | amount |
+      | reduction value | 5.00   |
+      | includes tax    | true   |
+      | from quantity   | 1      |
+    Then product "product_with_combinations" should have 2 specific prices
     When I duplicate product product_with_combinations to a copy_of_product_with_combinations
     Then product "copy_of_product_with_combinations" should have 2 specific prices
     # TODO: all sorts of other checks

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -19,6 +19,9 @@ Feature: Duplicate product from Back Office (BO).
     And language "language2" with locale "fr-FR" exists
     And carrier carrier1 named "ecoCarrier" exists
     And carrier carrier2 named "Fast carry" exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "Red" named "Red" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
     Given I add product "product1" with following information:
       | name[en-US] | smart sunglasses   |
       | name[fr-FR] | lunettes de soleil |
@@ -112,6 +115,36 @@ Feature: Duplicate product from Back Office (BO).
     And product product1 should have following seo options:
       | redirect_type   | 301-product |
       | redirect_target | product2    |
+    When I add a specific price specific_price1 to product product1 with following details:
+      | price           | 0.00   |
+      | reduction type  | amount |
+      | reduction value | 5.00   |
+      | includes tax    | true   |
+      | from quantity   | 1      |
+    Then product "product1" should have 1 specific prices
+    When I add product product_with_combinations with following information:
+      | name[en-US] | Jar of sand  |
+      | type        | combinations |
+    And I generate combinations for product product_with_combinations using following attributes:
+      | Color | [Red,Blue] |
+    Then product "product_with_combinations" should have following combinations:
+      | id reference                   | combination name | reference | attributes    | impact on price | quantity | is default |
+      | product_with_combinationsRed   | Color - Red      |           | [Color:Red]   | 0               | 0        | true       |
+      | product_with_combinationsBlue  | Color - Blue     |           | [Color:Blue]  | 0               | 0        | false      |
+    When I add a specific price specific_price1 to product product_with_combinations with following details:
+      | price           | 123.00                       |
+      | combination     | product_with_combinationsRed |
+      | reduction type  | amount                       |
+      | reduction value | 0.00                         |
+      | includes tax    | true                         |
+      | from quantity   | 1                            |
+    And I add a specific price specific_price2 to product product_with_combinations with following details:
+      | price           | 0.00   |
+      | reduction type  | amount |
+      | reduction value | 5.00   |
+      | includes tax    | true   |
+      | from quantity   | 1      |
+    Then product "product_with_combinations" should have 2 specific prices
 
   Scenario: I duplicate product
 #todo: add specific prices & priorities, test combinations, packs
@@ -203,5 +236,11 @@ Feature: Duplicate product from Back Office (BO).
     And product copy_of_product1 should have identical customization fields to product1
     And product copy_of_product1 should have 1 customizable text field
     And product copy_of_product1 should have 0 customizable file fields
+    And product "copy_of_product1" should have 1 specific prices
 #@todo: assert stock info
 #@todo: add tests for other type of products Pack, Virtual, Combinations
+
+  Scenario: I duplicate product with combinations
+    When I duplicate product product_with_combinations to a copy_of_product_with_combinations
+    Then product "copy_of_product_with_combinations" should have 2 specific prices
+    # TODO: all sorts of other checks


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix the duplication of specific prices that apply to a single combination. Currently they are not duplicated at all when the base product is duplicated.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26424.
| How to test?      | See steps in ticket.
| Possible impacts? | None that I'm aware of.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

This pull request is based on PR https://github.com/PrestaShop/PrestaShop/pull/12250.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26425)
<!-- Reviewable:end -->
