### PR TITLE
Add shop details support to classic

### DIFF
--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -461,7 +461,7 @@ class AdminStoresControllerCore extends AdminController
             ],
             'PS_SHOP_DETAILS' => [
                 'title' => $this->trans('Company details', [], 'Admin.Shopparameters.Feature'),
-                'hint' => $this->trans('Company's registration details (e.g. DNI, VAT, SIRET, RCS, etc.).', [], 'Admin.Shopparameters.Help'),
+                'hint' => $this->trans('Company\'s registration details (e.g. DNI, VAT, SIRET, RCS, etc.).', [], 'Admin.Shopparameters.Help'),
                 'validation' => 'isGenericName',
                 'type' => 'textarea',
                 'cols' => 30,

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -461,7 +461,7 @@ class AdminStoresControllerCore extends AdminController
             ],
             'PS_SHOP_DETAILS' => [
                 'title' => $this->trans('Company details', [], 'Admin.Shopparameters.Feature'),
-                'hint' => $this->trans('Shop registration information (e.g. DNI, VAT number, SIRET or RCS).', [], 'Admin.Shopparameters.Help'),
+                'hint' => $this->trans('Company's registration details (e.g. DNI, VAT, SIRET, RCS, etc.).', [], 'Admin.Shopparameters.Help'),
                 'validation' => 'isGenericName',
                 'type' => 'textarea',
                 'cols' => 30,

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -460,8 +460,8 @@ class AdminStoresControllerCore extends AdminController
                 'type' => 'text',
             ],
             'PS_SHOP_DETAILS' => [
-                'title' => $this->trans('Registration number', [], 'Admin.Shopparameters.Feature'),
-                'hint' => $this->trans('Shop registration information (e.g. SIRET or RCS).', [], 'Admin.Shopparameters.Help'),
+                'title' => $this->trans('Company details', [], 'Admin.Shopparameters.Feature'),
+                'hint' => $this->trans('Shop registration information (e.g. DNI, VAT number, SIRET or RCS).', [], 'Admin.Shopparameters.Help'),
                 'validation' => 'isGenericName',
                 'type' => 'textarea',
                 'cols' => 30,

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
@@ -59,4 +59,14 @@
       {mailto address=$contact_infos.email encode="javascript"}
     </div>
   {/if}
+  {if $contact_infos.details}
+    <hr/>
+    <div class="block">
+      <div class="icon"><i class="material-icons">&#xE88E;</i></div>
+      <div class="data">
+        {l s='Details:' d='Shop.Theme.Global'}<br/>
+        {$contact_infos.details}
+      </div>
+    </div>
+  {/if}
 </div>

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
@@ -64,7 +64,7 @@
     <div class="block">
       <div class="icon"><i class="material-icons">&#xE88E;</i></div>
       <div class="data">
-        {l s='Details:' d='Shop.Theme.Global'}<br/>
+        {l s='Company details:' d='Shop.Theme.Global'}<br/>
         {$contact_infos.details}
       </div>
     </div>

--- a/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
+++ b/themes/classic/modules/ps_contactinfo/ps_contactinfo-rich.tpl
@@ -65,7 +65,7 @@
       <div class="icon"><i class="material-icons">&#xE88E;</i></div>
       <div class="data">
         {l s='Company details:' d='Shop.Theme.Global'}<br/>
-        {$contact_infos.details}
+        {$contact_infos.details|nl2br nofilter}
       </div>
     </div>
   {/if}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Legal information is not displayed on contact page, while there is a field for that in Prestashop settings.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26809
| How to test?      | Fill the legal info in BO, apply https://github.com/PrestaShop/ps_contactinfo/pull/43 and go to contact page.
| Possible impacts? | None.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26832)
<!-- Reviewable:end -->
