### PR TITLE
Fix FormSubmitButton selector

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form-submit-button.ts
+++ b/admin-dev/themes/new-theme/js/components/form-submit-button.ts
@@ -60,7 +60,7 @@ export default class FormSubmitButton {
       (event: JQueryEventObject) => {
         event.preventDefault();
 
-        const $btn = $(this);
+        const $btn = $(event.target);
 
         if (
           $btn.data('form-confirm-message')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since #24791, we use the arrow function (`() => {}`) for `$(document).on()` which give `this` the instance of the class `FormSubmitButton` and not the selector like before. This PR fixes it by using `event.target` instead.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26985 & Fixes #27311
| How to test?      | Please see #26985
| Possible impacts? | This should have a (positive) impact where `FormSubmitButton` is used:<ul><li>The button to delete the cover image of category in Sell > Catalog > Categories</li><li>The button to delete the menu thumbnails image of category in Sell > Catalog > Categories</li></ul>


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27228)
<!-- Reviewable:end -->
