### PR TITLE
Remove header calculation and set toolbar to sticky

### DIFF
--- a/admin-dev/themes/new-theme/js/header.js
+++ b/admin-dev/themes/new-theme/js/header.js
@@ -33,7 +33,6 @@ export default class Header {
       this.initMultiStores();
       this.initNotificationsToggle();
       this.initSearch();
-      this.initContentDivOffset();
       refreshNotifications();
     });
   }
@@ -168,10 +167,10 @@ export default class Header {
     };
 
     // update the offset now
-    onToolbarResize();
+    //onToolbarResize();
 
     // update when resizing the window
-    $(window).resize(onToolbarResize);
+    //$(window).resize(onToolbarResize);
 
     // update when replacing the header with a vue header
     $(document).on('vueHeaderMounted', onToolbarResize);

--- a/admin-dev/themes/new-theme/js/header.js
+++ b/admin-dev/themes/new-theme/js/header.js
@@ -150,29 +150,4 @@ export default class Header {
       type: $('.notification-center .nav-link.active').attr('data-type'),
     });
   }
-
-  /**
-   * Updates the offset of the content div in whenever the header changes size
-   */
-  initContentDivOffset() {
-    const onToolbarResize = function () {
-      const toolbar = $('.header-toolbar').last();
-      const header = $('.main-header');
-      const content = $('.content-div');
-      const spacing = 15;
-
-      if (toolbar.length && header.length && content.length) {
-        content.css('padding-top', toolbar.outerHeight() + header.outerHeight() + spacing);
-      }
-    };
-
-    // update the offset now
-    //onToolbarResize();
-
-    // update when resizing the window
-    //$(window).resize(onToolbarResize);
-
-    // update when replacing the header with a vue header
-    $(document).on('vueHeaderMounted', onToolbarResize);
-  }
 }

--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -1,8 +1,6 @@
 .content-div {
   // stylelint-disable
-  padding-top:
-    $size-header-height + $size-header-toolbar-height +
-    ($grid-gutter-width / 2);
+  padding-top: 1rem;
   // stylelint-enable
   padding-right: $grid-gutter-width / 2;
   padding-bottom: $grid-gutter-width / 2;
@@ -18,7 +16,6 @@
   }
 
   @include media-breakpoint-down(sm) {
-    padding-top: 10.4rem;
     padding-right: 1rem;
     padding-left: 1rem;
 
@@ -54,6 +51,10 @@
       $grid-gutter-width + 2.5rem;
     // stylelint-enable
   }
+}
+
+#main-div {
+  padding-top: 2.5rem;
 }
 
 .page-sidebar-closed:not(.mobile) {

--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -41,15 +41,13 @@
   }
 
   &.-notoolbar {
-    padding-top: $size-header-height + $grid-gutter-width / 2;
-  }
+    padding-top: 0;
 
-  &.with-tabs {
-    // stylelint-disable
-    padding-top:
-      $size-header-height + $size-header-toolbar-height +
-      $grid-gutter-width + 2.5rem;
-    // stylelint-enable
+    .header-toolbar {
+      padding-left: 0;
+      margin: 0 -#{$grid-gutter-width / 2};
+      margin-bottom: 1rem;
+    }
   }
 }
 

--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -55,6 +55,10 @@
 
 #main-div {
   padding-top: 2.5rem;
+
+  @include media-breakpoint-down(md) {
+    padding-top: 3.5rem;
+  }
 }
 
 .page-sidebar-closed:not(.mobile) {

--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -1,4 +1,5 @@
 .header-toolbar {
+  // stylelint-disable-next-line
   position: sticky;
   top: 2.5rem;
   right: 0;

--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -1,13 +1,13 @@
 .header-toolbar {
-  position: fixed;
-  top: $size-header-height;
+  position: sticky;
+  top: 2.5rem;
   right: 0;
-  left: $size-navbar-width;
   z-index: 990; // popup menus' z-index is 1000, so it has to be just below that
+  padding-left: $size-navbar-width;
   background: $white;
   border-bottom: 0.0625rem solid $color-separator;
   @include transition(
-    left 0.5s ease
+    padding 0.5s ease
   ); // transition when collapsing the nav menu
 
   .mobile & {
@@ -15,12 +15,11 @@
   }
 
   @include media-breakpoint-down(md) {
-    left: 0;
+    padding-left: 0;
   }
 
   @include media-breakpoint-down(sm) {
     top: 3.5rem;
-    padding-top: 0.3rem;
   }
 
   .container-fluid {

--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -45,12 +45,16 @@
       position: fixed;
       top: 5rem;
       left: 75%;
-      display: block;
+      display: none;
       font-family: "Material Icons", sans-serif;
       font-size: 1.5rem;
       color: $white;
       pointer-events: none;
       content: "\e5cd";
+
+      @at-root .expanded & {
+        display: block;
+      }
 
       @include media-breakpoint-only(md) {
         left: 50%;

--- a/admin-dev/themes/new-theme/scss/pages/stock/stock_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/stock/stock_page.scss
@@ -8,6 +8,21 @@
 .stock-app {
   padding: 0;
 
+  .header-toolbar {
+    z-index: 989;
+    padding-left: 0;
+    margin: -($grid-gutter-width / 2);
+    margin-bottom: 1rem;
+
+    @at-root .multishop-enabled & {
+      top: 4.95rem;
+
+      @include media-breakpoint-down(md) {
+        top: 6.2rem;
+      }
+    }
+  }
+
   .table {
     td:first-child {
       // product description inside the product column
@@ -33,7 +48,7 @@
 
     .alert-box {
       position: fixed;
-      top: 40px;
+      top: 4rem;
       right: 5px;
       z-index: 1000; // above header toolbar
       padding-top: 28px;
@@ -305,4 +320,8 @@
       }
     }
   }
+}
+
+.adminstockmanagement > .header-toolbar .container-fluid {
+  display: none;
 }

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -5,7 +5,7 @@
 </head>
 
 <body
-  class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} {$smarty.get.controller|escape|strtolower}{if $collapse_menu} page-sidebar-closed{/if}"
+  class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} {$smarty.get.controller|escape|strtolower}{if $collapse_menu} page-sidebar-closed{/if}{if isset($is_multishop) && $is_multishop} multishop-enabled{/if}"
   {if isset($js_router_metadata.base_url)}data-base-url="{$js_router_metadata.base_url}"{/if}
   {if isset($js_router_metadata.token)}data-token="{$js_router_metadata.token}"{/if}
 >

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -82,13 +82,14 @@
   {include file='components/layout/nav_bar.tpl'}
 {/if}
 
+{if isset($page_header_toolbar)}{$page_header_toolbar}{/if}
+
 <div id="main-div">
     {if $install_dir_exists}
       <div class="alert alert-warning">
         {l s='For security reasons, you must also delete the /install folder.' d='Admin.Login.Notification'}
       </div>
     {else}
-      {if isset($page_header_toolbar)}{$page_header_toolbar}{/if}
       {if isset($modal_module_list)}{$modal_module_list}{/if}
 
       <div class="{if $display_header}content-div{/if} {if !isset($page_header_toolbar)}-notoolbar{/if} {if $current_tab_level == 3}with-tabs{/if}">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Content padding is changing based on header size but causing some layout shifting, fixed it by changing the header toolbar to sticky and remove header calculation
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26383.
| How to test?      | Refresh the page on order page for example, the layout shouldn't change his position, same on mobile also take care of the stock page which has a different header and please take care also of testing without multishop enable
| Possible impacts? | Content padding


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26613)
<!-- Reviewable:end -->
