### PR TITLE
Fix label_attr check in form_rest macro

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/macros.html.twig
@@ -274,7 +274,7 @@
         {% endif %}
         {{ extraVars.label }}
 
-        {% if form.vars.label_attr and form.vars.label_attr['popover'] %}
+        {% if form.vars.label_attr is defined and form.vars.label_attr['popover'] is defined %}
           {{ include('@Common/HelpBox/helpbox.html.twig', {'content': form.vars.label_attr['popover']}) }}
         {% endif %}
       </label>

--- a/tests/UI/campaigns/sanity/01_installShop/01_installShop.js
+++ b/tests/UI/campaigns/sanity/01_installShop/01_installShop.js
@@ -167,7 +167,7 @@ describe('Install Prestashop', async () => {
         {
           step: {
             name: 'Install addons modules',
-            timeout: 60000,
+            timeout: 120000,
           },
         },
     },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Because of a wrong `if` statement in twig, an undefined variable was accessed, leading to an exception. This PR aims to fix it by fixing the `if` statement.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26786
| How to test?      | Please see #26786
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26987)
<!-- Reviewable:end -->
