### PR TITLE
Avoid using _PS_PRICE_COMPUTE_PRECISION_

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -319,7 +319,7 @@ abstract class PaymentModuleCore extends Module
             // Amount paid by customer is not the right one -> Status = payment error
             // We don't use the following condition to avoid the float precision issues : http://www.php.net/manual/en/language.types.float.php
             // if ($order->total_paid != $order->total_paid_real)
-            // We use number_format in order to compare two string
+            // We use number_format to convert the numbers to strings and strcmp to compare them to avoid auto reconversions to numbers in PHP < 8.0
             $comp_precision = Context::getContext()->getComputingPrecision();
             if ($order_status->logable && (strcmp(number_format($cart_total_paid, $comp_precision), number_format($amount_paid, $comp_precision)) != 0)) {
                 PrestaShopLogger::addLog('PaymentModule::validateOrder - Total paid amount does not match cart total', 3, null, 'Cart', (int) $id_cart, true);

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -320,7 +320,9 @@ abstract class PaymentModuleCore extends Module
             // We don't use the following condition to avoid the float precision issues : http://www.php.net/manual/en/language.types.float.php
             // if ($order->total_paid != $order->total_paid_real)
             // We use number_format in order to compare two string
-            if ($order_status->logable && number_format($cart_total_paid, Context::getContext()->getComputingPrecision()) != number_format($amount_paid, _PS_PRICE_COMPUTE_PRECISION_)) {
+            $comp_precision = Context::getContext()->getComputingPrecision();
+            if ($order_status->logable && (strcmp(number_format($cart_total_paid, $comp_precision), number_format($amount_paid, $comp_precision)) != 0) ) {
+                PrestaShopLogger::addLog('PaymentModule::validateOrder - Total paid amount does not match cart total', 3, null, 'Cart', (int) $id_cart, true);
                 $id_order_state = Configuration::get('PS_OS_ERROR');
             }
 

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -321,7 +321,7 @@ abstract class PaymentModuleCore extends Module
             // if ($order->total_paid != $order->total_paid_real)
             // We use number_format in order to compare two string
             $comp_precision = Context::getContext()->getComputingPrecision();
-            if ($order_status->logable && (strcmp(number_format($cart_total_paid, $comp_precision), number_format($amount_paid, $comp_precision)) != 0) ) {
+            if ($order_status->logable && (strcmp(number_format($cart_total_paid, $comp_precision), number_format($amount_paid, $comp_precision)) != 0)) {
                 PrestaShopLogger::addLog('PaymentModule::validateOrder - Total paid amount does not match cart total', 3, null, 'Cart', (int) $id_cart, true);
                 $id_order_state = Configuration::get('PS_OS_ERROR');
             }

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -321,7 +321,7 @@ abstract class PaymentModuleCore extends Module
             // if ($order->total_paid != $order->total_paid_real)
             // We use number_format to convert the numbers to strings and strcmp to compare them to avoid auto reconversions to numbers in PHP < 8.0
             $comp_precision = Context::getContext()->getComputingPrecision();
-            if ($order_status->logable && (strcmp(number_format($cart_total_paid, $comp_precision), number_format($amount_paid, $comp_precision)) != 0)) {
+            if ($order_status->logable && (number_format($cart_total_paid, $comp_precision) !== number_format($amount_paid, $comp_precision))) {
                 PrestaShopLogger::addLog('PaymentModule::validateOrder - Total paid amount does not match cart total', 3, null, 'Cart', (int) $id_cart, true);
                 $id_order_state = Configuration::get('PS_OS_ERROR');
             }

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -319,7 +319,7 @@ abstract class PaymentModuleCore extends Module
             // Amount paid by customer is not the right one -> Status = payment error
             // We don't use the following condition to avoid the float precision issues : http://www.php.net/manual/en/language.types.float.php
             // if ($order->total_paid != $order->total_paid_real)
-            // We use number_format to convert the numbers to strings and strcmp to compare them to avoid auto reconversions to numbers in PHP < 8.0
+            // We use number_format to convert the numbers to strings and strict inequality to compare them to avoid auto reconversions to numbers in PHP < 8.0
             $comp_precision = Context::getContext()->getComputingPrecision();
             if ($order_status->logable && (number_format($cart_total_paid, $comp_precision) !== number_format($amount_paid, $comp_precision))) {
                 PrestaShopLogger::addLog('PaymentModule::validateOrder - Total paid amount does not match cart total', 3, null, 'Cart', (int) $id_cart, true);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | PaymentModule::validateOrder is using the deprecated config constant<br>`_PS_PRICE_COMPUTE_PRECISION_` to generate a string representation of the total amount paid with a payment module and comparing that to the cart total string representation calculated with `Context::getContext()->getComputingPrecision()`. This check will always fail when a currency with a decimal precision is different than the present `_PS_PRICE_COMPUTE_PRECISION_ = 2` constant, hence the order will be placed in a payment error status and no log or further details will be displayed. This happens for example while using MercadoPago payment module v4.8.0 (official partner). Apparently _PS_PRICE_COMPUTE_PRECISION_ was deprecated in 1.7.7.x but this core class still uses it. The proposed change substitutes the constant with the precision value obtained from the context, just like it is used in the rest of the source code. Also a log is added to register this error situation. 
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26553
| How to test?      | Create a currency with decimal values different than "2", make a purchase in the FO, order is created with status Configuration::get('PS_OS_ERROR') instead of a valid one. Full details in bug report. 
| Possible impacts? | This is a core PaymentModule change so impact might be big, I'd check for all and any regressions regarding payments. There is still another place that `_PS_PRICE_COMPUTE_PRECISION_` [is in use in PaymentModule](https://github.com/PrestaShop/PrestaShop/blob/586dbdbb3c60899f9f07b1eb41864b9e4333175a/classes/PaymentModule.php#L1148), this should be probably addressed in a different issue. 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26824)
<!-- Reviewable:end -->
