### PR TITLE
Remove Activity Shop from Installer & Config

### DIFF
--- a/install-dev/classes/datas.php
+++ b/install-dev/classes/datas.php
@@ -40,7 +40,6 @@
  * @property string $database_prefix
  * @property string $database_engine
  * @property string $shop_name
- * @property int $shop_activity
  * @property string $shop_country
  * @property string $admin_firstname
  * @property string $admin_lastname
@@ -139,11 +138,6 @@ class Datas
             'name' => 'name',
             'validate' => 'isGenericName',
             'default' => 'PrestaShop',
-        ],
-        'shop_activity' => [
-            'name' => 'activity',
-            'default' => 0,
-            'validate' => 'isInt',
         ],
         'shop_country' => [
             'name' => 'country',

--- a/install-dev/classes/session.php
+++ b/install-dev/classes/session.php
@@ -41,7 +41,6 @@
  * @property string $database_engine
  * @property string $shop_name
  * @property array $xml_loader_ids
- * @property int $shop_activity
  * @property string $shop_country
  * @property string $admin_firstname
  * @property string $admin_lastname

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -255,7 +255,6 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
 
         return $this->model_install->configureShop([
             'shop_name' => $this->datas->shop_name,
-            'shop_activity' => $this->datas->shop_activity,
             'shop_country' => $this->datas->shop_country,
             'shop_timezone' => $this->datas->timezone,
             'use_smtp' => false,
@@ -293,7 +292,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         }
 
         $this->model_install->xml_loader_ids = $this->datas->xml_loader_ids;
-        $result = $this->model_install->installFixtures(null, ['shop_activity' => $this->datas->shop_activity, 'shop_country' => $this->datas->shop_country]);
+        $result = $this->model_install->installFixtures(null, ['shop_country' => $this->datas->shop_country]);
         $this->datas->xml_loader_ids = $this->model_install->xml_loader_ids;
 
         return $result;

--- a/install-dev/controllers/http/configure.php
+++ b/install-dev/controllers/http/configure.php
@@ -32,10 +32,6 @@ class InstallControllerHttpConfigure extends InstallControllerHttp implements Ht
     /**
      * @var array
      */
-    public $list_activities = [];
-    /**
-     * @var array
-     */
     public $list_countries = [];
     /**
      * @var string
@@ -50,7 +46,6 @@ class InstallControllerHttpConfigure extends InstallControllerHttp implements Ht
         if (Tools::isSubmit('shop_name')) {
             // Save shop configuration
             $this->session->shop_name = trim(Tools::getValue('shop_name'));
-            $this->session->shop_activity = Tools::getValue('shop_activity');
             $this->session->install_type = Tools::getValue('db_mode');
             $this->session->enable_ssl = Tools::getValue('enable_ssl');
             $this->session->shop_country = Tools::getValue('shop_country');
@@ -241,33 +236,6 @@ class InstallControllerHttpConfigure extends InstallControllerHttp implements Ht
      */
     public function display()
     {
-        // List of activities
-        $list_activities = [
-            1 => $this->translator->trans('Lingerie and Adult', [], 'Install'),
-            2 => $this->translator->trans('Animals and Pets', [], 'Install'),
-            3 => $this->translator->trans('Art and Culture', [], 'Install'),
-            4 => $this->translator->trans('Babies', [], 'Install'),
-            5 => $this->translator->trans('Beauty and Personal Care', [], 'Install'),
-            6 => $this->translator->trans('Cars', [], 'Install'),
-            7 => $this->translator->trans('Computer Hardware and Software', [], 'Install'),
-            8 => $this->translator->trans('Download', [], 'Install'),
-            9 => $this->translator->trans('Fashion and accessories', [], 'Install'),
-            10 => $this->translator->trans('Flowers, Gifts and Crafts', [], 'Install'),
-            11 => $this->translator->trans('Food and beverage', [], 'Install'),
-            12 => $this->translator->trans('HiFi, Photo and Video', [], 'Install'),
-            13 => $this->translator->trans('Home and Garden', [], 'Install'),
-            14 => $this->translator->trans('Home Appliances', [], 'Install'),
-            15 => $this->translator->trans('Jewelry', [], 'Install'),
-            16 => $this->translator->trans('Mobile and Telecom', [], 'Install'),
-            17 => $this->translator->trans('Services', [], 'Install'),
-            18 => $this->translator->trans('Shoes and accessories', [], 'Install'),
-            19 => $this->translator->trans('Sports and Entertainment', [], 'Install'),
-            20 => $this->translator->trans('Travel', [], 'Install'),
-        ];
-
-        asort($list_activities);
-        $this->list_activities = $list_activities;
-
         // Countries list
         $this->list_countries = [];
         $countries = $this->language->getCountries();

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -208,7 +208,6 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
 
         $success = $this->model_install->configureShop([
             'shop_name' => $this->session->shop_name,
-            'shop_activity' => $this->session->shop_activity,
             'shop_country' => $this->session->shop_country,
             'shop_timezone' => $this->session->shop_timezone,
             'admin_firstname' => $this->session->admin_firstname,
@@ -269,7 +268,7 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
         $this->initializeContext();
 
         $this->model_install->xml_loader_ids = $this->session->xml_loader_ids;
-        if (!$this->model_install->installFixtures(Tools::getValue('entity', null), ['shop_activity' => $this->session->shop_activity, 'shop_country' => $this->session->shop_country]) || $this->model_install->getErrors()) {
+        if (!$this->model_install->installFixtures(Tools::getValue('entity', null), ['shop_country' => $this->session->shop_country]) || $this->model_install->getErrors()) {
             $this->ajaxJsonAnswer(false, $this->model_install->getErrors());
         }
         $this->session->xml_loader_ids = $this->model_install->xml_loader_ids;

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -715,9 +715,6 @@ Country</value>
   <configuration id="PS_MAIL_METHOD" name="PS_MAIL_METHOD">
     <value>1</value>
   </configuration>
-  <configuration id="PS_SHOP_ACTIVITY" name="PS_SHOP_ACTIVITY">
-    <value>Animaux</value>
-  </configuration>
   <configuration id="PS_LOGO" name="PS_LOGO">
     <value>logo.png</value>
   </configuration>

--- a/install-dev/theme/views/configure.php
+++ b/install-dev/theme/views/configure.php
@@ -37,20 +37,6 @@
   </div>
 
   <div class="field clearfix">
-	<label for="infosActivity" class="aligned"><?php echo $this->translator->trans('Main activity', [], 'Install'); ?></label>
-	<div class="contentinput">
-	  <select id="infosActivity" name="shop_activity" class="chosen">
-		<option value="0" style="font-weight: bold" <?php if (!$this->session->shop_activity) { ?>selected="selected"<?php } ?>><?php echo $this->translator->trans('Please choose your main activity', [], 'Install'); ?></option>
-		<?php foreach ($this->list_activities as $i => $activity) { ?>
-		  <option value="<?php echo $i; ?>" <?php if (isset($this->session->shop_activity) && $this->session->shop_activity == $i) { ?>selected="selected"<?php } ?>><?php echo $activity; ?></option>
-		<?php } ?>
-		<option value="0"><?php echo $this->translator->trans('Other activity...', [], 'Install'); ?></option>
-	  </select>
-	</div>
-	<p class="userInfos aligned"><?php echo $this->translator->trans('Help us learn more about your store so we can offer you optimal guidance and the best features for your business!', [], 'Install'); ?></p>
-  </div>
-
-  <div class="field clearfix">
 	<label class="aligned"><?php echo $this->translator->trans('Install demonstration data', [], 'Install'); ?></label>
 	<div class="contentinput">
 	  <label>

--- a/src/Adapter/Preferences/PreferencesConfiguration.php
+++ b/src/Adapter/Preferences/PreferencesConfiguration.php
@@ -62,7 +62,6 @@ class PreferencesConfiguration implements DataConfigurationInterface
             'display_manufacturers' => $this->configuration->getBoolean('PS_DISPLAY_MANUFACTURERS'),
             'display_best_sellers' => $this->configuration->getBoolean('PS_DISPLAY_BEST_SELLERS'),
             'multishop_feature_active' => $this->configuration->getBoolean('PS_MULTISHOP_FEATURE_ACTIVE'),
-            'shop_activity' => $this->configuration->get('PS_SHOP_ACTIVITY'),
         ];
     }
 
@@ -102,7 +101,6 @@ class PreferencesConfiguration implements DataConfigurationInterface
         $this->configuration->set('PS_DISPLAY_MANUFACTURERS', $configuration['display_manufacturers']);
         $this->configuration->set('PS_DISPLAY_BEST_SELLERS', $configuration['display_best_sellers']);
         $this->configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', $configuration['multishop_feature_active']);
-        $this->configuration->set('PS_SHOP_ACTIVITY', $configuration['shop_activity']);
 
         return [];
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -203,34 +203,6 @@ class PreferencesType extends TranslatorAwareType
                     'The multistore feature allows you to manage several e-shops with one Back Office. If this feature is enabled, a "Multistore" page will be available in the "Advanced Parameters" menu.',
                     'Admin.Shopparameters.Help'
                 ),
-            ])
-            ->add('shop_activity', ChoiceType::class, [
-                'required' => false,
-                'placeholder' => $this->trans('-- Please choose your main activity --', 'Install'),
-                'choices' => [
-                    'Animals and Pets' => 2,
-                    'Art and Culture' => 3,
-                    'Babies' => 4,
-                    'Beauty and Personal Care' => 5,
-                    'Cars' => 6,
-                    'Computer Hardware and Software' => 7,
-                    'Download' => 8,
-                    'Fashion and accessories' => 9,
-                    'Flowers, Gifts and Crafts' => 10,
-                    'Food and beverage' => 11,
-                    'HiFi, Photo and Video' => 12,
-                    'Home and Garden' => 13,
-                    'Home Appliances' => 14,
-                    'Jewelry' => 15,
-                    'Lingerie and Adult' => 1,
-                    'Mobile and Telecom' => 16,
-                    'Services' => 17,
-                    'Shoes and accessories' => 18,
-                    'Sport and Entertainment' => 19,
-                    'Travel' => 20,
-                ],
-                'label' => $this->trans('Main Shop Activity', 'Admin.Shopparameters.Feature'),
-                'choice_translation_domain' => 'Install',
             ]);
     }
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -732,7 +732,6 @@ class Install extends AbstractInstall
 
         $default_data = [
             'shop_name' => 'My Shop',
-            'shop_activity' => '',
             'shop_country' => 'us',
             'shop_timezone' => 'US/Eastern', // TODO : this timezone is deprecated
             'use_smtp' => false,
@@ -759,7 +758,6 @@ class Install extends AbstractInstall
         Configuration::updateGlobalValue('PS_INSTALL_VERSION', _PS_INSTALL_VERSION_);
         Configuration::updateGlobalValue('PS_LOCALE_LANGUAGE', $this->language->getLanguageIso());
         Configuration::updateGlobalValue('PS_SHOP_NAME', $data['shop_name']);
-        Configuration::updateGlobalValue('PS_SHOP_ACTIVITY', $data['shop_activity']);
         Configuration::updateGlobalValue('PS_COUNTRY_DEFAULT', $id_country);
         Configuration::updateGlobalValue('PS_LOCALE_COUNTRY', $data['shop_country']);
         Configuration::updateGlobalValue('PS_TIMEZONE', $data['shop_timezone']);

--- a/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
+++ b/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
@@ -63,7 +63,6 @@ class PreferencesConfigurationTest extends TestCase
                 [
                     ['PS_PRICE_ROUND_MODE', null, null, 'test'],
                     ['PS_ROUND_TYPE', null, null, 'test'],
-                    ['PS_SHOP_ACTIVITY', null, null, 'test'],
                 ]
             );
 
