### PR TITLE
Remove content div transition

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -8,10 +8,6 @@
   padding-bottom: $grid-gutter-width / 2;
   padding-left: $size-navbar-width + ($grid-gutter-width / 2);
 
-  @include transition(
-    padding 0.5s ease
-  ); // transition when collapsing the nav menu
-
   // with hidden navbar
   @include media-breakpoint-down(md) {
     padding-left: $grid-gutter-width / 2;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | it seems the nav transition for the padding was copied over to the content div which is sightly annoying on every page load. 
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #26383
| How to test?      | load the BO and click between Orders/Invoices/Credit slips etc and see it no longer slowly transitions down. 
| Possible impacts? | none

no-longer-transitions
![no-longer-transitions](https://user-images.githubusercontent.com/3083014/139494988-570fdc9c-ff13-4117-9108-3e81fd2ed85a.gif)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
Could this be considered for the hacktoberfest labels please.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26490)
<!-- Reviewable:end -->
