### PR TITLE
use 2x images URLs

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -42,6 +42,8 @@ use Store;
  */
 class ImageRetriever
 {
+    const HIGH_RES_URL_SUFFIX = '2x';
+
     /**
      * @var Link
      */
@@ -190,7 +192,7 @@ class ImageRetriever
             if ($generateHighDpiImages) {
                 $resizedImagePathHighDpi = implode(DIRECTORY_SEPARATOR, [
                     $imageFolderPath,
-                    $id_image . '-' . $image_type['name'] . '2x.' . $ext,
+                    $id_image . '-' . $image_type['name'] . self::HIGH_RES_URL_SUFFIX . '.' . $ext,
                 ]);
                 if (!file_exists($resizedImagePathHighDpi)) {
                     ImageManager::resize(
@@ -205,7 +207,7 @@ class ImageRetriever
             $url = $this->link->$getImageURL(
                 isset($object->link_rewrite) ? $object->link_rewrite : $object->name,
                 $id_image,
-                $image_type['name'] . ($generateHighDpiImages ? '2x' : '')
+                $image_type['name'] . ($generateHighDpiImages ? self::HIGH_RES_URL_SUFFIX : '')
             );
 
             $urls[$image_type['name']] = [

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -205,7 +205,7 @@ class ImageRetriever
             $url = $this->link->$getImageURL(
                 isset($object->link_rewrite) ? $object->link_rewrite : $object->name,
                 $id_image,
-                $image_type['name']
+                $image_type['name'] . ($generateHighDpiImages?"2x":"")
             );
 
             $urls[$image_type['name']] = [

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -205,7 +205,7 @@ class ImageRetriever
             $url = $this->link->$getImageURL(
                 isset($object->link_rewrite) ? $object->link_rewrite : $object->name,
                 $id_image,
-                $image_type['name'] . ($generateHighDpiImages?"2x":"")
+                $image_type['name'] . ($generateHighDpiImages ? '2x' : '')
             );
 
             $urls[$image_type['name']] = [

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -192,7 +192,7 @@ class ImageRetriever
             if ($generateHighDpiImages) {
                 $resizedImagePathHighDpi = implode(DIRECTORY_SEPARATOR, [
                     $imageFolderPath,
-                    $id_image . '-' . $image_type['name'] . self::HIGH_RES_URL_SUFFIX . '.' . $ext,
+                    $id_image . '-' . $image_type['name'] . static::HIGH_RES_URL_SUFFIX . '.' . $ext,
                 ]);
                 if (!file_exists($resizedImagePathHighDpi)) {
                     ImageManager::resize(

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -207,7 +207,7 @@ class ImageRetriever
             $url = $this->link->$getImageURL(
                 isset($object->link_rewrite) ? $object->link_rewrite : $object->name,
                 $id_image,
-                $image_type['name'] . ($generateHighDpiImages ? self::HIGH_RES_URL_SUFFIX : '')
+                $image_type['name'] . ($generateHighDpiImages ? static::HIGH_RES_URL_SUFFIX : '')
             );
 
             $urls[$image_type['name']] = [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Here is my fix suggestion for this issue: https://github.com/PrestaShop/PrestaShop/issues/26599 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26599
| How to test?      | On a retina-enabled device, display a product with a 2x image and when the high-DPI mode is enabled in the configuration. You should see it in high-res. Tested on macOS.
| Possible impacts? | Code that uses the `ImageRetriever` class


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26877)
<!-- Reviewable:end -->
