### PR TITLE
Changed colorPicker width in BackOffice

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -735,9 +735,8 @@
 									{$asso_shop}
 								{elseif $input.type == 'color'}
 								<div class="form-group">
-									<div class="col-lg-2">
-										<div class="row">
-											<div class="input-group">
+									<div class="col-lg-6">
+										<div class="input-group">
 												<input type="color"
 												data-hex="true"
 												{if isset($input.class)} class="{$input.class}"
@@ -745,7 +744,6 @@
 												name="{$input.name}"
 												value="{$fields_value[$input.name]|escape:'html':'UTF-8'}" />
 											</div>
-										</div>
 									</div>
 								</div>
 								{elseif $input.type == 'date'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Check the colorPicker in Attributes>Color, OrderSettings>OrderStatuses and Multistore>ShopGroup
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26384 
| How to test?      | Check all colorPicker used in BO
| Possible impacts? | no impact


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26494)
<!-- Reviewable:end -->
