### PR TITLE
Improvements to profiling: display order of query execution,

### DIFF
--- a/tools/profiling/Db.php
+++ b/tools/profiling/Db.php
@@ -110,9 +110,9 @@ abstract class Db extends DbCore
             $stack_light = [];
             foreach ($stack as $call) {
                 $stack_light[] = [
-                    'file' => isset($call['file']) ? $call['file'] : 'undefined',
-                    'line' => isset($call['line']) ? $call['line'] : 'undefined',
-                    'function' => isset($call['function']) ? $call['function'] : 'undefined',
+                    'file' => $call['file'] ?? 'undefined',
+                    'line' => $call['line'] ?? 'undefined',
+                    'function' => $call['function'] ?? 'undefined',
                 ];
             }
 

--- a/tools/profiling/Db.php
+++ b/tools/profiling/Db.php
@@ -103,13 +103,17 @@ abstract class Db extends DbCore
         if (!$explain) {
             $end = microtime(true);
 
-            $stack = debug_backtrace(0);
+            $stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
             while (preg_match('@[/\\\\]classes[/\\\\]db[/\\\\]@i', $stack[0]['file'])) {
                 array_shift($stack);
             }
             $stack_light = [];
             foreach ($stack as $call) {
-                $stack_light[] = ['file' => isset($call['file']) ? $call['file'] : 'undefined', 'line' => isset($call['line']) ? $call['line'] : 'undefined'];
+                $stack_light[] = [
+                    'file' => isset($call['file']) ? $call['file'] : 'undefined',
+                    'line' => isset($call['line']) ? $call['line'] : 'undefined',
+                    'function' => isset($call['function']) ? $call['function'] : 'undefined',
+                ];
             }
 
             $this->queries[] = [

--- a/tools/profiling/ObjectModel.php
+++ b/tools/profiling/ObjectModel.php
@@ -37,7 +37,7 @@ abstract class ObjectModel extends ObjectModelCore
         }
 
         $class_list = ['ObjectModel', 'ObjectModelCore', $classname, $classname . 'Core'];
-        $backtrace = debug_backtrace();
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
         foreach ($backtrace as $trace_id => $row) {
             if (!isset($backtrace[$trace_id]['class']) || !in_array($backtrace[$trace_id]['class'], $class_list)) {
                 break;
@@ -49,8 +49,10 @@ abstract class ObjectModel extends ObjectModelCore
         --$trace_id;
 
         self::$debug_list[$classname][] = [
-            'file' => @$backtrace[$trace_id]['file'],
-            'line' => @$backtrace[$trace_id]['line'],
+            'file' => $backtrace[$trace_id]['file'] ?? '',
+            'line' => $backtrace[$trace_id]['line'] ?? 0,
+            'function' => $backtrace[$trace_id]['function'] ?? 0,
+            'id' => $id,
         ];
     }
 }

--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -224,7 +224,7 @@ class Profiler
         // Sum querying time
         $queries = Db::getInstance()->queries;
         uasort($queries, [$this, 'sortByQueryTime']);
-        foreach ($queries as $data) {
+        foreach ($queries as $id => $data) {
             $this->totalQueryTime += $data['time'];
 
             $queryRow = [
@@ -235,6 +235,7 @@ class Profiler
                 'rows' => 1,
                 'group_by' => false,
                 'stack' => [],
+                'id' => $id,
             ];
 
             if (preg_match('/^\s*select\s+/i', $data['query'])) {
@@ -254,7 +255,7 @@ class Profiler
 
             array_shift($data['stack']);
             foreach ($data['stack'] as $call) {
-                $queryRow['stack'][] = str_replace('\\', '/', substr($call['file'], strlen(_PS_ROOT_DIR_))) . ':' . $call['line'];
+                $queryRow['stack'][] = str_replace('\\', '/', substr($call['file'], strlen(_PS_ROOT_DIR_))) . ':' . $call['line'] . ' (' . $call['function'] . ')';
             }
 
             $this->queries[] = $queryRow;

--- a/tools/profiling/templates/objectmodel.tpl
+++ b/tools/profiling/templates/objectmodel.tpl
@@ -47,7 +47,7 @@
           </td>
           <td>
             {foreach $info as $trace}
-              {str_replace([_PS_ROOT_DIR_, '\\'], ['', '/'], $trace['file'])} [{$trace['line']}]
+              {str_replace([_PS_ROOT_DIR_, '\\'], ['', '/'], $trace['file'])}:{$trace['line']} ({$trace['function']}) [id: {$trace['id']}]
               <br />
             {/foreach}
           </td>

--- a/tools/profiling/templates/stopwatch.tpl
+++ b/tools/profiling/templates/stopwatch.tpl
@@ -47,7 +47,7 @@
         {$callstack_md5 = md5($callstack)}
         <tr>
           <td>{$data['id']}</td>
-          <td class="pre"><pre>{preg_replace("/(^[\s]*)/m", "", htmlspecialchars($data['query'], ENT_NOQUOTES, 'utf-8', false))}</pre></td>
+          <td class="pre" style="max-width: 60vw"><pre>{preg_replace("/(^[\s]*)/m", "", htmlspecialchars($data['query'], ENT_NOQUOTES, 'utf-8', false))}</pre></td>
           <td data-value="{$data['time']}">
             {load_time data=($data['time'] * 1000)}
           </td>

--- a/tools/profiling/templates/stopwatch.tpl
+++ b/tools/profiling/templates/stopwatch.tpl
@@ -32,6 +32,7 @@
   <table class="table table-condensed table-bordered sortable">
     <thead>
       <tr>
+        <th>#</th>
         <th>Query</th>
         <th>Time (ms)</th>
         <th>Rows</th>
@@ -45,6 +46,7 @@
         {$callstack = implode('<br>', $data['stack'])}
         {$callstack_md5 = md5($callstack)}
         <tr>
+          <td>{$data['id']}</td>
           <td class="pre"><pre>{preg_replace("/(^[\s]*)/m", "", htmlspecialchars($data['query'], ENT_NOQUOTES, 'utf-8', false))}</pre></td>
           <td data-value="{$data['time']}">
             {load_time data=($data['time'] * 1000)}


### PR DESCRIPTION
display function in stacktrace.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improve Profiling mode: add a column with execution order in Stopwatch SQL, add the function name in the stacktrace, add max-width of *Queries* column
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26745.
| How to test?      | 1. Enable profiling mode. 2. Scroll down to `Stopwatch SQL` section. 3. Notice a) There is a new initial column with a number: it's the order of executions. You can click on the header to reorder the table. b) The query column has a max width, and the table fits on the screen width (desktop). c) The function name displays in the stacktrace (click on the filename to expand the stacktrace)
| Possible impacts? | None.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26746)
<!-- Reviewable:end -->
