### PR TITLE
Use filename property instead of generating a new filename + remove duplicate code for PDF invoice formatting

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -613,7 +613,7 @@ abstract class PaymentModuleCore extends Module
                     Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => $order_invoice_list]);
                     $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty);
                     $file_attachement['content'] = $pdf->render(false);
-                    $file_attachement['name'] = Configuration::get('PS_INVOICE_PREFIX', (int) $order->id_lang, null, $order->id_shop) . sprintf('%06d', $order->invoice_number) . '.pdf';
+                    $file_attachement['name'] = $pdf->getFilename();
                     $file_attachement['mime'] = 'application/pdf';
                     $this->context->language = $currentLanguage;
                     $this->context->getTranslator()->setLocale($currentLanguage->locale);

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -537,13 +537,13 @@ class OrderHistoryCore extends ObjectModel
                         Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => $invoice]);
                         $pdf = new PDF($invoice, PDF::TEMPLATE_INVOICE, $context->smarty);
                         $file_attachement['invoice']['content'] = $pdf->render(false);
-                        $file_attachement['invoice']['name'] = Configuration::get('PS_INVOICE_PREFIX', (int) $order->id_lang, null, $order->id_shop) . sprintf('%06d', $order->invoice_number) . '.pdf';
+                        $file_attachement['invoice']['name'] = $pdf->getFilename();
                         $file_attachement['invoice']['mime'] = 'application/pdf';
                     }
                     if ($result['pdf_delivery'] && $order->delivery_number) {
                         $pdf = new PDF($invoice, PDF::TEMPLATE_DELIVERY_SLIP, $context->smarty);
                         $file_attachement['delivery']['content'] = $pdf->render(false);
-                        $file_attachement['delivery']['name'] = Configuration::get('PS_DELIVERY_PREFIX', (int) $order->id_lang, null, $order->id_shop) . sprintf('%06d', $order->delivery_number) . '.pdf';
+                        $file_attachement['delivery']['name'] = $pdf->getFilename();
                         $file_attachement['delivery']['mime'] = 'application/pdf';
                     }
 

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -501,17 +501,10 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
     {
         $id_lang = Context::getContext()->language->id;
         $id_shop = (int) $this->order->id_shop;
-        $format = '%1$s%2$06d';
-
-        if (Configuration::get('PS_INVOICE_USE_YEAR')) {
-            $format = Configuration::get('PS_INVOICE_YEAR_POS') ? '%1$s%3$s-%2$06d' : '%1$s%2$06d-%3$s';
-        }
 
         return sprintf(
-            $format,
-            Configuration::get('PS_INVOICE_PREFIX', $id_lang, null, $id_shop),
-            $this->order_invoice->number,
-            date('Y', strtotime($this->order_invoice->date_add))
-        ) . '.pdf';
+            '%s.pdf',
+            $this->order_invoice->getInvoiceNumberFormatted($id_lang, $id_shop)
+        );
     }
 }

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -115,6 +115,8 @@ class PDFCore
         if (count($this->objects) > 1) { // when bulk mode only
             $this->send_bulk_flag = true;
         }
+
+        $this->setFilename();
     }
 
     /**
@@ -135,13 +137,6 @@ class PDFCore
             $template = $this->getTemplateObject($object);
             if (!$template) {
                 continue;
-            }
-
-            if (empty($this->filename)) {
-                $this->filename = $template->getFilename();
-                if (count($this->objects) > 1) {
-                    $this->filename = $template->getBulkFilename();
-                }
             }
 
             $template->assignHookData($object);
@@ -165,7 +160,7 @@ class PDFCore
                 ob_clean();
             }
 
-            return $this->pdf_renderer->render($this->filename, $display);
+            return $this->pdf_renderer->render($this->getFilename(), $display);
         }
     }
 
@@ -194,5 +189,48 @@ class PDFCore
         }
 
         return $class;
+    }
+
+    /**
+     * Get the PDF filename based on the objects.
+     *
+     * @return string
+     */
+    public function getFilename(): string
+    {
+        if (empty($this->filename)) {
+            $this->setFilename();
+        }
+
+        return $this->filename;
+    }
+
+    /**
+     * Set the PDF filename based on the objects.
+     *
+     * @return bool
+     */
+    public function setFilename(): bool
+    {
+        $bulk = (1 < count($this->objects));
+
+        foreach ($this->objects as $object) {
+            $template = $this->getTemplateObject($object);
+            if (!$template) {
+                continue;
+            }
+
+            if ($bulk) {
+                $this->filename = $template->getBulkFilename();
+            } else {
+                $this->filename = $template->getFilename();
+            }
+
+            if (!empty($this->filename)) {
+                break;
+            }
+        }
+
+        return !empty($this->filename);
     }
 }


### PR DESCRIPTION
Prevents inconsistency with overrides.
After extra commits:
- Refer to the PDF filename instead of using duplicate code for PDF filename.
- Reuse OrderInvoice code to get PDF filename. This makes sure the invoice formatting logic is only done in one single place: the OrderInvoice class.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We used a override on the invoice number. Unfortunately the filename and invoice number is hardcoded in some locations. This PR fixes one of these.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26646.
| How to test?      | Override `getInvoiceNumberFormatted()` in `order/OrderInvoice.php` and that override should work in all locations where invoice numbers are used, even PDF filenames.
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26587)
<!-- Reviewable:end -->
