### PR TITLE
Remove Tools::addonsRequest('service') calls (Part 2)

### DIFF
--- a/.github/workflows/phpstan/return-types-for-new-class-methods-rule-exclusion-list.php
+++ b/.github/workflows/phpstan/return-types-for-new-class-methods-rule-exclusion-list.php
@@ -2304,7 +2304,6 @@ $baseline = [
     'PrestaShopBundle\Service\TranslationService::requiresThemeTranslationsFactory',
     'PrestaShopBundle\Service\TranslationService::listDomainTranslation',
     'PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient::getPrestaTrustCheck',
-    'PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient::getServices',
     'PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient::getCategories',
     'PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient::getModule',
     'PrestaShopBundle\Controller\Admin\Improve\Design\PositionsController::unhookAction',

--- a/src/Adapter/Addons/AddonsDataProvider.php
+++ b/src/Adapter/Addons/AddonsDataProvider.php
@@ -115,8 +115,6 @@ class AddonsDataProvider implements AddonsInterface
 
         try {
             switch ($action) {
-                case 'service':
-                    return $this->marketplaceClient->getServices();
                 case 'module':
                     return $this->marketplaceClient->getModule($params['id_module']);
                 case 'categories':

--- a/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
@@ -98,17 +98,6 @@ class ApiClient
         $this->queryParameters = $this->defaultQueryParameters;
     }
 
-    public function getServices()
-    {
-        $response = $this->setMethod('listing')
-            ->setAction('service')
-            ->getResponse();
-
-        $responseArray = json_decode($response);
-
-        return isset($responseArray->services) ? $responseArray->services : [];
-    }
-
     public function getCategories()
     {
         $response = $this->setMethod('listing')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove Tools::addonsRequest('service') calls (Part 2)
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #24741
| How to test?      | 

**BC Breaks:**
* Removed method `getServices` in class `PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27112)
<!-- Reviewable:end -->
