### PR TITLE
Add redirect with notifications

### DIFF
--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -253,14 +253,14 @@ class OrderControllerCore extends FrontController
         if (count($presentedCart['products']) <= 0 || $presentedCart['minimalPurchaseRequired']) {
             // if there is no product in current cart, redirect to cart page
             $cartLink = $this->context->link->getPageLink('cart');
-            Tools::redirect($cartLink);
+            $this->redirectWithNotifications($cartLink);
         }
 
         $product = $this->context->cart->checkQuantities(true);
         if (is_array($product)) {
             // if there is an issue with product quantities, redirect to cart page
             $cartLink = $this->context->link->getPageLink('cart', null, null, ['action' => 'show']);
-            Tools::redirect($cartLink);
+            $this->redirectWithNotifications($cartLink)
         }
 
         $this->checkoutProcess

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -260,7 +260,7 @@ class OrderControllerCore extends FrontController
         if (is_array($product)) {
             // if there is an issue with product quantities, redirect to cart page
             $cartLink = $this->context->link->getPageLink('cart', null, null, ['action' => 'show']);
-            $this->redirectWithNotifications($cartLink)
+            $this->redirectWithNotifications($cartLink);
         }
 
         $this->checkoutProcess


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When you do a reorder with OOS products, there are too many redirects that you lose the error.  Indeed, the duplication of the basket generates an error in `$this-errors[] ` which is not displayed during the redirection on the index.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |no
| Deprecations?     |no
| Fixed ticket?     | Fixes #26804
| How to test?      | Try to re-encode an order with 1 OOS products with a refusal on the add cart. You will be redirected to the index with no apparent error message. After the fix, you will see the message.
| Possible impacts? | I think everything is alright.

PrestaShop partnered : Wepika

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26791)
<!-- Reviewable:end -->
