### PR TITLE
Allow overriding _PS_DISPLAY_COMPATIBILITY_WARNING_ in defines_custom.inc.php

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -29,7 +29,9 @@ if (!defined('_PS_MODE_DEV_')) {
     define('_PS_MODE_DEV_', true);
 }
 /* Compatibility warning */
-define('_PS_DISPLAY_COMPATIBILITY_WARNING_', true);
+if (!defined('_PS_DISPLAY_COMPATIBILITY_WARNING_')) {
+    define('_PS_DISPLAY_COMPATIBILITY_WARNING_', true);
+}
 if (_PS_MODE_DEV_ === true) {
     $errorReportingLevel = E_ALL | E_STRICT;
     /* @phpstan-ignore-next-line */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | With the usage of defines_custom.inc.php file, we can define some consts but not the `_PS_DISPLAY_COMPATIBILITY_WARNING_` one.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | n/d.
| Possible impacts? | n/d.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27127)
<!-- Reviewable:end -->
