### PR TITLE
Carrier field in invoice must not be displayed if order is virtual

### DIFF
--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -358,6 +358,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
             'ps_price_compute_precision' => Context::getContext()->getComputingPrecision(),
             'round_type' => $round_type,
             'legal_free_text' => $legal_free_text,
+            'is_virtual_order' => $this->order->isVirtual(),
         ];
 
         if (Tools::getValue('debug')) {

--- a/pdf/invoice.tpl
+++ b/pdf/invoice.tpl
@@ -98,14 +98,16 @@
 		<td colspan="1">&nbsp;</td>
 	</tr>
 
-	<tr>
-		<td colspan="6" class="left">
+	{if isset($is_virtual_order) && !$is_virtual_order}
+  <tr>
+    <td colspan="6" class="left">
 
-			{$shipping_tab}
+      {$shipping_tab}
 
-		</td>
-		<td colspan="1">&nbsp;</td>
-	</tr>
+    </td>
+    <td colspan="1">&nbsp;</td>
+  </tr>
+  {/if}
 
 	<tr>
 		<td colspan="12" height="10">&nbsp;</td>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The Carrier field in the invoice must not be displayed if an order is virtual i.e if all products of an order are virtual.
| Type?             | bug fix
| Category?         | BO 
| Fixed ticket?     | Fixes #26977
| How to test?      | Go to the front end and add one or more than one virtual product to the cart. Make a successful order. Now go to the back office and download the invoice for that order. Since the order contains all virtual products that mean no shipping is required but the string is appearing https://prnt.sc/u1sfdh that is incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27001)
<!-- Reviewable:end -->
