### PR TITLE
Allow Profiler to work with directly included modules

### DIFF
--- a/tools/profiling/Hook.php
+++ b/tools/profiling/Hook.php
@@ -64,8 +64,8 @@ class Hook extends HookCore
         $result = parent::coreRenderWidget($module, $registeredHookName, $params);
 
         if (!$registeredHookName) {
-			$registeredHookName = 'directWidget';
-		}
+            $registeredHookName = 'directWidget';
+        }
 
         Profiler::getInstance()->interceptHook(
             $registeredHookName,

--- a/tools/profiling/Hook.php
+++ b/tools/profiling/Hook.php
@@ -63,6 +63,10 @@ class Hook extends HookCore
 
         $result = parent::coreRenderWidget($module, $registeredHookName, $params);
 
+        if (!$registeredHookName) {
+			$registeredHookName = 'directWidget';
+		}
+
         Profiler::getInstance()->interceptHook(
             $registeredHookName,
             [


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Some theme developers (like Iqit on the theme "warehouse") include directly their modules on the tpls using things like "_{widget name="iqitsearch"}_". With that, when you enable _PS_DEBUG_PROFILING_ PrestaShop dies because the Profiler expect a hook name, that is not included on the widget declaration. With this change over the Profiler, this works again and set this type of actions with the name "directWidget" over the profiler table.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Use the warehouse template and enable _PS_DEBUG_PROFILING_ on your defines.inc.php
| Possible impacts? | None, include really a little workaround when the hook name is null to continue profiling PrestaShop

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26735)
<!-- Reviewable:end -->
