### PR TITLE
Adding customers static cache property in Product ObjectModel

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -437,6 +437,9 @@ class ProductCore extends ObjectModel
      */
     protected static $cacheStock = [];
 
+    /** @var array */
+    protected static $_customers = [];
+
     /**
      * Product can be temporary saved in database
      */
@@ -852,7 +855,10 @@ class ProductCore extends ObjectModel
     public static function initPricesComputation($id_customer = null)
     {
         if ((int) $id_customer > 0) {
-            $customer = new Customer((int) $id_customer);
+            if (!isset(self::$_customers[$id_customer])) {
+                self::$_customers[$id_customer] = new Customer((int) $id_customer);
+            }
+            $customer = self::$_customers[$id_customer];
             if (!Validate::isLoadedObject($customer)) {
                 die(Tools::displayError());
             }


### PR DESCRIPTION
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR will lower a bit of Customer ObjecModel instances calls
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Turn on profiling. Go to prestashop home page. Look for ObjectModel instances - Customer. You should see multiple of them in `/classes/Product.php [664]`. In 1.7.6.9 there's `4` instances and in my weshop there was `31` instance before this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27020)
<!-- Reviewable:end -->
