### PR TITLE
Fix tests 'Open help bar' on stocks page

### DIFF
--- a/tests/UI/pages/BO/catalog/stocks/index.js
+++ b/tests/UI/pages/BO/catalog/stocks/index.js
@@ -317,6 +317,28 @@ class Stocks extends BOBasePage {
       this.waitForVisibleSelector(page, `${this.advancedFiltersButton}[aria-expanded='${toOpen.toString()}']`),
     ]);
   }
+
+  /**
+   * @override
+   * Open help side bar
+   * @param page {Page} Browser tab
+   * @returns {Promise<boolean>}
+   */
+  async openHelpSideBar(page) {
+    await page.$eval(this.helpButton, el => el.click());
+    return this.elementVisible(page, `${this.rightSidebar}.sidebar-open`, 2000);
+  }
+
+  /**
+   * @override
+   * Close help side bar
+   * @param page {Page} Browser tab
+   * @returns {Promise<boolean>}
+   */
+  async closeHelpSideBar(page) {
+    await page.$eval(this.helpButton, el => el.click());
+    return this.elementVisible(page, `${this.rightSidebar}:not(.sidebar-open)`, 2000);
+  }
 }
 
 module.exports = new Stocks();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fix tests 'Open help bar' on stocks page
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | no tests needed
| Possible impacts? | none
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26942)
<!-- Reviewable:end -->
