### PR TITLE
Fix button alignment inside input-group

### DIFF
--- a/themes/classic/_dev/css/partials/_commons.scss
+++ b/themes/classic/_dev/css/partials/_commons.scss
@@ -152,6 +152,8 @@ small.value {
 }
 
 .input-group {
+  display: flex;
+
   &.focus {
     outline: 0.1875rem solid $brand-primary;
   }
@@ -161,10 +163,13 @@ small.value {
   }
 
   .input-group-btn {
-    height: 100%;
+    width: auto;
 
     > .btn {
-      padding: 0.625rem 1rem;
+      display: flex;
+      align-items: center;
+      height: 100%;
+      padding: 0.25rem 1rem;
       margin-left: 0;
       font-size: 0.6875rem;
       font-weight: 500;

--- a/themes/classic/_dev/css/partials/_commons.scss
+++ b/themes/classic/_dev/css/partials/_commons.scss
@@ -163,6 +163,7 @@ small.value {
   }
 
   .input-group-btn {
+    display: block;
     width: auto;
 
     > .btn {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Now input-group buttons are properly aligned and follow input height changes on all browsers
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26644 .
| How to test?      | Go to login/create account page.
| Possible impacts? | Every `class="input-group"`, but already checked all from Classic theme v.1.7.8.x


![psform](https://user-images.githubusercontent.com/5007456/142504079-fc8673b8-d3c0-4508-8a3d-4d9c5a8767d5.gif)
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26673)
<!-- Reviewable:end -->
