### PR TITLE
make unit test runner return 0 when deprecations

### DIFF
--- a/tests/Unit/phpunit.xml
+++ b/tests/Unit/phpunit.xml
@@ -4,6 +4,7 @@
 >
   <php>
     <server name="KERNEL_CLASS" value="AppKernel" />
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
   </php>
     <testsuites>
         <testsuite name="Unit">


### PR DESCRIPTION
…so we can run all the test suite at once with composer test-all, just like in the CI

Fixes https://github.com/PrestaShop/PrestaShop/issues/26720

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I implemented my suggestion: https://github.com/PrestaShop/PrestaShop/issues/26720#issuecomment-986254036
| Type?             | bug fix 
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{26720}.
| How to test?      | Run `composer test-all`: the full test suite is run, not only unit tests.
| Possible impacts? | none than I think of


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26875)
<!-- Reviewable:end -->
