### PR TITLE
Fixed wishlist button disappear when products are filtered

### DIFF
--- a/themes/classic/templates/catalog/listing/product-list.tpl
+++ b/themes/classic/templates/catalog/listing/product-list.tpl
@@ -46,29 +46,23 @@
     <section id="products">
       {if $listing.products|count}
 
-        <div>
-          {block name='product_list_top'}
-            {include file='catalog/_partials/products-top.tpl' listing=$listing}
-          {/block}
-        </div>
+        {block name='product_list_top'}
+          {include file='catalog/_partials/products-top.tpl' listing=$listing}
+        {/block}
 
         {block name='product_list_active_filters'}
-          <div id="" class="hidden-sm-down">
+          <div class="hidden-sm-down">
             {$listing.rendered_active_filters nofilter}
           </div>
         {/block}
 
-        <div>
-          {block name='product_list'}
-            {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-xs-6 col-xl-4"}
-          {/block}
-        </div>
+        {block name='product_list'}
+          {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-xs-6 col-xl-4"}
+        {/block}
 
-        <div>
-          {block name='product_list_bottom'}
-            {include file='catalog/_partials/products-bottom.tpl' listing=$listing}
-          {/block}
-        </div>
+        {block name='product_list_bottom'}
+          {include file='catalog/_partials/products-bottom.tpl' listing=$listing}
+        {/block}
 
       {else}
         <div id="js-product-list-top"></div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | New PR here, Old PR #26486 <br/><br/>Fix wishlist button disappears while using Faceted Search.<br/><br/> Instead of changing selector of MutationObserver blockwishlist `document.querySelectorAll('#products, .featured-products')` that detect changes on these direct childs.<br/><br/>I prefer to remove this useless div and be consistent to the product list page when products are not displayed. In this case, the element `#products` has childs `#js-product-list-top, #js-product-list, #js-product-list-bottom` directly in it, without `<div>`.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26327.
| How to test?      | See how to test section of issue
| Possible impacts? | 

# Breaking changes
We mark this PR as a BC because we removed some divs that might be used by any modules/theme developers but which looks useless

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26526)
<!-- Reviewable:end -->
