### PR TITLE
Fixed display of errors in Carrier Wizard

### DIFF
--- a/admin-dev/themes/default/scss/controllers/_carrier-wizard.scss
+++ b/admin-dev/themes/default/scss/controllers/_carrier-wizard.scss
@@ -18,7 +18,6 @@
     clear: both;
 
     div.content {
-      position: absolute;
       display: block;
       width: 100%;
       clear: both;
@@ -156,11 +155,11 @@
     background-color: #ffd;
     border: 1px solid #ffd700;
     @include border-radius(5px);
-  }
 
-  .msgBox .content {
-    float: left;
-    padding: 0;
+    .content {
+      float: left;
+      padding: 0;
+    }
   }
 
   #carrier_logo_block {
@@ -206,11 +205,11 @@
   }
 
   .actionBar {
-    height: 30px;
-  }
+    display: flex;
+    flex-direction: row-reverse;
 
-  .actionBar a {
-    float: right;
-    margin-right: 10px;
+    a {
+      margin-right: 10px;
+    }
   }
 }

--- a/js/admin/carrier_wizard.js
+++ b/js/admin/carrier_wizard.js
@@ -125,7 +125,6 @@ function onShowStepCallback()
 		$(this).closest('li').addClass($(this).attr('class'));
 	});
 	$('#carrier_logo_block').prependTo($('div.content').filter(function() { return $(this).css('display') != 'none' }).find('.defaultForm').find('fieldset'));
-	resizeWizard();
 }
 
 function onFinishCallback(obj, context)
@@ -141,7 +140,6 @@ function onFinishCallback(obj, context)
 			if (data.has_error)
 			{
 				displayError(data.errors, context.fromStep);
-				resizeWizard();
 			}
 			else
 				window.location.href = carrierlist_url;
@@ -308,7 +306,6 @@ function validateSteps(fromStep, toStep)
 						$(this).closest('div.input-group').removeClass('has-error');
 					});
 					displayError(datas.errors, fromStep);
-					resizeWizard();
 				}
 			},
 			error: function(XMLHttpRequest, textStatus, errorThrown) {
@@ -335,16 +332,11 @@ function displayError(errors, step_number)
 	bind_inputs();
 }
 
-function resizeWizard()
-{
-	resizeInterval = setInterval(function (){$("#carrier_wizard").smartWizard('fixHeight'); clearInterval(resizeInterval)}, 100);
-}
-
 function bind_inputs()
 {
 	$('input').focus(function () {
 		$(this).closest('div.input-group').removeClass('has-error');
-		$('#carrier_wizard .actionBar a.btn').not('.buttonFinish').removeClass('disabled');
+		$('#carrier_wizard .actionBar a.btn').removeClass('disabled');
 		$('.wizard_error').fadeOut('fast', function () { $(this).remove()});
 	});
 
@@ -610,7 +602,6 @@ function add_new_range()
 	bind_inputs();
 	rebuildTabindex();
 	displayRangeType();
-	resizeWizard();
 	return false;
 }
 
@@ -687,7 +678,6 @@ function checkRangeContinuity(reordering)
 		$('.ranges_not_follow').fadeOut();
 	else
 		$('.ranges_not_follow').fadeIn();
-	resizeWizard();
 }
 
 function getCorrectRangePosistion(current_inf, current_sup)

--- a/js/jquery/plugins/smartWizard/jquery.smartWizard.js
+++ b/js/jquery/plugins/smartWizard/jquery.smartWizard.js
@@ -184,7 +184,6 @@ function SmartWizard(target, options) {
                 }
             }
         }
-        $this.elmStepContainer.height(_step($this, selStep).outerHeight());
         var prevCurStepIdx = $this.curStepIdx;
         $this.curStepIdx =  stepIdx;
         if ($this.options.transitionEffect == 'slide'){
@@ -375,18 +374,6 @@ function SmartWizard(target, options) {
         }else{
             $(this.steps.eq(stepnum-1), this.target).removeClass("errorStep");
         }
-    }
-
-    SmartWizard.prototype.fixHeight = function(){
-        var height = 0;
-
-        var selStep = this.steps.eq(this.curStepIdx);
-        var stepContainer = _step(this, selStep);
-        height += stepContainer.children().outerHeight() > 1000 && !this.curStepIdx ? 720 : stepContainer.children().outerHeight();
-
-        // These values (5 and 20) are experimentally chosen.
-        stepContainer.height(height + 5);
-        this.elmStepContainer.height(height + 20);
     }
 
     _init(this);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed display of errors in Carrier Wizard : Removed the use of `fixHeight` in smartWizard as it use for calculating outerHeight on all children... except `outerHeight` method on a selector fetch the outerHeight on first element of a selector and not all children :boom:. Removing the `position:absolute` allows the correct use of HTML block with CSS.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26187
| How to test?      | Cf. #26187


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26522)
<!-- Reviewable:end -->
