### PR TITLE
Cart: replace this->getAssociatedLanguage()->getId() by equivalent th…

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -59,11 +59,11 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     /** @var int|null Language ID */
     protected $id_lang = null;
 
-    /** @var int|null Language ID
-     * This is the same as $id_lang except in the following case:
-     * If $id_lang is invalid (e.g. due to a removed language) $id_lang_associated is the default language
+    /** @var Language|null Language ID
+     * This is the same Language as the $id_lang except in the following case:
+     * If $id_lang is invalid (e.g. due to a removed language) $lang_associated is the default language
      */
-    protected $id_lang_associated = null;
+    protected $lang_associated = null;
 
     /** @var int|null Shop ID */
     protected $id_shop = null;
@@ -391,15 +391,15 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
      */
     public function getAssociatedLanguage(): Language
     {
-        if (!is_null($this->id_lang_associated)) {
-            return $this->id_lang_associated;
+        if (!is_null($this->lang_associated)) {
+            return $this->lang_associated;
         }
-        $this->id_lang_associated = new Language($this->id_lang);
-        if (null === $this->id_lang_associated->id) {
-            $this->id_lang_associated = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        $this->lang_associated = new Language($this->id_lang);
+        if (null === $this->lang_associated->id) {
+            $this->lang_associated = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
         }
 
-        return $this->id_lang_associated;
+        return $this->lang_associated;
     }
 
     /**

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -391,7 +391,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
      */
     public function getAssociatedLanguage(): Language
     {
-        if (!is_null($this->lang_associated)) {
+        if (null !== $this->lang_associated) {
             return $this->lang_associated;
         }
         $this->lang_associated = new Language($this->id_lang);

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -59,6 +59,12 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     /** @var int|null Language ID */
     protected $id_lang = null;
 
+    /** @var int|null Language ID
+     * This is the same as $id_lang except in the following case:
+     * If $id_lang is invalid (e.g. due to a removed language) $id_lang_associated is the default language
+     */
+    protected $id_lang_associated = null;
+
     /** @var int|null Shop ID */
     protected $id_shop = null;
 
@@ -385,12 +391,15 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
      */
     public function getAssociatedLanguage(): Language
     {
-        $language = new Language($this->id_lang);
-        if (null === $language->id) {
-            $language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
+        if (!is_null($this->id_lang_associated)) {
+            return $this->id_lang_associated;
+        }
+        $this->id_lang_associated = new Language($this->id_lang);
+        if (null === $this->id_lang_associated->id) {
+            $this->id_lang_associated = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
         }
 
-        return $language;
+        return $this->id_lang_associated;
     }
 
     /**


### PR DESCRIPTION
…is->id_lang

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Inefficient access of $this->id_lang. using inefficient $this->getAssociatedLanguage()->getId() instead of straight forward member access.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26787.
| How to test?      | In Profiling mode, compare number of instances of ObjectModel Language (edit by @jolelievre make sure this doesn't impact the initial fox for https://github.com/PrestaShop/PrestaShop/issues/22611 but it's already covered by a Behat test so it should be fine)
| Possible impacts? | There is no impact possible. The method getAssociatedLanguage() uses default language, when $this->id_lang is not a valid language. But this test is already performed in the constructor [getAssociatedLanguage()](https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Cart.php#L203)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26788)
<!-- Reviewable:end -->
