### PR TITLE
Fix modal position on safari on order page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig
@@ -24,84 +24,84 @@
  *#}
 
 <div class="modal fade" id="addOrderDiscountModal" tabindex="-1" role="dialog">
-  {{ form_start(addOrderCartRuleForm, {'action': path('admin_orders_add_cart_rule', {'orderId': orderForViewing.id})}) }}
     <div class="modal-dialog" role="document">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title">
-            {{ 'Add new cart rule'|trans({}, 'Admin.Catalog.Feature') }}
-          </h5>
-          <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
-            <span aria-hidden="true">×</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <div class="row">
-            <div class="col">
-              <div class="form-group">
-                <label class="form-control-label" for="{{ addOrderCartRuleForm.name.vars.id }}">
-                  {{ 'Name'|trans({}, 'Admin.Global') }}
-                </label>
-
-                {{ form_widget(addOrderCartRuleForm.name) }}
-              </div>
-            </div>
+      {{ form_start(addOrderCartRuleForm, {'action': path('admin_orders_add_cart_rule', {'orderId': orderForViewing.id})}) }}
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">
+              {{ 'Add new cart rule'|trans({}, 'Admin.Catalog.Feature') }}
+            </h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+              <span aria-hidden="true">×</span>
+            </button>
           </div>
-
-          <div class="row">
-            <div class="col">
-              <div class="form-group">
-                <label class="form-control-label" for="{{ addOrderCartRuleForm.type.vars.id }}">
-                  {{ 'Type'|trans({}, 'Admin.Global') }}
-                </label>
-
-                {{ form_widget(addOrderCartRuleForm.type) }}
-              </div>
-            </div>
-            <div class="col">
-              <div class="form-group mb-0">
-                <label class="form-control-label" for="{{ addOrderCartRuleForm.value.vars.id }}">
-                  {{ 'Value'|trans({}, 'Admin.Global') }}
-                </label>
-
-                <div class="input-group">
-                  <div class="input-group-prepend">
-                    <div class="input-group-text" id="add_order_cart_rule_value_unit" data-currency-symbol="{{ orderCurrency.symbol }}">%</div>
-                  </div>
-                  {{ form_widget(addOrderCartRuleForm.value) }}
-                </div>
-                <small class="text-muted js-cart-rule-value-help d-none">
-                  {{ 'This value must include taxes.'|trans({}, 'Admin.Orderscustomers.Notification') }}
-                </small>
-              </div>
-            </div>
-          </div>
-
-          <div class="{% if not orderForViewing.hasInvoice %}d-none{% endif %}">
+          <div class="modal-body">
             <div class="row">
               <div class="col">
                 <div class="form-group">
-                  <label class="form-control-label" for="{{ addOrderCartRuleForm.invoice_id.vars.id }}">
-                    {{ 'Invoice'|trans({}, 'Admin.Global') }}
+                  <label class="form-control-label" for="{{ addOrderCartRuleForm.name.vars.id }}">
+                    {{ 'Name'|trans({}, 'Admin.Global') }}
                   </label>
 
