### PR TITLE
Don't encode quotes in column name filter value

### DIFF
--- a/src/PrestaShopBundle/Entity/AdminFilter.php
+++ b/src/PrestaShopBundle/Entity/AdminFilter.php
@@ -352,7 +352,10 @@ class AdminFilter
                 'filter' => FILTER_CALLBACK,
                 'options' => $filterMinMax(FILTER_SANITIZE_NUMBER_INT),
             ],
-            'filter_column_name' => FILTER_SANITIZE_STRING,
+            'filter_column_name' => [
+                'filter' => FILTER_SANITIZE_STRING,
+                'flags' => FILTER_FLAG_NO_ENCODE_QUOTES,
+            ],
             'filter_column_reference' => FILTER_SANITIZE_STRING,
             'filter_column_name_category' => FILTER_SANITIZE_STRING,
             'filter_column_price' => [

--- a/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
@@ -65,7 +65,9 @@ class AdminFilterTest extends TestCase
     {
         return [
             'quote_in_name' => [['filter_column_name' => 't\'est'], 't\'est'],
-            'double_quote_in_name' => [['filter_column_name' => 't\"est'], 't\"est'],
+            'double_quote_in_name' => [['filter_column_name' => 't"est'], 't"est'],
+            'lot_of_double_quote' => [['filter_column_name' => 't""e""s""t""""'], 't""e""s""t""""'],
+            'lot_of_quote' => [['filter_column_name' => "t'''e''s't''"], "t'''e''s't''"],
         ];
     }
 }

--- a/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace Tests\Unit\PrestaShopBundle\Entity;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Unit\PrestaShopBundle\Entity;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Entity\AdminFilter;
+
+class AdminFilterTest extends TestCase
+{
+    private $emptyFilter;
+
+    protected function setUp() : void
+    {
+        $this->emptyFilter = AdminFilter::getProductCatalogEmptyFilter();
+    }
+
+    public function testGetProductCatalogEmptyFilter()
+    {
+        $this->assertEmpty($this->emptyFilter['filter_category']);
+        $this->assertEmpty($this->emptyFilter['filter_column_id_product']);
+        $this->assertEmpty($this->emptyFilter['filter_column_name']);
+        $this->assertEmpty($this->emptyFilter['filter_column_reference']);
+        $this->assertEmpty($this->emptyFilter['filter_column_price']);
+        $this->assertEmpty($this->emptyFilter['filter_column_sav_quantity']);
+        $this->assertEmpty($this->emptyFilter['filter_column_active']);
+
+    }
+
+    /**
+     * @dataProvider productFilterProviderByName
+     */
+    public function testSetProductCatalogFilterByName(array $filter, $expected)
+    {
+        $setFilter = (new AdminFilter())
+            ->setProductCatalogFilter($filter)
+            ->getProductCatalogFilter();
+
+        $this->assertSame($expected, $setFilter['filter_column_name']);
+    }
+
+
+
+    public function productFilterProviderByName() : array
+    {
+        return [
+            'quote_in_name'         => [['filter_column_name' => 't\'est'], 't\'est'],
+            'double_quote_in_name'  => [['filter_column_name' => 't\"est'], 't\"est'],
+        ];
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
@@ -40,7 +40,7 @@ class AdminFilterTest extends TestCase
         $this->emptyFilter = AdminFilter::getProductCatalogEmptyFilter();
     }
 
-    public function testGetProductCatalogEmptyFilter()
+    public function testGetProductCatalogEmptyFilter(): void
     {
         $this->assertEmpty($this->emptyFilter['filter_category']);
         $this->assertEmpty($this->emptyFilter['filter_column_id_product']);

--- a/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
@@ -33,7 +33,7 @@ class AdminFilterTest extends TestCase
 {
     private $emptyFilter;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->emptyFilter = AdminFilter::getProductCatalogEmptyFilter();
     }
@@ -47,7 +47,6 @@ class AdminFilterTest extends TestCase
         $this->assertEmpty($this->emptyFilter['filter_column_price']);
         $this->assertEmpty($this->emptyFilter['filter_column_sav_quantity']);
         $this->assertEmpty($this->emptyFilter['filter_column_active']);
-
     }
 
     /**
@@ -62,13 +61,11 @@ class AdminFilterTest extends TestCase
         $this->assertSame($expected, $setFilter['filter_column_name']);
     }
 
-
-
-    public function productFilterProviderByName() : array
+    public function productFilterProviderByName(): array
     {
         return [
-            'quote_in_name'         => [['filter_column_name' => 't\'est'], 't\'est'],
-            'double_quote_in_name'  => [['filter_column_name' => 't\"est'], 't\"est'],
+            'quote_in_name' => [['filter_column_name' => 't\'est'], 't\'est'],
+            'double_quote_in_name' => [['filter_column_name' => 't\"est'], 't\"est'],
         ];
     }
 }

--- a/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
+++ b/tests/Unit/PrestaShopBundle/Entity/AdminFilterTest.php
@@ -54,7 +54,7 @@ class AdminFilterTest extends TestCase
     /**
      * @dataProvider productFilterProviderByName
      */
-    public function testSetProductCatalogFilterByName(array $filter, $expected)
+    public function testSetProductCatalogFilterByName(array $filter, string $expected): void
     {
         $setFilter = (new AdminFilter())
             ->setProductCatalogFilter($filter)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?   | Currently, single quotes in column name grid filtering get escaped to the corresponding html code, interfering with search results. Resolved by not escaping single quotes in filter value. Safe, because the sql query string gets escaped further down in the sql query itself
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | nothing i can think of
| Deprecations?     |  no
| Fixed ticket?     | Fixes #26550 
| How to test?      | See issue description
| Possible impacts? | none i can think of


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26561)
<!-- Reviewable:end -->
