### PR TITLE
Move informational message in my account sections to template

### DIFF
--- a/controllers/front/AddressesController.php
+++ b/controllers/front/AddressesController.php
@@ -51,11 +51,6 @@ class AddressesControllerCore extends FrontController
      */
     public function initContent()
     {
-        if (count($this->context->customer->getSimpleAddresses()) <= 0) {
-            $link = '<a href="' . $this->context->link->getPageLink('address', true) . '">' . $this->trans('Add a new address', [], 'Shop.Theme.Actions') . '</a>';
-            $this->warning[] = $this->trans('No addresses are available. %s', [$link], 'Shop.Notifications.Success');
-        }
-
         parent::initContent();
         $this->setTemplate('customer/addresses');
     }

--- a/controllers/front/DiscountController.php
+++ b/controllers/front/DiscountController.php
@@ -41,14 +41,8 @@ class DiscountControllerCore extends FrontController
             Tools::redirect('index.php');
         }
 
-        $cart_rules = $this->getTemplateVarCartRules();
-
-        if (count($cart_rules) <= 0) {
-            $this->warning[] = $this->trans('You do not have any vouchers.', [], 'Shop.Notifications.Warning');
-        }
-
         $this->context->smarty->assign([
-            'cart_rules' => $cart_rules,
+            'cart_rules' => $this->getTemplateVarCartRules(),
         ]);
 
         parent::initContent();

--- a/controllers/front/HistoryController.php
+++ b/controllers/front/HistoryController.php
@@ -52,14 +52,8 @@ class HistoryControllerCore extends FrontController
             $this->warning[] = $this->trans('If you have just placed an order, it may take a few minutes for it to be validated. Please refresh this page if your order is missing.', [], 'Shop.Notifications.Warning');
         }
 
-        $orders = $this->getTemplateVarOrders();
-
-        if (count($orders) <= 0) {
-            $this->warning[] = $this->trans('You have not placed any orders.', [], 'Shop.Notifications.Warning');
-        }
-
         $this->context->smarty->assign([
-            'orders' => $orders,
+            'orders' => $this->getTemplateVarOrders(),
         ]);
 
         parent::initContent();

--- a/controllers/front/OrderFollowController.php
+++ b/controllers/front/OrderFollowController.php
@@ -102,16 +102,7 @@ class OrderFollowControllerCore extends FrontController
             Tools::redirect('index.php');
         }
 
-        $ordersReturn = $this->getTemplateVarOrdersReturns();
-        if (count($ordersReturn) <= 0) {
-            $this->warning[] = $this->trans(
-                'You have no merchandise return authorizations.',
-                [],
-                'Shop.Notifications.Error'
-            );
-        }
-
-        $this->context->smarty->assign('ordersReturn', $ordersReturn);
+        $this->context->smarty->assign('ordersReturn', $this->getTemplateVarOrdersReturns());
 
         parent::initContent();
         $this->setTemplate('customer/order-follow');

--- a/controllers/front/OrderSlipController.php
+++ b/controllers/front/OrderSlipController.php
@@ -41,14 +41,8 @@ class OrderSlipControllerCore extends FrontController
             Tools::redirect('index.php');
         }
 
-        $credit_slips = $this->getTemplateVarCreditSlips();
-
-        if (count($credit_slips) <= 0) {
-            $this->warning[] = $this->trans('You have not received any credit slips.', [], 'Shop.Notifications.Warning');
-        }
-
         $this->context->smarty->assign([
-            'credit_slips' => $credit_slips,
+            'credit_slips' => $this->getTemplateVarCreditSlips(),
         ]);
 
         parent::initContent();

--- a/themes/classic/templates/customer/addresses.tpl
+++ b/themes/classic/templates/customer/addresses.tpl
@@ -39,7 +39,7 @@
     {/foreach}
   {else}
     <div class="alert alert-info" role="alert" data-alert="info">
