### PR TITLE
Improve CMS edit page footer

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -26,29 +26,38 @@
 {% form_theme cmsPageForm 'PrestaShopBundle:Admin/TwigTemplateForm:prestashop_ui_kit.html.twig' %}
 
 {{ form_start(cmsPageForm) }}
-  <div class="card">
-    <div class="card-header">
-      {{ 'Page'|trans({}, 'Admin.Shopparameters.Feature') }}
+<div class="card">
+  <div class="card-header">
+    {{ 'Page'|trans({}, 'Admin.Shopparameters.Feature') }}
+  </div>
+  <div class="card-block row">
+    <div class="card-text">
+      {{ form_widget(cmsPageForm) }}
     </div>
-    <div class="card-block row">
-      <div class="card-text">
-        {{ form_widget(cmsPageForm) }}
-      </div>
-    </div>
+  </div>
 
-    <div class="card-footer">
-      <div class="d-inline-flex">
-        <a href="{{ path('admin_cms_pages_index', {'id_cms_category' : cmsCategoryParentId}) }}" class="btn btn-outline-secondary" id="cancel-link">
-          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-        </a>
-      </div>
+  <div class="card-footer d-flex">
+    <a href="{{ path('admin_cms_pages_index', {'id_cms_category' : cmsCategoryParentId}) }}" class="btn btn-outline-secondary" id="cancel-link">
+      {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+    </a>
 
-      <div class="d-inline-flex float-right">
-        <button type="submit" class="btn btn-primary" name="save-and-preview" id="save-and-preview-button">
+    <div class="d-none d-lg-flex ml-auto ">
+      <button type="submit" class="btn btn-primary" name="save-and-preview" id="save-and-preview-button">
         {{ 'Save and preview'|trans({}, 'Admin.Actions') }}
       </button>
-
       <button type="submit" class="btn btn-primary ml-3" id="save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+    </div>
+
+    <div class="d-lg-none ml-auto">
+      <div class="btn-group dropup">
+        <button type="submit" class="btn btn-primary" id="save-button-mobile">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
+        <button type="button" class="btn btn-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
+        </button>
+        <div class="dropdown-menu dropdown-menu-right">
+          <button type="submit" class="dropdown-item" name="save-and-preview" id="save-and-preview-button-mobile">{{ 'Save and preview'|trans({}, 'Admin.Actions') }}</button>
+        </div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
Replacement of https://github.com/PrestaShop/PrestaShop/pull/26704 which I screwed up... :-)

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR turns two buttons into btn group on smaller screens. Drops up and left.
| Type?             | Bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26633
| How to test?      | Compare before and after.
| Possible impacts? | 

**Screenshot**
![Multimédia1](https://user-images.githubusercontent.com/6097524/142880614-7f73b53c-dc05-4fbe-9c54-648122dc99ae.gif)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/26704)
<!-- Reviewable:end -->
