### PR TITLE
Fix missing canonicals

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -40,6 +40,32 @@ use PrestaShop\PrestaShop\Core\Product\Search\SortOrder;
 abstract class ProductListingFrontControllerCore extends ProductPresentingFrontController
 {
     /**
+     * Generates an URL to a product listing controller
+     * with only the essential query params and page remaining.
+     *
+     * @param string $canonicalUrl an url to a listing controller page
+     *
+     * @return string a canonical URL for the current page in the list
+     */
+    public function buildPaginatedUrl(string $canonicalUrl): string
+    {
+        $parsedUrl = parse_url($canonicalUrl);
+        if (isset($parsedUrl['query'])) {
+            parse_str($parsedUrl['query'], $params);
+        } else {
+            $params = [];
+        }
+        $page = (int) Tools::getValue('page');
+        if ($page > 1) {
+            $params['page'] = $page;
+        } else {
+            unset($params['page']);
+        }
+
+        return http_build_url($parsedUrl, ['query' => http_build_query($params)]);
+    }
+
+    /**
      * Takes an associative array with at least the "id_product" key
      * and returns an array containing all information necessary for
      * rendering the product in the template.

--- a/controllers/front/listing/BestSalesController.php
+++ b/controllers/front/listing/BestSalesController.php
@@ -31,6 +31,11 @@ class BestSalesControllerCore extends ProductListingFrontController
 {
     public $php_self = 'best-sales';
 
+    public function getCanonicalURL(): string
+    {
+        return $this->buildPaginatedUrl($this->context->link->getPageLink('best-sales'));
+    }
+
     /**
      * Initializes controller.
      *

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -59,22 +59,8 @@ class CategoryControllerCore extends ProductListingFrontController
         if (!Validate::isLoadedObject($this->category)) {
             return '';
         }
-        $canonicalUrl = $this->context->link->getCategoryLink($this->category);
-        $parsedUrl = parse_url($canonicalUrl);
-        $params = [];
-        $page = (int) Tools::getValue('page');
 
-        if (isset($parsedUrl['query'])) {
-            parse_str($parsedUrl['query'], $params);
-        }
-
-        if ($page > 1) {
-            $params['page'] = $page;
-        } else {
-            unset($params['page']);
-        }
-
-        return http_build_url($parsedUrl, ['query' => http_build_query($params)]);
+        return $this->buildPaginatedUrl($this->context->link->getCategoryLink($this->category));
     }
 
     /**

--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -43,6 +43,15 @@ class ManufacturerControllerCore extends ProductListingFrontController
         }
     }
 
+    public function getCanonicalURL(): string
+    {
+        if (Validate::isLoadedObject($this->manufacturer)) {
+            return $this->buildPaginatedUrl($this->context->link->getManufacturerLink($this->manufacturer));
+        }
+
+        return $this->context->link->getPageLink('manufacturer');
+    }
+
     /**
      * Initialize manufaturer controller.
      *

--- a/controllers/front/listing/NewProductsController.php
+++ b/controllers/front/listing/NewProductsController.php
@@ -31,6 +31,11 @@ class NewProductsControllerCore extends ProductListingFrontController
 {
     public $php_self = 'new-products';
 
+    public function getCanonicalURL(): string
+    {
+        return $this->buildPaginatedUrl($this->context->link->getPageLink('new-products'));
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/controllers/front/listing/PricesDropController.php
+++ b/controllers/front/listing/PricesDropController.php
@@ -31,6 +31,11 @@ class PricesDropControllerCore extends ProductListingFrontController
 {
     public $php_self = 'prices-drop';
 
+    public function getCanonicalURL(): string
+    {
+        return $this->buildPaginatedUrl($this->context->link->getPageLink('prices-drop'));
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/controllers/front/listing/SearchController.php
+++ b/controllers/front/listing/SearchController.php
@@ -61,6 +61,11 @@ class SearchControllerCore extends ProductListingFrontController
         );
     }
 
+    public function getCanonicalURL(): string
+    {
+        return $this->buildPaginatedUrl($this->context->link->getPageLink('search', null, null, ['s' => $this->search_string]));
+    }
+
     /**
      * Ensure that no search results page is indexed by search engines.
      */

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -44,6 +44,15 @@ class SupplierControllerCore extends ProductListingFrontController
         }
     }
 
+    public function getCanonicalURL(): string
+    {
+        if (Validate::isLoadedObject($this->supplier)) {
+            return $this->buildPaginatedUrl($this->context->link->getSupplierLink($this->supplier));
+        }
+
+        return $this->context->link->getPageLink('supplier');
+    }
+
     /**
      * Initialize supplier controller.
      *


### PR DESCRIPTION
Add of canonical links for bestsales, manufacturer, newproducts, pricesdrop, search and supplier.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Added canonical url to various listing pages to solve issue 9503
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9503.
| How to test?      | See issue for details, but checking source code of affected controllers should be enough.
| Possible impacts? | Frontend template, header information regarding canonical url


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26774)
<!-- Reviewable:end -->
