### PR TITLE
Let Symfony handle kernel reboot

### DIFF
--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -70,17 +70,12 @@ final class SymfonyCacheClearer implements CacheClearerInterface
             // Clear cache
             $input = new ArrayInput([
                 'command' => 'cache:clear',
-                '--no-warmup' => true,
+                '--no-optional-warmers' => true,
                 '--env' => _PS_ENV_,
             ]);
 
             $output = new NullOutput();
             $application->run($input, $output);
-
-            // Reboot kernel
-            $realCacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
-            $warmupDir = substr($realCacheDir, 0, -1) . ('_' === substr($realCacheDir, -1) ? '-' : '_');
-            $kernel->reboot($warmupDir);
 
             Hook::exec('actionClearSf2Cache');
         });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Since #21429 has been merged, when the cache gets cleared, a new folder in `var/cache/` is created where the kernel warms up but is never used then. The command `cache:clear` can be used with the option `--no-optional-warmers` that will only reboot the kernel without warming optional cache as `SymfonyCacheClearer` was mean to do.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26924
| How to test?      | Try to install/uninstall `ps_facebook`, no `de_` or `pro_` folder should be present in the `/var/cache/` folder.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27035)
<!-- Reviewable:end -->
