### PR TITLE
Update function getCustomerOrders to avoid error

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -967,9 +967,9 @@ class OrderCore extends ObjectModel
         foreach ($res as $key => $val) {
             // In case order creation crashed midway some data might be absent
             $orderState = !empty($val['id_order_state']) ? $indexedOrderStates[$val['id_order_state']] : null;
-            $res[$key]['order_state'] = $orderState['name'] ?: null;
-            $res[$key]['invoice'] = $orderState['invoice'] ?: null;
-            $res[$key]['order_state_color'] = $orderState['color'] ?: null;
+            $res[$key]['order_state'] = $orderState['name'] ?? null;
+            $res[$key]['invoice'] = $orderState['invoice'] ?? null;
+            $res[$key]['order_state_color'] = $orderState['color'] ?? null;
         }
 
         return $res;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When an order is missing in table ps_order_history due to a crash during order creation, and when customer wants to see his/her order history,  today, it gives a "ContextErrorException : Trying to access array offset on value of type null", because $orderState becomes null and so $orderState['name'], $orderState['invoice'], $orderState['color'] can't exist. By using Null Coalescing Operator instead of Ternary Operator, we avoid the error.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27967
| How to test?      | See below
| Possible impacts? | Only order history in customer account.

### Description

Today, it gives a "ContextErrorException : Trying to access array offset on value of type null", if there was a crash during order creation, because $orderState becomes null and so $orderState['name'], $orderState['invoice'], $orderState['color'] can't exist.
By using Null Coalescing Operator instead of Ternary Operator, we avoid the error.

### How to test

1. Make an order in FO using customer ZJA
2. Remove its SQL lines from table ps_order_history table
3. Then browse customer account ZJA, click on order history.
4. See error

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27179)
<!-- Reviewable:end -->
