### PR TITLE
after upgrade error with mobile phone field if it is empty in database fix

### DIFF
--- a/src/Core/Domain/Address/QueryResult/EditableCustomerAddress.php
+++ b/src/Core/Domain/Address/QueryResult/EditableCustomerAddress.php
@@ -169,7 +169,7 @@ class EditableCustomerAddress
         string $address2,
         StateId $stateId,
         string $homePhone,
-        string $mobilePhone,
+        ?string $mobilePhone,
         string $other,
         array $requiredFields
     ) {

--- a/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderInvoiceAddressForViewing.php
@@ -102,7 +102,7 @@ class OrderInvoiceAddressForViewing
     private $phoneNumber;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $mobilePhoneNumber;
 
@@ -123,7 +123,7 @@ class OrderInvoiceAddressForViewing
      * @param string $countryName
      * @param string $postCode
      * @param string $phone
-     * @param string $phoneMobile
+     * @param string|null $phoneMobile
      * @param string|null $vatNumber
      * @param string|null $dni If null the DNI is not required for the country, else string
      */
@@ -139,7 +139,7 @@ class OrderInvoiceAddressForViewing
         string $countryName,
         string $postCode,
         string $phone,
-        string $phoneMobile,
+        ?string $phoneMobile = null,
         ?string $vatNumber = null,
         ?string $dni = null
     ) {
@@ -274,9 +274,9 @@ class OrderInvoiceAddressForViewing
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getMobilePhoneNumber(): string
+    public function getMobilePhoneNumber(): ?string
     {
         return $this->mobilePhoneNumber;
     }

--- a/src/Core/Domain/Order/QueryResult/OrderShippingAddressForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderShippingAddressForViewing.php
@@ -102,7 +102,7 @@ class OrderShippingAddressForViewing
     private $phoneNumber;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $mobilePhoneNumber;
 
@@ -123,7 +123,7 @@ class OrderShippingAddressForViewing
      * @param string $countryName
      * @param string $postCode
      * @param string $phone
-     * @param string $phoneMobile
+     * @param string|null $phoneMobile
      * @param string|null $vatNumber
      * @param string|null $dni If null the DNI is not required for the country, else string
      */
@@ -139,7 +139,7 @@ class OrderShippingAddressForViewing
         string $countryName,
         string $postCode,
         string $phone,
-        string $phoneMobile,
+        ?string $phoneMobile = null,
         ?string $vatNumber = null,
         ?string $dni = null
     ) {
@@ -258,9 +258,9 @@ class OrderShippingAddressForViewing
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getMobilePhoneNumber(): string
+    public function getMobilePhoneNumber(): ?string
     {
         return $this->mobilePhoneNumber;
     }


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | after upgrade from 1.7.6.5 error with mobile phone field if it is empty in database. php7.3
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | yes 
| Fixed ticket?     | 
| How to test?      | With database where mobilePhone is empty
| Possible impacts? | Back office customer address modify places


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26812)
<!-- Reviewable:end -->
