### PR TITLE
Fix default value for Jquery colorpicker

### DIFF
--- a/js/jquery/plugins/jquery.colorpicker.js
+++ b/js/jquery/plugins/jquery.colorpicker.js
@@ -53,8 +53,8 @@
 
     // update the colors of the newly created inputs
     $(document).ready(function() {
-      inputs.forEach(function() {
-        $.fn.mColorPicker.setTextColor($(this));
+      inputs.forEach(function(input) {
+        $.fn.mColorPicker.setTextColor(input);
       });
     });
 
@@ -118,8 +118,7 @@
   };
 
   $.fn.mColorPicker.drawPickerTriggers = function ($t) {
-
-    if ($t[0].nodeName.toLowerCase() != 'input') return false;
+    if (!$t.is('input')) return false;
 
     var id = $t.attr('id') || 'color_' + $.fn.mColorPicker.init.index++,
         hidden = false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | 2 fixes done : <ul><li>Use element in forEach callback instead of `this` (which refer to parent component)</li><li>Use `$t.is('input')` instead of `$t[0].nodeName` to test HTML element type</li></ul>
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27249
| How to test?      | Look at issue description
| Possible impacts? | Check colorpickers inside BO, including when multistore is enabled<br>Regression was previously introduced by https://github.com/PrestaShop/PrestaShop/pull/27114 : please test that issue expected behaviour too


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27330)
<!-- Reviewable:end -->
