### PR TITLE
Reset password form, display error for not existing customer email into database 

### DIFF
--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -66,14 +66,15 @@ class PasswordControllerCore extends FrontController
             $this->errors[] = $this->trans('Invalid email address.', [], 'Shop.Notifications.Error');
         } else {
             $customer = new Customer();
-            $customer->getByEmail($email);
+            $customer->getByEmail($email, null, true);
             if (null === $customer->email) {
-                $customer->email = Tools::getValue('email');
+                $this->errors[] = $this->trans('The given e-mail address does not exist in our database.', array(), 'Shop.Notifications.Error');
+                return;
             }
 
             if (!Validate::isLoadedObject($customer)) {
                 $this->success[] = $this->trans(
-                    'If this email address has been registered in our shop, you will receive a link to reset your password at %email%.',
+                    'You will receive a link to reset your password at %email%.',
                     ['%email%' => $customer->email],
                     'Shop.Notifications.Success'
                 );
@@ -109,7 +110,7 @@ class PasswordControllerCore extends FrontController
                         $customer->firstname . ' ' . $customer->lastname
                     )
                 ) {
-                    $this->success[] = $this->trans('If this email address has been registered in our shop, you will receive a link to reset your password at %email%.', ['%email%' => $customer->email], 'Shop.Notifications.Success');
+                    $this->success[] = $this->trans('You will receive a link to reset your password at %email%.', ['%email%' => $customer->email], 'Shop.Notifications.Success');
                     $this->setTemplate('customer/password-infos');
                 } else {
                     $this->errors[] = $this->trans('An error occurred while sending the email.', [], 'Shop.Notifications.Error');

--- a/controllers/front/PasswordController.php
+++ b/controllers/front/PasswordController.php
@@ -68,7 +68,8 @@ class PasswordControllerCore extends FrontController
             $customer = new Customer();
             $customer->getByEmail($email, null, true);
             if (null === $customer->email) {
-                $this->errors[] = $this->trans('The given e-mail address does not exist in our database.', array(), 'Shop.Notifications.Error');
+                $this->errors[] = $this->trans('The given e-mail address does not exist in our database.', [], 'Shop.Notifications.Error');
+
                 return;
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  1.7.8.x 
| Description?      |  For customer password reset form I added additional check if customer exists with given email and display appropriate error message. Also I changed wording for success alert since we are checking if customer exits and success alert contains sentence `If this email address has been registered in our shop`. 
| Type?             |  improvement
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26457 
| How to test?      | Steps inside issue should be enough to test it.
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26458)
<!-- Reviewable:end -->
