### PR TITLE
delete id_cart in cookie if this cart is deleted and a new cart is created

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -458,6 +458,11 @@ class FrontControllerCore extends Controller
             // Needed if the merchant want to give a free product to every visitors
             $this->context->cart = $cart;
             CartRule::autoAddToCart($this->context);
+            
+            // New cart created, the old cart id in the cookie is now useless
+            if(isset($this->context->cookie->id_cart)) {
+                unset($this->context->cookie->id_cart);
+            }
         } else {
             $this->context->cart = $cart;
         }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -458,9 +458,9 @@ class FrontControllerCore extends Controller
             // Needed if the merchant want to give a free product to every visitors
             $this->context->cart = $cart;
             CartRule::autoAddToCart($this->context);
-            
+
             // New cart created, the old cart id in the cookie is now useless
-            if(isset($this->context->cookie->id_cart)) {
+            if (isset($this->context->cookie->id_cart)) {
                 unset($this->context->cookie->id_cart);
             }
         } else {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If we have an id_cart set in the cookie associated to a deleted cart, it raises an error in context->updateCustomer(). So when we create a new cart, this old id_cart is now useless and can be deleted.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Delete an active cart in BO and add a product in this cart in the FO
| Possible impacts? | Cart

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26511)
<!-- Reviewable:end -->
