### PR TITLE
Remove Tools::addonsRequest('customer_themes') calls (Part 2)

### DIFF
--- a/.github/workflows/phpstan/return-types-for-new-class-methods-rule-exclusion-list.php
+++ b/.github/workflows/phpstan/return-types-for-new-class-methods-rule-exclusion-list.php
@@ -2309,7 +2309,6 @@ $baseline = [
     'PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient::getModule',
     'PrestaShopBundle\Controller\Admin\Improve\Design\PositionsController::unhookAction',
     'PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient::getModuleZip',
-    'PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient::getCustomerThemes',
     'PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient::getResponse',
     'PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient::getPostResponse',
     'PrestaShopBundle\Service\TranslationService::dataContainsSearchWord',

--- a/src/Adapter/Addons/AddonsDataProvider.php
+++ b/src/Adapter/Addons/AddonsDataProvider.php
@@ -117,9 +117,6 @@ class AddonsDataProvider implements AddonsInterface
             switch ($action) {
                 case 'service':
                     return $this->marketplaceClient->getServices();
-                case 'customer_themes':
-                    return $this->marketplaceClient
-                        ->getCustomerThemes();
                 case 'module':
                     return $this->marketplaceClient->getModule($params['id_module']);
                 case 'categories':

--- a/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
+++ b/src/PrestaShopBundle/Service/DataProvider/Marketplace/ApiClient.php
@@ -150,26 +150,6 @@ class ApiClient
             ->getPostResponse();
     }
 
-    /**
-     * Get list of themes bought by customer.
-     *
-     * @return object
-     */
-    public function getCustomerThemes()
-    {
-        $response = $this->setMethod('listing')
-            ->setAction('customer-themes')
-            ->getPostResponse();
-
-        $responseDecoded = json_decode($response);
-
-        if (!empty($responseDecoded->themes)) {
-            return $responseDecoded->themes;
-        }
-
-        return new \stdClass();
-    }
-
     public function getResponse()
     {
         return (string) $this->addonsApiClient


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove Tools::addonsRequest('customer_themes') calls (Part 2)
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #24747
| How to test?      | 

**BC Breaks:**
* Removed method `getCustomerThemes` in class `PrestaShopBundle\Service\DataProvider\Marketplace\ApiClient`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27113)
<!-- Reviewable:end -->
