### PR TITLE
Make Shop Parameters > Traffic & SEO > SEO & URLs forms multistore compatible

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/meta/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/meta/index.ts
@@ -67,4 +67,10 @@ $(() => {
 
   new TranslatableInput();
   new MetaPageNameOptionHandler();
+
+  window.prestashop.component.initComponents(
+    [
+      'MultistoreConfigField',
+    ],
+  );
 });

--- a/src/Adapter/Meta/SEOOptionsDataConfiguration.php
+++ b/src/Adapter/Meta/SEOOptionsDataConfiguration.php
@@ -26,25 +26,11 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Meta;
 
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 
-class SEOOptionsDataConfiguration implements DataConfigurationInterface
+class SEOOptionsDataConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var ConfigurationInterface
-     */
-    private $configuration;
-
-    /**
-     * @param ConfigurationInterface $configuration
-     */
-    public function __construct(ConfigurationInterface $configuration)
-    {
-        $this->configuration = $configuration;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Adapter/Meta/SEOOptionsDataConfiguration.php
+++ b/src/Adapter/Meta/SEOOptionsDataConfiguration.php
@@ -28,16 +28,26 @@ namespace PrestaShop\PrestaShop\Adapter\Meta;
 
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SEOOptionsDataConfiguration extends AbstractMultistoreConfiguration
 {
+    /**
+     * @var array<int, string>
+     */
+    private const CONFIGURATION_FIELDS = [
+        'product_attributes_in_title',
+    ];
+
     /**
      * {@inheritdoc}
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'product_attributes_in_title' => $this->configuration->getBoolean('PS_PRODUCT_ATTRIBUTES_IN_TITLE'),
+            'product_attributes_in_title' => (bool) $this->configuration->get('PS_PRODUCT_ATTRIBUTES_IN_TITLE', false, $shopConstraint),
         ];
     }
 
@@ -61,12 +71,14 @@ class SEOOptionsDataConfiguration extends AbstractMultistoreConfiguration
     }
 
     /**
-     * {@inheritdoc}
+     * @return OptionsResolver
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        return isset(
-            $configuration['product_attributes_in_title']
-        );
+        $resolver = (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('product_attributes_in_title', 'bool');
+
+        return $resolver;
     }
 }

--- a/src/Adapter/Meta/SEOOptionsDataConfiguration.php
+++ b/src/Adapter/Meta/SEOOptionsDataConfiguration.php
@@ -37,7 +37,7 @@ class SEOOptionsDataConfiguration extends AbstractMultistoreConfiguration
     public function getConfiguration()
     {
         return [
-            'product_attributes_in_title' => (bool) $this->configuration->get('PS_PRODUCT_ATTRIBUTES_IN_TITLE'),
+            'product_attributes_in_title' => $this->configuration->getBoolean('PS_PRODUCT_ATTRIBUTES_IN_TITLE'),
         ];
     }
 
@@ -49,7 +49,9 @@ class SEOOptionsDataConfiguration extends AbstractMultistoreConfiguration
         $errors = [];
         try {
             if ($this->validateConfiguration($configuration)) {
-                $this->configuration->set('PS_PRODUCT_ATTRIBUTES_IN_TITLE', $configuration['product_attributes_in_title']);
+                $shopConstraint = $this->getShopConstraint();
+
+                $this->updateConfigurationValue('PS_PRODUCT_ATTRIBUTES_IN_TITLE', 'product_attributes_in_title', $configuration, $shopConstraint);
             }
         } catch (CoreException $exception) {
             $errors[] = $exception->getMessage();

--- a/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
+++ b/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
@@ -86,15 +86,12 @@ final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
     public function updateConfiguration(array $configuration)
     {
         $errors = [];
+
         if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set('PS_REWRITING_SETTINGS', $configuration['friendly_url']);
-            $this->configuration->set('PS_ALLOW_ACCENTED_CHARS_URL', $configuration['accented_url']);
-            $this->configuration->set('PS_CANONICAL_REDIRECT', $configuration['canonical_url_redirection']);
-            $this->configuration->set('PS_HTACCESS_DISABLE_MULTIVIEWS', $configuration['disable_apache_multiview']);
-            $this->configuration->set('PS_HTACCESS_DISABLE_MODSEC', $configuration['disable_apache_mod_security']);
+            $shopConstraint = $this->getShopConstraint();
 
             if (!$this->htaccessFileGenerator->generateFile($configuration['disable_apache_multiview'])) {
-                $this->configuration->set('PS_REWRITING_SETTINGS', 0);
+                $configuration['friendly_url'] = 0;
 
                 $errorMessage = $this->translator
                     ->trans(
@@ -121,6 +118,12 @@ final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
 
                 $errors[] = $errorMessage;
             }
+
+            $this->updateConfigurationValue('PS_REWRITING_SETTINGS', 'friendly_url', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_ALLOW_ACCENTED_CHARS_URL', 'accented_url', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_CANONICAL_REDIRECT', 'canonical_url_redirection', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_HTACCESS_DISABLE_MULTIVIEWS', 'disable_apache_multiview', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_HTACCESS_DISABLE_MODSEC', 'disable_apache_mod_security', $configuration, $shopConstraint);
         }
 
         return $errors;

--- a/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
+++ b/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
@@ -28,20 +28,17 @@ namespace PrestaShop\PrestaShop\Adapter\Meta;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\File\HtaccessFileGenerator;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class SetUpUrlsDataConfiguration is responsible for saving, validating and getting configurations related with urls
  * configuration located in Shop parameters -> Traffic & Seo -> Seo & Urls.
  */
-final class SetUpUrlsDataConfiguration implements DataConfigurationInterface
+final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
 {
-    /**
-     * @var Configuration
-     */
-    private $configuration;
-
     /**
      * @var HtaccessFileGenerator
      */
@@ -56,15 +53,15 @@ final class SetUpUrlsDataConfiguration implements DataConfigurationInterface
      * SetUpUrlsDataConfiguration constructor.
      *
      * @param Configuration $configuration
+     * @param Context $shopContext
+     * @param FeatureInterface $multistoreFeature
      * @param HtaccessFileGenerator $htaccessFileGenerator
      * @param TranslatorInterface $translator
      */
-    public function __construct(
-        Configuration $configuration,
-        HtaccessFileGenerator $htaccessFileGenerator,
-        TranslatorInterface $translator
-    ) {
-        $this->configuration = $configuration;
+    public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature, HtaccessFileGenerator $htaccessFileGenerator, TranslatorInterface $translator)
+    {
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
+
         $this->htaccessFileGenerator = $htaccessFileGenerator;
         $this->translator = $translator;
     }

--- a/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
+++ b/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
@@ -105,7 +105,7 @@ final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
             $shopConstraint = $this->getShopConstraint();
 
             if (!$this->htaccessFileGenerator->generateFile($configuration['disable_apache_multiview'])) {
-                $configuration['friendly_url'] = 0;
+                $configuration['friendly_url'] = false;
 
                 $errorMessage = $this->translator
                     ->trans(

--- a/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
+++ b/src/Adapter/Meta/SetUpUrlsDataConfiguration.php
@@ -88,7 +88,7 @@ final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
         return [
             'friendly_url' => (bool) $this->configuration->get('PS_REWRITING_SETTINGS', false, $shopConstraint),
             'accented_url' => (bool) $this->configuration->get('PS_ALLOW_ACCENTED_CHARS_URL', false, $shopConstraint),
-            'canonical_url_redirection' => $this->configuration->get('PS_CANONICAL_REDIRECT', null, $shopConstraint),
+            'canonical_url_redirection' => (int) $this->configuration->get('PS_CANONICAL_REDIRECT', 0, $shopConstraint),
             'disable_apache_multiview' => (bool) $this->configuration->get('PS_HTACCESS_DISABLE_MULTIVIEWS', false, $shopConstraint),
             'disable_apache_mod_security' => (bool) $this->configuration->get('PS_HTACCESS_DISABLE_MODSEC', false, $shopConstraint),
         ];
@@ -152,7 +152,7 @@ final class SetUpUrlsDataConfiguration extends AbstractMultistoreConfiguration
             ->setDefined(self::CONFIGURATION_FIELDS)
             ->setAllowedTypes('friendly_url', 'bool')
             ->setAllowedTypes('accented_url', 'bool')
-            ->setAllowedTypes('canonical_url_redirection', 'string')
+            ->setAllowedTypes('canonical_url_redirection', 'int')
             ->setAllowedTypes('disable_apache_multiview', 'bool')
             ->setAllowedTypes('disable_apache_mod_security', 'bool');
 

--- a/src/Adapter/Meta/UrlSchemaDataConfiguration.php
+++ b/src/Adapter/Meta/UrlSchemaDataConfiguration.php
@@ -26,14 +26,16 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Meta;
 
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 
 /**
  * Class UrlSchemaDataConfiguration is responsible for validating, updating and retrieving data used in
  * Shop parameters -> Traffix & Seo -> Seo & Urls -> Set Shop URL form field.
  */
-final class UrlSchemaDataConfiguration implements DataConfigurationInterface
+final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
 {
     /**
      * @var array
@@ -41,20 +43,18 @@ final class UrlSchemaDataConfiguration implements DataConfigurationInterface
     private $rules;
 
     /**
-     * @var ConfigurationInterface
-     */
-    private $configuration;
-
-    /**
      * UrlSchemaDataConfiguration constructor.
      *
-     * @param ConfigurationInterface $configuration
+     * @param Configuration $configuration
+     * @param Context $shopContext
+     * @param FeatureInterface $multistoreFeature
      * @param array $rules
      */
-    public function __construct(ConfigurationInterface $configuration, array $rules)
+    public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature, array $rules)
     {
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
+
         $this->rules = $rules;
-        $this->configuration = $configuration;
     }
 
     /**

--- a/src/Adapter/Meta/UrlSchemaDataConfiguration.php
+++ b/src/Adapter/Meta/UrlSchemaDataConfiguration.php
@@ -64,7 +64,7 @@ final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
     {
         $configResult = [];
         foreach ($this->rules as $routeId => $defaultRule) {
-            $result = $this->getConfigurationValue($routeId) ?: $defaultRule;
+            $result = $this->configuration->get($this->getConfigurationKey($routeId)) ?: $defaultRule;
             $configResult[$routeId] = $result;
         }
 
@@ -77,8 +77,10 @@ final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
     public function updateConfiguration(array $configuration)
     {
         if ($this->validateConfiguration($configuration)) {
+            $shopConstraint = $this->getShopConstraint();
+
             foreach ($configuration as $routeId => $value) {
-                $this->updateConfigurationValue($routeId, $value);
+                $this->updateConfigurationValue($this->getConfigurationKey($routeId), $routeId, $configuration, $shopConstraint);
             }
         }
 
@@ -96,31 +98,6 @@ final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
         }
 
         return $configurationExists;
-    }
-
-    /**
-     * Gets configuration from configuration table.
-     *
-     * @param string $routeId
-     *
-     * @return string
-     */
-    private function getConfigurationValue($routeId)
-    {
-        return $this->configuration->get($this->getConfigurationKey($routeId));
-    }
-
-    /**
-     * Updates configuration data.
-     *
-     * @param string $routeId
-     * @param string $rule
-     *
-     * @return mixed
-     */
-    private function updateConfigurationValue($routeId, $rule)
-    {
-        return $this->configuration->set($this->getConfigurationKey($routeId), $rule);
     }
 
     /**

--- a/src/Adapter/Meta/UrlSchemaDataConfiguration.php
+++ b/src/Adapter/Meta/UrlSchemaDataConfiguration.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class UrlSchemaDataConfiguration is responsible for validating, updating and retrieving data used in
@@ -37,6 +38,19 @@ use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
  */
 final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
 {
+    /**
+     * @var array<int, string>
+     */
+    private const CONFIGURATION_FIELDS = [
+        'product_rule',
+        'category_rule',
+        'supplier_rule',
+        'manufacturer_rule',
+        'cms_rule',
+        'cms_category_rule',
+        'module',
+    ];
+
     /**
      * @var array
      */
@@ -63,8 +77,10 @@ final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
     public function getConfiguration()
     {
         $configResult = [];
+        $shopConstraint = $this->getShopConstraint();
+
         foreach ($this->rules as $routeId => $defaultRule) {
-            $result = $this->configuration->get($this->getConfigurationKey($routeId)) ?: $defaultRule;
+            $result = $this->configuration->get($this->getConfigurationKey($routeId), null, $shopConstraint) ?: $defaultRule;
             $configResult[$routeId] = $result;
         }
 
@@ -88,16 +104,21 @@ final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
     }
 
     /**
-     * {@inheritdoc}
+     * @return OptionsResolver
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        $configurationExists = true;
-        foreach (array_keys($configuration) as $routeId) {
-            $configurationExists &= isset($this->rules[$routeId]);
-        }
+        $resolver = (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('product_rule', 'string')
+            ->setAllowedTypes('category_rule', 'string')
+            ->setAllowedTypes('supplier_rule', 'string')
+            ->setAllowedTypes('manufacturer_rule', 'string')
+            ->setAllowedTypes('cms_rule', 'string')
+            ->setAllowedTypes('cms_category_rule', 'string')
+            ->setAllowedTypes('module', 'string');
 
-        return $configurationExists;
+        return $resolver;
     }
 
     /**

--- a/src/Adapter/Meta/UrlSchemaDataConfiguration.php
+++ b/src/Adapter/Meta/UrlSchemaDataConfiguration.php
@@ -39,19 +39,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
 {
     /**
-     * @var array<int, string>
-     */
-    private const CONFIGURATION_FIELDS = [
-        'product_rule',
-        'category_rule',
-        'supplier_rule',
-        'manufacturer_rule',
-        'cms_rule',
-        'cms_category_rule',
-        'module',
-    ];
-
-    /**
      * @var array
      */
     private $rules;
@@ -108,15 +95,13 @@ final class UrlSchemaDataConfiguration extends AbstractMultistoreConfiguration
      */
     protected function buildResolver(): OptionsResolver
     {
-        $resolver = (new OptionsResolver())
-            ->setDefined(self::CONFIGURATION_FIELDS)
-            ->setAllowedTypes('product_rule', 'string')
-            ->setAllowedTypes('category_rule', 'string')
-            ->setAllowedTypes('supplier_rule', 'string')
-            ->setAllowedTypes('manufacturer_rule', 'string')
-            ->setAllowedTypes('cms_rule', 'string')
-            ->setAllowedTypes('cms_category_rule', 'string')
-            ->setAllowedTypes('module', 'string');
+        $rulesIds = array_keys($this->rules);
+
+        $resolver = new OptionsResolver();
+        $resolver->setDefined($rulesIds);
+        foreach ($rulesIds as $ruleId) {
+            $resolver->setAllowedTypes($ruleId, 'string');
+        }
 
         return $resolver;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SEOOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SEOOptionsType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -50,7 +51,18 @@ class SEOOptionsType extends TranslatorAwareType
                     'Enable this option if you want to display your product\'s attributes in its meta title.',
                     'Admin.Shopparameters.Help'
                 ),
+                'multistore_configuration_key' => 'PS_PRODUCT_ATTRIBUTES_IN_TITLE',
             ])
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/SetUpUrlType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -104,6 +105,7 @@ class SetUpUrlType extends TranslatorAwareType
             ->add('friendly_url', SwitchType::class, [
                 'label' => $this->trans('Friendly URL', 'Admin.Global'),
                 'help' => $friendlyUrlHelp,
+                'multistore_configuration_key' => 'PS_REWRITING_SETTINGS',
             ])
             ->add('accented_url', SwitchType::class, [
                 'label' => $this->trans('Accented URL', 'Admin.Shopparameters.Feature'),
@@ -111,6 +113,7 @@ class SetUpUrlType extends TranslatorAwareType
                     'Enable this option if you want to allow accented characters in your friendly URLs. You should only activate this option if you are using non-Latin characters; for all the Latin charsets, your SEO will be better without this option.',
                     'Admin.Shopparameters.Help'
                 ),
+                'multistore_configuration_key' => 'PS_ALLOW_ACCENTED_CHARS_URL',
             ])
             ->add(
                 'canonical_url_redirection',
@@ -119,6 +122,7 @@ class SetUpUrlType extends TranslatorAwareType
                     'choices' => $this->canonicalUrlChoices,
                     'translation_domain' => false,
                     'label' => $this->trans('Redirect to the canonical URL', 'Admin.Shopparameters.Feature'),
+                    'multistore_configuration_key' => 'PS_CANONICAL_REDIRECT',
                 ]
             );
 
@@ -130,6 +134,7 @@ class SetUpUrlType extends TranslatorAwareType
                         'Enable this option only if you have problems with URL rewriting.',
                         'Admin.Shopparameters.Help'
                     ),
+                    'multistore_configuration_key' => 'PS_HTACCESS_DISABLE_MULTIVIEWS',
                 ])
                 ->add('disable_apache_mod_security', SwitchType::class, [
                     'label' => $this->trans('Disable Apache\'s mod_security module', 'Admin.Shopparameters.Feature'),
@@ -137,7 +142,18 @@ class SetUpUrlType extends TranslatorAwareType
                         'Some of PrestaShop\'s features might not work correctly with a specific configuration of Apache\'s mod_security module. We recommend to turn it off.',
                         'Admin.Shopparameters.Help'
                     ),
+                    'multistore_configuration_key' => 'PS_HTACCESS_DISABLE_MODSEC',
                 ]);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/UrlSchemaType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
 use PrestaShop\PrestaShop\Adapter\Routes\DefaultRouteProvider;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -65,6 +66,7 @@ class UrlSchemaType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'help' => $this->getKeywords('product_rule'),
