### PR TITLE
Customer is able to see order detail page via link even order share is disabled in multishop

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -183,27 +183,22 @@ class OrderDetailControllerCore extends FrontController
 
             $order = new Order($id_order);
             if (Validate::isLoadedObject($order) && $order->id_customer == $this->context->customer->id) {
-                $viewAccess = true;
                 if ($order->id_shop != $this->context->shop->id && $this->context->customer->id_shop_group == $this->context->shop->id_shop_group) {
                     $shopGroup = new ShopGroup($this->context->customer->id_shop_group);
                     if (!$shopGroup->share_order) {
-                        $viewAccess = false;
+                        $this->redirect_after = '404';
+                        $this->redirect();
                     }
                 }
-                if ($viewAccess) {
-                    $this->order_to_display = (new OrderPresenter())->present($order);
+                $this->order_to_display = (new OrderPresenter())->present($order);
 
-                    $this->reference = $order->reference;
+                $this->reference = $order->reference;
 
-                    $this->context->smarty->assign([
-                        'order' => $this->order_to_display,
-                        'orderIsVirtual' => $order->isVirtual(),
-                        'HOOK_DISPLAYORDERDETAIL' => Hook::exec('displayOrderDetail', ['order' => $order]),
-                    ]);
-                } else {
-                    $this->redirect_after = '404';
-                    $this->redirect();
-                }
+                $this->context->smarty->assign([
+                    'order' => $this->order_to_display,
+                    'orderIsVirtual' => $order->isVirtual(),
+                    'HOOK_DISPLAYORDERDETAIL' => Hook::exec('displayOrderDetail', ['order' => $order]),
+                ]);
             } else {
                 $this->redirect_after = '404';
                 $this->redirect();

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -199,6 +199,7 @@ class OrderDetailControllerCore extends FrontController
 
                     $this->context->smarty->assign([
                         'order' => $this->order_to_display,
+                        'orderIsVirtual' => $order->isVirtual(),
                         'HOOK_DISPLAYORDERDETAIL' => Hook::exec('displayOrderDetail', ['order' => $order]),
                     ]);
                 } else {

--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -184,12 +184,10 @@ class OrderDetailControllerCore extends FrontController
             $order = new Order($id_order);
             if (Validate::isLoadedObject($order) && $order->id_customer == $this->context->customer->id) {
                 $viewAccess = true;
-                if ($order->id_shop != $this->context->shop->id) {
-                    if ($this->context->customer->id_shop_group == $this->context->shop->id_shop_group) {
-                        $shopGroup = new ShopGroup($this->context->customer->id_shop_group);
-                        if (!$shopGroup->share_order) {
-                            $viewAccess = false;
-                        }
+                if ($order->id_shop != $this->context->shop->id && $this->context->customer->id_shop_group == $this->context->shop->id_shop_group) {
+                    $shopGroup = new ShopGroup($this->context->customer->id_shop_group);
+                    if (!$shopGroup->share_order) {
+                        $viewAccess = false;
                     }
                 }
                 if ($viewAccess) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Customer is able to see order detail page via link even order share is disabled in multishop
| Type?             | bug fix
| Category?         | FO
| Fixed ticket?     | Fixes #26953 
| How to test?      | See the description:
- Multishop is enabled, Suppose, there are two shops Shop A and Shop B with the same shop group SG-A
- Share customer enabled for shop group SG-A and order share is disabled.
- Now if a customer places an order from Shop A and login into Shop B then no order is visible because order share is disabled.
- But if customer open that order via the link then it is visible
- Order must not be visible on another shop if order share is disabled.
### Shop A
Orders page: https://nimb.ws/hPLHgV
Order Detail page https://nimb.ws/U9JVd6  (URL: http://localhost/ps1780/ShopA/en/index.php?controller=order-detail&id_order=20)
### Shop B
Orders page: https://nimb.ws/j85mZ6
Order Detail page https://nimb.ws/nSmuBp  (URL: http://localhost/ps1780/ShopB/en/index.php?controller=order-detail&id_order=20)
- Hence on ShopB Customer must not be able to see details.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26954)
<!-- Reviewable:end -->
