### PR TITLE
Move condition field from options to specifications tab

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -113,6 +113,21 @@
   }
 }
 
+.form-group.inline-switch-widget {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+
+  > * {
+    width: auto;
+  }
+
+  > .input-group {
+    min-width: 35px;
+    margin-top: -7px;
+  }
+}
+
 [class*="form-columns-"] {
   display: flex;
   flex-wrap: wrap;

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/OptionsCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/OptionsCommandsBuilder.php
@@ -39,11 +39,13 @@ final class OptionsCommandsBuilder implements ProductCommandsBuilderInterface
     public function buildCommands(ProductId $productId, array $formData): array
     {
         if (empty($formData['options']) &&
-            !isset($formData['description']['manufacturer'])) {
+            !isset($formData['description']['manufacturer']) &&
+            !isset($formData['specifications'])) {
             return [];
         }
 
         $options = $formData['options'] ?? [];
+        $specifications = $formData['specifications'] ?? [];
         $manufacturerId = isset($formData['description']['manufacturer']) ? (int) $formData['description']['manufacturer'] : null;
         $command = new UpdateProductOptionsCommand($productId->getValue());
 
@@ -59,11 +61,11 @@ final class OptionsCommandsBuilder implements ProductCommandsBuilderInterface
         if (isset($options['visibility']['online_only'])) {
             $command->setOnlineOnly((bool) $options['visibility']['online_only']);
         }
-        if (isset($options['show_condition'])) {
-            $command->setShowCondition((bool) $options['show_condition']);
+        if (isset($specifications['show_condition'])) {
+            $command->setShowCondition((bool) $specifications['show_condition']);
         }
-        if (isset($options['condition'])) {
-            $command->setCondition($options['condition']);
+        if (isset($specifications['condition'])) {
+            $command->setCondition($specifications['condition']);
         }
 
         if (null !== $manufacturerId) {

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -179,6 +179,9 @@ class ProductFormDataProvider implements FormDataProviderInterface
                 'manufacturer' => NoManufacturerId::NO_MANUFACTURER_ID,
                 'related_products' => [],
             ],
+            'specifications' => [
+                'condition' => ProductCondition::NEW,
+            ],
             'stock' => [
                 'quantities' => [
                     'delta_quantity' => [
@@ -215,7 +218,6 @@ class ProductFormDataProvider implements FormDataProviderInterface
                 'visibility' => [
                     'visibility' => ProductVisibility::VISIBLE_EVERYWHERE,
                 ],
-                'condition' => ProductCondition::NEW,
             ],
             'footer' => [
                 'active' => $this->defaultProductActivation,
@@ -346,6 +348,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
     private function extractSpecificationsData(ProductForEditing $productForEditing): array
     {
         $details = $productForEditing->getDetails();
+        $options = $productForEditing->getOptions();
 
         return [
             'references' => [
@@ -357,6 +360,8 @@ class ProductFormDataProvider implements FormDataProviderInterface
             ],
             'features' => $this->extractFeatureValues($productForEditing->getProductId()),
             'attachments' => $this->extractAttachmentsData($productForEditing),
+            'show_condition' => $options->showCondition(),
+            'condition' => $options->getCondition(),
             'customizations' => $this->extractCustomizationsData($productForEditing),
         ];
     }
@@ -560,8 +565,6 @@ class ProductFormDataProvider implements FormDataProviderInterface
                 'show_price' => $options->showPrice(),
                 'online_only' => $options->isOnlineOnly(),
             ],
-            'show_condition' => $options->showCondition(),
-            'condition' => $options->getCondition(),
             'suppliers' => $this->extractSuppliersData($productForEditing),
         ];
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
@@ -87,7 +87,7 @@ class CombinationFormType extends TranslatorAwareType
             ])
             ->add('images', ChoiceType::class, [
                 'label' => $this->trans('Images', 'Admin.Global'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'choices' => $this->imagesChoiceProvider->getChoices(['product_id' => $options['product_id']]),
                 'choice_attr' => function ($choice, $key) {
                     return ['data-image-url' => $key];

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
@@ -143,7 +143,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver->setDefaults([
             'label' => $this->trans('Price and impact', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'columns_number' => 3,
         ]);
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
@@ -110,7 +110,7 @@ class DescriptionType extends TranslatorAwareType
                         ]),
                     ],
                 ],
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'modify_all_shops' => true,
             ])
             ->add('description', TranslatableType::class, [
@@ -132,18 +132,18 @@ class DescriptionType extends TranslatorAwareType
                         ]),
                     ],
                 ],
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'modify_all_shops' => true,
             ])
             ->add('categories', CategoriesType::class, [
                 'label' => $this->trans('Categories', 'Admin.Global'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'product_id' => $productId,
             ])
             ->add('manufacturer', ManufacturerType::class)
             ->add('related_products', EntitySearchInputType::class, [
                 'label' => $this->trans('Related products', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'entry_type' => RelatedProductType::class,
                 'entry_options' => [
                     'block_prefix' => 'related_product',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
@@ -72,7 +72,7 @@ class ManufacturerType extends ChoiceType
 
         $resolver->setDefaults([
             'label' => $this->trans('Brand', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'required' => false,
             // placeholder false is important to avoid empty option in select input despite required being false
             'placeholder' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/OptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/OptionsType.php
@@ -27,13 +27,9 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Options;
 
-use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
-use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * This form class is responsible to generate the product options form.
@@ -41,47 +37,12 @@ use Symfony\Component\Translation\TranslatorInterface;
 class OptionsType extends TranslatorAwareType
 {
     /**
-     * @var FormChoiceProviderInterface
-     */
-    private $productConditionChoiceProvider;
-
-    /**
-     * @param TranslatorInterface $translator
-     * @param array $locales
-     * @param FormChoiceProviderInterface $productConditionChoiceProvider
-     */
-    public function __construct(
-        TranslatorInterface $translator,
-        array $locales,
-        FormChoiceProviderInterface $productConditionChoiceProvider
-    ) {
-        parent::__construct($translator, $locales);
-        $this->productConditionChoiceProvider = $productConditionChoiceProvider;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
             ->add('visibility', VisibilityType::class)
-            ->add('condition', ChoiceType::class, [
-                'choices' => $this->productConditionChoiceProvider->getChoices(),
-                'attr' => [
-                    'class' => 'custom-select',
-                ],
-                'required' => false,
-                // placeholder false is important to avoid empty option in select input despite required being false
-                'placeholder' => false,
-                'label' => $this->trans('Condition', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
-                'label_help_box' => $this->trans('Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces.', 'Admin.Catalog.Help'),
-            ])
-            ->add('show_condition', SwitchType::class, [
-                'required' => false,
-                'label' => $this->trans('Display condition on product page', 'Admin.Catalog.Feature'),
-            ])
             ->add('suppliers', SuppliersType::class)
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductAttachmentsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/ProductAttachmentsType.php
@@ -101,7 +101,7 @@ class ProductAttachmentsType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver->setDefaults([
             'label' => $this->trans('Attached files', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'label_help_box' => $this->trans('Instructions, size guide, or any file you want to add to a product.', 'Admin.Catalog.Help'),
             'label_subtitle' => $this->trans('Customers can download these files on the product page.', 'Admin.Catalog.Help'),
             'external_link' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/SuppliersType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/SuppliersType.php
@@ -120,7 +120,7 @@ class SuppliersType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver->setDefaults([
             'label' => $this->trans('Suppliers', 'Admin.Global'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'columns_number' => 2,
             'row_attr' => [
                 'class' => 'product-suppliers-block',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/VisibilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Options/VisibilityType.php
@@ -95,7 +95,7 @@ class VisibilityType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver->setDefaults([
             'label' => $this->trans('Visibility', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'label_subtitle' => $this->trans('Where do you want your product to appear?', 'Admin.Catalog.Feature'),
             'required' => false,
             'columns_number' => 4,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -128,7 +128,7 @@ class PricingType extends TranslatorAwareType
             ->add('wholesale_price', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'label_help_box' => $this->trans('The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin.', 'Admin.Catalog.Help'),
                 'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
                 'currency' => $this->defaultCurrency->iso_code,
@@ -141,12 +141,12 @@ class PricingType extends TranslatorAwareType
             ])
             ->add('specific_prices', SpecificPricesType::class, [
                 'label' => $this->trans('Specific prices', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'label_help_box' => $this->trans('You can set specific prices for customers belonging to different groups, different countries, etc.', 'Admin.Catalog.Help'),
             ])
             ->add('priority_management', UnavailableType::class, [
                 'label' => $this->trans('Priority management', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'label_help_box' => $this->trans('Sometimes one customer can fit into multiple price rules. Priorities allow you to define which rules apply first.', 'Admin.Catalog.Help'),
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
@@ -124,7 +124,7 @@ class RetailPriceType extends TranslatorAwareType
 
         $resolver->setDefaults([
             'label' => $this->trans('Retail price', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'label_help_box' => $this->trans('This is the net sales price for your customers. The retail price (tax incl.) will automatically be calculated using the selected tax rate.', 'Admin.Catalog.Help'),
             'required' => false,
             'columns_number' => 4,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/UnitPriceType.php
@@ -110,7 +110,7 @@ class UnitPriceType extends TranslatorAwareType
         $resolver->setDefaults([
             'label' => $this->trans('Display retail price per unit', 'Admin.Catalog.Feature'),
             'label_help_box' => $this->trans('Indicate the price for a single unit of the product. For instance, if you\'re selling fabrics, it would be the price per meter.', 'Admin.Catalog.Help'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'required' => false,
             'columns_number' => 4,
         ]);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
@@ -176,7 +176,7 @@ class RedirectOptionType extends TranslatorAwareType
                 'product_id' => null,
                 'required' => false,
                 'label' => $this->trans('Redirection page', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'label_help_box' => $this->trans('When your product is disabled, choose to which page you’d like to redirect the customers visiting its page by typing the product or category name.', 'Admin.Catalog.Help'),
                 'columns_number' => 2,
                 'row_attr' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -171,7 +171,7 @@ class SEOType extends TranslatorAwareType
             ->add('tags', TranslatableType::class, [
                 'required' => false,
                 'label' => $this->trans('Tags', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'help' => $this->trans('Use a comma to create separate tags. E.g.: dress, cotton, party dresses.', 'Admin.Catalog.Help'),
                 'options' => [
                     'constraints' => [
@@ -249,7 +249,7 @@ class SEOType extends TranslatorAwareType
             ->setDefaults([
                 'product_id' => null,
                 'label' => $this->trans('Search engine optimization', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'label_subtitle' => $this->trans('Improve your ranking and how your product page will appear in search engines results.', 'Admin.Catalog.Feature'),
                 'required' => false,
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
@@ -151,7 +151,7 @@ class DimensionsType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver->setDefaults([
             'label' => $this->trans('Package dimension', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'label_subtitle' => $this->trans('Adjust your shipping costs by filling in the product dimensions.', 'Admin.Catalog.Feature'),
             'required' => false,
             'columns_number' => 6,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/ShippingType.php
@@ -91,14 +91,14 @@ class ShippingType extends TranslatorAwareType
                 'multiple' => false,
                 'required' => false,
                 'label' => $this->trans('Delivery Time', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'label_help_box' => $this->trans('Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws.', 'Admin.Catalog.Help'),
             ])
             ->add('delivery_time_notes', DeliveryTimeNotesType::class)
             ->add('additional_shipping_cost', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Shipping fees', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'label_subtitle' => $this->trans('Does this product incur additional shipping costs?', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans('If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping.', 'Admin.Catalog.Help'),
                 'currency' => $this->currencyIsoCode,
@@ -114,7 +114,7 @@ class ShippingType extends TranslatorAwareType
                 'multiple' => true,
                 'required' => false,
                 'label' => $this->trans('Available carriers', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'alert_message' => $this->trans('If no carrier is selected then all the carriers will be available for customers orders.', 'Admin.Catalog.Notification'),
                 'alert_type' => 'warning',
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/CustomizationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/CustomizationsType.php
@@ -63,7 +63,7 @@ class CustomizationsType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver->setDefaults([
             'label' => $this->trans('Customization', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'label_subtitle' => $this->trans('Customers can personalize the product by entering some text or by providing custom image files.', 'Admin.Catalog.Feature'),
             'attr' => [
                 'class' => 'product-customizations-collection',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/ReferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/ReferencesType.php
@@ -97,7 +97,7 @@ class ReferencesType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver->setDefaults([
             'label' => $this->trans('References', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'required' => false,
         ]);
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsType.php
@@ -67,6 +67,13 @@ class SpecificationsType extends TranslatorAwareType
             ->add('references', ReferencesType::class)
             ->add('features', FeaturesType::class)
             ->add('attachments', ProductAttachmentsType::class)
+            ->add('show_condition', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans('Display condition on product page', 'Admin.Catalog.Feature'),
+                'label_tag_name' => 'h3',
+                'show_choices' => false,
+                'inline_switch' => true,
+            ])
             ->add('condition', ChoiceType::class, [
                 'choices' => $this->productConditionChoiceProvider->getChoices(),
                 'attr' => [
@@ -75,13 +82,8 @@ class SpecificationsType extends TranslatorAwareType
                 'required' => false,
                 // placeholder false is important to avoid empty option in select input despite required being false
                 'placeholder' => false,
-                'label' => $this->trans('Condition', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label' => false,
                 'label_help_box' => $this->trans('Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces.', 'Admin.Catalog.Help'),
-            ])
-            ->add('show_condition', SwitchType::class, [
-                'required' => false,
-                'label' => $this->trans('Display condition on product page', 'Admin.Catalog.Feature'),
             ])
             ->add('customizations', CustomizationsType::class)
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsType.php
@@ -28,13 +28,36 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Specification;
 
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Sell\Product\Options\ProductAttachmentsType;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class SpecificationsType extends TranslatorAwareType
 {
+    /**
+     * @var FormChoiceProviderInterface
+     */
+    private $productConditionChoiceProvider;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param FormChoiceProviderInterface $productConditionChoiceProvider
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        FormChoiceProviderInterface $productConditionChoiceProvider
+    ) {
+        parent::__construct($translator, $locales);
+        $this->productConditionChoiceProvider = $productConditionChoiceProvider;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -44,6 +67,22 @@ class SpecificationsType extends TranslatorAwareType
             ->add('references', ReferencesType::class)
             ->add('features', FeaturesType::class)
             ->add('attachments', ProductAttachmentsType::class)
+            ->add('condition', ChoiceType::class, [
+                'choices' => $this->productConditionChoiceProvider->getChoices(),
+                'attr' => [
+                    'class' => 'custom-select',
+                ],
+                'required' => false,
+                // placeholder false is important to avoid empty option in select input despite required being false
+                'placeholder' => false,
+                'label' => $this->trans('Condition', 'Admin.Catalog.Feature'),
+                'label_tag_name' => 'h2',
+                'label_help_box' => $this->trans('Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces.', 'Admin.Catalog.Help'),
+            ])
+            ->add('show_condition', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans('Display condition on product page', 'Admin.Catalog.Feature'),
+            ])
             ->add('customizations', CustomizationsType::class)
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsType.php
@@ -83,7 +83,6 @@ class SpecificationsType extends TranslatorAwareType
                 // placeholder false is important to avoid empty option in select input despite required being false
                 'placeholder' => false,
                 'label' => false,
-                'label_help_box' => $this->trans('Not all shops sell new products. This option enables you to indicate the condition of the product. It can be required on some marketplaces.', 'Admin.Catalog.Help'),
             ])
             ->add('customizations', CustomizationsType::class)
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -102,7 +102,7 @@ class AvailabilityType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver->setDefaults([
             'label' => $this->trans('Availability preferences', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
             'required' => false,
             'columns_number' => 3,
         ]);

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -124,7 +124,7 @@ class QuantityType extends TranslatorAwareType
         $resolver
             ->setDefaults([
                 'label' => $this->trans('Quantities', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'required' => false,
                 'product_id' => null,
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
@@ -110,7 +110,7 @@ class StockOptionsType extends TranslatorAwareType
         $resolver->setDefaults([
             'required' => false,
             'label' => $this->trans('Stock', 'Admin.Catalog.Feature'),
-            'label_tag_name' => 'h2',
+            'label_tag_name' => 'h3',
         ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -72,7 +72,7 @@ class StockType extends TranslatorAwareType
                 'choices' => $this->packStockTypeChoiceProvider->getChoices(),
                 'expanded' => true,
                 'label' => $this->trans('Pack quantities', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'required' => false,
             ])
             ->add('availability', AvailabilityType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
@@ -111,7 +111,7 @@ class VirtualProductFileType extends TranslatorAwareType implements EventSubscri
         $builder
             ->add('has_file', SwitchType::class, [
                 'label' => $this->trans('Does this product have an associated file?', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
             ])
             ->add('virtual_product_file_id', HiddenType::class)
             ->add('file', FileType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
@@ -50,6 +50,8 @@ class SwitchType extends AbstractType
                 'Yes' => true,
             ],
             'show_choices' => true,
+            // Force label and switch to be displayed on the same line (mainly useful for base ui kit)
+            'inline_switch' => false,
             'multiple' => false,
             'expanded' => false,
             'disabled' => false,
@@ -71,6 +73,17 @@ class SwitchType extends AbstractType
             $view->vars['attr']['class'] .= ' ' . $options['attr']['class'];
         }
         $view->vars['show_choices'] = $options['show_choices'];
+
+        // Add a class when inline mode is enabled
+        if ($options['inline_switch']) {
+            $rowAttributes = $options['row_attr'] ?? [];
+            if (!empty($rowAttributes['class'])) {
+                $rowAttributes['class'] .= ' inline-switch-widget';
+            } else {
+                $rowAttributes['class'] = 'inline-switch-widget';
+            }
+            $view->vars['row_attr'] = $rowAttributes;
+        }
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SwitchType.php
@@ -49,6 +49,7 @@ class SwitchType extends AbstractType
                 'No' => false,
                 'Yes' => true,
             ],
+            'show_choices' => true,
             'multiple' => false,
             'expanded' => false,
             'disabled' => false,
@@ -69,6 +70,7 @@ class SwitchType extends AbstractType
         if (isset($options['attr']['class'])) {
             $view->vars['attr']['class'] .= ' ' . $options['attr']['class'];
         }
+        $view->vars['show_choices'] = $options['show_choices'];
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1362,6 +1362,8 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\Specification\SpecificationsType'
     parent: 'form.type.translatable.aware'
     public: true
+    arguments:
+      - '@prestashop.core.form.choice_provider.product_condition_choice_provider'
     tags:
       - { name: form.type }
 
@@ -1580,8 +1582,6 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\Options\OptionsType'
     parent: 'form.type.translatable.aware'
     public: true
-    arguments:
-      - '@prestashop.core.form.choice_provider.product_condition_choice_provider'
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -576,7 +576,7 @@
             {% if disabled %}disabled=""{% endif %}
             type="radio"
           >
-          <label for="{{inputId}}">{{ choice.label|trans({}, choice_translation_domain) }}</label>
+          {% if show_choices %}<label for="{{inputId}}">{{ choice.label|trans({}, choice_translation_domain) }}</label>{% endif %}
         {% endfor %}
         <span class="slide-button"></span>
     </span>

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductOptionsCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductOptionsCommandsBuilderTest.php
@@ -89,7 +89,7 @@ class ProductOptionsCommandsBuilderTest extends AbstractProductCommandBuilderTes
         $command->setCondition(ProductCondition::NEW);
         yield [
             [
-                'options' => [
+                'specifications' => [
                     'condition' => 'new',
                 ],
             ],
@@ -97,12 +97,12 @@ class ProductOptionsCommandsBuilderTest extends AbstractProductCommandBuilderTes
         ];
 
         $command = new UpdateProductOptionsCommand($this->getProductId()->getValue());
-        $command->setShowCondition(false);
+        $command->setShowCondition(true);
         yield [
             [
-                'options' => [
+                'specifications' => [
                     'not_handled' => 0,
-                    'show_condition' => 0,
+                    'show_condition' => 1,
                 ],
             ],
             [$command],

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -115,6 +115,9 @@ class ProductFormDataProviderTest extends TestCase
                 'manufacturer' => NoManufacturerId::NO_MANUFACTURER_ID,
                 'related_products' => [],
             ],
+            'specifications' => [
+                'condition' => ProductCondition::NEW,
+            ],
             'stock' => [
                 'quantities' => [
                     'delta_quantity' => [
@@ -151,7 +154,6 @@ class ProductFormDataProviderTest extends TestCase
                 'visibility' => [
                     'visibility' => ProductVisibility::VISIBLE_EVERYWHERE,
                 ],
-                'condition' => ProductCondition::NEW,
             ],
             'footer' => [
                 'active' => false,
@@ -182,6 +184,9 @@ class ProductFormDataProviderTest extends TestCase
                 'manufacturer' => NoManufacturerId::NO_MANUFACTURER_ID,
                 'related_products' => [],
             ],
+            'specifications' => [
+                'condition' => ProductCondition::NEW,
+            ],
             'stock' => [
                 'quantities' => [
                     'delta_quantity' => [
@@ -218,7 +223,6 @@ class ProductFormDataProviderTest extends TestCase
                 'visibility' => [
                     'visibility' => ProductVisibility::VISIBLE_EVERYWHERE,
                 ],
-                'condition' => ProductCondition::NEW,
             ],
             'footer' => [
                 'active' => true,
@@ -755,14 +759,15 @@ class ProductFormDataProviderTest extends TestCase
         $expectedOutputData['options']['visibility']['available_for_order'] = false;
         $expectedOutputData['options']['visibility']['online_only'] = true;
         $expectedOutputData['options']['visibility']['show_price'] = false;
-        $expectedOutputData['options']['condition'] = ProductCondition::USED;
-        $expectedOutputData['options']['show_condition'] = true;
 
         $expectedOutputData['specifications']['references']['isbn'] = 'isbn_2';
         $expectedOutputData['specifications']['references']['upc'] = 'upc_2';
         $expectedOutputData['specifications']['references']['ean_13'] = 'ean13_2';
         $expectedOutputData['specifications']['references']['mpn'] = 'mpn_2';
         $expectedOutputData['specifications']['references']['reference'] = 'reference_2';
+
+        $expectedOutputData['specifications']['condition'] = ProductCondition::USED;
+        $expectedOutputData['specifications']['show_condition'] = true;
 
         $expectedOutputData['specifications']['attachments']['attached_files'] = [
             [
@@ -1454,6 +1459,8 @@ class ProductFormDataProviderTest extends TestCase
                 ],
                 'features' => [],
                 'attachments' => [],
+                'show_condition' => false,
+                'condition' => ProductCondition::NEW,
                 'customizations' => [],
             ],
             'stock' => [
@@ -1528,8 +1535,6 @@ class ProductFormDataProviderTest extends TestCase
                     'show_price' => true,
                     'online_only' => false,
                 ],
-                'show_condition' => false,
-                'condition' => ProductCondition::NEW,
                 'suppliers' => [],
             ],
             'footer' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Move condition field from options to specifications tab And add new options to `SwitchType` to customize its display which can now match the mockups (Also turn every h2 header into h3 in the product form)
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | Change the condition in the specifications tab It should work
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27275)
<!-- Reviewable:end -->

### Breaking Changes

`OptionsType` and `SpecificationType` constructor parameters have changed, but they are injected via the definition of service so it shouldn't have much impact