### PR TITLE
Remove empty methods in FrontController

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1046,28 +1046,6 @@ class FrontControllerCore extends Controller
         return strcasecmp(Tools::getToken(false), Tools::getValue('token')) == 0;
     }
 
-    /**
-     * @deprecated 1.7 use $this->registerJavascript() and $this->registerStylesheet() to manage your assets.
-     */
-    public function addMedia($media_uri, $css_media_type = null, $offset = null, $remove = false, $check_path = true)
-    {
-        /*
-        This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() and
-        $this->registerStylesheet() to manage your assets.
-         */
-    }
-
-    /**
-     * @deprecated 1.7 this method has not effect with PrestaShop 1.7+
-     */
-    public function removeMedia($media_uri, $css_media_type = null, $check_path = true)
-    {
-        /*
-        This function has no effect in PrestaShop 1.7 theme, use $this->registerJavascript() and
-        $this->registerStylesheet() to manage your assets.
-         */
-    }
-
     public function registerStylesheet($id, $relativePath, $params = [])
     {
         if (!is_array($params)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove empty methods in FrontController.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Possible impacts? | 

## BC Break

Delete `FrontController::addMedia()` and `FrontController::removeMedia()` functions that were emptied

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26931)
<!-- Reviewable:end -->
