### PR TITLE
In BackOffice, fixed the header search box oversized height

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -174,8 +174,8 @@ $header-text-color: #4e6167 !default;
         }
 
         .btn {
-          height: 0;
           width: 0;
+          height: 0;
           padding: 0;
           overflow: hidden;
           border: 0;

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -174,13 +174,13 @@ $header-text-color: #4e6167 !default;
         }
 
         .btn {
+          height: 0;
           width: 0;
           padding: 0;
           overflow: hidden;
           border: 0;
           // we can't use display:none or else the transition doesn't work
           opacity: 0;
-          height: 0;
         }
       }
     }

--- a/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_main_header.scss
@@ -180,6 +180,7 @@ $header-text-color: #4e6167 !default;
           border: 0;
           // we can't use display:none or else the transition doesn't work
           opacity: 0;
+          height: 0;
         }
       }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The header search box in new theme pages (e.g. Orders) has oversized height.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26635
| How to test?      | Go to BO > Orders. This problem can be seen more in RTL but exists (very little) in LTR too.
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26691)
<!-- Reviewable:end -->
