### PR TITLE
Fix listing classes when using facetedsearch

### DIFF
--- a/themes/classic/_dev/js/listing.js
+++ b/themes/classic/_dev/js/listing.js
@@ -230,7 +230,16 @@ function updateProductListDOM(data) {
   $(prestashop.themeSelectors.listing.listTop).replaceWith(
     data.rendered_products_top,
   );
-  $(prestashop.themeSelectors.listing.list).replaceWith(data.rendered_products);
+
+  const renderedProducts = $(data.rendered_products);
+  const productSelectors = $(prestashop.themeSelectors.listing.product, renderedProducts);
+
+  if (productSelectors.length > 0) {
+    productSelectors.removeClass().addClass($(prestashop.themeSelectors.listing.product).first().attr('class'));
+  }
+
+  $(prestashop.themeSelectors.listing.list).replaceWith(renderedProducts);
+
   $(prestashop.themeSelectors.listing.listBottom).replaceWith(
     data.rendered_products_bottom,
   );

--- a/themes/classic/_dev/js/selectors.js
+++ b/themes/classic/_dev/js/selectors.js
@@ -46,6 +46,7 @@ prestashop.themeSelectors = {
     searchFilters: '#search_filters',
     activeSearchFilters: '#js-active-search-filters',
     listTop: '#js-product-list-top',
+    product: '.js-product',
     list: '#js-product-list',
     listBottom: '#js-product-list-bottom',
     listHeader: '#js-product-list-header',

--- a/themes/classic/templates/catalog/_partials/miniatures/product.tpl
+++ b/themes/classic/templates/catalog/_partials/miniatures/product.tpl
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 {block name='product_miniature_item'}
-<div class="product{if !empty($productClasses)} {$productClasses}{/if}">
+<div class="js-product product{if !empty($productClasses)} {$productClasses}{/if}">
   <article class="product-miniature js-product-miniature" data-id-product="{$product.id_product}" data-id-product-attribute="{$product.id_product_attribute}">
     <div class="thumbnail-container">
       {block name='product_thumbnail'}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | We need to keep the same classes as the initial list after updating the product list, currently the facetedsearch module uses another template and it should be agnostic on this point because it can be used differently than on category pages and more
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26820.
| How to test?      | Check issue, same way but without the bug!
| Possible impacts? | Category FO listing


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26823)
<!-- Reviewable:end -->
