### PR TITLE
Fix position of cart crosselling hook

### DIFF
--- a/themes/classic/templates/checkout/cart-empty.tpl
+++ b/themes/classic/templates/checkout/cart-empty.tpl
@@ -24,10 +24,6 @@
  *}
 {extends file='checkout/cart.tpl'}
 
-{block name='content' append}
-  {hook h='displayCrossSellingShoppingCart'}
-{/block}
-
 {block name='continue_shopping' append}
   <a class="label" href="{$urls.pages.index}">
     <i class="material-icons">chevron_left</i>{l s='Continue shopping' d='Shop.Theme.Actions'}

--- a/themes/classic/templates/checkout/cart.tpl
+++ b/themes/classic/templates/checkout/cart.tpl
@@ -30,7 +30,7 @@
     <div class="cart-grid row">
 
       <!-- Left Block: cart product informations & shpping -->
-      <div class="cart-grid-body col-xs-12 col-lg-8">
+      <div class="cart-grid-body col-lg-8">
 
         <!-- cart products detailed -->
         <div class="card cart-container">
@@ -56,7 +56,7 @@
       </div>
 
       <!-- Right Block: cart subtotal & cart total -->
-      <div class="cart-grid-right col-xs-12 col-lg-4">
+      <div class="cart-grid-right col-lg-4">
 
         {block name='cart_summary'}
           <div class="card cart-summary">
@@ -83,5 +83,8 @@
       </div>
 
     </div>
+    
+    {hook h='displayCrossSellingShoppingCart'}
+    
   </section>
 {/block}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes position of cart crosselling, should be displayed in filled cart, not empty.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26660
| How to test?      | Output something to that hook and see that its displayed all the time.
| Possible impacts? | No


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26663)
<!-- Reviewable:end -->
