### PR TITLE
Remove deprecated methods into Helper models 

### DIFF
--- a/classes/helper/Helper.php
+++ b/classes/helper/Helper.php
@@ -109,32 +109,6 @@ class HelperCore
     }
 
     /**
-     * @deprecated 1.5.0
-     */
-    public static function renderAdminCategorieTree(
-        $translations,
-        $selected_cat = [],
-        $input_name = 'categoryBox',
-        $use_radio = false,
-        $use_search = false,
-        $disabled_categories = [],
-        $use_in_popup = false
-    ) {
-        Tools::displayAsDeprecated();
-
-        $helper = new Helper();
-        if (isset($translations['Root'])) {
-            $root = $translations['Root'];
-        } elseif (isset($translations['Home'])) {
-            $root = ['name' => $translations['Home'], 'id_category' => 1];
-        } else {
-            throw new PrestaShopException('Missing root category parameter.');
-        }
-
-        return $helper->renderCategoryTree($root, $selected_cat, $input_name, $use_radio, $use_search, $disabled_categories);
-    }
-
-    /**
      * @param array $root array with the name and ID of the tree root category, if null the Shop's root category will be used
      * @param array $selected_cat array of selected categories
      *
@@ -280,29 +254,6 @@ class HelperCore
     }
 
     /**
-     * use translations files to replace english expression.
-     *
-     * @deprecated use Context::getContext()->getTranslator()->trans($id, $parameters, $domain, $locale); instead
-     *
-     * @param mixed $string term or expression in english
-     * @param string $class
-     * @param bool $addslashes if set to true, the return value will pass through addslashes(). Otherwise, stripslashes().
-     * @param bool $htmlentities if set to true(default), the return value will pass through htmlentities($string, ENT_QUOTES, 'utf-8')
-     *
-     * @return string the translation if available, or the english default text
-     */
-    protected function l($string, $class = 'AdminTab', $addslashes = false, $htmlentities = true)
-    {
-        // if the class is extended by a module, use modules/[module_name]/xx.php lang file
-        $current_class = get_class($this);
-        if (Module::getModuleNameFromClass($current_class)) {
-            return Translate::getModuleTranslation(Module::$classInModule[$current_class], $string, $current_class);
-        }
-
-        return Translate::getAdminTranslation($string, get_class($this), $addslashes, $htmlentities);
-    }
-
-    /**
      * Render a form with potentials required fields.
      *
      * @param string $class_name
@@ -357,64 +308,6 @@ class HelperCore
         $html = $tpl->fetch();
         // Restore the previous context
         Context::getContext()->override_controller_name_for_translations = $override_controller_name_for_translations;
-
-        return $html;
-    }
-
-    /**
-     * Render shop list.
-     *
-     * @deprecated deprecated since 1.6.1.0 use HelperShop->getRenderedShopList
-     *
-     * @return string|null
-     */
-    public static function renderShopList()
-    {
-        Tools::displayAsDeprecated('Use HelperShop->getRenderedShopList instead');
-
-        if (!Shop::isFeatureActive() || Shop::getTotalShops(false, null) < 2) {
-            return null;
-        }
-
-        $tree = Shop::getTree();
-        $context = Context::getContext();
-
-        // Get default value
-        $shop_context = Shop::getContext();
-        if ($shop_context == Shop::CONTEXT_ALL || ($context->controller->multishop_context_group == false && $shop_context == Shop::CONTEXT_GROUP)) {
-            $value = '';
-        } elseif ($shop_context == Shop::CONTEXT_GROUP) {
-            $value = 'g-' . Shop::getContextShopGroupID();
-        } else {
-            $value = 's-' . Shop::getContextShopID();
-        }
-
-        // Generate HTML
-        $url = $_SERVER['REQUEST_URI'] . (($_SERVER['QUERY_STRING']) ? '&' : '?') . 'setShopContext=';
-        $shop = new Shop(Shop::getContextShopID());
-
-        // $html = '<a href="#"><i class="icon-home"></i> '.$shop->name.'</a>';
-        $html = '<select class="shopList" onchange="location.href = \'' . htmlspecialchars($url) . '\'+$(this).val();">';
-        $html .= '<option value="" class="first">' . Translate::getAdminTranslation('All shops') . '</option>';
-
-        foreach ($tree as $group_id => $group_data) {
-            if ((!isset($context->controller->multishop_context) || $context->controller->multishop_context & Shop::CONTEXT_GROUP)) {
-                $html .= '<option class="group" value="g-' . $group_id . '"' . (((empty($value) && $shop_context == Shop::CONTEXT_GROUP) || $value == 'g-' . $group_id) ? ' selected="selected"' : '') . ($context->controller->multishop_context_group == false ? ' disabled="disabled"' : '') . '>' . Translate::getAdminTranslation('Group:') . ' ' . htmlspecialchars($group_data['name']) . '</option>';
-            } else {
-                $html .= '<optgroup class="group" label="' . Translate::getAdminTranslation('Group:') . ' ' . htmlspecialchars($group_data['name']) . '"' . ($context->controller->multishop_context_group == false ? ' disabled="disabled"' : '') . '>';
-            }
-            if (!isset($context->controller->multishop_context) || $context->controller->multishop_context & Shop::CONTEXT_SHOP) {
-                foreach ($group_data['shops'] as $shop_id => $shop_data) {
-                    if ($shop_data['active']) {
-                        $html .= '<option value="s-' . $shop_id . '" class="shop"' . (($value == 's-' . $shop_id) ? ' selected="selected"' : '') . '>' . ($context->controller->multishop_context_group == false ? htmlspecialchars($group_data['name']) . ' - ' : '') . $shop_data['name'] . '</option>';
-                    }
-                }
-            }
-            if (!(!isset($context->controller->multishop_context) || $context->controller->multishop_context & Shop::CONTEXT_GROUP)) {
-                $html .= '</optgroup>';
-            }
-        }
-        $html .= '</select>';
 
         return $html;
     }

--- a/classes/helper/HelperOptions.php
+++ b/classes/helper/HelperOptions.php
@@ -212,7 +212,7 @@ class HelperOptionsCore extends Helper
                                 }
                             }
                         </script>';
-                    $field['link_remove_ip'] = '<button type="button" class="btn btn-default" onclick="addRemoteAddr();"><i class="icon-plus"></i> ' . $this->l('Add my IP', 'Helper') . '</button>';
+                    $field['link_remove_ip'] = '<button type="button" class="btn btn-default" onclick="addRemoteAddr();"><i class="icon-plus"></i> ' . Context::getContext()->getTranslator()->trans('Add my IP', [], 'Admin.Actions') . '</button>';
                 }
 
                 // Multishop default value
@@ -291,7 +291,7 @@ class HelperOptionsCore extends Helper
         if (method_exists($this, 'displayOptionTypeText')) {
             $this->displayOptionTypeText($key, $field, $value);
         }
-        echo $this->context->currency->getSign('right') . ' ' . $this->l('(tax excl.)', 'Helper');
+        echo $this->context->currency->getSign('right') . ' ' . Context::getContext()->getTranslator()->trans('(tax excl.)', [], 'Admin.Global');
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Helper models
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Helper::renderAdminCategorieTree()`
* Removed method : `Helper::l()`
* Removed method : `Helper::renderShopList()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26319)
<!-- Reviewable:end -->
