### PR TITLE
Disable 'Apply new Quantity' Button before request is sent

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/movement-type.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/movement-type.vue
@@ -57,6 +57,7 @@
     },
     methods: {
       sendQty(): void {
+        this.$store.state.hasQty = false;
         this.$store.dispatch('updateQtyByProductsId');
       },
     },

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/products-actions.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/products-actions.vue
@@ -125,6 +125,7 @@
         }
       },
       sendQty(): void {
+        this.$store.state.hasQty = false;
         this.$store.dispatch('updateQtyByProductsId');
       },
       onChange(value: number): void {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Disable Update Button before update request is sent, resolving the issue where a user could click rapidly click the button resulting in more than one update.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19789
| How to test?      | Navigate to Stock management page and update the available quantity to +20 or something and hit the 'Apply new Quantity' button multiple times as fast as possible. Only one request will be sent.
| Possible impacts? | No impact

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Reopend the PR because i didnt create branch last time and want to make other PRs.
Could this be considered for the hacktoberfest labels also please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26488)
<!-- Reviewable:end -->
