### PR TITLE
Fix Dockerfile for local image generation in branch 1.7.8.x under Linux

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -10,7 +10,11 @@ COPY /docker_run_git.sh /tmp/
 RUN mkdir -p /var/www/.npm
 RUN chown -R www-data:www-data /var/www/.npm
 
+# These two directories are docker mounted volumes
+RUN chown -R www-data:www-data /var/www/html/vendor
+RUN chown -R www-data:www-data /var/www/html/var
+
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt install -y nodejs
+RUN apt install -y nodejs npm
 
 CMD ["/tmp/docker_run_git.sh"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -15,6 +15,6 @@ RUN chown -R www-data:www-data /var/www/html/vendor
 RUN chown -R www-data:www-data /var/www/html/var
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt install -y nodejs npm
+RUN apt install -y nodejs
 
 CMD ["/tmp/docker_run_git.sh"]


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Default ownership of mounted volumes makes the docker-compose up fail under Linux. Details in #26950. Also this adds npm to the image.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26950 
| How to test?      |  Please follow the bug replication steps under #26950 
| Possible impacts? | Not sure, probably your build system and/or CI. Also installing npm allows the start script to automatically rebuild the assets, don't know if that is desirable default behavior in this branch.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26951)
<!-- Reviewable:end -->
