### PR TITLE
Fix Combination::getIdByReference returns wrong id

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -504,7 +504,7 @@ class CombinationCore extends ObjectModel
         $query = new DbQuery();
         $query->select('pa.id_product_attribute');
         $query->from('product_attribute', 'pa');
-        $query->where('pa.reference LIKE \'%' . pSQL($reference) . '%\'');
+        $query->where('pa.reference = \'' . pSQL($reference) . '\'');
         $query->where('pa.id_product = ' . (int) $idProduct);
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($query);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix Combination::getIdByReference() returns wrong id by remove LIKE search
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #20454, Fixes  #26467. 
| How to test?      | See how to test secton in issue
| Possible impacts? | This function is use during admin import


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26475)
<!-- Reviewable:end -->
