### PR TITLE
Introduce CQRS query to search combinations for association

### DIFF
--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -171,6 +171,15 @@ final class GetEditableCombinationsListHandler implements GetEditableCombination
                 $imageId = reset($defaultImageIds);
             }
 
+            if (null === $imageId) {
+                $imagePath = $this->productImagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
+            } else {
+                $imagePath = $this->productImagePathFactory->getPathByType(
+                    $imageId,
+                    ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT
+                );
+            }
+
             $impactOnPrice = new DecimalNumber($combination['price']);
             $combinationsForEditing[] = new EditableCombinationForListing(
                 $combinationId,
@@ -180,7 +189,7 @@ final class GetEditableCombinationsListHandler implements GetEditableCombination
                 (bool) $combination['default_on'],
                 $impactOnPrice,
                 (int) $this->stockAvailableRepository->getForCombination(new CombinationId($combinationId))->quantity,
-                $imageId ? $this->productImagePathFactory->getPathByType($imageId, ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT) : null
+                $imagePath
             );
         }
 

--- a/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\SearchCombinationsForAssociation;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryHandler\SearchCombinationsForAssociationHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForAssociation;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+
+class SearchCombinationsForAssociationHandler implements SearchCombinationsForAssociationHandlerInterface
+{
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+
+    /**
+     * @var ProductImagePathFactory
+     */
+    private $productImagePathFactory;
+
+    /**
+     * @param ProductRepository $productRepository
+     * @param ProductImagePathFactory $productImagePathFactory
+     */
+    public function __construct(
+        ProductRepository $productRepository,
+        ProductImagePathFactory $productImagePathFactory
+    ) {
+        $this->productRepository = $productRepository;
+        $this->productImagePathFactory = $productImagePathFactory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(SearchCombinationsForAssociation $query): array
+    {
+        $foundCombinations = $this->productRepository->searchCombinations(
+            $query->getPhrase(),
+            $query->getLanguageId(),
+            $query->getShopId(),
+            $query->getLimit()
+        );
+
+        $productsForAssociation = [];
+        foreach ($foundCombinations as $foundProduct) {
+            $productsForAssociation[] = $this->createResult($foundProduct);
+        }
+
+        return $productsForAssociation;
+    }
+
+    /**
+     * @param array $foundProduct
+     *
+     * @return CombinationForAssociation
+     */
+    private function createResult(array $foundProduct): CombinationForAssociation
+    {
+        if (empty($foundProduct['id_image'])) {
+            $imagePath = $this->productImagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_HOME_DEFAULT);
+        } else {
+            $imagePath = $this->productImagePathFactory->getPathByType(
+                new ImageId((int) $foundProduct['id_image']),
+                ProductImagePathFactory::IMAGE_TYPE_HOME_DEFAULT
+            );
+        }
+
+        return new CombinationForAssociation(
+            (int) $foundProduct['id_product'],
+            (int) $foundProduct['id_product_attribute'],
+            $foundProduct['name'],
+            $foundProduct['reference'] ?? '',
+            $imagePath
+        );
+    }
+}

--- a/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\SearchCombinationsForAssociation;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryHandler\SearchCombinationsForAssociationHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForAssociation;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\NoCombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
 
 class SearchCombinationsForAssociationHandler implements SearchCombinationsForAssociationHandlerInterface
@@ -97,9 +98,9 @@ class SearchCombinationsForAssociationHandler implements SearchCombinationsForAs
 
         return new CombinationForAssociation(
             (int) $foundProduct['id_product'],
-            (int) $foundProduct['id_product_attribute'],
+            (int) ($foundProduct['id_product_attribute'] ?? NoCombinationId::NO_COMBINATION_ID),
             $foundProduct['name'],
-            $foundProduct['reference'] ?? '',
+            $foundProduct['combination_reference'] ?? ($foundProduct['product_reference'] ?? ''),
             $imagePath
         );
     }

--- a/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
@@ -81,26 +81,31 @@ class SearchCombinationsForAssociationHandler implements SearchCombinationsForAs
     }
 
     /**
-     * @param array $foundProduct
+     * @param array $foundCombination
      *
      * @return CombinationForAssociation
      */
-    private function createResult(array $foundProduct): CombinationForAssociation
+    private function createResult(array $foundCombination): CombinationForAssociation
     {
-        if (empty($foundProduct['id_image'])) {
-            $imagePath = $this->productImagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_HOME_DEFAULT);
-        } else {
+        if (!empty($foundCombination['combination_image_id'])) {
             $imagePath = $this->productImagePathFactory->getPathByType(
-                new ImageId((int) $foundProduct['id_image']),
+                new ImageId((int) $foundCombination['combination_image_id']),
                 ProductImagePathFactory::IMAGE_TYPE_HOME_DEFAULT
             );
+        } elseif (!empty($foundCombination['id_image'])) {
+            $imagePath = $this->productImagePathFactory->getPathByType(
+                new ImageId((int) $foundCombination['id_image']),
+                ProductImagePathFactory::IMAGE_TYPE_HOME_DEFAULT
+            );
+        } else {
+            $imagePath = $this->productImagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_HOME_DEFAULT);
         }
 
         return new CombinationForAssociation(
-            (int) $foundProduct['id_product'],
-            (int) ($foundProduct['id_product_attribute'] ?? NoCombinationId::NO_COMBINATION_ID),
-            $foundProduct['name'],
-            $foundProduct['combination_reference'] ?? ($foundProduct['product_reference'] ?? ''),
+            (int) $foundCombination['id_product'],
+            (int) ($foundCombination['id_product_attribute'] ?? NoCombinationId::NO_COMBINATION_ID),
+            $foundCombination['name'],
+            $foundCombination['combination_reference'] ?? ($foundCombination['product_reference'] ?? ''),
             $imagePath
         );
     }

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -394,6 +394,8 @@ class ProductRepository extends AbstractObjectModelRepository
             ->addSelect('p.id_product, pa.id_product_attribute, pl.name, i.id_image')
             ->addSelect('p.reference as product_reference')
             ->addSelect('pa.reference as combination_reference')
