### PR TITLE
Multistore: fix configuration value not saved for current context

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -469,7 +469,7 @@ class ConfigurationCore extends ObjectModel
         foreach ($values as $lang => $value) {
             $storedValue = Configuration::get($key, $lang, $idShopGroup, $idShop);
             // if there isn't a $stored_value, we must insert $value
-            if ((!is_numeric($value) && $value === $storedValue) || (is_numeric($value) && $value == $storedValue && Configuration::hasKey($key, $lang))) {
+            if ((!is_numeric($value) && $value === $storedValue && Configuration::hasKey($key, $lang, $idShopGroup, $idShop)) || (is_numeric($value) && $value == $storedValue && Configuration::hasKey($key, $lang, $idShopGroup, $idShop))) {
                 continue;
             }
 

--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -469,7 +469,10 @@ class ConfigurationCore extends ObjectModel
         foreach ($values as $lang => $value) {
             $storedValue = Configuration::get($key, $lang, $idShopGroup, $idShop);
             // if there isn't a $stored_value, we must insert $value
-            if ((!is_numeric($value) && $value === $storedValue && Configuration::hasKey($key, $lang, $idShopGroup, $idShop)) || (is_numeric($value) && $value == $storedValue && Configuration::hasKey($key, $lang, $idShopGroup, $idShop))) {
+            if (
+              ((!is_numeric($value) && $value === $storedValue) || (is_numeric($value) && $value == $storedValue))
+               && Configuration::hasKey($key, $lang, $idShopGroup, $idShop)
+            ) {
                 continue;
             }
 

--- a/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
+++ b/tests/Integration/Core/Configuration/AbstractMultistoreConfigurationTest.php
@@ -200,6 +200,26 @@ class AbstractMultistoreConfigurationTest extends AbstractConfigurationTestCase
     }
 
     /**
+     * Tests that overriding an all shop config with the same value for a single shop context does work
+     *
+     * @throws \PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException
+     */
+    public function testCanUpdateWithSameValueAsParent(): void
+    {
+        // set a value for test_conf_2 in all shop
+        $testedObject = $this->getDummyMultistoreConfiguration(ShopConstraint::allShops());
+        $testedObject->updateConfiguration(['test_conf_1' => true, 'test_conf_2' => 'all_shop_value']);
+
+        // set the same value for test_conf_2 in single shop
+        $shopId = 1;
+        $testedObject = $this->getDummyMultistoreConfiguration(ShopConstraint::shop($shopId));
+        $testedObject->updateConfiguration(['test_conf_1' => true, 'test_conf_2' => 'all_shop_value', 'multistore_test_conf_2' => true]);
+
+        // the configuration must have a specific entry for TEST_CONF_2 in shop 1 context
+        $this->assertTrue(LegacyConfiguration::hasKey('TEST_CONF_2', null, null, $shopId));
+    }
+
+    /**
      * @return ShopContext
      */
     protected function createShopContextMock(): Context


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Configuration values were not saved for current multistore context when the value was the same as the parent value
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26967
| How to test?      | See issue
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26994)
<!-- Reviewable:end -->
