### PR TITLE
Updated state.xml MX Aguascalientes ISO 3166 code, and reorderded CMX…

### DIFF
--- a/install-dev/data/xml/state.xml
+++ b/install-dev/data/xml/state.xml
@@ -177,7 +177,7 @@
     <state id="DC" id_country="US" id_zone="North_America" iso_code="DC" tax_behavior="0" active="1">
       <name>District of Columbia</name>
     </state>
-    <state id="AGS" id_country="MX" id_zone="North_America" iso_code="AGS" tax_behavior="0" active="1">
+    <state id="AGU" id_country="MX" id_zone="North_America" iso_code="AGU" tax_behavior="0" active="1">
       <name>Aguascalientes</name>
     </state>
     <state id="BCN" id_country="MX" id_zone="North_America" iso_code="BCN" tax_behavior="0" active="1">
@@ -195,14 +195,14 @@
     <state id="CHH" id_country="MX" id_zone="North_America" iso_code="CHH" tax_behavior="0" active="1">
       <name>Chihuahua</name>
     </state>
+    <state id="CMX" id_country="MX" id_zone="North_America" iso_code="CMX" tax_behavior="0" active="1">
+      <name>Ciudad de México</name>
+    </state>
     <state id="COA" id_country="MX" id_zone="North_America" iso_code="COA" tax_behavior="0" active="1">
       <name>Coahuila</name>
     </state>
     <state id="COL" id_country="MX" id_zone="North_America" iso_code="COL" tax_behavior="0" active="1">
       <name>Colima</name>
-    </state>
-    <state id="CMX" id_country="MX" id_zone="North_America" iso_code="CMX" tax_behavior="0" active="1">
-      <name>Ciudad de México</name>
     </state>
     <state id="DUR" id_country="MX" id_zone="North_America" iso_code="DUR" tax_behavior="0" active="1">
       <name>Durango</name>


### PR DESCRIPTION
… to be alpabetically ordered.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      | The current ISO 3166 code for Aguascalientes is AGU according to https://www.iso.org/obp/ui/#iso:code:3166:MX
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27165
| How to test?      | 1. Install PrestaShop with the updated state.xml file. <br>2. In BO, go to International / Locations / States tab<br>3. Filter by Country = Mexico and look up for Aguascalientes code.
| Possible impacts? | None.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27166)
<!-- Reviewable:end -->
