### PR TITLE
Removed AdminParent controllers from search in BackOffice

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2443,9 +2443,8 @@ class AdminControllerCore extends Controller
         if (null !== $this->base_tpl_view) {
             $helper->base_tpl = $this->base_tpl_view;
         }
-        $view = $helper->generateView();
 
-        return $view;
+        return $helper->generateView();
     }
 
     public function getTemplateViewVars()

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -250,22 +250,44 @@ class AdminSearchControllerCore extends AdminController
     {
         $this->_list['features'] = [];
 
-        $result = Db::getInstance()->executeS(
-            'SELECT class_name, name, route_name
-            FROM ' . _DB_PREFIX_ . 'tab t
-            INNER JOIN ' . _DB_PREFIX_ . 'tab_lang tl ON (t.id_tab = tl.id_tab AND tl.id_lang = ' . (int) $this->context->employee->id_lang . ')
-            WHERE active = 1'
+        $sql = sprintf(
+            'SELECT class_name, name, route_name FROM %stab t INNER JOIN %stab_lang tl ON (t.id_tab = tl.id_tab AND tl.id_lang = %d) WHERE active = 1',
+            _DB_PREFIX_,
+            _DB_PREFIX_,
+            (int) $this->context->employee->id_lang
         );
+        $result = Db::getInstance()->executeS($sql);
+        $mainControllers = Dispatcher::getControllers([
+            _PS_ADMIN_DIR_ . '/tabs/',
+            _PS_ADMIN_CONTROLLER_DIR_,
+            _PS_OVERRIDE_DIR_ . 'controllers/admin/',
+        ]);
+
         foreach ($result as $row) {
-            if (
-                false !== stripos($row['name'], $this->query)
-                && Access::isGranted('ROLE_MOD_TAB_' . strtoupper($row['class_name']) . '_READ', $this->context->employee->id_profile)
-            ) {
-                $sfRouteParams = (!empty($row['route_name'])) ? ['route' => $row['route_name']] : [];
-                $this->_list['features'][$row['name']][] = [
-                    'link' => Context::getContext()->link->getAdminLink((string) $row['class_name'], true, $sfRouteParams),
-                ];
+            // Search pages with the query need
+            if (stripos($row['name'], $this->query) === false) {
+                continue;
             }
+            // Remove pages without access
+            if (!Access::isGranted('ROLE_MOD_TAB_' . strtoupper($row['class_name']) . '_READ', $this->context->employee->id_profile)) {
+                continue;
+            }
+            $tab = Tab::getInstanceFromClassName($row['class_name']);
+            if (!Validate::isLoadedObject($tab)) {
+                continue;
+            }
+            // Check if it's not a parent tab
+            if (!isset($mainControllers[strtolower($row['class_name'])])) {
+                $tabs = Tab::getTabs(Context::getContext()->language->id, $tab->id);
+                if (isset($tabs[0])) {
+                    continue;
+                }
+            }
+
+            $sfRouteParams = (!empty($row['route_name'])) ? ['route' => $row['route_name']] : [];
+            $this->_list['features'][$row['name']][] = [
+                'link' => Context::getContext()->link->getAdminLink((string) $row['class_name'], true, $sfRouteParams),
+            ];
         }
     }
 
@@ -422,7 +444,6 @@ class AdminSearchControllerCore extends AdminController
             }
 
             if ($this->isCountableAndNotEmpty($this->_list, 'orders')) {
-                $view = '';
                 $this->initOrderList();
 
                 $helper = new HelperList();
@@ -435,8 +456,7 @@ class AdminSearchControllerCore extends AdminController
                 $helper->currentIndex = $this->context->link->getAdminLink('AdminOrders', false);
                 $helper->token = Tools::getAdminTokenLite('AdminOrders');
 
-                $view = $helper->generateList($this->_list['orders'], $this->fields_list['orders']);
-                $this->tpl_view_vars['orders'] = $view;
+                $this->tpl_view_vars['orders'] = $helper->generateList($this->_list['orders'], $this->fields_list['orders']);
                 $this->tpl_view_vars['orderCount'] = count($this->_list['orders']);
             }
 

--- a/tests/Integration/Controllers/AdminSearchControllerCoreTest.php
+++ b/tests/Integration/Controllers/AdminSearchControllerCoreTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Controllers;
+
+use AdminSearchControllerCore;
+use Context;
+use Employee;
+use PHPUnit\Framework\TestCase;
+
+class AdminSearchControllerCoreTest extends TestCase
+{
+    /**
+     * @dataProvider dataProviderSearch
+     *
+     * @param string $query
+     * @param array $result
+     *
+     * @return void
+     */
+    public function testSearch(string $query, array $result): void
+    {
+        $_POST['bo_search_type'] = '';
+        $_POST['bo_query'] = $query;
+        Context::getContext()->employee = new Employee(1);
+
+        $controller = new AdminSearchControllerCore();
+        $controller->postProcess();
+        $controller->renderView();
+
+        $templateVars = $controller->getTemplateViewVars();
+
+        self::assertEquals($this->cleanDataToken($templateVars), $this->cleanDataToken($result));
+    }
+
+    public function dataProviderSearch(): array
+    {
+        return [
+            [
+                '',
+                [
+                    'query' => '',
+                    'show_toolbar' => true,
+                    'nb_results' => 0,
+                ],
+            ],
+            [
+                'orders',
+                [
+                    'query' => 'orders',
+                    'show_toolbar' => true,
+                    'nb_results' => 1,
+                    'features' => [
+                        'Orders' => [
+                            [
+                                'link' => 'http://localhost/admin-dev/index.php?controller=AdminOrders',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return array
+     */
+    private function cleanDataToken(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (is_string($value)) {
+                $data[$key] = preg_replace('#&token=[a-z0-9]+#', '', $value, 1);
+            }
+            if (is_array($value)) {
+                $data[$key] = $this->cleanDataToken($value);
+            }
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed AdminParent controllers from search in BackOffice
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26565
| How to test?      | Cf. #26565


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27012)
<!-- Reviewable:end -->
