### PR TITLE
Fixed Recalculate Shipping when the carrier of an order is changed

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -77,7 +77,7 @@ class OrderHistoryCore extends ObjectModel
      * Sets the new state of the given order.
      *
      * @param int $new_order_state
-     * @param int/object $id_order
+     * @param int|Order $id_order
      * @param bool $use_existing_payment
      */
     public function changeIdOrderState($new_order_state, $id_order, $use_existing_payment = false)
@@ -375,11 +375,11 @@ class OrderHistoryCore extends ObjectModel
 
         // set orders as paid
         if ($new_os->paid == 1) {
-            $invoices = $order->getInvoicesCollection();
             if ($order->total_paid != 0) {
                 $payment_method = Module::getInstanceByName($order->module);
             }
 
+            $invoices = $order->getInvoicesCollection();
             foreach ($invoices as $invoice) {
                 /** @var OrderInvoice $invoice */
                 $rest_paid = $invoice->getRestPaid();
@@ -388,26 +388,22 @@ class OrderHistoryCore extends ObjectModel
                     $payment->order_reference = Tools::substr($order->reference, 0, 9);
                     $payment->id_currency = $order->id_currency;
                     $payment->amount = $rest_paid;
-
-                    if ($order->total_paid != 0) {
-                        $payment->payment_method = $payment_method->displayName;
-                    } else {
-                        $payment->payment_method = null;
-                    }
+                    $payment->payment_method = $payment_method ? $payment_method->displayName : null;
+                    $payment->conversion_rate = $order->conversion_rate;
+                    $payment->save();
 
                     // Update total_paid_real value for backward compatibility reasons
-                    if ($payment->id_currency == $order->id_currency) {
-                        $order->total_paid_real += $payment->amount;
-                    } else {
-                        $order->total_paid_real += Tools::ps_round(Tools::convertPrice($payment->amount, $payment->id_currency, false), Context::getContext()->getComputingPrecision());
-                    }
+                    $order->total_paid_real += $rest_paid;
                     $order->save();
 
-                    $payment->conversion_rate = ($order ? $order->conversion_rate : 1);
-                    $payment->save();
-                    Db::getInstance()->execute('
-                    INSERT INTO `' . _DB_PREFIX_ . 'order_invoice_payment` (`id_order_invoice`, `id_order_payment`, `id_order`)
-                    VALUES(' . (int) $invoice->id . ', ' . (int) $payment->id . ', ' . (int) $order->id . ')');
+                    Db::getInstance()->insert(
+                        'order_invoice_payment',
+                        [
+                            'id_order_invoice' => (int) $invoice->id,
+                            'id_order_payment' => (int) $payment->id,
+                            'id_order' => (int) $order->id,
+                        ]
+                    );
                 }
             }
         }

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -773,6 +773,8 @@ class OrderInvoiceCore extends ObjectModel
      *
      * @param int $mod TAX_EXCL, TAX_INCL, DETAIL
      *
+     * @return float
+     *
      * @since 1.5.0.14
      */
     public function getSiblingTotal($mod = OrderInvoice::TAX_INCL)

--- a/src/Adapter/Order/OrderAmountUpdater.php
+++ b/src/Adapter/Order/OrderAmountUpdater.php
@@ -565,15 +565,13 @@ class OrderAmountUpdater
                 if ($freeShipping) {
                     $invoice->total_discount_tax_excl = $invoice->total_discount_tax_excl - $invoice->total_shipping_tax_excl + $totalShippingTaxExcluded;
                     $invoice->total_discount_tax_incl = $invoice->total_discount_tax_incl - $invoice->total_shipping_tax_incl + $totalShippingTaxIncluded;
+                } else {
+                    $invoice->total_paid_tax_incl -= ($invoice->total_shipping_tax_incl - $totalShippingTaxIncluded);
+                    $invoice->total_paid_tax_excl -= ($invoice->total_shipping_tax_excl - $totalShippingTaxExcluded);
                 }
 
                 $invoice->total_shipping_tax_incl = $totalShippingTaxIncluded;
                 $invoice->total_shipping_tax_excl = $totalShippingTaxExcluded;
