### PR TITLE
Refactor controller tests

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -133,3 +133,9 @@ services:
     factory: [ '@doctrine.orm.default_entity_manager', getRepository ]
     arguments:
       - PrestaShopBundle\Entity\AttributeGroup
+
+  prestashop.core.admin.feature_flag.repository:
+    class: Doctrine\ORM\EntityRepository
+    factory: [ '@doctrine.orm.default_entity_manager', getRepository ]
+    arguments:
+      - PrestaShopBundle\Entity\FeatureFlag

--- a/tests/Integration/Core/Form/IdentifiableObject/Handler/FormHandlerChecker.php
+++ b/tests/Integration/Core/Form/IdentifiableObject/Handler/FormHandlerChecker.php
@@ -53,6 +53,9 @@ class FormHandlerChecker implements FormHandlerInterface
         $this->formHandler = $formHandler;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function handle(FormInterface $form)
     {
         $result = $this->formHandler->handle($form);
@@ -61,11 +64,17 @@ class FormHandlerChecker implements FormHandlerInterface
         return $result;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function handleFor($id, FormInterface $form)
     {
-        return $this->formHandler->handleFor($form, $id);
+        return $this->formHandler->handleFor($id, $form);
     }
 
+    /**
+     * @return int
+     */
     public function getLastCreatedId(): int
     {
         return $this->lastCreatedId;

--- a/tests/Integration/Core/Form/IdentifiableObject/Handler/FormHandlerChecker.php
+++ b/tests/Integration/Core/Form/IdentifiableObject/Handler/FormHandlerChecker.php
@@ -39,7 +39,7 @@ class FormHandlerChecker implements FormHandlerInterface
     private $formHandler;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $lastCreatedId;
 
@@ -73,9 +73,9 @@ class FormHandlerChecker implements FormHandlerInterface
     }
 
     /**
-     * @return int
+     * @return int|null
      */
-    public function getLastCreatedId(): int
+    public function getLastCreatedId(): ?int
     {
         return $this->lastCreatedId;
     }

--- a/tests/Integration/PrestaShopBundle/Controller/FormFiller/FormChecker.php
+++ b/tests/Integration/PrestaShopBundle/Controller/FormFiller/FormChecker.php
@@ -63,9 +63,10 @@ class FormChecker
      */
     private function assertFormValue($expectedValue, $formValue, string $fieldName): void
     {
-        Assert::assertEquals(
-            $expectedValue,
-            $formValue,
+        // We use assertTrue instead of assertEquals because when it fails it raises an error related to Closure
+        // serialization which makes it very hard to debug (this is because of processIsolation)
+        Assert::assertTrue(
+            $expectedValue == $formValue,
             sprintf(
                 'Invalid value for field %s, expected %s but got %s instead.',
                 $fieldName,

--- a/tests/Integration/PrestaShopBundle/Controller/FormFiller/FormChecker.php
+++ b/tests/Integration/PrestaShopBundle/Controller/FormFiller/FormChecker.php
@@ -28,55 +28,50 @@ declare(strict_types=1);
 
 namespace Tests\Integration\PrestaShopBundle\Controller\FormFiller;
 
-use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use InvalidArgumentException;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\DomCrawler\Field\FormField;
 use Symfony\Component\DomCrawler\Form;
 
-class FormFiller
+class FormChecker
 {
     /**
      * @param Form $form
-     * @param array $formModifications
+     * @param array $expectedFormData
      *
      * @return Form
      */
-    public function fillForm(Form $form, array $formModifications): Form
+    public function checkForm(Form $form, array $expectedFormData): Form
     {
-        foreach ($formModifications as $fieldName => $formValue) {
-            if (!is_array($formValue)) {
+        foreach ($expectedFormData as $fieldName => $expectedFormDatum) {
+            if (!is_array($expectedFormDatum)) {
                 /** @var FormField $formField */
                 $formField = $form->get($fieldName);
-                $formField->setValue($formValue);
-
-                continue;
-            }
-
-            // For multi select checkboxes or select inputs
-            /** @var ChoiceFormField[]|ChoiceFormField $formFields */
-            $formFields = $form->get($fieldName);
-            if (!is_array($formFields)) {
-                $formFields->select($formValue);
-
-                continue;
-            }
-
-            // Multiple checkboxes are returned as array
-            foreach ($formFields as $formField) {
-                if ('checkbox' !== $formField->getType()) {
-                    $formField->select($formValue);
-
-                    continue;
-                }
-
-                $optionValue = $formField->availableOptionValues()[0];
-                if (in_array($optionValue, $formValue)) {
-                    $formField->tick();
-                } else {
-                    $formField->untick();
-                }
+                $this->assertFormValue($expectedFormDatum, $formField->getValue(), $fieldName);
+            } else {
+                throw new InvalidArgumentException('The check for array values has not been implemented yet, your turn!!');
             }
         }
 
         return $form;
+    }
+
+    /**
+     * @param mixed $expectedValue
+     * @param mixed $formValue
+     * @param string $fieldName
+     */
+    private function assertFormValue($expectedValue, $formValue, string $fieldName): void
+    {
+        Assert::assertEquals(
+            $expectedValue,
+            $formValue,
+            sprintf(
+                'Invalid value for field %s, expected %s but got %s instead.',
+                $fieldName,
+                $expectedValue,
+                (string) $formValue
+            )
+        );
     }
 }

--- a/tests/Integration/PrestaShopBundle/Controller/FormGridControllerTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Controller/FormGridControllerTestCase.php
@@ -53,7 +53,7 @@ abstract class FormGridControllerTestCase extends GridControllerTestCase
      *
      * - generateCreateUrl: returns the creation form url
      * - getFormHandlerChecker: return the form handler service which has been encapsulated and allows to get the created ID
-     * - getCreateSubmitButtonSelector (optional): returns the selector of the button allowing to select the form
+     * - getCreateSubmitButtonSelector: returns the selector of the button allowing to select the form
      *
      * @param array $formData
      *
@@ -76,7 +76,7 @@ abstract class FormGridControllerTestCase extends GridControllerTestCase
      * Edit an entity by filling the form page with the provided data. You will need to implement these methods:
      *
      * - generateEditUrl: returns the edit form url
-     * - getEditSubmitButtonSelector (optional): returns the selector of the button allowing to select the form
+     * - getEditSubmitButtonSelector: returns the selector of the button allowing to select the form
      *
      * @param array $routeParams
      * @param array $formData
@@ -93,7 +93,7 @@ abstract class FormGridControllerTestCase extends GridControllerTestCase
      * these methods:
      *
      * - generateEditUrl: returns the edit form url
-     * - getEditSubmitButtonSelector (optional): returns the selector of the button allowing to select the form
+     * - getEditSubmitButtonSelector: returns the selector of the button allowing to select the form
      *
      * @param array $routeParams
      * @param array $expectedFormData
@@ -117,13 +117,7 @@ abstract class FormGridControllerTestCase extends GridControllerTestCase
             $formData
         );
 
-        /*
-         * Without changing followRedirects to false when submitting the form
-         * $dataChecker->getLastCreatedId() returns null.
-         */
-        $this->client->followRedirects(false);
         $this->client->submit($filledEntityForm);
-        $this->client->followRedirects(true);
     }
 
     /**
@@ -146,10 +140,11 @@ abstract class FormGridControllerTestCase extends GridControllerTestCase
      */
     protected function deleteEntityFromPage(string $deleteRoute, array $routeParams): void
     {
-        $router = $this->client->getContainer()->get('router');
-        $deleteUrl = $router->generate($deleteRoute, $routeParams);
+        $deleteUrl = $this->router->generate($deleteRoute, $routeParams);
+
+        // Delete url performs the deletion and then redirects to the list
         $this->client->request('POST', $deleteUrl);
-        $this->assertResponseIsSuccessful();
+        $this->assertResponseRedirects();
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Controller/FormGridControllerTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Controller/FormGridControllerTestCase.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Controller;
+
+use Symfony\Component\DomCrawler\Form;
+use Tests\Integration\Core\Form\IdentifiableObject\Handler\FormHandlerChecker;
+use Tests\Integration\PrestaShopBundle\Controller\FormFiller\FormChecker;
+
+abstract class FormGridControllerTestCase extends GridControllerTestCase
+{
+    /**
+     * @var FormChecker
+     */
+    protected $formChecker;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->formChecker = new FormChecker();
+    }
+
+    /**
+     * Create an entity by filling the form page with the provided data. You will need to implement these methods:
+     *
+     * - generateCreateUrl: returns the creation form url
+     * - getFormHandlerChecker: return the form handler service which has been encapsulated and allows to get the created ID
+     * - getCreateSubmitButtonSelector (optional): returns the selector of the button allowing to select the form
+     *
+     * @param array $formData
+     *
+     * @return int Created entity ID
+     */
+    protected function createEntityFromPage(array $formData): int
+    {
+        $createEntityUrl = $this->generateCreateUrl();
+
+        $this->fillAndSubmitEntityForm($createEntityUrl, $formData, $this->getCreateSubmitButtonSelector());
+        $formHandlerChecker = $this->getFormHandlerChecker();
+
+        $testEntityId = $formHandlerChecker->getLastCreatedId();
+        self::assertNotNull($testEntityId);
+
+        return $testEntityId;
+    }
+
+    /**
+     * Edit an entity by filling the form page with the provided data. You will need to implement these methods:
+     *
+     * - generateEditUrl: returns the edit form url
+     * - getEditSubmitButtonSelector (optional): returns the selector of the button allowing to select the form
+     *
+     * @param array $routeParams
+     * @param array $formData
+     */
+    protected function editEntityFromPage(array $routeParams, array $formData): void
+    {
+        $editEntityUrl = $this->generateEditUrl($routeParams);
+
+        $this->fillAndSubmitEntityForm($editEntityUrl, $formData, $this->getEditSubmitButtonSelector());
+    }
+
+    /**
+     * Parses the entity value from the edit page and assert it matches the expected data. You will need to implement
+     * these methods:
+     *
+     * - generateEditUrl: returns the edit form url
+     * - getEditSubmitButtonSelector (optional): returns the selector of the button allowing to select the form
+     *
+     * @param array $routeParams
+     * @param array $expectedFormData
+     */
+    protected function assertFormValuesFromPage(array $routeParams, array $expectedFormData): void
+    {
+        $editEntityUrl = $this->generateEditUrl($routeParams);
+        $entityForm = $this->getFormFromPage($editEntityUrl, $this->getEditSubmitButtonSelector());
+        $this->formChecker->checkForm($entityForm, $expectedFormData);
+    }
+
+    /**
+     * @param string $formUrl
+     * @param array $formData
+     * @param string $formButtonSelector
+     */
+    protected function fillAndSubmitEntityForm(string $formUrl, array $formData, string $formButtonSelector = 'submit'): void
+    {
+        $filledEntityForm = $this->formFiller->fillForm(
+            $this->getFormFromPage($formUrl, $formButtonSelector),
+            $formData
+        );
+
+        /*
+         * Without changing followRedirects to false when submitting the form
+         * $dataChecker->getLastCreatedId() returns null.
+         */
+        $this->client->followRedirects(false);
+        $this->client->submit($filledEntityForm);
+        $this->client->followRedirects(true);
+    }
+
+    /**
+     * @param string $formUrl
+     * @param string $formButtonSelector
+     *
+     * @return Form
+     */
+    protected function getFormFromPage(string $formUrl, string $formButtonSelector): Form
+    {
+        $crawler = $this->client->request('GET', $formUrl);
+        $this->assertResponseIsSuccessful();
+
+        return $this->getFormByButton($crawler, $formButtonSelector);
+    }
+
+    /**
+     * @param string $deleteRoute
+     * @param array $routeParams
+     */
+    protected function deleteEntityFromPage(string $deleteRoute, array $routeParams): void
+    {
+        $router = $this->client->getContainer()->get('router');
+        $deleteUrl = $router->generate($deleteRoute, $routeParams);
+        $this->client->request('POST', $deleteUrl);
+        $this->assertResponseIsSuccessful();
+    }
+
+    /**
+     * Returns the url of the create page.
+     *
+     * @return string
+     */
+    abstract protected function generateCreateUrl(): string;
+
+    /**
+     * Returns the selector allowing to get the create form's submit button.
+     *
+     * @return string
+     */
+    abstract protected function getCreateSubmitButtonSelector(): string;
+
+    /**
+     * In test environment all form handlers are decorated inside a FormHandlerChecker which allows us to get the
+     * last created ID. This method must be implemented if you want to test your creation form, it returns the form
+     * handler service used in your creation form.
+     *
+     * @return FormHandlerChecker
+     */
+    abstract protected function getFormHandlerChecker(): FormHandlerChecker;
+
+    /**
+     * Returns the url of the edit page.
+     *
+     * @param array $routeParams
+     *
+     * @return string
+     */
+    abstract protected function generateEditUrl(array $routeParams): string;
+
+    /**
+     * Returns the selector allowing to get the edit form's submit button.
+     *
+     * @return string
+     */
+    abstract protected function getEditSubmitButtonSelector(): string;
+}

--- a/tests/Integration/PrestaShopBundle/Controller/GridControllerTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Controller/GridControllerTestCase.php
@@ -61,7 +61,7 @@ abstract class GridControllerTestCase extends WebTestCase
     }
 
     /**
-     * Calls the gris page and return the parsed entities it contains, based on the parseEntityFromRow that each
+     * Calls the grid page and return the parsed entities it contains, based on the parseEntityFromRow that each
      * sub-class must implement.
      *
      * @param array $routeParams

--- a/tests/Integration/PrestaShopBundle/Controller/GridControllerTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Controller/GridControllerTestCase.php
@@ -100,11 +100,19 @@ abstract class GridControllerTestCase extends WebTestCase
             ));
         }
 
-        $entities = $grid->filter('tbody tr')->each(function ($tr, $i) {
-            return $this->parseEntityFromRow($tr, $i);
-        });
-        foreach ($entities as $entity) {
-            $testEntityDTOCollection->add($entity);
+        // Get rows but filter the one that is used to indicate there is no result
+        $entitiesRows = $grid->filter('tbody tr:not(.empty_row)');
+
+        // If no rows are found the collection is empty
+        if ($entitiesRows->count()) {
+            $entities = $entitiesRows->each(function ($tr, $i) {
+                return $this->parseEntityFromRow($tr, $i);
+            });
+
+            // Fill the collection
+            foreach ($entities as $entity) {
+                $testEntityDTOCollection->add($entity);
+            }
         }
 
         return $testEntityDTOCollection;

--- a/tests/Integration/PrestaShopBundle/Controller/GridControllerTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Controller/GridControllerTestCase.php
@@ -28,12 +28,12 @@ declare(strict_types=1);
 
 namespace Tests\Integration\PrestaShopBundle\Controller;
 
-use PrestaShop\PrestaShop\Core\Exception\TypeException;
+use InvalidArgumentException;
 use Symfony\Bundle\FrameworkBundle\Client;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
+use Symfony\Component\Routing\RouterInterface;
 use Tests\Integration\PrestaShopBundle\Controller\FormFiller\FormFiller;
 
 abstract class GridControllerTestCase extends WebTestCase
@@ -44,47 +44,9 @@ abstract class GridControllerTestCase extends WebTestCase
     protected $client;
 
     /**
-     * Route to the grid you are testing
-     *
-     * @var string
+     * @var RouterInterface
      */
-    protected $gridRoute;
-
-    /**
-     * The id of the test entity with which filters will be tested
-     * Should be set during SetUp
-     *
-     * @var int
-     */
-    protected $testEntityId;
-
-    /**
-     * The name of entity you are testing, e.g.,address.
-     *
-     * @var string
-     */
-    protected $testEntityName;
-
-    /**
-     * The route to create entity
-     *
-     * @var string
-     */
-    protected $createEntityRoute;
-
-    /**
-     * The route to delete entity
-     *
-     * @var string
-     */
-    protected $deleteEntityRoute;
-
-    /**
-     * Amount of entities in starting list
-     *
-     * @var int
-     */
-    protected $initialEntityCount;
+    protected $router;
 
     /**
      * @var FormFiller
@@ -92,140 +54,82 @@ abstract class GridControllerTestCase extends WebTestCase
     protected $formFiller;
 
     /**
-     * Service id form form handler
-     *
-     * @var string
-     */
-    protected $formHandlerServiceId;
-
-    /**
-     * Save button id should always be the same, but can be overridden if needed
-     *
-     * @var string
-     */
-    protected $saveButtonId = 'save-button';
-
-    public function __construct($name = null, array $data = [], $dataName = '')
-    {
-        parent::__construct($name, $data, $dataName);
-
-        $this->formFiller = new FormFiller();
-    }
-
-    /**
      * Creates a test entity and ensures asserts that amount of entities in the list got increased by one
-     *
-     * @throws TypeException
      */
     public function setUp(): void
     {
         $this->client = static::createClient();
         $this->client->followRedirects(true);
-
-        /** Asserts that list contains as many entities as expected */
-        $crawler = $this->client->request('GET', $this->getIndexRoute($this->client->getKernel()->getContainer()->get('router')));
-        $this->assertResponseIsSuccessful();
-
-        $entities = $this->getEntityList($crawler);
-        $this->initialEntityCount = $entities->count();
-
-        $this->createTestEntity();
-
-        /** Asserts amount of entities in the list increased by one and test entity exists */
-        $crawler = $this->client->request('GET', $this->getIndexRoute($this->client->getKernel()->getContainer()->get('router')));
-        $entities = $this->getEntityList($crawler);
-        /* If this fails it means entity was not created correctly */
-        self::assertCount($this->initialEntityCount + 1, $entities);
-        $this->assertTestEntityExists($entities);
+        $this->router = $this->client->getContainer()->get('router');
+        $this->formFiller = new FormFiller();
     }
 
     /**
-     * Removes the created test entity and asserts that it was successfully removed from the list.
+     * Calls the gris page and return the parsed entities it contains, based on the parseEntityFromRow that each
+     * sub-class must implement.
      *
-     * @throws TypeException
+     * @param array $routeParams
+     *
+     * @return TestEntityDTOCollection
      */
-    public function tearDown(): void
+    protected function getEntitiesFromGrid(array $routeParams = []): TestEntityDTOCollection
     {
-        $this->client->followRedirects(true);
-        $router = $this->client->getContainer()->get('router');
-
-        /**
-         * Assumes that deletion route only requires id param and that id has format is $this->testEntityName . 'Id'
-         * If it's not the case you can always override tearDown with logic specific to grid you are testing
-         */
-        $deleteUrl = $router->generate($this->deleteEntityRoute, [$this->testEntityName . 'Id' => $this->testEntityId]);
-        $this->client->request('POST', $deleteUrl);
+        $gridUrl = $this->generateGridUrl($routeParams);
+        $crawler = $this->client->request('GET', $gridUrl);
         $this->assertResponseIsSuccessful();
 
-        $crawler = $this->client->request('GET', $this->getIndexRoute($this->client->getKernel()->getContainer()->get('router')));
-
-        $entities = $this->getEntityList($crawler);
-
-        /* If this fails it means entity deletion did not work as intended */
-        self::assertCount($this->initialEntityCount, $entities);
+        return $this->parseEntitiesFromGridTable($crawler);
     }
 
     /**
-     * @return void
+     * Parses all the entities' data from the grid table, based on the parseEntityFromRow that each sub-class must
+     * implement.
+     *
+     * @param Crawler $crawler
+     *
+     * @return TestEntityDTOCollection
      */
-    protected function createTestEntity(): void
+    protected function parseEntitiesFromGridTable(Crawler $crawler): TestEntityDTOCollection
     {
-        $router = $this->client->getContainer()->get('router');
-        $createEntityUrl = $router->generate($this->createEntityRoute);
+        $testEntityDTOCollection = new TestEntityDTOCollection();
+        $grid = $crawler->filter($this->getGridSelector());
+        if (empty($grid->count())) {
+            throw new InvalidArgumentException(sprintf(
+                'Could not find a grid matching CSS selector "%s"',
+                $this->getGridSelector()
+            ));
+        }
 
-        $crawler = $this->client->request('GET', $createEntityUrl);
-        $this->assertResponseIsSuccessful();
+        $entities = $grid->filter('tbody tr')->each(function ($tr, $i) {
+            return $this->parseEntityFromRow($tr, $i);
+        });
+        foreach ($entities as $entity) {
+            $testEntityDTOCollection->add($entity);
+        }
 
-        $submitButton = $crawler->selectButton($this->saveButtonId);
-        /** If you get "InvalidArgumentException: The current node list is empty" error here it means save button was not found */
-        $entityForm = $submitButton->form();
-
-        $entityForm = $this->formFiller->fillForm($entityForm, $this->getCreateEntityFormModifications());
-
-        /*
-         * Without changing followRedirects to false when submitting the form
-         * $dataChecker->getLastCreatedId() returns null.
-         */
-        $this->client->followRedirects(false);
-        $this->client->submit($entityForm);
-        $this->client->followRedirects(true);
-        $formHandlerChecker = $this->client->getContainer()->get($this->formHandlerServiceId);
-        $this->testEntityId = $formHandlerChecker->getLastCreatedId();
-        self::assertNotNull($this->testEntityId);
+        return $testEntityDTOCollection;
     }
 
     /**
-     * If this test fails it's likely problem with filters being incorrect or filtering not working
-     * Asserts that there is only one entity left in the list after using filters
+     * Calls the gris page with specific filters and return the parsed entities it contains, based on the
+     * parseEntityFromRow that each sub-class must implement.
      *
      * @param array $testFilters
+     * @param array $routeParams
      *
-     * @throws TypeException
+     * @return TestEntityDTOCollection
      */
-    protected function assertFiltersFindOnlyTestEntity(array $testFilters): void
+    protected function getFilteredEntitiesFromGrid(array $testFilters, array $routeParams = []): TestEntityDTOCollection
     {
-        $crawler = $this->client->request('GET', $this->getIndexRoute($this->client->getKernel()->getContainer()->get('router')));
+        $gridUrl = $this->generateGridUrl($routeParams);
+        $crawler = $this->client->request('GET', $gridUrl);
         $this->assertResponseIsSuccessful();
 
-        /** Assert that list contains all entities and thus not affected by anything */
-        $entities = $this->getEntityList($crawler);
-        self::assertCount($this->initialEntityCount + 1, $entities);
-
-        /**
-         * Submit filters
-         */
         $filterForm = $this->fillFiltersForm($crawler, $testFilters);
         $this->client->followRedirects(true);
-
         $crawler = $this->client->submit($filterForm);
 
-        /**
-         * Assert that there is only test entity left in the list after using filters
-         */
-        $entities = $this->getEntityList($crawler);
-
-        self::assertCount(1, $entities);
-        $this->assertTestEntityExists($entities);
+        return $this->parseEntitiesFromGridTable($crawler);
     }
 
     /**
@@ -236,61 +140,82 @@ abstract class GridControllerTestCase extends WebTestCase
      */
     protected function fillFiltersForm(Crawler $crawler, array $formModifications): Form
     {
-        $button = $crawler->selectButton($this->testEntityName . '[actions][search]');
-        $filtersForm = $button->form();
+        $filtersForm = $this->getFormByButton($crawler, $this->getFilterSearchButtonSelector());
         $this->formFiller->fillForm($filtersForm, $formModifications);
 
         return $filtersForm;
     }
 
     /**
-     * Asserts test entity exists with the list
+     * @param Crawler $crawler
+     * @param string $formButtonSelector
+     *
+     * @return Form
+     */
+    protected function getFormByButton(Crawler $crawler, string $formButtonSelector): Form
+    {
+        $submitButton = $crawler->selectButton($formButtonSelector);
+        try {
+            $form = $submitButton->form();
+        } catch (InvalidArgumentException $e) {
+            throw new InvalidArgumentException(sprintf(
+                'Could not find form in the page, maybe the button selector "%s" is not adapted, usually you can use the button id (without the #) or its name',
+                $formButtonSelector
+            ), $e->getCode(), $e);
+        }
+
+        return $form;
+    }
+
+    /**
+     * Asserts collection contains the entity matching the provided ID
      *
      * @param TestEntityDTOCollection $entities
+     * @param int $searchEntityId
      */
-    protected function assertTestEntityExists(TestEntityDTOCollection $entities): void
+    protected function assertCollectionContainsEntity(TestEntityDTOCollection $entities, int $searchEntityId): void
     {
         $ids = array_map(function ($entity) {
             return $entity->getId();
         }, iterator_to_array($entities));
-        self::assertContains($this->getTestEntity()->getId(), $ids);
+
+        $this->assertContains($searchEntityId, $ids);
     }
 
     /**
-     * @param Crawler $crawler
-     *
-     * @return TestEntityDTOCollection
-     *
-     * @throws TypeException
+     * These are the methods that need to be implemented by the sub-classes but since we are not sure that they will
+     * be used they are not pure abstract.
      */
-    protected function getEntityList(Crawler $crawler): TestEntityDTOCollection
-    {
-        $testEntityDTOCollection = new TestEntityDTOCollection();
-        $entities = $crawler->filter('#' . $this->testEntityName . '_grid_table')->filter('tbody tr')->each(function ($tr, $i) {
-            return $this->getEntity($tr, $i);
-        });
-        foreach ($entities as $entity) {
-            $testEntityDTOCollection->add($entity);
-        }
-
-        return $testEntityDTOCollection;
-    }
 
     /**
-     * Can be overridden if you need to manipulate route in in any way
-     *
-     * @param Router $router
+     * Returns the selector allowing to get the grid's search button.
      *
      * @return string
      */
-    protected function getIndexRoute(Router $router): string
-    {
-        return $router->generate($this->gridRoute);
-    }
+    abstract protected function getFilterSearchButtonSelector(): string;
 
-    abstract protected function getTestEntity(): TestEntityDTO;
+    /**
+     * @param array $routeParams
+     *
+     * @return string
+     */
+    abstract protected function generateGridUrl(array $routeParams = []): string;
 
-    abstract protected function getCreateEntityFormModifications(): array;
+    /**
+     * Returns the selector of the tested grid, for example: #products_grid_table
+     *
+     * @return string
+     */
+    abstract protected function getGridSelector(): string;
 
-    abstract protected function getEntity(Crawler $tr, int $i): TestEntityDTO;
+    /**
+     * This method parse a row from the grid and returns a TestEntityDTO which contains, at the minimum, the ID of the
+     * entity plus additional variables that you could wish to test.
+     *
+     * @param Crawler $tr
+     * @param int $i
+     *
+     * @return TestEntityDTO
+     */
+    abstract protected function parseEntityFromRow(Crawler $tr, int $i): TestEntityDTO;
 }

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -28,35 +28,29 @@ declare(strict_types=1);
 
 namespace Tests\Integration\PrestaShopBundle\Controller\Sell\Catalog;
 
-use PrestaShop\PrestaShop\Core\Exception\TypeException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
-use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\DomCrawler\Crawler;
-use Tests\Integration\PrestaShopBundle\Controller\GridControllerTestCase;
+use Tests\Integration\Core\Form\IdentifiableObject\Handler\FormHandlerChecker;
+use Tests\Integration\PrestaShopBundle\Controller\FormGridControllerTestCase;
 use Tests\Integration\PrestaShopBundle\Controller\TestEntityDTO;
 
-class ProductControllerTest extends GridControllerTestCase
+class ProductControllerTest extends FormGridControllerTestCase
 {
+    private const TEST_NAME = 'testProductName';
+    private const TEST_QUANTITY = 987;
+    private const TEST_PRICE = 87.7;
+
     /**
      * @var bool
      */
     private $changedProductFeatureFlag = false;
 
-    public function __construct($name = null, array $data = [], $dataName = '')
-    {
-        parent::__construct($name, $data, $dataName);
-
-        $this->createEntityRoute = 'admin_products_v2_create';
-        $this->testEntityName = 'product';
-        $this->deleteEntityRoute = 'admin_products_v2_delete';
-        $this->formHandlerServiceId = 'prestashop.core.form.identifiable_object.product_form_handler';
-        $this->saveButtonId = 'product_footer_save';
-    }
-
     public function setUp(): void
     {
-        $this->client = static::createClient();
-        $productFeatureFlag = $this->client->getContainer()->get('doctrine.orm.entity_manager')->getRepository('PrestaShopBundle:FeatureFlag')->findOneBy(['name' => FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2]);
+        parent::setUp();
+        $featureFlagRepository = $this->client->getContainer()->get('prestashop.core.admin.feature_flag.repository');
+        $productFeatureFlag = $featureFlagRepository->findOneBy(['name' => FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2]);
         if (!$productFeatureFlag->isEnabled()) {
             $featureFlagModifier = $this->client->getContainer()->get('prestashop.core.feature_flags.modifier');
             $featureFlagModifier->updateConfiguration(
@@ -66,8 +60,6 @@ class ProductControllerTest extends GridControllerTestCase
             );
             $this->changedProductFeatureFlag = true;
         }
-
-        parent::setUp();
     }
 
     public function tearDown(): void
@@ -83,76 +75,179 @@ class ProductControllerTest extends GridControllerTestCase
         }
     }
 
-    protected function getIndexRoute(Router $router): string
+    public function testIndex(): int
     {
-        /* Asserts amount of entities in the list increased by one and test entity exists */
-        return $router->generate('admin_products_v2_index',
-            [
-                '_route' => 0,
-                'product[offset]' => 0,
-                'product[limit]' => 100,
-            ]
-        );
+        $products = $this->getEntitiesFromGrid();
+        $this->assertNotEmpty($products);
+
+        return $products->count();
     }
 
     /**
-     * Tests all provided entity filters
-     * All filters are tested in one test make tests run faster
+     * @depends testIndex
      *
-     * @throws TypeException
+     * @param int $initialEntityCount
+     *
+     * @return int
      */
-    public function testProductFilters(): void
+    public function testCreate(int $initialEntityCount): int
     {
-        foreach ($this->getTestFilters() as $testFilter) {
-            $this->assertFiltersFindOnlyTestEntity($testFilter);
-        }
+        // First create product
+        $productType = ProductType::TYPE_STANDARD;
+        $formData = [
+            'product[type]' => $productType,
+        ];
+        $createdProductId = $this->createEntityFromPage($formData);
+
+        // Check that there is one more product in the list
+        $newProducts = $this->getEntitiesFromGrid();
+        $this->assertCount($initialEntityCount + 1, $newProducts);
+        $this->assertCollectionContainsEntity($newProducts, $createdProductId);
+
+        // Check that the product was correctly set with the expected type (the format in the form is not the same)
+        $expectedFormData = [
+            'product[header][type]' => $productType,
+        ];
+        $this->assertFormValuesFromPage(
+            ['productId' => $createdProductId],
+            $expectedFormData
+        );
+
+        return $createdProductId;
     }
 
     /**
-     * @return array
+     * @depends testCreate
+     *
+     * @param int $productId
+     *
+     * @return int
      */
-    protected function getTestFilters(): array
+    public function testEdit(int $productId): int
     {
-        /* @todo add rest of the tests, need for product form to be complete */
-        return [
-            ['product[name]' => 'stProd'],
+        // First update the product with a few data
+        $formData = [
+            'product[header][name][1]' => static::TEST_NAME,
+            'product[stock][quantities][quantity]' => static::TEST_QUANTITY,
+            'product[pricing][retail_price][price_tax_excluded]' => static::TEST_PRICE,
+        ];
+
+        $this->editEntityFromPage(['productId' => $productId], $formData);
+
+        // Then check that it was correctly updated
+        // Price is reformatted with 6 digits
+        $expectedFormData['product[pricing][retail_price][price_tax_excluded]'] = '87.700000';
+        $this->assertFormValuesFromPage(
+            ['productId' => $productId],
+            $expectedFormData
+        );
+
+        return $productId;
+    }
+
+    /**
+     * @depends testEdit
+     *
+     * @param int $productId
+     *
+     * @return int
+     */
+    public function testFilters(int $productId): int
+    {
+        // These are filters which are only supposed to match the created product, they might need to be updated
+        // in case the data from fixtures change and match these test data.
+        $gridFilters = [
             [
-                'product[id_product][min_field]' => $this->getTestEntity()->getId(),
-                'product[id_product][max_field]' => $this->getTestEntity()->getId(),
+                'product[name]' => static::TEST_NAME,
             ],
             [
-                'product[quantity][min_field]' => $this->getTestEntity()->quantity,
-                'product[quantity][max_field]' => $this->getTestEntity()->quantity,
+                'product[id_product][min_field]' => $productId,
+                'product[id_product][max_field]' => $productId,
             ],
             [
-                'product[price_tax_excluded][min_field]' => $this->getTestEntity()->price,
-                'product[price_tax_excluded][max_field]' => $this->getTestEntity()->price,
+                'product[quantity][min_field]' => static::TEST_QUANTITY,
+                'product[quantity][max_field]' => static::TEST_QUANTITY,
+            ],
+            [
+                'product[price_tax_excluded][min_field]' => static::TEST_PRICE,
+                'product[price_tax_excluded][max_field]' => static::TEST_PRICE,
             ],
         ];
+
+        foreach ($gridFilters as $testFilter) {
+            $products = $this->getFilteredEntitiesFromGrid($testFilter);
+            $this->assertEquals(1, count($products));
+            $this->assertCollectionContainsEntity($products, $productId);
+        }
+
+        return $productId;
     }
 
     /**
-     * @return TestEntityDTO
-     */
-    protected function getTestEntity(): TestEntityDTO
-    {
-        return new TestEntityDTO(
-            $this->testEntityId,
-            [
-                'name' => 'testProductName',
-                'quantity' => 987,
-                'price' => '87,7',
-            ]
-        );
-    }
-
-    /**
-     * @param $tr
-     * @param $i
+     * @depends testFilters
      *
-     * @return TestEntityDTO
+     * @param int $productId
      */
-    protected function getEntity(Crawler $tr, int $i): TestEntityDTO
+    public function testDelete(int $productId): void
+    {
+        $this->deleteEntityFromPage('admin_products_v2_delete', ['productId' => $productId]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getFilterSearchButtonSelector(): string
+    {
+        return 'product[actions][search]';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getCreateSubmitButtonSelector(): string
+    {
+        return 'product_create';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getEditSubmitButtonSelector(): string
+    {
+        return 'product_footer_save';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function generateCreateUrl(): string
+    {
+        return $this->router->generate('admin_products_v2_create');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function generateEditUrl(array $routeParams): string
+    {
+        return $this->router->generate('admin_products_v2_edit', $routeParams);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getFormHandlerChecker(): FormHandlerChecker
+    {
+        /** @var FormHandlerChecker $checker */
+        $checker = $this->client->getContainer()->get('prestashop.core.form.identifiable_object.product_form_handler');
+
+        return $checker;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function parseEntityFromRow(Crawler $tr, int $i): TestEntityDTO
     {
         return new TestEntityDTO(
             (int) trim($tr->filter('.column-id_product')->text()),
@@ -162,23 +257,25 @@ class ProductControllerTest extends GridControllerTestCase
     }
 
     /**
-     * Gets modifications that are needed to fill address form
-     *
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getCreateEntityFormModifications(): array
+    protected function generateGridUrl(array $routeParams = []): string
     {
-        /** @todo add rest of the tests, need for product form to be complete */
-        $testEntity = $this->getTestEntity();
+        if (empty($routeParams)) {
+            $routeParams = [
+                'product[offset]' => 0,
+                'product[limit]' => 100,
+            ];
+        }
 
-        return [
-            'product[header][name][1]' => $testEntity->name,
-            // 'product[shortcuts][stock][quantity]' => $testEntity->quantity,
-            'product[stock][quantities][quantity][delta]' => $testEntity->quantity,
-            'product[shipping][additional_shipping_cost]' => 0,
-            'product[pricing][retail_price][price_tax_excluded]' => $testEntity->price,
-            // 'product[shortcuts][retail_price][price_tax_excluded]' => $testEntity->price,
-            // 'product[shortcuts][retail_price][price_tax_included]' => $testEntity->price,
-        ];
+        return $this->router->generate('admin_products_v2_index', $routeParams);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getGridSelector(): string
+    {
+        return '#product_grid_table';
     }
 }

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -206,7 +206,13 @@ class ProductControllerTest extends FormGridControllerTestCase
      */
     public function testDelete(int $productId): void
     {
+        $products = $this->getEntitiesFromGrid();
+        $initialEntityCount = $products->count();
+
         $this->deleteEntityFromPage('admin_products_v2_delete', ['productId' => $productId]);
+
+        $newProducts = $this->getEntitiesFromGrid();
+        $this->assertCount($initialEntityCount - 1, $newProducts);
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -64,7 +64,6 @@ class ProductControllerTest extends FormGridControllerTestCase
 
     public function tearDown(): void
     {
-        parent::tearDown();
         if ($this->changedProductFeatureFlag) {
             $featureFlagModifier = $this->client->getContainer()->get('prestashop.core.feature_flags.modifier');
             $featureFlagModifier->updateConfiguration(
@@ -73,6 +72,9 @@ class ProductControllerTest extends FormGridControllerTestCase
                 ]
             );
         }
+
+        // Call parent tear down later or the kernel will be shut down
+        parent::tearDown();
     }
 
     public function testIndex(): int

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Customer/Address/AddressControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Customer/Address/AddressControllerTest.php
@@ -181,7 +181,13 @@ class AddressControllerTest extends FormGridControllerTestCase
      */
     public function testDelete(int $addressId): void
     {
+        $addresses = $this->getEntitiesFromGrid();
+        $initialEntityCount = $addresses->count();
+
         $this->deleteEntityFromPage('admin_addresses_delete', ['addressId' => $addressId]);
+
+        $newAddresses = $this->getEntitiesFromGrid();
+        $this->assertCount($initialEntityCount - 1, $newAddresses);
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Customer/Address/AddressControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Customer/Address/AddressControllerTest.php
@@ -29,97 +29,186 @@ declare(strict_types=1);
 namespace Tests\Integration\PrestaShopBundle\Controller\Sell\Customer\Address;
 
 use Country;
-use PrestaShop\PrestaShop\Core\Exception\TypeException;
 use Symfony\Component\DomCrawler\Crawler;
-use Tests\Integration\PrestaShopBundle\Controller\GridControllerTestCase;
+use Tests\Integration\Core\Form\IdentifiableObject\Handler\FormHandlerChecker;
+use Tests\Integration\PrestaShopBundle\Controller\FormGridControllerTestCase;
 use Tests\Integration\PrestaShopBundle\Controller\TestEntityDTO;
 
-class AddressControllerTest extends GridControllerTestCase
+class AddressControllerTest extends FormGridControllerTestCase
 {
     private $countryId;
 
-    public function __construct($name = null, array $data = [], $dataName = '')
-    {
-        parent::__construct($name, $data, $dataName);
+    private $backupCountry;
 
-        $this->createEntityRoute = 'admin_addresses_create';
-        $this->gridRoute = 'admin_addresses_index';
-        $this->testEntityName = 'address';
-        $this->deleteEntityRoute = 'admin_addresses_delete';
-        $this->formHandlerServiceId = 'prestashop.core.form.identifiable_object.handler.address_form_handler';
-    }
+    private $legacyContext;
 
     /**
-     * Tests all provided entity filters
-     * All filters are tested in one test make tests run faster
-     *
-     * @throws TypeException
+     * {@inheritDoc}
      */
-    public function testAddressFilters(): void
+    public function setUp(): void
     {
-        foreach ($this->getTestFilters() as $testFilter) {
-            $this->assertFiltersFindOnlyTestEntity($testFilter);
-        }
-    }
+        parent::setUp();
 
-    /**
-     * @return array
-     */
-    protected function getTestFilters(): array
-    {
-        return [
-            ['address[id_address]' => $this->getTestEntity()->getId()],
-            ['address[firstname]' => 'firstname'],
-            ['address[lastname]' => 'testLa'],
-            ['address[address1]' => 'address1'],
-            ['address[postcode]' => '11111'],
-            ['address[city]' => 'stcity'],
-            ['address[id_country]' => $this->countryId],
-        ];
-    }
-
-    /**
-     * @return TestEntityDTO
-     */
-    protected function getTestEntity(): TestEntityDTO
-    {
-        return new TestEntityDTO(
-            $this->testEntityId,
-            [
-                'firstName' => 'testfirstname',
-                'lastName' => 'testlastname',
-                'address' => 'testaddress1',
-                'postCode' => '11111',
-                'city' => 'testcity',
-                'country' => 'lithuania',
-            ]
-        );
-    }
-
-    /**
-     * @return void
-     */
-    protected function createTestEntity(): void
-    {
         // We get the country ID for Lithuania, and we set this country in the context so the controller will
         // generate a form adapted to this country (especially regarding states selector)
-        $this->countryId = Country::getByIso('LT');
-        $legacyContext = $this->client->getContainer()->get('prestashop.adapter.legacy.context');
-        $backupCountry = $legacyContext->getContext()->country;
-        $legacyContext->getContext()->country = new Country($this->countryId);
+        $this->legacyContext = $this->client->getContainer()->get('prestashop.adapter.legacy.context');
+        $this->backupCountry = $this->legacyContext->getContext()->country;
 
-        parent::createTestEntity();
-        // We can now reset the original context country
-        $legacyContext->getContext()->country = $backupCountry;
+        $this->countryId = Country::getByIso('LT');
+        $this->legacyContext->getContext()->country = new Country($this->countryId);
     }
 
     /**
-     * @param $tr
-     * @param $i
-     *
-     * @return TestEntityDTO
+     * {@inheritDoc}
      */
-    protected function getEntity(Crawler $tr, int $i): TestEntityDTO
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->legacyContext->getContext()->country = $this->backupCountry;
+    }
+
+    public function testIndex(): int
+    {
+        $adresses = $this->getEntitiesFromGrid();
+        $this->assertNotEmpty($adresses);
+
+        return $adresses->count();
+    }
+
+    /**
+     * @depends testIndex
+     *
+     * @param int $initialEntityCount
+     *
+     * @return int
+     */
+    public function testCreate(int $initialEntityCount): int
+    {
+        // First create address
+        $formData = [
+            'customer_address[customer_email]' => 'pub@prestashop.com',
+            'customer_address[alias]' => 'create_alias',
+            'customer_address[first_name]' => 'createfirstname',
+            'customer_address[last_name]' => 'createlastname',
+            'customer_address[address1]' => 'createaddress1',
+            'customer_address[postcode]' => '11111',
+            'customer_address[city]' => 'createcity',
+            'customer_address[id_country]' => $this->countryId,
+        ];
+        $addressId = $this->createEntityFromPage($formData);
+
+        // Check that there is one more address in the list
+        $newAddresses = $this->getEntitiesFromGrid();
+        $this->assertCount($initialEntityCount + 1, $newAddresses);
+        $this->assertCollectionContainsEntity($newAddresses, $addressId);
+
+        // Email is only used for initial association, but not editable after
+        unset($formData['customer_address[customer_email]']);
+        $this->assertFormValuesFromPage(
+            ['addressId' => $addressId],
+            $formData
+        );
+
+        return $addressId;
+    }
+
+    /**
+     * @depends testCreate
+     *
+     * @param int $addressId
+     *
+     * @return int
+     */
+    public function testEdit(int $addressId): int
+    {
+        // First update the address with a few data
+        $formData = [
+            'customer_address[alias]' => 'edit_alias',
+            'customer_address[first_name]' => 'editfirstname',
+            'customer_address[last_name]' => 'editlastname',
+            'customer_address[address1]' => 'editaddress1',
+            'customer_address[postcode]' => '11111',
+            'customer_address[city]' => 'editcity',
+            'customer_address[id_country]' => $this->countryId,
+        ];
+
+        $this->editEntityFromPage(['addressId' => $addressId], $formData);
+
+        // Then check that it was correctly updated
+        $this->assertFormValuesFromPage(
+            ['addressId' => $addressId],
+            $formData
+        );
+
+        return $addressId;
+    }
+
+    /**
+     * @depends testEdit
+     *
+     * @param int $addressId
+     *
+     * @return int
+     */
+    public function testFilters(int $addressId): int
+    {
+        $gridFilters = [
+            ['address[id_address]' => $addressId],
+            ['address[firstname]' => 'editfirstname'],
+            ['address[lastname]' => 'editlastname'],
+            ['address[address1]' => 'editaddress1'],
+            ['address[postcode]' => '11111'],
+            ['address[city]' => 'editcity'],
+            ['address[id_country]' => $this->countryId],
+        ];
+
+        foreach ($gridFilters as $testFilter) {
+            $addresses = $this->getFilteredEntitiesFromGrid($testFilter);
+            $this->assertEquals(1, count($addresses));
+            $this->assertCollectionContainsEntity($addresses, $addressId);
+        }
+
+        return $addressId;
+    }
+
+    /**
+     * @depends testFilters
+     *
+     * @param int $addressId
+     */
+    public function testDelete(int $addressId): void
+    {
+        $this->deleteEntityFromPage('admin_addresses_delete', ['addressId' => $addressId]);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function generateGridUrl(array $routeParams = []): string
+    {
+        return $this->router->generate('admin_addresses_index', $routeParams);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getGridSelector(): string
+    {
+        return '#address_grid_table';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getFilterSearchButtonSelector(): string
+    {
+        return 'address[actions][search]';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function parseEntityFromRow(Crawler $tr, int $i): TestEntityDTO
     {
         return new TestEntityDTO(
             (int) trim($tr->filter('.column-id_address')->text()),
@@ -135,23 +224,45 @@ class AddressControllerTest extends GridControllerTestCase
     }
 
     /**
-     * Gets modifications that are needed to fill address form
-     *
-     * @return array
+     * {@inheritDoc}
      */
-    protected function getCreateEntityFormModifications(): array
+    protected function generateCreateUrl(): string
     {
-        $testEntity = $this->getTestEntity();
+        return $this->router->generate('admin_addresses_create');
+    }
 
-        return [
-            'customer_address[customer_email]' => 'pub@prestashop.com',
-            'customer_address[alias]' => 'test_alias',
-            'customer_address[first_name]' => $testEntity->firstName,
-            'customer_address[last_name]' => $testEntity->lastName,
-            'customer_address[address1]' => $testEntity->address,
-            'customer_address[postcode]' => $testEntity->postCode,
-            'customer_address[city]' => $testEntity->city,
-            'customer_address[id_country]' => $this->countryId,
-        ];
+    /**
+     * {@inheritDoc}
+     */
+    protected function getCreateSubmitButtonSelector(): string
+    {
+        return 'save-button';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getFormHandlerChecker(): FormHandlerChecker
+    {
+        /** @var FormHandlerChecker $checker */
+        $checker = $this->client->getContainer()->get('prestashop.core.form.identifiable_object.handler.address_form_handler');
+
+        return $checker;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function generateEditUrl(array $routeParams): string
+    {
+        return $this->router->generate('admin_addresses_edit', $routeParams);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getEditSubmitButtonSelector(): string
+    {
+        return 'save-button';
     }
 }

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Customer/Address/AddressControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Customer/Address/AddressControllerTest.php
@@ -164,7 +164,10 @@ class AddressControllerTest extends FormGridControllerTestCase
 
         foreach ($gridFilters as $testFilter) {
             $addresses = $this->getFilteredEntitiesFromGrid($testFilter);
-            $this->assertEquals(1, count($addresses));
+            $this->assertGreaterThanOrEqual(1, count($addresses), sprintf(
+                'Expected at least one address with filters %s',
+                var_export($testFilter, true)
+            ));
             $this->assertCollectionContainsEntity($addresses, $addressId);
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Refactor the controller tests, too many things were happening inside the setUp method<br/>Which makes the base class difficult to reuse<br/>The generic behaviour remains the same but everything was split into separate methods that can be used when needed<br/>Also separate into two abstract classes depending if you need to test the grid only or the form with it (not possible to test the form without the grid though)
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | CI tests green
| Possible impacts? | Improved efficiency in testing controllers


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26437)
<!-- Reviewable:end -->
