### PR TITLE
Add allow-plugins entry for composer 2.2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -226,7 +226,11 @@
     "platform": {
       "php": "7.1.3"
     },
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true,
+      "composer/installers": true
+    }
   },
   "extra": {
     "symfony-app-dir": "app",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Since composer 2.2.0, [composer plugins contained in libraries required by composer need to be allowed in composer.json](https://getcomposer.org/doc/06-config.md#allow-plugins).
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | With composer 2.2.x, doing `composer install` should not ask if we trust plugins.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27083)
<!-- Reviewable:end -->
