### PR TITLE
Add the required length to create a webservice key into form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -87,7 +87,17 @@ class WebserviceKeyType extends TranslatorAwareType
         $builder
             ->add('key', GeneratableTextType::class, [
                 'label' => $this->trans('Key', 'Admin.Advparameters.Feature'),
-                'help' => $this->trans('Webservice account key.', 'Admin.Advparameters.Feature'),
+                'help' => sprintf(
+                    '%s<br>%s',
+                    $this->trans('Webservice account key.', 'Admin.Advparameters.Feature'),
+                    $this->trans(
+                        'Key should be at least %length% characters long.',
+                        'Admin.Notifications.Info',
+                        [
+                            '%length%' => Key::LENGTH,
+                        ]
+                    ),
+                ),
                 'generated_value_length' => Key::LENGTH,
                 'constraints' => [
                     new NotBlank([

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -96,7 +96,7 @@ class WebserviceKeyType extends TranslatorAwareType
                         [
                             '%length%' => Key::LENGTH,
                         ]
-                    ),
+                    )
                 ),
                 'generated_value_length' => Key::LENGTH,
                 'constraints' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Add the constraints (32 characthers) into the help of the key creation form.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #n/d.
| How to test?      |  See that when you want to create a webservice key, the "key" help will say you the number of needed characthers.
| Possible impacts? | Nothing.

Wording needed:

- Key should be at least %length% characters long. (Admin.Notifications.Info)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27108)
<!-- Reviewable:end -->
