### PR TITLE
POC optimize behat tests DB restoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,8 @@ tests-legacy/resources/modules/ps_sharebuttons
 # Installed with test data maybe via API push
 tests-legacy/resources/modules/ps_reminder
 
+tests/Resources/img/m/*
+!tests/Resources/img/m/.gitkeep
 tests/Resources/img/l/*
 !tests/Resources/img/l/.gitkeep
 tests/Resources/img/p/*

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -140,6 +140,12 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         'tabs' => 'tabs',
     ];
 
+    public static function resetStaticCache()
+    {
+        static::$loaded_classes = [];
+        static::resetCache();
+    }
+
     public static function resetCache()
     {
         static::$_checkedLangs = null;

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -136,6 +136,12 @@ class SpecificPriceCore extends ObjectModel
 
     protected static $psQtyDiscountOnCombination = null;
 
+    public static function resetStaticCache()
+    {
+        parent::resetStaticCache();
+        static::flushCache();
+    }
+
     /**
      * Flush local cache.
      */

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -602,7 +602,7 @@ abstract class DbCore
         }
 
         // This method must be used only with queries which display results
-        if (!preg_match('#^\s*\(?\s*(select|show|explain|describe|desc)\s#i', $sql)) {
+        if (!preg_match('#^\s*\(?\s*(select|show|explain|describe|desc|checksum)\s#i', $sql)) {
             /* @phpstan-ignore-next-line */
             if (defined('_PS_MODE_DEV_') && _PS_MODE_DEV_) {
                 throw new PrestaShopDatabaseException('Db->executeS() must be used only with select, show, explain or describe queries');

--- a/composer.json
+++ b/composer.json
@@ -192,6 +192,9 @@
         "create-test-table-dumps": [
           "@php ./tests/bin/create-test-tables-dump.php"
         ],
+      "restore-test-db": [
+        "@php ./tests/bin/restore-test-db.php"
+      ],
         "git-hook-install": "@php .github/contrib/install.php",
         "git-hook-uninstall": "@php .github/contrib/uninstall.php",
         "integration-behaviour-tests": [

--- a/composer.json
+++ b/composer.json
@@ -186,7 +186,11 @@
     "scripts": {
         "create-release": "@php tools/build/CreateRelease.php",
         "create-test-db": [
-            "@php ./tests/bin/create-test-db.php"
+            "@php ./tests/bin/create-test-db.php",
+            "@php ./tests/bin/create-test-tables-dump.php"
+        ],
+        "create-test-table-dumps": [
+          "@php ./tests/bin/create-test-tables-dump.php"
         ],
         "git-hook-install": "@php .github/contrib/install.php",
         "git-hook-uninstall": "@php .github/contrib/uninstall.php",

--- a/composer.json
+++ b/composer.json
@@ -208,6 +208,9 @@
         "restore-test-db": [
             "@php ./tests/bin/restore-test-db.php"
         ],
+        "restore-test-tables": [
+            "@php ./tests/bin/restore-test-tables.php"
+        ],
         "test-all": [
             "@composer unit-tests",
             "@composer integration-tests",

--- a/composer.json
+++ b/composer.json
@@ -224,6 +224,8 @@
         "create-release": "Create a release of PrestaShop, run the command with -h/--help argument for more information.",
         "create-test-db": "Create a Database for testing purposes",
         "create-test-table-dumps": "Create a dump of each table in the Database for testing purposes",
+        "restore-test-db": "Restore the whole DB in a single dump",
+        "restore-test-tables": "Restore all tables one by one, only when they have been modified",
         "test-all": "Launch all PHPUnit test suites"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -190,11 +190,8 @@
             "@php ./tests/bin/create-test-tables-dump.php"
         ],
         "create-test-table-dumps": [
-          "@php ./tests/bin/create-test-tables-dump.php"
+            "@php ./tests/bin/create-test-tables-dump.php"
         ],
-      "restore-test-db": [
-        "@php ./tests/bin/restore-test-db.php"
-      ],
         "git-hook-install": "@php .github/contrib/install.php",
         "git-hook-uninstall": "@php .github/contrib/uninstall.php",
         "integration-behaviour-tests": [
@@ -207,6 +204,9 @@
         "phpunit-endpoints": [
             "@composer create-test-db",
             "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-endpoints.xml"
+        ],
+        "restore-test-db": [
+            "@php ./tests/bin/restore-test-db.php"
         ],
         "test-all": [
             "@composer unit-tests",

--- a/composer.json
+++ b/composer.json
@@ -217,6 +217,7 @@
     "scripts-descriptions": {
         "create-release": "Create a release of PrestaShop, run the command with -h/--help argument for more information.",
         "create-test-db": "Create a Database for testing purposes",
+        "create-test-table-dumps": "Create a dump of each table in the Database for testing purposes",
         "test-all": "Launch all PHPUnit test suites"
     }
 }

--- a/src/PrestaShopBundle/Install/DatabaseDump.php
+++ b/src/PrestaShopBundle/Install/DatabaseDump.php
@@ -276,6 +276,22 @@ class DatabaseDump
     }
 
     /**
+     * Restore all tables (only modified tables are restored)
+     */
+    public static function restoreAllTables(): void
+    {
+        $dump = new static();
+
+        $tables = $dump->db->executeS('SHOW TABLES;');
+        foreach ($tables as $table) {
+            // $table is an array looking like this [Tables_in_database_name => 'ps_access']
+            $tableName = reset($table);
+            $tableName = substr($tableName, strlen($dump->dbPrefix));
+            $dump->restoreTable($tableName);
+        }
+    }
+
+    /**
      * Restore a list of tables in the database
      *
      * @param array $tableNames

--- a/src/PrestaShopBundle/Install/DatabaseDump.php
+++ b/src/PrestaShopBundle/Install/DatabaseDump.php
@@ -135,17 +135,20 @@ class DatabaseDump
      * Restore a specific table in the database.
      *
      * @param string $table
+     * @param bool $forceRestore
      */
-    public function restoreTable(string $table): void
+    public function restoreTable(string $table, bool $forceRestore = false): void
     {
         $tableName = $this->dbPrefix . $table;
         $this->checkTableDumpFile($tableName);
 
-        $dumpChecksum = file_get_contents($this->getTableChecksumPath($tableName));
-        $checksum = $this->getTableChecksum($tableName);
-        // Table was not modified, no need to restore
-        if ($checksum === $dumpChecksum) {
-            return;
+        if (!$forceRestore) {
+            $dumpChecksum = file_get_contents($this->getTableChecksumPath($tableName));
+            $checksum = $this->getTableChecksum($tableName);
+            // Table was not modified, no need to restore
+            if ($checksum === $dumpChecksum) {
+                return;
+            }
         }
 
         $dumpFile = $this->getTableDumpPath($tableName);
@@ -324,8 +327,10 @@ class DatabaseDump
 
     /**
      * Restore all tables (only modified tables are restored)
+     *
+     * @param bool $forceRestore
      */
-    public static function restoreAllTables(): void
+    public static function restoreAllTables(bool $forceRestore = false): void
     {
         $dump = new static();
 
@@ -334,7 +339,7 @@ class DatabaseDump
             // $table is an array looking like this [Tables_in_database_name => 'ps_access']
             $tableName = reset($table);
             $tableName = substr($tableName, strlen($dump->dbPrefix));
-            $dump->restoreTable($tableName);
+            $dump->restoreTable($tableName, $forceRestore);
         }
     }
 
@@ -342,13 +347,14 @@ class DatabaseDump
      * Restore a list of tables in the database
      *
      * @param array $tableNames
+     * @param bool $forceRestore
      */
-    public static function restoreTables(array $tableNames): void
+    public static function restoreTables(array $tableNames, bool $forceRestore = false): void
     {
         $dump = new static();
 
         foreach ($tableNames as $tableName) {
-            $dump->restoreTable($tableName);
+            $dump->restoreTable($tableName, $forceRestore);
         }
     }
 
@@ -356,8 +362,9 @@ class DatabaseDump
      * Restore a list of tables in the database which name match th regexp
      *
      * @param string $regexp
+     * @param bool $forceRestore
      */
-    public static function restoreMatchingTables(string $regexp): void
+    public static function restoreMatchingTables(string $regexp, bool $forceRestore = false): void
     {
         $dump = new static();
 
@@ -367,7 +374,7 @@ class DatabaseDump
             $tableName = reset($table);
             $tableName = substr($tableName, strlen($dump->dbPrefix));
             if (preg_match($regexp, $tableName)) {
-                $dump->restoreTable($tableName);
+                $dump->restoreTable($tableName, $forceRestore);
             }
         }
     }

--- a/src/PrestaShopBundle/Install/DatabaseDump.php
+++ b/src/PrestaShopBundle/Install/DatabaseDump.php
@@ -126,6 +126,13 @@ class DatabaseDump
         $this->exec($dumpCommand);
     }
 
+    private function checkDumpFile(): void
+    {
+        if (!file_exists($this->dumpFile)) {
+            throw new Exception('You need to run \'composer create-test-db\' to create the initial test database');
+        }
+    }
+
     private function dumpAllTables(): void
     {
         $db = Db::getInstance();
@@ -183,6 +190,13 @@ class DatabaseDump
         $dump = new static();
 
         $dump->dumpAllTables();
+    }
+
+    public static function checkDump(): void
+    {
+        $dump = new static();
+
+        $dump->checkDumpFile();
     }
 
     /**

--- a/src/PrestaShopBundle/Install/DatabaseDump.php
+++ b/src/PrestaShopBundle/Install/DatabaseDump.php
@@ -258,4 +258,25 @@ class DatabaseDump
             $dump->restoreTable($tableName);
         }
     }
+
+    /**
+     * Restore a list of tables in the database which name match th regexp
+     *
+     * @param string $regexp
+     */
+    public static function restoreMatchingTables(string $regexp): void
+    {
+        $dump = new static();
+
+        $db = Db::getInstance();
+        $tables = $db->executeS('SHOW TABLES;');
+        foreach ($tables as $table) {
+            // $table is an array looking like this [Tables_in_database_name => 'ps_access']
+            $tableName = reset($table);
+            $tableName = substr($tableName, strlen($dump->dbPrefix));
+            if (preg_match($regexp, $tableName)) {
+                $dump->restoreTable($tableName);
+            }
+        }
+    }
 }

--- a/src/PrestaShopBundle/Install/DatabaseDump.php
+++ b/src/PrestaShopBundle/Install/DatabaseDump.php
@@ -33,13 +33,60 @@ use Exception;
 
 class DatabaseDump
 {
+    /**
+     * Database host
+     *
+     * @var string
+     */
     private $host;
+
+    /**
+     * Database port
+     *
+     * @var int|string
+     */
     private $port;
+
+    /**
+     * Database user
+     *
+     * @var string
+     */
     private $user;
+
+    /**
+     * Database password
+     *
+     * @var string
+     */
     private $password;
+
+    /**
+     * Database name
+     *
+     * @var string
+     */
     private $databaseName;
+
+    /**
+     * Database prefix for table names
+     *
+     * @var string
+     */
     private $dbPrefix;
+
+    /**
+     * Generic dump file path (dump of the whole database)
+     *
+     * @var string
+     */
     private $dumpFile;
+
+    /**
+     * Db instance to perform queries
+     *
+     * @var Db
+     */
     private $db;
 
     /**
@@ -75,7 +122,7 @@ class DatabaseDump
     /**
      * Restore the dump to the actual database.
      */
-    public function restore()
+    public function restore(): void
     {
         $this->checkDumpFile();
 
@@ -115,7 +162,7 @@ class DatabaseDump
      *
      * @return string
      */
-    private function buildMySQLCommand($executable, array $arguments = [])
+    private function buildMySQLCommand($executable, array $arguments = []): string
     {
         $parts = [
             escapeshellarg($executable),
@@ -142,7 +189,7 @@ class DatabaseDump
      *
      * @throws Exception
      */
-    private function exec($command)
+    private function exec($command): array
     {
         $output = [];
         $ret = 1;
@@ -158,7 +205,7 @@ class DatabaseDump
     /**
      * The actual dump function.
      */
-    private function dump()
+    private function dump(): void
     {
         $dumpCommand = $this->buildMySQLCommand('mysqldump', [$this->databaseName]);
         $dumpCommand .= ' > ' . escapeshellarg($this->dumpFile) . ' 2> /dev/null';
@@ -236,7 +283,7 @@ class DatabaseDump
     /**
      * Make a database dump.
      */
-    public static function create()
+    public static function create(): void
     {
         $dump = new static();
 
@@ -246,7 +293,7 @@ class DatabaseDump
     /**
      * Make dump for each table in the database.
      */
-    public static function dumpTables()
+    public static function dumpTables(): void
     {
         $dump = new static();
 
@@ -268,7 +315,7 @@ class DatabaseDump
     /**
      * Restore a database dump.
      */
-    public static function restoreDb()
+    public static function restoreDb(): void
     {
         $dump = new static();
 

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -279,17 +279,6 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * This hook can be used to flag a scenario for database hard reset
-     *
-     * @BeforeScenario @database-scenario
-     */
-    public function cleanDatabaseHardPrepare()
-    {
-        static::restoreTestDB();
-        require_once _PS_ROOT_DIR_ . '/config/config.inc.php';
-    }
-
-    /**
      * @BeforeStep
      *
      * Clear Doctrine entity manager at each step in order to get fresh data
@@ -305,6 +294,17 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     public function rebootKernelOnDemand()
     {
         self::rebootKernel();
+    }
+
+    /**
+     * @Given I restore tables :tableNames
+     *
+     * @param string $tableNames
+     */
+    public function restoreTables(string $tableNames): void
+    {
+        $tables = explode(',', $tableNames);
+        DatabaseDump::restoreTables($tables);
     }
 
     private static function mockContext()
@@ -343,7 +343,6 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
 
     private static function restoreTestDB(): void
     {
-        DatabaseDump::checkDump();
         DatabaseDump::restoreDb();
     }
 

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -166,6 +166,17 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * This hook can be used to flag a feature for database hard reset
+     *
+     * @BeforeFeature @restore-all-tables-before-feature
+     */
+    public static function restoreAllTablesPrepareFeature()
+    {
+        DatabaseDump::restoreAllTables();
+        require_once _PS_ROOT_DIR_ . '/config/config.inc.php';
+    }
+
+    /**
      * This hook can be used to flag a feature for kernel reboot
      *
      * @BeforeFeature @reboot-kernel-before-feature

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -387,7 +387,7 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
         Category::resetStaticCache();
         Pack::resetStaticCache();
         Product::resetStaticCache();
-        Language::resetCache();
+        Language::resetStaticCache();
         Currency::resetStaticCache();
         TaxManagerFactory::resetStaticCache();
         Group::clearCachedValues();

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -157,10 +157,17 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     /**
      * This hook can be used to flag a feature for database hard reset
      *
+     * @deprecated since 8.0.0 and will be removed in next major.
+     *
      * @BeforeFeature @reset-database-before-feature
      */
     public static function cleanDatabaseHardPrepareFeature()
     {
+        @trigger_error(
+            'The @reset-database-before-feature tag is deprecated because there is a more optimized alternative use the @restore-all-tables-before-feature tag instead ',
+            E_USER_DEPRECATED
+        );
+
         static::restoreTestDB();
         require_once _PS_ROOT_DIR_ . '/config/config.inc.php';
     }

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -170,7 +170,7 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
      *
      * @BeforeFeature @restore-all-tables-before-feature
      */
-    public static function restoreAllTablesPrepareFeature()
+    public static function restoreAllTablesBeforeFeature()
     {
         DatabaseDump::restoreAllTables();
         require_once _PS_ROOT_DIR_ . '/config/config.inc.php';

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -188,7 +188,17 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
      *
      * @BeforeFeature @reboot-kernel-before-feature
      */
-    public static function rebootKernelPrepareFeature()
+    public static function rebootKernelBeforeFeature()
+    {
+        self::rebootKernel();
+    }
+
+    /**
+     * This hook can be used to flag a feature for kernel reboot
+     *
+     * @AfterFeature @reboot-kernel-after-feature
+     */
+    public static function rebootKernelAfterFeature()
     {
         self::rebootKernel();
     }
@@ -238,6 +248,14 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * @BeforeFeature @clear-cache-before-feature
+     */
+    public static function clearCacheBeforeFeature()
+    {
+        self::clearCache();
+    }
+
+    /**
      * @BeforeScenario @mock-context-on-scenario
      */
     public static function mockContextBeforeScenario()
@@ -267,14 +285,6 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     public static function resetContextAfterFeature()
     {
         self::resetContext();
-    }
-
-    /**
-     * @BeforeFeature @clear-cache-before-feature
-     */
-    public static function clearCacheBeforeFeature()
-    {
-        self::clearCache();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -54,7 +54,6 @@ use CustomizationField;
 use DateRange;
 use Employee;
 use EmployeeSession;
-use Exception;
 use Feature;
 use FeatureValue;
 use Gender;
@@ -344,10 +343,7 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
 
     private static function restoreTestDB(): void
     {
-        if (!file_exists(sprintf('%s/ps_dump_%s.sql', sys_get_temp_dir(), AppKernel::VERSION))) {
-            throw new Exception('You need to run \'composer create-test-db\' to create the initial test database');
-        }
-
+        DatabaseDump::checkDump();
         DatabaseDump::restoreDb();
     }
 

--- a/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
@@ -44,6 +44,11 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
      */
     protected $currencies = [];
 
+    /**
+     * @var Currency[]
+     */
+    protected $addedCurrencies = [];
+
     protected $previousDefaultCurrencyId;
 
     /**
@@ -63,9 +68,12 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
     public function cleanCurrencyFixtures()
     {
         Configuration::set('PS_CURRENCY_DEFAULT', $this->previousDefaultCurrencyId);
-        foreach ($this->currencies as $currency) {
+        // We only delete currencies that were added in the scenario, deleting the default currency would result in
+        // impacting the default currency
+        foreach ($this->addedCurrencies as $currency) {
             $currency->delete();
         }
+        $this->addedCurrencies = [];
         $this->currencies = [];
     }
 
@@ -84,6 +92,7 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
             $currency->active = 1;
             $currency->conversion_rate = $changeRate;
             $currency->add();
+            $this->addedCurrencies[] = $currency;
         } else {
             $currency = new Currency($currencyId);
             $currency->name = $currencyIsoCode;

--- a/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
@@ -52,7 +52,7 @@ use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 class CurrencyFeatureContext extends AbstractDomainFeatureContext
 {
     /**
-     * @BeforeFeature @reset-currencies-before-feature
+     * @BeforeFeature @restore-currencies-before-feature
      */
     public static function restoreCurrenciesTablesBeforeFeature(): void
     {
@@ -60,7 +60,7 @@ class CurrencyFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @AfterFeature @reset-currencies-after-feature
+     * @AfterFeature @restore-currencies-after-feature
      */
     public static function restoreCurrenciesTablesAfterFeature(): void
     {

--- a/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CurrencyFeatureContext.php
@@ -45,11 +45,37 @@ use PrestaShop\PrestaShop\Core\Domain\Currency\Query\GetReferenceCurrency;
 use PrestaShop\PrestaShop\Core\Domain\Currency\QueryResult\ReferenceCurrency;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShopBundle\Install\DatabaseDump;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 
 class CurrencyFeatureContext extends AbstractDomainFeatureContext
 {
+    /**
+     * @BeforeFeature @reset-currencies-before-feature
+     */
+    public static function restoreCurrenciesTablesBeforeFeature(): void
+    {
+        static::restoreCurrenciesTables();
+    }
+
+    /**
+     * @AfterFeature @reset-currencies-after-feature
+     */
+    public static function restoreCurrenciesTablesAfterFeature(): void
+    {
+        static::restoreCurrenciesTables();
+    }
+
+    private static function restoreCurrenciesTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'currency',
+            'currency_lang',
+            'currency_shop',
+        ]);
+    }
+
     /**
      * Random integer which should never exist in test database as currency id
      */

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -44,9 +44,22 @@ use Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContex
 class CommonProductFeatureContext extends AbstractProductFeatureContext
 {
     /**
+     * @AfterSuite
+     */
+    public static function restoreProductTablesAfterSuite(): void
+    {
+        static::restoreProductTables();
+    }
+
+    /**
      * @BeforeFeature @restore-products-before-feature
      */
-    public static function restoreProductTables(): void
+    public static function restoreProductTablesBeforeFeature(): void
+    {
+        static::restoreProductTables();
+    }
+
+    private static function restoreProductTables(): void
     {
         DatabaseDump::restoreTables([
             // Product data

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -34,6 +34,7 @@ use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShopBundle\Install\DatabaseDump;
 use Product;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\Util\CombinationDetails;
@@ -42,6 +43,34 @@ use Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContex
 
 class CommonProductFeatureContext extends AbstractProductFeatureContext
 {
+    /**
+     * @BeforeFeature @reset-products-before-feature
+     */
+    public static function restoreProductTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'product',
+            'product_attachment',
+            'product_attribute',
+            'product_attribute_combination',
+            'product_attribute_image',
+            'product_attribute_shop',
+            'product_carrier',
+            'product_country_tax',
+            'product_download',
+            'product_group_reduction_cache',
+            'product_lang',
+            'product_sale',
+            'product_shop',
+            'product_supplier',
+            'product_tag',
+
+            'category_product',
+            'feature_product',
+            'warehouse_product_location',
+        ]);
+    }
+
     /**
      * @Given product :productReference has following combinations:
      *

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -44,6 +44,18 @@ use Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContex
 class CommonProductFeatureContext extends AbstractProductFeatureContext
 {
     /**
+     * @todo: since product suite is the only one that has been properly optimized for now it is less resilient then
+     *        other suites which simply restore all tables. Each suite should be responsible for cleaning up its mess
+     *        but since it's not the case for now product suite needs to restore the DB itself.
+     *
+     * @BeforeSuite
+     */
+    public static function restoreAllTablesBeforeSuite(): void
+    {
+        DatabaseDump::restoreAllTables();
+    }
+
+    /**
      * @AfterSuite
      */
     public static function restoreProductTablesAfterSuite(): void

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShopBundle\Install\DatabaseDump;
 use Product;
 use RuntimeException;
+use Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\CombinationDetails;
 use Tests\Integration\Behaviour\Features\Context\Util\ProductCombinationFactory;
 use Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext;
@@ -61,6 +62,7 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
     public static function restoreProductTablesAfterSuite(): void
     {
         static::restoreProductTables();
+        LanguageFeatureContext::restoreLanguagesTablesAfterFeature();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -44,11 +44,12 @@ use Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContex
 class CommonProductFeatureContext extends AbstractProductFeatureContext
 {
     /**
-     * @BeforeFeature @reset-products-before-feature
+     * @BeforeFeature @restore-products-before-feature
      */
     public static function restoreProductTables(): void
     {
         DatabaseDump::restoreTables([
+            // Product data
             'product',
             'product_attachment',
             'product_attribute',
@@ -64,7 +65,23 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
             'product_shop',
             'product_supplier',
             'product_tag',
-
+            // Related products
+            'accessory',
+            // Customizations
+            'customization',
+            'customization_field',
+            'customization_field_lang',
+            'customized_data',
+            // Specific prices
+            'specific_price',
+            // Stock
+            'stock_available',
+            'stock_mvt',
+            // Images
+            'image',
+            'image_lang',
+            'image_shop',
+            // Miscellaneous relationships
             'category_product',
             'feature_product',
             'warehouse_product_location',

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPricePrioritiesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPricePrioritiesFeatureContext.php
@@ -33,10 +33,24 @@ use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Command\SetGlobalSpecificPricePriorityCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Command\SetSpecificPricePriorityForProductCommand;
+use PrestaShopBundle\Install\DatabaseDump;
 use SpecificPrice;
 
 class SpecificPricePrioritiesFeatureContext extends AbstractProductFeatureContext
 {
+    /**
+     * @AfterFeature @restore-specific-prices-priorities-after-feature
+     */
+    public static function restoreSpecificPricesPrioritiesAfterFeature(): void
+    {
+        // Specific price priorities is store in configuration, so we restore it
+        DatabaseDump::restoreTables([
+            'configuration',
+            'configuration_lang',
+        ]);
+        SpecificPrice::resetStaticCache();
+    }
+
     /**
      * @When I set following specific price priorities for product :productReference:
      *

--- a/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
@@ -28,10 +28,42 @@ namespace Tests\Integration\Behaviour\Features\Context;
 
 use Configuration;
 use Language;
+use PrestaShopBundle\Install\DatabaseDump;
 use RuntimeException;
 
 class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
 {
+    /**
+     * @BeforeFeature @restore-languages-before-feature
+     */
+    public static function restoreLanguagesTablesBeforeFeature(): void
+    {
+        static::restoreLanguagesTables();
+    }
+
+    /**
+     * @AfterFeature @restore-languages-after-feature
+     */
+    public static function restoreLanguagesTablesAfterFeature(): void
+    {
+        static::restoreLanguagesTables();
+    }
+
+    private static function restoreLanguagesTables(): void
+    {
+        // Removing Language manually includes cleaning all related lang tables which is faster than restoring
+        // each tables with a dump
+        $langIds = Language::getLanguages(false, false, true);
+        unset($langIds[0]);
+        foreach ($langIds as $langId) {
+            $lang = new Language($langId);
+            $lang->delete();
+        }
+
+        // We still restore lang table to reset increment ID
+        DatabaseDump::restoreTables(['lang']);
+    }
+
     /**
      *  @Given /^language with iso code "([^"]*)" is the default one$/
      */

--- a/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
@@ -27,6 +27,7 @@
 namespace Tests\Integration\Behaviour\Features\Context;
 
 use Configuration;
+use Db;
 use Language;
 use PrestaShopBundle\Install\DatabaseDump;
 use RuntimeException;
@@ -51,18 +52,17 @@ class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
 
     private static function restoreLanguagesTables(): void
     {
-        // Removing Language manually includes cleaning all related lang tables which is faster than restoring
-        // each tables with a dump
-        Language::resetStaticCache();
-        $langIds = Language::getLanguages(false, false, true);
+        // Removing Language manually includes cleaning all related lang tables, this cleaning is handled in
+        // Language::delete in a more efficient way than relying on table restoration
+        $langIds = Db::getInstance()->executeS(sprintf('SELECT id_lang FROM %slang;', _DB_PREFIX_));
         unset($langIds[0]);
         foreach ($langIds as $langId) {
-            $lang = new Language($langId);
+            $lang = new Language($langId['id_lang']);
             $lang->delete();
         }
 
         // We still restore lang table to reset increment ID
-        DatabaseDump::restoreTables(['lang'], true);
+        DatabaseDump::restoreTables(['lang']);
 
         // Restore static cache
         Language::resetStaticCache();

--- a/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
@@ -53,6 +53,7 @@ class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
     {
         // Removing Language manually includes cleaning all related lang tables which is faster than restoring
         // each tables with a dump
+        Language::resetStaticCache();
         $langIds = Language::getLanguages(false, false, true);
         unset($langIds[0]);
         foreach ($langIds as $langId) {
@@ -61,7 +62,10 @@ class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
         }
 
         // We still restore lang table to reset increment ID
-        DatabaseDump::restoreTables(['lang']);
+        DatabaseDump::restoreTables(['lang'], true);
+
+        // Restore static cache
+        Language::resetStaticCache();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/WebserviceEndpointFeatureContext.php
@@ -237,9 +237,7 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
         $_GET['output_format'] = $output;
 
         if ($requestMethod == 'PUT' || $requestMethod == 'POST') {
-            // Reset all data send to php://input mock
-            stream_wrapper_unregister('php');
-            stream_wrapper_register('php', StreamWrapperPHP::class);
+            StreamWrapperPHP::register();
             file_put_contents('php://input', 'xml=' . $postFields);
         }
 
@@ -259,6 +257,8 @@ class WebserviceEndpointFeatureContext extends AbstractPrestaShopFeatureContext
             $_GET['url'],
             $_GET['output_format']
         );
+
+        StreamWrapperPHP::unregister();
 
         return $return;
     }

--- a/tests/Integration/Behaviour/Features/Scenario/Address/customer_address.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Address/customer_address.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s address --tags customer-address
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @customer-address
 Feature: Address
   PrestaShop allows BO users to manage customer addresses

--- a/tests/Integration/Behaviour/Features/Scenario/Address/manufacturer_address.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Address/manufacturer_address.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s address --tags manufacturer-address
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @manufacturer-address
 Feature: Address
   PrestaShop allows BO users to manage manufacturer addresses

--- a/tests/Integration/Behaviour/Features/Scenario/Attachment/attachment_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Attachment/attachment_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s attachment --tags attachment-management
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-after-feature
 @reset-downloads-after-feature
 @attachment

--- a/tests/Integration/Behaviour/Features/Scenario/Attachment/attachment_search.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Attachment/attachment_search.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s attachment --tags search-attachment
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-after-feature
 @reset-downloads-after-feature
 @attachment

--- a/tests/Integration/Behaviour/Features/Scenario/Attribute/list_attribute_groups.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Attribute/list_attribute_groups.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s attribute --tags list-attribute-group
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @list-attribute-group
 Feature: Attribute Group
   PrestaShop allows BO users to list attribute groups

--- a/tests/Integration/Behaviour/Features/Scenario/CLDR/cldr.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CLDR/cldr.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cldr
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-after-feature
 Feature: CLDR display for prices
 

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/add_cartrule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/add_cartrule.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags bo-add-cart-rule
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Add cart rule in cart
   As a customer
   I must be able to correctly add cart rules in my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/gift_cartrule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/gift_cartrule.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-gift-cart-rule
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @cart-gift-cart-rule
 Feature: Add cart rule in cart
   As a customer

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/minimum_amount_cartrule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/minimum_amount_cartrule.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-minimum-amount-cart-rule
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @cart-minimum-amount-cart-rule
 Feature: Add cart rule in cart
   As a customer

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/CartRule/usage_limit_per_user.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml --tags remove-cart-rule
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @cart-rule-usage-limit
 
 Feature: A cart rule's usage limit per user is detected

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_combination.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Add product combination in cart
   As a customer
   I must be able to correctly add product combinations in my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_customization.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_customization.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Add product customization in cart
   As a customer
   I must be able to correctly add product customizations in my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_pack.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Add product pack in cart
   As a customer
   I must be able to correctly add product packs in my cart

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_standard_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Adding/Product/add_standard_product.feature
@@ -1,6 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags add-standard-product
 
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @add-standard-product
 Feature: Add product in cart
   As a customer

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/carrier.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/carrier.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with carriers
   As a customer
   I must be able to have correct cart total when selecting carriers

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/cart_rule_carrier_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/cart_rule_carrier_specific.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with carrier specific cart rules
   As a customer
   I must be able to have correct cart total when selecting carriers

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/change_carrier_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Carrier/change_carrier_cart_rule.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with carriers specific cart rules: carrier changes
   As a customer
   I must be able to have correct cart total when selecting carriers

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (amount) calculation with one cart rule
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_mono_virtual.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (amount) calculation with one cart rule
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_multiple.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (amount) calculation with multiple cart rules
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/amount_specific.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (amount) calculation with one cart rule restricted to one product
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/carrier.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/carrier.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with cart rules giving gift
   As a customer
   I must be able to have correct cart total when adding products, and adding cart rule with gift

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/cheapest_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/cheapest_product.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (percent) calculation with one cart rule restricted to cheapest product
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/ecotax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/ecotax.feature
@@ -1,6 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-calculation-cartrule-ecotax
 
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-scenario
 @cart-calculation-cartrule-ecotax
 Feature: Cart rule (percent) calculation with one cart rule

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/exclude_discounted_product.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (percent) calculation with one cart rule restricted to not already discounted product
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/free_shipping.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (amount) calculation with one cart rule offering free shipping
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/gift.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with cart rules giving gift
   As a customer
   I must be able to have correct cart total when adding products, and adding cart rule with gift

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/mixed.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/mixed.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (mixed) calculation with multiple cart rules
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/mixed_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/mixed_specific.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (percent) calculation with multiple cart rules restricted to one product
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_mono.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_mono.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (percent) calculation with one cart rule
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_multiple.feature
@@ -1,6 +1,6 @@
 #./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags calculation-cartrule-percent-multiple
 
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @calculation-cartrule-percent-multiple
 Feature: Cart rule (percent) calculation with multiple cart rules
   As a customer

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_no_code_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_no_code_multiple.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (percent) calculation with multiple cart rules without code
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (percent) calculation with one cart rule restricted to one product
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific_mono.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific_mono.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (percent) calculation with one cart rule restricted to one product
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/percent_specific_multiple.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart rule (percent) calculation with multiple cart rules restricted to one product
   As a customer
   I must be able to have correct cart total when adding cart rules

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Country/cart_rule_country_specific.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Country/cart_rule_country_specific.feature
@@ -1,6 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags calculation-country-cart-rule-specific
 
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @calculation-country-cart-rule-specific
 Feature: Cart calculation with country specific cart rules
   As a customer

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Currency/currency.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with currencies
   As a customer
   I must be able to have correct cart total when using distinct currencies

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Product/gift_wrapping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Product/gift_wrapping.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with only products and gift wrapping
   As a customer
   I must be able to have correct cart total when adding products, and selecting gift wrapping

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Product/only_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Product/only_products.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with only products
   As a customer
   I must be able to have correct cart total when adding products

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Product/specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Product/specific_price.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with only products with specific prices
   As a customer
   I must be able to have correct cart total when adding products

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_down.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_down.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with rounding mode DOWN
   As a customer
   I must be able to have correct cart total when configuration is set to different rounding modes

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_half_down.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_half_down.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with rounding mode HALF_DOWN
   As a customer
   I must be able to have correct cart total when configuration is set to different rounding modes

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_half_even.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_half_even.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with rounding mode HALF_EVEN
   As a customer
   I must be able to have correct cart total when configuration is set to different rounding modes

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_half_odd.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_half_odd.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with rounding mode HALF_ODD
   As a customer
   I must be able to have correct cart total when configuration is set to different rounding modes

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_half_up.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_half_up.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with rounding mode HALF_UP
   As a customer
   I must be able to have correct cart total when configuration is set to different rounding modes

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_up.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingMode/round_up.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with rounding mode UP
   As a customer
   I must be able to have correct cart total when configuration is set to different rounding modes

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_item.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with rounding type ITEM
   As a customer
   I must be able to have correct cart total when configuration is set to different rounding types

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_line.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_line.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with rounding type LINE
   As a customer
   I must be able to have correct cart total when configuration is set to different rounding types

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_total.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/RoundingType/round_total.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with rounding type TOTAL
   As a customer
   I must be able to have correct cart total when configuration is set to different rounding types

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/amount.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/amount.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with specific price rule (amount)
   As a customer
   I must be able to have correct cart total when adding specific price rule

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/mixed.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/mixed.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with specific price rule (mixed)
   As a customer
   I must be able to have correct cart total when adding specific price rule

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/percent.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/percent.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with specific price rule (percent)
   As a customer
   I must be able to have correct cart total when adding specific price rule

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/percent_multiple.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/percent_multiple.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with specific price rule (percent multiple)
   As a customer
   I must be able to have correct cart total when adding specific price rule

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/price_set.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/SpecificPriceRule/price_set.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with specific price rule (price set)
   As a customer
   I must be able to have correct cart total when adding specific price rule

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Taxes/tax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/Taxes/tax.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Cart calculation with tax
   As a customer
   I must be able to have correct cart total when using taxes

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/CartToOrder/cart_to_order.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Check cart to order data copy
   As a customer
   I must be able to have a correct order when validating payment step

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Deleting/delete_cart_rule_from_cart.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Deleting/delete_cart_rule_from_cart.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags bo-delete-cart-rule
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Delete cart rule from cart in Back Office (BO)
   As a BO user I must be able to delete cart rules from cart
   Background:

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Deleting/delete_product_from_cart.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Deleting/delete_product_from_cart.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags bo-delete-product
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Delete product from cart in Back Office (BO)
   As a BO user I must be able to delete products from cart
   Background:

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Delivery/delivery_options.feature
@@ -1,6 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags delivery-options
 
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @delivery-options
 @clear-cache-after-feature
 Feature: Compute correct delivery options

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Updating/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Updating/Product/update_pack.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart --tags cart-updating-product-pack
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @cart-updating-product-pack
 Feature: Add product pack in cart
   As a customer

--- a/tests/Integration/Behaviour/Features/Scenario/CartRule/cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CartRule/cart_rule.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart_rule
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Add cart rule
   PrestaShop allows BO users to create cart rules
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s category
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Category Management
   PrestaShop allows BO users to manage categories for products
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/CmsPage/cms_page_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/CmsPage/cms_page_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cms_page
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: CmsPage Management
   PrestaShop allows BO users to manage CMS pages
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Contact/contact.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Contact/contact.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Contact
   In order to create customizable contact us form for customers
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency --tags currency-data
 @restore-all-tables-before-feature
+@clear-cache-before-feature
 @currency-data
 Feature: Currency Data
   PrestaShop provides handlers for currency data

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency --tags currency-data
 @restore-all-tables-before-feature
+@currency-data
 Feature: Currency Data
   PrestaShop provides handlers for currency data
   As a BO user
@@ -10,7 +11,6 @@ Feature: Currency Data
     And language "language1" with locale "en-US" exists
     And language "language2" with locale "fr-FR" exists
 
-  @currency-data
   Scenario: Get data from an official currency
     When I request reference data for "EUR"
     Then I should get no error
@@ -25,7 +25,6 @@ Feature: Currency Data
       | patterns[en-US]  | ¤#,##0.00  |
       | patterns[fr-FR]  | #,##0.00 ¤ |
 
-  @currency-data
   Scenario: Get data from an unofficial currency
     When I request reference data for "BTC"
     Then I should get error that currency was not found
@@ -41,7 +40,6 @@ Feature: Currency Data
     When I request reference data for "BTC"
     Then I should get error that currency was not found
 
-  @currency-data
   Scenario: Get data from a customized currency
     When I add new currency "currency1" with following properties:
       | iso_code         | JPY        |

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency --tags currency-data
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Currency Data
   PrestaShop provides handlers for currency data
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_data.feature
@@ -1,6 +1,7 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency --tags currency-data
 @restore-all-tables-before-feature
 @clear-cache-before-feature
+@reboot-kernel-before-feature
 @currency-data
 Feature: Currency Data
   PrestaShop provides handlers for currency data

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency --tags currency-management
 @restore-all-tables-before-feature
+@clear-cache-before-feature
 @currency-management
 Feature: Currency Management
   PrestaShop allows BO users to manage currencies

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
@@ -1,6 +1,7 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency --tags currency-management
 @restore-all-tables-before-feature
 @clear-cache-before-feature
+@reboot-kernel-before-feature
 @currency-management
 Feature: Currency Management
   PrestaShop allows BO users to manage currencies

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Currency Management
   PrestaShop allows BO users to manage currencies
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Currency/currency_management.feature
@@ -1,5 +1,6 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s currency --tags currency-management
 @restore-all-tables-before-feature
+@currency-management
 Feature: Currency Management
   PrestaShop allows BO users to manage currencies
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer --tags customer-management
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @customer-management
 Feature: Customer Management
   PrestaShop allows BO users to manage customers in the Customers > Customers page

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_private_note.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_private_note.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer --tags customer-private-note
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @customer-private-note
 Feature: Setting private note about customer
   In order to have private notes about FO customers

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_required_fields_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_required_fields_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer --tags customer-required-fields
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @customer-required-fields
 Feature: Customer Required fields management
   PrestaShop allows BO users to manage required fields for FO customer profile

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/search_customers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/search_customers.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s customer --tags search-customers
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-feature
 @search-customers
 

--- a/tests/Integration/Behaviour/Features/Scenario/Database/sql_manager.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Database/sql_manager.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s database
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: SQL Manager
   PrestaShop allows BO users to manage SQL queries in the Configure > Advanced > Database page
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Feature/feature_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Feature/feature_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s feature --tags feature-management
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @feature-management
 Feature: Product feature management
   PrestaShop allows BO users to manage product features

--- a/tests/Integration/Behaviour/Features/Scenario/Feature/feature_value_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Feature/feature_value_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s feature --tags feature-value-management
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @feature-value-management
 Feature: Product feature value management
   PrestaShop allows BO users to manage product feature value

--- a/tests/Integration/Behaviour/Features/Scenario/FeatureFlag/feature_flag.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/FeatureFlag/feature_flag.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s feature_flag --tags feature-flag
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Feature Flag
   As a BO user
   I want to be able to try experimental features by toggling feature flags in the Back Office

--- a/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Language/language.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s language
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Language
 
   Background:

--- a/tests/Integration/Behaviour/Features/Scenario/Manufacturer/manufacturer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Manufacturer/manufacturer_management.feature
@@ -1,5 +1,5 @@
 #./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s manufacturer
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Manufacturer management
   As an employee
   I must be able to add, edit and delete manufacturers

--- a/tests/Integration/Behaviour/Features/Scenario/Meta/meta_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Meta/meta_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s meta
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Meta management (Traffic & Seo)
   PrestaShop allows BO users to manage page metadata - title, description, keywords, url_rewrite etc...
   As a BO user I must be able to create, edit, delete and update meta data.

--- a/tests/Integration/Behaviour/Features/Scenario/Misc/debug_mode.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Misc/debug_mode.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s misc
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Switch debug mode
   In order to see or hide what exactly is causing the error
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Misc/showcase_card.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Misc/showcase_card.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s misc
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Showcase card
   In order to hide not relevant information in the Back Office
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Misc/theme_mail_templates.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Misc/theme_mail_templates.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s misc --tags theme_mail_templates
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @theme_mail_templates
 Feature: Theme mail templates
   In order to use customized email templates in the Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/add_cart_rule_to_order.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags add-discounts-to-order
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @add-discounts-to-order
 Feature: Add discounts to order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/duplicate_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/duplicate_products.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags duplicate-products-in-order
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @duplicate-products-in-order
 Feature: Order from Back Office (BO)
   In order to manage orders for FO customers

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_add_payment.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags add-payment-to-order
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @add-payment-to-order
 Feature: Add payment to Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_address.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_address.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-address
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-address
 @clear-cache-before-feature
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cancel_product.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-cancel-product
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-cancel-product
 @clear-cache-before-feature
 Feature: Cancel Order Product from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_cart_rules.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-cart-rules
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-cart-rules
 @clear-cache-before-feature
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_currency.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags multiple-currencies-to-order
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @clear-cache-before-feature
 @multiple-currencies-to-order

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_customer.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_customer.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-customer
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @clear-cache-before-feature
 @order-customer

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_documents.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_documents.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-documents
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @clear-cache-before-feature
 @order-documents

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags basic-order-ecotax
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @clear-cache-before-feature
 @order-ecotax

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_cartrule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_cartrule.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-ecotax-cartrule
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @clear-cache-before-feature
 @order-ecotax

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_combination.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-ecotax-combination
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @clear-cache-before-feature
 @order-ecotax

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_odd_tax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_odd_tax.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags odd-order-ecotax
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @clear-cache-before-feature
 @order-ecotax

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_with_tax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_ecotax_with_tax.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-ecotax-with-tax
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reboot-kernel-before-feature
 @clear-cache-before-feature
 @order-ecotax

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_fixed_product_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_fixed_product_prices.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-fixed-product-prices
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-feature
 @order-fixed-product-prices
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_french_tax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_french_tax.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-french-tax
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-feature
 @order-french-tax
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-from-bo
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-from-bo
 Feature: Order from Back Office (BO)
   In order to manage orders for FO customers

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_from_bo.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-from-bo
 @restore-all-tables-before-feature
+@clear-cache-before-feature
 @order-from-bo
 Feature: Order from Back Office (BO)
   In order to manage orders for FO customers

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_gift_cart_rule.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_gift_cart_rule.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-gift-cart-rule
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-gift-cart-rule
 @clear-cache-before-feature
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_invoices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_invoices.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-multi-invoices
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-multi-invoices
 @clear-cache-before-feature
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_multi_shop.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-multi-shop
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @mock-context-on-scenario
 @clear-cache-before-feature
 @order-multi-shop

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_odd_tax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_odd_tax.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-odd-tax
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-feature
 @order-odd-tax
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_out_of_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_out_of_stock.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-out-of-stock
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reset-product-price-cache
 @order-out-of-stock
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_product.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-product
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @reset-product-price-cache
 @order-product
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_rounding_type.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-rounding-type
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-feature
 @order-rounding-type
 

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-shipping
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-shipping
 @clear-cache-before-feature
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping_recalculate.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_shipping_recalculate.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-shipping-recalculate
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-shipping-recalculate
 @clear-cache-before-feature
 Feature: Order from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_specific_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_specific_prices.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-specific-prices
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-specific-prices
 Feature: Order from Back Office (BO)
   In order to manage orders for FO customers

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_to_cart.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_to_cart.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-to-cart
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @order-to-cart
 Feature: Check order to cart data copy
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/partial_refund.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-partial-refund
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-feature
 Feature: Refund Order from Back Office (BO)
   In order to refund orders for FO customers

--- a/tests/Integration/Behaviour/Features/Scenario/Order/return_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/return_product.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-return-product
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-feature
 Feature: Refund Order from Back Office (BO)
   In order to refund orders for FO customers

--- a/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/standard_refund.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-standard-refund
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-feature
 Feature: Refund Order from Back Office (BO)
   In order to refund orders for FO customers

--- a/tests/Integration/Behaviour/Features/Scenario/OrderMessage/order_message_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/OrderMessage/order_message_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order_message
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Order message Management
   In order to have prepared reply messages about order
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/combinations_listing.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/combinations_listing.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags combinations-listing
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @combinations-listing

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/combinations_listing.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/combinations_listing.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags combinations-listing
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @combinations-listing

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/delete_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/delete_combination.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-combination
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @delete-combination

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/delete_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/delete_combination.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-combination
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @delete-combination

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/forbidden_actions.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/forbidden_actions.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags forbidden-combination-actions
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @forbidden-combination-actions

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/forbidden_actions.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/forbidden_actions.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags forbidden-combination-actions
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @forbidden-combination-actions

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/generate_combinations.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/generate_combinations.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags generate-combinations
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @generate-combinations

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/generate_combinations.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/generate_combinations.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags generate-combinations
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @generate-combinations

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags search-combinations
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @search-combinations
 Feature: Search combinations to associate them in the BO

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags search-combinations
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @clear-cache-before-feature
 @search-combinations
 Feature: Search combinations to associate them in the BO

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
@@ -1,6 +1,7 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags search-combinations
 @restore-products-before-feature
 @restore-languages-after-feature
+@reset-img-after-feature
 @clear-cache-before-feature
 @search-combinations
 Feature: Search combinations to associate them in the BO

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_details.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_details.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-details
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-details

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_details.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_details.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-details
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-details

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_from_listing.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_from_listing.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-from-listing
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-from-listing

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_from_listing.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_from_listing.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-from-listing
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-from-listing

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-images
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-combination

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_images.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-images
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-combination

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_prices.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-prices
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-prices

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_prices.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-prices
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-prices

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-stock
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-stock

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-stock
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-stock

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_suppliers.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-suppliers
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-suppliers

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_suppliers.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-suppliers
-@reset-products-before-feature
+@restore-products-before-feature
+@reset-currencies-after-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-suppliers

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_suppliers.feature
@@ -1,6 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-suppliers
 @restore-products-before-feature
-@reset-currencies-after-feature
+@restore-currencies-after-feature
 @clear-cache-before-feature
 @product-combination
 @update-combination-suppliers

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Image/add_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Image/add_image.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add-image
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-image

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Image/add_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Image/add_image.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add-image
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-image

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Image/delete_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Image/delete_image.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-image
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-image

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Image/delete_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Image/delete_image.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-image
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-image

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Image/update_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Image/update_image.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-image
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-image

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Image/update_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Image/update_image.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-image
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-image

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/add_specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/add_specific_price.feature
@@ -1,6 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add-specific-price
 @restore-products-before-feature
-@reset-currencies-after-feature
+@restore-currencies-after-feature
 @add-specific-price
 @specific-prices
 Feature: Update product options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/add_specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/add_specific_price.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add-specific-price
-@reset-products-before-feature
+@restore-products-before-feature
+@reset-currencies-after-feature
 @add-specific-price
 @specific-prices
 Feature: Update product options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/add_specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/add_specific_price.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add-specific-price
-@reset-database-before-feature
+@reset-products-before-feature
 @add-specific-price
 @specific-prices
 Feature: Update product options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/edit_specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/edit_specific_price.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags edit-specific-price
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @edit-specific-price
 @specific-prices

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/edit_specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/edit_specific_price.feature
@@ -1,6 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags edit-specific-price
 @restore-products-before-feature
-@reset-currencies-after-feature
+@restore-currencies-after-feature
 @clear-cache-before-feature
 @edit-specific-price
 @specific-prices

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/edit_specific_price.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/edit_specific_price.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags edit-specific-price
-@reset-products-before-feature
+@restore-products-before-feature
+@reset-currencies-after-feature
 @clear-cache-before-feature
 @edit-specific-price
 @specific-prices

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_price_priorities.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_price_priorities.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags specific-price-priorities
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @specific-price-priorities
 @specific-prices

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_price_priorities.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_price_priorities.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags specific-price-priorities
 @restore-products-before-feature
+@restore-specific-prices-priorities-after-feature
 @clear-cache-before-feature
 @specific-price-priorities
 @specific-prices

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_price_priorities.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_price_priorities.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags specific-price-priorities
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @specific-price-priorities
 @specific-prices

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/add_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/add_virtual_product_file.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add-virtual-product-file
-@reset-products-before-feature
+@restore-products-before-feature
 @virtual-product-file
 @add-virtual-product-file
 @reset-downloads-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/add_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/add_virtual_product_file.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add-virtual-product-file
-@reset-database-before-feature
+@reset-products-before-feature
 @virtual-product-file
 @add-virtual-product-file
 @reset-downloads-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/delete_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/delete_virtual_product_file.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-virtual-product-file
-@reset-database-before-feature
+@reset-products-before-feature
 @virtual-product-file
 @delete-virtual-product-file
 @reset-downloads-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/delete_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/delete_virtual_product_file.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-virtual-product-file
-@reset-products-before-feature
+@restore-products-before-feature
 @virtual-product-file
 @delete-virtual-product-file
 @reset-downloads-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/update_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/update_virtual_product_file.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-virtual-product-file
-@reset-products-before-feature
+@restore-products-before-feature
 @virtual-product-file
 @update-virtual-product-file
 @reset-downloads-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/update_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/update_virtual_product_file.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-virtual-product-file
-@reset-database-before-feature
+@reset-products-before-feature
 @virtual-product-file
 @update-virtual-product-file
 @reset-downloads-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @clear-cache-after-feature
 @add

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -1,4 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add
+@reset-products-before-feature
 @clear-cache-before-feature
 @clear-cache-after-feature
 @add
@@ -7,7 +8,6 @@ Feature: Add basic product from Back Office (BO)
   I need to be able to add new product with basic information from the BO
 
   Background:
-    Given I restore tables "product,product_lang,product_shop,product_attribute"
     Given language "language1" with locale "en-US" exists
     And category "home" in default language named "Home" exists
     And category "home" is the default one

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -1,5 +1,4 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add
-@reset-database-before-feature
 @clear-cache-before-feature
 @clear-cache-after-feature
 @add
@@ -8,6 +7,7 @@ Feature: Add basic product from Back Office (BO)
   I need to be able to add new product with basic information from the BO
 
   Background:
+    Given I restore tables "product,product_lang,product_shop,product_attribute"
     Given language "language1" with locale "en-US" exists
     And category "home" in default language named "Home" exists
     And category "home" is the default one

--- a/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags category-tree
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @category-tree
 Feature: Show category tree in product page (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags category-tree
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @category-tree
 Feature: Show category tree in product page (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/delete_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/delete_product.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @delete
 Feature: Delete products from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/delete_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/delete_product.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @delete
 Feature: Delete products from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags duplicate-product
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @duplicate-product
 @reset-downloads-after-feature
 @clear-cache-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags duplicate-product
-@reset-database-before-feature
+@reset-products-before-feature
 @duplicate-product
 @reset-downloads-after-feature
 @clear-cache-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags legacy-product-type
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @clear-cache-after-feature
 @legacy-product-type

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags legacy-product-type
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @clear-cache-after-feature
 @legacy-product-type

--- a/tests/Integration/Behaviour/Features/Scenario/Product/search_products_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/search_products_for_association.feature
@@ -1,6 +1,7 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags search-products
 @restore-products-before-feature
 @restore-languages-after-feature
+@reset-img-after-feature
 @clear-cache-before-feature
 @search-products
 Feature: Search products to associate them in the BO

--- a/tests/Integration/Behaviour/Features/Scenario/Product/search_products_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/search_products_for_association.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags search-products
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @clear-cache-before-feature
 @search-products
 Feature: Search products to associate them in the BO
@@ -8,7 +9,7 @@ Feature: Search products to associate them in the BO
 
   Background:
     Given language "english" with locale "en-US" exists
-    Given language "french" with locale "fr-FR" exists
+    And language "french" with locale "fr-FR" exists
     And language with iso code "en" is the default one
 
   Scenario: I can search products by name

--- a/tests/Integration/Behaviour/Features/Scenario/Product/search_products_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/search_products_for_association.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags search-products
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @search-products
 Feature: Search products to associate them in the BO

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-attachments
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @update-attachments
 @clear-cache-after-feature
 @reset-downloads-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_attachments.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-attachments
-@reset-database-before-feature
+@reset-products-before-feature
 @update-attachments
 @clear-cache-after-feature
 @reset-downloads-after-feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-basic-information
-@reset-products-before-feature
+@restore-products-before-feature
 @update-basic-information
 Feature: Update product basic information from Back Office (BO)
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-basic-information
-@reset-database-before-feature
+@reset-products-before-feature
 @update-basic-information
 Feature: Update product basic information from Back Office (BO)
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-categories
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @update-categories
 Feature: Update product categories from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-categories
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @clear-cache-before-feature
 @update-categories
 Feature: Update product categories from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_customization_fields.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_customization_fields.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-customization-fields
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @clear-cache-before-feature
 @update-customization-fields
 Feature: Update product customization fields in Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_customization_fields.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_customization_fields.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-customization-fields
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @update-customization-fields
 Feature: Update product customization fields in Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_details.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_details.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-details
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @update-details
 Feature: Update product details from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_details.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_details.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-details
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @update-details
 Feature: Update product details from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_feature_values.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_feature_values.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-feature-values
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @update-feature-values
 Feature: Update product details from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_feature_values.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_feature_values.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-feature-values
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @clear-cache-before-feature
 @update-feature-values
 Feature: Update product details from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-options
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @update-options
 Feature: Update product options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_options.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-options
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @update-options
 Feature: Update product options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-pack
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-after-feature
 @update-pack
 Feature: Add product to pack from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-pack
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-after-feature
 @update-pack
 Feature: Add product to pack from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-prices
-@reset-products-before-feature
+@restore-products-before-feature
 @update-prices
 Feature: Update product price fields from Back Office (BO).
   As a BO user I want to be able to update product fields associated with price.

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-prices
-@reset-database-before-feature
+@reset-products-before-feature
 @update-prices
 Feature: Update product price fields from Back Office (BO).
   As a BO user I want to be able to update product fields associated with price.

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-product-type
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @clear-cache-after-feature
 @update-product-type

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-product-type
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @clear-cache-after-feature
 @update-product-type

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags related-products
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @related-products
 Feature: Update product related products from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags related-products
 @restore-products-before-feature
+@reset-img-after-feature
 @clear-cache-before-feature
 @related-products
 Feature: Update product related products from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags related-products
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @related-products
 Feature: Update product related products from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-seo
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @clear-cache-before-feature
 @update-seo
 Feature: Update product SEO options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
@@ -1,6 +1,7 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-seo
 @restore-products-before-feature
 @restore-languages-after-feature
+@reset-img-after-feature
 @clear-cache-before-feature
 @update-seo
 Feature: Update product SEO options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-seo
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @update-seo
 Feature: Update product SEO options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-shipping
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @update-shipping
 Feature: Update product shipping options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-shipping
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @update-shipping
 Feature: Update product shipping options from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-status
-@reset-products-before-feature
+@restore-products-before-feature
 @clear-cache-before-feature
 @update-status
 Feature: Update product status from BO (Back Office)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-status
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @update-status
 Feature: Update product status from BO (Back Office)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-stock
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @reboot-kernel-before-feature
 @update-stock

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-stock
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @clear-cache-before-feature
 @reboot-kernel-before-feature
 @update-stock

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
@@ -1,6 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-suppliers
 @restore-products-before-feature
-@reset-currencies-after-feature
+@restore-currencies-after-feature
 @clear-cache-before-feature
 @update-suppliers
 Feature: Update product suppliers from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-suppliers
-@reset-products-before-feature
+@restore-products-before-feature
+@reset-currencies-after-feature
 @clear-cache-before-feature
 @update-suppliers
 Feature: Update product suppliers from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-suppliers
-@reset-database-before-feature
+@reset-products-before-feature
 @clear-cache-before-feature
 @update-suppliers
 Feature: Update product suppliers from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-tags
-@reset-database-before-feature
+@reset-products-before-feature
 @update-tags
 Feature: Update product tags from Back Office (BO)
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-tags
-@reset-products-before-feature
+@restore-products-before-feature
+@restore-languages-after-feature
 @update-tags
 Feature: Update product tags from Back Office (BO)
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/SearchEngine/search_engine_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/SearchEngine/search_engine_management.feature
@@ -1,5 +1,5 @@
 #./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s manufacturer
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Search engine management
   As an employee
   I must be able to add, edit and delete search engines

--- a/tests/Integration/Behaviour/Features/Scenario/Shop/search_shops.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shop/search_shops.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shop --tags search-shops
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @clear-cache-before-feature
 @search-shops
 

--- a/tests/Integration/Behaviour/Features/Scenario/Shop/shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Shop/shop.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s shop
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @shop
 Feature: Shop Management
   In order to personalize the shop

--- a/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
@@ -1,5 +1,5 @@
 #./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s supplier
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Supplier management
   As an employee
   I must be able to add, edit and delete suppliers from Back Office

--- a/tests/Integration/Behaviour/Features/Scenario/Tax/tax_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Tax/tax_management.feature
@@ -1,4 +1,4 @@
-@reset-database-before-feature
+@restore-all-tables-before-feature
 #./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s tax
 Feature: Manage tax
   As an employee

--- a/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/addresses.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Webservice/Endpoints/addresses.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s webservice --tags webservice-endpoints-addresses
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @webservice-endpoints-addresses
 Feature: Webservice key management
   PrestaShop allows BO users to manage Webservice keys

--- a/tests/Integration/Behaviour/Features/Scenario/Webservice/webservice_key_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Webservice/webservice_key_management.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s webservice --tags webservice-key-management
-@reset-database-before-feature
+@restore-all-tables-before-feature
 @webservice-key-management
 Feature: Webservice key management
   PrestaShop allows BO users to manage Webservice keys

--- a/tests/Integration/Behaviour/Features/Scenario/Zone/zone_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Zone/zone_management.feature
@@ -1,5 +1,5 @@
 #./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s manufacturer
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Zones management
   As an employee
   I must be able to add, edit and delete zones

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -280,7 +280,6 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\SupplierFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CommonDomainFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ManufacturerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateAttachmentFeatureContext

--- a/tests/Integration/Classes/ObjectModelTest.php
+++ b/tests/Integration/Classes/ObjectModelTest.php
@@ -32,6 +32,7 @@ use Configuration;
 use Db;
 use Language;
 use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Install\DatabaseDump;
 use Shop;
 use Tests\Resources\classes\TestableObjectModel;
 
@@ -113,6 +114,9 @@ class ObjectModelTest extends TestCase
         $this->assertEquals($localizedNames[$this->secondLanguageId], $secondLangObject->name);
     }
 
+    /**
+     * @depends testAdd
+     */
     public function testUpdate(): void
     {
         $quantity = 42;
@@ -165,6 +169,8 @@ class ObjectModelTest extends TestCase
     }
 
     /**
+     * @depends testUpdate
+     *
      * @dataProvider getPartialUpdates
      *
      * @param array $initialProperties
@@ -321,6 +327,8 @@ class ObjectModelTest extends TestCase
     }
 
     /**
+     * @depends testPartialUpdate
+     *
      * @dataProvider getMultiShopValues
      *
      * @param array $initialProperties
@@ -436,6 +444,8 @@ class ObjectModelTest extends TestCase
     }
 
     /**
+     * @depends testMultiShopUpdate
+     *
      * @dataProvider getPartialMultiShopValues
      *
      * @param array $initialProperties
@@ -591,6 +601,25 @@ class ObjectModelTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    /**
+     * @depends testPartialMultiShopUpdate
+     *
+     * Since we can't properly use setUpBEforeClass and setUpAfterClass we cannot clear our data properly so we cheat
+     * on rely on the "depends" annotation so that all tests happen in the expected sequence when they all finished we
+     * know everything was tested and we can clear the database.
+     */
+    public function testCleanUp(): void
+    {
+        $db = Db::getInstance();
+        $db->execute(sprintf('DROP TABLE %stestable_object', _DB_PREFIX_));
+        $db->execute(sprintf('DROP TABLE %stestable_object_lang', _DB_PREFIX_));
+        $db->execute(sprintf('DROP TABLE %stestable_object_shop', _DB_PREFIX_));
+        DatabaseDump::restoreAllTables();
+
+        // Just to make PHPUnit happy ^^
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/Resources/ResourceResetter.php
+++ b/tests/Resources/ResourceResetter.php
@@ -89,7 +89,7 @@ class ResourceResetter
     }
 
     /**
-     * Resets test images directory to initial state
+     * Resets test downloads directory to initial state
      */
     public function resetDownloads(): void
     {

--- a/tests/Resources/ResourceResetter.php
+++ b/tests/Resources/ResourceResetter.php
@@ -68,7 +68,7 @@ class ResourceResetter
      */
     public function backupImages(): void
     {
-        $this->filesystem->mirror(_PS_IMG_DIR_, $this->getBackupTestImgDir());
+        $this->filesystem->mirror(_PS_IMG_DIR_, $this->getBackupTestImgDir(), null, ['delete' => true]);
     }
 
     /**
@@ -76,7 +76,7 @@ class ResourceResetter
      */
     public function backupDownloads(): void
     {
-        $this->filesystem->mirror(_PS_DOWNLOAD_DIR_, $this->getBackupTestDownloadsDir());
+        $this->filesystem->mirror(_PS_DOWNLOAD_DIR_, $this->getBackupTestDownloadsDir(), null, ['delete' => true]);
     }
 
     /**
@@ -85,7 +85,7 @@ class ResourceResetter
     public function resetImages(): void
     {
         $this->filesystem->remove(_PS_IMG_DIR_);
-        $this->filesystem->mirror($this->getBackupTestImgDir(), _PS_IMG_DIR_);
+        $this->filesystem->mirror($this->getBackupTestImgDir(), _PS_IMG_DIR_, null, ['delete' => true]);
     }
 
     /**
@@ -94,7 +94,7 @@ class ResourceResetter
     public function resetDownloads(): void
     {
         $this->filesystem->remove(_PS_DOWNLOAD_DIR_);
-        $this->filesystem->mirror($this->getBackupTestDownloadsDir(), _PS_DOWNLOAD_DIR_);
+        $this->filesystem->mirror($this->getBackupTestDownloadsDir(), _PS_DOWNLOAD_DIR_, null, ['delete' => true]);
     }
 
     /**

--- a/tests/TestCase/SymfonyIntegrationTestCase.php
+++ b/tests/TestCase/SymfonyIntegrationTestCase.php
@@ -74,7 +74,6 @@ class SymfonyIntegrationTestCase extends WebTestCase
 
     private static function restoreTestDB(): void
     {
-        DatabaseDump::checkDump();
         DatabaseDump::restoreDb();
     }
 }

--- a/tests/TestCase/SymfonyIntegrationTestCase.php
+++ b/tests/TestCase/SymfonyIntegrationTestCase.php
@@ -26,8 +26,6 @@
 
 namespace Tests\TestCase;
 
-use AppKernel;
-use Exception;
 use PrestaShopBundle\Install\DatabaseDump;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -76,10 +74,7 @@ class SymfonyIntegrationTestCase extends WebTestCase
 
     private static function restoreTestDB(): void
     {
-        if (!file_exists(sprintf('%s/ps_dump_%s.sql', sys_get_temp_dir(), AppKernel::VERSION))) {
-            throw new Exception('You need to run \'composer create-test-db\' to create the initial test database');
-        }
-
+        DatabaseDump::checkDump();
         DatabaseDump::restoreDb();
     }
 }

--- a/tests/bin/create-test-tables-dump.php
+++ b/tests/bin/create-test-tables-dump.php
@@ -1,0 +1,37 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+use PrestaShopBundle\Install\DatabaseDump;
+
+define('_PS_ROOT_DIR_', dirname(__DIR__, 2));
+const _PS_IN_TEST_ = true;
+const __PS_BASE_URI__ = '/';
+const _PS_MODULE_DIR_ = _PS_ROOT_DIR_ . '/modules/';
+
+require_once _PS_ROOT_DIR_ . '/install-dev/init.php';
+
+DatabaseDump::dumpTables();

--- a/tests/bin/restore-test-db.php
+++ b/tests/bin/restore-test-db.php
@@ -1,0 +1,37 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+use PrestaShopBundle\Install\DatabaseDump;
+
+define('_PS_ROOT_DIR_', dirname(__DIR__, 2));
+const _PS_IN_TEST_ = true;
+const __PS_BASE_URI__ = '/';
+const _PS_MODULE_DIR_ = _PS_ROOT_DIR_ . '/modules/';
+
+require_once _PS_ROOT_DIR_ . '/install-dev/init.php';
+
+DatabaseDump::restoreDb();

--- a/tests/bin/restore-test-tables.php
+++ b/tests/bin/restore-test-tables.php
@@ -1,0 +1,37 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+use PrestaShopBundle\Install\DatabaseDump;
+
+define('_PS_ROOT_DIR_', dirname(__DIR__, 2));
+const _PS_IN_TEST_ = true;
+const __PS_BASE_URI__ = '/';
+const _PS_MODULE_DIR_ = _PS_ROOT_DIR_ . '/modules/';
+
+require_once _PS_ROOT_DIR_ . '/install-dev/init.php';
+
+DatabaseDump::restoreAllTables();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Our behat tests are quite long to run, this mostly because we need to reset the database at the beginning but we reset the whole database for each feature which takes quite some time. The purpose of this PR is to reduce this DB reset time:<br><br>- first, improve our `DatabaseDump` class which can now create an individual dump file for each table in the database<br>- then, similarly, the `DatabaseDump` is able to restore a specific table independently<br>- in `CommonFeatureContext`, which is used by every test, we add an endpoint that allows resetting a list of tables<br>- now, in tests that relied on `@reset-database-before-feature` we can replace this tag with an endpoint `Given I restore "product,product_shop"` so any feature can be optimized<br>- for this POC we introduce a new tag before feature `@reset-products-before-feature` which restore all tables related to product and can easily be assigned to all products features<br>- to optimize tables restoration even more the `DatabaseDump` table also stores checksum of each table, thus when attempting to restore a table it first checks if any modification was made thus reducing the number of required requests to restore the database<br>- this allowed to perform a quick migration of all suites by introducing the `@restore-all-tables-before-feature` tag which replcaes the former `@reset-database-before-feature`
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes #20487
| How to test?      | CI tests must be green (and faster ^^)
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26851)
<!-- Reviewable:end -->

### Deprecation

The tag `reset-database-before-feature` is deprecated and should be replaced by `restore-all-tables-before-feature`

### Optimization benchmark

I went through successive trials of optimization thanks to @mvorisek suggestion:

`restoreDb`: No optim just plain restor full DB
`restoreProductsTables`: First optim, restore only product tables one by one (and sometimes Languages and Currencies)
`restoreAllTables`: Restore all tables one by one but perform a checksum diff before applying it
`restoreProductsTablesWithChecksum`: Mix of both optim, restore product tables only but only when modified

`./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add`
restoreDb: 1m6.58s
restoreProductsTables: 0m9.44s
restoreAllTables: 0m3.09s
restoreProductsTablesWithChecksum: 0m2.67s

`./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product`
restoreDb: 45m59.43s
restoreProductsTables: 6m37.73s
restoreAllTables: 3m0.72s
restoreProductsTablesWithChecksum: 2m20.32s

`./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-from-bo`
restoreDb: 1m34.91s
restoreAllTables: 0m31.58s

`./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order`
restoreDb: 74m29.16s
restoreAllTables: 8m58.51s

`./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s cart`
restoreDb: 57m43.83s
restoreAllTables: 2m12.47s

**Important note:** these execution times were performed locally, they don't match the CI times which are much faster but they give us a hint on how speed proportionally evolves

### Summary sheet

![Capture d’écran 2021-12-06 à 15 45 30](https://user-images.githubusercontent.com/13801017/144866441-f9eccfa0-1415-4033-b7b3-1fd7bc001dd5.png)

### Optimization conclusion

- restoring customized tables instead of the whole DB increased the speed significantly: 85% reduced time
- the optimization to perform a checksum diff increased the speed even further (13-22% additional reduced time compared to first optim)
- the checksum optim can easily be applied without much work or thought to other suites right now (87% reduced time for order suite, 96% for cart suite)
- the bigger the suite the more efficient this optimization is
- applying more customized restorations per domain is still interesting to optimize even more, his can be done in a future PR for domain that have lots of tests (Order especially but other should be considered or at least tested)


### Next steps

**Optimize other suites**
The next step (once this POC PR is merged) will be to go though each feature files that resets the DB and perform similar optimization, either using the endpoint directly or by introducing a dedicated tag to restore a set of tables This optimization will be mostly important for long suites (Cart, Order, ...)

**Clean each suite**
Today each suite performs modification in the database without caring about the mess it does, this should not be allowed anymore, each suite should be responsible of its data and should be able to restore the Db the way it was before it started Og course this restoration should as optimized as possible This will allow other suites to be more optimized themselves since they won't have to clean the previous changes So they can either run independently or in a sequence of suites it should be the same

**Plan for cleaning**
- `DatabaseDump::getModifiedTables` add a small function that just returns the list of tables which don't match their initial checksum
- `CommonFeatureContext::checkDatabaseAfterSuite` add a static method bound to an `AfterSuite` event which gets the list of modified tables after each suite and throws an exception in case some tables are still modified The list of modified tables must be indicated to ease debugging
- Warning, since each suite will likely have to also rely on an `AfterSuite` event we need to be careful about the priority, the common feature check should be triggered last to let a chance to other context to clean themselves correctly