### PR TITLE
Prevent × symbol from being visible when mobile menu is not in expanded state in BO.

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -102,6 +102,10 @@
         left: 50%;
       }
     }
+    
+    &:not(.expanded)::before {
+      display: none;
+    }
 
     @include media-breakpoint-only(sm) {
       width: 60%;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Prevent &times; symbol from being visible when mobile menu is not in expanded state in BO.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #26626 
| How to test?      | Open BO. Reduce width to breakpoint smaller than desktop. Best visible adding background colour to header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26625)
<!-- Reviewable:end -->
