### PR TITLE
Replace a die() by PrestaShopException

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -356,7 +356,7 @@ class OrderHistoryCore extends ObjectModel
 
         // changes invoice number of order ?
         if (!Validate::isLoadedObject($new_os) || !Validate::isLoadedObject($order)) {
-            throw new \PrestaShopException($this->trans('Invalid new order status', [], 'Admin.Orderscustomers.Notification'));
+            throw new PrestaShopException($this->trans('Invalid new order status', [], 'Admin.Orderscustomers.Notification'));
         }
 
         // the order is valid if and only if the invoice is available and the order is not cancelled

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -356,7 +356,7 @@ class OrderHistoryCore extends ObjectModel
 
         // changes invoice number of order ?
         if (!Validate::isLoadedObject($new_os) || !Validate::isLoadedObject($order)) {
-            die(Tools::displayError($this->trans('Invalid new order status', [], 'Admin.Orderscustomers.Notification')));
+            throw new \PrestaShopException($this->trans('Invalid new order status', [], 'Admin.Orderscustomers.Notification'));
         }
 
         // the order is valid if and only if the invoice is available and the order is not cancelled


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If you create a module using the method OrderHistory::changeIdOrderState and if the first parameter which is an id of OrderState doesn't exist (or doesn't exist anymore) for some wierd (or bad) reason, your code found on an annoying Die. After that, you cannot catch, log, or do something to highlight the bug.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27115
| How to test?      | See sample module. Instead of returning an error with a Die, the error is catch by the module at step 4.
| Possible impacts? | Change an order status

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27116)
<!-- Reviewable:end -->
