### PR TITLE
Fix bad display of the notifications dropdown in medium screen

### DIFF
--- a/admin-dev/themes/new-theme/js/nav_bar.ts
+++ b/admin-dev/themes/new-theme/js/nav_bar.ts
@@ -245,9 +245,6 @@ export default class NavBar {
       .find('.employee_avatar .material-icons, .employee_avatar span')
       .wrap(`<a href='${profileLink}'></a>`);
     $('.js-mobile-menu').on('click', expand);
-    $('.js-notifs_dropdown').css({
-      height: window.innerHeight,
-    });
 
     function expand() {
       if ($('div.notification-center.dropdown').hasClass('open')) {

--- a/admin-dev/themes/new-theme/scss/components/_notifications.scss
+++ b/admin-dev/themes/new-theme/scss/components/_notifications.scss
@@ -31,8 +31,6 @@
 
   .dropdown-menu {
     min-width: 25rem;
-    // stylelint-disable-next-line
-    height: auto !important;
     padding: 0;
     margin: 0;
     @include border-radius(0);
@@ -138,6 +136,10 @@
             bottom: 0;
             display: block;
             width: 100%;
+
+            @include media-breakpoint-down("sm") {
+              top: 7.75rem;
+            }
           }
 
           @include media-breakpoint-down("sm") {
@@ -206,12 +208,6 @@
 
     #messages-tab::before {
       content: "\E0BE";
-    }
-
-    .no-notification {
-      @include media-breakpoint-down("sm") {
-        top: 7.75rem;
-      }
     }
 
     &.show {

--- a/admin-dev/themes/new-theme/scss/components/_notifications.scss
+++ b/admin-dev/themes/new-theme/scss/components/_notifications.scss
@@ -31,6 +31,8 @@
 
   .dropdown-menu {
     min-width: 25rem;
+    // stylelint-disable-next-line
+    height: auto !important;
     padding: 0;
     margin: 0;
     @include border-radius(0);
@@ -136,10 +138,6 @@
             bottom: 0;
             display: block;
             width: 100%;
-
-            .mobile & {
-              bottom: 3.125rem;
-            }
           }
 
           @include media-breakpoint-down("sm") {
@@ -211,7 +209,9 @@
     }
 
     .no-notification {
-      top: 7.75rem;
+      @include media-breakpoint-down("sm") {
+        top: 7.75rem;
+      }
     }
 
     &.show {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix oversized height of notifications dropdown in medium screen.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26792
| How to test?      | Go to BO > Orders. Open notifications dropdown and try to change the screen width.
| Possible impacts? | The notifications dropdown UI in new theme pages.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27285)
<!-- Reviewable:end -->
