### PR TITLE
Product page, Specific prices - Change currency don't change Symbol

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/catalog/product/selectors-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog/product/selectors-map.ts
@@ -29,6 +29,7 @@ export default {
   priceForm: '#specific_price_form',
   save: '#specific_price_form .js-save',
   openCreate: '#js-open-create-specific-price-form',
+  idCurrency: (selectorPrefix: string): string => `${selectorPrefix}sp_id_currency`,
   leavBPrice: (selectorPrefix: string): string => `${selectorPrefix}leave_bprice`,
   reductionType: (selectorPrefix: string): string => `${selectorPrefix}sp_reduction_type`,
   modalCancel: '#form_modal_cancel',

--- a/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
@@ -181,6 +181,9 @@ class SpecificPriceFormHandler {
     // eslint-disable-next-line
     $(SpecificMap.reductionType(selectorPrefix)).on('change', () => this.enableSpecificPriceTaxFieldIfEligible(usePrefixForCreate),
     );
+
+    $(SpecificMap.idCurrency(selectorPrefix)).on('change', () => this.changeCurrencySymbol(usePrefixForCreate),
+    );
   }
 
   /**
@@ -205,10 +208,14 @@ class SpecificPriceFormHandler {
     $(SpecificMap.reductionType).on('change', () => this.enableSpecificPriceTaxFieldIfEligible(usePrefixForCreate),
     );
 
+    $(SpecificMap.idCurrency(selectorPrefix)).on('change', () => this.changeCurrencySymbol(usePrefixForCreate),
+    );
+
     this.reinitializeDatePickers();
 
     this.initializeLeaveBPriceField(usePrefixForCreate);
     this.enableSpecificPriceTaxFieldIfEligible(usePrefixForCreate);
+    this.changeCurrencySymbol(usePrefixForCreate);
   }
 
   /**
@@ -446,6 +453,21 @@ class SpecificPriceFormHandler {
     } else {
       $(`${selectorPrefix}sp_reduction_tax`).show();
     }
+  }
+
+  /**
+   * @param boolean usePrefixForCreate
+   *
+   * @private
+   */
+  private changeCurrencySymbol(
+    usePrefixForCreate: boolean,
+  ): void {
+    const selectorPrefix = this.getPrefixSelector(usePrefixForCreate);
+    const currencySymbol = $(`${selectorPrefix}sp_id_currency option:selected`).data('currency-symbol');
+
+    $(`${selectorPrefix}sp_price`).parent().find('.input-group-append .input-group-text').text(currencySymbol);
+    $(`${selectorPrefix}sp_reduction_type option[value="amount"]`).text(currencySymbol);
   }
 
   /**

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -122,10 +122,7 @@ class ProductSpecificPrice extends CommonAbstractType
             $countryDataprovider->getCountries($this->locales[0]['id_lang']),
             'id_country'
         );
-        $this->currencies = $this->formatDataChoicesList(
-            $currencyDataprovider->getCurrencies(),
-            'id_currency'
-        );
+        $this->currencies = $currencyDataprovider->getCurrencies();
         $this->groups = $this->formatDataChoicesList(
             $groupDataprovider->getGroups($this->locales[0]['id_lang']),
             'id_group'
@@ -168,7 +165,16 @@ class ProductSpecificPrice extends CommonAbstractType
             'sp_id_currency',
             FormType\ChoiceType::class,
             [
-                'choices' => $this->currencies,
+                'choices' => $this->formatDataChoicesList($this->currencies, 'id_currency'),
+                'choice_attr' => function ($val, $key, $index) {
+                    foreach ($this->currencies as $currency) {
+                        if ($currency['id'] == $val) {
+                            return [
+                                'data-currency-symbol' => $currency['symbol'],
+                            ];
+                        }
+                    }
+                },
                 'required' => false,
                 'label' => false,
                 'attr' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When we change the currency condition for a specific price, the default currency change by the currency symbol selected.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26482.
| How to test?      | See issue
| Possible impacts? | Need to check in multishop context maybe


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26485)
<!-- Reviewable:end -->
