### PR TITLE
Fix Attributes with comma not displayed in Stock management

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/movement-line.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/movement-line.vue
@@ -33,7 +33,7 @@
           <p>
             {{ product.product_name }}
             <small v-if="hasCombination"><br>
-              {{ combinationName }}
+              {{ product.combination_name }}
             </small>
           </p>
         </PSMedia>

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/product-line.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/product-line.vue
@@ -39,7 +39,7 @@
           <p>
             {{ product.product_name }}
             <small v-if="hasCombination"><br>
-              {{ combinationName }}
+              {{ product.combination_name }}
             </small>
           </p>
         </PSMedia>

--- a/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/mixins/product-desc.js
@@ -35,17 +35,6 @@ export default {
 
       return null;
     },
-    combinationName() {
-      const combinations = this.product.combination_name.split(',');
-      const attributes = this.product.attribute_name.split(',');
-      const separator = ' - ';
-      let attr = '';
-      combinations.forEach((attribute, index) => {
-        const value = attribute.trim().slice(attributes[index].trim().length + separator.length);
-        attr += attr.length ? ` - ${value}` : value;
-      });
-      return attr;
-    },
     hasCombination() {
       return !!this.product.combination_id;
     },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | If a product attribute contain a comma (,) the product is not displayed in stock management. For example a shoe size 37,5 is not displayed, a 37 1/2 shoe size work perfectly.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26429.
| How to test?      | Go to 'Stock management' -> Search a product which contain product attribute with comma, it will be not displayed...
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26447)
<!-- Reviewable:end -->
