### PR TITLE
Refactor and simplify rendering of KPI row

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_kpi.scss
@@ -1,27 +1,43 @@
-.kpi-container {
+.kpi-row {
   position: relative;
-  display: block;
-  padding-top: 0.9375rem;
-  padding-bottom: 0.9375rem;
-  text-align: center;
+  display: flex;
+  align-items: stretch;
   text-decoration: none;
-  background: $white;
   @include border-radius($card-border-radius);
 
-  @include media-breakpoint-down(sm) {
-    background: none;
+  @include media-breakpoint-up(xl) {
+    max-width: 1240px;
+    padding-top: 0.9375rem;
+    padding-bottom: 0.9375rem;
+    margin: 0 auto;
+    text-align: center;
 
-    &:not(.box-stats) {
-      padding: 0;
+    .box-stats {
+      margin: 0 auto;
     }
+  }
 
-    &.box-stats {
+  @include media-breakpoint-down(lg) {
+    overflow-x: auto;
+
+    .box-stats {
       width: max-content;
       min-width: 13rem;
       padding: 1rem;
+      margin-right: 1rem;
+      text-decoration: none;
       background-color: $white;
-      box-shadow: 0 8px 16px 0 rgba($black, 0.1);
+      border: $card-border-width solid $card-border-color;
+      box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.06);
       @include border-radius($card-border-radius);
+    }
+
+    .box-stats:last-child {
+      margin-right: 4.4rem;
+    }
+
+    &:hover {
+      text-decoration: none;
     }
 
     .kpi-content {
@@ -37,37 +53,6 @@
         }
       }
     }
-
-    > .row {
-      display: flex;
-      flex-wrap: nowrap;
-      align-items: center;
-      // stylelint-disable
-      justify-content: flex-start !important;
-      padding: 1.1rem 0.6rem;
-      padding-top: 0.5rem;
-      margin: 0 -1rem !important;
-      overflow: scroll;
-      // stylelint-enable
-
-      > div {
-        margin: 0 0.5rem;
-
-        &:last-child {
-          .box-stats {
-            margin-right: 1rem;
-          }
-        }
-
-        i {
-          font-size: 1.5rem;
-        }
-      }
-    }
-  }
-
-  &:hover {
-    text-decoration: none;
   }
 }
 
@@ -76,13 +61,8 @@
   top: 0;
   right: 0;
   z-index: 1;
-
-  @include media-breakpoint-down(sm) {
-    button {
-      display: none;
-    }
-  }
 }
+
 
 .kpi-content {
   position: relative;
@@ -137,7 +117,7 @@
 }
 
 // specific design for orders page. If design tends to repeat use this for all kpi's in all pages
