### PR TITLE
Index for search products having an & sign in name

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -133,14 +133,14 @@ class SearchCore
     public static function extractKeyWords($string, $id_lang, $indexation = false, $iso_code = false)
     {
         if (!stripos($string, '&')) {
-            $sanitizedString = Search::sanitize($string, $id_lang, false, Context::getContext()->language->iso_code);
+            $sanitizedString = Search::sanitize($string, $id_lang, false, $iso_code);
         } else {
             $preWords = explode('&', $string);
             $sanitizedWords = [];
             $sanitizedString = '';
 
             for ($i = 0; $i < count($preWords); ++$i) {
-                $wd = Search::sanitize($preWords[$i], $id_lang, false, Context::getContext()->language->iso_code);
+                $wd = Search::sanitize($preWords[$i], $id_lang, false, $iso_code);
                 array_push($sanitizedWords, $wd);
                 $sanitizedString .= $i < (count($preWords) - 1) ? $preWords[$i] . '&' : $preWords[$i];
             }

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -132,7 +132,20 @@ class SearchCore
 
     public static function extractKeyWords($string, $id_lang, $indexation = false, $iso_code = false)
     {
-        $sanitizedString = Search::sanitize($string, $id_lang, $indexation, $iso_code, false);
+        if (!stripos($string, '&')) {
+            $sanitizedString = Search::sanitize($string, $id_lang, false, Context::getContext()->language->iso_code);
+        } else {
+            $preWords = explode('&', $string);
+            $sanitizedWords = [];
+            $sanitizedString = '';
+
+            for ($i = 0; $i < count($preWords); ++$i) {
+                $wd = Search::sanitize($preWords[$i], $id_lang, false, Context::getContext()->language->iso_code);
+                array_push($sanitizedWords, $wd);
+                $sanitizedString .= $i < (count($preWords) - 1) ? $preWords[$i] . '&' : $preWords[$i];
+            }
+        }
+
         $words = explode(' ', $sanitizedString);
         if (strpos($string, '-') !== false) {
             $sanitizedString = Search::sanitize($string, $id_lang, $indexation, $iso_code, true);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There are many products in all industries having the name containing this sign and currently such products are skipped from the search results. Example: a beverages retailer will not find in the search results whisky brands named like J&B.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26020 .
| How to test?      | Add an & sign to a product name, re index the products in Shop Parameters -> Search then search for this product in FO.
| Possible impacts? |No impact..


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26964)
<!-- Reviewable:end -->
