### PR TITLE
Stack min-max inputs to get more space

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -104,7 +104,8 @@ table .thead-default .column-headers th:last-child .grid-actions-header-text {
 }
 
 table .column-filters {
-  th .btn {
+  th .btn,
+  td .btn {
     white-space: nowrap;
   }
 

--- a/admin-dev/themes/new-theme/scss/pages/product/products_catalog.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/products_catalog.scss
@@ -31,11 +31,6 @@
       font-weight: 400;
     }
 
-    .form-min-max {
-      display: inline-block;
-      width: 48%;
-    }
-
     .action-enabled {
       color: $brand-success;
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_inputs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_inputs.html.twig
@@ -118,6 +118,10 @@
 </script>
 <div id="{{ input_name }}_div">
     <input type="hidden" id="{{ input_name }}" name="{{ input_name }}" value="" sql="{{ value }}" />
-    <input class="form-control form-min-max" type="text" id="{{ input_name }}_min" value="" placeholder="{{ minLabel|default('Min') }}" {% if disabled|default(false) %}disabled{% endif %} aria-label="{{ "%inputId% Minimum Input"|trans({'%inputId%': input_name}, 'Admin.Global') }}" />
-    <input class="form-control form-min-max" type="text" id="{{ input_name }}_max" value="" placeholder="{{ maxLabel|default('Max') }}" {% if disabled|default(false) %}disabled{% endif %} aria-label="{{ "%inputId% Maximum Input"|trans({'%inputId%': input_name}, 'Admin.Global') }}" />
+    <div>
+        <input class="form-control form-min-max" type="text" id="{{ input_name }}_min" value="" placeholder="{{ minLabel|default('Min') }}" {% if disabled|default(false) %}disabled{% endif %} aria-label="{{ "%inputId% Minimum Input"|trans({'%inputId%': input_name}, 'Admin.Global') }}" />
+    </div>
+    <div>
+        <input class="form-control form-min-max" type="text" id="{{ input_name }}_max" value="" placeholder="{{ maxLabel|default('Max') }}" {% if disabled|default(false) %}disabled{% endif %} aria-label="{{ "%inputId% Maximum Input"|trans({'%inputId%': input_name}, 'Admin.Global') }}" />
+    </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -85,7 +85,7 @@
       {% block product_catalog_form_table_filters %}
         {% set filters_disabled = activate_drag_and_drop %}
         <tr class="column-filters">
-          <th class="text-center" style="vertical-align: middle;">
+          <td class="text-center" style="vertical-align: middle;">
             {% block product_catalog_filter_select_all %}
               <div class="md-checkbox md-checkbox-inline">
                 <label>
@@ -99,8 +99,8 @@
                 </label>
               </div>
             {% endblock %}
-          </th>
-          <th>
+          </td>
+          <td>
             {% include '@PrestaShop/Admin/Helpers/range_inputs.html.twig' with {
               'input_name': "filter_column_id_product",
               'min': '0',
@@ -110,9 +110,9 @@
               'value': filter_column_id_product,
               'disabled': filters_disabled,
             } %}
-          </th>
-          <th>&nbsp;</th>
-          <th>
+          </td>
+          <td>&nbsp;</td>
+          <td>
             <input
               type="text"
               class="form-control"
@@ -122,8 +122,8 @@
               aria-label="{{ "%inputId% input"|trans({'%inputId%': 'filter_column_name'}, 'Admin.Global') }}"
               {% if filters_disabled %}disabled{% endif %}
             />
-          </th>
-          <th>
+          </td>
+          <td>
             <input
               type="text"
               class="form-control"
@@ -133,8 +133,8 @@
               aria-label="{{ "%inputId% input"|trans({'%inputId%': 'filter_column_reference'}, 'Admin.Global') }}"
               {% if filters_disabled %}disabled{% endif %}
             />
-          </th>
-          <th>
+          </td>
+          <td>
             <input
               type="text"
               class="form-control"
@@ -144,8 +144,8 @@
               aria-label="{{ "%inputId% input"|trans({'%inputId%': 'filter_column_name_category'}, 'Admin.Global') }}"
               {% if filters_disabled %}disabled{% endif %}
             />
-          </th>
-          <th class="text-center">
+          </td>
+          <td class="text-center">
             {% include '@PrestaShop/Admin/Helpers/range_inputs.html.twig' with {
               'input_name': "filter_column_price",
               'min': '0',
@@ -155,10 +155,10 @@
               'value': filter_column_price,
               'disabled': filters_disabled,
             } %}
-          </th>
-          <th class="text-center"></th>
+          </td>
+          <td class="text-center"></td>
           {% if configuration('PS_STOCK_MANAGEMENT') %}
-          <th class="text-center">
+          <td class="text-center">
             {% include '@PrestaShop/Admin/Helpers/range_inputs.html.twig' with {
               'input_name': "filter_column_sav_quantity",
               'min': '-1000000',
@@ -168,12 +168,12 @@
               'value': filter_column_sav_quantity,
               'disabled': filters_disabled,
             } %}
-          </th>
+          </td>
           {% else %}
-            <th></th>
+            <td></td>
           {% endif %}
 
-          <th id="product_filter_column_active" class="text-center">
+          <td id="product_filter_column_active" class="text-center">
             <div class="form-select">
               <select class="custom-select"  name="filter_column_active"{% if filters_disabled %} disabled{% endif %} aria-label="{{ "%inputId% select"|trans({'%inputId%': 'filter_column_active'}, 'Admin.Global') }}"
                 >
@@ -182,17 +182,17 @@
                 <option value="0" {% if (filter_column_active is defined) and filter_column_active == '0' %}selected="selected"{% endif %}>Inactive</option>
               </select>
             </div>
-          </th>
+          </td>
           {% if has_category_filter == true %}
-            <th>
+            <td>
               {% if not(activate_drag_and_drop) %}
                 <input type="button" class="btn btn-outline-secondary" name="products_filter_position_asc" value="{{ "Reorder"|trans({}, 'Admin.Actions') }}" onclick="productOrderPrioritiesTable();" />
                 {% else %}
                 <input type="button" id="bulk_edition_save_keep" class="btn" onclick="bulkProductAction(this, 'edition');" value="{{ "Save & refresh"|trans({}, 'Admin.Actions')|raw }}" />
               {% endif %}
-            </th>
+            </td>
           {% endif %}
-          <th class="text-right" style="width: 5rem">
+          <td class="text-right" style="width: 5rem">
             <button
               type="submit"
               class="btn btn-primary"
@@ -212,7 +212,7 @@
               <i class="material-icons">clear</i>
               {{ "Reset"|trans({}, 'Admin.Actions') }}
             </button>
-          </th>
+          </td>
         </tr>
       {% endblock %}
     </thead>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I stacked min-max inputs on product page (as we do in date inputs on order page), to get more space.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26192
| How to test?      | Try sorting and filtering, should work fine.
| Possible impacts? | -

**After change**
![Výstřižek](https://user-images.githubusercontent.com/6097524/142399449-2831d6eb-c463-4b5c-9fa1-ec25b73fb93a.JPG)

ping @NeOMakinG @prestascott 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26665)
<!-- Reviewable:end -->