-
-                if (!$freeShipping) {
-                    $invoice->total_paid_tax_incl -= ($invoice->total_shipping_tax_incl - $totalShippingTaxIncluded);
-                    $invoice->total_paid_tax_excl -= ($invoice->total_shipping_tax_excl - $totalShippingTaxExcluded);
-                }
             }
 
             if (!$invoice->update()) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -718,10 +718,9 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
      */
     public function updateOrdersToStatuses(string $orderReferencesString, string $status)
     {
-        /** @var string[] $orderReferencesString */
-        $orderReferencesString = explode(',', $orderReferencesString);
+        $orderReferences = explode(',', $orderReferencesString);
         $ordersIds = [];
-        foreach ($orderReferencesString as $orderReference) {
+        foreach ($orderReferences as $orderReference) {
             $ordersIds[] = SharedStorage::getStorage()->get($orderReference);
         }
 

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
@@ -73,10 +73,10 @@ Feature: Add payment to Order from Back Office (BO)
       | transaction_id | test123             |
       | currency       | USD                 |
       | amount         | 6.00                |
-    Then order "bo_order1" payments should have the following details:
+    Then order "bo_order1" payment in first position should have the following details:
       | date           | 2019-11-26 13:56:23 |
-      | payment_method | Payments by check   |
-      | transaction_id | test123             |
+      | paymentMethod  | Payments by check   |
+      | transactionId  | test123             |
       | amount         | $6.00               |
     And order "bo_order1" should have the following details:
       | total_paid_real | 6.000000 |
@@ -89,10 +89,10 @@ Feature: Add payment to Order from Back Office (BO)
       | transaction_id | test123             |
       | currency       | currency2           |
       | amount         | 6.00                |
-    Then order "bo_order1" payments should have the following details:
+    Then order "bo_order1" payment in first position should have the following details:
       | date           | 2019-11-26 13:56:23 |
-      | payment_method | Payments by check   |
-      | transaction_id | test123             |
+      | paymentMethod  | Payments by check   |
+      | transactionId  | test123             |
       | amount         | €6.00               |
     And order "bo_order1" should have the following details:
       | total_paid_real | 6.820000 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -97,10 +97,10 @@ Feature: Order from Back Office (BO)
       | transaction_id | test123             |
       | currency       | USD                 |
       | amount         | 6.00                |
-    Then order "bo_order1" payments should have the following details:
+    Then order "bo_order1" payment in first position should have the following details:
       | date           | 2019-11-26 13:56:23 |
-      | payment_method | Payments by check   |
-      | transaction_id | test123             |
+      | paymentMethod  | Payments by check   |
+      | transactionId  | test123             |
       | amount         | $6.00               |
     And order "bo_order1" should have following details:
       | total_products           | 23.80 |

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping_recalculate.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping_recalculate.feature
@@ -23,9 +23,10 @@ Feature: Order from Back Office (BO)
     And I add 2 products "Mug The best is yet to come" to the cart "dummy_cart"
     And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart"
 
-  Scenario: With PS_ORDER_RECALCULATE_SHIPPING = 1, check the total price is recalculated
+  Scenario: With PS_ORDER_RECALCULATE_SHIPPING = 1 & status = Awaiting bank wire payment, check the total price is recalculated
     Given shop configuration for "PS_ORDER_RECALCULATE_SHIPPING" is set to 1
-    And I select carrier "default_carrier" for cart "dummy_cart"
+    And I enable carrier "weight_carrier"
+    When I select carrier "default_carrier" for cart "dummy_cart"
     Then cart "dummy_cart" should have "default_carrier" as a carrier
     When I add order "bo_order1" with the following details:
       | cart                | dummy_cart                 |
@@ -40,8 +41,8 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0     |
-      | total_discounts_tax_incl | 0.0   |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 30.800 |
       | total_paid_tax_incl      | 32.650 |
       | total_paid               | 32.650 |
@@ -50,21 +51,84 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_incl  | 7.42   |
     When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "weight_carrier"
     Then order "bo_order1" should have "weight_carrier" as a carrier
-    ## Shipping equals to 0 as 2 products in cart have no weight
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0     |
-      | total_discounts_tax_incl | 0.0   |
-      | total_paid_tax_excl      | 23.800 |
-      | total_paid_tax_incl      | 25.230 |
-      | total_paid               | 25.230 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 25.800 |
+      | total_paid_tax_incl      | 27.350 |
+      | total_paid               | 27.350 |
       | total_paid_real          | 0.0    |
-      | total_shipping_tax_excl  | 0.0    |
-      | total_shipping_tax_incl  | 0.0   |
+      | total_shipping_tax_excl  | 2.00   |
+      | total_shipping_tax_incl  | 2.12   |
+    Then order "bo_order1" has 0 payments
 
-  Scenario: With PS_ORDER_RECALCULATE_SHIPPING = 0, check the total price is not recalculated
+  Scenario: With PS_ORDER_RECALCULATE_SHIPPING = 1 & status = Processing in progress, check the total price is recalculated
+    Given shop configuration for "PS_ORDER_RECALCULATE_SHIPPING" is set to 1
+    And I enable carrier "weight_carrier"
+    And there is a product in the catalog named "Shipping Product" with a price of 15.0 and 100 items in stock
+    And product "Shipping Product" weight is 0.63 kg
+    And I add 1 products "Shipping Product" to the cart "dummy_cart"
+    And I select carrier "weight_carrier" for cart "dummy_cart"
+    Then cart "dummy_cart" should have "weight_carrier" as a carrier
+    When I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Processing in progress     |
+    Then order "bo_order1" should have 3 products in total
+    And order "bo_order1" should have 1 invoice
+    And order "bo_order1" should have 0 cart rule
+    # Carrier less expensive is chosen by default
+    And order "bo_order1" should have "weight_carrier" as a carrier
+    And order "bo_order1" should have following details:
+      | total_products           | 38.800 |
+      | total_products_wt        | 41.130 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 43.800 |
+      | total_paid_tax_incl      | 46.430 |
+      | total_paid               | 46.430 |
+      | total_paid_real          | 46.430 |
+      | total_shipping_tax_excl  | 5.0    |
+      | total_shipping_tax_incl  | 5.30   |
+    When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "default_carrier"
+    Then order "bo_order1" should have "default_carrier" as a carrier
+    And order "bo_order1" should have following details:
+      | total_products           | 38.800 |
+      | total_products_wt        | 41.130 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 45.800 |
+      | total_paid_tax_incl      | 48.550 |
+      | total_paid               | 48.550 |
+      | total_paid_real          | 46.430 |
+      | total_shipping_tax_excl  | 7.0    |
+      | total_shipping_tax_incl  | 7.42   |
+    Then order "bo_order1" has 1 payments
+    And order "bo_order1" payment in first position should have the following details:
+      | paymentMethod  | Dummy payment   |
+      | transactionId  |                 |
+      | amount         | $46.43          |
+      | invoiceNumber  | #IN000001       |
+    ## Change to paid order status
+    When I update orders "bo_order1" statuses to "Shipped"
+    Then order "bo_order1" has 2 payments
+    And order "bo_order1" payment in first position should have the following details:
+      | paymentMethod  | Dummy payment   |
+      | transactionId  |                 |
+      | amount         | $46.43          |
+      | invoiceNumber  | #IN000001       |
+    And order "bo_order1" payment in second position should have the following details:
+      | paymentMethod  | Dummy payment   |
+      | transactionId  |                 |
+      | amount         | $2.12           |
+      | invoiceNumber  | #IN000001       |
+
+  Scenario: With PS_ORDER_RECALCULATE_SHIPPING = 0 & status = Awaiting bank wire payment, check the total price is not recalculated
     Given shop configuration for "PS_ORDER_RECALCULATE_SHIPPING" is set to 0
+    And I select carrier "default_carrier" for cart "dummy_cart"
     And I add order "bo_order1" with the following details:
       | cart                | dummy_cart                 |
       | message             | test                       |
@@ -78,8 +142,8 @@ Feature: Order from Back Office (BO)
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0     |
-      | total_discounts_tax_incl | 0.0   |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 30.800 |
       | total_paid_tax_incl      | 32.650 |
       | total_paid               | 32.650 |
@@ -88,15 +152,92 @@ Feature: Order from Back Office (BO)
       | total_shipping_tax_incl  | 7.42   |
     When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "weight_carrier"
     Then order "bo_order1" should have "weight_carrier" as a carrier
-    ## Shipping equals to 0 as 2 products in cart have no weight
     And order "bo_order1" should have following details:
       | total_products           | 23.800 |
       | total_products_wt        | 25.230 |
-      | total_discounts_tax_excl | 0.0     |
-      | total_discounts_tax_incl | 0.0   |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
       | total_paid_tax_excl      | 30.800 |
       | total_paid_tax_incl      | 32.650 |
       | total_paid               | 32.650 |
       | total_paid_real          | 0.0    |
       | total_shipping_tax_excl  | 7.0    |
       | total_shipping_tax_incl  | 7.42   |
+    Then order "bo_order1" has 0 payments
+
+  Scenario: With PS_ORDER_RECALCULATE_SHIPPING = 0 & status = Processing in progress, check the total price is recalculated
+    Given shop configuration for "PS_ORDER_RECALCULATE_SHIPPING" is set to 0
+    And I enable carrier "weight_carrier"
+    And there is a product in the catalog named "Shipping Product" with a price of 15.0 and 100 items in stock
+    And product "Shipping Product" weight is 0.63 kg
+    And I add 1 products "Shipping Product" to the cart "dummy_cart"
+    And I select carrier "weight_carrier" for cart "dummy_cart"
+    Then cart "dummy_cart" should have "weight_carrier" as a carrier
+    When I add order "bo_order1" with the following details:
+      | cart                | dummy_cart                 |
+      | message             | test                       |
+      | payment module name | dummy_payment              |
+      | status              | Processing in progress     |
+    Then order "bo_order1" should have 3 products in total
+    And order "bo_order1" should have 1 invoice
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products          | 38.800 |
+      | total_products_wt       | 41.130 |
+      | total_discount_tax_excl | 0.0    |
+      | total_discount_tax_incl | 0.0    |
+      | total_paid_tax_excl     | 43.800 |
+      | total_paid_tax_incl     | 46.430 |
+      | total_shipping_tax_excl | 5.0    |
+      | total_shipping_tax_incl | 5.30   |
+    And order "bo_order1" should have 0 cart rule
+    # Carrier less expensive is chosen by default
+    And order "bo_order1" should have "weight_carrier" as a carrier
+    And order "bo_order1" should have following details:
+      | total_products           | 38.800 |
+      | total_products_wt        | 41.130 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 43.800 |
+      | total_paid_tax_incl      | 46.430 |
+      | total_paid               | 46.430 |
+      | total_paid_real          | 46.430 |
+      | total_shipping_tax_excl  | 5.0    |
+      | total_shipping_tax_incl  | 5.30   |
+    When I update order "bo_order1" Tracking number to "TEST1234" and Carrier to "default_carrier"
+    Then order "bo_order1" should have "default_carrier" as a carrier
+    And order "bo_order1" should have following details:
+      | total_products           | 38.800 |
+      | total_products_wt        | 41.130 |
+      | total_discounts_tax_excl | 0.0    |
+      | total_discounts_tax_incl | 0.0    |
+      | total_paid_tax_excl      | 43.800 |
+      | total_paid_tax_incl      | 46.430 |
+      | total_paid               | 46.430 |
+      | total_paid_real          | 46.430 |
+      | total_shipping_tax_excl  | 5.0    |
+      | total_shipping_tax_incl  | 5.30   |
+    And order "bo_order1" should have 1 invoice
+    And the first invoice from order "bo_order1" should have following details:
+      | total_products          | 38.800 |
+      | total_products_wt       | 41.130 |
+      | total_discount_tax_excl | 0.0    |
+      | total_discount_tax_incl | 0.0    |
+      | total_paid_tax_excl     | 43.800 |
+      | total_paid_tax_incl     | 46.430 |
+      | total_shipping_tax_excl  | 5.0    |
+      | total_shipping_tax_incl  | 5.30   |
+    And order "bo_order1" has 1 payments
+    And order "bo_order1" payment in first position should have the following details:
+      | paymentMethod  | Dummy payment   |
+      | transactionId  |                 |
+      | amount         | $46.43          |
+      | invoiceNumber  | #IN000002       |
+    ## Change to paid order status
+    When I update orders "bo_order1" statuses to "Shipped"
+    Then order "bo_order1" should have 1 invoice
+    And order "bo_order1" has 1 payments
+    And order "bo_order1" payment in first position should have the following details:
+      | paymentMethod  | Dummy payment   |
+      | transactionId  |                 |
+      | amount         | $46.43          |
+      | invoiceNumber  | #IN000002       |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixed Recalculate Shipping when the carrier of an order is changed
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25565 
| How to test?      | Cf. #25565 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26481)
<!-- Reviewable:end -->

## Specs

https://github.com/PrestaShop/prestashop-specs/pull/258

we can test this issue https://github.com/PrestaShop/PrestaShop/issues/24598 when testing this PR