+                'multistore_configuration_key' => 'PS_ROUTE_product_rule',
             ])
             ->add('category_rule', TextType::class, [
                 'label' => $this->trans(
@@ -72,6 +74,7 @@ class UrlSchemaType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'help' => $this->getKeywords('category_rule'),
+                'multistore_configuration_key' => 'PS_ROUTE_category_rule',
             ])
             ->add('supplier_rule', TextType::class, [
                 'label' => $this->trans(
@@ -79,6 +82,7 @@ class UrlSchemaType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'help' => $this->getKeywords('supplier_rule'),
+                'multistore_configuration_key' => 'PS_ROUTE_supplier_rule',
             ])
             ->add('manufacturer_rule', TextType::class, [
                 'label' => $this->trans(
@@ -86,6 +90,7 @@ class UrlSchemaType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'help' => $this->getKeywords('manufacturer_rule'),
+                'multistore_configuration_key' => 'PS_ROUTE_manufacturer_rule',
             ])
             ->add('cms_rule', TextType::class, [
                 'label' => $this->trans(
@@ -93,6 +98,7 @@ class UrlSchemaType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'help' => $this->getKeywords('cms_rule'),
+                'multistore_configuration_key' => 'PS_ROUTE_cms_rule',
             ])
             ->add('cms_category_rule', TextType::class, [
                 'label' => $this->trans(
@@ -100,6 +106,7 @@ class UrlSchemaType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'help' => $this->getKeywords('cms_category_rule'),
+                'multistore_configuration_key' => 'PS_ROUTE_cms_category_rule',
             ])
             ->add('module', TextType::class, [
                 'label' => $this->trans(
@@ -107,6 +114,7 @@ class UrlSchemaType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'help' => $this->getKeywords('module'),
+                'multistore_configuration_key' => 'PS_ROUTE_module',
             ]);
     }
 
@@ -148,5 +156,15 @@ class UrlSchemaType extends TranslatorAwareType
                     '%keywords%' => implode(', ', $formattedKeyWords),
                 ]
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/meta.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/meta.yml
@@ -54,7 +54,7 @@ admin_metas_delete_bulk:
 
 admin_metas_set_up_urls_save:
   path: /set-up-urls
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\MetaController::processSetUpUrlsFormAction'
     _legacy_controller: AdminMeta
@@ -69,14 +69,14 @@ admin_metas_shop_urls_save:
 
 admin_metas_url_schema_save:
   path: /url-schema
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\MetaController::processUrlSchemaFormAction'
     _legacy_controller: AdminMeta
 
 admin_metas_seo_options_save:
   path: /seo-options
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\MetaController::processSeoOptionsFormAction'
     _legacy_controller: AdminMeta

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -224,6 +224,8 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Meta\SetUpUrlsDataConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
       - '@prestashop.adapter.file.htaccess_file_generator'
       - '@translator'
 
@@ -238,12 +240,16 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Meta\UrlSchemaDataConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
       - '@=service("prestashop.adapter.data_provider.default_route").getRules()'
 
   prestashop.adapter.meta.seo_options.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Meta\SEOOptionsDataConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.core.team.employee.configuration.employee_options_configuration:
     class: 'PrestaShop\PrestaShop\Core\Team\Employee\Configuration\EmployeeOptionsConfiguration'

--- a/tests/Unit/Adapter/Meta/SEOOptionsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SEOOptionsDataConfigurationTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Preferences;
+
+use PrestaShop\PrestaShop\Adapter\Meta\SEOOptionsDataConfiguration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Tests\TestCase\AbstractConfigurationTestCase;
+
+class SEOOptionsDataConfigurationTest extends AbstractConfigurationTestCase
+{
+    private const SHOP_ID = 42;
+
+    /**
+     * @dataProvider provideShopConstraints
+     *
+     * @param ShopConstraint $shopConstraint
+     */
+    public function testGetConfiguration(ShopConstraint $shopConstraint): void
+    {
+        $sEOOptionsDataConfiguration = new SEOOptionsDataConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $this->mockShopConfiguration
+            ->method('getShopConstraint')
+            ->willReturn($shopConstraint);
+
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['PS_PRODUCT_ATTRIBUTES_IN_TITLE', false, $shopConstraint, true],
+                ]
+            );
+
+        $result = $sEOOptionsDataConfiguration->getConfiguration();
+        $this->assertSame(
+            [
+                'product_attributes_in_title' => true,
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidConfiguration
+     *
+     * @param string $exception
+     * @param array $values
+     */
+    public function testUpdateConfigurationWithInvalidConfiguration(string $exception, array $values): void
+    {
+        $sEOOptionsDataConfiguration = new SEOOptionsDataConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $this->expectException($exception);
+        $sEOOptionsDataConfiguration->updateConfiguration($values);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideInvalidConfiguration(): array
+    {
+        return [
+            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            [InvalidOptionsException::class, ['product_attributes_in_title' => 'wrong_type',]],
+        ];
+    }
+
+    public function testSuccessfulUpdate(): void
+    {
+        $sEOOptionsDataConfiguration = new SEOOptionsDataConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $res = $sEOOptionsDataConfiguration->updateConfiguration([
+            'product_attributes_in_title' => true,
+        ]);
+
+        $this->assertSame([], $res);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideShopConstraints(): array
+    {
+        return [
+            [ShopConstraint::shop(self::SHOP_ID)],
+            [ShopConstraint::shopGroup(self::SHOP_ID)],
+            [ShopConstraint::allShops()],
+        ];
+    }
+}

--- a/tests/Unit/Adapter/Meta/SEOOptionsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SEOOptionsDataConfigurationTest.php
@@ -89,7 +89,7 @@ class SEOOptionsDataConfigurationTest extends AbstractConfigurationTestCase
     {
         return [
             [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
-            [InvalidOptionsException::class, ['product_attributes_in_title' => 'wrong_type',]],
+            [InvalidOptionsException::class, ['product_attributes_in_title' => 'wrong_type']],
         ];
     }
 

--- a/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
@@ -70,7 +70,7 @@ class SetUpUrlsDataConfigurationTest extends AbstractConfigurationTestCase
     /**
      * @return HtaccessFileGenerator
      */
-    protected function createHtaccessFileGeneratorMock()
+    protected function createHtaccessFileGeneratorMock(): HtaccessFileGenerator
     {
         $stub = $this->getMockBuilder(HtaccessFileGenerator::class)
             ->disableOriginalConstructor()
@@ -85,7 +85,7 @@ class SetUpUrlsDataConfigurationTest extends AbstractConfigurationTestCase
     /**
      * @return TranslatorInterface
      */
-    protected function createTranslatorMock()
+    protected function createTranslatorMock(): TranslatorInterface
     {
         return $this->getMockBuilder(TranslatorInterface::class)
             ->disableOriginalConstructor()

--- a/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Meta;
+
+use PrestaShop\PrestaShop\Adapter\File\HtaccessFileGenerator;
+use PrestaShop\PrestaShop\Adapter\Meta\SetUpUrlsDataConfiguration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\Translation\TranslatorInterface;
+use Tests\TestCase\AbstractConfigurationTestCase;
+
+class SetUpUrlsDataConfigurationTest extends AbstractConfigurationTestCase
+{
+    private const SHOP_ID = 42;
+
+    private const VALID_CONFIGURATION = [
+        'friendly_url' => true,
+        'accented_url' => true,
+        'canonical_url_redirection' => 1,
+        'disable_apache_multiview' => true,
+        'disable_apache_mod_security' => true,
+    ];
+
+    /**
+     * @var HtaccessFileGenerator
+     */
+    private $mockHtaccessFileGenerator;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $mockTranslator;
+
+    protected function setUp(): void
+    {
+        $this->mockConfiguration = $this->createConfigurationMock();
+        $this->mockShopConfiguration = $this->createShopContextMock();
+        $this->mockMultistoreFeature = $this->createMultistoreFeatureMock();
+        $this->mockHtaccessFileGenerator = $this->createHtaccessFileGeneratorMock();
+        $this->mockTranslator = $this->createTranslatorMock();
+    }
+
+    /**
+     * @return HtaccessFileGenerator
+     */
+    protected function createHtaccessFileGeneratorMock()
+    {
+        return $this->getMockBuilder(HtaccessFileGenerator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return TranslatorInterface
+     */
+    protected function createTranslatorMock()
+    {
+        return $this->getMockBuilder(TranslatorInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+
+    /**
+     * @dataProvider provideShopConstraints
+     *
+     * @param ShopConstraint $shopConstraint
+     */
+    public function testGetConfiguration(ShopConstraint $shopConstraint): void
+    {
+        $setUpUrlsDataConfiguration = new SetUpUrlsDataConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature,
+            $this->mockHtaccessFileGenerator,
+            $this->mockTranslator
+        );
+
+        $this->mockShopConfiguration
+            ->method('getShopConstraint')
+            ->willReturn($shopConstraint);
+
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['PS_REWRITING_SETTINGS', false, $shopConstraint, true],
+                    ['PS_ALLOW_ACCENTED_CHARS_URL', false, $shopConstraint, true],
+                    ['PS_CANONICAL_REDIRECT', 0, $shopConstraint, 1],
+                    ['PS_HTACCESS_DISABLE_MULTIVIEWS', false, $shopConstraint, true],
+                    ['PS_HTACCESS_DISABLE_MODSEC', false, $shopConstraint, true],                    
+                ]
+            );
+
+        $result = $setUpUrlsDataConfiguration->getConfiguration();
+        $this->assertSame(static::VALID_CONFIGURATION,
+            $result
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidConfiguration
+     *
+     * @param string $exception
+     * @param array $values
+     */
+    public function testUpdateConfigurationWithInvalidConfiguration(string $exception, array $values): void
+    {
+        $setUpUrlsDataConfiguration = new SetUpUrlsDataConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature,
+            $this->mockHtaccessFileGenerator,
+            $this->mockTranslator
+        );
+
+        $this->expectException($exception);
+        $setUpUrlsDataConfiguration->updateConfiguration($values);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideInvalidConfiguration(): array
+    {
+        return [
+            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['friendly_url' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['accented_url' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['canonical_url_redirection' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['disable_apache_multiview' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['disable_apache_mod_security' => 'wrong_type'])],
+        ];
+    }
+
+    public function testSuccessfulUpdate(): void
+    {
+        $setUpUrlsDataConfiguration = new SetUpUrlsDataConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature,
+            $this->mockHtaccessFileGenerator,
+            $this->mockTranslator
+        );
+
+        $res = $setUpUrlsDataConfiguration->updateConfiguration(self::VALID_CONFIGURATION);
+
+        $this->assertSame([], $res);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideShopConstraints(): array
+    {
+        return [
+            [ShopConstraint::shop(self::SHOP_ID)],
+            [ShopConstraint::shopGroup(self::SHOP_ID)],
+            [ShopConstraint::allShops()],
+        ];
+    }
+}

--- a/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
+++ b/tests/Unit/Adapter/Meta/SetUpUrlsDataConfigurationTest.php
@@ -115,7 +115,7 @@ class SetUpUrlsDataConfigurationTest extends AbstractConfigurationTestCase
                     ['PS_ALLOW_ACCENTED_CHARS_URL', false, $shopConstraint, true],
                     ['PS_CANONICAL_REDIRECT', 0, $shopConstraint, 1],
                     ['PS_HTACCESS_DISABLE_MULTIVIEWS', false, $shopConstraint, true],
-                    ['PS_HTACCESS_DISABLE_MODSEC', false, $shopConstraint, true],                    
+                    ['PS_HTACCESS_DISABLE_MODSEC', false, $shopConstraint, true],
                 ]
             );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add multistore checkboxes/dropdowns on SEO & URLs page
| Type?             | new feature
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #19368. Fixes #19320.
| How to test?      | See issues
| Possible impacts? | -
| Sponsor company | @Creabilis

## BC BREAKS:

- `SetUpUrlsDataConfiguration` (constructor)
- `UrlSchemaDataConfiguration ` (constructor)
- `SEOOptionsDataConfiguration ` (constructor)

These data configuration classes now extend `AbstractMultistoreConfiguration`, which implies those BC break.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26716)
<!-- Reviewable:end -->
