### PR TITLE
Use latest npm version on JS routing GA

### DIFF
--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -52,6 +52,9 @@ jobs:
           restore-keys: |
                  ${{ runner.os }}-composer-
 
+      - name: Update npm
+        run: npm install npm -g
+
       - name: Install Composer dependencies
         run: composer install --prefer-dist
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | the JS routing GA is using npm 6 while our packages.json are using version 7+
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The GA should work fine and package.json and package-lock.json should use version 7-8
| Possible impacts? | Routing JSON GA


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26464)
<!-- Reviewable:end -->