+            ->addSelect('ai.id_image as combination_image_id')
+            ->leftJoin('p', $this->dbPrefix . 'product_attribute_image', 'ai', 'ai.id_product_attribute = pa.id_product_attribute')
             ->addOrderBy('pl.name', 'ASC')
             ->addGroupBy('p.id_product, pa.id_product_attribute')
         ;

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -391,7 +391,9 @@ class ProductRepository extends AbstractObjectModelRepository
     {
         $qb = $this->getSearchQueryBuilder($searchPhrase, $languageId, $shopId, $limit);
         $qb
-            ->addSelect('p.id_product, pa.id_product_attribute, pl.name, p.reference, i.id_image')
+            ->addSelect('p.id_product, pa.id_product_attribute, pl.name, i.id_image')
+            ->addSelect('p.reference as product_reference')
+            ->addSelect('pa.reference as combination_reference')
             ->addOrderBy('pl.name', 'ASC')
             ->addGroupBy('p.id_product, pa.id_product_attribute')
         ;

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Repository;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\AbstractObjectModelRepository;
 use PrestaShop\PrestaShop\Adapter\Manufacturer\Repository\ManufacturerRepository;
@@ -368,6 +369,46 @@ class ProductRepository extends AbstractObjectModelRepository
      */
     public function searchProducts(string $searchPhrase, LanguageId $languageId, ShopId $shopId, ?int $limit = null): array
     {
+        $qb = $this->getSearchQueryBuilder($searchPhrase, $languageId, $shopId, $limit);
+        $qb
+            ->addSelect('p.id_product, pl.name, p.reference, i.id_image')
+            ->addOrderBy('pl.name', 'ASC')
+            ->addGroupBy('p.id_product')
+        ;
+
+        return $qb->execute()->fetchAllAssociative();
+    }
+
+    /**
+     * @param string $searchPhrase
+     * @param LanguageId $languageId
+     * @param ShopId $shopId
+     * @param int|null $limit
+     *
+     * @return array<int, array<string, int|string>>
+     */
+    public function searchCombinations(string $searchPhrase, LanguageId $languageId, ShopId $shopId, ?int $limit = null): array
+    {
+        $qb = $this->getSearchQueryBuilder($searchPhrase, $languageId, $shopId, $limit);
+        $qb
+            ->addSelect('p.id_product, pa.id_product_attribute, pl.name, p.reference, i.id_image')
+            ->addOrderBy('pl.name', 'ASC')
+            ->addGroupBy('p.id_product, pa.id_product_attribute')
+        ;
+
+        return $qb->execute()->fetchAllAssociative();
+    }
+
+    /**
+     * @param string $searchPhrase
+     * @param LanguageId $languageId
+     * @param ShopId $shopId
+     * @param int|null $limit
+     *
+     * @return QueryBuilder
+     */
+    private function getSearchQueryBuilder(string $searchPhrase, LanguageId $languageId, ShopId $shopId, ?int $limit): QueryBuilder
+    {
         $qb = $this->connection->createQueryBuilder();
         $qb
             ->addSelect('p.id_product, pl.name, p.reference, i.id_image')
@@ -408,6 +449,6 @@ class ProductRepository extends AbstractObjectModelRepository
             $qb->setMaxResults($limit);
         }
 
-        return $qb->execute()->fetchAllAssociative();
+        return $qb;
     }
 }

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -372,8 +372,9 @@ class ProductRepository extends AbstractObjectModelRepository
         $qb = $this->getSearchQueryBuilder($searchPhrase, $languageId, $shopId, $limit);
         $qb
             ->addSelect('p.id_product, pl.name, p.reference, i.id_image')
-            ->addOrderBy('pl.name', 'ASC')
             ->addGroupBy('p.id_product')
+            ->addOrderBy('pl.name', 'ASC')
+            ->addOrderBy('p.id_product', 'ASC')
         ;
 
         return $qb->execute()->fetchAllAssociative();
@@ -396,8 +397,10 @@ class ProductRepository extends AbstractObjectModelRepository
             ->addSelect('pa.reference as combination_reference')
             ->addSelect('ai.id_image as combination_image_id')
             ->leftJoin('p', $this->dbPrefix . 'product_attribute_image', 'ai', 'ai.id_product_attribute = pa.id_product_attribute')
-            ->addOrderBy('pl.name', 'ASC')
             ->addGroupBy('p.id_product, pa.id_product_attribute')
+            ->addOrderBy('pl.name', 'ASC')
+            ->addOrderBy('p.id_product', 'ASC')
+            ->addOrderBy('pa.id_product_attribute', 'ASC')
         ;
 
         return $qb->execute()->fetchAllAssociative();

--- a/src/Core/Domain/Product/Combination/Query/SearchCombinationsForAssociation.php
+++ b/src/Core/Domain/Product/Combination/Query/SearchCombinationsForAssociation.php
@@ -71,7 +71,7 @@ class SearchCombinationsForAssociation
             throw new ProductConstraintException('Search limit must be a positive integer or null', ProductConstraintException::INVALID_SEARCH_LIMIT);
         }
 
