### PR TITLE
Hide default spin buttons for input number

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_ps_number.scss
+++ b/admin-dev/themes/new-theme/scss/components/_ps_number.scss
@@ -5,13 +5,13 @@
   /* Chrome, Safari, Edge, Opera */
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
     margin: 0;
+    appearance: none;
   }
 
   /* Firefox */
-  input[type=number] {
-    -moz-appearance: textfield;
+  input[type="number"] {
+    appearance: textfield;
   }
 
   .danger {

--- a/admin-dev/themes/new-theme/scss/components/_ps_number.scss
+++ b/admin-dev/themes/new-theme/scss/components/_ps_number.scss
@@ -2,8 +2,16 @@
   position: relative;
   display: inline-block;
 
-  input[type="number"] {
-    appearance: textfield;
+  /* Chrome, Safari, Edge, Opera */
+  input::-webkit-outer-spin-button,
+  input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  input[type=number] {
+    -moz-appearance: textfield;
   }
 
   .danger {

--- a/admin-dev/themes/new-theme/scss/components/_ps_number.scss
+++ b/admin-dev/themes/new-theme/scss/components/_ps_number.scss
@@ -2,9 +2,8 @@
   position: relative;
   display: inline-block;
 
-  input[type="number"]::-webkit-inner-spin-button,
-  input[type="number"]::-webkit-outer-spin-button {
-    appearance: none;
+  input[type="number"] {
+    appearance: textfield;
   }
 
   .danger {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Hide default spin buttons for input number.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26796
| How to test?      | Go to BO > Catalog > Stock
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27257)
<!-- Reviewable:end -->
