### PR TITLE
Increase maximum country state name length from 32 to 80 characters

### DIFF
--- a/classes/State.php
+++ b/classes/State.php
@@ -54,7 +54,7 @@ class StateCore extends ObjectModel
             'id_country' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'id_zone' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedId', 'required' => true],
             'iso_code' => ['type' => self::TYPE_STRING, 'validate' => 'isStateIsoCode', 'required' => true, 'size' => 7],
-            'name' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 32],
+            'name' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'required' => true, 'size' => 80],
             'active' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
         ],
     ];

--- a/controllers/admin/AdminStatesController.php
+++ b/controllers/admin/AdminStatesController.php
@@ -153,7 +153,7 @@ class AdminStatesControllerCore extends AdminController
                     'type' => 'text',
                     'label' => $this->trans('Name', [], 'Admin.Global'),
                     'name' => 'name',
-                    'maxlength' => 32,
+                    'maxlength' => 80,
                     'required' => true,
                     'hint' => $this->trans('Provide the state name to be displayed in addresses and on invoices.', [], 'Admin.International.Help'),
                 ],

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -2049,7 +2049,7 @@ CREATE TABLE `PREFIX_state` (
   `id_state` int(10) unsigned NOT NULL auto_increment,
   `id_country` int(11) unsigned NOT NULL,
   `id_zone` int(11) unsigned NOT NULL,
-  `name` varchar(64) NOT NULL,
+  `name` varchar(80) NOT NULL,
   `iso_code` varchar(7) NOT NULL,
   `tax_behavior` smallint(1) NOT NULL DEFAULT '0',
   `active` tinyint(1) NOT NULL DEFAULT '0',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixes a bug when importing localization packs, and a State name is greater than 32 characters (e.g. US pack trying to import "United States Minor Outlying Islands"). Alternatively, it allows to set up state names up to 80 characters long.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27156
| How to test?      | Go to BO / Improve / International / Localization / Localization pack you want to import.<br>Select United States.<br>Check States.<br>Click Import.
| Possible impacts? | None that I know of.

![image](https://user-images.githubusercontent.com/36200981/147842028-ac72ea22-3f8d-4bd6-b326-602bf9b95c72.png)

The database table `ps_stat`e already considers `name` to be up to 64 characters, but `State.php` defines this field as a 32 character size.

Updated for consistency and to avoid errors as the one in #27156 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27162)
<!-- Reviewable:end -->
