### PR TITLE
Handle product tags in v2 page

### DIFF
--- a/admin-dev/themes/new-theme/js/components/taggable-field.ts
+++ b/admin-dev/themes/new-theme/js/components/taggable-field.ts
@@ -27,7 +27,83 @@ const {$} = window;
 
 interface TaggableFieldParams {
   tokenFieldSelector: string;
-  options: any;
+  options: TaggableFieldOptions;
+}
+interface TaggableFieldOptions {
+  /**
+   * Tokens (or tags). Can be:
+   * - a string with comma-separated values ("one,two,three")
+   * - an array of strings (["one","two","three"])
+   * - an array of objects ([{ value: "one", label: "Einz" }, { value: "two", label: "Zwei" }])
+   * @default []
+   */
+  tokens?: string | string[],
+  /**
+   * Maximum number of tokens allowed. 0 = unlimited
+   * @default 0
+   */
+  limit?: number,
+  /**
+   * Minimum length required for token value.
+   * @default 0
+   */
+  minLength?: number,
+  /**
+   * Minimum input field width. In pixels.
+   * @default 60
+   */
+  minWidth?: number,
+  /**
+   * jQuery UI Autocomplete options
+   * @default {}
+   */
+  autocomplete?: any,
+  /**
+   * Whether to show autocomplete suggestions menu on focus or not. Works only for jQuery UI Autocomplete,
+   * as Typeahead has no support for this kind of behavior.
+   * @default false
+   */
+  showAutocompleteOnFocus?: boolean,
+  /**
+   * Arguments for Twitter Typeahead. The first argument should be an options hash (or null if you want to use the
+   * defaults). The second argument should be a dataset. You can add multiple datasets:
+   * typeahead: [options, dataset1, dataset2]
+   * @default {}
+   */
+  typeahead?: any,
+  /**
+   * Whether to turn input into tokens when tokenfield loses focus or not.
+   * @default false
+   */
+  createTokensOnBlur?: boolean,
+  /**
+   * A character or an array of characters that will trigger token creation on keypress event. Defaults to ',' (comma).
+   * Note - this does not affect Enter or Tab keys, as they are handled in the keydown event. The first delimiter will
+   * be used as a separator when getting the list of tokens or copy-pasting tokens.
+   * @default ','
+   */
+  delimiter?: string | string[],
+  /**
+   * Whether to insert spaces after each token when getting a comma-separated list of tokens. This affects both value
+   * returned by getTokensList() and the value of the original input field.
+   * @default true
+   */
+  beautify?: boolean,
+  /**
+   * HTML type attribute for the token input. This is useful for specifying an HTML5 input type like 'email', 'url' or
+   * 'tel' which allows mobile browsers to show a specialized virtual keyboard optimized for different types of input.
+   * This only sets the type of the visible token input but does not touch the original input field. So you may set
+   * the original input to have type="text" but set this inputType option to 'email' if you only want to take advantage
+   * of the email style keyboard on mobile, but don't want to enable HTML5 native email validation on the original
+   * hidden input.
+   * @default 'text'
+   */
+  inputType?: string,
+  /**
+   * Limit the number of characters allowed by token.
+   * @default 0
+   */
+  maxCharacters?: number;
 }
 
 /**
@@ -43,5 +119,12 @@ export default class TaggableField {
    */
   constructor({tokenFieldSelector, options = {}}: TaggableFieldParams) {
     $(tokenFieldSelector).tokenfield(options);
+
+    const maxCharacters: number = options.maxCharacters || 0;
+
+    if (maxCharacters > 0) {
+      const $inputFields = $(tokenFieldSelector).siblings('.token-input');
+      $inputFields.prop('maxlength', maxCharacters);
+    }
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
@@ -81,7 +81,6 @@ export default class ProductSEOManager {
       options: {
         createTokensOnBlur: true,
         delimiter: ',',
-        minWidth: '768px',
       },
     });
   }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
@@ -81,6 +81,7 @@ export default class ProductSEOManager {
       options: {
         createTokensOnBlur: true,
         delimiter: ',',
+        minWidth: '768px',
       },
     });
   }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
@@ -26,6 +26,7 @@ import Serp from '@app/utils/serp';
 import {EventEmitter} from 'events';
 import RedirectOptionManager from '@pages/product/edit/redirect-option-manager';
 import ProductMap from '@pages/product/product-map';
+import TaggableField from '@components/taggable-field';
 
 const {$} = window;
 
@@ -74,5 +75,12 @@ export default class ProductSEOManager {
       },
       previewUrl,
     );
+
+    new TaggableField({
+      tokenFieldSelector: ProductMap.seo.tagFields,
+      options: {
+        createTokensOnBlur: true,
+      },
+    });
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
@@ -81,6 +81,8 @@ export default class ProductSEOManager {
       options: {
         createTokensOnBlur: true,
         delimiter: ',',
+        // Tag entity is limited to 32 characters
+        maxCharacters: 32,
       },
     });
   }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