-        if (strlen($phrase) < static::SEARCH_PHRASE_MIN_LENGTH) {
+        if (mb_strlen($phrase) < static::SEARCH_PHRASE_MIN_LENGTH) {
             throw new ProductConstraintException(sprintf(
                 'Search phase must have a minimum length of %d characters.',
                 static::SEARCH_PHRASE_MIN_LENGTH

--- a/src/Core/Domain/Product/Combination/Query/SearchCombinationsForAssociation.php
+++ b/src/Core/Domain/Product/Combination/Query/SearchCombinationsForAssociation.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query;
+
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
+
+class SearchCombinationsForAssociation
+{
+    /**
+     * This is the minimum length of search phrase
+     */
+    const SEARCH_PHRASE_MIN_LENGTH = 3;
+
+    /**
+     * @var string
+     */
+    private $phrase;
+
+    /**
+     * @var LanguageId
+     */
+    private $languageId;
+
+    /**
+     * @var ShopId
+     */
+    private $shopId;
+
+    /**
+     * @var int|null
+     */
+    private $limit;
+
+    /**
+     * @param string $phrase
+     * @param int $languageId
+     * @param int $shopId
+     * @param int|null $limit
+     */
+    public function __construct(string $phrase, int $languageId, int $shopId, ?int $limit = null)
+    {
+        if (null !== $limit && $limit <= 0) {
+            throw new ProductConstraintException('Search limit must be a positive integer or null', ProductConstraintException::INVALID_SEARCH_LIMIT);
+        }
+
+        if (strlen($phrase) < static::SEARCH_PHRASE_MIN_LENGTH) {
+            throw new ProductConstraintException(sprintf(
+                'Search phase must have a minimum length of %d characters.',
+                static::SEARCH_PHRASE_MIN_LENGTH
+            ), ProductConstraintException::INVALID_SEARCH_PHRASE_LENGTH);
+        }
+
+        $this->phrase = $phrase;
+        $this->limit = $limit;
+        $this->shopId = new ShopId($shopId);
+        $this->languageId = new LanguageId($languageId);
+    }
+
+    /**
+     * @return string
+     */
+    public function getPhrase(): string
+    {
+        return $this->phrase;
+    }
+
+    /**
+     * @return ShopId
+     */
+    public function getShopId(): ShopId
+    {
+        return $this->shopId;
+    }
+
+    /**
+     * @return LanguageId
+     */
+    public function getLanguageId(): LanguageId
+    {
+        return $this->languageId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+}

--- a/src/Core/Domain/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandlerInterface.php
+++ b/src/Core/Domain/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandlerInterface.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\SearchCombinationsForAssociation;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForAssociation;
+
+/**
+ * Search a list of combination that you can associate with, the query result contains minimum information
+ * to display the product (the returned list can contain product which have no combinations).
+ */
+interface SearchCombinationsForAssociationHandlerInterface
+{
+    /**
+     * @param SearchCombinationsForAssociation $query
+     *
+     * @return CombinationForAssociation[]
+     */
+    public function handle(SearchCombinationsForAssociation $query): array;
+}

--- a/src/Core/Domain/Product/Combination/QueryResult/CombinationForAssociation.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/CombinationForAssociation.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult;
+
+class CombinationForAssociation
+{
+    /**
+     * @var int
+     */
+    private $productId;
+
+    /**
+     * @var int
+     */
+    private $combinationId;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $reference;
+
+    /**
+     * @var string
+     */
+    private $imageUrl;
+
+    /**
+     * @param int $productId
+     * @param int $combinationId
+     * @param string $name
+     * @param string $reference
+     * @param string $imageUrl
+     */
+    public function __construct(int $productId, int $combinationId, string $name, string $reference, string $imageUrl)
+    {
+        $this->productId = $productId;
+        $this->combinationId = $combinationId;
+        $this->name = $name;
+        $this->reference = $reference;
+        $this->imageUrl = $imageUrl;
+    }
+
+    /**
+     * @return int
+     */
+    public function getProductId(): int
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCombinationId(): int
+    {
+        return $this->combinationId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReference(): string
+    {
+        return $this->reference;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImageUrl(): string
+    {
+        return $this->imageUrl;
+    }
+}

--- a/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
@@ -71,7 +71,7 @@ class EditableCombinationForListing
     private $quantity;
 
     /**
-     * @var string|null
+     * @var string
      */
     private $imageUrl;
 
@@ -83,7 +83,7 @@ class EditableCombinationForListing
      * @param bool $default
      * @param DecimalNumber $impactOnPrice
      * @param int $quantity
-     * @param string|null $imageUrl
+     * @param string $imageUrl
      */
     public function __construct(
         int $combinationId,
@@ -93,7 +93,7 @@ class EditableCombinationForListing
         bool $default,
         DecimalNumber $impactOnPrice,
         int $quantity,
-        ?string $imageUrl = null
+        string $imageUrl
     ) {
         $this->combinationId = $combinationId;
         $this->attributesInformation = $attributesInformation;
@@ -162,9 +162,9 @@ class EditableCombinationForListing
     }
 
     /**
-     * @return string|null
+     * @return string
      */
-    public function getImageUrl(): ?string
+    public function getImageUrl(): string
     {
         return $this->imageUrl;
     }

--- a/src/Core/Domain/Product/Query/SearchProductsForAssociation.php
+++ b/src/Core/Domain/Product/Query/SearchProductsForAssociation.php
@@ -70,7 +70,7 @@ class SearchProductsForAssociation
         if (null !== $limit && $limit <= 0) {
             throw new ProductConstraintException('Search limit must be a positive integer or null', ProductConstraintException::INVALID_SEARCH_LIMIT);
         }
-        if (strlen($phrase) < static::SEARCH_PHRASE_MIN_LENGTH) {
+        if (mb_strlen($phrase) < static::SEARCH_PHRASE_MIN_LENGTH) {
             throw new ProductConstraintException(sprintf(
                 'Search phase must have a minimum length of %d characters.',
                 static::SEARCH_PHRASE_MIN_LENGTH

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -62,6 +62,15 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\GetEditableCombinationsList
 
+  prestashop.adapter.product.combination.query_handler.search_combinations_for_association_handler:
+    class: PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler\SearchCombinationsForAssociationHandler
+    arguments:
+      - '@prestashop.adapter.product.repository.product_repository'
+      - '@prestashop.adapter.product.image.product_image_url_factory'
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\SearchCombinationsForAssociation
+
   prestashop.adapter.product.combination.validate.combination_validator:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Validate\CombinationValidator
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
@@ -296,9 +296,7 @@ class CombinationListingFeatureContext extends AbstractCombinationFeatureContext
                 'Unexpected attributes count in combination'
             );
 
-            if (empty($expectedCombination['image url'])) {
-                Assert::assertNull($editableCombinationForListing->getImageUrl(), 'Unexpected combination image');
-            } else {
+            if (!empty($expectedCombination['image url'])) {
                 $realImageUrl = $this->getRealImageUrl($expectedCombination['image url']);
                 Assert::assertEquals(
                     $realImageUrl,

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/SearchCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/SearchCombinationFeatureContext.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination;
+
+use Behat\Gherkin\Node\TableNode;
+use Configuration;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\SearchCombinationsForAssociation;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForAssociation;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\NoCombinationId;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
+
+class SearchCombinationFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I search for combinations with locale :localeReference matching :search I should get following results:
+     *
+     * @param string $localeReference
+     * @param string $search
+     * @param TableNode $tableNode
+     */
+    public function assertSearchCombinations(string $localeReference, string $search, TableNode $tableNode): void
+    {
+        $language = $this->getSharedStorage()->get($localeReference);
+        /** @var CombinationForAssociation[] $foundCombinations */
+        $foundCombinations = $this->getQueryBus()->handle(new SearchCombinationsForAssociation(
+            $search,
+            (int) $language->id,
+            (int) Configuration::get('PS_SHOP_DEFAULT')
+        ));
+        $expectedRelatedCombinations = $tableNode->getColumnsHash();
+
+        Assert::assertEquals(count($expectedRelatedCombinations), count($foundCombinations));
+
+        $index = 0;
+        foreach ($expectedRelatedCombinations as $expectedRelatedCombination) {
+            $foundCombinationForAssociation = $foundCombinations[$index];
+
+            $expectedProductId = $this->getSharedStorage()->get($expectedRelatedCombination['product']);
+            Assert::assertEquals(
+                $expectedProductId,
+                $foundCombinationForAssociation->getProductId(),
+                sprintf(
+                    'Invalid product ID, expected %d but got %d instead.',
+                    $expectedProductId,
+                    $foundCombinationForAssociation->getProductId()
+                )
+            );
+
+            $expectedCombinationId = !empty($expectedRelatedCombination['combination']) ?
+                $this->getSharedStorage()->get($expectedRelatedCombination['combination']) :
+                NoCombinationId::NO_COMBINATION_ID;
+            Assert::assertEquals(
+                $expectedCombinationId,
+                $foundCombinationForAssociation->getCombinationId(),
+                sprintf(
+                    'Invalid combination ID, expected %d but got %d instead.',
+                    $expectedCombinationId,
+                    $foundCombinationForAssociation->getCombinationId()
+                )
+            );
+
+            Assert::assertEquals(
+                $expectedRelatedCombination['name'],
+                $foundCombinationForAssociation->getName(),
+                sprintf(
+                    'Invalid product name, expected %s but got %s instead.',
+                    $expectedRelatedCombination['name'],
+                    $foundCombinationForAssociation->getName()
+                )
+            );
+
+            Assert::assertEquals(
+                $expectedRelatedCombination['reference'],
+                $foundCombinationForAssociation->getReference(),
+                sprintf(
+                    'Invalid product reference, expected %s but got %s instead.',
+                    $expectedRelatedCombination['reference'],
+                    $foundCombinationForAssociation->getReference()
+                )
+            );
+
+            $realImageUrl = $this->getRealImageUrl($expectedRelatedCombination['image url']);
+            Assert::assertEquals(
+                $realImageUrl,
+                $foundCombinationForAssociation->getImageUrl(),
+                sprintf(
+                    'Invalid product image url, expected %s but got %s instead.',
+                    $realImageUrl,
+                    $foundCombinationForAssociation->getImageUrl()
+                )
+            );
+
+            ++$index;
+        }
+    }
+
+    /**
+     * @When I search for combinations with locale :localeReference matching :search I should get no results
+     *
+     * @param string $localeReference
+     * @param string $search
+     */
+    public function assertNoProductsFound(string $localeReference, string $search): void
+    {
+        $language = $this->getSharedStorage()->get($localeReference);
+        /** @var CombinationForAssociation[] $foundProducts */
+        $foundProducts = $this->getQueryBus()->handle(new SearchCombinationsForAssociation(
+            $search,
+            (int) $language->id,
+            (int) Configuration::get('PS_SHOP_DEFAULT')
+        ));
+        Assert::assertEmpty($foundProducts);
+    }
+}

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
@@ -1,0 +1,293 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags search-combinations
+@reset-database-before-feature
+@clear-cache-before-feature
+@search-combinations
+Feature: Search combinations to associate them in the BO
+  As an employee
+  I need to be able to search for combinations in the BO to associate them
+
+  Background:
+    Given language "english" with locale "en-US" exists
+    And language "french" with locale "fr-FR" exists
+    And language with iso code "en" is the default one
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Red" named "Red" in en language exists
+    And attribute "Pink" named "Pink" in en language exists
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
+    And attribute "Red" named "Red" in en language exists
+
+  Scenario: I can search combinations by name
+    When I add product "beer_bottle" with following information:
+      | name[en-US] | bottle of beer     |
+      | name[fr-FR] | bouteille de biere |
+      | type        | standard           |
+    And I add product "product2" with following information:
+      | name[en-US] | bottle of cider    |
+      | name[fr-FR] | bouteille de cidre |
+      | type        | standard           |
+    When I search for combinations with locale "english" matching "beer" I should get following results:
+      | product  | name           | reference | image url                                             |
+      | beer_bottle | bottle of beer |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "bOtT" I should get following results:
+      | product  | name            | reference | image url                                             |
+      | beer_bottle | bottle of beer  |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product2 | bottle of cider |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "french" matching "biere" I should get following results:
+      | product  | name               | reference | image url                                             |
+      | beer_bottle | bouteille de biere |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "french" matching "BoU" I should get following results:
+      | product  | name               | reference | image url                                             |
+      | beer_bottle | bouteille de biere |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product2 | bouteille de cidre |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "french" matching "beer" I should get no results
+    And I search for combinations with locale "english" matching "biere" I should get no results
+
+  Scenario: I can search combinations by references
+    When I add product "product3" with following information:
+      | name[en-US] | bottle of champaign    |
+      | name[fr-FR] | bouteille de champagne |
+      | type        | standard               |
+    When I search for combinations with locale "english" matching "978-3-16-148410-0" I should get no results
+    And I search for combinations with locale "english" matching "72527273070" I should get no results
+    And I search for combinations with locale "english" matching "978020137962" I should get no results
+    And I search for combinations with locale "english" matching "mpn1" I should get no results
+    And I search for combinations with locale "english" matching "ref1" I should get no results
+    When I update product "product3" details with following values:
+      | isbn      | 978-3-16-148410-0 |
+      | upc       | 72527273070       |
+      | ean13     | 978020137962      |
+      | mpn       | mpn1              |
+      | reference | ref1              |
+    Then product "product3" should have following details:
+      | product detail | value             |
+      | isbn           | 978-3-16-148410-0 |
+      | upc            | 72527273070       |
+      | ean13          | 978020137962      |
+      | mpn            | mpn1              |
+      | reference      | ref1              |
+    # Search by all types of references matching product3
+    When I search for combinations with locale "english" matching "978-3-16-148410-0" I should get following results:
+      | product  | name                | reference | image url                                             |
+      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "72527273070" I should get following results:
+      | product  | name                | reference | image url                                             |
+      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "978020137962" I should get following results:
+      | product  | name                | reference | image url                                             |
+      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "mpn1" I should get following results:
+      | product  | name                | reference | image url                                             |
+      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "ref1" I should get following results:
+      | product  | name                | reference | image url                                             |
+      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+
+  Scenario: I can search combinations by combination references
+    Given I add product "product4" with following information:
+      | name[en-US] | bottle of wine   |
+      | name[fr-FR] | bouteille de vin |
+      | type        | combinations     |
+    And I generate combinations for product product4 using following attributes:
+      | Color | [Red,White,Pink] |
+    And product "product4" should have following combinations:
+      | id reference  | combination name | reference | attributes    | impact on price | quantity | is default |
+      | product4Red   | Color - Red      |           | [Color:Red]   | 0               | 0        | true       |
+      | product4White | Color - White    |           | [Color:White] | 0               | 0        | false      |
+      | product4Pink  | Color - Pink     |           | [Color:Pink]  | 0               | 0        | false      |
+    When I search for combinations with locale "english" matching "154867313573" I should get no results
+    And I search for combinations with locale "english" matching "978-3-16-148410-3" I should get no results
+    And I search for combinations with locale "english" matching "mpn3red" I should get no results
+    And I search for combinations with locale "english" matching "ref3red" I should get no results
+    And I search for combinations with locale "english" matching "137684192354" I should get no results
+    And I search for combinations with locale "english" matching "1357321357213" I should get no results
+    And I search for combinations with locale "english" matching "978-3-16-148410-4" I should get no results
+    And I search for combinations with locale "english" matching "mpn3white" I should get no results
+    And I search for combinations with locale "english" matching "ref3white" I should get no results
+    And I search for combinations with locale "english" matching "3543213543213" I should get no results
+    When I update combination "product4Red" details with following values:
+      | ean13            | 154867313573      |
+      | isbn             | 978-3-16-148410-3 |
+      | mpn              | mpn3red           |
+      | reference        | ref3red           |
+      | upc              | 137684192354      |
+    And I update combination "product4White" details with following values:
+      | ean13            | 1357321357213     |
+      | isbn             | 978-3-16-148410-4 |
+      | mpn              | mpn3white         |
+      | reference        | ref3white         |
+      | upc              | 354321354321      |
+    Then combination "product4Red" should have following details:
+      | combination detail | value             |
+      | ean13              | 154867313573      |
+      | isbn               | 978-3-16-148410-3 |
+      | mpn                | mpn3red           |
+      | reference          | ref3red           |
+      | upc                | 137684192354      |
+    Then combination "product4White" should have following details:
+      | combination detail | value             |
+      | ean13              | 1357321357213     |
+      | isbn               | 978-3-16-148410-4 |
+      | mpn                | mpn3white         |
+      | reference          | ref3white         |
+      | upc                | 354321354321     |
+    # Search by all types of references matching product4Red combination
+    When I search for combinations with locale "english" matching "154867313573" I should get following results:
+      | product  | combination | name           | reference | image url                                             |
+      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "978-3-16-148410-3" I should get following results:
+      | product  | combination | name           | reference | image url                                             |
+      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "mpn3red" I should get following results:
+      | product  | combination | name           | reference | image url                                             |
+      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "ref3red" I should get following results:
+      | product  | combination | name           | reference | image url                                             |
+      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "137684192354" I should get following results:
+      | product  | combination | name           | reference | image url                                             |
+      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    # Search by all types of references matching product4White combination
+    When I search for combinations with locale "english" matching "1357321357213" I should get following results:
+      | product  | combination   | name           | reference | image url                                             |
+      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "978-3-16-148410-4" I should get following results:
+      | product  | combination   | name           | reference | image url                                             |
+      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "mpn3white" I should get following results:
+      | product  | combination   | name           | reference | image url                                             |
+      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "ref3white" I should get following results:
+      | product  | combination   | name           | reference | image url                                             |
+      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "354321354321" I should get following results:
+      | product  | combination   | name           | reference | image url                                             |
+      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    # Search by types that match both combinations, both are returned
+    When I search for combinations with locale "english" matching "mpn3" I should get following results:
+      | product  | combination   | name           | reference | image url                                             |
+      | product4 | product4Red   | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "ref3" I should get following results:
+      | product  | combination   | name           | reference | image url                                             |
+      | product4 | product4Red   | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    # Search by types that match two combinations and a product
+    When I search for combinations with locale "english" matching "mpn" I should get following results:
+      | product  | combination   | name                | reference | image url                                             |
+      | product3 |               | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product4 | product4Red   | bottle of wine      | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product4 | product4White | bottle of wine      | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I search for combinations with locale "english" matching "ref" I should get following results:
+      | product  | combination   | name                | reference | image url                                             |
+      | product3 |               | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product4 | product4Red   | bottle of wine      | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product4 | product4White | bottle of wine      | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+
+  Scenario: Search results include the appropriate images
+    Given following image types should be applicable to products:
+      | reference     | name           | width | height |
+      | cartDefault   | cart_default   | 125   | 125    |
+      | homeDefault   | home_default   | 250   | 250    |
+      | largeDefault  | large_default  | 800   | 800    |
+      | mediumDefault | medium_default | 452   | 452    |
+      | smallDefault  | small_default  | 98    | 98     |
+    When I add product "lemonade_can" with following information:
+      | name[en-US] | can of lemonade     |
+      | name[fr-FR] | canette de limonade |
+      | type        | standard            |
+    And I add product "coke_can" with following information:
+      | name[en-US] | can of coke     |
+      | name[fr-FR] | canette de coca |
+      | type        | standard        |
+    # Note: search results are ordered by name
+    When I search for combinations with locale "english" matching "can" I should get following results:
+      | product      | name            | reference | image url                                             |
+      | coke_can     | can of coke     |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemonade_can | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And product "coke_can" should have no images
+    When I add new image "image1" named "app_icon.png" to product "coke_can"
+    And I add new image "image2" named "logo.jpg" to product "coke_can"
+    And I update image "image2" with following information:
+      | cover | true |
+    Then product "coke_can" should have following images:
+      | image reference | is cover | legend[en-US] | legend[fr-FR] | position | image url                            | thumbnail url                                      |
+      | image1          | false    |               |               | 1        | http://myshop.com/img/p/{image1}.jpg | http://myshop.com/img/p/{image1}-small_default.jpg |
+      | image2          | true     |               |               | 2        | http://myshop.com/img/p/{image2}.jpg | http://myshop.com/img/p/{image2}-small_default.jpg |
+    # Search returns the cover image url when present
+    When I search for combinations with locale "english" matching "can" I should get following results:
+      | product      | name            | reference | image url                                             |
+      | coke_can     | can of coke     |           | http://myshop.com/img/p/{image2}-home_default.jpg     |
+      | lemonade_can | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+
+  Scenario: I associate images to a combination
+    Given I add product "lemonTShirt" with following information:
+      | name[en-US] | lemon t-shirt  |
+      | name[fr-FR] | t-shirt citron |
+      | type        | combinations   |
+    And product lemonTShirt type should be combinations
+    And I generate combinations for product lemonTShirt using following attributes:
+      | Size  | [S,M]         |
+      | Color | [White,Black] |
+    And product "lemonTShirt" should have following combinations:
+      | id reference      | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                               |
+      | lemonTShirtSWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | lemonTShirtSBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | lemonTShirtMWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | lemonTShirtMBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    # No image can be returned for both products
+    When I search for combinations with locale "english" matching "lemon" I should get following results:
+      | product      | combination       | name            | reference | image url                                             |
+      | lemonade_can |                   | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtSWhite | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtSBlack | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtMWhite | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtMBlack | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I add new image "lemonImage1" named "app_icon.png" to product "lemonTShirt"
+    And I add new image "lemonImage2" named "logo.jpg" to product "lemonTShirt"
+    And I add new image "lemonImage3" named "app_icon.png" to product "lemonTShirt"
+    And I add new image "lemonImage4" named "logo.jpg" to product "lemonTShirt"
+    # The fallback image is the first one from the product
+    And product "lemonTShirt" should have following combinations:
+      | id reference      | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                               |
+      | lemonTShirtSWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
+      | lemonTShirtSBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
+      | lemonTShirtMWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
+      | lemonTShirtMBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
+    # Search results follow the same principle
+    When I search for combinations with locale "english" matching "lemon" I should get following results:
+      | product      | combination       | name            | reference | image url                                              |
+      | lemonade_can |                   | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg  |
+      | lemonTShirt  | lemonTShirtSWhite | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtSBlack | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtMWhite | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtMBlack | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
+    And combination "lemonTShirtSWhite" should have no images
+    When I associate "[lemonImage2,lemonImage3]" to combination "lemonTShirtSWhite"
+    Then combination "lemonTShirtSWhite" should have following images "[lemonImage2,lemonImage3]"
+    When I associate "[lemonImage4]" to combination "lemonTShirtMWhite"
+    Then combination "lemonTShirtMWhite" should have following images "[lemonImage4]"
+    When I associate "[lemonImage4,lemonImage3]" to combination "lemonTShirtMBlack"
+    Then combination "lemonTShirtMBlack" should have following images "[lemonImage4,lemonImage3]"
+    # Now the combination image is the first one in its own associated images (first by image creation oder)
+    And product "lemonTShirt" should have following combinations:
+      | id reference      | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                          |
+      | lemonTShirtSWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{lemonImage2}-small_default.jpg |
+      | lemonTShirtSBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
+      | lemonTShirtMWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage4}-small_default.jpg |
+      | lemonTShirtMBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage3}-small_default.jpg |
+    # Search results follow the same principle
+    When I search for combinations with locale "english" matching "lemon" I should get following results:
+      | product      | combination       | name            | reference | image url                                              |
+      | lemonade_can |                   | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg  |
+      | lemonTShirt  | lemonTShirtSWhite | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage2}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtSBlack | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtMWhite | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage4}-home_default.jpg |
+      | lemonTShirt  | lemonTShirtMBlack | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage3}-home_default.jpg |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
@@ -29,29 +29,29 @@ Feature: Search combinations to associate them in the BO
       | name[en-US] | bottle of beer     |
       | name[fr-FR] | bouteille de biere |
       | type        | standard           |
-    And I add product "product2" with following information:
+    And I add product "cider_bottle" with following information:
       | name[en-US] | bottle of cider    |
       | name[fr-FR] | bouteille de cidre |
       | type        | standard           |
     When I search for combinations with locale "english" matching "beer" I should get following results:
-      | product  | name           | reference | image url                                             |
+      | product     | name           | reference | image url                                             |
       | beer_bottle | bottle of beer |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "bOtT" I should get following results:
-      | product  | name            | reference | image url                                             |
-      | beer_bottle | bottle of beer  |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | product2 | bottle of cider |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product      | name            | reference | image url                                             |
+      | beer_bottle  | bottle of beer  |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | cider_bottle | bottle of cider |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "french" matching "biere" I should get following results:
-      | product  | name               | reference | image url                                             |
+      | product     | name               | reference | image url                                             |
       | beer_bottle | bouteille de biere |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "french" matching "BoU" I should get following results:
-      | product  | name               | reference | image url                                             |
-      | beer_bottle | bouteille de biere |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | product2 | bouteille de cidre |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product      | name               | reference | image url                                             |
+      | beer_bottle  | bouteille de biere |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | cider_bottle | bouteille de cidre |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "french" matching "beer" I should get no results
     And I search for combinations with locale "english" matching "biere" I should get no results
 
   Scenario: I can search combinations by references
-    When I add product "product3" with following information:
+    When I add product "champaign_bottle" with following information:
       | name[en-US] | bottle of champaign    |
       | name[fr-FR] | bouteille de champagne |
       | type        | standard               |
@@ -60,48 +60,48 @@ Feature: Search combinations to associate them in the BO
     And I search for combinations with locale "english" matching "978020137962" I should get no results
     And I search for combinations with locale "english" matching "mpn1" I should get no results
     And I search for combinations with locale "english" matching "ref1" I should get no results
-    When I update product "product3" details with following values:
+    When I update product "champaign_bottle" details with following values:
       | isbn      | 978-3-16-148410-0 |
       | upc       | 72527273070       |
       | ean13     | 978020137962      |
       | mpn       | mpn1              |
       | reference | ref1              |
-    Then product "product3" should have following details:
+    Then product "champaign_bottle" should have following details:
       | product detail | value             |
       | isbn           | 978-3-16-148410-0 |
       | upc            | 72527273070       |
       | ean13          | 978020137962      |
       | mpn            | mpn1              |
       | reference      | ref1              |
-    # Search by all types of references matching product3
+    # Search by all types of references matching champaign_bottle
     When I search for combinations with locale "english" matching "978-3-16-148410-0" I should get following results:
-      | product  | name                | reference | image url                                             |
-      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product          | name                | reference | image url                                             |
+      | champaign_bottle | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "72527273070" I should get following results:
-      | product  | name                | reference | image url                                             |
-      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product          | name                | reference | image url                                             |
+      | champaign_bottle | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "978020137962" I should get following results:
-      | product  | name                | reference | image url                                             |
-      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product          | name                | reference | image url                                             |
+      | champaign_bottle | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "mpn1" I should get following results:
-      | product  | name                | reference | image url                                             |
-      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product          | name                | reference | image url                                             |
+      | champaign_bottle | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "ref1" I should get following results:
-      | product  | name                | reference | image url                                             |
-      | product3 | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product          | name                | reference | image url                                             |
+      | champaign_bottle | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
 
   Scenario: I can search combinations by combination references
-    Given I add product "product4" with following information:
+    Given I add product "wine_bottle" with following information:
       | name[en-US] | bottle of wine   |
       | name[fr-FR] | bouteille de vin |
       | type        | combinations     |
-    And I generate combinations for product product4 using following attributes:
+    And I generate combinations for product wine_bottle using following attributes:
       | Color | [Red,White,Pink] |
-    And product "product4" should have following combinations:
-      | id reference  | combination name | reference | attributes    | impact on price | quantity | is default |
-      | product4Red   | Color - Red      |           | [Color:Red]   | 0               | 0        | true       |
-      | product4White | Color - White    |           | [Color:White] | 0               | 0        | false      |
-      | product4Pink  | Color - Pink     |           | [Color:Pink]  | 0               | 0        | false      |
+    And product "wine_bottle" should have following combinations:
+      | id reference      | combination name | reference | attributes    | impact on price | quantity | is default |
+      | wine_bottle_red   | Color - Red      |           | [Color:Red]   | 0               | 0        | true       |
+      | wine_bottle_white | Color - White    |           | [Color:White] | 0               | 0        | false      |
+      | wine_bottle_pink  | Color - Pink     |           | [Color:Pink]  | 0               | 0        | false      |
     When I search for combinations with locale "english" matching "154867313573" I should get no results
     And I search for combinations with locale "english" matching "978-3-16-148410-3" I should get no results
     And I search for combinations with locale "english" matching "mpn3red" I should get no results
@@ -112,84 +112,84 @@ Feature: Search combinations to associate them in the BO
     And I search for combinations with locale "english" matching "mpn3white" I should get no results
     And I search for combinations with locale "english" matching "ref3white" I should get no results
     And I search for combinations with locale "english" matching "3543213543213" I should get no results
-    When I update combination "product4Red" details with following values:
+    When I update combination "wine_bottle_red" details with following values:
       | ean13            | 154867313573      |
       | isbn             | 978-3-16-148410-3 |
       | mpn              | mpn3red           |
       | reference        | ref3red           |
       | upc              | 137684192354      |
-    And I update combination "product4White" details with following values:
+    And I update combination "wine_bottle_white" details with following values:
       | ean13            | 1357321357213     |
       | isbn             | 978-3-16-148410-4 |
       | mpn              | mpn3white         |
       | reference        | ref3white         |
       | upc              | 354321354321      |
-    Then combination "product4Red" should have following details:
+    Then combination "wine_bottle_red" should have following details:
       | combination detail | value             |
       | ean13              | 154867313573      |
       | isbn               | 978-3-16-148410-3 |
       | mpn                | mpn3red           |
       | reference          | ref3red           |
       | upc                | 137684192354      |
-    Then combination "product4White" should have following details:
+    Then combination "wine_bottle_white" should have following details:
       | combination detail | value             |
       | ean13              | 1357321357213     |
       | isbn               | 978-3-16-148410-4 |
       | mpn                | mpn3white         |
       | reference          | ref3white         |
-      | upc                | 354321354321     |
-    # Search by all types of references matching product4Red combination
+      | upc                | 354321354321      |
+    # Search by all types of references matching wine_bottle_red combination
     When I search for combinations with locale "english" matching "154867313573" I should get following results:
-      | product  | combination | name           | reference | image url                                             |
-      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination     | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "978-3-16-148410-3" I should get following results:
-      | product  | combination | name           | reference | image url                                             |
-      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination     | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "mpn3red" I should get following results:
-      | product  | combination | name           | reference | image url                                             |
-      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination     | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "ref3red" I should get following results:
-      | product  | combination | name           | reference | image url                                             |
-      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination     | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "137684192354" I should get following results:
-      | product  | combination | name           | reference | image url                                             |
-      | product4 | product4Red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-    # Search by all types of references matching product4White combination
+      | product     | combination     | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    # Search by all types of references matching wine_bottle_white combination
     When I search for combinations with locale "english" matching "1357321357213" I should get following results:
-      | product  | combination   | name           | reference | image url                                             |
-      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "978-3-16-148410-4" I should get following results:
-      | product  | combination   | name           | reference | image url                                             |
-      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "mpn3white" I should get following results:
-      | product  | combination   | name           | reference | image url                                             |
-      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "ref3white" I should get following results:
-      | product  | combination   | name           | reference | image url                                             |
-      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "354321354321" I should get following results:
-      | product  | combination   | name           | reference | image url                                             |
-      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     # Search by types that match both combinations, both are returned
     When I search for combinations with locale "english" matching "mpn3" I should get following results:
-      | product  | combination   | name           | reference | image url                                             |
-      | product4 | product4Red   | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_red   | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "ref3" I should get following results:
-      | product  | combination   | name           | reference | image url                                             |
-      | product4 | product4Red   | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | product4 | product4White | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name           | reference | image url                                             |
+      | wine_bottle | wine_bottle_red   | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     # Search by types that match two combinations and a product
     When I search for combinations with locale "english" matching "mpn" I should get following results:
-      | product  | combination   | name                | reference | image url                                             |
-      | product3 |               | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | product4 | product4Red   | bottle of wine      | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | product4 | product4White | bottle of wine      | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product          | combination       | name                | reference | image url                                             |
+      | champaign_bottle |                   | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle      | wine_bottle_red   | bottle of wine      | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle      | wine_bottle_white | bottle of wine      | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "ref" I should get following results:
-      | product  | combination   | name                | reference | image url                                             |
-      | product3 |               | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | product4 | product4Red   | bottle of wine      | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | product4 | product4White | bottle of wine      | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product          | combination       | name                | reference | image url                                             |
+      | champaign_bottle |                   | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle      | wine_bottle_red   | bottle of wine      | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle      | wine_bottle_white | bottle of wine      | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
 
   Scenario: Search results include the appropriate images
     Given following image types should be applicable to products:
@@ -213,81 +213,81 @@ Feature: Search combinations to associate them in the BO
       | coke_can     | can of coke     |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
       | lemonade_can | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And product "coke_can" should have no images
-    When I add new image "image1" named "app_icon.png" to product "coke_can"
-    And I add new image "image2" named "logo.jpg" to product "coke_can"
-    And I update image "image2" with following information:
+    When I add new image "can_image1" named "app_icon.png" to product "coke_can"
+    And I add new image "can_image2" named "logo.jpg" to product "coke_can"
+    And I update image "can_image2" with following information:
       | cover | true |
     Then product "coke_can" should have following images:
-      | image reference | is cover | legend[en-US] | legend[fr-FR] | position | image url                            | thumbnail url                                      |
-      | image1          | false    |               |               | 1        | http://myshop.com/img/p/{image1}.jpg | http://myshop.com/img/p/{image1}-small_default.jpg |
-      | image2          | true     |               |               | 2        | http://myshop.com/img/p/{image2}.jpg | http://myshop.com/img/p/{image2}-small_default.jpg |
+      | image reference | is cover | legend[en-US] | legend[fr-FR] | position | image url                                | thumbnail url                                          |
+      | can_image1      | false    |               |               | 1        | http://myshop.com/img/p/{can_image1}.jpg | http://myshop.com/img/p/{can_image1}-small_default.jpg |
+      | can_image2      | true     |               |               | 2        | http://myshop.com/img/p/{can_image2}.jpg | http://myshop.com/img/p/{can_image2}-small_default.jpg |
     # Search returns the cover image url when present
     When I search for combinations with locale "english" matching "can" I should get following results:
       | product      | name            | reference | image url                                             |
-      | coke_can     | can of coke     |           | http://myshop.com/img/p/{image2}-home_default.jpg     |
+      | coke_can     | can of coke     |           | http://myshop.com/img/p/{can_image2}-home_default.jpg |
       | lemonade_can | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
 
   Scenario: I associate images to a combination
-    Given I add product "lemonTShirt" with following information:
+    Given I add product "lemon_tshirt" with following information:
       | name[en-US] | lemon t-shirt  |
       | name[fr-FR] | t-shirt citron |
       | type        | combinations   |
-    And product lemonTShirt type should be combinations
-    And I generate combinations for product lemonTShirt using following attributes:
+    And product lemon_tshirt type should be combinations
+    And I generate combinations for product lemon_tshirt using following attributes:
       | Size  | [S,M]         |
       | Color | [White,Black] |
-    And product "lemonTShirt" should have following combinations:
-      | id reference      | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                               |
-      | lemonTShirtSWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{no_picture}-small_default.jpg |
-      | lemonTShirtSBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
-      | lemonTShirtMWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
-      | lemonTShirtMBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    And product "lemon_tshirt" should have following combinations:
+      | id reference         | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                              |
+      | lemon_tshirt_s_white | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | lemon_tshirt_s_black | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | lemon_tshirt_m_white | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | lemon_tshirt_m_black | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     # No image can be returned for both products
     When I search for combinations with locale "english" matching "lemon" I should get following results:
-      | product      | combination       | name            | reference | image url                                             |
-      | lemonade_can |                   | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtSWhite | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtSBlack | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtMWhite | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtMBlack | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-    And I add new image "lemonImage1" named "app_icon.png" to product "lemonTShirt"
-    And I add new image "lemonImage2" named "logo.jpg" to product "lemonTShirt"
-    And I add new image "lemonImage3" named "app_icon.png" to product "lemonTShirt"
-    And I add new image "lemonImage4" named "logo.jpg" to product "lemonTShirt"
+      | product       | combination          | name            | reference | image url                                             |
+      | lemonade_can  |                      | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_s_white | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    And I add new image "lemon_image1" named "app_icon.png" to product "lemon_tshirt"
+    And I add new image "lemon_image2" named "logo.jpg" to product "lemon_tshirt"
+    And I add new image "lemon_image3" named "app_icon.png" to product "lemon_tshirt"
+    And I add new image "lemon_image4" named "logo.jpg" to product "lemon_tshirt"
     # The fallback image is the first one from the product
-    And product "lemonTShirt" should have following combinations:
-      | id reference      | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                               |
-      | lemonTShirtSWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
-      | lemonTShirtSBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
-      | lemonTShirtMWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
-      | lemonTShirtMBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
+    And product "lemon_tshirt" should have following combinations:
+      | id reference         | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                                |
+      | lemon_tshirt_s_white | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{lemon_image1}-small_default.jpg |
+      | lemon_tshirt_s_black | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemon_image1}-small_default.jpg |
+      | lemon_tshirt_m_white | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      | http://myshop.com/img/p/{lemon_image1}-small_default.jpg |
+      | lemon_tshirt_m_black | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemon_image1}-small_default.jpg |
     # Search results follow the same principle
     When I search for combinations with locale "english" matching "lemon" I should get following results:
-      | product      | combination       | name            | reference | image url                                              |
-      | lemonade_can |                   | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg  |
-      | lemonTShirt  | lemonTShirtSWhite | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtSBlack | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtMWhite | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtMBlack | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
-    And combination "lemonTShirtSWhite" should have no images
-    When I associate "[lemonImage2,lemonImage3]" to combination "lemonTShirtSWhite"
-    Then combination "lemonTShirtSWhite" should have following images "[lemonImage2,lemonImage3]"
-    When I associate "[lemonImage4]" to combination "lemonTShirtMWhite"
-    Then combination "lemonTShirtMWhite" should have following images "[lemonImage4]"
-    When I associate "[lemonImage4,lemonImage3]" to combination "lemonTShirtMBlack"
-    Then combination "lemonTShirtMBlack" should have following images "[lemonImage4,lemonImage3]"
+      | product       | combination          | name            | reference | image url                                               |
+      | lemonade_can  |                      | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg   |
+      | lemon_tshirt  | lemon_tshirt_s_white | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+    And combination "lemon_tshirt_s_white" should have no images
+    When I associate "[lemon_image2,lemon_image3]" to combination "lemon_tshirt_s_white"
+    Then combination "lemon_tshirt_s_white" should have following images "[lemon_image2,lemon_image3]"
+    When I associate "[lemon_image4]" to combination "lemon_tshirt_m_white"
+    Then combination "lemon_tshirt_m_white" should have following images "[lemon_image4]"
+    When I associate "[lemon_image4,lemon_image3]" to combination "lemon_tshirt_m_black"
+    Then combination "lemon_tshirt_m_black" should have following images "[lemon_image4,lemon_image3]"
     # Now the combination image is the first one in its own associated images (first by image creation oder)
-    And product "lemonTShirt" should have following combinations:
-      | id reference      | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                          |
-      | lemonTShirtSWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{lemonImage2}-small_default.jpg |
-      | lemonTShirtSBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage1}-small_default.jpg |
-      | lemonTShirtMWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage4}-small_default.jpg |
-      | lemonTShirtMBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemonImage3}-small_default.jpg |
+    And product "lemon_tshirt" should have following combinations:
+      | id reference         | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                                |
+      | lemon_tshirt_s_white | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{lemon_image2}-small_default.jpg |
+      | lemon_tshirt_s_black | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemon_image1}-small_default.jpg |
+      | lemon_tshirt_m_white | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      | http://myshop.com/img/p/{lemon_image4}-small_default.jpg |
+      | lemon_tshirt_m_black | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemon_image3}-small_default.jpg |
     # Search results follow the same principle
     When I search for combinations with locale "english" matching "lemon" I should get following results:
