### PR TITLE
Make sure `checkSelectPrivilege` check privileges for both InnoDB and MyISAM

### DIFF
--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -454,8 +454,7 @@ class DbMySQLiCore extends Db
         }
 
         foreach ($enginesToTest as $engineToTest) {
-            $link->query('
-            CREATE TABLE `' . $prefix . 'test` (
+            $link->query('CREATE TABLE `' . $prefix . 'test` (
                 `test` tinyint(1) unsigned NOT NULL
             ) ENGINE=' . $engineToTest);
 

--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -448,27 +448,27 @@ class DbMySQLiCore extends Db
             return false;
         }
 
-        if ($engine === null) {
-            $engine = 'MyISAM';
+        $enginesToTest = ['InnoDB', 'MyISAM'];
+        if ($engine !== null) {
+            $enginesToTest = [$engine];
         }
 
-        // Create a table
-        $link->query('
-		CREATE TABLE `' . $prefix . 'test` (
-			`test` tinyint(1) unsigned NOT NULL
-		) ENGINE=' . $engine);
+        foreach ($enginesToTest as $engineToTest) {
+            $link->query('
+            CREATE TABLE `' . $prefix . 'test` (
+                `test` tinyint(1) unsigned NOT NULL
+            ) ENGINE=' . $engineToTest);
 
-        // Select content
-        $result = $link->query('SELECT * FROM `' . $prefix . 'test`');
+            $result = $link->query('SELECT * FROM `' . $prefix . 'test`');
 
-        // Drop the table
-        $link->query('DROP TABLE `' . $prefix . 'test`');
+            if ($result) {
+                $link->query('DROP TABLE `' . $prefix . 'test`');
 
-        if (!$result) {
-            return $link->error;
+                return true;
+            }
         }
 
-        return true;
+        return $link->error;
     }
 
     /**

--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -461,9 +461,9 @@ class DbMySQLiCore extends Db
 
             $result = $link->query('SELECT * FROM `' . $prefix . 'test`');
 
-            if ($result) {
-                $link->query('DROP TABLE `' . $prefix . 'test`');
+            $link->query('DROP TABLE `' . $prefix . 'test`');
 
+            if ($result) {
                 return true;
             }
         }

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -398,8 +398,7 @@ class DbPDOCore extends Db
         }
 
         foreach ($enginesToTest as $engineToTest) {
-            $link->query('
-            CREATE TABLE `' . $prefix . 'test` (
+            $link->query('CREATE TABLE `' . $prefix . 'test` (
                 `test` tinyint(1) unsigned NOT NULL
             ) ENGINE=' . $engineToTest);
 

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -392,29 +392,29 @@ class DbPDOCore extends Db
             return false;
         }
 
-        if ($engine === null) {
-            $engine = 'MyISAM';
+        $enginesToTest = ['InnoDB', 'MyISAM'];
+        if ($engine !== null) {
+            $enginesToTest = [$engine];
         }
 
-        // Create a table
-        $link->query('
-		CREATE TABLE `' . $prefix . 'test` (
-			`test` tinyint(1) unsigned NOT NULL
-		) ENGINE=' . $engine);
+        foreach ($enginesToTest as $engineToTest) {
+            $link->query('
+            CREATE TABLE `' . $prefix . 'test` (
+                `test` tinyint(1) unsigned NOT NULL
+            ) ENGINE=' . $engineToTest);
 
-        // Select content
-        $result = $link->query('SELECT * FROM `' . $prefix . 'test`');
+            $result = $link->query('SELECT * FROM `' . $prefix . 'test`');
 
-        // Drop the table
-        $link->query('DROP TABLE `' . $prefix . 'test`');
+            if ($result) {
+                $link->query('DROP TABLE `' . $prefix . 'test`');
 
-        if (!$result) {
-            $error = $link->errorInfo();
-
-            return $error[2];
+                return true;
+            }
         }
 
-        return true;
+        $error = $link->errorInfo();
+
+        return $error[2];
     }
 
     /**

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -404,7 +404,7 @@ class DbPDOCore extends Db
             ) ENGINE=' . $engineToTest);
 
             $result = $link->query('SELECT * FROM `' . $prefix . 'test`');
-            
+
             $link->query('DROP TABLE `' . $prefix . 'test`');
 
             if ($result) {

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -404,10 +404,10 @@ class DbPDOCore extends Db
             ) ENGINE=' . $engineToTest);
 
             $result = $link->query('SELECT * FROM `' . $prefix . 'test`');
+            
+            $link->query('DROP TABLE `' . $prefix . 'test`');
 
             if ($result) {
-                $link->query('DROP TABLE `' . $prefix . 'test`');
-
                 return true;
             }
         }


### PR DESCRIPTION
This PR completes #14402 (reported in #12675 and #20676) for `checkSelectPrivilege()`.

The previous implementation only checks MyISAM when no engine was specified.
The new implementation checks InnoDB and MyISAM if no engine is specified.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | During the database check the installation process tries to run a `SELECT` statement on a test table under the specified database. The engine fallbacks to default one which in this case was MyISAM which on some hosting environments is not supported. This PR enables check also for InnoDB engine.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #12675
| How to test?      | To test it easily you can try to install PrestaShop using MySQL engine with disabled MyISAM support.

NOTE: As a quickfix, if you need to get the installer runing on InnoDB, you could also just replace the following:

```diff
--- classes/db/DbPDO.ORIG.php	2021-10-04 18:11:53.000000000 +0200
+++ classes/db/DbPDO.php	2021-11-12 12:35:11.840528301 +0100
@@ -411,7 +411,7 @@
        }

        if ($engine === null) {
-            $engine = 'MyISAM';
+            $engine = 'InnoDB';
        }

        // Create a table

--- classes/db/DbMySQLi.ORIG.php	2021-10-04 18:11:53.000000000 +0200
+++ classes/db/DbMySQLi.php	2021-11-12 12:34:54.823606056 +0100
@@ -449,7 +449,7 @@
        }

        if ($engine === null) {
-            $engine = 'MyISAM';
+            $engine = 'InnoDB';
        }

        // Create a table
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26588)
<!-- Reviewable:end -->
