### PR TITLE
Fix error if OrderStateId not exists

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -966,7 +966,7 @@ class OrderCore extends ObjectModel
 
         foreach ($res as $key => $val) {
             // In case order creation crashed midway some data might be absent
-            $orderState = !empty($val['id_order_state']) ? $indexedOrderStates[$val['id_order_state']] : null;
+            $orderState = !empty($val['id_order_state']) ? ($indexedOrderStates[$val['id_order_state']] ?? null) : null;
             $res[$key]['order_state'] = $orderState['name'] ?: null;
             $res[$key]['invoice'] = $orderState['invoice'] ?: null;
             $res[$key]['order_state_color'] = $orderState['color'] ?: null;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      | Fixing issue https://github.com/PrestaShop/PrestaShop/issues/27342
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #27342 
| How to test?      | Try to delete an Order State and after that try to open an order with that Order State Id


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27341)
<!-- Reviewable:end -->
