### PR TITLE
Use reverse translation for Tabs with no wording and domain

### DIFF
--- a/src/Adapter/EntityTranslation/TabTranslator.php
+++ b/src/Adapter/EntityTranslation/TabTranslator.php
@@ -69,7 +69,7 @@ class TabTranslator extends EntityTranslator
     {
         $tableName = $this->dbPrefix . 'tab';
 
-        $sql = "SELECT id_tab, wording, wording_domain FROM $tableName";
+        $sql = "SELECT id_tab, wording, wording_domain FROM $tableName WHERE wording > '' and wording_domain > ''";
         $results = $this->db->executeS($sql);
 
         $souceIndex = [];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Read below
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Read below
| Possible impacts? | This impacts tab translation only

## Disclaimer

I haven't tried to reproduce this edge case bug out of lack of time, but theoretically it should happen.

## Steps to test/reproduce

1. Remove wording and wording_domain from an existing Tab in the `ps_tab` table. Make that the wording can be found in the `Admin.Navigation.Menu` domain and that that wording is translated in the language you'll be adding.
2. Make sure that you see the menu item
3. Install a new language
3. Without this change, the menu item should remain untranslated. With this change, the menu item should be translated, even though it didn't have wording and wording_domain.

## Context

Tabs (menu items) are stored translated in the `tab_lang` table. When a new language is installed, or when the wording itself is translated using the translator interface, the [entity translation process](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.0/src/PrestaShopBundle/Controller/Api/TranslationController.php#L357-L359) is triggered to insert the appropriate translations in `tab_lang`. To translate Tabs, we originally used reverse translation, which consists in taking the wording from `tab_lang` in the default language, performing a reverse dictionary lookup in the [declared translation domain for Tabs](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.0/classes/lang/TabLang.php#L32) to get the original key, then use that key to translate into the target language. 

Since this technique produced approximate results, in 1.7.8.0 we introduced wording and wording_domain in Tab so that we could just use whatever wording was defined there instead of performing reverse translation. But since not all Tabs have wording and wording domain, we fallback to reverse translation when those aren't defined.

## The bug

It looks like I forgot to account for empty wording and wording_domain when building the `$sourceIndex`. Since an item is added for every tab, even if empty, then the fallback in `doTranslate()` never happens. This fix filters out empty wording and wording_domain from the results, which should restore reverse translation for the cases that apply.



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27011)
<!-- Reviewable:end -->
