### PR TITLE
Allow null for ip maintenance and maintenance message fields

### DIFF
--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -77,8 +77,8 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
         $resolver = new OptionsResolver();
         $resolver->setDefined(self::CONFIGURATION_FIELDS);
         $resolver->setAllowedTypes('enable_shop', 'bool');
-        $resolver->setAllowedTypes('maintenance_ip', 'string');
-        $resolver->setAllowedTypes('maintenance_text', 'array');
+        $resolver->setAllowedTypes('maintenance_ip', ['string', 'null']);
+        $resolver->setAllowedTypes('maintenance_text', ['array', 'null']);
 
         return $resolver;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In maintenance configuration form, option resolver must allow null for IP maintenance and maintenance text message fields
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27065
| How to test?      | See issue, and reproduction video here: [27065](https://watch.screencastify.com/v/klKReCtvPQiVMiYcX1Ua)
| Possible impacts? | /


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27066)
<!-- Reviewable:end -->
