### PR TITLE
Add SQL transactions support to Db and use them when moving carrier

### DIFF
--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -58,6 +58,9 @@ abstract class DbCore
     /** @var PDO|mysqli|resource|null Resource link */
     protected $link;
 
+    /** @var int Transactions depth level */
+    protected $transactionsDepth = 0;
+
     /** @var PDOStatement|mysqli_result|resource|bool SQL cached result */
     protected $result;
 
@@ -201,6 +204,27 @@ abstract class DbCore
      * @return string
      */
     abstract public function getBestEngine();
+
+    /**
+     * Initiate a new transaction.
+     *
+     * @return bool
+     */
+    abstract protected function _beginTransaction(): bool;
+
+    /**
+     * Commit a transaction.
+     *
+     * @return bool
+     */
+    abstract protected function _commit(): bool;
+
+    /**
+     * Roll back a transaction.
+     *
+     * @return bool
+     */
+    abstract protected function _rollBack(): bool;
 
     /**
      * Returns database object instance.
@@ -356,6 +380,72 @@ abstract class DbCore
         if ($this->link) {
             $this->disconnect();
         }
+    }
+
+    /**
+     * Initiate a new transaction.
+     *
+     * @return bool
+     */
+    public function beginTransaction(): bool
+    {
+        if ($this->transactionsDepth > 0) {
+            ++$this->transactionsDepth;
+
+            return true;
+        }
+
+        if ($this->_beginTransaction()) {
+            ++$this->transactionsDepth;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Commit a transaction.
+     *
+     * @return bool
+     */
+    public function commit(): bool
+    {
+        if ($this->transactionsDepth == 0) {
+            return false;
+        } elseif ($this->transactionsDepth > 1) {
+            --$this->transactionsDepth;
+
+            return true;
+        } elseif ($this->_commit()) {
+            --$this->transactionsDepth;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Roll back a transaction.
+     *
+     * @return bool
+     */
+    public function rollBack(): bool
+    {
+        if ($this->transactionsDepth == 0) {
+            return false;
+        } elseif ($this->transactionsDepth > 1) {
+            --$this->transactionsDepth;
+
+            return true;
+        } elseif ($this->_rollBack()) {
+            --$this->transactionsDepth;
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -390,6 +390,36 @@ class DbMySQLiCore extends Db
     }
 
     /**
+     * Initiate a new transaction.
+     *
+     * @return bool
+     */
+    protected function _beginTransaction(): bool
+    {
+        return $this->link->begin_transaction();
+    }
+
+    /**
+     * Commit a transaction.
+     *
+     * @return bool
+     */
+    protected function _commit(): bool
+    {
+        return $this->link->commit();
+    }
+
+    /**
+     * Roll back a transaction.
+     *
+     * @return bool
+     */
+    protected function _rollBack(): bool
+    {
+        return $this->link->rollback();
+    }
+
+    /**
      * Tries to connect to the database and create a table (checking creation privileges).
      *
      * @param string $server

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -483,6 +483,36 @@ class DbPDOCore extends Db
     }
 
     /**
+     * Initiate a new transaction.
+     *
+     * @return bool
+     */
+    protected function _beginTransaction(): bool
+    {
+        return $this->link->beginTransaction();
+    }
+
+    /**
+     * Commit a transaction.
+     *
+     * @return bool
+     */
+    protected function _commit(): bool
+    {
+        return $this->link->commit();
+    }
+
+    /**
+     * Roll back a transaction.
+     *
+     * @return bool
+     */
+    protected function _rollBack(): bool
+    {
+        return $this->link->rollBack();
+    }
+
+    /**
      * Try a connection to the database and set names to UTF-8.
      *
      * @see Db::checkEncoding()


### PR DESCRIPTION
```
Carrier: use transaction when moving carrier

It's required to keep database in consistent state if a later query
fails for whatever reason. As much as it's unlikely in this simple case
it's still a good practice and provides an example of using
transactions.
```
```
Db: add support for SQL transactions

Transactions should be used when executing multiple related queries.
They are required to keep database in consistent state in case of any
errors.

MySQL supports transactions only when using InnoDB however this code is
safe even for MyISAM. PHP "checks for transaction capabilities" for a
given driver only. So this code won't cause exception on MyISAM (it'll
just do nothing).

Ref: https://www.php.net/manual/en/pdo.transactions.php
```

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | All **related** database change queries should be executed in a single transaction. This way we make sure database won't get in inconsistent state if processing fails at some point.<br>This Pull Request adds transactions support to the `Db` API and uses it when moving a carrier. PrestaShop code should be updated incrementally to use transactions in all critical actions. Moving a carrier is just a simple case to start with.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Those changes are **inspired** by my problems with **orders** inconsistenty as reported in the [#17347](https://github.com/PrestaShop/PrestaShop/issues/17347). As this point I focused on moving carrier though (to start with something simple).
| How to test?      | Navigate to Shipping → Carriers & make sure carriers can be moved up/down.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

This pull request is a continuation of my work first started in the [17360](https://github.com/PrestaShop/PrestaShop/pull/17360)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26966)
<!-- Reviewable:end -->
