### PR TITLE
Fix the display of the State field and the Zip/Postal in the add new Tax rule page

### DIFF
--- a/admin-dev/themes/default/template/controllers/tax_rules/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/tax_rules/helpers/form/form.tpl
@@ -26,9 +26,9 @@
 
 {block name="label"}
 	{if $input.name == 'zipcode' && isset($input.label)}
-		<label id="zipcode-label" class="control-label col-lg-3">{$input.label}</label>
+		<label id="zipcode-label" class="control-label col-lg-4">{$input.label}</label>
 	{elseif $input.name == 'states[]'}
-		<label id="states-label" class="control-label col-lg-3">{$input.label}</label>
+		<label id="states-label" class="control-label col-lg-4">{$input.label}</label>
 	{else}
 		{$smarty.block.parent}
 	{/if}


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | In the BO > Taxes > Tax rule page, in the "add new tax rule" section, the State field and the Zip/Postal code range filed are not aligned.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26491
| How to test?      | see issue
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26492)
<!-- Reviewable:end -->
