### PR TITLE
Add packed product type

### DIFF
--- a/admin-dev/themes/new-theme/js/components/entity-search-input.ts
+++ b/admin-dev/themes/new-theme/js/components/entity-search-input.ts
@@ -28,11 +28,13 @@ import ComponentsMap from '@components/components-map';
 import ConfirmModal from '@components/modal';
 // @ts-ignore-next-line
 import Bloodhound from 'typeahead.js';
+import {isUndefined} from '@PSTypes/typeguard';
 
 const EntitySearchInputMap = ComponentsMap.entitySearchInput;
 
 type RemoveFunction = (item: any) => void;
 type SelectFunction = ($node: JQuery, item: any) => void;
+type SuggestionFunction = (entity: any) => string;
 export interface EntitySearchInputOptions extends OptionsObject {
   prototypeTemplate: string,
   prototypeIndex: string,
@@ -58,6 +60,8 @@ export interface EntitySearchInputOptions extends OptionsObject {
 
   onRemovedContent: RemoveFunction | undefined,
   onSelectedContent: SelectFunction | undefined,
+
+  suggestionTemplate: SuggestionFunction | undefined,
 }
 export interface ModalOptions extends OptionsObject {
   id: string;
@@ -206,6 +210,9 @@ export default class EntitySearchInput {
       onRemovedContent: undefined,
       onSelectedContent: undefined,
       responseTransformer: (response: any) => response || [],
+
+      // Template function
+      suggestionTemplate: undefined,
     };
 
     Object.keys(defaultOptions).forEach((optionName) => {
@@ -281,15 +288,7 @@ export default class EntitySearchInput {
       value: this.options.identifierField,
       minLength: this.options.minLength,
       templates: {
-        suggestion: (entity: any) => {
-          let entityImage = '';
-
-          if (Object.prototype.hasOwnProperty.call(entity, 'image')) {
-            entityImage = `<img src="${entity.image}" /> `;
-          }
-
-          return `<div class="search-suggestion">${entityImage}${entity[this.options.suggestionField]}</div>`;
-        },
+        suggestion: (entity: any) => this.showSuggestion(entity),
       },
       onSelect: (selectedItem: any) => {
         // When limit is one we cannot select additional elements so we replace them instead
@@ -307,6 +306,20 @@ export default class EntitySearchInput {
         autoSearchConfig,
       );
     }
+  }
+
+  private showSuggestion(entity: any): string {
+    if (!isUndefined(this.options.suggestionTemplate)) {
+      return this.options.suggestionTemplate(entity);
+    }
+
+    let entityImage = '';
+
+    if (Object.prototype.hasOwnProperty.call(entity, 'image')) {
+      entityImage = `<img src="${entity.image}" /> `;
+    }
+
+    return `<div class="search-suggestion">${entityImage}${entity[this.options.suggestionField]}</div>`;
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
@@ -40,6 +40,7 @@ import ProductSEOManager from '@pages/product/edit/product-seo-manager';
 import ProductTypeSwitcher from '@pages/product/edit/product-type-switcher';
 import VirtualProductManager from '@pages/product/edit/virtual-product-manager';
 import RelatedProductsManager from '@pages/product/edit/related-products-manager';
+import PackedProductsManager from '@pages/product/edit/packed-products-manager';
 import CreateProductModal from '@pages/product/components/create-product-modal';
 import SpecificPricesManager from '@pages/product/edit/specific-prices-manager';
 import initDropzone from '@pages/product/components/dropzone';
@@ -91,6 +92,9 @@ $(() => {
   new ProductFooterManager();
   new ProductModulesManager();
   new RelatedProductsManager(eventEmitter);
+  if (productType === ProductConst.PRODUCT_TYPE.PACK) {
+    new PackedProductsManager(eventEmitter);
+  }
   new CreateProductModal();
   new PriceSummary(productFormModel);
 

--- a/admin-dev/themes/new-theme/js/pages/product/edit/packed-products-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/packed-products-manager.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+import EntitySearchInput from '@components/entity-search-input';
+import ProductMap from '@pages/product/product-map';
+import ProductEventMap from '@pages/product/product-event-map';
+import {EventEmitter} from 'events';
+
+export default class PackedProductsManager {
+  private eventEmitter: EventEmitter;
+
+  private entitySearchInput: EntitySearchInput;
+
+  constructor(eventEmitter: EventEmitter) {
+    this.eventEmitter = eventEmitter;
+    this.entitySearchInput = new EntitySearchInput($(ProductMap.packedProducts.searchInput), {
+      onRemovedContent: () => this.eventEmitter.emit(ProductEventMap.updateSubmitButtonState),
+      onSelectedContent: () => this.eventEmitter.emit(ProductEventMap.updateSubmitButtonState),
+    });
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/product/edit/packed-products-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/packed-products-manager.ts
@@ -35,9 +35,34 @@ export default class PackedProductsManager {
 
   constructor(eventEmitter: EventEmitter) {
     this.eventEmitter = eventEmitter;
-    this.entitySearchInput = new EntitySearchInput($(ProductMap.packedProducts.searchInput), {
+    const $searchInput = $(ProductMap.packedProducts.searchInput);
+    const referenceLabel = $searchInput.data('referenceLabel') ?? '(Ref: %s)';
+    this.entitySearchInput = new EntitySearchInput($searchInput, {
       onRemovedContent: () => this.eventEmitter.emit(ProductEventMap.updateSubmitButtonState),
       onSelectedContent: () => this.eventEmitter.emit(ProductEventMap.updateSubmitButtonState),
+      suggestionTemplate: (combination: any) => {
+        let reference = '';
+
+        if (combination.reference) {
+          reference = `<span class="combination-reference">(${combination.reference})</span>`;
+        }
+
+        return `<div class="search-suggestion"><img src="${combination.image}" /> ${combination.name}${reference}</div>`;
+      },
+      responseTransformer: (response: any) => {
+        Object.keys(response).forEach((key) => {
+          if (Object.prototype.hasOwnProperty.call(response, key)) {
+            const combination = response[key];
+
+            if (combination.reference) {
+              // eslint-disable-next-line no-param-reassign
+              response[key].reference = referenceLabel.replace('%s', combination.reference);
+            }
+          }
+        });
+
+        return response;
+      },
     });
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -355,4 +355,7 @@ export default {
       priorityTypeCheckboxesSelector: 'input[name="product[pricing][priority_management][use_custom_priority]"]',
     },
   },
+  packedProducts: {
+    searchInput: '#product_stock_packed_products',
+  },
 };

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1465,6 +1465,44 @@ $product-page-padding-bottom: 80px !default;
   }
 }
 
+.product_packed_products {
+  .search-with-icon {
+    max-width: 377px;
+  }
+
+  .entities-list-container {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-right: -0.5em;
+    margin-left: -0.5em;
+  }
+
+  .packed-product {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    max-width: 180px;
+    margin: 0.5rem;
+
+    &-image {
+      margin-bottom: 0.5rem;
+    }
+
+    &-legend,
+    &-quantity {
+      max-width: 100%;
+
+      .text-preview {
+        display: inline-block;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+    }
+  }
+}
+
 // Some of the following styles target product page v2 components, but since the are new and only used in the new
 // page there is no need to scope them inside the product-page-v2 class
 .create-product-form {

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1495,9 +1495,11 @@ $product-page-padding-bottom: 80px !default;
     }
 
     .packed-product-legend,
+    .packed-product-reference,
     .packed-product-quantity {
       max-width: 100%;
 
+      .reference-preview,
       .text-preview {
         display: inline-block;
         max-width: 100%;

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1470,35 +1470,53 @@ $product-page-padding-bottom: 80px !default;
     max-width: 377px;
   }
 
+  .combination-reference {
+    margin-left: 0.5rem;
+  }
+
   .entities-list-container {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    margin-right: -0.5em;
-    margin-left: -0.5em;
+    gap: 1rem;
   }
 
-  .packed-product {
+  li.packed-product {
     display: flex;
     flex-direction: column;
     width: 100%;
     max-width: 180px;
-    margin: 0.5rem;
+    // stylelint-disable-next-line
+    padding: 0 !important;
+    border: none;
 
-    &-image {
+    .packed-product-image {
       margin-bottom: 0.5rem;
     }
 
-    &-legend,
-    &-quantity {
+    .packed-product-legend,
+    .packed-product-quantity {
       max-width: 100%;
 
       .text-preview {
         display: inline-block;
         max-width: 100%;
         overflow: hidden;
+        font-weight: 600;
         text-overflow: ellipsis;
       }
+
+      .reference-preview {
+        font-weight: 500;
+      }
+    }
+
+    .packed-product-quantity {
+      margin-top: 0.5rem;
+    }
+
+    .form-group {
+      margin-bottom: 0;
     }
   }
 }

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -141,6 +141,7 @@ class CombinationCore extends ObjectModel
         }
 
         $this->deleteFromSupplier($this->id_product);
+        $this->deleteFromPack();
         Product::updateDefaultAttribute($this->id_product);
         Tools::clearColorListCache((int) $this->id_product);
 
@@ -158,6 +159,17 @@ class CombinationCore extends ObjectModel
     {
         return Db::getInstance()->delete('product_supplier', 'id_product = ' . (int) $idProduct
             . ' AND id_product_attribute = ' . (int) $this->id);
+    }
+
+    /**
+     * Delete association with Pack.
+     *
+     * @return bool
+     */
+    protected function deleteFromPack(): bool
+    {
+        return Db::getInstance()->delete('pack', 'id_product_item = ' . (int) $this->id_product
+            . ' AND id_product_attribute_item = ' . (int) $this->id);
     }
 
     /**

--- a/src/Adapter/Attribute/Repository/AttributeRepository.php
+++ b/src/Adapter/Attribute/Repository/AttributeRepository.php
@@ -117,26 +117,16 @@ class AttributeRepository extends AbstractObjectModelRepository
     public function getAttributesInfoByCombinationIds(array $combinationIds, LanguageId $langId): array
     {
         $attributeCombinationAssociations = $this->getAttributeCombinationAssociations($combinationIds);
-
-        $attributeIds = array_unique(array_map(function (array $attributeByCombination): int {
+        $attributeIds = array_unique(array_map(static function (array $attributeByCombination): int {
             return (int) $attributeByCombination['id_attribute'];
         }, $attributeCombinationAssociations));
 
         $attributesInfoByAttributeId = $this->getAttributesInformation($attributeIds, $langId->getValue());
 
-        $attributesInfoByCombinationId = [];
-        foreach ($attributeCombinationAssociations as $attributeCombinationAssociation) {
-            $combinationId = (int) $attributeCombinationAssociation['id_product_attribute'];
-            $attributeId = (int) $attributeCombinationAssociation['id_attribute'];
-            $attributesInfoByCombinationId[$combinationId][] = new CombinationAttributeInformation(
-                (int) $attributesInfoByAttributeId[$attributeId]['id_attribute_group'],
-                $attributesInfoByAttributeId[$attributeId]['attribute_group_name'],
-                (int) $attributesInfoByAttributeId[$attributeId]['id_attribute'],
-                $attributesInfoByAttributeId[$attributeId]['attribute_name']
-            );
-        }
-
-        return $attributesInfoByCombinationId;
+        return $this->buildCombinationAttributeInformationList(
+            $attributeCombinationAssociations,
+            $attributesInfoByAttributeId
+        );
     }
 
     /**
@@ -210,5 +200,30 @@ class AttributeRepository extends AbstractObjectModelRepository
         }
 
         return $attributesInfoByAttributeId;
+    }
+
+    /**
+     * @param array<int, array<string, int>> $attributeCombinationAssociations
+     * @param array<int, array<string, mixed>> $attributesInfoByAttributeId
+     *
+     * @return array<int, CombinationAttributeInformation[]>
+     */
+    private function buildCombinationAttributeInformationList(
+        array $attributeCombinationAssociations,
+        array $attributesInfoByAttributeId
+    ): array {
+        $attributesInfoByCombinationId = [];
+        foreach ($attributeCombinationAssociations as $attributeCombinationAssociation) {
+            $combinationId = (int) $attributeCombinationAssociation['id_product_attribute'];
+            $attributeId = (int) $attributeCombinationAssociation['id_attribute'];
+            $attributesInfoByCombinationId[$combinationId][] = new CombinationAttributeInformation(
+                (int) $attributesInfoByAttributeId[$attributeId]['id_attribute_group'],
+                $attributesInfoByAttributeId[$attributeId]['attribute_group_name'],
+                (int) $attributesInfoByAttributeId[$attributeId]['id_attribute'],
+                $attributesInfoByAttributeId[$attributeId]['attribute_name']
+            );
+        }
+
+        return $attributesInfoByCombinationId;
     }
 }

--- a/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
@@ -28,13 +28,17 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler;
 
+use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\SearchCombinationsForAssociation;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryHandler\SearchCombinationsForAssociationHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForAssociation;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\NoCombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
+use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilderInterface;
 
 class SearchCombinationsForAssociationHandler implements SearchCombinationsForAssociationHandlerInterface
 {
@@ -49,15 +53,31 @@ class SearchCombinationsForAssociationHandler implements SearchCombinationsForAs
     private $productImagePathFactory;
 
     /**
+     * @var AttributeRepository
+     */
+    protected $attributeRepository;
+
+    /**
+     * @var CombinationNameBuilderInterface
+     */
+    protected $combinationNameBuilder;
+
+    /**
      * @param ProductRepository $productRepository
+     * @param AttributeRepository $attributeRepository
      * @param ProductImagePathFactory $productImagePathFactory
+     * @param CombinationNameBuilderInterface $combinationNameBuilder
      */
     public function __construct(
         ProductRepository $productRepository,
-        ProductImagePathFactory $productImagePathFactory
+        AttributeRepository $attributeRepository,
+        ProductImagePathFactory $productImagePathFactory,
+        CombinationNameBuilderInterface $combinationNameBuilder
     ) {
         $this->productRepository = $productRepository;
         $this->productImagePathFactory = $productImagePathFactory;
+        $this->attributeRepository = $attributeRepository;
+        $this->combinationNameBuilder = $combinationNameBuilder;
     }
 
     /**
@@ -74,7 +94,7 @@ class SearchCombinationsForAssociationHandler implements SearchCombinationsForAs
 
         $productsForAssociation = [];
         foreach ($foundCombinations as $foundProduct) {
-            $productsForAssociation[] = $this->createResult($foundProduct);
+            $productsForAssociation[] = $this->createResult($foundProduct, $query->getLanguageId());
         }
 
         return $productsForAssociation;
@@ -85,7 +105,7 @@ class SearchCombinationsForAssociationHandler implements SearchCombinationsForAs
      *
      * @return CombinationForAssociation
      */
-    private function createResult(array $foundCombination): CombinationForAssociation
+    protected function createResult(array $foundCombination, LanguageId $languageId): CombinationForAssociation
     {
         if (!empty($foundCombination['combination_image_id'])) {
             $imagePath = $this->productImagePathFactory->getPathByType(
@@ -101,12 +121,27 @@ class SearchCombinationsForAssociationHandler implements SearchCombinationsForAs
             $imagePath = $this->productImagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_HOME_DEFAULT);
         }
 
+        $combinationId = (int) ($foundCombination['id_product_attribute'] ?? NoCombinationId::NO_COMBINATION_ID);
+
         return new CombinationForAssociation(
             (int) $foundCombination['id_product'],
-            (int) ($foundCombination['id_product_attribute'] ?? NoCombinationId::NO_COMBINATION_ID),
-            $foundCombination['name'],
+            $combinationId,
+            $this->buildName($foundCombination['name'], $combinationId, $languageId),
             $foundCombination['combination_reference'] ?? ($foundCombination['product_reference'] ?? ''),
             $imagePath
         );
+    }
+
+    protected function buildName(string $productName, int $combinationId, LanguageId $languageId): string
+    {
+        if ($combinationId === NoCombinationId::NO_COMBINATION_ID) {
+            return $productName;
+        }
+        $attributesInformation = $this->attributeRepository->getAttributesInfoByCombinationIds(
+            [new CombinationId($combinationId)],
+            $languageId
+        );
+
+        return $this->combinationNameBuilder->buildFullName($productName, $attributesInformation[$combinationId]);
     }
 }

--- a/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
@@ -89,6 +89,7 @@ class SearchCombinationsForAssociationHandler implements SearchCombinationsForAs
             $query->getPhrase(),
             $query->getLanguageId(),
             $query->getShopId(),
+            $query->getFilters(),
             $query->getLimit()
         );
 

--- a/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/SearchCombinationsForAssociationHandler.php
@@ -128,7 +128,7 @@ class SearchCombinationsForAssociationHandler implements SearchCombinationsForAs
             (int) $foundCombination['id_product'],
             $combinationId,
             $this->buildName($foundCombination['name'], $combinationId, $languageId),
-            $foundCombination['combination_reference'] ?? ($foundCombination['product_reference'] ?? ''),
+            $foundCombination['combination_reference'] ?: ($foundCombination['product_reference'] ?: ''),
             $imagePath
         );
     }

--- a/src/Adapter/Product/Options/RedirectTargetProvider.php
+++ b/src/Adapter/Product/Options/RedirectTargetProvider.php
@@ -112,8 +112,8 @@ class RedirectTargetProvider
      */
     private function getProductTarget(int $redirectTargetId): ProductRedirectTarget
     {
-        $languageId = (int) $this->legacyContext->getLanguage()->id;
-        $product = $this->productPreviewRepository->getPreview(
+        $languageId = $this->legacyContext->getLanguage()->id;
+        $productPreview = $this->productPreviewRepository->getPreview(
             new ProductId($redirectTargetId),
             new LanguageId($languageId)
         );
@@ -121,8 +121,8 @@ class RedirectTargetProvider
         return new ProductRedirectTarget(
             $redirectTargetId,
             ProductRedirectTarget::PRODUCT_TYPE,
-            $product->getName(),
-            $product->getImage()
+            $productPreview->getName(),
+            $productPreview->getImage()
         );
     }
 

--- a/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
+++ b/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
@@ -138,11 +138,9 @@ class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
                 $name = $this->combinationNameBuilder->buildFullName($name, $attributesInformations[$combinationId]);
             }
             $reference = '';
-            if (!empty($packedItem['reference']) or !empty($packedItem['packed_reference'])) {
-                if (empty($packedItem['reference'])) {
-                    $packedItem['reference'] = $packedItem['packed_reference'];
-                }
-                $reference = $this->translator->trans('Ref: %s', ['%s' => $packedItem['reference']], 'Admin.Catalog.Feature');
+            if (!empty($packedItem['combination_reference']) || !empty($packedItem['product_reference'])) {
+                $reference = empty($packedItem['combination_reference']) ? $packedItem['product_reference'] : $packedItem['combination_reference'];
+                $reference = $this->translator->trans('Ref: %s', ['%s' => $reference], 'Admin.Catalog.Feature');
             }
 
             $packedProducts[] = new PackedProductDetails(

--- a/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
+++ b/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryHandler\GetPackedProduct
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryResult\PackedProductDetails;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Handles GetPackedProducts query using legacy object model
@@ -71,6 +72,11 @@ class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
     protected $productImageRepository;
 
     /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
      * @param int $defaultLangId
      * @param ProductPackRepository $productPackRepository
      * @param AttributeRepository $attributeRepository
@@ -82,13 +88,15 @@ class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
         ProductPackRepository $productPackRepository,
         AttributeRepository $attributeRepository,
         CombinationNameBuilder $combinationNameBuilder,
-        ProductImageRepository $productImageRepository
+        ProductImageRepository $productImageRepository,
+        TranslatorInterface $translator
     ) {
         $this->productRepository = $productPackRepository;
         $this->combinationNameBuilder = $combinationNameBuilder;
         $this->attributeRepository = $attributeRepository;
         $this->languageId = $defaultLangId;
         $this->productImageRepository = $productImageRepository;
+        $this->translator = $translator;
     }
 
     /**
@@ -129,13 +137,17 @@ class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
             if ($combinationId > 0) {
                 $name = $this->combinationNameBuilder->buildFullName($name, $attributesInformations[$combinationId]);
             }
+            $reference = '';
+            if (!empty($packedItem['reference'])) {
+                $reference = $this->translator->trans('Ref: %s', ['%s' => $packedItem['reference']], 'Admin.Catalog.Feature');
+            }
 
             $packedProducts[] = new PackedProductDetails(
                 (int) $packedItem['id_product_item'],
                 (int) $packedItem['quantity'],
                 (int) $combinationId,
                 (string) $name,
-                (string) $packedItem['reference'],
+                (string) $reference,
                 $coverUrl
             );
         }

--- a/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
+++ b/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
@@ -138,7 +138,10 @@ class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
                 $name = $this->combinationNameBuilder->buildFullName($name, $attributesInformations[$combinationId]);
             }
             $reference = '';
-            if (!empty($packedItem['reference'])) {
+            if (!empty($packedItem['reference']) or !empty($packedItem['packed_reference'])) {
+                if (empty($packedItem['reference'])) {
+                    $packedItem['reference'] = $packedItem['packed_reference'];
+                }
                 $reference = $this->translator->trans('Ref: %s', ['%s' => $packedItem['reference']], 'Admin.Catalog.Feature');
             }
 

--- a/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
@@ -28,16 +28,84 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Pack\Repository;
 
+use Doctrine\DBAL\Connection;
 use Pack;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Exception\ProductPackException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackId;
 use PrestaShop\PrestaShop\Core\Domain\Product\QuantifiedProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
 use PrestaShopException;
+use Throwable;
 
-class ProductPackRepository
+class ProductPackRepository extends AbstractObjectModelRepository
 {
+    /**
+     * @var Connection
+     */
+    protected $connection;
+
+    /**
+     * @var string
+     */
+    protected $dbPrefix;
+
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix
+    ) {
+        $this->connection = $connection;
+        $this->dbPrefix = $dbPrefix;
+    }
+
+    /**
+     * @param ProductId $productId
+     * @param LanguageId $languageId
+     *
+     * @return array<array<string, string>>
+     *                             e.g [
+     *                             ['id_product_item' => '1', 'id_product_attribute_item' => '1', 'name' => 'Product name', 'reference' => 'demo15', 'quantity' => '1'],
+     *                             ['id_product_item' => '2', 'id_product_attribute_item' => '1', 'name' => 'Product name2', 'reference' => 'demo16', 'quantity' => '1'],
+     *                             ]
+     *
+     * @throws CoreException
+     */
+    public function getPackedProducts(ProductId $productId, LanguageId $languageId): array
+    {
+        $this->assertProductExists($productId);
+        $productIdValue = $productId->getValue();
+
+        try {
+            $qb = $this->connection->createQueryBuilder();
+            $qb->select('pack.id_product_item, pack.id_product_attribute_item, pack.quantity, packed.reference, language.name')
+                ->from($this->dbPrefix . 'pack', 'pack')
+                ->leftJoin('pack', $this->dbPrefix . 'product', 'product', 'product.id_product = pack.id_product_pack')
+                ->leftJoin('pack', $this->dbPrefix . 'product', 'packed', 'packed.id_product = pack.id_product_item')
+                ->leftJoin('pack', $this->dbPrefix . 'product_lang', 'language', 'pack.id_product_item = language.id_product')
+                ->where('pack.id_product_pack = :idProduct')
+                ->andWhere('language.id_lang = :idLanguage')
+                ->orderBy('pack.id_product_item', 'ASC')
+                ->setParameter('idProduct', $productId->getValue())
+                ->setParameter('idLanguage', $languageId->getValue());
+            $packedProducts = $qb->execute()->fetchAll();
+        } catch (Throwable $exception) {
+            throw new CoreException(
+                sprintf(
+                    'Error occurred when fetching related products for product #%d',
+                    $productIdValue
+                ),
+                $exception->getCode(),
+                $exception
+            );
+        }
+
+        return $packedProducts;
+    }
+
     /**
      * @param PackId $packId
      * @param QuantifiedProduct $productForPacking
@@ -120,5 +188,13 @@ class ProductPackRepository
             $product->getProductId()->getValue(),
             isset($combinationId) ? $combinationId : ''
         );
+    }
+
+    /**
+     * @param ProductId $productId
+     */
+    protected function assertProductExists(ProductId $productId): void
+    {
+        $this->assertObjectModelExists($productId->getValue(), 'product', ProductNotFoundException::class);
     }
 }

--- a/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
@@ -63,7 +63,7 @@ class ProductPackRepository extends AbstractObjectModelRepository
     }
 
     /**
-     * @param ProductId $productId
+     * @param PackId $productId
      * @param LanguageId $languageId
      *
      * @return array<array<string, string>>
@@ -74,7 +74,7 @@ class ProductPackRepository extends AbstractObjectModelRepository
      *
      * @throws CoreException
      */
-    public function getPackedProducts(ProductId $productId, LanguageId $languageId): array
+    public function getPackedProducts(PackId $productId, LanguageId $languageId): array
     {
         $this->assertProductExists($productId);
         $productIdValue = $productId->getValue();
@@ -165,6 +165,28 @@ class ProductPackRepository extends AbstractObjectModelRepository
                 $e
             );
         }
+    }
+
+    /**
+     * @param ProductId $productId
+     *
+     * @return array
+     */
+    public function getPacksContaining(ProductId $productId): array
+    {
+        $this->assertProductExists($productId);
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('pack.id_product_pack')
+            ->from($this->dbPrefix . 'pack', 'pack')
+            ->where('pack.id_product_item = :productId')
+            ->setParameter('productId', $productId->getValue())
+        ;
+
+        $packs = $qb->execute()->fetchAllAssociative();
+
+        return array_map(function (array $packData) {
+            return new PackId((int) $packData['id_product_pack']);
+        }, $packs);
     }
 
     /**

--- a/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
@@ -81,9 +81,10 @@ class ProductPackRepository extends AbstractObjectModelRepository
 
         try {
             $qb = $this->connection->createQueryBuilder();
-            $qb->select('pack.id_product_item, pack.id_product_attribute_item, pack.quantity, packed.reference, language.name')
+            $qb->select('pack.id_product_item, pack.id_product_attribute_item, pack.quantity, attribute.reference,  packed.reference as packed_reference, language.name')
                 ->from($this->dbPrefix . 'pack', 'pack')
                 ->leftJoin('pack', $this->dbPrefix . 'product', 'product', 'product.id_product = pack.id_product_pack')
+                ->leftJoin('pack', $this->dbPrefix . 'product_attribute', 'attribute', 'pack.id_product_attribute_item = attribute.id_product_attribute')
                 ->leftJoin('pack', $this->dbPrefix . 'product', 'packed', 'packed.id_product = pack.id_product_item')
                 ->leftJoin('pack', $this->dbPrefix . 'product_lang', 'language', 'pack.id_product_item = language.id_product')
                 ->where('pack.id_product_pack = :idProduct')

--- a/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
@@ -81,11 +81,10 @@ class ProductPackRepository extends AbstractObjectModelRepository
 
         try {
             $qb = $this->connection->createQueryBuilder();
-            $qb->select('pack.id_product_item, pack.id_product_attribute_item, pack.quantity, attribute.reference,  packed.reference as packed_reference, language.name')
+            $qb->select('pack.id_product_item, pack.id_product_attribute_item, pack.quantity, attribute.reference as combination_reference, product.reference as product_reference, language.name')
                 ->from($this->dbPrefix . 'pack', 'pack')
-                ->leftJoin('pack', $this->dbPrefix . 'product', 'product', 'product.id_product = pack.id_product_pack')
+                ->leftJoin('pack', $this->dbPrefix . 'product', 'product', 'pack.id_product_item = product.id_product')
                 ->leftJoin('pack', $this->dbPrefix . 'product_attribute', 'attribute', 'pack.id_product_attribute_item = attribute.id_product_attribute')
-                ->leftJoin('pack', $this->dbPrefix . 'product', 'packed', 'packed.id_product = pack.id_product_item')
                 ->leftJoin('pack', $this->dbPrefix . 'product_lang', 'language', 'pack.id_product_item = language.id_product')
                 ->where('pack.id_product_pack = :idProduct')
                 ->andWhere('language.id_lang = :idLanguage')

--- a/src/Adapter/Product/Pack/Update/ProductPackUpdater.php
+++ b/src/Adapter/Product/Pack/Update/ProductPackUpdater.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QuantifiedProduct;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShopException;
+use Product;
 
 /**
  * Provides methods related to Product Pack update

--- a/src/Adapter/Product/Pack/Update/ProductPackUpdater.php
+++ b/src/Adapter/Product/Pack/Update/ProductPackUpdater.php
@@ -40,7 +40,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QuantifiedProduct;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShopException;
-use Product;
 
 /**
  * Provides methods related to Product Pack update

--- a/src/Adapter/Product/Repository/ProductPreviewRepository.php
+++ b/src/Adapter/Product/Repository/ProductPreviewRepository.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Repository;
 
-use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
@@ -53,23 +52,15 @@ class ProductPreviewRepository
     private $productImageRepository;
 
     /**
-     * @var ProductImagePathFactory
-     */
-    private $productImagePathFactory;
-
-    /**
      * @param ProductRepository $productRepository
      * @param ProductImageRepository $productImageRepository
-     * @param ProductImagePathFactory $productImagePathFactory
      */
     public function __construct(
         ProductRepository $productRepository,
-        ProductImageRepository $productImageRepository,
-        ProductImagePathFactory $productImagePathFactory
+        ProductImageRepository $productImageRepository
     ) {
         $this->productRepository = $productRepository;
         $this->productImageRepository = $productImageRepository;
-        $this->productImagePathFactory = $productImagePathFactory;
     }
 
     /**
@@ -84,11 +75,7 @@ class ProductPreviewRepository
     {
         $product = $this->productRepository->get($productId);
         $name = $product->name[$languageId->getValue()] ?? reset($product->name);
-        $imageId = $this->productImageRepository->getDefaultImageId($productId);
-        $imagePath = $imageId ?
-            $this->productImagePathFactory->getPath($imageId) :
-            $this->productImagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT)
-        ;
+        $imagePath = $this->productImageRepository->getProductCoverUrl($productId);
 
         return new ProductPreview(
             $productId->getValue(),

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -455,7 +455,7 @@ class ProductRepository extends AbstractObjectModelRepository
         if (!empty($filters)) {
             foreach ($filters as $type => $filter) {
                 switch ($type) {
-                    case 'filteredType':
+                    case 'filteredTypes':
                         $qb->andWhere('p.product_type not in(:filter)')
                             ->setParameter('filter', implode(', ', $filter));
                         break;

--- a/src/Adapter/Product/Update/ProductTypeUpdater.php
+++ b/src/Adapter/Product/Update/ProductTypeUpdater.php
@@ -29,11 +29,13 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Update;
 
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationDeleter;
+use PrestaShop\PrestaShop\Adapter\Product\Pack\Repository\ProductPackRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Pack\Update\ProductPackUpdater;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Update\ProductStockUpdater;
 use PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Update\VirtualProductUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\InvalidProductTypeException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
@@ -68,6 +70,11 @@ class ProductTypeUpdater
     private $productStockUpdater;
 
     /**
+     * @var ProductPackRepository
+     */
+    private $productPackRepository;
+
+    /**
      * @param ProductRepository $productRepository
      * @param ProductPackUpdater $productPackUpdater
      * @param CombinationDeleter $combinationDeleter
@@ -79,13 +86,15 @@ class ProductTypeUpdater
         ProductPackUpdater $productPackUpdater,
         CombinationDeleter $combinationDeleter,
         VirtualProductUpdater $virtualProductUpdater,
-        ProductStockUpdater $productStockUpdater
+        ProductStockUpdater $productStockUpdater,
+        ProductPackRepository $productPackRepository
     ) {
         $this->productRepository = $productRepository;
         $this->productPackUpdater = $productPackUpdater;
         $this->combinationDeleter = $combinationDeleter;
         $this->virtualProductUpdater = $virtualProductUpdater;
         $this->productStockUpdater = $productStockUpdater;
+        $this->productPackRepository = $productPackRepository;
     }
 
     /**
@@ -94,9 +103,12 @@ class ProductTypeUpdater
      *
      * @throws CannotUpdateProductException
      * @throws ProductConstraintException
+     * @throws InvalidProductTypeException
      */
     public function updateType(ProductId $productId, ProductType $productType): void
     {
+        $this->checkExistingPackAssociation($productId, $productType);
+
         $product = $this->productRepository->get($productId);
 
         // First remove the associations before the type is updated (since these actions are only allowed for a certain type)
@@ -150,5 +162,20 @@ class ProductTypeUpdater
     {
         // Product type is bound to all shops, so when we reset stock because of type change it must be applied to all associated shops
         $this->productStockUpdater->resetStock($productId, ShopConstraint::allShops());
+    }
+
+    private function checkExistingPackAssociation(ProductId $productId, ProductType $productType): void
+    {
+        if ($productType->getValue() !== ProductType::TYPE_PACK) {
+            return;
+        }
+
+        $packsAssociatedToProduct = $this->productPackRepository->getPacksContaining($productId);
+        if (!empty($packsAssociatedToProduct)) {
+            throw new InvalidProductTypeException(
+                InvalidProductTypeException::EXPECTED_NO_EXISTING_PACK_ASSOCIATIONS,
+                'You cannot change this product into a pack because it is already associated as a pack content'
+            );
+        }
     }
 }

--- a/src/Core/Domain/Product/Combination/Query/SearchCombinationsForAssociation.php
+++ b/src/Core/Domain/Product/Combination/Query/SearchCombinationsForAssociation.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query;
 
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 class SearchCombinationsForAssociation
@@ -58,14 +59,27 @@ class SearchCombinationsForAssociation
      * @var int|null
      */
     private $limit;
+    /**
+     * @var array<string>
+     */
+    protected $filters;
 
     /**
      * @param string $phrase
      * @param int $languageId
      * @param int $shopId
+     * @param array $filters
      * @param int|null $limit
+     *
+     * @throws ProductConstraintException
+     * @throws ShopException
      */
-    public function __construct(string $phrase, int $languageId, int $shopId, ?int $limit = null)
+    public function __construct(
+        string $phrase,
+        int $languageId,
+        int $shopId,
+        array $filters = [],
+        ?int $limit = null)
     {
         if (null !== $limit && $limit <= 0) {
             throw new ProductConstraintException('Search limit must be a positive integer or null', ProductConstraintException::INVALID_SEARCH_LIMIT);
@@ -82,6 +96,7 @@ class SearchCombinationsForAssociation
         $this->limit = $limit;
         $this->shopId = new ShopId($shopId);
         $this->languageId = new LanguageId($languageId);
+        $this->filters = $filters;
     }
 
     /**
@@ -114,5 +129,13 @@ class SearchCombinationsForAssociation
     public function getLimit(): ?int
     {
         return $this->limit;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getFilters(): array
+    {
+        return $this->filters;
     }
 }

--- a/src/Core/Domain/Product/Exception/InvalidProductTypeException.php
+++ b/src/Core/Domain/Product/Exception/InvalidProductTypeException.php
@@ -61,6 +61,11 @@ class InvalidProductTypeException extends ProductException
     public const EXPECTED_NO_COMBINATIONS_TYPE = 50;
 
     /**
+     * Code used when trying to change a product into a pack while it is already associated with another.
+     */
+    public const EXPECTED_NO_EXISTING_PACK_ASSOCIATIONS = 60;
+
+    /**
      * @param int $code
      * @param string $message
      * @param Throwable|null $previous

--- a/src/Core/Domain/Product/Pack/Command/SetPackProductsCommand.php
+++ b/src/Core/Domain/Product/Pack/Command/SetPackProductsCommand.php
@@ -90,7 +90,6 @@ class SetPackProductsCommand
 
         foreach ($products as $product) {
             $this->assertQuantity($product['quantity']);
-
             $this->products[] = new QuantifiedProduct(
                 $product['product_id'],
                 $product['quantity'],

--- a/src/Core/Domain/Product/Pack/Command/SetPackProductsCommand.php
+++ b/src/Core/Domain/Product/Pack/Command/SetPackProductsCommand.php
@@ -89,11 +89,11 @@ class SetPackProductsCommand
         }
 
         foreach ($products as $product) {
-            $this->assertQuantity($product['quantity']);
+            $this->assertQuantity((int) $product['quantity']);
             $this->products[] = new QuantifiedProduct(
-                $product['product_id'],
-                $product['quantity'],
-                isset($product['combination_id']) ? $product['combination_id'] : null
+                (int) $product['product_id'],
+                (int) $product['quantity'],
+                isset($product['combination_id']) ? (int) $product['combination_id'] : null
             );
         }
     }

--- a/src/Core/Domain/Product/Pack/Query/GetPackedProducts.php
+++ b/src/Core/Domain/Product/Pack/Query/GetPackedProducts.php
@@ -28,6 +28,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query;
 
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
 /**
@@ -41,11 +43,18 @@ class GetPackedProducts
     private $packId;
 
     /**
-     * @param int $packId id of product which represents the pack
+     * @var LanguageId
      */
-    public function __construct(int $packId)
+    protected $languageId;
+
+    /**
+     * @param int $packId
+     * @param int $languageId
+     */
+    public function __construct(int $packId, int $languageId)
     {
-        $this->packId = new ProductId($packId);
+        $this->packId = new PackId($packId);
+        $this->languageId = new LanguageId($languageId);
     }
 
     /**
@@ -54,5 +63,13 @@ class GetPackedProducts
     public function getPackId(): ProductId
     {
         return $this->packId;
+    }
+
+    /**
+     * @return LanguageId
+     */
+    public function getLanguageId(): LanguageId
+    {
+        return $this->languageId;
     }
 }

--- a/src/Core/Domain/Product/Pack/Query/GetPackedProducts.php
+++ b/src/Core/Domain/Product/Pack/Query/GetPackedProducts.php
@@ -30,7 +30,6 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query;
 
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackId;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 
 /**
  * Retrieves product from a pack
@@ -38,7 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 class GetPackedProducts
 {
     /**
-     * @var ProductId
+     * @var PackId
      */
     private $packId;
 
@@ -58,9 +57,9 @@ class GetPackedProducts
     }
 
     /**
-     * @return ProductId
+     * @return PackId
      */
-    public function getPackId(): ProductId
+    public function getPackId(): PackId
     {
         return $this->packId;
     }

--- a/src/Core/Domain/Product/Pack/QueryResult/PackedProductDetails.php
+++ b/src/Core/Domain/Product/Pack/QueryResult/PackedProductDetails.php
@@ -69,15 +69,15 @@ class PackedProductDetails
      * @param int $combinationId
      * @param string $productName
      * @param string $reference
-     * @param ?string $imageUrl
+     * @param string $imageUrl
      */
     public function __construct(
         int $productId,
         int $quantity,
-        ?int $combinationId,
+        int $combinationId,
         string $productName,
         string $reference,
-        ?string $imageUrl
+        string $imageUrl
     ) {
         $this->productId = $productId;
         $this->quantity = $quantity;

--- a/src/Core/Domain/Product/Pack/QueryResult/PackedProductDetails.php
+++ b/src/Core/Domain/Product/Pack/QueryResult/PackedProductDetails.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryResult;
+
+/**
+ * Holds packed product data
+ */
+class PackedProductDetails
+{
+    /**
+     * @var int
+     */
+    protected $productId;
+
+    /**
+     * @var string
+     */
+    protected $productName;
+
+    /**
+     * @var int
+     */
+    protected $quantity;
+
+    /**
+     * @var int
+     */
+    protected $combinationId;
+
+    /**
+     * @var string
+     */
+    protected $reference;
+
+    /**
+     * @var string
+     */
+    protected $imageUrl;
+
+    /**
+     * @param int $productId
+     * @param int $quantity
+     * @param int $combinationId
+     * @param string $productName
+     * @param string $reference
+     * @param ?string $imageUrl
+     */
+    public function __construct(
+        int $productId,
+        int $quantity,
+        ?int $combinationId,
+        string $productName,
+        string $reference,
+        ?string $imageUrl
+    ) {
+        $this->productId = $productId;
+        $this->quantity = $quantity;
+        $this->combinationId = $combinationId;
+        $this->productName = $productName;
+        $this->reference = $reference;
+        $this->imageUrl = $imageUrl;
+    }
+
+    /**
+     * @return int
+     */
+    public function getProductId(): int
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCombinationId(): int
+    {
+        return $this->combinationId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProductName(): string
+    {
+        return $this->productName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getReference(): string
+    {
+        return $this->reference;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImageUrl(): string
+    {
+        return $this->imageUrl;
+    }
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/PackedProductsCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/PackedProductsCommandsBuilder.php
@@ -24,20 +24,34 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryHandler;
+declare(strict_types=1);
 
-use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query\GetPackedProducts;
-use PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryResult\PackedProductDetails;
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product;
 
-/**
- * Defines contract for GetPackedProductsHandler
- */
-interface GetPackedProductsHandlerInterface
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\RemoveAllProductsFromPackCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\SetPackProductsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+
+class PackedProductsCommandsBuilder implements ProductCommandsBuilderInterface
 {
     /**
-     * @param GetPackedProducts $query
-     *
-     * @return PackedProductDetails[]
+     * {@inheritDoc}
      */
-    public function handle(GetPackedProducts $query): array;
+    public function buildCommands(ProductId $productId, array $formData): array
+    {
+        if (!isset($formData['stock']['packed_products'])) {
+            return [];
+        }
+
+        $packedProducts = $formData['stock']['packed_products'];
+        if (empty($packedProducts)) {
+            return [new RemoveAllProductsFromPackCommand($productId->getValue())];
+        }
+        $command = new SetPackProductsCommand(
+            $productId->getValue(),
+            $packedProducts
+        );
+
+        return [$command];
+    }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/PackedProductsCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/PackedProductsCommandsBuilder.php
@@ -31,6 +31,7 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Prod
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\RemoveAllProductsFromPackCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\SetPackProductsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 
 class PackedProductsCommandsBuilder implements ProductCommandsBuilderInterface
 {
@@ -39,7 +40,8 @@ class PackedProductsCommandsBuilder implements ProductCommandsBuilderInterface
      */
     public function buildCommands(ProductId $productId, array $formData): array
     {
-        if (!isset($formData['stock']['packed_products'])) {
+        $initialType = $formData['header']['initial_type'] ?? null;
+        if ($initialType !== ProductType::TYPE_PACK || !isset($formData['stock']['packed_products'])) {
             return [];
         }
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -34,6 +34,8 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCust
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Query\GetProductFeatureValues;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\QueryResult\ProductFeatureValue;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query\GetPackedProducts;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryResult\PackedProductDetails;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\LocalizedTags;
@@ -184,6 +186,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
         $relatedProductsData = [];
         foreach ($relatedProducts as $relatedProduct) {
             $productName = $relatedProduct->getName();
+
             if (!empty($relatedProduct->getReference())) {
                 $productName .= sprintf(
                     ' (ref: %s)',
@@ -199,6 +202,37 @@ class ProductFormDataProvider implements FormDataProviderInterface
         }
 
         return $relatedProductsData;
+    }
+
+    /**
+     * @param int $productId
+     *
+     * @return array<int, array<string, int|string>>
+     */
+    protected function extractPackedProducts(int $productId): array
+    {
+        /** @var PackedProductDetails[] $packedProductsDetails
+         */
+        $packedProductsDetails = $this->queryBus->handle(
+            new GetPackedProducts(
+                $productId,
+                $this->contextLangId
+            )
+        );
+        $packedProductsData = [];
+        foreach ($packedProductsDetails as $packedProductDetails) {
+            $packedProductsData[] = [
+                'product_id' => $packedProductDetails->getProductId(),
+                'name' => $packedProductDetails->getProductName(),
+                'reference' => $packedProductDetails->getReference(),
+                'combination_id' => $packedProductDetails->getCombinationId(),
+                'image' => $packedProductDetails->getImageUrl(),
+                'quantity' => $packedProductDetails->getQuantity(),
+                'unique_identifier' => $packedProductDetails->getProductId() . '_' . $packedProductDetails->getCombinationId(),
+            ];
+        }
+
+        return $packedProductsData;
     }
 
     /**
@@ -352,6 +386,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
                 'available_later_label' => $stockInformation->getLocalizedAvailableLaterLabels(),
                 'available_date' => $availableDate ? $availableDate->format(DateTime::DEFAULT_DATE_FORMAT) : '',
             ],
+            'packed_products' => $this->extractPackedProducts($productForEditing->getProductId()),
         ];
     }
 

--- a/src/Core/Product/Combination/NameBuilder/CombinationNameBuilder.php
+++ b/src/Core/Product/Combination/NameBuilder/CombinationNameBuilder.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CombinationAttributeInformation;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Builds combination name by attributes information
@@ -35,16 +36,68 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CombinationAttributeIn
 class CombinationNameBuilder implements CombinationNameBuilderInterface
 {
     /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * @var string
+     */
+    protected $attributesSeparator;
+
+    /**
+     * @var string
+     */
+    private $attributesInsideSeparator;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        string $attributesSeparator,
+        string $attributesInsideSeparator
+    ) {
+        $this->translator = $translator;
+        $this->attributesSeparator = $attributesSeparator;
+        $this->attributesInsideSeparator = $attributesInsideSeparator;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildName(array $attributesInfo): string
     {
-        return implode(', ', array_map(function (CombinationAttributeInformation $combinationAttributeInfo): string {
-            return sprintf(
-                '%s - %s',
-                $combinationAttributeInfo->getAttributeGroupName(),
-                $combinationAttributeInfo->getAttributeName()
-            );
-        }, $attributesInfo));
+        return implode(
+            $this->attributesSeparator,
+            array_map(
+                [$this, 'translateAttribute'],
+                $attributesInfo
+            )
+        );
+    }
+
+    protected function translateAttribute(CombinationAttributeInformation $combinationAttributeInfo): string
+    {
+        return $this->translator->trans(
+            '%attribute_group_name% ' . $this->attributesInsideSeparator . ' %attribute_name%',
+            [
+                '%attribute_group_name%' => $combinationAttributeInfo->getAttributeGroupName(),
+                '%attribute_name%' => $combinationAttributeInfo->getAttributeName(),
+            ],
+            'Admin.Catalog.Feature'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildFullName(string $productName, array $attributesInfo): string
+    {
+        return $this->translator->trans(
+            '%product_name%: %combination_details%',
+            [
+                '%product_name%' => $productName,
+                '%combination_details%' => $this->buildName($attributesInfo),
+            ],
+            'Admin.Catalog.Feature'
+        );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -140,6 +140,7 @@ class CombinationController extends FrameworkBundleAdminController
                 $request->get('query', ''),
                 $language->getId(),
                 (int) $shopId,
+                $request->get('filters', []),
                 (int) $request->get('limit', 20)
             ));
         } catch (ProductConstraintException $e) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -203,7 +203,6 @@ class ProductController extends FrameworkBundleAdminController
 
         try {
             $productForm->handleRequest($request);
-
             $result = $this->getProductFormHandler()->handleFor($productId, $productForm);
 
             if ($result->isSubmitted()) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\BulkProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotBulkDeleteProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotDeleteProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductPositionException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\InvalidProductTypeException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\DuplicateFeatureValueAssociationException;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\InvalidAssociatedFeatureException;
@@ -774,6 +775,12 @@ class ProductController extends FrameworkBundleAdminController
             SpecificPriceConstraintException::class => [
                 SpecificPriceConstraintException::DUPLICATE_PRIORITY => $this->trans(
                     'The selected condition must be different in each field to set an order of priority.',
+                    'Admin.Notifications.Error'
+                ),
+            ],
+            InvalidProductTypeException::class => [
+                InvalidProductTypeException::EXPECTED_NO_EXISTING_PACK_ASSOCIATIONS => $this->trans(
+                    'This product cannot be changed into a pack because it is already associated to another pack.',
                     'Admin.Notifications.Error'
                 ),
             ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
@@ -94,7 +94,6 @@ class ProductTypeListener implements EventSubscriberInterface
     {
         if ($form->has('options')) {
             $form->remove('combinations');
-            unset($data['combinations']);
         }
     }
 
@@ -103,14 +102,12 @@ class ProductTypeListener implements EventSubscriberInterface
         if ($form->has('options')) {
             $optionsForm = $form->get('options');
             $optionsForm->remove('product_suppliers');
-            unset($data['options']['product_suppliers']);
         }
     }
 
     protected function removeStock(FormInterface $form, array &$data): void
     {
         $form->remove('stock');
-        unset($data['stock']);
     }
 
     protected function removePackStockType(FormInterface $form, array &$data): void
@@ -120,7 +117,6 @@ class ProductTypeListener implements EventSubscriberInterface
         }
         $stock = $form->get('stock');
         $stock->remove('pack_stock_type');
-        unset($data['stock']['pack_stock_type']);
     }
 
     protected function removePack(FormInterface $form, array &$data): void
@@ -130,7 +126,6 @@ class ProductTypeListener implements EventSubscriberInterface
         }
         $stock = $form->get('stock');
         $stock->remove('packed_products');
-        unset($data['stock']['packed_products']);
     }
 
     protected function removeVirtualProduct(FormInterface $form, array &$data): void
@@ -140,7 +135,6 @@ class ProductTypeListener implements EventSubscriberInterface
         }
         $stock = $form->get('stock');
         $stock->remove('virtual_product_file');
-        unset($data['stock']['virtual_product_file']);
     }
 
     protected function removeStockMovementsIfNecessary(FormInterface $form, array &$data): void
@@ -155,14 +149,12 @@ class ProductTypeListener implements EventSubscriberInterface
         $quantities = $stock->get('quantities');
         if ($quantities->has('stock_movements') && empty($data['stock']['quantities']['stock_movements'])) {
             $quantities->remove('stock_movements');
-            unset($data['stock']['stock_movements']);
         }
     }
 
     protected function removeShipping(FormInterface $form, array &$data): void
     {
         $form->remove('shipping');
-        unset($data['shipping']);
     }
 
     protected function removeEcotax(FormInterface $form, array &$data): void

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
@@ -63,41 +63,41 @@ class ProductTypeListener implements EventSubscriberInterface
         $initialProductType = $data['header']['initial_type'] ?? $productType;
 
         if (ProductType::TYPE_COMBINATIONS === $productType) {
-            $this->removeSuppliers($form, $data);
-            $this->removeStock($form, $data);
+            $this->removeSuppliers($form);
+            $this->removeStock($form);
         } else {
-            $this->removeCombinations($form, $data);
+            $this->removeCombinations($form);
         }
 
         if (ProductType::TYPE_PACK !== $productType) {
-            $this->removePackStockType($form, $data);
-            $this->removePack($form, $data);
+            $this->removePackStockType($form);
+            $this->removePack($form);
         }
 
         $this->removeStockMovementsIfNecessary($form, $data);
 
         if (ProductType::TYPE_VIRTUAL === $productType) {
-            $this->removeShipping($form, $data);
+            $this->removeShipping($form);
             // We don't remove the ecotax during the transition request because we could lose the ecotax data
             // and some part of the price with it
             if (ProductType::TYPE_VIRTUAL === $initialProductType) {
-                $this->removeEcotax($form, $data);
+                $this->removeEcotax($form);
             }
         } else {
-            $this->removeVirtualProduct($form, $data);
+            $this->removeVirtualProduct($form);
         }
 
         $event->setData($data);
     }
 
-    protected function removeCombinations(FormInterface $form, array &$data): void
+    protected function removeCombinations(FormInterface $form): void
     {
         if ($form->has('options')) {
             $form->remove('combinations');
         }
     }
 
-    protected function removeSuppliers(FormInterface $form, array &$data): void
+    protected function removeSuppliers(FormInterface $form): void
     {
         if ($form->has('options')) {
             $optionsForm = $form->get('options');
@@ -105,12 +105,12 @@ class ProductTypeListener implements EventSubscriberInterface
         }
     }
 
-    protected function removeStock(FormInterface $form, array &$data): void
+    protected function removeStock(FormInterface $form): void
     {
         $form->remove('stock');
     }
 
-    protected function removePackStockType(FormInterface $form, array &$data): void
+    protected function removePackStockType(FormInterface $form): void
     {
         if (!$form->has('stock')) {
             return;
@@ -119,7 +119,7 @@ class ProductTypeListener implements EventSubscriberInterface
         $stock->remove('pack_stock_type');
     }
 
-    protected function removePack(FormInterface $form, array &$data): void
+    protected function removePack(FormInterface $form): void
     {
         if (!$form->has('stock')) {
             return;
@@ -128,7 +128,7 @@ class ProductTypeListener implements EventSubscriberInterface
         $stock->remove('packed_products');
     }
 
-    protected function removeVirtualProduct(FormInterface $form, array &$data): void
+    protected function removeVirtualProduct(FormInterface $form): void
     {
         if (!$form->has('stock')) {
             return;
@@ -137,7 +137,7 @@ class ProductTypeListener implements EventSubscriberInterface
         $stock->remove('virtual_product_file');
     }
 
-    protected function removeStockMovementsIfNecessary(FormInterface $form, array &$data): void
+    protected function removeStockMovementsIfNecessary(FormInterface $form, array $data): void
     {
         if (!$form->has('stock')) {
             return;
@@ -152,12 +152,12 @@ class ProductTypeListener implements EventSubscriberInterface
         }
     }
 
-    protected function removeShipping(FormInterface $form, array &$data): void
+    protected function removeShipping(FormInterface $form): void
     {
         $form->remove('shipping');
     }
 
-    protected function removeEcotax(FormInterface $form, array &$data): void
+    protected function removeEcotax(FormInterface $form): void
     {
         if (!$form->has('pricing')) {
             return;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
@@ -65,7 +65,7 @@ class ProductTypeListener implements EventSubscriberInterface
         if (ProductType::TYPE_COMBINATIONS === $productType) {
             $this->removeSuppliers($form);
             $this->removeStock($form);
-        } else {
+        } elseif ($initialProductType !== ProductType::TYPE_COMBINATIONS) {
             $this->removeCombinations($form);
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/PackedProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/PackedProductType.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product\Stock;
+
+use PrestaShopBundle\Form\Admin\Type\ImagePreviewType;
+use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+
+class PackedProductType extends TranslatorAwareType
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('unique_identifier', HiddenType::class, [
+                'label' => false,
+            ])
+            ->add('product_id', HiddenType::class, [
+                'label' => false,
+            ])
+            ->add('image', ImagePreviewType::class, [
+                'label' => false,
+            ])
+            ->add('combination_id', HiddenType::class, [
+                'label' => false,
+            ])
+            ->add('name', TextPreviewType::class, [
+                'label' => false,
+            ])
+            ->add('reference', TextPreviewType::class, [
+                'label' => false,
+            ])
+            // @Todo must be an IntegerType or NumberType, but according with a prototype EntitySearchInputType limitation, set to TextType
+            // @link https://github.com/PrestaShop/PrestaShop/issues/28513
+            ->add('quantity', TextType::class, [
+                'label' => false,
+                'attr' => [
+                    'class' => 'js-comma-transformer',
+                ],
+                'constraints' => [
+                    new NotBlank([]),
+                    new Type([
+                        'type' => 'numeric',
+                    ]),
+                    new GreaterThanOrEqual([
+                        'value' => 1,
+                    ]),
+                ],
+            ])
+        ;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/PackedProductType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/PackedProductType.php
@@ -63,6 +63,7 @@ class PackedProductType extends TranslatorAwareType
             ])
             ->add('reference', TextPreviewType::class, [
                 'label' => false,
+                'preview_class' => 'reference-preview',
             ])
             // @Todo must be an IntegerType or NumberType, but according with a prototype EntitySearchInputType limitation, set to TextType
             // @link https://github.com/PrestaShop/PrestaShop/issues/28513

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -28,10 +28,12 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Stock;
 
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Type\EntitySearchInputType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class StockType extends TranslatorAwareType
@@ -42,17 +44,33 @@ class StockType extends TranslatorAwareType
     private $packStockTypeChoiceProvider;
 
     /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var string
+     */
+    protected $employeeIsoCode;
+
+    /**
      * @param TranslatorInterface $translator
+     * @param RouterInterface $router,
      * @param array $locales
      * @param FormChoiceProviderInterface $packStockTypeChoiceProvider
+     * @param string $employeeIsoCode
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        FormChoiceProviderInterface $packStockTypeChoiceProvider
+        FormChoiceProviderInterface $packStockTypeChoiceProvider,
+        RouterInterface $router,
+        string $employeeIsoCode
     ) {
         parent::__construct($translator, $locales);
         $this->packStockTypeChoiceProvider = $packStockTypeChoiceProvider;
+        $this->router = $router;
+        $this->employeeIsoCode = $employeeIsoCode;
     }
 
     /**
@@ -61,6 +79,25 @@ class StockType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            ->add('packed_products', EntitySearchInputType::class, [
+                'label' => $this->trans('Pack of products', 'Admin.Catalog.Feature'),
+                'label_tag_name' => 'h2',
+                'entry_type' => PackedProductType::class,
+                'entry_options' => [
+                    'block_prefix' => 'packed',
+                ],
+                'remote_url' => $this->router->generate('admin_products_v2_search_combinations', [
+                    'languageCode' => $this->employeeIsoCode,
+                    'query' => '__QUERY__',
+                ]),
+                'attr' => [
+                    'class' => 'product_packed_products',
+                ],
+                'min_length' => 3,
+                'filtered_identities' => $options['product_id'] > 0 ? [$options['product_id'] . '_0'] : [],
+                'identifier_field' => 'unique_identifier',
+                'placeholder' => $this->trans('Search combination', 'Admin.Catalog.Help'),
+            ])
             ->add('quantities', QuantityType::class, [
                 'product_id' => $options['product_id'],
             ])
@@ -74,6 +111,7 @@ class StockType extends TranslatorAwareType
                 'label' => $this->trans('Pack quantities', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
                 'required' => false,
+                'placeholder' => false,
                 'modify_all_shops' => true,
             ])
             ->add('availability', AvailabilityType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Stock;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\EntitySearchInputType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -88,6 +89,9 @@ class StockType extends TranslatorAwareType
                 ],
                 'remote_url' => $this->router->generate('admin_products_v2_search_combinations', [
                     'languageCode' => $this->employeeIsoCode,
+                    'filters' => [
+                        'filteredTypes' => [ProductType::TYPE_PACK],
+                    ],
                     'query' => '__QUERY__',
                 ]),
                 'attr' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -96,6 +96,7 @@ class StockType extends TranslatorAwareType
                 ]),
                 'attr' => [
                     'class' => 'product_packed_products',
+                    'data-reference-label' => $this->trans('Ref: %s', 'Admin.Catalog.Feature'),
                 ],
                 'min_length' => 3,
                 'filtered_identities' => $options['product_id'] > 0 ? [$options['product_id'] . '_0'] : [],

--- a/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/EntitySearchInputType.php
@@ -123,7 +123,6 @@ class EntitySearchInputType extends CollectionType
             // field name in record dataset which should be used to show suggestion in search dropdown
             'suggestion_field' => 'name',
         ]);
-
         $resolver->setAllowedTypes('allow_search', ['bool']);
         $resolver->setAllowedTypes('search_attr', ['array']);
         $resolver->setAllowedTypes('list_attr', ['array']);

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/product.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/product.yml
@@ -181,3 +181,12 @@ admin_products_v2_search_associations:
     _legacy_controller: AdminProducts
   requirements:
     languageCode: !php/const PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\TagIETF::IETF_TAG_REGEXP
+
+admin_products_v2_search_combinations:
+  path: /search/combination/{languageCode}
+  methods: [ GET, POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\CombinationController::searchCombinationProductsAction
+    _legacy_controller: AdminProducts
+  requirements:
+    languageCode: !php/const PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\TagIETF::IETF_TAG_REGEXP

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -309,6 +309,7 @@ services:
       - '@prestashop.adapter.product.validate.product_validator'
       - '@prestashop.adapter.tax_rules_group.repository.tax_rules_group_repository'
       - '@prestashop.adapter.manufacturer.repository.manufacturer_repository'
+      - '@prestashop.adapter.product.pack.repository.product_pack_repository'
 
   prestashop.adapter.product.repository.product_multi_shop_repository:
     class: PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository
@@ -504,7 +505,6 @@ services:
     arguments:
       - '@prestashop.adapter.product.repository.product_repository'
       - '@prestashop.adapter.product.image.repository.product_image_repository'
-      - '@prestashop.adapter.product.image.product_image_url_factory'
 
   prestashop.adapter.product.update.product_shop_updater:
     class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductShopUpdater

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -335,6 +335,7 @@ services:
       - '@prestashop.adapter.product.combination.update.combination_deleter'
       - '@prestashop.adapter.product.virtual_product.update.virtual_product_updater'
       - '@prestashop.adapter.product.stock.update.product_stock_updater'
+      - '@prestashop.adapter.product.pack.repository.product_pack_repository'
 
   prestashop.adapter.product.command_handler.delete_product_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\DeleteProductHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -73,7 +73,9 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler\SearchCombinationsForAssociationHandler
     arguments:
       - '@prestashop.adapter.product.repository.product_repository'
+      - '@prestashop.adapter.attribute.repository.attribute_repository'
       - '@prestashop.adapter.product.image.product_image_url_factory'
+      - '@prestashop.core.product.combination.name_builder.combination_name_builder'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\SearchCombinationsForAssociation

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -59,6 +59,8 @@ services:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
       - '@prestashop.adapter.product.image.validate.product_image_validator'
+      - '@prestashop.adapter.product.image.product_image_url_factory'
+      - '@prestashop.adapter.product.combination.repository.combination_repository'
 
   prestashop.adapter.product.image.update.product_image_updater:
     class: PrestaShop\PrestaShop\Adapter\Product\Image\Update\ProductImageUpdater

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_pack.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_pack.yml
@@ -4,6 +4,9 @@ services:
 
   prestashop.adapter.product.pack.repository.product_pack_repository:
     class: PrestaShop\PrestaShop\Adapter\Product\Pack\Repository\ProductPackRepository
+    arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'
 
   prestashop.adapter.product.pack.update.product_pack_updater:
     class: PrestaShop\PrestaShop\Adapter\Product\Pack\Update\ProductPackUpdater
@@ -27,10 +30,14 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\RemoveAllProductsFromPackCommand
 
-  prestashop.adapter.product.pack.command_handler.get_packed_products_handler:
+  prestashop.adapter.product.query_handler.get_packed_products_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Pack\QueryHandler\GetPackedProductsHandler
     arguments:
-      - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_LANG_DEFAULT')"
+      - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
+      - '@prestashop.adapter.product.pack.repository.product_pack_repository'
+      - '@prestashop.adapter.attribute.repository.attribute_repository'
+      - '@prestashop.core.product.combination.name_builder.combination_name_builder'
+      - '@prestashop.adapter.product.image.repository.product_image_repository'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query\GetPackedProducts

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_pack.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_pack.yml
@@ -38,6 +38,7 @@ services:
       - '@prestashop.adapter.attribute.repository.attribute_repository'
       - '@prestashop.core.product.combination.name_builder.combination_name_builder'
       - '@prestashop.adapter.product.image.repository.product_image_repository'
+      - '@translator'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query\GetPackedProducts

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_seo.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_seo.yml
@@ -5,6 +5,6 @@ services:
   prestashop.adapter.product.options.redirect_target_provider:
     class: PrestaShop\PrestaShop\Adapter\Product\Options\RedirectTargetProvider
     arguments:
-      - '@prestashop.adapter.product.repository.product_preview_repository'
+      - "@prestashop.adapter.product.image.repository.product_image_repository"
       - '@prestashop.adapter.category.repository.category_preview_repository'
       - '@prestashop.adapter.legacy.context'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_seo.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_seo.yml
@@ -5,6 +5,6 @@ services:
   prestashop.adapter.product.options.redirect_target_provider:
     class: PrestaShop\PrestaShop\Adapter\Product\Options\RedirectTargetProvider
     arguments:
-      - "@prestashop.adapter.product.image.repository.product_image_repository"
+      - '@prestashop.adapter.product.repository.product_preview_repository'
       - '@prestashop.adapter.category.repository.category_preview_repository'
       - '@prestashop.adapter.legacy.context'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1453,6 +1453,8 @@ services:
     public: true
     arguments:
       - '@prestashop.core.form.choice_provider.pack_stock_type_choice_provider'
+      - '@router'
+      - '@=service("prestashop.adapter.legacy.context").getEmployeeLanguageIso()'
     tags:
       - { name: form.type }
 
@@ -1648,6 +1650,13 @@ services:
 
   form.type.sell.product.seo.serp_type:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\SEO\SerpType'
+    parent: 'form.type.translatable.aware'
+    public: true
+    tags:
+      - { name: form.type }
+
+  form.type.sell.product.stock.packed_type:
+    class: 'PrestaShopBundle\Form\Admin\Sell\Product\Stock\PackedProductType'
     parent: 'form.type.translatable.aware'
     public: true
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -96,6 +96,10 @@ services:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\SpecificPricePriorityCommandsBuilder
     tags: [ 'core.product_command_builder' ]
 
+  prestashop.core.form.command_builder.product.packed_products_commands_builder:
+    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\PackedProductsCommandsBuilder
+    tags: [ 'core.product_command_builder' ]
+
   # Combination builders
   prestashop.core.form.command_builder.combination.combination_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilder

--- a/src/PrestaShopBundle/Resources/config/services/core/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/product.yml
@@ -11,4 +11,10 @@ services:
     class: PrestaShop\PrestaShop\Core\Product\Combination\Generator\CombinationGenerator
 
   prestashop.core.product.combination.name_builder.combination_name_builder:
+    arguments:
+      - '@translator'
+      # separator between attributes (ex : size: M, color: blue), to be replaced by a configuration parameter (env or php const)
+      # https://github.com/PrestaShop/PrestaShop/issues/28512
+      - ', '
+      - '@=service("prestashop.adapter.legacy.configuration").get("PS_ATTRIBUTE_ANCHOR_SEPARATOR")'
     class: PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/tabs.html.twig
@@ -55,6 +55,8 @@
         <a href="#stock-tab" role="tab" data-toggle="tab" class="nav-link">
           {% if productType == 'virtual' %}
             {{ 'Virtual product'|trans({}, 'Admin.Catalog.Feature') }}
+          {% elseif productType == 'pack' %}
+            {{ 'Pack'|trans({}, 'Admin.Catalog.Feature') }}
           {% else %}
             {{ 'Stocks'|trans({}, 'Admin.Catalog.Feature') }}
           {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
@@ -53,6 +53,28 @@
   </li>
 {% endblock %}
 
+{% block packed_product_row %}
+  <li class="packed-product entity-item">
+    <div class="packed-product-image">
+      {{ form_widget(form.image) }}
+    </div>
+    <div class="packed-product-legend">
+      {{ form_widget(form.name, {prefix: '<i class="material-icons entity-item-delete">delete</i>'}) }}
+      {{ form_widget(form.reference)}}
+    </div>
+    <div class="form-group">
+      <div class="packed-product-quantity">
+        {{ form_widget(form.quantity) }}
+        {{ form_errors(form.quantity) }}
+      </div>
+    </div>
+    {{ form_widget(form.product_id) }}
+    {{ form_widget(form.unique_identifier) }}
+    {{ form_widget(form.combination_id) }}
+  </li>
+{% endblock %}
+
+
 {% block product_type_row %}
   <div class="product-type-selector">
     <div class="product-type-choices">

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/SearchCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/SearchCombinationFeatureContext.php
@@ -153,7 +153,7 @@ class SearchCombinationFeatureContext extends AbstractProductFeatureContext
     {
         $language = $this->getSharedStorage()->get($localeReference);
         $filters = [
-            'filteredType' => [ProductType::TYPE_PACK],
+            'filteredTypes' => [ProductType::TYPE_PACK],
         ];
 
         /** @var ProductForAssociation[] $foundProducts */
@@ -220,16 +220,16 @@ class SearchCombinationFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @When I search for products with locale :localeReference matching :search for :packedProductReference I should get no results:
+     * @When I search for combinations with locale :localeReference matching :search for packs I should get no results
      *
      * @param string $localeReference
      * @param string $search
      */
-    public function assertSearchProductsForPackNoResults(string $localeReference, string $search, string $packedProductReference): void
+    public function assertSearchProductsForPackNoResults(string $localeReference, string $search): void
     {
         $language = $this->getSharedStorage()->get($localeReference);
         $filters = [
-            'filteredType' => [ProductType::TYPE_PACK],
+            'filteredTypes' => [ProductType::TYPE_PACK],
         ];
 
         /** @var ProductForAssociation[] $foundProducts */

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/SearchCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/SearchCombinationFeatureContext.php
@@ -34,6 +34,8 @@ use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Query\SearchCombinationsForAssociation;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForAssociation;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\NoCombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForAssociation;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 
 class SearchCombinationFeatureContext extends AbstractProductFeatureContext
@@ -136,6 +138,109 @@ class SearchCombinationFeatureContext extends AbstractProductFeatureContext
             (int) $language->id,
             (int) Configuration::get('PS_SHOP_DEFAULT')
         ));
+
         Assert::assertEmpty($foundProducts);
+    }
+
+    /**
+     * @When I search for products with locale :localeReference matching :search for :packedProductReference I should get following results:
+     *
+     * @param string $localeReference
+     * @param string $search
+     * @param TableNode $tableNode
+     */
+    public function assertSearchProductsForPack(string $localeReference, string $search, string $packedProductReference, TableNode $tableNode): void
+    {
+        $language = $this->getSharedStorage()->get($localeReference);
+        $filters = [
+            'filteredType' => [ProductType::TYPE_PACK],
+        ];
+
+        /** @var ProductForAssociation[] $foundProducts */
+        $foundProducts = $this->getQueryBus()->handle(new SearchCombinationsForAssociation(
+            $search,
+            (int) $language->id,
+            (int) Configuration::get('PS_SHOP_DEFAULT'),
+            $filters,
+            20
+        ));
+
+        $expectedRelatedProducts = $tableNode->getColumnsHash();
+
+        Assert::assertEquals(count($expectedRelatedProducts), count($foundProducts));
+
+        $index = 0;
+        foreach ($expectedRelatedProducts as $expectedRelatedProduct) {
+            $foundProductForAssociation = $foundProducts[$index];
+
+            $expectedProductId = $this->getSharedStorage()->get($expectedRelatedProduct['product']);
+            Assert::assertEquals(
+                $expectedProductId,
+                $foundProductForAssociation->getProductId(),
+                sprintf(
+                    'Invalid product ID, expected %d but got %d instead.',
+                    $expectedProductId,
+                    $foundProductForAssociation->getProductId()
+                )
+            );
+
+            Assert::assertEquals(
+                $expectedRelatedProduct['name'],
+                $foundProductForAssociation->getName(),
+                sprintf(
+                    'Invalid product name, expected %s but got %s instead.',
+                    $expectedRelatedProduct['name'],
+                    $foundProductForAssociation->getName()
+                )
+            );
+
+            Assert::assertEquals(
+                $expectedRelatedProduct['reference'],
+                $foundProductForAssociation->getReference(),
+                sprintf(
+                    'Invalid product reference, expected %s but got %s instead.',
+                    $expectedRelatedProduct['reference'],
+                    $foundProductForAssociation->getReference()
+                )
+            );
+
+            $realImageUrl = $this->getRealImageUrl($expectedRelatedProduct['image url']);
+            Assert::assertEquals(
+                $realImageUrl,
+                $foundProductForAssociation->getImageUrl(),
+                sprintf(
+                    'Invalid product image url, expected %s but got %s instead.',
+                    $realImageUrl,
+                    $foundProductForAssociation->getImageUrl()
+                )
+            );
+
+            ++$index;
+        }
+    }
+
+    /**
+     * @When I search for products with locale :localeReference matching :search for :packedProductReference I should get no results:
+     *
+     * @param string $localeReference
+     * @param string $search
+     */
+    public function assertSearchProductsForPackNoResults(string $localeReference, string $search, string $packedProductReference): void
+    {
+        $language = $this->getSharedStorage()->get($localeReference);
+        $filters = [
+            'filteredType' => [ProductType::TYPE_PACK],
+        ];
+
+        /** @var ProductForAssociation[] $foundProducts */
+        $foundProducts = $this->getQueryBus()->handle(new SearchCombinationsForAssociation(
+            $search,
+            (int) $language->id,
+            (int) Configuration::get('PS_SHOP_DEFAULT'),
+            $filters,
+            20
+        ));
+
+        Assert::assertEquals(0, count($foundProducts));
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductTypeFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductTypeFeatureContext.php
@@ -43,7 +43,11 @@ class ProductTypeFeatureContext extends AbstractProductFeatureContext
     {
         $productId = (int) $this->getSharedStorage()->get($productReference);
 
-        $this->getCommandBus()->handle(new UpdateProductTypeCommand($productId, $productType));
+        try {
+            $this->getCommandBus()->handle(new UpdateProductTypeCommand($productId, $productType));
+        } catch (InvalidProductTypeException $e) {
+            $this->setLastException($e);
+        }
     }
 
     /**
@@ -72,5 +76,13 @@ class ProductTypeFeatureContext extends AbstractProductFeatureContext
                 break;
         }
         $this->assertLastErrorIs(InvalidProductTypeException::class, $errorCode);
+    }
+
+    /**
+     * @Then I should get error that the product is already associated to a pack
+     */
+    public function assertLastErrorForbiddenAssociations(): void
+    {
+        $this->assertLastErrorIs(InvalidProductTypeException::class, InvalidProductTypeException::EXPECTED_NO_EXISTING_PACK_ASSOCIATIONS);
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
-use Pack;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
@@ -37,7 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\RemoveAllProductsFrom
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\SetPackProductsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Exception\ProductPackConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query\GetPackedProducts;
-use PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryResult\PackedProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryResult\PackedProductDetails;
 use RuntimeException;
 
 class UpdatePackFeatureContext extends AbstractProductFeatureContext
@@ -94,12 +93,17 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
     {
         $packId = $this->getSharedStorage()->get($packReference);
 
-        $packedProducts = $this->getQueryBus()->handle(new GetPackedProducts($packId));
+        $packedProducts = $this->getQueryBus()->handle(
+            new GetPackedProducts(
+                $packId,
+                $this->getDefaultLangId()
+            )
+        );
         Assert::assertEmpty($packedProducts);
     }
 
     /**
-     * @Then pack :packReference should contain products with following quantities:
+     * @Then pack :packReference should contain products with following details:
      *
      * @param string $packReference
      * @param TableNode $table
@@ -108,31 +112,57 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
     {
         $data = $table->getColumnsHash();
         $packId = $this->getSharedStorage()->get($packReference);
-        /** @var array<int, PackedProduct> $packedProducts */
-        $packedProducts = $this->getQueryBus()->handle(new GetPackedProducts($packId));
+        /** @var array<int, PackedProductDetails> $packedProducts */
+        $packedProducts = $this->getQueryBus()->handle(
+            new GetPackedProducts(
+                $packId,
+                $this->getDefaultLangId()
+            )
+        );
         $notExistingProducts = [];
 
-        foreach ($data as $row) {
-            $productReference = $row['product'];
-            $expectedQty = (int) $row['quantity'];
+        foreach ($data as $expectedPackedProduct) {
+            $productReference = $expectedPackedProduct['product'];
+            $expectedQuantity = (int) $expectedPackedProduct['quantity'];
+            $expectedName = $expectedPackedProduct['name'];
+            $expectedCombination = $expectedPackedProduct['combination'];
             $expectedPackedProductId = $this->getSharedStorage()->get($productReference);
-            $expectedCombinationId = $this->getExpectedCombinationId($row);
-
+            $expectedCombinationId = !empty($expectedPackedProduct['combination']) ? $this->getSharedStorage()->get($expectedPackedProduct['combination']) : 0;
             $foundProduct = false;
 
             foreach ($packedProducts as $key => $packedProduct) {
                 if ($packedProduct->getProductId() === $expectedPackedProductId) {
                     $foundProduct = true;
+
                     Assert::assertEquals(
-                        $expectedQty,
+                        $expectedName,
+                        $packedProduct->getProductName(),
+                        sprintf('Unexpected name of packed product "%s"', $productReference)
+                    );
+
+                    if ($expectedCombination !== '') {
+                        Assert::assertEquals(
+                            $expectedCombinationId,
+                            $packedProduct->getCombinationId(),
+                            sprintf('Unexpected combination (%s) of packed product "%s"', $expectedCombinationId, $productReference)
+                        );
+                    }
+
+                    Assert::assertEquals(
+                        $expectedQuantity,
                         $packedProduct->getQuantity(),
                         sprintf('Unexpected quantity of packed product "%s"', $productReference)
                     );
 
+                    $realImageUrl = $this->getRealImageUrl($expectedPackedProduct['image url']);
                     Assert::assertEquals(
-                        $expectedCombinationId,
-                        $packedProduct->getCombinationId(),
-                        sprintf('Unexpected packed product "%s" combination', $productReference)
+                        $realImageUrl,
+                        $packedProduct->getImageUrl(),
+                        sprintf(
+                            'Invalid product image url, expected %s but got %s instead.',
+                            $realImageUrl,
+                            $packedProduct->getImageUrl()
+                        )
                     );
 
                     //unset asserted product to check if there was any excessive actual products after loops
@@ -143,9 +173,9 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
 
             if (!$foundProduct) {
                 if ($expectedCombinationId) {
-                    $notExistingProducts[$productReference][$row['combination']] = $expectedQty;
+                    $notExistingProducts[$productReference][$expectedPackedProduct['combination']] = $expectedQuantity;
                 } else {
-                    $notExistingProducts[$productReference] = $expectedQty;
+                    $notExistingProducts[$productReference] = $expectedQuantity;
                 }
             }
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
@@ -165,6 +165,14 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
                         )
                     );
 
+                    if (isset($expectedPackedProduct['reference'])) {
+                        Assert::assertEquals(
+                            $expectedPackedProduct['reference'],
+                            $packedProduct->getReference(),
+                            sprintf('Unexpected reference of packed product "%s"', $productReference)
+                        );
+                    }
+
                     //unset asserted product to check if there was any excessive actual products after loops
                     unset($packedProducts[$key]);
                     break;

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
@@ -310,18 +310,13 @@ Feature: Search combinations to associate them in the BO
       | name[en-US] | shot of Kir Breton        |
       | name[fr-FR] | petit verre de Kir Breton |
       | type        | standard                  |
-
-    Then I search for products with locale "english" matching "kir breton" for "packedProduct" I should get following results:
+    When I search for products with locale "english" matching "kir breton" for "packedProduct" I should get following results:
       | product  | name               | reference | image url                                             |
       | product2 | shot of Kir Breton |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-    Then I search for products with locale "french" matching "petit verre" for "packedProduct" I should get following results:
+    When I search for products with locale "french" matching "petit verre" for "packedProduct" I should get following results:
       | product  | name                      | reference | image url                                             |
       | product2 | petit verre de Kir Breton |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
       | product1 | petit verre de Rhum Blanc |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-
-  Scenario: I perform a search for candidate to be packed and I get no result, also if packs are available
-    Then I search for products with locale "english" matching "pack of shots" for "packedProduct" I should get no results:
-
-  Scenario: I perform a search for candidate to be packed and I get no result, also if packs himself fits the search
-    Then I search for products with locale "english" matching "Diplomatico" for "packedProduct" I should get no results:
+    When I search for combinations with locale "english" matching "pack of shots" for packs I should get no results
+    When I search for combinations with locale "english" matching "Diplomatico" for packs I should get no results
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
@@ -26,6 +26,7 @@ Feature: Search combinations to associate them in the BO
     And attribute "Blue" named "Blue" in en language exists
     And attribute "Red" named "Red" in en language exists
 
+
   Scenario: I can search combinations by name
     When I add product "beer_bottle" with following information:
       | name[en-US] | bottle of beer     |
@@ -293,3 +294,34 @@ Feature: Search combinations to associate them in the BO
       | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt: Size - S, Color - Black |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
       | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt: Size - M, Color - White |           | http://myshop.com/img/p/{lemon_image4}-home_default.jpg |
       | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt: Size - M, Color - Black |           | http://myshop.com/img/p/{lemon_image3}-home_default.jpg |
+
+  Scenario: I perform a search for candidate to be packed and I get result, but no pack is available
+    Given I add product "packedProduct" with following information:
+      | name[en-US] | pack of shots of Diplomatico Rum |
+      | type        | pack                             |
+    And I add product "secondPackedProduct" with following information:
+      | name[en-US] | pack of shots of White Rum |
+      | type        | pack                       |
+    And I add product "product1" with following information:
+      | name[en-US] | shot of White Rum         |
+      | name[fr-FR] | petit verre de Rhum Blanc |
+      | type        | standard                  |
+    And I add product "product2" with following information:
+      | name[en-US] | shot of Kir Breton        |
+      | name[fr-FR] | petit verre de Kir Breton |
+      | type        | standard                  |
+
+    Then I search for products with locale "english" matching "kir breton" for "packedProduct" I should get following results:
+      | product  | name               | reference | image url                                             |
+      | product2 | shot of Kir Breton |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    Then I search for products with locale "french" matching "petit verre" for "packedProduct" I should get following results:
+      | product  | name                      | reference | image url                                             |
+      | product2 | petit verre de Kir Breton |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product1 | petit verre de Rhum Blanc |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+
+  Scenario: I perform a search for candidate to be packed and I get no result, also if packs are available
+    Then I search for products with locale "english" matching "pack of shots" for "packedProduct" I should get no results:
+
+  Scenario: I perform a search for candidate to be packed and I get no result, also if packs himself fits the search
+    Then I search for products with locale "english" matching "Diplomatico" for "packedProduct" I should get no results:
+

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
@@ -142,56 +142,56 @@ Feature: Search combinations to associate them in the BO
       | upc                | 354321354321      |
     # Search by all types of references matching wine_bottle_red combination
     When I search for combinations with locale "english" matching "154867313573" I should get following results:
-      | product     | combination     | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination     | name                        | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine: Color - Red | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "978-3-16-148410-3" I should get following results:
-      | product     | combination     | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination     | name                         | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine: Color - Red  | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "mpn3red" I should get following results:
-      | product     | combination     | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination     | name                         | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine: Color - Red  | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "ref3red" I should get following results:
-      | product     | combination     | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination     | name                         | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine: Color - Red  | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "137684192354" I should get following results:
-      | product     | combination     | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_red | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination     | name                         | reference | image url                                             |
+      | wine_bottle | wine_bottle_red | bottle of wine: Color - Red  | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     # Search by all types of references matching wine_bottle_white combination
     When I search for combinations with locale "english" matching "1357321357213" I should get following results:
-      | product     | combination       | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name                          | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "978-3-16-148410-4" I should get following results:
-      | product     | combination       | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name                          | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "mpn3white" I should get following results:
-      | product     | combination       | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name                          | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "ref3white" I should get following results:
-      | product     | combination       | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name                          | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "354321354321" I should get following results:
-      | product     | combination       | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name                          | reference | image url                                             |
+      | wine_bottle | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     # Search by types that match both combinations, both are returned
     When I search for combinations with locale "english" matching "mpn3" I should get following results:
-      | product     | combination       | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_red   | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name                          | reference | image url                                             |
+      | wine_bottle | wine_bottle_red   | bottle of wine: Color - Red   | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "ref3" I should get following results:
-      | product     | combination       | name           | reference | image url                                             |
-      | wine_bottle | wine_bottle_red   | bottle of wine | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | wine_bottle | wine_bottle_white | bottle of wine | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product     | combination       | name                          | reference | image url                                             |
+      | wine_bottle | wine_bottle_red   | bottle of wine: Color - Red   | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     # Search by types that match two combinations and a product
     When I search for combinations with locale "english" matching "mpn" I should get following results:
-      | product          | combination       | name                | reference | image url                                             |
-      | champaign_bottle |                   | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | wine_bottle      | wine_bottle_red   | bottle of wine      | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | wine_bottle      | wine_bottle_white | bottle of wine      | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product          | combination       | name                          | reference | image url                                             |
+      | champaign_bottle |                   | bottle of champaign           | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle      | wine_bottle_red   | bottle of wine: Color - Red   | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle      | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I search for combinations with locale "english" matching "ref" I should get following results:
-      | product          | combination       | name                | reference | image url                                             |
-      | champaign_bottle |                   | bottle of champaign | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | wine_bottle      | wine_bottle_red   | bottle of wine      | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | wine_bottle      | wine_bottle_white | bottle of wine      | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product          | combination       | name                          | reference | image url                                             |
+      | champaign_bottle |                   | bottle of champaign           | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle      | wine_bottle_red   | bottle of wine: Color - Red   | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle      | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
 
   Scenario: Search results include the appropriate images
     Given following image types should be applicable to products:
@@ -246,12 +246,12 @@ Feature: Search combinations to associate them in the BO
       | lemon_tshirt_m_black | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     # No image can be returned for both products
     When I search for combinations with locale "english" matching "lemon" I should get following results:
-      | product       | combination          | name            | reference | image url                                             |
-      | lemonade_can  |                      | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_s_white | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt   |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | product       | combination          | name                                    | reference | image url                                             |
+      | lemonade_can  |                      | can of lemonade                         |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_s_white | lemon t-shirt: Size - S, Color - White  |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt: Size - S, Color - Black  |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt: Size - M, Color - White  |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt: Size - M, Color - Black  |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
     And I add new image "lemon_image1" named "app_icon.png" to product "lemon_tshirt"
     And I add new image "lemon_image2" named "logo.jpg" to product "lemon_tshirt"
     And I add new image "lemon_image3" named "app_icon.png" to product "lemon_tshirt"
@@ -265,12 +265,12 @@ Feature: Search combinations to associate them in the BO
       | lemon_tshirt_m_black | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemon_image1}-small_default.jpg |
     # Search results follow the same principle
     When I search for combinations with locale "english" matching "lemon" I should get following results:
-      | product       | combination          | name            | reference | image url                                               |
-      | lemonade_can  |                      | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg   |
-      | lemon_tshirt  | lemon_tshirt_s_white | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+      | product       | combination          | name                                    | reference | image url                                               |
+      | lemonade_can  |                      | can of lemonade                         |           | http://myshop.com/img/p/{no_picture}-home_default.jpg   |
+      | lemon_tshirt  | lemon_tshirt_s_white | lemon t-shirt: Size - S, Color - White  |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt: Size - S, Color - Black  |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt: Size - M, Color - White  |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt: Size - M, Color - Black  |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
     And combination "lemon_tshirt_s_white" should have no images
     When I associate "[lemon_image2,lemon_image3]" to combination "lemon_tshirt_s_white"
     Then combination "lemon_tshirt_s_white" should have following images "[lemon_image2,lemon_image3]"
@@ -287,9 +287,9 @@ Feature: Search combinations to associate them in the BO
       | lemon_tshirt_m_black | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      | http://myshop.com/img/p/{lemon_image3}-small_default.jpg |
     # Search results follow the same principle
     When I search for combinations with locale "english" matching "lemon" I should get following results:
-      | product       | combination          | name            | reference | image url                                               |
-      | lemonade_can  |                      | can of lemonade |           | http://myshop.com/img/p/{no_picture}-home_default.jpg   |
-      | lemon_tshirt  | lemon_tshirt_s_white | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image2}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image4}-home_default.jpg |
-      | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt   |           | http://myshop.com/img/p/{lemon_image3}-home_default.jpg |
+      | product       | combination          | name                                   | reference | image url                                               |
+      | lemonade_can  |                      | can of lemonade                        |           | http://myshop.com/img/p/{no_picture}-home_default.jpg   |
+      | lemon_tshirt  | lemon_tshirt_s_white | lemon t-shirt: Size - S, Color - White |           | http://myshop.com/img/p/{lemon_image2}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_s_black | lemon t-shirt: Size - S, Color - Black |           | http://myshop.com/img/p/{lemon_image1}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_white | lemon t-shirt: Size - M, Color - White |           | http://myshop.com/img/p/{lemon_image4}-home_default.jpg |
+      | lemon_tshirt  | lemon_tshirt_m_black | lemon t-shirt: Size - M, Color - Black |           | http://myshop.com/img/p/{lemon_image3}-home_default.jpg |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/search_combinations_for_association.feature
@@ -26,7 +26,6 @@ Feature: Search combinations to associate them in the BO
     And attribute "Blue" named "Blue" in en language exists
     And attribute "Red" named "Red" in en language exists
 
-
   Scenario: I can search combinations by name
     When I add product "beer_bottle" with following information:
       | name[en-US] | bottle of beer     |
@@ -141,6 +140,16 @@ Feature: Search combinations to associate them in the BO
       | mpn                | mpn3white         |
       | reference          | ref3white         |
       | upc                | 354321354321      |
+    # General reference on product will be used for pink wine which has no reference on the combination
+    When I update product "wine_bottle" details with following values:
+      | reference | ref3wine |
+    Then product "wine_bottle" should have following details:
+      | product detail | value    |
+      | isbn           |          |
+      | upc            |          |
+      | ean13          |          |
+      | mpn            |          |
+      | reference      | ref3wine |
     # Search by all types of references matching wine_bottle_red combination
     When I search for combinations with locale "english" matching "154867313573" I should get following results:
       | product     | combination     | name                        | reference | image url                                             |
@@ -173,7 +182,7 @@ Feature: Search combinations to associate them in the BO
     And I search for combinations with locale "english" matching "354321354321" I should get following results:
       | product     | combination       | name                          | reference | image url                                             |
       | wine_bottle | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-    # Search by types that match both combinations, both are returned
+    # Search by types that match multiple combinations
     When I search for combinations with locale "english" matching "mpn3" I should get following results:
       | product     | combination       | name                          | reference | image url                                             |
       | wine_bottle | wine_bottle_red   | bottle of wine: Color - Red   | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
@@ -182,7 +191,8 @@ Feature: Search combinations to associate them in the BO
       | product     | combination       | name                          | reference | image url                                             |
       | wine_bottle | wine_bottle_red   | bottle of wine: Color - Red   | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
       | wine_bottle | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-    # Search by types that match two combinations and a product
+      | wine_bottle | wine_bottle_pink  | bottle of wine: Color - Pink  | ref3wine  | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+    # Search by types that match multiple combinations and a product
     When I search for combinations with locale "english" matching "mpn" I should get following results:
       | product          | combination       | name                          | reference | image url                                             |
       | champaign_bottle |                   | bottle of champaign           | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
@@ -193,6 +203,7 @@ Feature: Search combinations to associate them in the BO
       | champaign_bottle |                   | bottle of champaign           | ref1      | http://myshop.com/img/p/{no_picture}-home_default.jpg |
       | wine_bottle      | wine_bottle_red   | bottle of wine: Color - Red   | ref3red   | http://myshop.com/img/p/{no_picture}-home_default.jpg |
       | wine_bottle      | wine_bottle_white | bottle of wine: Color - White | ref3white | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+      | wine_bottle      | wine_bottle_pink  | bottle of wine: Color - Pink  | ref3wine  | http://myshop.com/img/p/{no_picture}-home_default.jpg |
 
   Scenario: Search results include the appropriate images
     Given following image types should be applicable to products:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -31,7 +31,7 @@ Feature: Duplicate product from Back Office (BO).
       | name[en-US] | Reading glasses |
       | name[fr-FR] | lunettes        |
       | type        | standard        |
-    And I update product "product1" basic information with following values:
+    Given I update product "product1" basic information with following values:
       | description[en-US]       | nice sunglasses            |
       | description[fr-FR]       | belles lunettes            |
       | description_short[en-US] | Simple & nice sunglasses   |
@@ -128,7 +128,7 @@ Feature: Duplicate product from Back Office (BO).
     Then product "product1" should have 1 specific prices
 
   Scenario: I duplicate product
-#todo: add specific prices & priorities, test combinations, packs
+#todo: add specific prices & priorities, test combinations
     When I duplicate product product1 to a copy_of_product1
     And product "copy_of_product1" should be disabled
     And product "copy_of_product1" type should be standard
@@ -249,3 +249,25 @@ Feature: Duplicate product from Back Office (BO).
     When I duplicate product product_with_combinations to a copy_of_product_with_combinations
     Then product "copy_of_product_with_combinations" should have 2 specific prices
     # TODO: all sorts of other checks
+
+  Scenario: I duplicate packed product
+    Given I add product "product3" with following information:
+      | name[en-US] | packed product |
+      | name[fr-FR] | produit packagé|
+      | type        | pack           |
+    And I update pack "product3" with following product quantities:
+      | product  | combination | quantity |
+      | product1 |             | 2        |
+      | product2 |             | 3        |
+    When I duplicate product product3 to a copy_of_product3
+    And product "copy_of_product3" should be disabled
+    And product "copy_of_product3" type should be pack
+    And product "copy_of_product3" localized "name" should be:
+      | locale | value                       |
+      | en-US  | copy of packed product    |
+      | fr-FR  | copie de produit packagé |
+    And pack copy_of_product3 should contain products with following details:
+      | product  | combination | name             | quantity | image url                                              |
+      | product1 |             | smart sunglasses |        2 | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | product2 |             | Reading glasses  |        3 | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -73,9 +73,9 @@ Feature: Add product to pack from Back Office (BO)
       | product  | quantity |
       | product2 | 5        |
     Then product "productPack1" type should be pack
-    And pack "productPack1" should contain products with following quantities:
-      | product  | quantity |
-      | product2 | 5        |
+    And pack "productPack1" should contain products with following details:
+      | product  | combination | name             | quantity | image url                                              |
+      | product2 |             | shady sunglasses | 5        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
 
   Scenario: I add virtual products to a pack
     Given I add product "productPack2" with following information:
@@ -85,9 +85,11 @@ Feature: Add product to pack from Back Office (BO)
     And I add product "product3" with following information:
       | name[en-US] | summerstreet |
       | type        | virtual      |
+    And I add new image "image3" named "logo.jpg" to product "product3"
     And I add product "product4" with following information:
       | name[en-US] | winterstreet |
       | type        | virtual      |
+    And I add new image "image4" named "logo.jpg" to product "product4"
     And product "product3" type should be virtual
     And product "product4" type should be virtual
     When I update pack "productPack2" with following product quantities:
@@ -95,22 +97,22 @@ Feature: Add product to pack from Back Office (BO)
       | product3 | 3        |
       | product4 | 20       |
     Then product "productPack2" type should be pack
-    And pack productPack2 should contain products with following quantities:
-      | product  | quantity |
-      | product3 | 3        |
-      | product4 | 20       |
+    And pack "productPack2" should contain products with following details:
+      | product  | combination | name             | quantity | image url                            |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg |
+      | product4 |             | winterstreet     | 20       | http://myshop.com/img/p/{image4}.jpg |
 
   Scenario: I update pack by removing one of the products
-    Given pack productPack2 should contain products with following quantities:
-      | product  | quantity |
-      | product3 | 3        |
-      | product4 | 20       |
+    When pack productPack2 should contain products with following details:
+      | product  | combination | name             | quantity | image url                            |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg |
+      | product4 |             | winterstreet     | 20       | http://myshop.com/img/p/{image4}.jpg |
     When I update pack "productPack2" with following product quantities:
       | product  | quantity |
       | product3 | 3        |
-    And pack productPack2 should contain products with following quantities:
-      | product  | quantity |
-      | product3 | 3        |
+    And pack "productPack2" should contain products with following details:
+      | product  | combination | name             | quantity | image url                            |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg |
 
   Scenario: I add pack product to a pack
     Given product "productPack1" type should be pack
@@ -131,10 +133,10 @@ Feature: Add product to pack from Back Office (BO)
       | product2 | 2        |
       | product3 | 3        |
     Then product "productPack4" type should be pack
-    And pack productPack4 should contain products with following quantities:
-      | product  | quantity |
-      | product2 | 2        |
-      | product3 | 3        |
+    And pack productPack4 should contain products with following details:
+      | product  | combination | name             | quantity | image url                                              |
+      | product2 |             | shady sunglasses | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg                   |
 
   Scenario: I add product with negative quantity to a pack
     Given product "product2" type should be standard
@@ -147,11 +149,11 @@ Feature: Add product to pack from Back Office (BO)
 
   Scenario: I remove all products from existing pack
     Given product "productPack4" type should be pack
-    And pack productPack4 should contain products with following quantities:
-      | product  | quantity |
-      | product2 | 2        |
-      | product3 | 3        |
-    When I remove all products from pack productPack4
+    When pack productPack4 should contain products with following details:
+      | product  | name             | combination | quantity | image url                                              |
+      | product2 | shady sunglasses |             | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | product3 | summerstreet     |             | 3        | http://myshop.com/img/p/{image3}.jpg                   |
+    And I remove all products from pack productPack4
     Then product "productPack4" type should be pack
     And pack "productPack4" should be empty
 
@@ -160,7 +162,7 @@ Feature: Add product to pack from Back Office (BO)
       | name[en-US] | regular skirt |
       | type        | combinations  |
     When I generate combinations for product productSkirt1 using following attributes:
-      | Size  | [S,M]              |
+      | Size  | [S,M]         |
       | Color | [White,Black] |
     Then product "productSkirt1" should have following combinations:
       | id reference        | combination name        | reference | attributes           | impact on price | quantity | is default |
@@ -168,6 +170,15 @@ Feature: Add product to pack from Back Office (BO)
       | productSkirt1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
       | productSkirt1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
       | productSkirt1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+    And I add new image "skirtWhiteS" named "app_icon.png" to product "productSkirt1"
+    And I add new image "skirtWhiteM" named "logo.jpg" to product "productSkirt1"
+    And I add new image "skirtBlackS" named "app_icon.png" to product "productSkirt1"
+    And I add new image "skirtBlackM" named "logo.jpg" to product "productSkirt1"
+    And I associate "[skirtWhiteS]" to combination "productSkirt1SWhite"
+    And I associate "[skirtBlackS]" to combination "productSkirt1SBlack"
+    And I associate "[skirtWhiteM]" to combination "productSkirt1MWhite"
+    And I associate "[skirtBlackM]" to combination "productSkirt1MBlack"
+    And I add new image "image3" named "logo.jpg" to product "product3"
     And product productSkirt1 type should be combinations
     And product "productPack4" type should be pack
     When I update pack productPack4 with following product quantities:
@@ -176,11 +187,11 @@ Feature: Add product to pack from Back Office (BO)
       | productSkirt1 | productSkirt1MWhite | 11       |
       | productSkirt1 | productSkirt1MBlack | 12       |
     Then product "productPack4" type should be pack
-    And pack productPack4 should contain products with following quantities:
-      | product       | combination         | quantity |
-      | productSkirt1 | productSkirt1SWhite | 10       |
-      | productSkirt1 | productSkirt1MWhite | 11       |
-      | productSkirt1 | productSkirt1MBlack | 12       |
+    And pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg |
 
   Scenario: Add combination & standard product to a pack
     Given product "product2" type should be standard
@@ -198,40 +209,40 @@ Feature: Add product to pack from Back Office (BO)
       | productSkirt1 | productSkirt1MBlack | 12       |
       | product2      |                     | 2        |
     Then product "productPack4" type should be pack
-    And pack productPack4 should contain products with following quantities:
-      | product       | combination         | quantity |
-      | productSkirt1 | productSkirt1SWhite | 10       |
-      | productSkirt1 | productSkirt1MWhite | 11       |
-      | productSkirt1 | productSkirt1MBlack | 12       |
-      | product2      |                     | 2        |
+    And pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
 
   Scenario: I remove one combination of same product from existing pack and change another combination quantity
     Given product "productPack4" type should be pack
-    And pack productPack4 should contain products with following quantities:
-      | product       | combination         | quantity |
-      | productSkirt1 | productSkirt1SWhite | 10       |
-      | productSkirt1 | productSkirt1MWhite | 11       |
-      | productSkirt1 | productSkirt1MBlack | 12       |
-      | product2      |                     | 2        |
-    When I update pack productPack4 with following product quantities:
-      | product       | combination         | quantity |
-      | productSkirt1 | productSkirt1SWhite | 10       |
-      | productSkirt1 | productSkirt1MBlack | 9        |
-      | product2      |                     | 2        |
-    Then pack productPack4 should contain products with following quantities:
+    When pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    And I update pack productPack4 with following product quantities:
       | product       | combination         | quantity |
       | productSkirt1 | productSkirt1SWhite | 10       |
       | productSkirt1 | productSkirt1MBlack | 9        |
       | product2      |                     | 2        |
+    Then pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     Then product "productPack4" type should be pack
 
   Scenario: I remove all products from existing pack when it contains combination and standard products
     Given product "productPack4" type should be pack
-    And pack productPack4 should contain products with following quantities:
-      | product       | combination         | quantity |
-      | productSkirt1 | productSkirt1SWhite | 10       |
-      | productSkirt1 | productSkirt1MBlack | 9        |
-      | product2      |                     | 2        |
-    When I remove all products from pack productPack4
+    When pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    And I remove all products from pack productPack4
     Then product "productPack4" type should be pack
     And pack "productPack4" should be empty

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -172,6 +172,10 @@ Feature: Add product to pack from Back Office (BO)
       | productSkirt1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
       | productSkirt1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
       | productSkirt1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+    And I update product "productSkirt1" details with following values:
+      | reference | productSkirtRef |
+    And I update combination "productSkirt1SWhite" details with following values:
+      | reference | productSkirtSWhiteRef |
     And I add new image "skirtWhiteS" named "app_icon.png" to product "productSkirt1"
     And I add new image "skirtWhiteM" named "logo.jpg" to product "productSkirt1"
     And I add new image "skirtBlackS" named "app_icon.png" to product "productSkirt1"
@@ -180,7 +184,7 @@ Feature: Add product to pack from Back Office (BO)
     And I associate "[skirtBlackS]" to combination "productSkirt1SBlack"
     And I associate "[skirtWhiteM]" to combination "productSkirt1MWhite"
     And I associate "[skirtBlackM]" to combination "productSkirt1MBlack"
-    And I add new image "image3" named "logo.jpg" to product "product3"
+    And I add new image "image3" named "logo.jpg" to product "productSkirt1"
     And product productSkirt1 type should be combinations
     And product "productPack4" type should be pack
     When I update pack productPack4 with following product quantities:
@@ -190,20 +194,20 @@ Feature: Add product to pack from Back Office (BO)
       | productSkirt1 | productSkirt1MBlack | 12       |
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following details:
-      | product       | name                                   | combination         | quantity | image url                                              |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg |
+      | product       | name                                   | combination         | quantity | image url                                 | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg | Ref: productSkirtRef       |
 
   Scenario: Add combination & standard product to a pack
     Given product "product2" type should be standard
     And product productSkirt1 type should be combinations
     And product "productSkirt1" should have following combinations:
-      | id reference        | combination name        | reference | attributes           | impact on price | quantity | is default |
-      | productSkirt1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
-      | productSkirt1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
-      | productSkirt1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
-      | productSkirt1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | id reference        | combination name        | reference             | attributes           | impact on price | quantity | is default |
+      | productSkirt1SWhite | Size - S, Color - White | productSkirtSWhiteRef | [Size:S,Color:White] | 0               | 0        | true       |
+      | productSkirt1SBlack | Size - S, Color - Black |                       | [Size:S,Color:Black] | 0               | 0        | false      |
+      | productSkirt1MWhite | Size - M, Color - White |                       | [Size:M,Color:White] | 0               | 0        | false      |
+      | productSkirt1MBlack | Size - M, Color - Black |                       | [Size:M,Color:Black] | 0               | 0        | false      |
     When I update pack productPack4 with following product quantities:
       | product       | combination         | quantity |
       | productSkirt1 | productSkirt1SWhite | 10       |
@@ -212,11 +216,11 @@ Feature: Add product to pack from Back Office (BO)
       | product2      |                     | 2        |
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following details:
-      | product       | name                                   | combination         | quantity | image url                                              |
-      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              |
-      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              |
-      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
 
   Scenario: I remove one combination of same product from existing pack and change another combination quantity
     Given product "productPack4" type should be pack

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -252,3 +252,29 @@ Feature: Add product to pack from Back Office (BO)
     And I remove all products from pack productPack4
     Then product "productPack4" type should be pack
     And pack "productPack4" should be empty
+
+  Scenario: I remove a product or a combination its relation should also be removed if it was associated with a pack
+    Given I update pack productPack4 with following product quantities:
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MWhite | 11       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
+      | product2      |                     | 2        |
+    Then product "productPack4" type should be pack
+    And pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
+    When I delete product product2
+    Then pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+    When I delete combination productSkirt1MWhite
+    Then pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -278,3 +278,29 @@ Feature: Add product to pack from Back Office (BO)
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
       | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
       | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+
+  Scenario: I cannot change a product type to a pack if it is already associated with a pack
+    Given I add product "product5" with following information:
+      | name[en-US] | shady sunglasses |
+      | type        | standard         |
+    And product "product5" type should be standard
+    Given I update pack productPack4 with following product quantities:
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
+      | product5      |                     | 2        |
+    Then product "productPack4" type should be pack
+    And pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | product5      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |                            |
+    When I update product "product5" type to pack
+    Then I should get error that the product is already associated to a pack
+    And product "product5" type should be standard
+    And product "productPack4" type should be pack
+    And pack productPack4 should contain products with following details:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | product5      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |                            |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -68,14 +68,16 @@ Feature: Add product to pack from Back Office (BO)
     And I add product "product2" with following information:
       | name[en-US] | shady sunglasses |
       | type        | standard         |
+    And I update product "product2" details with following values:
+      | reference | ref1              |
     And product "product2" type should be standard
     When I update pack "productPack1" with following product quantities:
       | product  | quantity |
       | product2 | 5        |
     Then product "productPack1" type should be pack
     And pack "productPack1" should contain products with following details:
-      | product  | combination | name             | quantity | image url                                              |
-      | product2 |             | shady sunglasses | 5        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | product  | combination | name             | quantity | image url                                              | reference |
+      | product2 |             | shady sunglasses | 5        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1 |
 
   Scenario: I add virtual products to a pack
     Given I add product "productPack2" with following information:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
@@ -158,9 +158,9 @@ Feature: Add basic product from Back Office (BO)
       | product  | quantity |
       | product2 | 5        |
     Then product "productPack1" type should be pack
-    And pack "productPack1" should contain products with following quantities:
-      | product  | quantity |
-      | product2 | 5        |
+    And pack "productPack1" should contain products with following details:
+      | product  | combination | quantity | name             | image url                                              |
+      | product2 |             | 5        | shady sunglasses | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     When I update product "productPack1" type to standard
     Then product "productPack1" type should be standard
     And pack "productPack1" should be empty

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
@@ -56,9 +56,9 @@ Feature: Update product stock from Back Office (BO)
       | product  | quantity |
       | product2 | 5        |
     Then product "productPack1" type should be pack
-    And pack "productPack1" should contain products with following quantities:
-      | product  | quantity |
-      | product2 | 5        |
+    And pack "productPack1" should contain products with following details:
+      | product  | combination | quantity | name             | image url                                              |
+      | product2 |             | 5        | shady sunglasses | http://myshop.com/img/p/{no_picture}-small_default.jpg |
     And product "productPack1" should have following stock information:
       | pack_stock_type | default |
     When I update product "productPack1" stock with following information:

--- a/tests/Integration/PrestaShopBundle/Form/EventListener/FormListenerTestCase.php
+++ b/tests/Integration/PrestaShopBundle/Form/EventListener/FormListenerTestCase.php
@@ -95,6 +95,29 @@ class FormListenerTestCase extends KernelTestCase
     /**
      * @param FormInterface $form
      * @param string $typeName
+     * @param bool $shouldExist
+     */
+    protected function assertDataExistsInForm(FormInterface $form, string $typeName, bool $shouldExist): void
+    {
+        $levels = explode('.', $typeName);
+        $data = $form->getData();
+
+        if ($shouldExist) {
+            foreach ($levels as $level) {
+                $this->assertArrayHasKey($level, $data);
+                $data = $data[$level];
+            }
+        } else {
+            foreach ($levels as $level) {
+                $data = $data[$level];
+            }
+            $this->assertNull($data);
+        }
+    }
+
+    /**
+     * @param FormInterface $form
+     * @param string $typeName
      *
      * @return FormInterface
      */

--- a/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
@@ -65,45 +65,65 @@ class ProductTypeListenerTest extends FormListenerTestCase
 
     public function getFormTypeExpectationsBasedOnProductType(): Generator
     {
-        yield [ProductType::TYPE_STANDARD, 'options.product_suppliers', true];
-        yield [ProductType::TYPE_PACK, 'options.product_suppliers', true];
-        yield [ProductType::TYPE_VIRTUAL, 'options.product_suppliers', true];
-        yield [ProductType::TYPE_COMBINATIONS, 'options.product_suppliers', false];
+        yield 'pack in standard context' => [ProductType::TYPE_STANDARD, 'stock.packed_products', false];
+        yield 'pack in pack context' => [ProductType::TYPE_PACK, 'stock.packed_products', true];
+        yield 'pack in combination context' => [ProductType::TYPE_COMBINATIONS, 'stock.packed_products', false];
+        yield 'pack in virtual context' => [ProductType::TYPE_VIRTUAL, 'stock.packed_products', false];
 
-        yield [ProductType::TYPE_STANDARD, 'stock', true];
-        yield [ProductType::TYPE_PACK, 'stock', true];
-        yield [ProductType::TYPE_VIRTUAL, 'stock', true];
-        yield [ProductType::TYPE_COMBINATIONS, 'stock', false];
+        yield 'product_supplier in standard context' => [ProductType::TYPE_STANDARD, 'options.product_suppliers', true];
+        yield 'product_supplier in pack context' => [ProductType::TYPE_PACK, 'options.product_suppliers', true];
+        yield 'product_supplier in virtual context' => [ProductType::TYPE_VIRTUAL, 'options.product_suppliers', true];
+        yield 'product_supplier in combination context' => [ProductType::TYPE_COMBINATIONS, 'options.product_suppliers', false];
 
-        yield [ProductType::TYPE_STANDARD, 'shipping', true];
-        yield [ProductType::TYPE_PACK, 'shipping', true];
-        yield [ProductType::TYPE_VIRTUAL, 'shipping', false];
-        yield [ProductType::TYPE_COMBINATIONS, 'shipping', true];
+        yield 'stock in standard context' => [ProductType::TYPE_STANDARD, 'stock', true];
+        yield 'stock in pack context' => [ProductType::TYPE_PACK, 'stock', true];
+        yield 'stock in combination context' => [ProductType::TYPE_VIRTUAL, 'stock', true];
+        yield 'stock in virtual context' => [ProductType::TYPE_COMBINATIONS, 'stock', false];
 
-        yield [ProductType::TYPE_STANDARD, 'stock.pack_stock_type', false];
-        yield [ProductType::TYPE_PACK, 'stock.pack_stock_type', true];
-        yield [ProductType::TYPE_VIRTUAL, 'stock.pack_stock_type', false];
-        yield [ProductType::TYPE_COMBINATIONS, 'stock.pack_stock_type', false];
+        yield 'shipping in standard context' => [ProductType::TYPE_STANDARD, 'shipping', true];
+        yield 'shipping in pack context' => [ProductType::TYPE_PACK, 'shipping', true];
+        yield 'shipping in combination context' => [ProductType::TYPE_VIRTUAL, 'shipping', false];
+        yield 'shipping in virtual context' => [ProductType::TYPE_COMBINATIONS, 'shipping', true];
 
-        yield [ProductType::TYPE_STANDARD, 'stock.virtual_product_file', false];
-        yield [ProductType::TYPE_PACK, 'stock.virtual_product_file', false];
-        yield [ProductType::TYPE_VIRTUAL, 'stock.virtual_product_file', true];
-        yield [ProductType::TYPE_COMBINATIONS, 'stock.virtual_product_file', false];
+        yield 'retail_price.ecotax in standard context' => [ProductType::TYPE_STANDARD, 'pricing.retail_price.ecotax', true];
+        yield 'retail_price.ecotax in pack context' => [ProductType::TYPE_PACK, 'pricing.retail_price.ecotax', true];
+        yield 'retail_price.ecotax in virtual context' => [ProductType::TYPE_VIRTUAL, 'pricing.retail_price.ecotax', false];
+        yield 'retail_price.ecotax in combination context' => [ProductType::TYPE_COMBINATIONS, 'pricing.retail_price.ecotax', true];
 
-        yield [ProductType::TYPE_STANDARD, 'combinations', false];
-        yield [ProductType::TYPE_PACK, 'combinations', false];
-        yield [ProductType::TYPE_VIRTUAL, 'combinations', false];
-        yield [ProductType::TYPE_COMBINATIONS, 'combinations', true];
+        yield 'pack_stock_type in standard context' => [ProductType::TYPE_STANDARD, 'stock.pack_stock_type', false];
+        yield 'pack_stock_type in pack context' => [ProductType::TYPE_PACK, 'stock.pack_stock_type', true];
+        yield 'pack_stock_type in combination context' => [ProductType::TYPE_VIRTUAL, 'stock.pack_stock_type', false];
+        yield 'pack_stock_type in virtual context' => [ProductType::TYPE_COMBINATIONS, 'stock.pack_stock_type', false];
 
-        yield [ProductType::TYPE_STANDARD, 'pricing.retail_price.ecotax_tax_excluded', true];
-        yield [ProductType::TYPE_PACK, 'pricing.retail_price.ecotax_tax_excluded', true];
-        yield [ProductType::TYPE_VIRTUAL, 'pricing.retail_price.ecotax_tax_excluded', false];
-        yield [ProductType::TYPE_COMBINATIONS, 'pricing.retail_price.ecotax_tax_excluded', true];
+        yield 'virtual_product_file in standard context' => [ProductType::TYPE_STANDARD, 'stock.virtual_product_file', false];
+        yield 'virtual_product_file in pack context' => [ProductType::TYPE_PACK, 'stock.virtual_product_file', false];
+        yield 'virtual_product_file in combination context' => [ProductType::TYPE_VIRTUAL, 'stock.virtual_product_file', true];
+        yield 'virtual_product_file in virtual context' => [ProductType::TYPE_COMBINATIONS, 'stock.virtual_product_file', false];
 
-        yield [ProductType::TYPE_STANDARD, 'pricing.retail_price.ecotax_tax_included', true];
-        yield [ProductType::TYPE_PACK, 'pricing.retail_price.ecotax_tax_included', true];
-        yield [ProductType::TYPE_VIRTUAL, 'pricing.retail_price.ecotax_tax_included', false];
-        yield [ProductType::TYPE_COMBINATIONS, 'pricing.retail_price.ecotax_tax_included', true];
+        yield 'pack_stock_type in standard context' => [ProductType::TYPE_STANDARD, 'stock.pack_stock_type', false];
+        yield 'pack_stock_type in pack context' => [ProductType::TYPE_PACK, 'stock.pack_stock_type', true];
+        yield 'pack_stock_type in combination context' => [ProductType::TYPE_VIRTUAL, 'stock.pack_stock_type', false];
+        yield 'pack_stock_type in virtual context' => [ProductType::TYPE_COMBINATIONS, 'stock.pack_stock_type', false];
+
+        yield 'virtual_product_file in standard context' => [ProductType::TYPE_STANDARD, 'stock.virtual_product_file', false];
+        yield 'virtual_product_file in pack context' => [ProductType::TYPE_PACK, 'stock.virtual_product_file', false];
+        yield 'virtual_product_file in combination context' => [ProductType::TYPE_VIRTUAL, 'stock.virtual_product_file', true];
+        yield 'virtual_product_file in virtual context' => [ProductType::TYPE_COMBINATIONS, 'stock.virtual_product_file', false];
+
+        yield 'combinations in standard context' => [ProductType::TYPE_STANDARD, 'combinations', false];
+        yield 'combinations in pack context' => [ProductType::TYPE_PACK, 'combinations', false];
+        yield 'combinations in virtual context' => [ProductType::TYPE_VIRTUAL, 'combinations', false];
+        yield 'combinations in combination context' => [ProductType::TYPE_COMBINATIONS, 'combinations', true];
+
+        yield 'ecotax_tax_excluded in standard context' => [ProductType::TYPE_STANDARD, 'pricing.retail_price.ecotax_tax_excluded', true];
+        yield 'ecotax_tax_excluded in pack context' => [ProductType::TYPE_PACK, 'pricing.retail_price.ecotax_tax_excluded', true];
+        yield 'ecotax_tax_excluded in virtual context' => [ProductType::TYPE_VIRTUAL, 'pricing.retail_price.ecotax_tax_excluded', false];
+        yield 'ecotax_tax_excluded in combination context' => [ProductType::TYPE_COMBINATIONS, 'pricing.retail_price.ecotax_tax_excluded', true];
+
+        yield 'ecotax_tax_included in standard context' => [ProductType::TYPE_STANDARD, 'pricing.retail_price.ecotax_tax_included', true];
+        yield 'ecotax_tax_included in pack context' => [ProductType::TYPE_PACK, 'pricing.retail_price.ecotax_tax_included', true];
+        yield 'ecotax_tax_included in virtual context' => [ProductType::TYPE_VIRTUAL, 'pricing.retail_price.ecotax_tax_included', false];
+        yield 'ecotax_tax_included in combination context' => [ProductType::TYPE_COMBINATIONS, 'pricing.retail_price.ecotax_tax_included', true];
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace Tests\Integration\PrestaShopBundle\Form\EventListener;
 
-use Generator;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShopBundle\Form\Admin\Sell\Product\EventListener\ProductTypeListener;
 use Symfony\Component\Form\FormEvents;
@@ -63,13 +62,8 @@ class ProductTypeListenerTest extends FormListenerTestCase
         $this->assertFormTypeExistsInForm($form, $formTypeName, $shouldExist);
     }
 
-    public function getFormTypeExpectationsBasedOnProductType(): Generator
+    public function getFormTypeExpectationsBasedOnProductType(): iterable
     {
-        yield 'pack in standard context' => [ProductType::TYPE_STANDARD, 'stock.packed_products', false];
-        yield 'pack in pack context' => [ProductType::TYPE_PACK, 'stock.packed_products', true];
-        yield 'pack in combination context' => [ProductType::TYPE_COMBINATIONS, 'stock.packed_products', false];
-        yield 'pack in virtual context' => [ProductType::TYPE_VIRTUAL, 'stock.packed_products', false];
-
         yield 'product_supplier in standard context' => [ProductType::TYPE_STANDARD, 'options.product_suppliers', true];
         yield 'product_supplier in pack context' => [ProductType::TYPE_PACK, 'options.product_suppliers', true];
         yield 'product_supplier in virtual context' => [ProductType::TYPE_VIRTUAL, 'options.product_suppliers', true];
@@ -90,15 +84,10 @@ class ProductTypeListenerTest extends FormListenerTestCase
         yield 'retail_price.ecotax in virtual context' => [ProductType::TYPE_VIRTUAL, 'pricing.retail_price.ecotax', false];
         yield 'retail_price.ecotax in combination context' => [ProductType::TYPE_COMBINATIONS, 'pricing.retail_price.ecotax', true];
 
-        yield 'pack_stock_type in standard context' => [ProductType::TYPE_STANDARD, 'stock.pack_stock_type', false];
-        yield 'pack_stock_type in pack context' => [ProductType::TYPE_PACK, 'stock.pack_stock_type', true];
-        yield 'pack_stock_type in combination context' => [ProductType::TYPE_VIRTUAL, 'stock.pack_stock_type', false];
-        yield 'pack_stock_type in virtual context' => [ProductType::TYPE_COMBINATIONS, 'stock.pack_stock_type', false];
-
-        yield 'virtual_product_file in standard context' => [ProductType::TYPE_STANDARD, 'stock.virtual_product_file', false];
-        yield 'virtual_product_file in pack context' => [ProductType::TYPE_PACK, 'stock.virtual_product_file', false];
-        yield 'virtual_product_file in combination context' => [ProductType::TYPE_VIRTUAL, 'stock.virtual_product_file', true];
-        yield 'virtual_product_file in virtual context' => [ProductType::TYPE_COMBINATIONS, 'stock.virtual_product_file', false];
+        yield 'pack in standard context' => [ProductType::TYPE_STANDARD, 'stock.packed_products', false];
+        yield 'pack in pack context' => [ProductType::TYPE_PACK, 'stock.packed_products', true];
+        yield 'pack in combination context' => [ProductType::TYPE_COMBINATIONS, 'stock.packed_products', false];
+        yield 'pack in virtual context' => [ProductType::TYPE_VIRTUAL, 'stock.packed_products', false];
 
         yield 'pack_stock_type in standard context' => [ProductType::TYPE_STANDARD, 'stock.pack_stock_type', false];
         yield 'pack_stock_type in pack context' => [ProductType::TYPE_PACK, 'stock.pack_stock_type', true];
@@ -143,7 +132,7 @@ class ProductTypeListenerTest extends FormListenerTestCase
         $this->adaptProductFormBasedOnProductType($form, $newProductType);
     }
 
-    public function getFormTypeSwitching(): Generator
+    public function getFormTypeSwitching(): iterable
     {
         $productTypes = [
             ProductType::TYPE_STANDARD,

--- a/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
@@ -79,11 +79,6 @@ class ProductTypeListenerTest extends FormListenerTestCase
         yield 'shipping in combination context' => [ProductType::TYPE_VIRTUAL, 'shipping', false];
         yield 'shipping in virtual context' => [ProductType::TYPE_COMBINATIONS, 'shipping', true];
 
-        yield 'retail_price.ecotax in standard context' => [ProductType::TYPE_STANDARD, 'pricing.retail_price.ecotax', true];
-        yield 'retail_price.ecotax in pack context' => [ProductType::TYPE_PACK, 'pricing.retail_price.ecotax', true];
-        yield 'retail_price.ecotax in virtual context' => [ProductType::TYPE_VIRTUAL, 'pricing.retail_price.ecotax', false];
-        yield 'retail_price.ecotax in combination context' => [ProductType::TYPE_COMBINATIONS, 'pricing.retail_price.ecotax', true];
-
         yield 'pack in standard context' => [ProductType::TYPE_STANDARD, 'stock.packed_products', false];
         yield 'pack in pack context' => [ProductType::TYPE_PACK, 'stock.packed_products', true];
         yield 'pack in combination context' => [ProductType::TYPE_COMBINATIONS, 'stock.packed_products', false];

--- a/tests/Integration/PrestaShopBundle/Form/TestProductFormType.php
+++ b/tests/Integration/PrestaShopBundle/Form/TestProductFormType.php
@@ -54,12 +54,13 @@ class TestProductFormType extends CommonAbstractType
         ;
 
         $stockForm = $builder->get('stock');
+        $stockForm->add('packed_products', FormType::class);
         $stockForm->add('pack_stock_type', ChoiceType::class);
         $stockForm->add('virtual_product_file', FormType::class);
         $stockForm->add('quantities', FormType::class);
 
-        $quantitiesForm = $stockForm->get('quantities');
-        $quantitiesForm->add('stock_movements', FormType::class);
+        $quantities = $stockForm->get('quantities');
+        $quantities->add('stock_movements', FormType::class);
 
         $optionsForm = $builder->get('options');
         $optionsForm->add('product_suppliers', ChoiceType::class);

--- a/tests/Resources/Translator/DummyTranslator.php
+++ b/tests/Resources/Translator/DummyTranslator.php
@@ -25,28 +25,45 @@
  */
 declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder;
+namespace Tests\Resources\Translator;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CombinationAttributeInformation;
+use Symfony\Component\Translation\TranslatorInterface;
 
-interface CombinationNameBuilderInterface
+class DummyTranslator implements TranslatorInterface
 {
     /**
-     * Build combination name from related attributes and attribute group names
-     *
-     * @param CombinationAttributeInformation[] $attributesInfo
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function buildName(array $attributesInfo): string;
+    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null): string
+    {
+        return 'not implemented yet';
+    }
 
     /**
-     * Build combination full name from related product and attributes and attribute group names
-     *
-     * @param string $productName
-     * @param CombinationAttributeInformation[] $attributesInfo
-     *
-     * @return string
+     * {@inheritdoc}
      */
-    public function buildFullName(string $productName, array $attributesInfo): string;
+    public function setLocale($locale)
+    {
+        // not implemented yet
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLocale()
+    {
+        return 'not implemented yet';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function trans($id, array $parameters = [], $domain = null, $locale = null)
+    {
+        return str_replace(
+            array_keys($parameters),
+            array_values($parameters),
+            $id
+        );
+    }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/PackedProductsCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/PackedProductsCommandsBuilderTest.php
@@ -30,6 +30,7 @@ namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\RemoveAllProductsFromPackCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\SetPackProductsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\PackedProductsCommandsBuilder;
 
 class PackedProductsCommandsBuilderTest extends AbstractProductCommandBuilderTest
@@ -69,6 +70,35 @@ class PackedProductsCommandsBuilderTest extends AbstractProductCommandBuilderTes
                     'packed_products' => [],
                 ],
             ],
+            [],
+        ];
+
+        yield [
+            [
+                'stock' => [
+                    'packed_products' => [
+                        [
+                            'product_id' => 23,
+                            'name' => 'dontcare',
+                            'image' => 'notused',
+                            'quantity' => 3,
+                            'combination_id' => 0,
+                        ],
+                    ],
+                ],
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'header' => [
+                    'initial_type' => ProductType::TYPE_PACK,
+                ],
+                'stock' => [
+                    'packed_products' => [],
+                ],
+            ],
             [new RemoveAllProductsFromPackCommand($this->getProductId()->getValue())],
         ];
 
@@ -84,6 +114,9 @@ class PackedProductsCommandsBuilderTest extends AbstractProductCommandBuilderTes
         );
         yield [
             [
+                'header' => [
+                    'initial_type' => ProductType::TYPE_PACK,
+                ],
                 'stock' => [
                     'packed_products' => [
                         [
@@ -116,6 +149,9 @@ class PackedProductsCommandsBuilderTest extends AbstractProductCommandBuilderTes
         );
         yield [
             [
+                'header' => [
+                    'initial_type' => ProductType::TYPE_PACK,
+                ],
                 'stock' => [
                     'packed_products' => [
                         [

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/PackedProductsCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/PackedProductsCommandsBuilderTest.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\RemoveAllProductsFromPackCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\SetPackProductsCommand;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\PackedProductsCommandsBuilder;
+
+class PackedProductsCommandsBuilderTest extends AbstractProductCommandBuilderTest
+{
+    /**
+     * @dataProvider getExpectedCommands
+     *
+     * @param array $formData
+     * @param array $expectedCommands
+     */
+    public function testBuildCommand(array $formData, array $expectedCommands)
+    {
+        $builder = new PackedProductsCommandsBuilder();
+        $builtCommands = $builder->buildCommands($this->getProductId(), $formData);
+        $this->assertEquals($expectedCommands, $builtCommands);
+    }
+
+    public function getExpectedCommands(): iterable
+    {
+        yield [
+            [
+                'random' => ['useless'],
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'stock' => [],
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'stock' => [
+                    'packed_products' => [],
+                ],
+            ],
+            [new RemoveAllProductsFromPackCommand($this->getProductId()->getValue())],
+        ];
+
+        $command = new SetPackProductsCommand(
+            $this->getProductId()->getValue(),
+            [
+                [
+                    'product_id' => 23,
+                    'quantity' => 3,
+                    'combination_id' => 0,
+                ],
+            ]
+        );
+        yield [
+            [
+                'stock' => [
+                    'packed_products' => [
+                        [
+                            'product_id' => 23,
+                            'name' => 'dontcare',
+                            'image' => 'notused',
+                            'quantity' => 3,
+                            'combination_id' => 0,
+                        ],
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new SetPackProductsCommand(
+            $this->getProductId()->getValue(),
+            [
+                [
+                    'product_id' => 23,
+                    'quantity' => 3,
+                    'combination_id' => 0,
+                ],
+                [
+                    'product_id' => 42,
+                    'quantity' => 5,
+                    'combination_id' => 0,
+                ],
+            ]
+        );
+        yield [
+            [
+                'stock' => [
+                    'packed_products' => [
+                        [
+                            'product_id' => 23,
+                            'name' => 'dontcare',
+                            'image' => 'notused',
+                            'quantity' => 3,
+                            'combination_id' => 0,
+                        ],
+                        [
+                            'product_id' => '42',
+                            'name' => 'dontcare',
+                            'image' => 'notused',
+                            'quantity' => 5,
+                            'combination_id' => 0,
+                        ],
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -307,6 +307,7 @@ class ProductFormDataProviderTest extends TestCase
         $expectedOutputData['header']['name'] = $localizedValues;
         $expectedOutputData['header']['initial_type'] = ProductType::TYPE_VIRTUAL;
         $expectedOutputData['header']['type'] = ProductType::TYPE_VIRTUAL;
+        $expectedOutputData['header']['initial_type'] = ProductType::TYPE_VIRTUAL;
         $expectedOutputData['header']['cover_thumbnail'] = $newCover;
 
         $expectedOutputData['description']['description'] = $localizedValues;

--- a/tests/Unit/Core/Product/Combination/NameBuilder/CombinationNameBuilderTest.php
+++ b/tests/Unit/Core/Product/Combination/NameBuilder/CombinationNameBuilderTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CombinationAttributeInformation;
 use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilder;
+use Tests\Resources\Translator\DummyTranslator;
 
 class CombinationNameBuilderTest extends TestCase
 {
@@ -43,8 +44,35 @@ class CombinationNameBuilderTest extends TestCase
      */
     public function testItBuildsCombinationName(array $combinationAttributesInfo, string $expected): void
     {
-        $nameBuilder = new CombinationNameBuilder();
+        $nameBuilder = new CombinationNameBuilder(
+            new DummyTranslator(),
+            ', ',
+            '-'
+        );
+
         $actual = $nameBuilder->buildName($combinationAttributesInfo);
+
+        Assert::assertSame($expected, $actual);
+    }
+
+    /**
+     * @dataProvider getDataForTestItBuildsCombinationFullName
+     *
+     * @param array $productNameAndCombinationAttributesInfo
+     * @param string $expected
+     */
+    public function testItBuildsCombinationFullName(array $productNameAndCombinationAttributesInfo, string $expected): void
+    {
+        $nameBuilder = new CombinationNameBuilder(
+            new DummyTranslator(),
+            ', ',
+            '-'
+        );
+
+        $actual = $nameBuilder->buildFullName(
+            $productNameAndCombinationAttributesInfo['productName'],
+            $productNameAndCombinationAttributesInfo['combinationAttributesInfo']
+        );
 
         Assert::assertSame($expected, $actual);
     }
@@ -54,49 +82,96 @@ class CombinationNameBuilderTest extends TestCase
      */
     public function getDataForTestItBuildsCombinationName(): Generator
     {
-        yield [[
-            new CombinationAttributeInformation(
-                1,
-                'Size',
-                1,
-                'S'
-            ),
-            new CombinationAttributeInformation(
-                2,
-                'Color',
-                5,
-                'Grey'
-            ),
-            new CombinationAttributeInformation(
-                3,
-                'Dimension',
-                19,
-                '40x60cm'
-            ),
-        ], 'Size - S, Color - Grey, Dimension - 40x60cm'];
+        foreach ($this->getCombinationNameData() as $data) {
+            $data = array_values($data)[0];
+            yield $data;
+        }
+    }
 
-        yield [[
-            new CombinationAttributeInformation(
-                2,
-                'Color',
-                5,
-                'Grey'
-            ),
-            new CombinationAttributeInformation(
-                3,
-                'Dimension',
-                19,
-                '40x60cm'
-            ),
-        ], 'Color - Grey, Dimension - 40x60cm'];
+    public function getCombinationNameData(): Generator
+    {
+        yield [
+            'SGrey40x60' => [
+                [
+                    new CombinationAttributeInformation(
+                        1,
+                        'Size',
+                        1,
+                        'S'
+                    ),
+                    new CombinationAttributeInformation(
+                        2,
+                        'Color',
+                        5,
+                        'Grey'
+                    ),
+                    new CombinationAttributeInformation(
+                        3,
+                        'Dimension',
+                        19,
+                        '40x60cm'
+                    ),
+                ],
+                'Size - S, Color - Grey, Dimension - 40x60cm',
+            ],
+        ];
 
-        yield [[
-            new CombinationAttributeInformation(
-                2,
-                'Color',
-                5,
-                'Grey'
-            ),
-        ], 'Color - Grey'];
+        yield [
+            'Grey40x60' => [
+                [
+                    new CombinationAttributeInformation(
+                        2,
+                        'Color',
+                        5,
+                        'Grey'
+                    ),
+                    new CombinationAttributeInformation(
+                        3,
+                        'Dimension',
+                        19,
+                        '40x60cm'
+                    ),
+                ],
+                'Color - Grey, Dimension - 40x60cm',
+            ],
+        ];
+
+        yield [
+            'Grey' => [
+                [
+                    new CombinationAttributeInformation(
+                        2,
+                        'Color',
+                        5,
+                        'Grey'
+                    ),
+                ],
+                'Color - Grey',
+            ],
+        ];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getDataForTestItBuildsCombinationFullName(): Generator
+    {
+        $productType = [
+            'SGrey40x60' => 'Shirt',
+            'Grey40x60' => 'Frame',
+            'Grey' => 'Mug',
+        ];
+
+        foreach ($this->getCombinationNameData() as $data) {
+            foreach ($data as $combinationName => $expected) {
+                yield [
+                    [
+                        'combinationAttributesInfo' => array_values($expected)[0],
+                        'productName' => $productType[$combinationName],
+                    ],
+                    $productType[$combinationName] . ': ' . array_values($expected)[1],
+                ];
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Packed products management on page product V2
| Type?             | new feature
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     |  Fix #28957
| How to test?      | Try the whole lifecycle of a pack<br><ul><li>open a packed object</li><li>change quantities and persist</li><li>remove product from package and persist</li><li>add a product (combinated or not) and persist</li></ul>
| Possible impacts? | don't know

:notebook:  BC Breaks

In src/Adapter/Product/Pack/Repository/ProductPackRepository.php :
- Added constructor that takes 2 parameters (a Connection and string as dbPrefix)

In src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php : 
- Added 2 more parameters (RouterInterface $router and  string $employeeIsoCode)

In src/Core/Domain/Product/Pack/Query/GetPackedProducts.php : 
- Added one parameter int $languageId

## Specs
https://build.prestashop.com/prestashop-specs/1.7/back-office/catalog/products/add-edit-v2.html#pack-tab

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27304)
<!-- Reviewable:end -->
