### PR TITLE
Remove shudrum/array-finder from composer deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,6 @@
         "prestashop/statsstock": "^2",
         "prestashop/translationtools-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^5.1",
-        "shudrum/array-finder": "^1.1.0",
         "smarty/smarty": "^3.1.39",
         "soundasleep/html2text": "^0.5.0",
         "swiftmailer/swiftmailer": "~6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8102c815e2af40f4559ec5fd2412d5d1",
+    "content-hash": "03980fd765a8075e49451d209ba7b2e9",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -8071,50 +8071,6 @@
                 "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/v5.6.1"
             },
             "time": "2020-08-25T19:10:18+00:00"
-        },
-        {
-            "name": "shudrum/array-finder",
-            "version": "v1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Shudrum/ArrayFinder.git",
-                "reference": "42380f01017371b7a1e8e02b0bf12cb534e454d7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Shudrum/ArrayFinder/zipball/42380f01017371b7a1e8e02b0bf12cb534e454d7",
-                "reference": "42380f01017371b7a1e8e02b0bf12cb534e454d7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Shudrum\\Component\\ArrayFinder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Julien Martin",
-                    "email": "martin.julien82@gmail.com"
-                }
-            ],
-            "description": "ArrayFinder component",
-            "homepage": "https://github.com/Shudrum/ArrayFinder",
-            "support": {
-                "issues": "https://github.com/Shudrum/ArrayFinder/issues",
-                "source": "https://github.com/Shudrum/ArrayFinder/tree/master"
-            },
-            "time": "2016-02-01T12:23:32+00:00"
         },
         {
             "name": "smarty/smarty",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove shudrum/array-finder from composer deps as it is not used anymore by the Core
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/19243
| How to test?      | No need for QA as this code is not used anymore anywhere
| Possible impacts? | This dependency is not used anymore anywhere

### BC Break

Removing a composer dependency is a BC break.

For the reasons explained in the [issue #19243](https://github.com/PrestaShop/PrestaShop/issues/19243) I introduced a Symfony ArrayFinder to replace Shudrum ArrayFinder

Code in PhpParameters.php and Theme.php has been updated to rely on Symfony ArrayFinder instead of Shudrum ArrayFinder. We can now remove the dead code.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26923)
<!-- Reviewable:end -->
