### PR TITLE
Add product link in order preview

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderPreviewHandler.php
@@ -233,7 +233,8 @@ final class GetOrderPreviewHandler implements GetOrderPreviewHandlerInterface
                 (int) $detail['product_quantity'],
                 $locale->formatPrice($unitPrice, $currency->iso_code),
                 $locale->formatPrice($totalPrice, $currency->iso_code),
-                $locale->formatPrice((string) $totalTaxAmount, $currency->iso_code)
+                $locale->formatPrice((string) $totalTaxAmount, $currency->iso_code),
+                (int) $detail['id_product']
             );
         }
 

--- a/src/Core/Domain/Order/QueryResult/OrderPreviewProductDetail.php
+++ b/src/Core/Domain/Order/QueryResult/OrderPreviewProductDetail.php
@@ -79,7 +79,7 @@ class OrderPreviewProductDetail
      * @param string $unitPrice
      * @param string $totalPrice
      * @param string $totalTax
-     * @param int|null $id
+     * @param int $id
      */
     public function __construct(
         string $name,

--- a/src/Core/Domain/Order/QueryResult/OrderPreviewProductDetail.php
+++ b/src/Core/Domain/Order/QueryResult/OrderPreviewProductDetail.php
@@ -67,7 +67,7 @@ class OrderPreviewProductDetail
     private $location;
 
     /**
-     * @var int|null
+     * @var int
      */
     private $id;
 
@@ -89,7 +89,7 @@ class OrderPreviewProductDetail
         string $unitPrice,
         string $totalPrice,
         string $totalTax,
-        ?int $id = null
+        int $id
     ) {
         $this->name = $name;
         $this->quantity = $quantity;
@@ -158,9 +158,9 @@ class OrderPreviewProductDetail
     }
 
     /**
-     * @return int|null
+     * @return int
      */
-    public function getId(): ?int
+    public function getId(): int
     {
         return $this->id;
     }

--- a/src/Core/Domain/Order/QueryResult/OrderPreviewProductDetail.php
+++ b/src/Core/Domain/Order/QueryResult/OrderPreviewProductDetail.php
@@ -79,7 +79,7 @@ class OrderPreviewProductDetail
      * @param string $unitPrice
      * @param string $totalPrice
      * @param string $totalTax
-     * @param string|null $id
+     * @param int|null $id
      */
     public function __construct(
         string $name,

--- a/src/Core/Domain/Order/QueryResult/OrderPreviewProductDetail.php
+++ b/src/Core/Domain/Order/QueryResult/OrderPreviewProductDetail.php
@@ -67,6 +67,11 @@ class OrderPreviewProductDetail
     private $location;
 
     /**
+     * @var int|null
+     */
+    private $id;
+
+    /**
      * @param string $name
      * @param string $reference
      * @param string $location
@@ -74,6 +79,7 @@ class OrderPreviewProductDetail
      * @param string $unitPrice
      * @param string $totalPrice
      * @param string $totalTax
+     * @param string|null $id
      */
     public function __construct(
         string $name,
@@ -82,7 +88,8 @@ class OrderPreviewProductDetail
         int $quantity,
         string $unitPrice,
         string $totalPrice,
-        string $totalTax
+        string $totalTax,
+        ?int $id = null
     ) {
         $this->name = $name;
         $this->quantity = $quantity;
@@ -91,6 +98,7 @@ class OrderPreviewProductDetail
         $this->totalTax = $totalTax;
         $this->reference = $reference;
         $this->location = $location;
+        $this->id = $id;
     }
 
     /**
@@ -147,5 +155,13 @@ class OrderPreviewProductDetail
     public function getLocation(): string
     {
         return $this->location;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getId(): ?int
+    {
+        return $this->id;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
@@ -139,7 +139,7 @@
           <tbody>
           {% for productDetail in orderPreview.productDetails %}
             <tr class="{% if loop.index > productsPreviewLimit %}js-product-preview-more d-none{% endif %}">
-              <td class="p-1">{{ productDetail.name }}</td>
+              <td class="p-1"><a href="{{ path('admin_product_form', {'id': productDetail.id}) }}" target="_blank">{{ productDetail.name }}</a></td>
               <td class="p-1">{{ productDetail.reference }}</td>
               <td class="p-1 js-cell-product-stock-location">
                 {% if productDetail.location is not empty %}{{ productDetail.location }}{% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
@@ -139,7 +139,7 @@
           <tbody>
           {% for productDetail in orderPreview.productDetails %}
             <tr class="{% if loop.index > productsPreviewLimit %}js-product-preview-more d-none{% endif %}">
-              <td class="p-1"><a href="{{ path('admin_product_form', {'id': productDetail.id}) }}" target="_blank">{{ productDetail.name }}</a></td>
+              <td class="p-1"><a class="px-0 external-link" href="{{ path('admin_product_form', {'id': productDetail.id}) }}" target="_blank">{{ productDetail.name }}</a></td>
               <td class="p-1">{{ productDetail.reference }}</td>
               <td class="p-1 js-cell-product-stock-location">
                 {% if productDetail.location is not empty %}{{ productDetail.location }}{% endif %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add product link in order preview.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27267
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/27267
| Possible impacts? | N/A

**:notebook: BC Break :**
* In `PrestaShop\PrestaShop\Core\Domain\Order\QueryResult\OrderPreviewProductDetail` : 
  * Added parameter `int $id`




<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27268)
<!-- Reviewable:end -->
