### PR TITLE
[FO] Fixed display html in order message

### DIFF
--- a/themes/classic/templates/customer/_partials/order-messages.tpl
+++ b/themes/classic/templates/customer/_partials/order-messages.tpl
@@ -33,7 +33,7 @@
             {$message.message_date}
           </div>
           <div class="col-sm-8">
-            {$message.message|escape:"html"}
+            {$message.message nofilter}
           </div>
         </div>
       {/foreach}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | HTML element `<br/>` is shown in the message section
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26532 and still fix #24901.
| How to test?      | How to test section
| Possible impacts? | Issue fixed that introduce this bug #24901

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26537)
<!-- Reviewable:end -->
