### PR TITLE
Prevent customization modal open if qty changed in cart on classic

### DIFF
--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -178,6 +178,10 @@ $(document).ready(() => {
   function sendUpdateQuantityInCartRequest(updateQuantityInCartUrl, requestData, $target) {
     abortPreviousRequests();
 
+    $('.customization-modal').on('show.bs.modal', (event) => {
+      event.preventDefault();
+    });
+
     return $.ajax({
       url: updateQuantityInCartUrl,
       method: 'POST',
@@ -189,6 +193,7 @@ $(document).ready(() => {
     })
       .then((resp) => {
         CheckUpdateQuantityOperations.checkUpdateOpertation(resp);
+
         $target.val(resp.quantity);
 
         let dataset;

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -178,7 +178,7 @@ $(document).ready(() => {
   function sendUpdateQuantityInCartRequest(updateQuantityInCartUrl, requestData, $target) {
     abortPreviousRequests();
 
-    $('.customization-modal').on('show.bs.modal', (event) => {
+    $(prestashop.themeSelectors.product.customizationModal).on('show.bs.modal', (event) => {
       event.preventDefault();
     });
 

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -40,6 +40,12 @@ $(document).ready(() => {
   });
 
   prestashop.on('updatedCart', () => {
+    window.shouldPreventModal = false;
+
+    $(prestashop.themeSelectors.product.customizationModal).on('show.bs.modal', (modalEvent) => {
+      preventCustomModalOpen(modalEvent);
+    });
+
     createSpin();
   });
 
@@ -125,12 +131,23 @@ $(document).ready(() => {
 
   const getTouchSpinInput = ($button) => $($button.parents(prestashop.themeSelectors.cart.touchspin).find('input'));
 
-  const handleCartAction = (event) => {
-    event.preventDefault();
+  const preventCustomModalOpen = (event) => {
+    if (window.shouldPreventModal) {
+      event.preventDefault();
 
-    $(prestashop.themeSelectors.product.customizationModal).on('show.bs.modal', (modalEvent) => {
-      modalEvent.preventDefault();
-    });
+      return false;
+    }
+
+    return true;
+  };
+
+  $(prestashop.themeSelectors.product.customizationModal).on('show.bs.modal', (modalEvent) => {
+    preventCustomModalOpen(modalEvent);
+  });
+
+  const handleCartAction = (event) => {
+    window.shouldPreventModal = true;
+    event.preventDefault();
 
     const $target = $(event.currentTarget);
     const {dataset} = event.currentTarget;
@@ -181,10 +198,7 @@ $(document).ready(() => {
 
   function sendUpdateQuantityInCartRequest(updateQuantityInCartUrl, requestData, $target) {
     abortPreviousRequests();
-
-    $(prestashop.themeSelectors.product.customizationModal).on('show.bs.modal', (event) => {
-      event.preventDefault();
-    });
+    window.shouldPreventModal = true;
 
     return $.ajax({
       url: updateQuantityInCartUrl,
@@ -245,6 +259,7 @@ $(document).ready(() => {
     const targetValue = $target.val();
     /* eslint-disable */
     if (targetValue != parseInt(targetValue, 10) || targetValue < 0 || isNaN(targetValue)) {
+      window.shouldPreventModal = false;
       $target.val(baseValue);
       return;
     }

--- a/themes/classic/_dev/js/cart.js
+++ b/themes/classic/_dev/js/cart.js
@@ -128,6 +128,10 @@ $(document).ready(() => {
   const handleCartAction = (event) => {
     event.preventDefault();
 
+    $(prestashop.themeSelectors.product.customizationModal).on('show.bs.modal', (modalEvent) => {
+      modalEvent.preventDefault();
+    });
+
     const $target = $(event.currentTarget);
     const {dataset} = event.currentTarget;
     const cartAction = parseCartAction($target, event.namespace);

--- a/themes/classic/_dev/js/components/debounce.js
+++ b/themes/classic/_dev/js/components/debounce.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+
+export default function debounce(func, timeout = 300) {
+  let timer;
+
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => { func.apply(this, args); }, timeout);
+  };
+}

--- a/themes/classic/_dev/js/selectors.js
+++ b/themes/classic/_dev/js/selectors.js
@@ -38,6 +38,7 @@ prestashop.themeSelectors = {
     selected: '.selected, .js-thumb-selected',
     modalProductCover: '.js-modal-product-cover',
     cover: '.js-qv-product-cover',
+    customizationModal: '.js-customization-modal',
   },
   listing: {
     searchFilterToggler: '#search_filter_toggler, .js-search-toggler',

--- a/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
+++ b/themes/classic/templates/checkout/_partials/cart-detailed-product-line.tpl
@@ -78,7 +78,7 @@
       {block name='cart_detailed_product_line_customization'}
         {foreach from=$product.customizations item="customization"}
           <a href="#" data-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
-          <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
+          <div class="modal fade customization-modal js-customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
             <div class="modal-dialog" role="document">
               <div class="modal-content">
                 <div class="modal-header">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We need to avoid the modal of customization to be opened right after manually changing the qty of the product
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26852.
| How to test?      | See issue
| Possible impacts? | Cart FO


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26854)
<!-- Reviewable:end -->
