### PR TITLE
Set rightSidebar as global scoped

### DIFF
--- a/admin-dev/themes/default/js/bundle/default.js
+++ b/admin-dev/themes/default/js/bundle/default.js
@@ -18,7 +18,8 @@ $(document).ready(function () {
   });
 });
 
-const rightSidebar = (function () {
+// eslint-disable-next-line
+window.rightSidebar = (function () {
   return {
     init() {
       $('.btn-sidebar').on('click', function initLoadQuickNav() {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | PageSpeed mod for Apache server bundles the javascript for delivery optimization but that is not compatible with the new versions of file https://github.com/PrestaShop/PrestaShop/blob/develop/admin-dev/themes/default/js/bundle/default.js <br>The incompatibility arises because an incorrect scope of a javascript declaration.<br>That file loads the global rightSidebar using "const" but, as explained here: https://www.freecodecamp.org/news/var-let-and-const-whats-the-difference/#const , "const" is block scoped.<br>If rightSidebar is going to be globally used, "var" should be used instead (https://www.freecodecamp.org/news/var-let-and-const-whats-the-difference/#var).<br>Although global variables are discouraged, the rightSidebar is designed as a global variables, changing that behavior will require a refactor of the code.... rightSidebar was declared using "var" a few months ago.<br>The change was introduced at this huge eslint PR: https://github.com/PrestaShop/PrestaShop/pull/22999/files#diff-652322c22d05461f6ff2962e23cceb8958b2d7cabbc2e2cc0485aefdd827eb13L21<br>Please, consider a rollback to "var" or assign it as a window property until a refactor of that code is applied.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27180.
| How to test?      | (in a server with PageSpeed JS optimizer enabled https://www.modpagespeed.com/doc/filter-js-combine, and with the PS experimental features disabled)<br><br>1.- Go to the products section of the BO<br>2.- Go to the details page of a specific product with combinations<br>3.- Go to the combinations section<br>4 .- Click on the pen icon of a combination<br>5 .- You will not be able to edit the combination
| Possible impacts? | There is no secondary impact.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27335)
<!-- Reviewable:end -->