-      {l s='No addresses are available.' d='Shop.Notifications.Success'} <a href="{$urls.pages.address}" title="{l s='Add a new address.' d='Shop.Theme.Actions'}">{l s='Add a new address.' d='Shop.Theme.Actions'}</a>
+      {l s='No addresses are available.' d='Shop.Notifications.Success'} <a href="{$urls.pages.address}" title="{l s='Add a new address' d='Shop.Theme.Actions'}">{l s='Add a new address' d='Shop.Theme.Actions'}</a>
     </div>
   {/if}
   <div class="clearfix"></div>

--- a/themes/classic/templates/customer/addresses.tpl
+++ b/themes/classic/templates/customer/addresses.tpl
@@ -29,13 +29,19 @@
 {/block}
 
 {block name='page_content'}
-  {foreach $customer.addresses as $address}
-    <div class="col-lg-4 col-md-6 col-sm-6">
-    {block name='customer_address'}
-      {include file='customer/_partials/block-address.tpl' address=$address}
-    {/block}
+  {if $customer.addresses}
+    {foreach $customer.addresses as $address}
+      <div class="col-lg-4 col-md-6 col-sm-6">
+      {block name='customer_address'}
+        {include file='customer/_partials/block-address.tpl' address=$address}
+      {/block}
+      </div>
+    {/foreach}
+  {else}
+    <div class="alert alert-info" role="alert" data-alert="info">
+      {l s='No addresses are available.' d='Shop.Notifications.Success'} <a href="{$urls.pages.address}" title="{l s='Add a new address.' d='Shop.Theme.Actions'}">{l s='Add a new address.' d='Shop.Theme.Actions'}</a>
     </div>
-  {/foreach}
+  {/if}
   <div class="clearfix"></div>
   <div class="addresses-footer">
     <a href="{$urls.pages.address}" data-link-action="add-address">

--- a/themes/classic/templates/customer/discount.tpl
+++ b/themes/classic/templates/customer/discount.tpl
@@ -92,5 +92,7 @@
         </div>
       {/foreach}
     </div>
-  {/if}
+    {else}
+      <div class="alert alert-info" role="alert" data-alert="info">{l s='You do not have any vouchers.' d='Shop.Notifications.Warning'}</div>
+    {/if}
 {/block}

--- a/themes/classic/templates/customer/discount.tpl
+++ b/themes/classic/templates/customer/discount.tpl
@@ -92,7 +92,7 @@
         </div>
       {/foreach}
     </div>
-    {else}
-      <div class="alert alert-info" role="alert" data-alert="info">{l s='You do not have any vouchers.' d='Shop.Notifications.Warning'}</div>
-    {/if}
+  {else}
+    <div class="alert alert-info" role="alert" data-alert="info">{l s='You do not have any vouchers.' d='Shop.Notifications.Warning'}</div>
+  {/if}
 {/block}

--- a/themes/classic/templates/customer/history.tpl
+++ b/themes/classic/templates/customer/history.tpl
@@ -115,5 +115,7 @@
       {/foreach}
     </div>
 
-  {/if}
+    {else}
+      <div class="alert alert-info" role="alert" data-alert="info">{l s='You have not placed any orders.' d='Shop.Notifications.Warning'}</div>
+    {/if}
 {/block}

--- a/themes/classic/templates/customer/history.tpl
+++ b/themes/classic/templates/customer/history.tpl
@@ -115,7 +115,7 @@
       {/foreach}
     </div>
 
-    {else}
-      <div class="alert alert-info" role="alert" data-alert="info">{l s='You have not placed any orders.' d='Shop.Notifications.Warning'}</div>
-    {/if}
+  {else}
+    <div class="alert alert-info" role="alert" data-alert="info">{l s='You have not placed any orders.' d='Shop.Notifications.Warning'}</div>
+  {/if}
 {/block}

--- a/themes/classic/templates/customer/history.tpl
+++ b/themes/classic/templates/customer/history.tpl
@@ -114,7 +114,6 @@
         </div>
       {/foreach}
     </div>