@@ -97,7 +96,6 @@ class PreferencesConfigurationTest extends TestCase
                 'display_manufacturers' => true,
                 'display_best_sellers' => false,
                 'multishop_feature_active' => true,
-                'shop_activity' => 'test',
             ],
             $result
         );
@@ -149,7 +147,6 @@ class PreferencesConfigurationTest extends TestCase
                     'display_manufacturers' => true,
                     'display_best_sellers' => false,
                     'multishop_feature_active' => true,
-                    'shop_activity' => 'test',
                 ]
             )
         );
@@ -179,7 +176,6 @@ class PreferencesConfigurationTest extends TestCase
                     ['PS_MULTISHOP_FEATURE_ACTIVE', true],
                     ['PS_PRICE_ROUND_MODE', 'test'],
                     ['PS_ROUND_TYPE', 'test'],
-                    ['PS_SHOP_ACTIVITY', 'test'],
                 ]
             );
 
@@ -205,7 +201,6 @@ class PreferencesConfigurationTest extends TestCase
                     'display_manufacturers' => true,
                     'display_best_sellers' => false,
                     'multishop_feature_active' => true,
-                    'shop_activity' => 'test',
                 ]
             )
         );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove Activity Shop from Installer & Config (Only used by Addons)
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | N/A
| Possible impacts? | N/A

**:notebook: BC Breaks :**
* Removed configuration `PS_SHOP_ACTIVITY`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26850)
<!-- Reviewable:end -->
