### PR TITLE
Add displayAdminProductsCombinationsBulkBottom hook

### DIFF
--- a/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
+++ b/admin-dev/themes/new-theme/js/product-page/product-bulk-combinations.js
@@ -268,6 +268,7 @@ class Combination {
         convertedInput = `${this.inputPattern}attribute_priceTI`;
         break;
       default:
+        convertedInput = `${this.inputPattern}${bulkInput}`;
     }
 
     return convertedInput;

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -771,6 +771,11 @@
       <title>Display new elements in back office product page, Quantities/Combinations tab</title>
       <description>This hook launches modules when the back office product page is displayed</description>
     </hook>
+    <hook id="displayAdminProductsCombinationsBulkBottom">
+      <name>displayAdminProductsCombinationsBulkBottom</name>
+      <title>Display new elements in back office product page, bulk form of the Combinations tab</title>
+      <description>This hook launches modules when the back office product page is displayed</description>
+    </hook>
     <hook id="displayAdminProductsPriceStepBottom">
       <name>displayAdminProductsPriceStepBottom</name>
       <title>Display new elements in back office product page, Price tab</title>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combinations_bulk.html.twig
@@ -94,6 +94,9 @@
       </span>
     </div>
   </div>
+
+  {{ renderhook('displayAdminProductsCombinationsBulkBottom', { 'id_product': id_product }) }}
+  
 </div>
 <div class="row justify-content-end mt-3">
     <button id="delete-combinations" class="btn btn-outline-secondary mr-3" data="{{ path('admin_delete_attribute', {'idProduct': id_product}) }}">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a hook to display custom fields in bulk edit combinations legacy form.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Resolves #26842
| How to test?      | Add the new hook to the database and hook a module to it.<br> To test it fully, you should hook a module which add a form field and hook it to 'hookAdminProductsCombinationsStepBottom' too, but it's quite tedious for this minimal change.
| Possible impacts? | Bulk combination form in combination tab product page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26841)
<!-- Reviewable:end -->
