### PR TITLE
Add hook actionCartGetOrderTotalAfter

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2219,7 +2219,7 @@ class CartCore extends ObjectModel
         
         $value = Hook::exec(
             'actionCartGetOrderTotalAfter',
-            array(
+            [
                 'order_total' => $value,
                 'cart' => $this,
                 'context' => Context::getContext(),
@@ -2229,7 +2229,7 @@ class CartCore extends ObjectModel
                 'id_carrier' => $id_carrier,
                 'use_cache' => $use_cache,
                 'keepOrderPrices' => $keepOrderPrices
-            ),
+            ],
             null,
             true
         );

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2216,6 +2216,23 @@ class CartCore extends ObjectModel
         // TAXES ?
 
         $value = $withTaxes ? $amount->getTaxIncluded() : $amount->getTaxExcluded();
+        
+        $value = Hook::exec(
+            'actionCartGetOrderTotalAfter',
+            array(
+                'order_total' => $value,
+                'cart' => $this,
+                'context' => Context::getContext(),
+                'withTaxes' => $withTaxes,
+                'type' => $type,
+                'products' => $products,
+                'id_carrier' => $id_carrier,
+                'use_cache' => $use_cache,
+                'keepOrderPrices' => $keepOrderPrices
+            ),
+            null,
+            true
+        );
 
         // ROUND AND RETURN
 

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3525,5 +3525,10 @@
       <title>Payment options Presenter</title>
       <description>This hook is called before payment options are presented</description>
     </hook>
+    <hook id="actionCartGetOrderTotalAfter">
+      <name>actionCartGetOrderTotalAfter</name>
+      <title>Get cart total after</title>
+      <description>This hook allows you to increase or reduce cart total</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3528,7 +3528,7 @@
     <hook id="actionCartGetOrderTotalAfter">
       <name>actionCartGetOrderTotalAfter</name>
       <title>Get cart total after</title>
-      <description>This hook allows you to increase or reduce cart total</description>
+      <description>This hook allows you to modify the cart total amount</description>
     </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add new hook before returning cart total. Increase or reduce cart total depending on hooked modules
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26275.
| How to test?      | Install https://github.com/PrestaShop/ps_checkpayment<br>With ps_qualityassurance, register new hook name: actionCartGetOrderTotalAfter. Add: `return 12;`<br>Make an order on frontoffice<br>Check that the cart is reduced from 12€
| Possible impacts? | Impact order total. Orders must be corrected after being registered on shop.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26378)
<!-- Reviewable:end -->