-                  {{ form_widget(addOrderCartRuleForm.invoice_id, {'attr': {
-                    'disabled': not orderForViewing.hasInvoice
-                  }}) }}
+                  {{ form_widget(addOrderCartRuleForm.name) }}
+                </div>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="col">
+                <div class="form-group">
+                  <label class="form-control-label" for="{{ addOrderCartRuleForm.type.vars.id }}">
+                    {{ 'Type'|trans({}, 'Admin.Global') }}
+                  </label>
+
+                  {{ form_widget(addOrderCartRuleForm.type) }}
+                </div>
+              </div>
+              <div class="col">
+                <div class="form-group mb-0">
+                  <label class="form-control-label" for="{{ addOrderCartRuleForm.value.vars.id }}">
+                    {{ 'Value'|trans({}, 'Admin.Global') }}
+                  </label>
+
+                  <div class="input-group">
+                    <div class="input-group-prepend">
+                      <div class="input-group-text" id="add_order_cart_rule_value_unit" data-currency-symbol="{{ orderCurrency.symbol }}">%</div>
+                    </div>
+                    {{ form_widget(addOrderCartRuleForm.value) }}
+                  </div>
+                  <small class="text-muted js-cart-rule-value-help d-none">
+                    {{ 'This value must include taxes.'|trans({}, 'Admin.Orderscustomers.Notification') }}
+                  </small>
+                </div>
+              </div>
+            </div>
+
+            <div class="{% if not orderForViewing.hasInvoice %}d-none{% endif %}">
+              <div class="row">
+                <div class="col">
+                  <div class="form-group">
+                    <label class="form-control-label" for="{{ addOrderCartRuleForm.invoice_id.vars.id }}">
+                      {{ 'Invoice'|trans({}, 'Admin.Global') }}
+                    </label>
+
+                    {{ form_widget(addOrderCartRuleForm.invoice_id, {'attr': {
+                      'disabled': not orderForViewing.hasInvoice
+                    }}) }}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+              {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+            </button>
+            <button type="submit" class="btn btn-primary" id="add_order_cart_rule_submit">
+              {{ 'Add'|trans({}, 'Admin.Actions') }}
+            </button>
+          </div>
         </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
-            {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-          </button>
-          <button type="submit" class="btn btn-primary" id="add_order_cart_rule_submit">
-            {{ 'Add'|trans({}, 'Admin.Actions') }}
-          </button>
-        </div>
-      </div>
+      {{ form_end(addOrderCartRuleForm) }}
     </div>
-  {{ form_end(addOrderCartRuleForm) }}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_product_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/add_product_modal.html.twig
@@ -24,94 +24,94 @@
  *#}
 
 <div class="modal fade" id="addOrderProductModal" tabindex="-1" role="dialog">
-  {{ form_start(addProductToOrderForm, {'action': '#'}) }}
   <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">
-          {{ 'Add a product'|trans({}, 'Admin.Orderscustomers.Feature') }}
-        </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
-          <span aria-hidden="true">×</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        <div class="row">
-          <div class="col">
-            <div class="form-group">
-              <label class="form-control-label" for="{{ addProductToOrderForm.product_id.vars.id }}">
-                {{ 'Product'|trans({}, 'Admin.Global') }}
-              </label>
+    {{ form_start(addProductToOrderForm, {'action': '#'}) }}
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">
+            {{ 'Add a product'|trans({}, 'Admin.Orderscustomers.Feature') }}
+          </h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <div class="row">
+            <div class="col">
+              <div class="form-group">
+                <label class="form-control-label" for="{{ addProductToOrderForm.product_id.vars.id }}">
+                  {{ 'Product'|trans({}, 'Admin.Global') }}
+                </label>
 
-              {{ form_widget(addProductToOrderForm.product_id) }}
+                {{ form_widget(addProductToOrderForm.product_id) }}
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="row">
-          <div class="col">
-            <div class="form-group">
-              <label class="form-control-label" for="{{ addProductToOrderForm.combination_id.vars.id }}">
-                {{ 'Combination'|trans({}, 'Admin.Global') }}
-              </label>
+          <div class="row">
+            <div class="col">
+              <div class="form-group">
+                <label class="form-control-label" for="{{ addProductToOrderForm.combination_id.vars.id }}">
+                  {{ 'Combination'|trans({}, 'Admin.Global') }}
+                </label>
 
-              {{ form_widget(addProductToOrderForm.combination_id) }}
+                {{ form_widget(addProductToOrderForm.combination_id) }}
+              </div>
             </div>
           </div>
-        </div>
 
-        <div class="row">
-          <div class="col">
-            <div class="form-group">
-              <label class="form-control-label" for="{{ addProductToOrderForm.price_tax_excl.vars.id }}">
-                {{ 'Price tax excluded'|trans({}, 'Admin.Advparameters.Feature') }}
-              </label>
+          <div class="row">
+            <div class="col">
+              <div class="form-group">
+                <label class="form-control-label" for="{{ addProductToOrderForm.price_tax_excl.vars.id }}">
+                  {{ 'Price tax excluded'|trans({}, 'Admin.Advparameters.Feature') }}
+                </label>
 
-              <div class="input-group">
-                {{ form_widget(addProductToOrderForm.price_tax_excl) }}
-                <div class="input-group-append">
-                  <span class="input-group-text">{{ orderForViewing.currencyId }}</span>
+                <div class="input-group">
+                  {{ form_widget(addProductToOrderForm.price_tax_excl) }}
+                  <div class="input-group-append">
+                    <span class="input-group-text">{{ orderForViewing.currencyId }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="col">
+              <div class="form-group mb-0">
+                <label class="form-control-label" for="{{ addProductToOrderForm.price_tax_incl.vars.id }}">
+                  {{ 'Price tax included'|trans({}, 'Admin.Advparameters.Feature') }}
+                </label>
+
+                <div class="input-group">
+                  {{ form_widget(addProductToOrderForm.price_tax_incl) }}
+                  <div class="input-group-append">
+                    <span class="input-group-text">{{ orderForViewing.currencyId }}</span>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-          <div class="col">
-            <div class="form-group mb-0">
-              <label class="form-control-label" for="{{ addProductToOrderForm.price_tax_incl.vars.id }}">
-                {{ 'Price tax included'|trans({}, 'Admin.Advparameters.Feature') }}
-              </label>
 
-              <div class="input-group">
-                {{ form_widget(addProductToOrderForm.price_tax_incl) }}
-                <div class="input-group-append">
-                  <span class="input-group-text">{{ orderForViewing.currencyId }}</span>
-                </div>
+          <div class="row">
+            <div class="col">
+              <div class="form-group">
+                <label class="form-control-label" for="{{ addProductToOrderForm.quantity.vars.id }}">
+                  {{ 'Quantity'|trans({}, 'Admin.Global') }}
+                </label>
+
+                {{ form_widget(addProductToOrderForm.quantity) }}
               </div>
             </div>
           </div>
         </div>
-
-        <div class="row">
-          <div class="col">
-            <div class="form-group">
-              <label class="form-control-label" for="{{ addProductToOrderForm.quantity.vars.id }}">
-                {{ 'Quantity'|trans({}, 'Admin.Global') }}
-              </label>
-
-              {{ form_widget(addProductToOrderForm.quantity) }}
-            </div>
-          </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+            {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+          </button>
+          <button type="submit" class="btn btn-primary">
+            {{ 'Add'|trans({}, 'Admin.Actions') }}
+          </button>
         </div>
       </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
-          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-        </button>
-        <button type="submit" class="btn btn-primary">
-          {{ 'Add'|trans({}, 'Admin.Actions') }}
-        </button>
-      </div>
-    </div>
+    {{ form_end(addProductToOrderForm) }}
   </div>
-  {{ form_end(addProductToOrderForm) }}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_customer_address_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_customer_address_modal.html.twig
@@ -25,39 +25,39 @@
 
 {% if changeOrderAddressForm is not null %}
   <div class="modal fade" id="updateCustomerAddressModal">
-    {{ form_start(changeOrderAddressForm,
-      {'action': path('admin_orders_change_customer_address', {'orderId': orderForViewing.id, 'customerId': orderForViewing.customer.id})}) }}
       <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title">
-              {{ 'Select another address'|trans({}, 'Admin.Actions') }}
-            </h5>
+        {{ form_start(changeOrderAddressForm,
+          {'action': path('admin_orders_change_customer_address', {'orderId': orderForViewing.id, 'customerId': orderForViewing.customer.id})}) }}
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">
+                {{ 'Select another address'|trans({}, 'Admin.Actions') }}
+              </h5>
 
-            <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
-              <span aria-hidden="true">×</span>
-            </button>
-          </div>
+              <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+                <span aria-hidden="true">×</span>
+              </button>
+            </div>
 
-          <div class="modal-body">
-            <div class="form-group m-0">
-              {{ form_widget(changeOrderAddressForm.new_address_id) }}
+            <div class="modal-body">
+              <div class="form-group m-0">
+                {{ form_widget(changeOrderAddressForm.new_address_id) }}
+              </div>
+            </div>
+
+            {{ form_widget(changeOrderAddressForm.address_type) }}
+
+            <div class="modal-footer">
+              <button id="change-address-cancel-button" type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+                {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+              </button>
+
+              <button id="change-address-submit-button" type="submit" class="btn btn-primary">
+                {{ 'Select'|trans({}, 'Admin.Actions') }}
+              </button>
             </div>
           </div>
-
-          {{ form_widget(changeOrderAddressForm.address_type) }}
-
-          <div class="modal-footer">
-            <button id="change-address-cancel-button" type="button" class="btn btn-outline-secondary" data-dismiss="modal">
-              {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-            </button>
-
-            <button id="change-address-submit-button" type="submit" class="btn btn-primary">
-              {{ 'Select'|trans({}, 'Admin.Actions') }}
-            </button>
-          </div>
-        </div>
+        {{ form_end(changeOrderAddressForm) }}
       </div>
-    {{ form_end(changeOrderAddressForm) }}
   </div>
 {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig
@@ -24,55 +24,55 @@
  *#}
 
 <div class="modal fade" id="updateOrderShippingModal" tabindex="-1" role="dialog">
-  {{ form_start(updateOrderShippingForm, {
-    'action': path('admin_orders_update_shipping', {'orderId': orderForViewing.id})
-  }) }}
   <div class="modal-dialog" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">{{ 'Edit shipping details'|trans({}, 'Admin.Orderscustomers.Feature') }}</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
-          <span aria-hidden="true">×</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        {% if not configuration('PS_ORDER_RECALCULATE_SHIPPING') %}
-          <div class="alert alert-info" role="alert">
-            <p class="alert-text">
-              {{ 'Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings'|trans({}, 'Admin.Orderscustomers.Notification') }}
-            </p>
+    {{ form_start(updateOrderShippingForm, {
+      'action': path('admin_orders_update_shipping', {'orderId': orderForViewing.id})
+    }) }}
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">{{ 'Edit shipping details'|trans({}, 'Admin.Orderscustomers.Feature') }}</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="{{ 'Close'|trans({}, 'Admin.Actions') }}">
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          {% if not configuration('PS_ORDER_RECALCULATE_SHIPPING') %}
+            <div class="alert alert-info" role="alert">
+              <p class="alert-text">
+                {{ 'Please note that carrier change will not recalculate your shipping costs, if you want to change this please visit Shop Parameters > Order Settings'|trans({}, 'Admin.Orderscustomers.Notification') }}
+              </p>
+            </div>
+          {% endif %}
+
+          <div class="form-group">
+            <label class="form-control-label" for="{{ updateOrderShippingForm.tracking_number.vars.id }}">
+              {{ 'Tracking number'|trans({}, 'Admin.Shipping.Feature') }}
+            </label>
+
+            {{ form_widget(updateOrderShippingForm.tracking_number) }}
           </div>
-        {% endif %}
 
-        <div class="form-group">
-          <label class="form-control-label" for="{{ updateOrderShippingForm.tracking_number.vars.id }}">
-            {{ 'Tracking number'|trans({}, 'Admin.Shipping.Feature') }}
-          </label>
+          <div class="form-group">
+            <label class="form-control-label" for="{{ updateOrderShippingForm.new_carrier_id.vars.id }}">
+              {{ 'Carrier'|trans({}, 'Admin.Global') }}
+            </label>
 
-          {{ form_widget(updateOrderShippingForm.tracking_number) }}
+            {{ form_widget(updateOrderShippingForm.new_carrier_id) }}
+          </div>
+
+          <div class="d-none">
+            {{ form_rest(updateOrderShippingForm) }}
+          </div>
         </div>
-
-        <div class="form-group">
-          <label class="form-control-label" for="{{ updateOrderShippingForm.new_carrier_id.vars.id }}">
-            {{ 'Carrier'|trans({}, 'Admin.Global') }}
-          </label>
-
-          {{ form_widget(updateOrderShippingForm.new_carrier_id) }}
-        </div>
-
-        <div class="d-none">
-          {{ form_rest(updateOrderShippingForm) }}
+        <div class="modal-footer">
+          <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
+            {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+          </button>
+          <button type="submit" class="btn btn-primary">
+            {{ 'Update'|trans({}, 'Admin.Actions') }}
+          </button>
         </div>
       </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-outline-secondary" data-dismiss="modal">
-          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-        </button>
-        <button type="submit" class="btn btn-primary">
-          {{ 'Update'|trans({}, 'Admin.Actions') }}
-        </button>
-      </div>
-    </div>
+    {{ form_end(updateOrderShippingForm) }}
   </div>
-  {{ form_end(updateOrderShippingForm) }}
 </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Form structure was wrong on the order page modals
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22315.
| How to test?      | Go on order view page on safari and open every modals
| Possible impacts? | Order page modals


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26465)
<!-- Reviewable:end -->
