### PR TITLE
Fix post install error when fixture installation is disabled

### DIFF
--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -83,6 +83,9 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
         }
 
         try {
+            $validateFixturesInstallation = $this->session->install_type == 'full';
+            $fixturesInstalled = !empty($this->session->process_validated['installFixtures']);
+
             if (Tools::getValue('generateSettingsFile')) {
                 $this->processGenerateSettingsFile();
             } elseif (Tools::getValue('installDatabase') && !empty($this->session->process_validated['generateSettingsFile'])) {
@@ -104,7 +107,7 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
                 $this->processInstallTheme();
             } elseif (Tools::getValue('installFixtures') && !empty($this->session->process_validated['installTheme'])) {
                 $this->processInstallFixtures();
-            } elseif (Tools::getValue('postInstall') && !empty($this->session->process_validated['installFixtures'])) {
+            } elseif (Tools::getValue('postInstall') && (!$validateFixturesInstallation || $fixturesInstalled)) {
                 $this->processPostInstall();
             }
         } catch (\Exception $e) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When the demo data installation is disabled, the post install step raises an error
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26892
| How to test?      | See issue for steps
| Possible impacts? | Shouldn't impact any other areas of PrestaShop


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26893)
<!-- Reviewable:end -->
