### PR TITLE
Fix left padding of header when sidebar menu is closed

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_content_div.scss
@@ -62,6 +62,12 @@
 .page-sidebar-closed:not(.mobile) {
   .content-div {
     padding-left: $size-navbar-width-mini + ($grid-gutter-width / 2);
+
+    &.-notoolbar {
+      .header-toolbar {
+        padding-left: 0;
+      }
+    }
   }
 }
 

--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -144,6 +144,6 @@
 
 .page-sidebar-closed:not(.mobile) {
   .header-toolbar {
-    left: $size-navbar-width-mini;
+    padding-left: 3rem;
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Header had a big white space when left menu was closed
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27243.
| How to test?      | See issue, you should test the header when sidebar menu is closed on some pages (and on product page)
| Possible impacts? | Header


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27259)
<!-- Reviewable:end -->
