### PR TITLE
Return integer instead of bool into checkModulesNames()

### DIFF
--- a/controllers/admin/AdminStatsTabController.php
+++ b/controllers/admin/AdminStatsTabController.php
@@ -169,10 +169,7 @@ abstract class AdminStatsTabControllerCore extends AdminController
 
     public function checkModulesNames($a, $b): int
     {
-        if ($a['displayName'] == $b['displayName']) {
-            return 0;
-        }
-        return ($a['displayName'] < $b['displayName']) ? -1 : 1;
+        return strcasecmp($a['displayName'], $b['displayName']);
     }
 
     protected function getModules()

--- a/controllers/admin/AdminStatsTabController.php
+++ b/controllers/admin/AdminStatsTabController.php
@@ -167,9 +167,12 @@ abstract class AdminStatsTabControllerCore extends AdminController
         return $tpl->fetch();
     }
 
-    public function checkModulesNames($a, $b)
+    public function checkModulesNames($a, $b): int
     {
-        return (bool) ($a['displayName'] > $b['displayName']);
+        if ($a['displayName'] == $b['displayName']) {
+            return 0;
+        }
+        return ($a['displayName'] < $b['displayName']) ? -1 : 1;
     }
 
     protected function getModules()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When you visits the stats tab, you have an error due to the use of uasort with a method that return a bool. As it's deprecated into newer PHP version, it show an error.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #27086.
| How to test?      | Visit the Stats tab, see that you have an error and the listing of menus displayed in ascendant order. Use this PR and see that you still have the right order but without the error.
| Possible impacts? | n/d.

# BC Break

`AdminStatsTabController::checkModulesNames` now returns an int instead of a boolean
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27091)
<!-- Reviewable:end -->
