### PR TITLE
Don't reassign global vars in front controller

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -108,15 +108,8 @@ class CartControllerCore extends FrontController
         if (!Tools::getValue('ajax')) {
             $this->checkCartProductsMinimalQuantities();
         }
-        $presenter = new CartPresenter();
-        $presented_cart = $presenter->present($this->context->cart, $shouldSeparateGifts = true);
 
-        $this->context->smarty->assign([
-            'cart' => $presented_cart,
-            'static_token' => Tools::getToken(false),
-        ]);
-
-        if (count($presented_cart['products']) > 0) {
+        if ($this->context->cart->hasProducts()) {
             $this->setTemplate('checkout/cart');
         } else {
             $this->context->smarty->assign([

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -312,7 +312,6 @@ class OrderControllerCore extends FrontController
 
         $this->context->smarty->assign([
             'checkout_process' => new RenderableProxy($this->checkoutProcess),
-            'cart' => $presentedCart,
             'display_transaction_updated_info' => Tools::getIsset('updatedTransaction'),
             'tos_cms' => $this->getDefaultTermsAndConditions(),
         ]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Don't reassign global vars in front controller. This change fixes minor code issues I found while working on another bug. Already assigned in `FrontControllerCore::assignGeneralPurposeVariables()`
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28067
| How to test?      | Make cart and order controller work fine :)
| Possible impacts? | Make cart and order controller work fine :)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27227)
<!-- Reviewable:end -->
