### PR TITLE
Order::$total_paid_real is not deprecated and used in the new Order page

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -107,7 +107,7 @@ class OrderCore extends ObjectModel
     /** @var float Total to pay tax excluded */
     public $total_paid_tax_excl;
 
-    /** @var float Total really paid @deprecated 1.5.0.1 */
+    /** @var float Total really paid */
     public $total_paid_real;
 
     /** @var float Products total */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Order::$total_paid_real is not deprecated and used in the new Order page.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need QA.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26683)
<!-- Reviewable:end -->
