### PR TITLE
[BO] Fixes missed linking of CSS bundles for RTL 

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
@@ -26,7 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_sufix ~ '.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_suffix ~ '.css') }}" />
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
@@ -26,7 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme'~_rtl~'.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_sufix ~ '.css') }}" />
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
@@ -26,7 +26,11 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme_rtl.css') }}" />
+{% endif %}
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
@@ -26,11 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme_rtl.css') }}" />
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme'~_rtl~'.css') }}" />
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
@@ -26,7 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_sufix ~ '.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_suffix ~ '.css') }}" />
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
@@ -26,7 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme'~_rtl~'.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_sufix ~ '.css') }}" />
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
@@ -26,7 +26,11 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme_rtl.css') }}" />
+{% endif %}
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
@@ -26,11 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme_rtl.css') }}" />
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme'~_rtl~'.css') }}" />
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
@@ -26,7 +26,7 @@
 {% form_theme categories '@PrestaShop/Admin/Product/Themes/categories_theme.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog'~_rtl~'.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
@@ -26,11 +26,7 @@
 {% form_theme categories '@PrestaShop/Admin/Product/Themes/categories_theme.html.twig' %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog.css') }}" type="text/css" media="all">
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog_rtl.css') }}" type="text/css" media="all">
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog'~_rtl~'.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
@@ -26,7 +26,11 @@
 {% form_theme categories '@PrestaShop/Admin/Product/Themes/categories_theme.html.twig' %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog.css') }}" type="text/css" media="all">
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog_rtl.css') }}" type="text/css" media="all">
+{% endif %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
@@ -26,7 +26,7 @@
 {% form_theme categories '@PrestaShop/Admin/Product/Themes/categories_theme.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -25,11 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_rtl.css') }}" type="text/css" media="all">
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product'~_rtl~'.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -25,7 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -25,7 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product'~_rtl~'.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -25,7 +25,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_rtl.css') }}" type="text/css" media="all">
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
@@ -25,7 +25,11 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme_rtl.css') }}" />
+{% endif %}
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
@@ -25,11 +25,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme.css') }}" />
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme_rtl.css') }}" />
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme'~_rtl~'.css') }}" />
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
@@ -25,7 +25,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme'~_rtl~'.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_sufix ~ '.css') }}" />
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
@@ -25,7 +25,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_sufix ~ '.css') }}" />
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_suffix ~ '.css') }}" />
 {% endblock %}
 
 {% block title %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
@@ -28,7 +28,7 @@
 {% form_theme combinationForm.suppliers '@PrestaShop/Admin/Sell/Catalog/Product/Form/suppliers_form_theme.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
@@ -28,11 +28,7 @@
 {% form_theme combinationForm.suppliers '@PrestaShop/Admin/Sell/Catalog/Product/Form/suppliers_form_theme.html.twig' %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_rtl.css') }}" type="text/css" media="all">
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product'~_rtl~'.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
@@ -28,7 +28,7 @@
 {% form_theme combinationForm.suppliers '@PrestaShop/Admin/Sell/Catalog/Product/Form/suppliers_form_theme.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product'~_rtl~'.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
@@ -28,7 +28,11 @@
 {% form_theme combinationForm.suppliers '@PrestaShop/Admin/Sell/Catalog/Product/Form/suppliers_form_theme.html.twig' %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_rtl.css') }}" type="text/css" media="all">
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -28,7 +28,11 @@
 {% form_theme productForm with ['@PrestaShop/Admin/Sell/Catalog/Product/Form/product_form_theme.html.twig'] only %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_rtl.css') }}" type="text/css" media="all">
+{% endif %}
 {% endblock %}
 
 {# We empty the parent content header block because session alert is gonna be displayed inside the content #}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -28,7 +28,7 @@
 {% form_theme productForm with ['@PrestaShop/Admin/Sell/Catalog/Product/Form/product_form_theme.html.twig'] only %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product'~_rtl~'.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {# We empty the parent content header block because session alert is gonna be displayed inside the content #}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -28,7 +28,7 @@
 {% form_theme productForm with ['@PrestaShop/Admin/Sell/Catalog/Product/Form/product_form_theme.html.twig'] only %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {# We empty the parent content header block because session alert is gonna be displayed inside the content #}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -28,11 +28,7 @@
 {% form_theme productForm with ['@PrestaShop/Admin/Sell/Catalog/Product/Form/product_form_theme.html.twig'] only %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_rtl.css') }}" type="text/css" media="all">
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product'~_rtl~'.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {# We empty the parent content header block because session alert is gonna be displayed inside the content #}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
@@ -28,7 +28,7 @@
 {% set layoutTitle = 'Create order'|trans({}, 'Admin.Orderscustomers.Feature') %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders'~_rtl~'.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
@@ -28,7 +28,11 @@
 {% set layoutTitle = 'Create order'|trans({}, 'Admin.Orderscustomers.Feature') %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders.css') }}" type="text/css" media="all">
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders_rtl.css') }}" type="text/css" media="all">
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
@@ -28,11 +28,7 @@
 {% set layoutTitle = 'Create order'|trans({}, 'Admin.Orderscustomers.Feature') %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders.css') }}" type="text/css" media="all">
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders_rtl.css') }}" type="text/css" media="all">
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders'~_rtl~'.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
@@ -28,7 +28,7 @@
 {% set layoutTitle = 'Create order'|trans({}, 'Admin.Orderscustomers.Feature') %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
@@ -26,7 +26,11 @@
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders.css') }}" type="text/css" media="all">
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders_rtl.css') }}" type="text/css" media="all">
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
@@ -26,7 +26,7 @@
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders'~_rtl~'.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
@@ -26,11 +26,7 @@
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders.css') }}" type="text/css" media="all">
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders_rtl.css') }}" type="text/css" media="all">
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders'~_rtl~'.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
@@ -26,7 +26,7 @@
 {% extends 'PrestaShopBundle:Admin:layout.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -31,7 +31,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -31,11 +31,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders.css') }}" type="text/css" media="all">
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders_rtl.css') }}" type="text/css" media="all">
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders'~_rtl~'.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -31,7 +31,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders.css') }}" type="text/css" media="all">
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders_rtl.css') }}" type="text/css" media="all">
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -31,7 +31,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders'~_rtl~'.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
@@ -25,7 +25,11 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+{% if not is_lang_rtl %}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page.css') }}" type="text/css" media="all">
+{% else %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page_rtl.css') }}" type="text/css" media="all">
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
@@ -25,11 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
-{% if not is_lang_rtl %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page.css') }}" type="text/css" media="all">
-{% else %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page_rtl.css') }}" type="text/css" media="all">
-{% endif %}
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page'~_rtl~'.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
@@ -25,7 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page'~_rtl~'.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Stock/overview.html.twig
@@ -25,7 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page' ~ rtl_sufix ~ '.css') }}" type="text/css" media="all">
+  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 
 {% block content %}

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -102,7 +102,7 @@ class LayoutExtension extends \Twig_Extension implements GlobalsInterface
             'default_currency_symbol' => $defaultCurrency instanceof Currency ? $defaultCurrency->getSymbol() : null,
             'root_url' => $rootUrl,
             'js_translatable' => [],
-            'is_lang_rtl' => $this->context->getContext()->language->is_rtl
+            'is_lang_rtl' => $this->context->getContext()->language->is_rtl,
         ];
     }
 

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -102,6 +102,7 @@ class LayoutExtension extends \Twig_Extension implements GlobalsInterface
             'default_currency_symbol' => $defaultCurrency instanceof Currency ? $defaultCurrency->getSymbol() : null,
             'root_url' => $rootUrl,
             'js_translatable' => [],
+            'is_lang_rtl' => $this->context->getContext()->language->is_rtl
         ];
     }
 

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -102,7 +102,7 @@ class LayoutExtension extends \Twig_Extension implements GlobalsInterface
             'default_currency_symbol' => $defaultCurrency instanceof Currency ? $defaultCurrency->getSymbol() : null,
             'root_url' => $rootUrl,
             'js_translatable' => [],
-            '_rtl' => $this->context->getContext()->language->is_rtl ? '_rtl' : '',
+            'rtl_sufix' => $this->context->getContext()->language->is_rtl ? '_rtl' : '',
         ];
     }
 

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -102,7 +102,7 @@ class LayoutExtension extends \Twig_Extension implements GlobalsInterface
             'default_currency_symbol' => $defaultCurrency instanceof Currency ? $defaultCurrency->getSymbol() : null,
             'root_url' => $rootUrl,
             'js_translatable' => [],
-            'is_lang_rtl' => $this->context->getContext()->language->is_rtl,
+            '_rtl' => $this->context->getContext()->language->is_rtl ? '_rtl' : '',
         ];
     }
 

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -102,7 +102,7 @@ class LayoutExtension extends \Twig_Extension implements GlobalsInterface
             'default_currency_symbol' => $defaultCurrency instanceof Currency ? $defaultCurrency->getSymbol() : null,
             'root_url' => $rootUrl,
             'js_translatable' => [],
-            'rtl_sufix' => $this->context->getContext()->language->is_rtl ? '_rtl' : '',
+            'rtl_suffix' => $this->context->getContext()->language->is_rtl ? '_rtl' : '',
         ];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | In BackOffice for each CSS file, a RTL version of CSS created automatically after PS build but these files didn't link to the corresponding pages.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #26422
| How to test?      | Change employee's language to RTL and go to the pages that has been modified (Orders, Order page, Catalog, Product page and Stocks). See the Browser's inspector for CSS files. The RTL version of CSS linked to the page.
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26451)
<!-- Reviewable:end -->
