### PR TITLE
Do not autohook ps_featuredproducts on displayCrossSellingShoppingCart

### DIFF
--- a/themes/classic/config/theme.yml
+++ b/themes/classic/config/theme.yml
@@ -98,8 +98,6 @@ global_settings:
       #  - blockreassurance
       displayOrderConfirmation2:
         - ps_featuredproducts
-      displayCrossSellingShoppingCart:
-        - ps_featuredproducts
 
   image_types:
     cart_default:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Featured product module shouldn't be hooked on displayCrossSellingShoppingCart by default and shouldn't be displayed by default in the cart. - https://github.com/PrestaShop/PrestaShop/pull/26663#issuecomment-979038447
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | None
| How to test?      | -
| Possible impacts? | -

Related PR - https://github.com/PrestaShop/ps_featuredproducts/pull/45

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27022)
<!-- Reviewable:end -->
