### PR TITLE
Add actionAdminControllerSetMedia to hooks that could be executed even if the module is disabled

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1098,7 +1098,7 @@ class HookCore extends ObjectModel
         $sql = new DbQuery();
         $sql->select('h.`name` as hook, m.`id_module`, h.`id_hook`, m.`name` as module');
         $sql->from('module', 'm');
-        if (!in_array($hookName, ['displayBackOfficeHeader', 'displayAdminLogin'])) {
+        if (!in_array($hookName, ['displayBackOfficeHeader', 'displayAdminLogin', 'actionAdminControllerSetMedia'])) {
             $sql->join(
                 Shop::addSqlAssociation(
                     'module',


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add actionAdminControllerSetMedia to hooks that could be executed even if the module is disabled. This hook is used to add somes assets on the Back Office, like module configuration.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use a module with actionAdminControllerSetMedia and see that it will not be executed if it's disabled.
| Possible impacts? | n/d


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26993)
<!-- Reviewable:end -->
