### PR TITLE
Fix uploader types validation

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -476,7 +476,7 @@ class ImageManagerCore
     public static function isCorrectImageFileExt($filename, $authorizedExtensions = null)
     {
         // Filter on file extension
-        if ($authorizedExtensions === null) {
+        if (empty($authorizedExtensions)) {
             $authorizedExtensions = static::EXTENSIONS_SUPPORTED;
         }
         $nameExplode = explode('.', $filename);

--- a/classes/Uploader.php
+++ b/classes/Uploader.php
@@ -366,7 +366,7 @@ class UploaderCore
         $types = $this->getAcceptTypes();
 
         //TODO check mime type.
-        if (!in_array(Tools::strtolower(pathinfo($file['name'], PATHINFO_EXTENSION)), $types)) {
+        if (!empty($types) && !in_array(Tools::strtolower(pathinfo($file['name'], PATHINFO_EXTENSION)), $types)) {
             $file['error'] = Context::getContext()->getTranslator()->trans('Filetype not allowed', [], 'Admin.Notifications.Error');
 
             return false;

--- a/src/Adapter/Image/Uploader/AbstractImageUploader.php
+++ b/src/Adapter/Image/Uploader/AbstractImageUploader.php
@@ -61,7 +61,14 @@ abstract class AbstractImageUploader
             || !ImageManager::isCorrectImageFileExt($image->getClientOriginalName())
             || preg_match('/\%00/', $image->getClientOriginalName()) // prevent null byte injection
         ) {
-            throw new UploadedImageConstraintException(sprintf('Image format "%s", not recognized, allowed formats are: .gif, .jpg, .png', $image->getClientOriginalExtension()), UploadedImageConstraintException::UNRECOGNIZED_FORMAT);
+            throw new UploadedImageConstraintException(
+                sprintf(
+                    'Image format "%s", not recognized, allowed formats are: %s',
+                    $image->getClientOriginalExtension(),
+                    join(', ', ImageManager::EXTENSIONS_SUPPORTED)
+                ),
+                UploadedImageConstraintException::UNRECOGNIZED_FORMAT
+            );
         }
     }
 

--- a/src/Adapter/Image/Uploader/CategoryMenuThumbnailUploader.php
+++ b/src/Adapter/Image/Uploader/CategoryMenuThumbnailUploader.php
@@ -39,7 +39,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 /**
  * Class CategoryMenuThumbnailUploader.
  */
-final class CategoryMenuThumbnailUploader implements ImageUploaderInterface
+final class CategoryMenuThumbnailUploader extends AbstractImageUploader implements ImageUploaderInterface
 {
     /**
      * @var CacheClearer
@@ -61,6 +61,7 @@ final class CategoryMenuThumbnailUploader implements ImageUploaderInterface
      */
     public function upload($categoryId, UploadedFile $uploadedImage)
     {
+        $this->checkImageIsAllowedForUpload($uploadedImage);
         //Get total of image already present in directory
         $files = scandir(_PS_CAT_IMG_DIR_, SCANDIR_SORT_NONE);
         $usedKeys = [];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 use Category;
 use Dispatcher;
 use Exception;
+use ImageManager;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDeleteCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDisableCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkEnableCategoriesCommand;
@@ -56,6 +57,7 @@ use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\MenuThumbnailId;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CategoryGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\CategoryFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
@@ -891,6 +893,15 @@ class CategoryController extends FrameworkBundleAdminController
                 '%s %s',
                 $this->trans('An error occurred while uploading the image:', 'Admin.Catalog.Notification'),
                 $this->trans('You cannot upload more files', 'Admin.Notifications.Error')
+            ),
+            UploadedImageConstraintException::class => sprintf(
+                '%s %s',
+                $this->trans('An error occurred while uploading the image:', 'Admin.Catalog.Notification'),
+                $this->trans(
+                    'Image format not recognized, allowed formats are: %s',
+                    'Admin.Notifications.Error',
+                    [implode(', ', ImageManager::EXTENSIONS_SUPPORTED)]
+                )
             ),
         ];
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
 use Category;
+use Dispatcher;
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDeleteCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDisableCategoriesCommand;
@@ -306,6 +307,11 @@ class CategoryController extends FrameworkBundleAdminController
         }
 
         $defaultGroups = $this->get('prestashop.adapter.group.provider.default_groups_provider')->getGroups();
+
+        // If we don't create the dispatcher instance with the current request,
+        // a new instance will be created later using `SymfonyRequest::createFromGlobals()`
+        // but as we may have already uploaded files, this can throw an exception
+        Dispatcher::getInstance($request);
 
         return $this->render(
             '@PrestaShop/Admin/Sell/Catalog/Categories/edit.html.twig',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -113,7 +113,9 @@
           {% if allowMenuThumbnailsUpload %}
             {{ form_widget(categoryForm.menu_thumbnail_images) }}
           {% else %}
-            {{ form_widget(categoryForm.menu_thumbnail_images, {'attr': {'class': 'd-none'}}) }}
+            <div class="d-none">
+              {{ form_widget(categoryForm.menu_thumbnail_images) }}
+            </div>
 
             <div class="alert alert-warning" role="alert">
               <p class="alert-text">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since PR #26164, the default value for `$_accept_types` is an empty array (it was `null` before) and the validation processes didn't take the empty array for "accept all" like it was when the default value was `null`. This PR fixes it by taking an empty array as "accept all" types.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27237 & #27303
| How to test?      | Please see #27237 & #27303
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27240)
<!-- Reviewable:end -->
