### PR TITLE
Fix version number before and after 8.0

### DIFF
--- a/tests/Unit/Core/Foundation/VersionTest.php
+++ b/tests/Unit/Core/Foundation/VersionTest.php
@@ -509,6 +509,20 @@ class VersionTest extends TestCase
                     'buildMeta' => 'nightly.20190526',
                 ],
             ],
+            '1.8.1.2' => [
+                '1.8.1.2',
+                [
+                    'version' => '1.8.1.2',
+                    'fullVersion' => '1.8.1.2',
+                    'semVersion' => '8.1.2',
+                    'majorString' => '1.8',
+                    'major' => 8,
+                    'minor' => 1,
+                    'patch' => 2,
+                    'preRelease' => '',
+                    'buildMeta' => '',
+                ],
+            ],
             '8.1.2' => [
                 '8.1.2',
                 [

--- a/tests/Unit/Core/Foundation/VersionTest.php
+++ b/tests/Unit/Core/Foundation/VersionTest.php
@@ -414,10 +414,10 @@ class VersionTest extends TestCase
             '7.5.0' => [
                 '7.5.0',
                 [
-                    'version' => '7.5.0',
-                    'fullVersion' => '7.5.0',
+                    'version' => '1.7.5.0',
+                    'fullVersion' => '1.7.5.0',
                     'semVersion' => '7.5.0',
-                    'majorString' => '7',
+                    'majorString' => '1.7',
                     'major' => 7,
                     'minor' => 5,
                     'patch' => 0,
@@ -428,10 +428,10 @@ class VersionTest extends TestCase
             '7.5.1' => [
                 '7.5.1',
                 [
-                    'version' => '7.5.1',
-                    'fullVersion' => '7.5.1',
+                    'version' => '1.7.5.1',
+                    'fullVersion' => '1.7.5.1',
                     'semVersion' => '7.5.1',
-                    'majorString' => '7',
+                    'majorString' => '1.7',
                     'major' => 7,
                     'minor' => 5,
                     'patch' => 1,
@@ -442,10 +442,10 @@ class VersionTest extends TestCase
             '7.6.0' => [
                 '7.6.0',
                 [
-                    'version' => '7.6.0',
-                    'fullVersion' => '7.6.0',
+                    'version' => '1.7.6.0',
+                    'fullVersion' => '1.7.6.0',
                     'semVersion' => '7.6.0',
-                    'majorString' => '7',
+                    'majorString' => '1.7',
                     'major' => 7,
                     'minor' => 6,
                     'patch' => 0,
@@ -456,10 +456,10 @@ class VersionTest extends TestCase
             '7.6.0-dev' => [
                 '7.6.0-dev',
                 [
-                    'version' => '7.6.0',
-                    'fullVersion' => '7.6.0-dev',
+                    'version' => '1.7.6.0',
+                    'fullVersion' => '1.7.6.0-dev',
                     'semVersion' => '7.6.0-dev',
-                    'majorString' => '7',
+                    'majorString' => '1.7',
                     'major' => 7,
                     'minor' => 6,
                     'patch' => 0,
@@ -470,10 +470,10 @@ class VersionTest extends TestCase
             '7.6.0+test.build' => [
                 '7.6.0+test.build',
                 [
-                    'version' => '7.6.0',
-                    'fullVersion' => '7.6.0+test.build',
+                    'version' => '1.7.6.0',
+                    'fullVersion' => '1.7.6.0+test.build',
                     'semVersion' => '7.6.0+test.build',
-                    'majorString' => '7',
+                    'majorString' => '1.7',
                     'major' => 7,
                     'minor' => 6,
                     'patch' => 0,
@@ -484,10 +484,10 @@ class VersionTest extends TestCase
             '7.7.0-beta.1+build.156' => [
                 '7.7.0-beta.1+build.156',
                 [
-                    'version' => '7.7.0',
-                    'fullVersion' => '7.7.0-beta.1+build.156',
+                    'version' => '1.7.7.0',
+                    'fullVersion' => '1.7.7.0-beta.1+build.156',
                     'semVersion' => '7.7.0-beta.1+build.156',
-                    'majorString' => '7',
+                    'majorString' => '1.7',
                     'major' => 7,
                     'minor' => 7,
                     'patch' => 0,
@@ -498,10 +498,10 @@ class VersionTest extends TestCase
             '7.7.0-dev+nightly.20190526' => [
                 '7.7.0-dev+nightly.20190526',
                 [
-                    'version' => '7.7.0',
-                    'fullVersion' => '7.7.0-dev+nightly.20190526',
+                    'version' => '1.7.7.0',
+                    'fullVersion' => '1.7.7.0-dev+nightly.20190526',
                     'semVersion' => '7.7.0-dev+nightly.20190526',
-                    'majorString' => '7',
+                    'majorString' => '1.7',
                     'major' => 7,
                     'minor' => 7,
                     'patch' => 0,
@@ -521,6 +521,20 @@ class VersionTest extends TestCase
                     'patch' => 2,
                     'preRelease' => '',
                     'buildMeta' => '',
+                ],
+            ],
+            '10.4.5-beta.1+build.156' => [
+                '10.4.5-beta.1+build.156',
+                [
+                    'version' => '10.4.5',
+                    'fullVersion' => '10.4.5-beta.1+build.156',
+                    'semVersion' => '10.4.5-beta.1+build.156',
+                    'majorString' => '10',
+                    'major' => 10,
+                    'minor' => 4,
+                    'patch' => 5,
+                    'preRelease' => 'beta.1',
+                    'buildMeta' => 'build.156',
                 ],
             ],
         ];

--- a/tests/Unit/Core/Foundation/VersionTest.php
+++ b/tests/Unit/Core/Foundation/VersionTest.php
@@ -414,10 +414,10 @@ class VersionTest extends TestCase
             '7.5.0' => [
                 '7.5.0',
                 [
-                    'version' => '1.7.5.0',
-                    'fullVersion' => '1.7.5.0',
+                    'version' => '7.5.0',
+                    'fullVersion' => '7.5.0',
                     'semVersion' => '7.5.0',
-                    'majorString' => '1.7',
+                    'majorString' => '7',
                     'major' => 7,
                     'minor' => 5,
                     'patch' => 0,
@@ -428,10 +428,10 @@ class VersionTest extends TestCase
             '7.5.1' => [
                 '7.5.1',
                 [
-                    'version' => '1.7.5.1',
-                    'fullVersion' => '1.7.5.1',
+                    'version' => '7.5.1',
+                    'fullVersion' => '7.5.1',
                     'semVersion' => '7.5.1',
-                    'majorString' => '1.7',
+                    'majorString' => '7',
                     'major' => 7,
                     'minor' => 5,
                     'patch' => 1,
@@ -442,10 +442,10 @@ class VersionTest extends TestCase
             '7.6.0' => [
                 '7.6.0',
                 [
-                    'version' => '1.7.6.0',
-                    'fullVersion' => '1.7.6.0',
+                    'version' => '7.6.0',
+                    'fullVersion' => '7.6.0',
                     'semVersion' => '7.6.0',
-                    'majorString' => '1.7',
+                    'majorString' => '7',
                     'major' => 7,
                     'minor' => 6,
                     'patch' => 0,
@@ -456,10 +456,10 @@ class VersionTest extends TestCase
             '7.6.0-dev' => [
                 '7.6.0-dev',
                 [
-                    'version' => '1.7.6.0',
-                    'fullVersion' => '1.7.6.0-dev',
+                    'version' => '7.6.0',
+                    'fullVersion' => '7.6.0-dev',
                     'semVersion' => '7.6.0-dev',
-                    'majorString' => '1.7',
+                    'majorString' => '7',
                     'major' => 7,
                     'minor' => 6,
                     'patch' => 0,
@@ -470,10 +470,10 @@ class VersionTest extends TestCase
             '7.6.0+test.build' => [
                 '7.6.0+test.build',
                 [
-                    'version' => '1.7.6.0',
-                    'fullVersion' => '1.7.6.0+test.build',
+                    'version' => '7.6.0',
+                    'fullVersion' => '7.6.0+test.build',
                     'semVersion' => '7.6.0+test.build',
-                    'majorString' => '1.7',
+                    'majorString' => '7',
                     'major' => 7,
                     'minor' => 6,
                     'patch' => 0,
@@ -481,13 +481,13 @@ class VersionTest extends TestCase
                     'buildMeta' => 'test.build',
                 ],
             ],
-            '7.0-beta.1+build.156' => [
+            '7.7.0-beta.1+build.156' => [
                 '7.7.0-beta.1+build.156',
                 [
-                    'version' => '1.7.7.0',
-                    'fullVersion' => '1.7.7.0-beta.1+build.156',
+                    'version' => '7.7.0',
+                    'fullVersion' => '7.7.0-beta.1+build.156',
                     'semVersion' => '7.7.0-beta.1+build.156',
-                    'majorString' => '1.7',
+                    'majorString' => '7',
                     'major' => 7,
                     'minor' => 7,
                     'patch' => 0,
@@ -498,10 +498,10 @@ class VersionTest extends TestCase
             '7.7.0-dev+nightly.20190526' => [
                 '7.7.0-dev+nightly.20190526',
                 [
-                    'version' => '1.7.7.0',
-                    'fullVersion' => '1.7.7.0-dev+nightly.20190526',
+                    'version' => '7.7.0',
+                    'fullVersion' => '7.7.0-dev+nightly.20190526',
                     'semVersion' => '7.7.0-dev+nightly.20190526',
-                    'majorString' => '1.7',
+                    'majorString' => '7',
                     'major' => 7,
                     'minor' => 7,
                     'patch' => 0,
@@ -512,10 +512,10 @@ class VersionTest extends TestCase
             '8.1.2' => [
                 '8.1.2',
                 [
-                    'version' => '1.8.1.2',
-                    'fullVersion' => '1.8.1.2',
+                    'version' => '8.1.2',
+                    'fullVersion' => '8.1.2',
                     'semVersion' => '8.1.2',
-                    'majorString' => '1.8',
+                    'majorString' => '8',
                     'major' => 8,
                     'minor' => 1,
                     'patch' => 2,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Version number returned depends on whether the pattern is 1.X or not. If the version given is 1.7.7.2 for example, the full version is 1.7.7.2, the major string is 1.7, the major number is 7, minor is 7 and patch is 2.<br>If the version is 8.1.2, majorString is 8, major is 8, minor 1 and patch 2.<br><br>This will fix the translation languages load as described in #26756 and the toolbar version bug in #26760 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26756 and #26760 
| How to test?      | Follow descriptions in the issues linked
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26789)
<!-- Reviewable:end -->
