### PR TITLE
Fixes form throwing exception when rendering from module

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -88,7 +88,7 @@
 
 {# Show link to import file sample #}
 {% macro import_file_sample(label, filename) %}
-    <a id="download-sample-{{ filename }}-file-link" class="list-group-item list-group-item-action" 
+    <a id="download-sample-{{ filename }}-file-link" class="list-group-item list-group-item-action"
        href="{{ path('admin_import_sample_download', {'sampleName': filename}) }}">
         {{ label|trans({}, 'Admin.Advparameters.Feature') }}
     </a>
@@ -274,7 +274,7 @@
         {% endif %}
         {{ extraVars.label }}
 
-        {% if form.vars.label_attr and form.vars.label_attr['popover'] %}
+        {% if form.vars.label_attr is defined and form.vars.label_attr and form.vars.label_attr['popover'] %}
           {{ include('@Common/HelpBox/helpbox.html.twig', {'content': form.vars.label_attr['popover']}) }}
         {% endif %}
       </label>

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -274,7 +274,7 @@
         {% endif %}
         {{ extraVars.label }}
 
-        {% if form.vars.label_attr is defined and form.vars.label_attr and form.vars.label_attr['popover'] %}
+        {% if form.vars.label_attr is defined and form.vars.label_attr['popover'] is defined %}
           {{ include('@Common/HelpBox/helpbox.html.twig', {'content': form.vars.label_attr['popover']}) }}
         {% endif %}
       </label>

--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -88,7 +88,7 @@
 
 {# Show link to import file sample #}
 {% macro import_file_sample(label, filename) %}
-    <a id="download-sample-{{ filename }}-file-link" class="list-group-item list-group-item-action"
+    <a id="download-sample-{{ filename }}-file-link" class="list-group-item list-group-item-action" 
        href="{{ path('admin_import_sample_download', {'sampleName': filename}) }}">
         {{ label|trans({}, 'Admin.Advparameters.Feature') }}
     </a>


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes issue with form throwing exception in certain cases when rendering from module
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26786
| How to test?      | Should not be able to reproduce bug described in issue



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26986)
<!-- Reviewable:end -->
