### PR TITLE
Fixed Product description block width.

### DIFF
--- a/themes/classic/templates/catalog/product.tpl
+++ b/themes/classic/templates/catalog/product.tpl
@@ -47,7 +47,6 @@
 {/block}
 
 {block name='content'}
-
   <section id="main">
     <meta content="{$product.url}">
 
@@ -69,8 +68,8 @@
             {/block}
           </section>
         {/block}
-        </div>
-        <div class="col-md-6">
+      </div>
+      <div class="col-md-6">
           {block name='page_header_container'}
             {block name='page_header'}
               <h1 class="h1">{block name='page_title'}{$product.name}{/block}</h1>
@@ -137,8 +136,12 @@
             {block name='hook_display_reassurance'}
               {hook h='displayReassurance'}
             {/block}
-
-            {block name='product_tabs'}
+          </div>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+          {block name='product_tabs'}
               <div class="tabs">
                 <ul class="nav nav-tabs" role="tablist">
                   {if $product.description}
@@ -184,42 +187,42 @@
                 </ul>
 
                 <div class="tab-content" id="tab-content">
-                 <div class="tab-pane fade in{if $product.description} active js-product-tab-active{/if}" id="description" role="tabpanel">
-                   {block name='product_description'}
-                     <div class="product-description">{$product.description nofilter}</div>
-                   {/block}
-                 </div>
+                  <div class="tab-pane fade in{if $product.description} active js-product-tab-active{/if}" id="description" role="tabpanel">
+                    {block name='product_description'}
+                      <div class="product-description">{$product.description nofilter}</div>
+                    {/block}
+                  </div>
 
-                 {block name='product_details'}
-                   {include file='catalog/_partials/product-details.tpl'}
-                 {/block}
+                  {block name='product_details'}
+                    {include file='catalog/_partials/product-details.tpl'}
+                  {/block}
 
-                 {block name='product_attachments'}
-                   {if $product.attachments}
-                    <div class="tab-pane fade in" id="attachments" role="tabpanel">
-                       <section class="product-attachments">
-                         <p class="h5 text-uppercase">{l s='Download' d='Shop.Theme.Actions'}</p>
-                         {foreach from=$product.attachments item=attachment}
-                           <div class="attachment">
-                             <h4><a href="{url entity='attachment' params=['id_attachment' => $attachment.id_attachment]}">{$attachment.name}</a></h4>
-                             <p>{$attachment.description}</p>
-                             <a href="{url entity='attachment' params=['id_attachment' => $attachment.id_attachment]}">
-                               {l s='Download' d='Shop.Theme.Actions'} ({$attachment.file_size_formatted})
-                             </a>
-                           </div>
-                         {/foreach}
-                       </section>
-                     </div>
-                   {/if}
-                 {/block}
+                  {block name='product_attachments'}
+                    {if $product.attachments}
+                      <div class="tab-pane fade in" id="attachments" role="tabpanel">
+                        <section class="product-attachments">
+                          <p class="h5 text-uppercase">{l s='Download' d='Shop.Theme.Actions'}</p>
+                          {foreach from=$product.attachments item=attachment}
+                            <div class="attachment">
+                              <h4><a href="{url entity='attachment' params=['id_attachment' => $attachment.id_attachment]}">{$attachment.name}</a></h4>
+                              <p>{$attachment.description}</p>
+                              <a href="{url entity='attachment' params=['id_attachment' => $attachment.id_attachment]}">
+                                {l s='Download' d='Shop.Theme.Actions'} ({$attachment.file_size_formatted})
+                              </a>
+                            </div>
+                          {/foreach}
+                        </section>
+                      </div>
+                    {/if}
+                  {/block}
 
-                 {foreach from=$product.extraContent item=extra key=extraKey}
-                 <div class="tab-pane fade in {$extra.attr.class}" id="extra-{$extraKey}" role="tabpanel" {foreach $extra.attr as $key => $val} {$key}="{$val}"{/foreach}>
-                   {$extra.content nofilter}
-                 </div>
-                 {/foreach}
+                  {foreach from=$product.extraContent item=extra key=extraKey}
+                  <div class="tab-pane fade in {$extra.attr.class}" id="extra-{$extraKey}" role="tabpanel" {foreach $extra.attr as $key => $val} {$key}="{$val}"{/foreach}>
+                    {$extra.content nofilter}
+                  </div>
+                  {/foreach}
+                </div>
               </div>
-            </div>
           {/block}
         </div>
       </div>
@@ -256,5 +259,4 @@
       </footer>
     {/block}
   </section>
-
 {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      | Fixes ticket, adding a new row for Product Description with one full size column.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27278
| How to test?      | 1. Go to the FO.<br>2. Select any given product.<br>3. Watch for product description block. It should be full with for any width size (including greater than 767px)
| Possible impacts? | None.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27279)
<!-- Reviewable:end -->
