### PR TITLE
Do not trust the new composer binary mode (cherry pick of #27067)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -99,7 +99,7 @@ jobs:
             run: composer install --ansi --prefer-dist --no-interaction --no-progress
 
         -   name: Run phpunit
-            run: ./vendor/bin/phpunit -c tests/Unit/phpunit.xml
+            run: ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml
             env:
                 SYMFONY_DEPRECATIONS_HELPER: disabled
 

--- a/composer.json
+++ b/composer.json
@@ -185,30 +185,30 @@
     ],
     "phpunit-legacy": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit.xml"
+      "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests-legacy/phpunit.xml"
     ],
     "phpunit-endpoints": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-endpoints.xml"
+      "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests-legacy/phpunit-endpoints.xml"
     ],
     "unit-tests": [
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Unit/phpunit.xml"
+      "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml"
     ],
     "integration-tests": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests/Integration/phpunit.xml"
+      "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Integration/phpunit.xml"
     ],
     "phpunit-admin": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/phpunit-admin.xml"
+      "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests-legacy/phpunit-admin.xml"
     ],
     "phpunit-sf": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/sf-tests.xml"
+      "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests-legacy/sf-tests.xml"
     ],
     "phpunit-controllers": [
       "@composer create-test-db",
-      "@php -d date.timezone=UTC ./vendor/bin/phpunit -c tests-legacy/old-controllers.xml"
+      "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests-legacy/old-controllers.xml"
     ],
     "integration-behaviour-tests": [
       "@php -d date.timezone=UTC ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml  --format progress --no-snippets --strict"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Because of https://github.com/composer/composer/pull/10137 the binaries inside the vendor directory are not longer symlink
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27067)
<!-- Reviewable:end -->
