### PR TITLE
Fix form mapper to handle mapping with only one selector

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/form-object-mapper.ts
+++ b/admin-dev/themes/new-theme/js/components/form/form-object-mapper.ts
@@ -181,7 +181,12 @@ export default class FormObjectMapper {
       return undefined;
     }
 
-    const inputNames = this.fullModelMapping[modelKey];
+    let inputNames = this.fullModelMapping[modelKey];
+
+    // Turn single identifier into array to limit duplicated code in the following code
+    if (!Array.isArray(inputNames)) {
+      inputNames = [inputNames];
+    }
 
     // We must loop manually to keep the order in configuration,
     // if we use jQuery multiple selectors the collection


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A bug was introduced in this PR https://github.com/PrestaShop/PrestaShop/pull/27273 which removed multiple selectors from the mapping it turns out one part of the form mapper code didn't handle single selector correctly There was a js error which broke all the other JS features
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27316
| How to test?      | Open the page V2 the images and combination tab should work correctly again
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27317)
<!-- Reviewable:end -->
