### PR TITLE
Do not trust the new composer binary mode for CI

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -125,7 +125,7 @@ jobs:
         run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
       - name: Run phpunit (without DB)
-        run: ./vendor/bin/phpunit -c tests/Unit/phpunit.xml
+        run: ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml
         env:
           SYMFONY_DEPRECATIONS_HELPER: disabled
 

--- a/composer.json
+++ b/composer.json
@@ -198,11 +198,11 @@
         ],
         "integration-tests": [
             "@composer create-test-db",
-            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Integration/phpunit.xml"
+            "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Integration/phpunit.xml"
         ],
         "phpunit-endpoints": [
             "@composer create-test-db",
-            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-endpoints.xml"
+            "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests-legacy/phpunit-endpoints.xml"
         ],
         "restore-test-db": [
             "@php ./tests/bin/restore-test-db.php"
@@ -216,7 +216,7 @@
             "@composer integration-behaviour-tests"
         ],
         "unit-tests": [
-            "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Unit/phpunit.xml"
+            "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml"
         ]
     },
     "scripts-descriptions": {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Because of https://github.com/composer/composer/pull/10137 the binaries inside the vendor directory are not longer symlink
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is green
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27067)
<!-- Reviewable:end -->
