### PR TITLE
Use getSemVersion instead of getVersion to have the correct version

### DIFF
--- a/src/Adapter/Language/LanguagePackInstaller.php
+++ b/src/Adapter/Language/LanguagePackInstaller.php
@@ -64,7 +64,7 @@ final class LanguagePackInstaller implements LanguagePackInstallerInterface
     public function downloadAndInstallLanguagePack($iso)
     {
         $freshInstall = empty(Language::getIdByIso($iso));
-        $result = Language::downloadAndInstallLanguagePack($iso, $this->version->getVersion(), null, $freshInstall);
+        $result = Language::downloadAndInstallLanguagePack($iso, $this->version->getSemVersion(), null, $freshInstall);
 
         if (false === $result) {
             return [

--- a/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
+++ b/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
@@ -56,7 +56,7 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
      */
     public function getLanguagePackList()
     {
-        $normalizedLink = str_replace('%ps_version%', $this->version->getVersion(), self::PACK_LINK);
+        $normalizedLink = str_replace('%ps_version%', $this->version->getSemVersion(), self::PACK_LINK);
         $jsonResponse = file_get_contents($normalizedLink);
 
         $result = [];

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -176,7 +176,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function generateSidebarLink($section, $title = false)
     {
-        $version = $this->get('prestashop.core.foundation.version')->getVersion();
+        $version = $this->get('prestashop.core.foundation.version')->getSemVersion();
         $legacyContext = $this->get('prestashop.adapter.legacy.context');
 
         if (empty($title)) {

--- a/src/PrestaShopBundle/Resources/config/services/bundle/data_collector.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/data_collector.yml
@@ -24,7 +24,7 @@ services:
   # Web Profiler Bundle
   data_collector.config:
     class: Symfony\Component\HttpKernel\DataCollector\ConfigDataCollector
-    arguments: [ "PrestaShop", "@=service('prestashop.core.foundation.version').getVersion()" ]
+    arguments: [ "PrestaShop", "@=service('prestashop.core.foundation.version').getSemVersion()" ]
     public: false
     calls:
       - [ "setKernel", [ "@kernel" ] ]

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -101,7 +101,7 @@ services:
       - "@=service('prestashop.adapter.data_provider.country').getIsoCodebyId()"
       - "@prestashop.adapter.tools"
       - "@=service('prestashop.adapter.legacy.configuration').get('_PS_BASE_URL_')"
-      - "@=service('prestashop.core.foundation.version').getVersion()"
+      - "@=service('prestashop.core.foundation.version').getSemVersion()"
     calls:
       - [ "setSslVerification", [ "%prestashop.addons.api_client.verify_ssl%" ] ]
 

--- a/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/config.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/config.html.twig
@@ -100,7 +100,7 @@
             <div class="sf-toolbar-info-piece">
                 <b>Resources</b>
                 <span>
-                    {% set appVersion = collector.applicationversion|join()[:3] %}
+                    {% set appVersion = collector.applicationversion|join()[:1] %}
                     <a href="https://devdocs.prestashop.com/{{ appVersion }}/" rel="help">
                         Read PrestaShop {{ collector.applicationversion }} Docs
                     </a>
@@ -224,7 +224,7 @@
         <div class="sf-toolbar-info-piece">
           <b>Resources</b>
           <span>
-            {% set appVersion = collector.applicationversion|join()[:3] %}
+            {% set appVersion = collector.applicationversion|join()[:1] %}
               <a href="https://devdocs.prestashop.com/{{ appVersion }}/" rel="help">
                   Read PrestaShop {{ collector.applicationversion }} Docs
               </a>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Using getVersion will return the wrong version number for non legacy (not 4 digits) versions. To fix this, we replace getVersion calls by getSemVersion where it's relevant
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26756 and #26760 
| How to test?      | Follow descriptions in the issues linked
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26934)
<!-- Reviewable:end -->
