### PR TITLE
Add Windows 11 to guest UserAgent

### DIFF
--- a/classes/Guest.php
+++ b/classes/Guest.php
@@ -157,6 +157,7 @@ class GuestCore extends ObjectModel
     protected function getOs($userAgent)
     {
         $osArray = [
+            'Windows 11' => 'Windows NT 11',
             'Windows 10' => 'Windows NT 10',
             'Windows 8.1' => 'Windows NT 6.3',
             'Windows 8' => 'Windows NT 6.2',

--- a/install-dev/data/xml/operating_system.xml
+++ b/install-dev/data/xml/operating_system.xml
@@ -22,6 +22,9 @@
     <operating_system id="Windows_10">
       <name>Windows 10</name>
     </operating_system>
+    <operating_system id="Windows_11">
+      <name>Windows 11</name>
+    </operating_system>
     <operating_system id="MacOsX">
       <name>MacOsX</name>
     </operating_system>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add Windows 11 to guest UserAgent.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27081
| How to test?      | <p>1. Install PS.</p> <p>2. It will create an entry `Windows 11` in \<prefix>_operating_system database table.</p> <p>3. To test Guest.php, you need Windows 11 installed, so $_SERVER['HTTP_USER_AGENT'] contains string Windows 11.</p>
| Possible impacts? | None.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27080)
<!-- Reviewable:end -->