-.orders-kpi {
+.adminorders {
   .kpi-content {
     .kpi-description {
       display: flex;
@@ -153,15 +133,9 @@
   }
 }
 
-.container-fluid {
-  > .kpi-container {
-    padding-right: 1rem;
-    padding-left: 1rem;
-  }
-}
-
+// Remove backgrounds from card below SM breakpoint
 .card-kpis {
-  @include media-breakpoint-down(sm) {
+  @include media-breakpoint-down(lg) {
     background-color: inherit;
     border: none;
     box-shadow: inherit;

--- a/admin-dev/themes/new-theme/template/helpers/kpi/kpi.tpl
+++ b/admin-dev/themes/new-theme/template/helpers/kpi/kpi.tpl
@@ -23,33 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
 
-{if isset($href) && $href}
-  <a href="{$href|escape:'html':'UTF-8'}" id="{$id|escape:'html':'UTF-8'}" class="kpi-container box-stats">
-{else}
-  <div id="{$id|escape:'html':'UTF-8'}" class="kpi-container box-stats">
-{/if}
-  <div class="kpi-content -{$color|escape}" data-original-title="{$tooltip|escape}" data-toggle="pstooltip">
-    {if isset($icon) && $icon}
-      <i class="material-icons">{$icon|escape}</i>
-    {/if}
-    {if isset($chart) && $chart}
-      <div class="boxchart-overlay">
-        <div class="boxchart">
-        </div>
-      </div>
-    {/if}
-    <span class="title">{$title|escape}</span>
-    <div class="kpi-description">
-      <div class="subtitle">{$subtitle|escape}</div>
-      <div class="value">{$value|escape|replace:'&amp;':'&'}</div>
-    </div>
-  </div>
-{if isset($href) && $href}
-  </a>
-{else}
-  </div>
-{/if}
-
 <script>
   function refresh_{$id|replace:'-':'_'|addslashes}()
   {
@@ -117,3 +90,31 @@
     {/if}
   </script>
 {/if}
+
+{if isset($href) && $href}
+  <a href="{$href|escape:'html':'UTF-8'}" id="{$id|escape:'html':'UTF-8'}" class="kpi-container box-stats">
+{else}
+  <div id="{$id|escape:'html':'UTF-8'}" class="kpi-container box-stats">
+{/if}
+  <div class="kpi-content -{$color|escape}" data-original-title="{$tooltip|escape}" data-toggle="pstooltip">
+    {if isset($icon) && $icon}
+      <i class="material-icons">{$icon|escape}</i>
+    {/if}
+    {if isset($chart) && $chart}
+      <div class="boxchart-overlay">
+        <div class="boxchart">
+        </div>
+      </div>
+    {/if}
+    <span class="title">{$title|escape}</span>
+    <div class="kpi-description">
+      <div class="subtitle">{$subtitle|escape}</div>
+      <div class="value">{$value|escape|replace:'&amp;':'&'}</div>
+    </div>
+  </div>
+{if isset($href) && $href}
+  </a>
+{else}
+  </div>
+{/if}
+

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Kpi/kpi_row.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Kpi/kpi_row.html.twig
@@ -24,23 +24,22 @@
  *#}
 
 {% block kpi_row %}
-    <div class="container">
-        <div class="kpi-container">
-            <div class="row justify-content-around">
-                {% for kpi in kpiRow.kpis %}
-                    <div>
-                        {{ kpi|raw }}
-                    </div>
-                {% endfor %}
-            </div>
-        </div>
+  <div class="card card-kpis">
+
+    <div class="kpi-row">
+      {% for kpi in kpiRow.kpis %}
+        {{ kpi|raw }}
+      {% endfor %}
     </div>
 
     {% if kpiRow.allowRefresh %}
-      <div class="kpi-refresh">
-        <button class="refresh-kpis btn btn-primary" type="button">
-          <i class="material-icons">refresh</i>
-        </button>
-      </div>
+    <div class="kpi-refresh">
+      <button class="refresh-kpis btn btn-primary" type="button">
+        <i class="material-icons">refresh</i>
+      </button>
+    </div>
     {% endif %}
+
+  </div>
 {% endblock %}
+

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Translations/translations_settings.html.twig
@@ -27,14 +27,12 @@
 {% trans_default_domain 'Admin.International.Feature' %}
 
 {% block content %}
-  <div class="card card-kpis">
-    {% block translations_kpis_row %}
-      {{ render(controller(
-        'PrestaShopBundle:Admin\\Common:renderKpiRow',
-        { 'kpiRow': kpiRow }
-      )) }}
-    {% endblock %}
-  </div>
+  {% block translations_kpis_row %}
+    {{ render(controller(
+      'PrestaShopBundle:Admin\\Common:renderKpiRow',
+      { 'kpiRow': kpiRow }
+    )) }}
+  {% endblock %}
 
   {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/modify_translations.html.twig' %}
   {% include '@PrestaShop/Admin/Improve/International/Translations/Blocks/add_update_language.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/index.html.twig
@@ -35,14 +35,10 @@
   {% endblock %}
 
   {% block categories_kpis %}
-    <div class="card card-kpis">
-      <div class="row">
-        {{ render(controller(
-              'PrestaShopBundle:Admin\\Common:renderKpiRow',
-              { 'kpiRow': categoriesKpi }
-            )) }}
-      </div>
-    </div>
+    {{ render(controller(
+      'PrestaShopBundle:Admin\\Common:renderKpiRow',
+      { 'kpiRow': categoriesKpi }
+    )) }}
   {% endblock %}
 
   {% block categories_breadcrumb %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/index.html.twig
@@ -34,14 +34,10 @@
   {% endblock %}
 
   {% block customers_kpis %}
-    <div class="card card-kpis">
-      <div class="row">
-        {{ render(controller(
-          'PrestaShopBundle:Admin\\Common:renderKpiRow',
-          { 'kpiRow': customersKpi }
-        )) }}
-      </div>
-    </div>
+    {{ render(controller(
+      'PrestaShopBundle:Admin\\Common:renderKpiRow',
+      { 'kpiRow': customersKpi }
+    )) }}
   {% endblock %}
 
   {% block customers_listing %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Cart/view.html.twig
@@ -27,14 +27,10 @@
 
 {% block content %}
   {% block cart_kpis %}
-    <div class="card card-kpis">
-      <div class="row">
-        {{ render(controller(
-          'PrestaShopBundle:Admin\\Common:renderKpiRow',
-          { 'kpiRow': cartKpi }
-        )) }}
-      </div>
-    </div>
+    {{ render(controller(
+      'PrestaShopBundle:Admin\\Common:renderKpiRow',
+      { 'kpiRow': cartKpi }
+    )) }}
   {% endblock %}
 
   <div class="row">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
@@ -33,14 +33,10 @@
   {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/change_orders_status_modal.html.twig' %}
 
   {% block orders_kpi %}
-    <div class="card card-kpis">
-      <div class="row orders-kpi">
-        {{ render(controller(
-          'PrestaShopBundle:Admin\\Common:renderKpiRow',
-          { 'kpiRow': orderKpi }
-        )) }}
-      </div>
-    </div>
+    {{ render(controller(
+      'PrestaShopBundle:Admin\\Common:renderKpiRow',
+      { 'kpiRow': orderKpi }
+    )) }}
   {% endblock %}
 
   {% block order_grid_row %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Refactored rendering of KPIs on modern pages. Much simplier code, removed coding mistakes, ability to refresh on mobile (left more space for the floating button).
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26667
| How to test?      | Open KPIs on all pages and check that they behave better than before - Orders, Categories, Customers, Shopping carts and Translations.
| Possible impacts? | No

**Result**
(header and menu removed on the gif)
![KPI](https://user-images.githubusercontent.com/6097524/142415602-03c0a511-18e6-4d7d-aae8-f5bc9e5ec3a6.gif)

ping @NeOMakinG 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26669)
<!-- Reviewable:end -->
