### PR TITLE
Fix dropdown align on email theme page

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_grid.scss
+++ b/admin-dev/themes/new-theme/scss/components/_grid.scss
@@ -67,7 +67,7 @@ table.grid-ordering-column tr.position-row-while-drag {
 .adminmailtheme {
   .action-type {
     .text-right {
-      .btn.tooltip-link {
+      .btn.preview-link {
         justify-content: flex-end;
       }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Dropdown text should be aligned to left, not to right on emailtheme page
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26604
| How to test?      | See issue
| Possible impacts? | Email theme BO page


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26714)
<!-- Reviewable:end -->
