### PR TITLE
Fix legacy tinymce layout is too small

### DIFF
--- a/admin-dev/themes/default/scss/partials/_tinymce.scss
+++ b/admin-dev/themes/default/scss/partials/_tinymce.scss
@@ -805,6 +805,12 @@ body .mce-abs-layout-item {
 }
 
 .mce-btn-group {
+  > div {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
   .mce-btn {
     border: solid 1px #ccc;
     border-radius: 0;

--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -111,7 +111,7 @@
                     {/if}
 										{if $languages|count > 1}
 										<div class="translatable-field lang-{$language.id_lang}" {if $language.id_lang != $defaultFormLanguage}style="display:none"{/if}>
-											<div class="col-lg-9">
+											<div class="col-lg-10">
 										{/if}
 												{if $input.type == 'tags'}
 													{literal}
@@ -435,7 +435,7 @@
 										{foreach $languages as $language}
 											{if $languages|count > 1}
 											<div class="form-group translatable-field lang-{$language.id_lang}"{if $language.id_lang != $defaultFormLanguage} style="display:none;"{/if}>
-												<div class="col-lg-9">
+												<div class="col-lg-10">
 											{/if}
 													{if isset($input.maxchar) && $input.maxchar}
 													<div class="input-group">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Tinyce MCE was col-lg-9 while the other column was col-lg-2, it needs more spaces
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/ps_customtext/pull/64.
| How to test?      | Test the ps_customtext module, also check if there are other tinymce in default pages
| Possible impacts? | Textarea/tinymce default theme pages


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26430)
<!-- Reviewable:end -->