-
   {else}
     <div class="alert alert-info" role="alert" data-alert="info">{l s='You have not placed any orders.' d='Shop.Notifications.Warning'}</div>
   {/if}

--- a/themes/classic/templates/customer/order-follow.tpl
+++ b/themes/classic/templates/customer/order-follow.tpl
@@ -91,7 +91,7 @@
       {/foreach}
     </div>
 
-    {else}
-      <div class="alert alert-info" role="alert" data-alert="info">{l s='You have no merchandise return authorizations.' d='Shop.Notifications.Error'}</div>
-    {/if}
+  {else}
+    <div class="alert alert-info" role="alert" data-alert="info">{l s='You have no merchandise return authorizations.' d='Shop.Notifications.Error'}</div>
+  {/if}
 {/block}

--- a/themes/classic/templates/customer/order-follow.tpl
+++ b/themes/classic/templates/customer/order-follow.tpl
@@ -29,11 +29,9 @@
 {/block}
 
 {block name='page_content'}
+  <h6>{l s='Here is a list of pending merchandise returns' d='Shop.Theme.Customeraccount'}</h6>
 
   {if $ordersReturn && count($ordersReturn)}
-
-    <h6>{l s='Here is a list of pending merchandise returns' d='Shop.Theme.Customeraccount'}</h6>
-
     <table class="table table-striped table-bordered hidden-sm-down">
       <thead class="thead-default">
         <tr>
@@ -93,6 +91,7 @@
       {/foreach}
     </div>
 
-  {/if}
-
+    {else}
+      <div class="alert alert-info" role="alert" data-alert="info">{l s='You have no merchandise return authorizations.' d='Shop.Notifications.Error'}</div>
+    {/if}
 {/block}

--- a/themes/classic/templates/customer/order-follow.tpl
+++ b/themes/classic/templates/customer/order-follow.tpl
@@ -90,7 +90,6 @@
         </div>
       {/foreach}
     </div>
-
   {else}
     <div class="alert alert-info" role="alert" data-alert="info">{l s='You have no merchandise return authorizations.' d='Shop.Notifications.Error'}</div>
   {/if}

--- a/themes/classic/templates/customer/order-slip.tpl
+++ b/themes/classic/templates/customer/order-slip.tpl
@@ -30,6 +30,7 @@
 
 {block name='page_content'}
   <h6>{l s='Credit slips you have received after canceled orders.' d='Shop.Theme.Customeraccount'}</h6>
+
   {if $credit_slips}
     <table class="table table-striped table-bordered hidden-sm-down">
       <thead class="thead-default">
@@ -76,5 +77,7 @@
         </div>
       {/foreach}
     </div>
-  {/if}
+    {else}
+      <div class="alert alert-info" role="alert" data-alert="info">{l s='You have not received any credit slips.' d='Shop.Notifications.Warning'}</div>
+    {/if}
 {/block}

--- a/themes/classic/templates/customer/order-slip.tpl
+++ b/themes/classic/templates/customer/order-slip.tpl
@@ -77,7 +77,7 @@
         </div>
       {/foreach}
     </div>
-    {else}
-      <div class="alert alert-info" role="alert" data-alert="info">{l s='You have not received any credit slips.' d='Shop.Notifications.Warning'}</div>
-    {/if}
+  {else}
+    <div class="alert alert-info" role="alert" data-alert="info">{l s='You have not received any credit slips.' d='Shop.Notifications.Warning'}</div>
+  {/if}
 {/block}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Notifications should not be responsible for showing informational messages about empty data. They are intended for one-time flash messages about success or errors, not about not having any orders.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26749
| How to test?      | See my account section before and after, the errors will be under the heading in a content, not in a place for notifications on the top.
| Possible impacts? | People with old template would not see these messages.

- Approved by @matks in the issue
- Related theme-refacto PR: https://github.com/PrestaShop/theme-refacto/pull/124
- Small BC break, but nothing serious.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26806)
<!-- Reviewable:end -->
