### PR TITLE
Fixed error message when the order language is different of the employee language

### DIFF
--- a/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddCartRuleToOrderHandler.php
@@ -31,6 +31,7 @@ use CartRule;
 use Configuration;
 use Currency;
 use Customer;
+use Language;
 use Order;
 use OrderInvoice;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
@@ -80,6 +81,7 @@ final class AddCartRuleToOrderHandler extends AbstractOrderHandler implements Ad
         $this->contextStateManager
             ->setCurrency(new Currency($order->id_currency))
             ->setCustomer(new Customer($order->id_customer))
+            ->setLanguage((new Language($order->id_lang)))
             ->setShop(new Shop($order->id_shop))
         ;
 

--- a/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/DeleteCartRuleFromOrderHandler.php
@@ -30,6 +30,7 @@ use Cart;
 use CartRule;
 use Currency;
 use Customer;
+use Language;
 use Order;
 use OrderCartRule;
 use OrderDetail;
@@ -98,6 +99,7 @@ final class DeleteCartRuleFromOrderHandler extends AbstractOrderHandler implemen
         $this->contextStateManager
             ->setCurrency(new Currency($order->id_currency))
             ->setCustomer(new Customer($order->id_customer))
+            ->setLanguage(new Language($order->id_lang))
             ->setShop(new Shop($order->id_shop))
         ;
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -87,7 +87,8 @@ services:
   prestashop.adapter.order.command_handler.update_order_shipping_details_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\UpdateOrderShippingDetailsHandler
     arguments:
-        - '@prestashop.adapter.order.amount.updater'
+      - '@prestashop.adapter.order.amount.updater'
+      - '@prestashop.adapter.context_state_manager'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand

--- a/tests/Unit/Adapter/ContextStateManagerTest.php
+++ b/tests/Unit/Adapter/ContextStateManagerTest.php
@@ -143,6 +143,7 @@ namespace Tests\Unit\Adapter {
                 'language' => $this->createContextFieldMock(Language::class, 42),
             ]);
             $this->assertEquals(42, $context->language->id);
+            $this->assertEquals('test42', $context->getTranslator()->getLocale());
 
             $contextStateManager = new ContextStateManager($this->legacyContext);
             $this->assertNull($contextStateManager->getContextFieldsStack());
@@ -150,14 +151,17 @@ namespace Tests\Unit\Adapter {
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 51));
             $this->assertEquals(51, $context->language->id);
             $this->assertCount(1, $contextStateManager->getContextFieldsStack());
+            $this->assertEquals('test51', $context->getTranslator()->getLocale());
 
             $contextStateManager->setLanguage($this->createContextFieldMock(Language::class, 69));
             $this->assertEquals(69, $context->language->id);
             $this->assertCount(1, $contextStateManager->getContextFieldsStack());
+            $this->assertEquals('test69', $context->getTranslator()->getLocale());
 
             $contextStateManager->restorePreviousContext();
             $this->assertEquals(42, $context->language->id);
             $this->assertNull($contextStateManager->getContextFieldsStack());
+            $this->assertEquals('test42', $context->getTranslator()->getLocale());
         }
 
         public function testShopState()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixed error message when the order language is different of the employee language
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26547
| How to test?      | Cf. #26547

**Description :**
* When you are using the backoffice, you consider that the `translator` is in :fr: 
* When you use (for example) the `AddCartRuleToOrderHandler`, and you go in the `OrderAmountUpdater`
  * The ContextStateManager change the Language of the context in the language of the order so in :gb: in our example
  * When the email send acts, that uses `Context::getContext()->getTranslator()` which changes its `translator` in :gb: 
  * The ContextStateManager restore the language in :fr: 
* At this moment, we have : 
  * `Context::getContext()->language` is in :fr: 
  * `translator` is is :gb: 
  
It's why we need to synchronize the translator with language when we use the ContexteStateManager.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26590)
<!-- Reviewable:end -->
