### PR TITLE
Remove calls to addons API when searching in BO

### DIFF
--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -149,48 +149,15 @@ $(function() {
     </div>
     {/if}
 
-    {if isset($addons) && $addons}
-    <div class="panel">
-        <h3>
-            {if $addons|@count == 1}
-                {l s='1 addon' d='Admin.Navigation.Search'}
-            {else}
-                {l s='%d addons' sprintf=[$addons|@count] d='Admin.Navigation.Search'}
-            {/if}
-        </h3>
-        <table class="table">
-            <tbody>
-            {foreach $addons key=key item=addon}
-                <tr>
-                    <td><a href="{$addon.href|escape:'html':'UTF-8'}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" target="_blank" rel="noopener noreferrer nofollow"><strong><i class="icon-external-link-sign"></i> {$addon.title|escape:'html':'UTF-8'}</strong></a></td>
-                    <td><a href="{$addon.href|escape:'html':'UTF-8'}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" target="_blank" rel="noopener noreferrer nofollow">{if is_string($addon.description)}{$addon.description|truncate:256:'...'|escape:'html':'UTF-8'}{/if}</a></td>
-                </tr>
-            {/foreach}
-        </tbody>
-            <tfoot>
-                <tr>
-                    <td colspan="2" class="text-center"><a href="https://addons.prestashop.com/search.php?search_query={$query|urlencode}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" target="_blank" rel="noopener noreferrer nofollow"><strong>{l s='Show more results...' d='Admin.Navigation.Search'}</strong></a></td>
-                </tr>
-            </tfoot>
-        </table>
-    </div>
-    {/if}
-
 {/if}
 <div class="row">
-    <div class="col-lg-4">
+    <div class="col-lg-6">
         <div class="panel">
             <h3>{l s='Search doc.prestashop.com' d='Admin.Navigation.Search'}</h3>
             <a href="https://doc.prestashop.com/dosearchsite.action?spaceSearch=true&amp;queryString={$query}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="btn btn-default _blank">{l s='Go to the documentation' d='Admin.Navigation.Search'}</a>
         </div>
     </div>
-    <div class="col-lg-4">
-        <div class="panel">
-            <h3>{l s='Search addons.prestashop.com' d='Admin.Navigation.Search'}</h3>
-            <a href="https://addons.prestashop.com/search.php?search_query={$query}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content={if $host_mode}cloud{else}download{/if}" class="btn btn-default _blank">{l s='Go to Addons' d='Admin.Navigation.Search'}</a>
-        </div>
-    </div>
-    <div class="col-lg-4">
+    <div class="col-lg-6">
         <div class="panel">
             <h3>{l s='Search prestashop.com forum' d='Admin.Navigation.Search'}</h3>
             <a href="https://www.google.fr/search?q=site%3Aprestashop.com%2Fforums%2F+{$query}" class="btn btn-default _blank">{l s='Go to the Forum' d='Admin.Navigation.Search'}</a>

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -245,19 +245,6 @@ class AdminSearchControllerCore extends AdminController
                 $this->_list['modules'][] = $module;
             }
         }
-
-        if (!is_numeric(trim($this->query)) && !Validate::isEmail($this->query)) {
-            $iso_lang = Tools::strtolower(Context::getContext()->language->iso_code);
-            $iso_country = Tools::strtolower(Country::getIsoById(Configuration::get('PS_COUNTRY_DEFAULT')));
-            if (($json_content = Tools::file_get_contents('https://api-addons.prestashop.com/' . _PS_VERSION_ . '/search/' . urlencode($this->query) . '/' . $iso_country . '/' . $iso_lang . '/')) != false) {
-                $results = json_decode($json_content, true);
-                if (isset($results['id'])) {
-                    $this->_list['addons'] = [$results];
-                } else {
-                    $this->_list['addons'] = $results;
-                }
-            }
-        }
     }
 
     /**
@@ -461,10 +448,6 @@ class AdminSearchControllerCore extends AdminController
 
             if ($this->isCountableAndNotEmpty($this->_list, 'modules')) {
                 $this->tpl_view_vars['modules'] = $this->_list['modules'];
-            }
-
-            if ($this->isCountableAndNotEmpty($this->_list, 'addons')) {
-                $this->tpl_view_vars['addons'] = $this->_list['addons'];
             }
 
             return parent::renderView();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove call to addons.prestashop when searching in back-office. Also, remove a static block in results page.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of #24639 
| How to test?      | On the search results page, the block, "Search addons.prestashop" is deleted.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

![image](https://user-images.githubusercontent.com/1721887/145195490-66040f36-773f-47d7-8c6a-c562976e2d3a.png)
![image](https://user-images.githubusercontent.com/1721887/145195888-9ea617ab-75f7-4898-9c75-f3adf4f5f999.png)




<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26909)
<!-- Reviewable:end -->
