### PR TITLE
Add new Twig namespace PrestaShopCore

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -12,7 +12,8 @@ parameters:
   AdapterSecurityAdminClass: PrestaShop\PrestaShop\Adapter\Security\Admin
   translator.class: PrestaShopBundle\Translation\Translator
   translator.data_collector: PrestaShopBundle\Translation\DataCollectorTranslator
-  admin_page: "%kernel.root_dir%/../src/PrestaShopBundle/Resources/views/Admin"
+  prestashop_views: "%kernel.root_dir%/../src/PrestaShopBundle/Resources/views"
+  admin_page: "%prestashop_views%/Admin"
   env(PS_LOG_OUTPUT): "%kernel.logs_dir%/%kernel.environment%.log"
   mail_themes_uri: "/mails/themes"
   mail_themes_dir: "%kernel.project_dir%%mail_themes_uri%"
@@ -87,6 +88,7 @@ twig:
     '%admin_page%/Configure/ShopParameters': ShopParameters
     '%kernel.root_dir%/../modules': Modules
     '%mail_themes_dir%': MailThemes
+    '%prestashop_views%': PrestaShopCore
   globals:
     webpack_server: false
     multistore_field_prefix: !php/const PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since the path syntax in twig using colon (`PrestaShopBundle:path:to:twig:file`) is not available anymore, the only way for a module to override **and** extends a core template is by using the `!` after the `@` in the namespace (`@!PrestaShop/path/to/twig/file`). Although this is working for 1.7.x & 8.x, this PR aims to add a new namespace (`@PrestaShopCore`) that modules **can't** override allowing modules to be sure to extends from the core file and not an override without the need to use the `!` (`@PrestaShopCore/path/to/twig/file`).
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | Install this module: [prestashopcore.zip](https://github.com/PrestaShop/PrestaShop/files/7753254/prestashopcore.zip) and refresh the module manager page. You should see ![Capture d’écran 2021-12-21 à 12 04 56](https://user-images.githubusercontent.com/2168836/146920329-e89180eb-6cff-4791-864f-983c71ccf00a.png)
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27044)
<!-- Reviewable:end -->
