### PR TITLE
Optimize cart list in customer detail (a bit)

### DIFF
--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -314,7 +314,7 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
         foreach ($result as $row) {
             $cart = new Cart((int) row['id_cart']);
             $customerCarts[] = new CartInformation(
-                sprintf('%06d', $row['id_cart'])
+                sprintf('%06d', $row['id_cart']),
                 Tools::displayDate($row['date_add'], null, true),
                 $this->locale->formatPrice($cart->getOrderTotal(true), $row['iso_code']),
                 $row['carrier_name']

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -312,7 +312,7 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
         
         $customerCarts = [];
         foreach ($result as $row) {
-            $cart = new Cart((int) row['id_cart']);
+            $cart = new Cart((int) $row['id_cart']);
             $customerCarts[] = new CartInformation(
                 sprintf('%06d', $row['id_cart']),
                 Tools::displayDate($row['date_add'], null, true),

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -309,7 +309,7 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
         LEFT JOIN ' . _DB_PREFIX_ . 'currency cu ON cu.id_currency = c.id_currency
         WHERE c.`id_customer` = ' . (int) $customer->id . '
         ORDER BY c.`date_add` DESC');
-        
+
         $customerCarts = [];
         foreach ($result as $row) {
             $cart = new Cart((int) $row['id_cart']);

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -302,28 +302,24 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
      */
     private function getCustomerCarts(Customer $customer)
     {
-        $carts = Cart::getCustomerCarts($customer->id);
+        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
+        SELECT c.id_cart, c.date_add, ca.name as carrier_name, c.id_currency, cu.iso_code as currency_iso_code
+        FROM ' . _DB_PREFIX_ . 'cart c
+        LEFT JOIN ' . _DB_PREFIX_ . 'carrier ca ON ca.id_carrier = c.id_carrier
+        LEFT JOIN ' . _DB_PREFIX_ . 'currency cu ON cu.id_currency = c.id_currency
+        WHERE c.`id_customer` = ' . (int) $customer->id . '
+        ORDER BY c.`date_add` DESC');
+        
         $customerCarts = [];
-
-        foreach ($carts as $cart) {
-            $cart = new Cart((int) $cart['id_cart']);
-            Context::getContext()->cart = $cart;
-
-            $currency = new Currency($cart->id_currency);
-            Context::getContext()->currency = $currency;
-
-            $carrier = new Carrier($cart->id_carrier);
-            $summary = $cart->getSummaryDetails();
-
+        foreach ($result as $row) {
+            $cart = new Cart((int) row['id_cart']);
             $customerCarts[] = new CartInformation(
-                sprintf('%06d', $cart->id),
-                Tools::displayDate($cart->date_add, null, true),
-                $this->locale->formatPrice($summary['total_price'], $currency->iso_code),
-                $carrier->name
+                sprintf('%06d', $row['id_cart'])
+                Tools::displayDate($row['date_add'], null, true),
+                $this->locale->formatPrice($cart->getOrderTotal(true), $row['iso_code']),
+                $row['carrier_name']
             );
         }
-
-        Context::getContext()->currency = Currency::getDefaultCurrency();
 
         return $customerCarts;
     }

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Customer\QueryHandler;
 
-use Carrier;
 use Cart;
 use CartRule;
 use Category;

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -316,7 +316,7 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
             $customerCarts[] = new CartInformation(
                 sprintf('%06d', $row['id_cart']),
                 Tools::displayDate($row['date_add'], null, true),
-                $this->locale->formatPrice($cart->getOrderTotal(true), $row['iso_code']),
+                $this->locale->formatPrice($cart->getOrderTotal(true), $row['currency_iso_code']),
                 $row['carrier_name']
             );
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I speed up the cart listing on customer page a little bit. More info below.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25683 - only partial improvement, do not close
| How to test?      | Create many carts, and then open "View customer" page. Compare loading time before and after.
| Possible impacts? | Open customer detail and see that it works the same. Enable debug profilling in config/defines.ing and see that query count is reduced.

### Investigation
When customer has few orders, the page is slow AF. It's only slow because of carts listing.
Test scenario: 58 orders, 60 carts, 92 bought products, FAST SERVER

### Numbers of queries and time
| Case         | Queries | Time
| ----------------- | ----------------- | -----------------
| Original | 2070 | 2 seconds
| With my PR | 1720 | 1,4 seconds
| Without cart listing at all, but everything else | 73 | 0,3 seconds
| With cart listing at all, but no cart total | 74 | 0,3 seconds
| With cart listing, creating cart object, price formatting, but replacing `$cart->getOrderTotal(true)` for hardcoded number | 135 | 0,35 seconds

### Solutions
- Completely refactor cart calculation
- Cache cart total after every calculation to ps_cart table
- Remove cart total from all cart listings


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26689)
<!-- Reviewable:end -->
