### PR TITLE
Set correct "attributes_quantity" on the group level

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -719,17 +719,17 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                         INNER JOIN `' . _DB_PREFIX_ . 'stock_available` pa ON pa.id_product_attribute = pac2.id_product_attribute
                         WHERE pac2.`id_product_attribute` IN (' . implode(',', array_map('intval', $id_product_attributes)) . ')
                         AND pac2.id_attribute NOT IN (' . implode(',', array_map('intval', $current_selected_attributes)) . ')');
-					foreach ($id_attributes as $k => $row) {
-						$id_attributes[$k] = (int) $row['id_attribute'];
-						$qty = (int) $row['quantity'];
-						if ($qty <= 0) {
-							$group['attributes_quantity'][$row['id_attribute']] = $qty;
-							if (Product::isAvailableWhenOutOfStock($this->product->out_of_stock)) {
-								$group['attributes_quantity'][$row['id_attribute']] = 1;
-							} elseif (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
-								unset($id_attributes[$k]);
-							}
-						}
+                    foreach ($id_attributes as $k => $row) {
+                        $id_attributes[$k] = (int) $row['id_attribute'];
+                        $qty = (int) $row['quantity'];
+                        if ($qty <= 0) {
+                            $group['attributes_quantity'][$row['id_attribute']] = $qty;
+                            if (Product::isAvailableWhenOutOfStock($this->product->out_of_stock)) {
+                                $group['attributes_quantity'][$row['id_attribute']] = 1;
+                            } elseif (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
+                                unset($id_attributes[$k]);
+                            }
+                        }
                     }
                     foreach ($group['attributes'] as $key => $attribute) {
                         if (!in_array((int) $key, $id_attributes)) {


### PR DESCRIPTION
Setting the correct quantity attribution per attribute on each attribute selection to display correctly the other attributes available with the current selection. This is userful for other templates (not classic) that have implemented on the product-variants.tpl the attribute quantity class
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Setting the correct quantity attribution per attribute on each attribute selection to display correctly the other attributes available with the current selection. This is userful for other templates (not classic) that have implemented on the product-variants.tpl the attribute quantity class
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Use another theme, like "warehouse" and in a product with combinations set one combination with at least two groups (size and color for example) without stock. You will see the attribute without stock appear "greyed" indicating out of stock on the variants options selectors
| Possible impacts? | As per see, none impact due classic theme don't use nothing of "group.attributes_quantity" on "product-variations.tpl". On other themes, will see a correct behavior of the attributes that can be out of stock with the current selection

![image](https://user-images.githubusercontent.com/5998908/143261894-dfca231c-e270-4272-8463-744faf00ed1b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26733)
<!-- Reviewable:end -->
