### PR TITLE
Use 2x images URLs

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -206,7 +206,7 @@ class ImageRetriever
             $url = $this->link->$getImageURL(
                 isset($object->link_rewrite) ? $object->link_rewrite : $object->name,
                 $id_image,
-                $image_type['name']
+                $image_type['name'] . ($generateHighDpiImages?"2x":"")
             );
 
             $urls[$image_type['name']] = [

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -206,7 +206,7 @@ class ImageRetriever
             $url = $this->link->$getImageURL(
                 isset($object->link_rewrite) ? $object->link_rewrite : $object->name,
                 $id_image,
-                $image_type['name'] . ($generateHighDpiImages?"2x":"")
+                $image_type['name'] . ($generateHighDpiImages ? '2x' : '')
             );
 
             $urls[$image_type['name']] = [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Here is my fix suggestion for this issue: https://github.com/PrestaShop/PrestaShop/issues/26599 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26599
| How to test?      | On a retina-enabled device, display a product with a 2x image and when the high-DPI mode is enabled in the configuration. You should see it in high-res. Tested on macOS.
| Possible impacts? | Code that uses the `ImageRetriever` class


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26876)
<!-- Reviewable:end -->
