### PR TITLE
Fix forbidden access page in Front Office

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -607,11 +607,20 @@ class FrontControllerCore extends Controller
     }
 
     /**
-     * Renders and outputs maintenance page and ends controller process.
+     * Initialize the invalid doom page of death.
      */
     public function initCursedPage()
     {
-        $this->displayMaintenancePage();
+        header('HTTP/1.1 403 Forbidden');
+
+        $this->registerStylesheet('theme-error', '/assets/css/error.css', ['media' => 'all', 'priority' => 50]);
+        $this->context->smarty->assign([
+            'layout' => 'layouts/layout-error.tpl',
+            'urls' => $this->getTemplateVarUrls(),
+            'shop' => $this->getTemplateVarShop(),
+            'stylesheets' => $this->getStylesheets(),
+        ]);
+        $this->layout = 'errors/forbidden.tpl';
     }
 
     /**

--- a/themes/classic/templates/errors/forbidden.tpl
+++ b/themes/classic/templates/errors/forbidden.tpl
@@ -25,6 +25,26 @@
 {extends file=$layout}
 
 {block name='content'}
-  <section id="main">
-  </section>
+
+  {block name='page_header_container'}
+    <header class="page-header">
+      <div class="logo"><img src="{$shop.logo}" alt="logo" loading="lazy"></div>
+        {block name='page_header'}
+          <h1>{block name='page_title'}{$shop.name}{/block}</h1>
+        {/block}
+    </header>
+  {/block}
+
+  {block name='page_content_container'}
+    <section id="content" class="page-content page-restricted">
+        {block name='page_content'}
+          <h2>{l s='403 Forbidden' d='Shop.Theme.Global'}</h2>
+          <p>{l s="You are not allowed to access this page." d="Shop.Theme.Global"}</p>
+        {/block}
+    </section>
+  {/block}
+
+  {block name='page_footer_container'}
+
+  {/block}
 {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There is a logic error in Front controllers described in the original ticket. This change fixes the bug by using the already existing, but unused, "forbidden" template.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27094
| How to test?      | See issue to reproduce. With the PR, you get a nice error message instead of a crash.
| Possible impacts? | This only affects access to the Front office. If you put the shop in maintenance mode, you should still get the maintenance page, even if checkAccess() returns false.

## Details

Make sure to read the issue to understand the original bug.

I made `initCursedPage()` show an error page instead of redirecting to `displayMaintenancePage()` which will never display the maintenance page, since the shop has to not be in maintenance mode to get to this method being called.

The "forbidden" error template existed already, but wasn't used anywhere. I updated it to look like the "restricted country" template (the one you get when the shop is not accessible from your country), an a simple wording:

<img width="770" alt="Forbidden page" src="https://user-images.githubusercontent.com/1009343/147365840-7146a3c7-c04f-4c2c-9784-a5deb8a1202d.png">

I searched and I found that initCursedPage() is only called (by the Core at least) in the explained cases. So there are no caveats as far as I can tell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27095)
<!-- Reviewable:end -->