-      | product      | combination       | name            | reference | image url                                              |
-      | lemonade_can |                   | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg  |
-      | lemonTShirt  | lemonTShirtSWhite | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage2}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtSBlack | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage1}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtMWhite | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage4}-home_default.jpg |
-      | lemonTShirt  | lemonTShirtMBlack | lemon t-shirt   |           | http://myshop.com/img/p/{lemonImage3}-home_default.jpg |
+      | product       | combination          | name            | reference | image url                                               |
+      | lemonade_can  |                      | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg   |
+      | lemon_tshirt  | lemon_tshirt_s_white | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image2}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image4}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image3}-home_default.jpg |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
@@ -66,6 +66,7 @@ Feature: Associate combination image from Back Office (BO)
     Then combination "product1SWhite" should have following images "[image2]"
     When I associate "[image3, image4]" to combination "product1MBlack"
     Then combination "product1MBlack" should have following images "[image3, image4]"
+    # Now the combination image is the first one in its own associated images
     And product "product1" should have following combinations:
       | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default | image url                                          |
       | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       | http://myshop.com/img/p/{image2}-small_default.jpg |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -303,6 +303,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationStockFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SearchCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\SpecificPriceContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\FeatureFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\FeatureValueFeatureContext

--- a/tests/Unit/Core/Domain/Product/Query/SearchCombinationsForAssociationTest.php
+++ b/tests/Unit/Core/Domain/Product/Query/SearchCombinationsForAssociationTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Product\Query;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\SearchCombinationsForAssociation;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
+use Throwable;
+
+class SearchCombinationsForAssociationTest extends TestCase
+{
+    private const LANGUAGE_ID = 42;
+    private const SHOP_ID = 51;
+
+    /**
+     * @dataProvider getValidParameters
+     *
+     * @param string $phrase
+     * @param int $languageId
+     * @param int $shopId
+     * @param int|null $limit
+     */
+    public function testValidQuery(string $phrase, int $languageId, int $shopId, ?int $limit): void
+    {
+        $query = new SearchCombinationsForAssociation($phrase, $languageId, $shopId, $limit);
+        $this->assertNotNull($query);
+        $this->assertEquals($phrase, $query->getPhrase());
+        $this->assertEquals($languageId, $query->getLanguageId()->getValue());
+        $this->assertEquals($shopId, $query->getShopId()->getValue());
+        $this->assertEquals($limit, $query->getLimit());
+    }
+
+    public function getValidParameters(): iterable
+    {
+        yield [
+            'mug',
+            static::LANGUAGE_ID,
+            static::SHOP_ID,
+            null,
+        ];
+
+        yield [
+            'mug',
+            static::LANGUAGE_ID,
+            static::SHOP_ID,
+            1,
+        ];
+
+        yield [
+            'pretty mug',
+            static::LANGUAGE_ID,
+            static::SHOP_ID,
+            1,
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidParameters
+     *
+     * @param string $phrase
+     * @param int $languageId
+     * @param int $shopId
+     * @param int|null $limit
+     * @param int $errorCode
+     */
+    public function testInvalidQuery(string $phrase, int $languageId, int $shopId, ?int $limit, string $exceptionClass, int $errorCode): void
+    {
+        $caughtException = null;
+        try {
+            new SearchCombinationsForAssociation($phrase, $languageId, $shopId, $limit);
+        } catch (Throwable $e) {
+            $caughtException = $e;
+        }
+        $this->assertNotNull($caughtException);
+        $this->assertInstanceOf($exceptionClass, $caughtException);
+        $this->assertEquals($errorCode, $caughtException->getCode());
+    }
+
+    public function getInvalidParameters(): iterable
+    {
+        yield [
+            'mu',
+            static::LANGUAGE_ID,
+            static::SHOP_ID,
+            null,
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_SEARCH_PHRASE_LENGTH,
+        ];
+
+        yield [
+            'u',
+            static::LANGUAGE_ID,
+            static::SHOP_ID,
+            null,
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_SEARCH_PHRASE_LENGTH,
+        ];
+
+        yield [
+            '',
+            static::LANGUAGE_ID,
+            static::SHOP_ID,
+            null,
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_SEARCH_PHRASE_LENGTH,
+        ];
+
+        yield [
+            'mug',
+            static::LANGUAGE_ID,
+            static::SHOP_ID,
+            0,
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_SEARCH_LIMIT,
+        ];
+
+        yield [
+            'mug',
+            static::LANGUAGE_ID,
+            static::SHOP_ID,
+            -1,
+            ProductConstraintException::class,
+            ProductConstraintException::INVALID_SEARCH_LIMIT,
+        ];
+
+        yield [
+            'mug',
+            0,
+            static::SHOP_ID,
+            null,
+            LanguageException::class,
+            0,
+        ];
+
+        yield [
+            'mug',
+            static::LANGUAGE_ID,
+            0,
+            null,
+            ShopException::class,
+            0,
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Introduce `SearchCombinationsForAssociation` query which is similar to `SearchProductssForAssociation` except it returns the details of all matching combinations instead of grouping them by product. This is a pre-requisite for the API that will be used to edit pack associations.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | CI tests green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26506)
<!-- Reviewable:end -->

### BC breaks

`EditableCombinationForListing::imageUrl` is not optional any more, it is always prefilled with a value even if it is the fallback URL (no content)