@@ -80,6 +80,7 @@ export default class ProductSEOManager {
       tokenFieldSelector: ProductMap.seo.tagFields,
       options: {
         createTokensOnBlur: true,
+        delimiter: ',',
       },
     });
   }

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -162,6 +162,8 @@ export default {
     defaultDescription: '.serp-default-description',
     watchedDescription: '.serp-watched-description',
     watchedMetaUrl: '.serp-watched-url:input',
+    // @TODO(NeOMakinG): This feels weird, we would prefer selecting a js- class only instead
+    // But it's linked to a class duplicate in the taggable field markup not linked to the current PR
     tagFields: 'input.js-taggable-field',
     redirectOption: {
       typeInput: '#product_seo_redirect_option_type',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -162,6 +162,7 @@ export default {
     defaultDescription: '.serp-default-description',
     watchedDescription: '.serp-watched-description',
     watchedMetaUrl: '.serp-watched-url:input',
+    tagFields: 'input.js-taggable-field',
     redirectOption: {
       typeInput: '#product_seo_redirect_option_type',
       targetInput: '#product_seo_redirect_option_target',

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1121,14 +1121,6 @@ $product-page-padding-bottom: 80px !default;
     }
   }
 
-  #form_step6_tags .token-input {
-    min-width: 768px;
-  }
-
-  #form_step3_tags .token-input {
-    min-width: 768px;
-  }
-
   .alert-info {
     &.alert-experimental {
       &::before {
@@ -1287,7 +1279,9 @@ $product-page-padding-bottom: 80px !default;
     }
   }
 
+  // @TODO(NeOMakinG): Most of these styles could be moved to the global tokenfield style
   .tokenfield {
+    min-height: 100%;
     padding: 0.15rem;
 
     .token {
@@ -1309,10 +1303,27 @@ $product-page-padding-bottom: 80px !default;
       }
     }
 
-    @media only screen and (min-width: 768px) {
-      .token-input {
-        min-width: 768px;
-      }
+    // @TODO(NeOMakinG): This could probably be done on every token-input of the BO
+    input.token-input[type="text"] {
+      // stylelint-disable-next-line declaration-no-important
+      width: 100% !important;
+      max-width: 768px;
+    }
+  }
+
+  // @TODO(NeOMakinG): Moove this to a global file, because every locale-input-group should be the same
+  // But it can be done in this PR as it require more global QA on every forms
+  .locale-input-group {
+    flex-wrap: nowrap;
+
+    > div {
+      flex-shrink: 1;
+      width: 100%;
+    }
+
+    .dropdown {
+      flex-shrink: 0;
+      width: auto;
     }
   }
 }

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1340,8 +1340,10 @@ $product-page-padding-bottom: 80px !default;
   }
 
   .tokenfield {
+    padding: 0.15rem;
+
     .token {
-      padding: 0.5rem 0.8rem;
+      padding: 0.4rem 0.7rem;
       background-color: $gray-medium;
       @include border-radius(0.25rem);
 

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1286,6 +1286,35 @@ $product-page-padding-bottom: 80px !default;
       }
     }
   }
+
+  .tokenfield {
+    padding: 0.15rem;
+
+    .token {
+      padding: 0.4rem 0.7rem;
+      background-color: $gray-medium;
+      @include border-radius(0.25rem);
+
+      .close {
+        float: left;
+        margin: 0 0.4rem 0 0;
+        font-size: 1.5rem;
+        line-height: 1rem;
+        color: $white;
+        opacity: 1;
+
+        &:hover {
+          opacity: 0.5;
+        }
+      }
+    }
+
+    @media only screen and (min-width: 768px) {
+      .token-input {
+        min-width: 768px;
+      }
+    }
+  }
 }
 
 // Some of the following styles target product page v2 components, but since the are new and only used in the new
@@ -1336,33 +1365,6 @@ $product-page-padding-bottom: 80px !default;
 
     .material-icons {
       color: $brand-primary;
-    }
-  }
-
-  .tokenfield {
-    padding: 0.15rem;
-
-    .token {
-      padding: 0.4rem 0.7rem;
-      background-color: $gray-medium;
-      @include border-radius(0.25rem);
-
-      .close {
-        float: left;
-        margin: 0 0.4rem 0 0;
-        font-size: 1.5rem;
-        line-height: 1rem;
-        color: $white;
-        opacity: 1;
-
-        &:hover {
-          opacity: 0.5;
-        }
-      }
-    }
-
-    .token-input {
-      min-width: 768px;
     }
   }
 }

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1360,6 +1360,10 @@ $product-page-padding-bottom: 80px !default;
         }
       }
     }
+
+    .token-input {
+      min-width: 768px;
+    }
   }
 }
 

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1302,13 +1302,6 @@ $product-page-padding-bottom: 80px !default;
         }
       }
     }
-
-    // @TODO(NeOMakinG): This could probably be done on every token-input of the BO
-    input.token-input[type="text"] {
-      // stylelint-disable-next-line declaration-no-important
-      width: 100% !important;
-      max-width: 768px;
-    }
   }
 
   // @TODO(NeOMakinG): Moove this to a global file, because every locale-input-group should be the same

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1338,6 +1338,27 @@ $product-page-padding-bottom: 80px !default;
       color: $brand-primary;
     }
   }
+
+  .tokenfield {
+    .token {
+      padding: 0.5rem 0.8rem;
+      background-color: $gray-medium;
+      @include border-radius(0.25rem);
+
+      .close {
+        float: left;
+        margin: 0 0.4rem 0 0;
+        font-size: 1.5rem;
+        line-height: 1rem;
+        color: $white;
+        opacity: 1;
+
+        &:hover {
+          opacity: 0.5;
+        }
+      }
+    }
+  }
 }
 
 #modal-create-product-attachment {

--- a/classes/Tag.php
+++ b/classes/Tag.php
@@ -110,7 +110,8 @@ class TagCore extends ObjectModel
                 if (!Validate::isGenericName($tag)) {
                     return false;
                 }
-                $tag = trim(Tools::substr($tag, 0, self::$definition['fields']['name']['size']));
+                $tagMaxLength = self::$definition['fields']['name']['size'];
+                $tag = trim(Tools::substr(trim($tag), 0, $tagMaxLength));
                 $tagObj = new Tag(null, $tag, (int) $idLang);
 
                 /* Tag does not exist in database */

--- a/src/Adapter/Product/Repository/TagRepository.php
+++ b/src/Adapter/Product/Repository/TagRepository.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Repository;
 
+use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
@@ -41,6 +42,26 @@ use Tag;
  */
 class TagRepository
 {
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     */
+    public function __construct(Connection $connection, string $dbPrefix)
+    {
+        $this->connection = $connection;
+        $this->dbPrefix = $dbPrefix;
+    }
+
     public function addTagsByLanguage(ProductId $productId, LocalizedTags $localizedTags): void
     {
         $productIdValue = $productId->getValue();
@@ -109,5 +130,34 @@ class TagRepository
                 sprintf('Error occurred when trying to delete product #%d tags', $productIdValue
             ));
         }
+    }
+
+    /**
+     * @param ProductId $productId
+     *
+     * @return array Localized tags for a product
+     */
+    public function getProductTags(ProductId $productId): array
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('t.id_lang, t.name')
+            ->from($this->dbPrefix . 'tag', 't')
+            ->leftJoin('t', $this->dbPrefix . 'product_tag', 'pt', 'pt.id_tag = t.id_tag')
+            ->where('pt.id_product = :productId')
+            ->setParameter('productId', $productId->getValue())
+        ;
+
+        $result = $qb->execute()->fetchAllAssociative();
+        if (empty($result)) {
+            return [];
+        }
+
+        $localizedTags = [];
+        foreach ($result as $row) {
+            $localizedTags[(int) $row['id_lang']][] = $row['name'];
+        }
+
+        return $localizedTags;
     }
 }

