### PR TITLE
Fixed incompatibility of private property in PS 1.7.8.0

### DIFF
--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -57,7 +57,7 @@ class PDFCore
     /**
      * @var Smarty
      */
-    private $smarty;
+    protected $smarty;
 
     const TEMPLATE_INVOICE = 'Invoice';
     const TEMPLATE_ORDER_RETURN = 'OrderReturn';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR fix incompatibility of private property in PS 1.7.8.0
| Type?             | bug fix
| Category?         | FO / BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #26606
| How to test?      | If a module inherited from the PDF class is incompatible with version 1.7.8.0, here we tried to fix the problem. 
| Possible impacts? | Nothing.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26598)
<!-- Reviewable:end -->
