### PR TITLE
Remove useless legacyContextLoader

### DIFF
--- a/src/PrestaShopBundle/Command/ConfigCommand.php
+++ b/src/PrestaShopBundle/Command/ConfigCommand.php
@@ -30,7 +30,6 @@ namespace PrestaShopBundle\Command;
 
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider;
-use PrestaShop\PrestaShop\Adapter\LegacyContextLoader;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Symfony\Component\Console\Command\Command;
@@ -96,12 +95,10 @@ class ConfigCommand extends Command
     private $idLang;
 
     public function __construct(
-        LegacyContextLoader $legacyContextLoader,
         ShopConfigurationInterface $configuration,
         LanguageDataProvider $languageDataProvider
     ) {
         parent::__construct();
-        $legacyContextLoader->loadGenericContext();
         $this->configuration = $configuration;
         $this->languageDataProvider = $languageDataProvider;
     }

--- a/src/PrestaShopBundle/Command/DebugCommand.php
+++ b/src/PrestaShopBundle/Command/DebugCommand.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Command;
 
 use PrestaShop\PrestaShop\Adapter\Debug\DebugMode;
-use PrestaShop\PrestaShop\Adapter\LegacyContextLoader;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\Command\SwitchDebugModeCommand;
 use Symfony\Component\Console\Command\Command;
@@ -61,12 +60,11 @@ class DebugCommand extends Command
      */
     private $debugConfiguration;
 
-    public function __construct(CommandBusInterface $commandBus, DebugMode $debugConfiguration, LegacyContextLoader $legacyContextLoader)
+    public function __construct(CommandBusInterface $commandBus, DebugMode $debugConfiguration)
     {
         parent::__construct();
         $this->commandBus = $commandBus;
         $this->debugConfiguration = $debugConfiguration;
-        $legacyContextLoader->loadGenericContext();
     }
 
     protected function configure()

--- a/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/command.yml
@@ -50,13 +50,11 @@ services:
     arguments:
       - '@prestashop.core.command_bus'
       - '@prestashop.adapter.debug_mode'
-      - '@prestashop.adapter.legacy_context_loader'
     tags:
       - 'console.command'
 
   PrestaShopBundle\Command\ConfigCommand:
     arguments:
-      - '@prestashop.adapter.legacy_context_loader'
       - '@prestashop.adapter.legacy.configuration'
       - '@prestashop.adapter.data_provider.language'
     tags:

--- a/tests/Unit/PrestaShopBundle/Command/ConfigCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/Command/ConfigCommandTest.php
@@ -31,7 +31,6 @@ namespace Tests\Unit\PrestaShopBundle\Command;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider;
-use PrestaShop\PrestaShop\Adapter\LegacyContextLoader;
 use PrestaShopBundle\Command\ConfigCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -128,21 +127,11 @@ class ConfigCommandTest extends TestCase
     protected function getCommandTester(): CommandTester
     {
         $command = new ConfigCommand(
-            $this->mockLegacyContextLoader(),
             $this->mockConfiguration(),
             $this->mockLanguageDataProvider()
         );
 
         return new CommandTester($command);
-    }
-
-    protected function mockLegacyContextLoader(): LegacyContextLoader
-    {
-        $legacyContextLoaderMock = $this->getMockBuilder(LegacyContextLoader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        return $legacyContextLoaderMock;
     }
 
     protected function mockConfiguration(): Configuration

--- a/tests/Unit/PrestaShopBundle/Command/DebugCommandTest.php
+++ b/tests/Unit/PrestaShopBundle/Command/DebugCommandTest.php
@@ -30,7 +30,6 @@ namespace Tests\Unit\PrestaShopBundle\Command;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Debug\DebugMode;
-use PrestaShop\PrestaShop\Adapter\LegacyContextLoader;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShopBundle\Command\DebugCommand;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -41,8 +40,7 @@ class DebugCommandTest extends TestCase
     {
         $command = new DebugCommand(
             $this->mockCommandBus(),
-            $this->mockDebugMode(),
-            $this->mockLegacyContextLoader()
+            $this->mockDebugMode()
         );
         $commandTester = new CommandTester($command);
 
@@ -55,15 +53,6 @@ class DebugCommandTest extends TestCase
 
         $this->assertEquals(DebugCommand::STATUS_ERROR, $commandTester->execute(['value' => 'asdf']));
         $this->assertStringContainsString('Input cannot be determined', $commandTester->getDisplay());
-    }
-
-    protected function mockLegacyContextLoader(): LegacyContextLoader
-    {
-        $legacyContextLoaderMock = $this->getMockBuilder(LegacyContextLoader::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        return $legacyContextLoaderMock;
     }
 
     protected function mockDebugMode(): DebugMode


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | During the upgrade using the autoupgrade module, the database is upgraded with a Symfony command. To be able to execute this command, all commands (services tagged with `console.command`) are added to the Symfony container. As `LegacyContextLoader::LoadGenericContext();` is called in the command's constructor, it resets the context employee even if we don't use the command. The problem is that we need to have a valid employee with enough rights to enable the theme during the upgrade process, just after the db upgrade. This PR Solve the issue by simply removing the `LegacyContextLoader` as it doesn't seem useful.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes partially #26503
| How to test?      | CI Should be green
| Possible impacts? | Can impact command `prestashop:config` & `prestashop:debug` even though I didn't encounter any issue on my side

### BC Break
The first argument of `PrestaShopBundle\Command\ConfigCommand` has been removed (`LegacyContextLoader `)
The last argument of has `PrestaShopBundle\Command\DebugCommand` has been removed (`LegacyContextLoader `)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27276)
<!-- Reviewable:end -->