--- a/src/Adapter/Product/Repository/TagRepository.php
+++ b/src/Adapter/Product/Repository/TagRepository.php
@@ -137,7 +137,7 @@ class TagRepository
      *
      * @return array Localized tags for a product
      */
-    public function getProductTags(ProductId $productId): array
+    public function getLocalizedProductTags(ProductId $productId): array
     {
         $qb = $this->connection->createQueryBuilder();
         $qb

--- a/src/Adapter/Product/Update/ProductTagUpdater.php
+++ b/src/Adapter/Product/Update/ProductTagUpdater.php
@@ -115,7 +115,7 @@ class ProductTagUpdater
      */
     private function hasModification(ProductId $productId, array $localizedTagsList): bool
     {
-        $localizedProductTags = $this->tagRepository->getProductTags($productId);
+        $localizedProductTags = $this->tagRepository->getLocalizedProductTags($productId);
         $currentTagLanguages = array_keys($localizedProductTags);
         $updateTagLanguages = array_map(static function (LocalizedTags $localizedTags): int {
             return $localizedTags->getLanguageId()->getValue();
@@ -132,7 +132,7 @@ class ProductTagUpdater
 
             $currentTags = $this->stringifyTags($localizedProductTags[$localizedTags->getLanguageId()->getValue()] ?? []);
             $updateTags = $this->stringifyTags($localizedTags->getTags() ?? []);
-            if ($currentTags != $updateTags) {
+            if ($currentTags !== $updateTags) {
                 return true;
             }
         }

--- a/src/Adapter/Product/Update/ProductTagUpdater.php
+++ b/src/Adapter/Product/Update/ProductTagUpdater.php
@@ -84,21 +84,19 @@ class ProductTagUpdater
         // delete all tags for product if array is empty
         if (empty($localizedTagsList)) {
             $this->tagRepository->deleteAllTags($productId);
+        } else {
+            foreach ($localizedTagsList as $localizedTags) {
+                // delete all this product tags for this lang
+                $this->tagRepository->deleteTagsByLanguage($productId, $localizedTags->getLanguageId());
 
-            return;
-        }
+                // empty tags means to delete all previous tags, which is already done above.
+                if ($localizedTags->isEmpty()) {
+                    continue;
+                }
 
-        foreach ($localizedTagsList as $localizedTags) {
-            // delete all this product tags for this lang
-            $this->tagRepository->deleteTagsByLanguage($productId, $localizedTags->getLanguageId());
-
-            // empty tags means to delete all previous tags, which is already done above.
-            if ($localizedTags->isEmpty()) {
-                continue;
+                // assign new tags to product
+                $this->tagRepository->addTagsByLanguage($productId, $localizedTags);
             }
-
-            // assign new tags to product
-            $this->tagRepository->addTagsByLanguage($productId, $localizedTags);
         }
 
         // Since tags have been modified we need to update the indexation values (only for active products)

--- a/src/Adapter/Product/Update/ProductTagUpdater.php
+++ b/src/Adapter/Product/Update/ProductTagUpdater.php
@@ -131,7 +131,7 @@ class ProductTagUpdater
             }
 
             $currentTags = $this->stringifyTags($localizedProductTags[$localizedTags->getLanguageId()->getValue()] ?? []);
-            $updateTags = $this->stringifyTags($localizedTags->getTags() ?? []);
+            $updateTags = $this->stringifyTags($localizedTags->getTags());
             if ($currentTags !== $updateTags) {
                 return true;
             }

--- a/src/Adapter/Product/Update/ProductTagUpdater.php
+++ b/src/Adapter/Product/Update/ProductTagUpdater.php
@@ -46,12 +46,20 @@ class ProductTagUpdater
     private $tagRepository;
 
     /**
+     * @var ProductIndexationUpdater
+     */
+    private $productIndexationUpdater;
+
+    /**
      * @param TagRepository $tagRepository
+     * @param ProductIndexationUpdater $productIndexationUpdater
      */
     public function __construct(
-        TagRepository $tagRepository
+        TagRepository $tagRepository,
+        ProductIndexationUpdater $productIndexationUpdater
     ) {
         $this->tagRepository = $tagRepository;
+        $this->productIndexationUpdater = $productIndexationUpdater;
     }
 
     /**
@@ -66,6 +74,12 @@ class ProductTagUpdater
     public function setProductTags(Product $product, array $localizedTagsList): void
     {
         $productId = new ProductId((int) $product->id);
+
+        // We check if the values have changed, it represents an additional query to check but it's better than performing
+        // an update of search indexes for nothing.
+        if (!$this->hasModification($productId, $localizedTagsList)) {
+            return;
+        }
 
         // delete all tags for product if array is empty
         if (empty($localizedTagsList)) {
@@ -86,5 +100,55 @@ class ProductTagUpdater
             // assign new tags to product
             $this->tagRepository->addTagsByLanguage($productId, $localizedTags);
         }
+
+        // Since tags have been modified we need to update the indexation values (only for active products)
+        if ($product->active) {
+            $this->productIndexationUpdater->updateIndexation($product);
+        }
+    }
+
+    /**
+     * @param ProductId $productId
+     * @param LocalizedTags[] $localizedTagsList
+     *
+     * @return bool
+     */
+    private function hasModification(ProductId $productId, array $localizedTagsList): bool
+    {
+        $localizedProductTags = $this->tagRepository->getProductTags($productId);
+        $currentTagLanguages = array_keys($localizedProductTags);
+        $updateTagLanguages = array_map(static function (LocalizedTags $localizedTags): int {
+            return $localizedTags->getLanguageId()->getValue();
+        }, $localizedTagsList);
+
+        if (array_diff($currentTagLanguages, $updateTagLanguages)) {
+            return true;
+        }
+
+        foreach ($localizedTagsList as $localizedTags) {
+            if (empty($localizedProductTags[$localizedTags->getLanguageId()->getValue()])) {
+                return true;
+            }
+
+            $currentTags = $this->stringifyTags($localizedProductTags[$localizedTags->getLanguageId()->getValue()] ?? []);
+            $updateTags = $this->stringifyTags($localizedTags->getTags() ?? []);
+            if ($currentTags != $updateTags) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string[] $tags
+     *
+     * @return string
+     */
+    private function stringifyTags(array $tags): string
+    {
+        asort($tags);
+
+        return implode(';', $tags);
     }
 }

--- a/src/Core/Domain/Product/Command/SetProductTagsCommand.php
+++ b/src/Core/Domain/Product/Command/SetProductTagsCommand.php
@@ -31,7 +31,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\LocalizedTags;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
-use RuntimeException;
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 
 /**
  * Updates product tags in provided languages
@@ -77,12 +77,12 @@ class SetProductTagsCommand
     /**
      * @param array[] $localizedTags key-value pairs where each key represents language id and value is the array of tags
      *
-     * @throws ProductConstraintException
+     * @throws ProductConstraintException|InvalidArgumentException
      */
     private function setLocalizedTagsList(array $localizedTags): void
     {
         if (empty($localizedTags)) {
-            throw new RuntimeException(sprintf(
+            throw new InvalidArgumentException(sprintf(
                 'Empty array of product tags provided in %s. To remove all product tags use %s.',
                 self::class,
                 RemoveAllProductTagsCommand::class

--- a/src/Core/Domain/Product/ValueObject/LocalizedTags.php
+++ b/src/Core/Domain/Product/ValueObject/LocalizedTags.php
@@ -91,7 +91,9 @@ class LocalizedTags
      */
     private function setTags(array $tags): void
     {
-        foreach ($tags as $key => $tag) {
+        $this->tags = [];
+
+        foreach ($tags as $tag) {
             //skip empty value
             if (empty($tag)) {
                 continue;

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilder.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetProductTagsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductSeoCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
@@ -75,11 +76,24 @@ class SEOCommandsBuilder implements MultiShopProductCommandsBuilderInterface
             ])
         ;
         $commandBuilder = new CommandBuilder($config);
-
-        return $commandBuilder->buildCommands(
+        $commands = $commandBuilder->buildCommands(
             $formData,
             new UpdateProductSeoCommand($productId->getValue(), $singleShopConstraint),
             new UpdateProductSeoCommand($productId->getValue(), ShopConstraint::allShops())
         );
+
+        if (!empty($seoData['tags'])) {
+            $parsedTags = [];
+            foreach ($seoData['tags'] as $langId => $rawTags) {
+                $parsedTags[$langId] = !empty($rawTags) ? explode(',', $rawTags) : [];
+            }
+
+            $commands[] = new SetProductTagsCommand(
+                $productId->getValue(),
+                $parsedTags
+            );
+        }
+
+        return $commands;
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilder.php
@@ -33,10 +33,10 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetProductTagsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductSeoCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilder;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilderConfig;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\DataField;
-use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 
 /**
  * Builder used to build UpdateSEO
@@ -84,6 +84,7 @@ class SEOCommandsBuilder implements MultiShopProductCommandsBuilderInterface
             new UpdateProductSeoCommand($productId->getValue(), ShopConstraint::allShops())
         );
 
+        $seoData = $formData['seo'] ?? [];
         if (isset($seoData['tags'])) {
             if (!empty($seoData['tags'])) {
                 if (!is_array($seoData['tags'])) {
@@ -91,14 +92,20 @@ class SEOCommandsBuilder implements MultiShopProductCommandsBuilderInterface
                 }
 
                 $parsedTags = [];
+                $allEmpty = true;
                 foreach ($seoData['tags'] as $langId => $rawTags) {
                     $parsedTags[$langId] = !empty($rawTags) ? explode(',', $rawTags) : [];
+                    $allEmpty = $allEmpty && empty($rawTags);
                 }
 
-                $commands[] = new SetProductTagsCommand(
-                    $productId->getValue(),
-                    $parsedTags
-                );
+                if ($allEmpty) {
+                    $commands[] = new RemoveAllProductTagsCommand($productId->getValue());
+                } else {
+                    $commands[] = new SetProductTagsCommand(
+                        $productId->getValue(),
+                        $parsedTags
+                    );
+                }
             } else {
                 $commands[] = new RemoveAllProductTagsCommand($productId->getValue());
             }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilder.php
@@ -84,8 +84,10 @@ class SEOCommandsBuilder implements MultiShopProductCommandsBuilderInterface
 
         if (!empty($seoData['tags'])) {
             $parsedTags = [];
-            foreach ($seoData['tags'] as $langId => $rawTags) {
-                $parsedTags[$langId] = !empty($rawTags) ? explode(',', $rawTags) : [];
+            if (is_array($seoData['tags'])) {
+                foreach ($seoData['tags'] as $langId => $rawTags) {
+                    $parsedTags[$langId] = !empty($rawTags) ? explode(',', $rawTags) : [];
+                }
             }
 
             $commands[] = new SetProductTagsCommand(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product\SEO;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShopBundle\Form\Admin\Type\TextWithLengthCounterType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
@@ -91,8 +92,6 @@ class SEOType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $invalidCharsText = sprintf('%s <>={}', $this->trans('Invalid characters:', 'Admin.Notifications.Info'));
-
         $builder
             ->add('serp', SerpType::class)
             ->add('meta_title', TranslatableType::class, [
@@ -180,7 +179,7 @@ class SEOType extends TranslatorAwareType
                 'help' => sprintf(
                     '%s %s',
                     $this->trans('To add tags, click in the field, write something, and then press the "Enter" key.', 'Admin.Shopparameters.Help'),
-                    $invalidCharsText
+                    $this->trans('Invalid characters: %s', 'Admin.Notifications.Info', [TypedRegexValidator::GENERIC_NAME_CHARS])
                 ),
                 'options' => [
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -176,10 +176,10 @@ class SEOType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Tags', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
-                'label_subtitle' => $this->trans('Enter the keywords that customers might search for when looking for this product. Separate each tag with a comma.', 'Admin.Catalog.Feature'),
+                'label_subtitle' => $this->trans('Enter the keywords that customers might search for when looking for this product.', 'Admin.Catalog.Feature'),
                 'help' => sprintf(
                     '%s %s',
-                    $this->trans('To add tags, click in the field, write something, and then press the "Enter" key or comma.', 'Admin.Shopparameters.Help'),
+                    $this->trans('Separate each tag with a comma or press the Enter key.', 'Admin.Shopparameters.Help'),
                     $this->trans('Invalid characters: %s', 'Admin.Notifications.Info', [TypedRegexValidator::GENERIC_NAME_CHARS])
                 ),
                 'external_link' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -91,6 +91,8 @@ class SEOType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $invalidCharsText = sprintf('%s <>={}', $this->trans('Invalid characters:', 'Admin.Notifications.Info'));
+
         $builder
             ->add('serp', SerpType::class)
             ->add('meta_title', TranslatableType::class, [
@@ -175,7 +177,11 @@ class SEOType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Tags', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
-                'help' => $this->trans('Use a comma to create separate tags. E.g.: dress, cotton, party dresses.', 'Admin.Catalog.Help'),
+                'help' => sprintf(
+                    '%s %s',
+                    $this->trans('To add tags, click in the field, write something, and then press the "Enter" key.', 'Admin.Shopparameters.Help'),
+                    $invalidCharsText
+                ),
                 'options' => [
                     'constraints' => [
                         new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -179,7 +179,7 @@ class SEOType extends TranslatorAwareType
                 'label_subtitle' => $this->trans('Enter the keywords that customers might search for when looking for this product.', 'Admin.Catalog.Feature'),
                 'help' => sprintf(
                     '%s %s',
-                    $this->trans('Separate each tag with a comma or press the Enter key.', 'Admin.Shopparameters.Help'),
+                    $this->trans('Separate each tag with a comma or press the Enter key.', 'Admin.Catalog.Help'),
                     $this->trans('Invalid characters: %s', 'Admin.Notifications.Info', [TypedRegexValidator::GENERIC_NAME_CHARS])
                 ),
                 'external_link' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -176,11 +176,16 @@ class SEOType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Tags', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
+                'label_subtitle' => $this->trans('Enter the keywords that customers might search for when looking for this product. Separate each tag with a comma.', 'Admin.Catalog.Feature'),
                 'help' => sprintf(
                     '%s %s',
-                    $this->trans('To add tags, click in the field, write something, and then press the "Enter" key.', 'Admin.Shopparameters.Help'),
+                    $this->trans('To add tags, click in the field, write something, and then press the "Enter" key or comma.', 'Admin.Shopparameters.Help'),
                     $this->trans('Invalid characters: %s', 'Admin.Notifications.Info', [TypedRegexValidator::GENERIC_NAME_CHARS])
                 ),
+                'external_link' => [
+                    'href' => $this->legacyContext->getAdminLink('AdminTags', true),
+                    'text' => $this->trans('[1]Manage all tags[/1]', 'Admin.Catalog.Feature'),
+                ],
                 'options' => [
                     'constraints' => [
                         new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
@@ -190,18 +195,6 @@ class SEOType extends TranslatorAwareType
                     ],
                     'required' => false,
                 ],
-                'alert_title' => $this->trans('Tags are meant to help your customers find your products via the search bar.', 'Admin.Catalog.Help'),
-                'alert_message' => [
-                    $this->trans('Choose terms and keywords that your customers will use to search for this product and make sure you are consistent with the tags you may have already used.', 'Admin.Catalog.Help'),
-                    $this->trans('You can manage tag aliases in the [1]Search section[/1]. If you add new tags, you have to rebuild the index.', 'Admin.Catalog.Help', [
-                        '[1]' => sprintf(
-                            '<a target="_blank" href="%s">',
-                            $this->legacyContext->getAdminLink('AdminSearchConf')
-                        ),
-                        '[/1]' => '</a>',
-                    ]),
-                ],
-                'modify_all_shops' => true,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableType.php
@@ -141,6 +141,7 @@ class TranslatableType extends TranslatorAwareType
             }
         }
 
+        /** @var FormInterface $varsForm */
         $varsForm = $view->vars['errors']->getForm();
         $view->vars['errors'] = new FormErrorIterator($varsForm, $errors);
         $view->vars['locales'] = $options['locales'];
@@ -212,10 +213,6 @@ class TranslatableType extends TranslatorAwareType
      */
     private function getErrorsByLocale(FormView $view, FormInterface $form, array $locales)
     {
-        if (count($locales) <= 1) {
-            return null;
-        }
-
         $formErrors = $form->getErrors(true);
 
         if (0 === $formErrors->count()) {

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -382,11 +382,15 @@ services:
 
   prestashop.adapter.product.repository.tag_repository:
     class: PrestaShop\PrestaShop\Adapter\Product\Repository\TagRepository
+    arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'
 
   prestashop.adapter.product.updater.product_tag_updater:
     class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductTagUpdater
     arguments:
       - '@prestashop.adapter.product.repository.tag_repository'
+      - '@prestashop.adapter.product.update.product_indexation_updater'
 
   prestashop.adapter.product.update.product_category_updater:
     class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductCategoryUpdater

--- a/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
@@ -128,7 +128,9 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
     public function setCurrentCurrency($currencyName)
     {
         $this->checkCurrencyWithNameExists($currencyName);
-        $this->getCurrentCart()->id_currency = $this->currencies[$currencyName]->id;
+        if ($this->getCurrentCart()) {
+            $this->getCurrentCart()->id_currency = $this->currencies[$currencyName]->id;
+        }
         Context::getContext()->currency = $this->currencies[$currencyName];
     }
 

--- a/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
@@ -128,7 +128,7 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
     public function setCurrentCurrency($currencyName)
     {
         $this->checkCurrencyWithNameExists($currencyName);
-        if ($this->getCurrentCart()) {
+        if ($this->getCurrentCart() !== null) {
             $this->getCurrentCart()->id_currency = $this->currencies[$currencyName]->id;
         }
         Context::getContext()->currency = $this->currencies[$currencyName];

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
@@ -171,3 +171,29 @@ Feature: Update product tags from Back Office (BO)
     When I remove all product "productTags" tags
     When I search for products on front office with sentence "time" with locale "en-US" I should find nothing
     And I search for products on front office with sentence "temps" with locale "fr-FR" I should find nothing
+
+  Scenario: I update tags with duplicate values (add space in the value to make sure they are correctly trimmed)
+    And product "productTags" localized "tags" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    When I update product "productTags" tags with following values:
+      | tags[en-US] | Set_of_biological_beauty_product,Set_of_biological_beauty_product, Set_of_biological_beauty_product |
+      | tags[fr-FR] | Ensembles_des_produits_de_beauté,Ensembles_des_produits_de_beauté, Ensembles_des_produits_de_beauté |
+    And product "productTags" localized "tags" should be:
+      | locale | value                            |
+      | en-US  | Set_of_biological_beauty_product |
+      | fr-FR  | Ensembles_des_produits_de_beauté |
+
+  Scenario: I update tags with too long values only 32 characters are saved
+    And product "productTags" localized "tags" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    When I update product "productTags" tags with following values:
+      | tags[en-US] | Set_of_biological_beauty_product_for_the_morning |
+      | tags[fr-FR] | Ensembles_des_produits_de_beauté_pour_le_matin   |
+    And product "productTags" localized "tags" should be:
+      | locale | value                            |
+      | en-US  | Set_of_biological_beauty_product |
+      | fr-FR  | Ensembles_des_produits_de_beauté |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
@@ -10,67 +10,67 @@ Feature: Update product tags from Back Office (BO)
     Given language "language1" with locale "en-US" exists
     And language with iso code "en" is the default one
     And language "language2" with locale "fr-FR" exists
-    And I add product "product3" with following information:
+    And I add product "productTags" with following information:
       | name[en-US] | Mechanical watch |
       | name[fr-FR] | montre mécanique |
       | type        | standard         |
-    And product "product3" localized "name" should be:
+    And product "productTags" localized "name" should be:
       | locale | value            |
       | en-US  | Mechanical watch |
       | fr-FR  | montre mécanique |
 
   Scenario: I update product tags in multiple languages
-    And product "product3" localized "tags" should be:
+    And product "productTags" localized "tags" should be:
       | locale | value |
       | en-US  |       |
       | fr-FR  |       |
-    When I update product "product3" tags with following values:
+    When I update product "productTags" tags with following values:
       | tags[en-US] | mechanic,watch   |
       | tags[fr-FR] | montre,mécanique |
-    And product "product3" localized "tags" should be:
+    And product "productTags" localized "tags" should be:
       | locale | value            |
       | en-US  | mechanic,watch   |
       | fr-FR  | montre,mécanique |
-    When I update product "product3" tags with following values:
+    When I update product "productTags" tags with following values:
       | tags[en-US] | mechanic,watch |
       | tags[fr-FR] |                |
-    And product "product3" localized "tags" should be:
+    And product "productTags" localized "tags" should be:
       | locale | value          |
       | en-US  | mechanic,watch |
       | fr-FR  |                |
-    When I update product "product3" tags with following values:
+    When I update product "productTags" tags with following values:
       | tags[fr-FR] | montre |
-    And product "product3" localized "tags" should be:
+    And product "productTags" localized "tags" should be:
       | locale | value          |
       | en-US  | mechanic,watch |
       | fr-FR  | montre         |
 
   Scenario: Update product tags with invalid values
-    When I update product "product3" tags with following values:
+    When I update product "productTags" tags with following values:
       | tags[en-US] | mechanic,watch   |
       | tags[fr-FR] | montre,mécanique |
-    Then product "product3" localized "tags" should be:
+    Then product "productTags" localized "tags" should be:
       | locale | value            |
       | en-US  | mechanic,watch   |
       | fr-FR  | montre,mécanique |
-    When I update product "product3" tags with following values:
+    When I update product "productTags" tags with following values:
       | tags[en-US] | #<{ |
     Then I should get error that product tag is invalid
-    And product "product3" localized "tags" should be:
+    And product "productTags" localized "tags" should be:
       | locale | value            |
       | en-US  | mechanic,watch   |
       | fr-FR  | montre,mécanique |
 
   Scenario: Remove all product tags
-    When I update product "product3" tags with following values:
+    When I update product "productTags" tags with following values:
       | tags[en-US] | mechanic,watch   |
       | tags[fr-FR] | montre,mécanique |
-    Then product "product3" localized "tags" should be:
+    Then product "productTags" localized "tags" should be:
       | locale | value            |
       | en-US  | mechanic,watch   |
       | fr-FR  | montre,mécanique |
-    When I remove all product "product3" tags
-    And product "product3" localized "tags" should be:
+    When I remove all product "productTags" tags
+    And product "productTags" localized "tags" should be:
       | locale | value |
       | en-US  |       |
       | fr-FR  |       |
@@ -81,28 +81,28 @@ Feature: Update product tags from Back Office (BO)
     And currency "currency1" is the current one
     # Disable fuzzy search, only search by tag value
     And shop configuration for "PS_SEARCH_FUZZY" is set to 0
-    When I update product "product3" tags with following values:
+    When I update product "productTags" tags with following values:
       | tags[en-US] | time  |
       | tags[fr-FR] | temps |
-    Then product "product3" localized "tags" should be:
+    Then product "productTags" localized "tags" should be:
       | locale | value |
       | en-US  | time  |
       | fr-FR  | temps |
     # When product is disabled it is not indexed
     When I search for products on front office with sentence "time" with locale "en-US" I should find nothing
     And I search for products on front office with sentence "temps" with locale "fr-FR" I should find nothing
-    Given I enable product "product3"
+    Given I enable product "productTags"
     When I search for products on front office with sentence "time" with locale "en-US" I should find:
       | product_id | name             |
-      | product3   | Mechanical watch |
+      | productTags   | Mechanical watch |
     And I search for products on front office with sentence "temps" with locale "fr-FR" I should find:
       | product_id | name             |
-      | product3   | montre mécanique |
+      | productTags   | montre mécanique |
     # Now update the tags the search returns different results
-    When I update product "product3" tags with following values:
+    When I update product "productTags" tags with following values:
       | tags[en-US] | running |
       | tags[fr-FR] | course  |
-    Then product "product3" localized "tags" should be:
+    Then product "productTags" localized "tags" should be:
       | locale | value   |
       | en-US  | running |
       | fr-FR  | course  |
@@ -110,10 +110,64 @@ Feature: Update product tags from Back Office (BO)
     And I search for products on front office with sentence "temps" with locale "fr-FR" I should find nothing
     When I search for products on front office with sentence "running" with locale "en-US" I should find:
       | product_id | name             |
-      | product3   | Mechanical watch |
+      | productTags   | Mechanical watch |
     And I search for products on front office with sentence "course" with locale "fr-FR" I should find:
       | product_id | name             |
-      | product3   | montre mécanique |
-    When I disable product "product3"
+      | productTags   | montre mécanique |
+    When I disable product "productTags"
     When I search for products on front office with sentence "running" with locale "en-US" I should find nothing
     And I search for products on front office with sentence "course" with locale "fr-FR" I should find nothing
+
+  Scenario: Tags can be used for product search, when they are empty they are not searchable anymore
+    # Enable the context currency which is needed in search
+    Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
+    And currency "currency1" is the current one
+    # Disable fuzzy search, only search by tag value
+    And shop configuration for "PS_SEARCH_FUZZY" is set to 0
+    # Ebale product and add some tags to it
+    Given I enable product "productTags"
+    When I update product "productTags" tags with following values:
+      | tags[en-US] | time  |
+      | tags[fr-FR] | temps |
+    Then product "productTags" localized "tags" should be:
+      | locale | value |
+      | en-US  | time  |
+      | fr-FR  | temps |
+    When I search for products on front office with sentence "time" with locale "en-US" I should find:
+      | product_id | name             |
+      | productTags   | Mechanical watch |
+    And I search for products on front office with sentence "temps" with locale "fr-FR" I should find:
+      | product_id | name             |
+      | productTags   | montre mécanique |
+    # Remove tags by setting no value for each language
+    When I update product "productTags" tags with following values:
+      | tags[en-US] | |
+      | tags[fr-FR] | |
+    When I search for products on front office with sentence "time" with locale "en-US" I should find nothing
+    And I search for products on front office with sentence "temps" with locale "fr-FR" I should find nothing
+
+  Scenario: Tags can be used for product search, when they are all removed they are not searchable anymore
+    # Enable the context currency which is needed in search
+    Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
+    And currency "currency1" is the current one
+    # Disable fuzzy search, only search by tag value
+    And shop configuration for "PS_SEARCH_FUZZY" is set to 0
+    # Ebale product and add some tags to it
+    Given I enable product "productTags"
+    When I update product "productTags" tags with following values:
+      | tags[en-US] | time  |
+      | tags[fr-FR] | temps |
+    Then product "productTags" localized "tags" should be:
+      | locale | value |
+      | en-US  | time  |
+      | fr-FR  | temps |
+    When I search for products on front office with sentence "time" with locale "en-US" I should find:
+      | product_id | name             |
+      | productTags   | Mechanical watch |
+    And I search for products on front office with sentence "temps" with locale "fr-FR" I should find:
+      | product_id | name             |
+      | productTags   | montre mécanique |
+    # Remove tags by removing them all
+    When I remove all product "productTags" tags
+    When I search for products on front office with sentence "time" with locale "en-US" I should find nothing
+    And I search for products on front office with sentence "temps" with locale "fr-FR" I should find nothing

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_tags.feature
@@ -6,7 +6,7 @@ Feature: Update product tags from Back Office (BO)
   As a BO user
   I need to be able to update product tags from BO
 
-  Scenario: I update product tags in multiple languages
+  Background:
     Given language "language1" with locale "en-US" exists
     And language with iso code "en" is the default one
     And language "language2" with locale "fr-FR" exists
@@ -18,6 +18,8 @@ Feature: Update product tags from Back Office (BO)
       | locale | value            |
       | en-US  | Mechanical watch |
       | fr-FR  | montre mécanique |
+
+  Scenario: I update product tags in multiple languages
     And product "product3" localized "tags" should be:
       | locale | value |
       | en-US  |       |
@@ -44,25 +46,74 @@ Feature: Update product tags from Back Office (BO)
       | fr-FR  | montre         |
 
   Scenario: Update product tags with invalid values
-    Given product "product3" localized "tags" should be:
-      | locale | value          |
-      | en-US  | mechanic,watch |
-      | fr-FR  | montre         |
+    When I update product "product3" tags with following values:
+      | tags[en-US] | mechanic,watch   |
+      | tags[fr-FR] | montre,mécanique |
+    Then product "product3" localized "tags" should be:
+      | locale | value            |
+      | en-US  | mechanic,watch   |
+      | fr-FR  | montre,mécanique |
     When I update product "product3" tags with following values:
       | tags[en-US] | #<{ |
     Then I should get error that product tag is invalid
     And product "product3" localized "tags" should be:
-      | locale | value          |
-      | en-US  | mechanic,watch |
-      | fr-FR  | montre         |
+      | locale | value            |
+      | en-US  | mechanic,watch   |
+      | fr-FR  | montre,mécanique |
 
   Scenario: Remove all product tags
-    Given product "product3" localized "tags" should be:
-      | locale | value          |
-      | en-US  | mechanic,watch |
-      | fr-FR  | montre         |
+    When I update product "product3" tags with following values:
+      | tags[en-US] | mechanic,watch   |
+      | tags[fr-FR] | montre,mécanique |
+    Then product "product3" localized "tags" should be:
+      | locale | value            |
+      | en-US  | mechanic,watch   |
+      | fr-FR  | montre,mécanique |
     When I remove all product "product3" tags
     And product "product3" localized "tags" should be:
       | locale | value |
       | en-US  |       |
       | fr-FR  |       |
+
+  Scenario: Tags can be used for product search
+    # Enable the context currency which is needed in search
+    Given there is a currency named "currency1" with iso code "USD" and exchange rate of 0.92
+    And currency "currency1" is the current one
+    # Disable fuzzy search, only search by tag value
+    And shop configuration for "PS_SEARCH_FUZZY" is set to 0
+    When I update product "product3" tags with following values:
+      | tags[en-US] | time  |
+      | tags[fr-FR] | temps |
+    Then product "product3" localized "tags" should be:
+      | locale | value |
+      | en-US  | time  |
+      | fr-FR  | temps |
+    # When product is disabled it is not indexed
+    When I search for products on front office with sentence "time" with locale "en-US" I should find nothing
+    And I search for products on front office with sentence "temps" with locale "fr-FR" I should find nothing
+    Given I enable product "product3"
+    When I search for products on front office with sentence "time" with locale "en-US" I should find:
+      | product_id | name             |
+      | product3   | Mechanical watch |
+    And I search for products on front office with sentence "temps" with locale "fr-FR" I should find:
+      | product_id | name             |
+      | product3   | montre mécanique |
+    # Now update the tags the search returns different results
+    When I update product "product3" tags with following values:
+      | tags[en-US] | running |
+      | tags[fr-FR] | course  |
+    Then product "product3" localized "tags" should be:
+      | locale | value   |
+      | en-US  | running |
+      | fr-FR  | course  |
+    When I search for products on front office with sentence "time" with locale "en-US" I should find nothing
+    And I search for products on front office with sentence "temps" with locale "fr-FR" I should find nothing
+    When I search for products on front office with sentence "running" with locale "en-US" I should find:
+      | product_id | name             |
+      | product3   | Mechanical watch |
+    And I search for products on front office with sentence "course" with locale "fr-FR" I should find:
+      | product_id | name             |
+      | product3   | montre mécanique |
+    When I disable product "product3"
+    When I search for products on front office with sentence "running" with locale "en-US" I should find nothing
+    And I search for products on front office with sentence "course" with locale "fr-FR" I should find nothing

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilderTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetProductTagsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductSeoCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
@@ -194,6 +195,54 @@ class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
                 ],
             ],
             [$command],
+        ];
+
+        $localizedTagsData = [
+            1 => 'coton,bonbon',
+            2 => 'cotton,candy',
+        ];
+        $localizedTags = [
+            1 => ['coton', 'bonbon'],
+            2 => ['cotton', 'candy'],
+        ];
+        $tagCommands = new SetProductTagsCommand($this->getProductId()->getValue(), $localizedTags);
+        yield 'tags and seo command' => [
+            [
+                'seo' => [
+                    'redirect_option' => [
+                        'type' => RedirectType::TYPE_CATEGORY_TEMPORARY,
+                        'target' => [
+                            'id' => 51,
+                        ],
+                    ],
+                    'tags' => $localizedTagsData,
+                ],
+            ],
+            [$command, $tagCommands],
+        ];
+
+        $localizedTagsData = [
+            1 => 'coton,bonbon',
+            2 => null,
+        ];
+        $localizedTags = [
+            1 => ['coton', 'bonbon'],
+            2 => [],
+        ];
+        $tagCommands = new SetProductTagsCommand($this->getProductId()->getValue(), $localizedTags);
+        yield 'tags with empty values' => [
+            [
+                'seo' => [
+                    'redirect_option' => [
+                        'type' => RedirectType::TYPE_CATEGORY_TEMPORARY,
+                        'target' => [
+                            'id' => 51,
+                        ],
+                    ],
+                    'tags' => $localizedTagsData,
+                ],
+            ],
+            [$command, $tagCommands],
         ];
     }
 

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilderTest.php
@@ -291,7 +291,7 @@ class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
 
     public function testInvalidTags(): void
     {
-        $builder = new SEOCommandsBuilder(self::MULTI_SHOP_PREFIX);
+        $builder = new SEOCommandsBuilder(self::MODIFY_ALL_SHOPS_PREFIX);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected tags to be a localized array');
@@ -300,7 +300,7 @@ class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
             'seo' => [
                 'tags' => 'cotton, candy',
             ],
-        ], $this->singleShopConstraint);
+        ], $this->getSingleShopConstraint());
     }
 
     /**

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilderTest.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetProductTagsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductSeoCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\SEOCommandsBuilder;
 
 class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
@@ -244,6 +245,18 @@ class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
             ],
             [$command, $tagCommands],
         ];
+    }
+
+    public function testInvalidTags(): void
+    {
+        $builder = new SEOCommandsBuilder();
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder->buildCommands($this->getProductId(), [
+            'seo' => [
+                'tags' => 'cotton, candy',
+            ],
+        ]);
     }
 
     /**

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/SEOCommandsBuilderTest.php
@@ -208,7 +208,20 @@ class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
             2 => ['cotton', 'candy'],
         ];
         $tagCommands = new SetProductTagsCommand($this->getProductId()->getValue(), $localizedTags);
-        yield 'tags and seo command' => [
+        yield 'tags command' => [
+            [
+                'seo' => [
+                    'tags' => $localizedTagsData,
+                ],
+            ],
+            [$tagCommands],
+        ];
+
+        $command = $this
+            ->getSingleShopCommand()
+            ->setRedirectOption(RedirectType::TYPE_CATEGORY_TEMPORARY, 51)
+        ;
+        yield 'seo command and tags command' => [
             [
                 'seo' => [
                     'redirect_option' => [
@@ -224,24 +237,6 @@ class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
         ];
 
         $localizedTagsData = [
-            1 => null,
-            2 => null,
-        ];
-        $localizedTags = [
-            1 => [],
-            2 => [],
-        ];
-        $tagCommands = new SetProductTagsCommand($this->getProductId()->getValue(), $localizedTags);
-        yield 'tags command with only empty values' => [
-            [
-                'seo' => [
-                    'tags' => $localizedTagsData,
-                ],
-            ],
-            [$tagCommands],
-        ];
-
-        $localizedTagsData = [
             1 => 'coton,bonbon',
             2 => null,
         ];
@@ -251,6 +246,20 @@ class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
         ];
         $tagCommands = new SetProductTagsCommand($this->getProductId()->getValue(), $localizedTags);
         yield 'tags with empty value for one language' => [
+            [
+                'seo' => [
+                    'tags' => $localizedTagsData,
+                ],
+            ],
+            [$tagCommands],
+        ];
+
+        $localizedTagsData = [
+            1 => null,
+            2 => null,
+        ];
+        $tagCommands = new RemoveAllProductTagsCommand($this->getProductId()->getValue());
+        yield 'remove tags command with all localized values empty' => [
             [
                 'seo' => [
                     'tags' => $localizedTagsData,
@@ -282,7 +291,7 @@ class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
 
     public function testInvalidTags(): void
     {
-        $builder = new SEOCommandsBuilder();
+        $builder = new SEOCommandsBuilder(self::MULTI_SHOP_PREFIX);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected tags to be a localized array');
@@ -291,7 +300,7 @@ class SEOCommandsBuilderTest extends AbstractProductCommandBuilderTest
             'seo' => [
                 'tags' => 'cotton, candy',
             ],
-        ]);
+        ], $this->singleShopConstraint);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Integrate taggable component in product page v2, and integrate `SetProductTagsCommand` into the `SEOCommandsBuilder`
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | Go to product experimental page and edit some tags
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27328)
<!-- Reviewable:end -->

### Breaking Change

- `SetProductTagsCommand` now throws a `PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException` exception instead of a `RuntimeException` when empty tags is provided as argument
- `TagRepository` now needs two parameters to handle Doctrine connection queries
- `ProductTagUpdater` now depends on `ProductIndexationUpdater`
