### PR TITLE
Remove duplicate call hook actionAdminProductsListingFieldsModifier

### DIFF
--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -315,17 +315,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         }
 
         $sqlGroupBy = [];
-
-        // exec legacy hook but with different parameters (retro-compat < 1.7 is broken here)
-        Hook::exec('actionAdminProductsListingFieldsModifier', [
-            '_ps_version' => AppKernel::VERSION,
-            'sql_select' => &$sqlSelect,
-            'sql_table' => &$sqlTable,
-            'sql_where' => &$sqlWhere,
-            'sql_group_by' => &$sqlGroupBy,
-            'sql_order' => &$sqlOrder,
-            'sql_limit' => &$sqlLimit,
-        ]);
+        
         foreach ($filterParams as $filterParam => $filterValue) {
             if (!$filterValue && $filterValue !== '0') {
                 continue;

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -315,7 +315,6 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         }
 
         $sqlGroupBy = [];
-        
         foreach ($filterParams as $filterParam => $filterValue) {
             if (!$filterValue && $filterValue !== '0') {
                 continue;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove duplicate call to hook actionAdminProductsListingFieldsModifier. The same hook is called two times with the same parameters. So if any module will use this hook, it will call two times. Hence the first hook is useless because it is called before filter operation so the filter will not work if used by any module
| Type?             | Improvement
| Category?         | CO
| How to test?      | With ps_qualityassurance installed, register the hook `actionAdminProductsListingFieldsModifier`. Go on the admin page `products`. Back to ps_qualityassurance, in hook call logs, you should see only 1 trigger for the hook `actionAdminProductsListingFieldsModifier`.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26952)
<!-- Reviewable:end -->
