### PR TITLE
Instead of testing each hook if it is active, query once and cache.

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1269,7 +1269,10 @@ class HookCore extends ObjectModel
      */
     public static function getHookStatusByName($hook_name): bool
     {
-        if (!Cache::isStored('hook_active')) {
+        $hook_names = [];
+        if (Cache::isStored('hook_active')) {
+            $hook_names = Cache::retrieve('hook_active');
+        } else {
             $sql = new DbQuery();
             $sql->select('name');
             $sql->from('hook', 'h');
@@ -1283,6 +1286,6 @@ class HookCore extends ObjectModel
             }
         }
 
-        return in_array($hook_name, Cache::retrieve('hook_active'));
+        return in_array($hook_name, $hook_names);
     }
 }

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1267,9 +1267,9 @@ class HookCore extends ObjectModel
      *
      * @return bool
      */
-    public static function getHookStatusByName($hook_name, $refreshCache = false): bool
+    public static function getHookStatusByName($hook_name): bool
     {
-        if ($refreshCache || !Cache::isStored('hook_active')) {
+        if (!Cache::isStored('hook_active')) {
             $sql = new DbQuery();
             $sql->select('name');
             $sql->from('hook', 'h');

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -131,7 +131,7 @@ class HookCore extends ObjectModel
         return parent::add($autodate, $null_values);
     }
 
-    public function clearCache(bool $all = false): bool
+    public function clearCache($all = false)
     {
         Cache::clean('hook_*');
         parent::clearCache($all);

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -131,7 +131,7 @@ class HookCore extends ObjectModel
         return parent::add($autodate, $null_values);
     }
 
-    public function clearCache($all = false)
+    public function clearCache(bool $all = false): bool
     {
         Cache::clean('hook_*');
         parent::clearCache($all);
@@ -1276,7 +1276,10 @@ class HookCore extends ObjectModel
             $sql->where('h.active = 1');
             $active_hooks = Db::getInstance()->executeS($sql);
             if (!empty($active_hooks)) {
-                Cache::store('hook_active', array_column($active_hooks, 'name'));
+                $hook_names = array_column($active_hooks, 'name');
+                if (is_array($hook_names)) {
+                    Cache::store('hook_active', $hook_names);
+                }
             }
         }
 

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -61,6 +61,11 @@ class HookCore extends ObjectModel
     public static $native_module;
 
     /**
+     * @var array|null Names of active hooks
+     */
+    protected static $active_hooks = null;
+
+    /**
      * @see ObjectModel::$definition
      */
     public static $definition = [
@@ -1262,11 +1267,14 @@ class HookCore extends ObjectModel
      */
     public static function getHookStatusByName($hook_name): bool
     {
-        $sql = new DbQuery();
-        $sql->select('active');
-        $sql->from('hook', 'h');
-        $sql->where('h.name = "' . pSQL($hook_name) . '"');
+        if (is_null(self::$active_hooks)) {
+            $sql = new DbQuery();
+            $sql->select('name');
+            $sql->from('hook', 'h');
+            $sql->where('h.active = 1');
+            self::$active_hooks = array_column(Db::getInstance()->executeS($sql), 'name');
+        }
 
-        return (bool) Db::getInstance()->getValue($sql);
+        return in_array($hook_name, self::$active_hooks);
     }
 }

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -126,14 +126,17 @@ class HookCore extends ObjectModel
     public function add($autodate = true, $null_values = false)
     {
         Cache::clean('hook_idsbyname');
-        Cache::clean('hook_active');
+        Cache::clean('hook_idsbyname_withalias');
+        Cache::clean('active_hooks');
 
         return parent::add($autodate, $null_values);
     }
 
     public function clearCache($all = false)
     {
-        Cache::clean('hook_*');
+        Cache::clean('hook_idsbyname');
+        Cache::clean('hook_idsbyname_withalias');
+        Cache::clean('active_hooks');
         parent::clearCache($all);
     }
 
@@ -1270,8 +1273,8 @@ class HookCore extends ObjectModel
     public static function getHookStatusByName($hook_name): bool
     {
         $hook_names = [];
-        if (Cache::isStored('hook_active')) {
-            $hook_names = Cache::retrieve('hook_active');
+        if (Cache::isStored('active_hooks')) {
+            $hook_names = Cache::retrieve('active_hooks');
         } else {
             $sql = new DbQuery();
             $sql->select('name');
@@ -1281,7 +1284,7 @@ class HookCore extends ObjectModel
             if (!empty($active_hooks)) {
                 $hook_names = array_column($active_hooks, 'name');
                 if (is_array($hook_names)) {
-                    Cache::store('hook_active', $hook_names);
+                    Cache::store('active_hooks', $hook_names);
                 }
             }
         }

--- a/tests-legacy/Unit/Controller/Admin/AdminTabsControllerTest.php
+++ b/tests-legacy/Unit/Controller/Admin/AdminTabsControllerTest.php
@@ -105,8 +105,9 @@ class AdminTabsControllerTest extends UnitTestCase
                 if ($subject instanceof DbQuery) {
                     $builtQuery = $subject->build();
 
-                    // It should select modules
-                    return strpos($builtQuery, 'module') !== false;
+                    // It should select modules and test if hook is active
+                    return strpos($builtQuery, 'module') !== false ||
+                        strpos($builtQuery, 'hook') !== false;
 
                 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Reduce the number of queries on one by page by 50 - 150 (!)
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26747.
| How to test?      | Compare any FO page in Profiling mode before an after fix.
| Possible impacts? | Performance improvement. No other impact is possible, the cange is very constrained.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26748)
<!-- Reviewable:end -->
