### PR TITLE
Remove lazy load for logo

### DIFF
--- a/themes/classic/templates/_partials/helpers.tpl
+++ b/themes/classic/templates/_partials/helpers.tpl
@@ -29,7 +29,6 @@
       class="logo img-fluid"
       src="{$shop.logo_details.src}"
       alt="{$shop.name}"
-      loading="lazy"
       width="{$shop.logo_details.width}"
       height="{$shop.logo_details.height}">
   </a>


### PR DESCRIPTION
Logo img is above a fold, so it should be not lazyloaded.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Images which are above a fold should not be lazyloaded, its bad for performance and pagespeed tools complain about that too.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     |  Fixes #26666
| How to test?      | Just look if the logo is loading properly (no need to test overwise)
| Possible impacts? | Logo loading


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26658)
<!-- Reviewable:end -->
