### PR TITLE
Autoremove cart rule when its not valid

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -492,7 +492,7 @@ class CartCore extends ObjectModel
         if ($autoAdd) {
             $cache_key = 'Cart::getCartRules_autoRemoveFromCart';
             if (!Cache::isStored($cache_key)) {
-                //CartRule::autoRemoveFromCart($virtual_context, $useOrderPrices, false);
+                CartRule::autoRemoveFromCart($virtual_context, $useOrderPrices, false);
                 Cache::store($cache_key, true);
             }
             CartRule::autoAddToCart($virtual_context, $useOrderPrices);

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -491,7 +491,7 @@ class CartCore extends ObjectModel
         }
         if ($autoAdd) {
             $cache_key = 'Cart::getCartRules_autoRemoveFromCart';
-            if (!Cache::isStored($cache_key)) {
+            if (Configuration::get('PS_AUTOREMOVE_NOT_VALID_CARTRULES') && !Cache::isStored($cache_key)) {
                 CartRule::autoRemoveFromCart($virtual_context, $useOrderPrices, false);
                 Cache::store($cache_key, true);
             }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -490,6 +490,11 @@ class CartCore extends ObjectModel
             return [];
         }
         if ($autoAdd) {
+            $cache_key = 'Cart::getCartRules_autoRemoveFromCart';
+            if (!Cache::isStored($cache_key)) {
+                //CartRule::autoRemoveFromCart($virtual_context, $useOrderPrices, false);
+                Cache::store($cache_key, true);
+            }
             CartRule::autoAddToCart($virtual_context, $useOrderPrices);
         }
 

--- a/src/Adapter/Order/GeneralConfiguration.php
+++ b/src/Adapter/Order/GeneralConfiguration.php
@@ -55,6 +55,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             'disable_reordering_option' => $this->configuration->getBoolean('PS_DISALLOW_HISTORY_REORDERING'),
             'purchase_minimum_value' => $this->configuration->get('PS_PURCHASE_MINIMUM'),
             'recalculate_shipping_cost' => $this->configuration->getBoolean('PS_ORDER_RECALCULATE_SHIPPING'),
+            'autoremove_not_valid_cartrules' => $this->configuration->getBoolean('PS_AUTOREMOVE_NOT_VALID_CARTRULES'),
             'allow_multishipping' => $this->configuration->getBoolean('PS_ALLOW_MULTISHIPPING'),
             'allow_delayed_shipping' => $this->configuration->getBoolean('PS_SHIP_WHEN_AVAILABLE'),
             'enable_tos' => $this->configuration->getBoolean('PS_CONDITIONS'),
@@ -73,6 +74,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             $this->configuration->set('PS_DISALLOW_HISTORY_REORDERING', $configuration['disable_reordering_option']);
             $this->configuration->set('PS_PURCHASE_MINIMUM', $configuration['purchase_minimum_value']);
             $this->configuration->set('PS_ORDER_RECALCULATE_SHIPPING', $configuration['recalculate_shipping_cost']);
+            $this->configuration->set('PS_AUTOREMOVE_NOT_VALID_CARTRULES', $configuration['autoremove_not_valid_cartrules']);
             $this->configuration->set('PS_ALLOW_MULTISHIPPING', $configuration['allow_multishipping']);
             $this->configuration->set('PS_SHIP_WHEN_AVAILABLE', $configuration['allow_delayed_shipping']);
             $this->configuration->set('PS_CONDITIONS', $configuration['enable_tos']);
@@ -93,6 +95,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             $configuration['disable_reordering_option'],
             $configuration['purchase_minimum_value'],
             $configuration['recalculate_shipping_cost'],
+            $configuration['autoremove_not_valid_cartrules'],
             $configuration['allow_multishipping'],
             $configuration['allow_delayed_shipping'],
             $configuration['enable_tos'],

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -103,7 +103,6 @@ class GeneralType extends TranslatorAwareType
             ->add('autoremove_not_valid_cartrules', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Automatically remove invalid promo codes from the cart', 'Admin.Shopparameters.Feature'),
-                'help' => $this->trans('Automatically removes expired or no valid cart rules from cart.', 'Admin.Shopparameters.Help'),
             ]);
 
         if ($isMultishippingEnabled) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -99,6 +99,11 @@ class GeneralType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Recalculate shipping costs after editing the order', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Automatically updates the shipping costs when you edit an order.', 'Admin.Shopparameters.Help'),
+            ])
+            ->add('autoremove_not_valid_cartrules', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans('Autoremove cart rules not valid from cart', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Automatically removes expired or no valid cart rules from cart.', 'Admin.Shopparameters.Help'),
             ]);
 
         if ($isMultishippingEnabled) {

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -102,7 +102,7 @@ class GeneralType extends TranslatorAwareType
             ])
             ->add('autoremove_not_valid_cartrules', SwitchType::class, [
                 'required' => false,
-                'label' => $this->trans('Autoremove cart rules not valid from cart', 'Admin.Shopparameters.Feature'),
+                'label' => $this->trans('Automatically remove invalid promo codes from the cart', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Automatically removes expired or no valid cart rules from cart.', 'Admin.Shopparameters.Help'),
             ]);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add the ability to remove cart rules that are already added on cart.  It don't change the current behaviour, cause it's conditioned with a new Configuration variable. 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19393 #26235.
| How to test?      |  1. Create a valid Cart rule on BO,  and then add it on FO. <br /> 2. Change the cart rule status to false on BO.  (Make sure at least there's another CartRule active) <br /> 3. Refresh the page on FO and see that cart rule still there (actual behaviour) <br /> 4. Go to BO - Shop Parameters - Order Settings -> Check to true the new configuration: "Autoremove cart rules not valid from cart" <br /> 5. Go to FO, refresh the page, and see that the disabled cart ruled it's deleted.
| Possible impacts? | Not impacts on my tests. Only make people happy with this Feature or Bug Fix :) 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26811)
<!-- Reviewable:end -->
