### PR TITLE
improved hook actionValidateCustomerAddressForm validation

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -107,7 +107,9 @@ class CustomerAddressFormCore extends AbstractForm
         $is_valid = $this->validateFieldsValues();
 
         if (($hookReturn = Hook::exec('actionValidateCustomerAddressForm', ['form' => $this])) !== '') {
-            $is_valid &= (bool) $hookReturn;
+            if (is_bool($hookReturn)) {
+                $is_valid &= $hookReturn;
+            }
         }
 
         return $is_valid && parent::validate();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Bug appears  when hook actionValidateCustomerAddressForm is not registered. In class CustomerAddressFormCore method validate()  Hook::exec returned value 'Null' is evaluated as false that fails form validation process even when all fields are fulfilled properly.  
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26925
| How to test?      | Ensure that actionValidateCustomerAddressForm is not registered. It will be impossible complete address checkout step.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26926)
<!-- Reviewable:end -->
