### PR TITLE
Upgrade Smarty to 3.4.43

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "prestashop/gridhtml": "^2",
     "prestashop/gsitemap": "^4",
     "prestashop/pagesnotfound": "^2",
-    "prestashop/productcomments": "^4.0",
+    "prestashop/productcomments": "^5.0",
     "prestashop/ps_banner": "^2",
     "prestashop/ps_categorytree": "^2",
     "prestashop/ps_checkpayment": "^2",

--- a/composer.lock
+++ b/composer.lock
@@ -7014,16 +7014,16 @@
         },
         {
             "name": "smarty/smarty",
-            "version": "v3.1.39",
+            "version": "v3.1.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smarty-php/smarty.git",
-                "reference": "e27da524f7bcd7361e3ea5cdfa99c4378a7b5419"
+                "reference": "273f7e00fec034f6d61112552e9caf08d19565b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/e27da524f7bcd7361e3ea5cdfa99c4378a7b5419",
-                "reference": "e27da524f7bcd7361e3ea5cdfa99c4378a7b5419",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/273f7e00fec034f6d61112552e9caf08d19565b7",
+                "reference": "273f7e00fec034f6d61112552e9caf08d19565b7",
                 "shasum": ""
             },
             "require": {
@@ -7071,9 +7071,9 @@
                 "forum": "http://www.smarty.net/forums/",
                 "irc": "irc://irc.freenode.org/smarty",
                 "issues": "https://github.com/smarty-php/smarty/issues",
-                "source": "https://github.com/smarty-php/smarty/tree/v3.1.39"
+                "source": "https://github.com/smarty-php/smarty/tree/v3.1.43"
             },
-            "time": "2021-02-17T21:57:51+00:00"
+            "time": "2022-01-10T09:52:40+00:00"
         },
         {
             "name": "soundasleep/html2text",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd93c72eebb06658e639f69beae80be9",
+    "content-hash": "559aa893c10b591d4fa882d8b7cffbc2",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -4699,23 +4699,22 @@
         },
         {
             "name": "prestashop/productcomments",
-            "version": "v4.2.2",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/productcomments.git",
-                "reference": "0058f82c6ed69cf545d07c787e10949a459bd011"
+                "reference": "c08d1ded67f75bde9dc06109748d0fd2e74d8c65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/productcomments/zipball/0058f82c6ed69cf545d07c787e10949a459bd011",
-                "reference": "0058f82c6ed69cf545d07c787e10949a459bd011",
+                "url": "https://api.github.com/repos/PrestaShop/productcomments/zipball/c08d1ded67f75bde9dc06109748d0fd2e74d8c65",
+                "reference": "c08d1ded67f75bde9dc06109748d0fd2e74d8c65",
                 "shasum": ""
             },
             "require": {
                 "doctrine/cache": "^1.6",
                 "guzzlehttp/cache-subscriber": "^0.2.0",
                 "php": ">=5.6.0",
-                "prestashop/circuit-breaker": "^3.0.0",
                 "symfony/css-selector": "^3.4 || ^4.4 || ^5.0"
             },
             "require-dev": {
@@ -4744,9 +4743,9 @@
             "description": "PrestaShop module productcomments",
             "homepage": "https://github.com/PrestaShop/productcomments",
             "support": {
-                "source": "https://github.com/PrestaShop/productcomments/tree/v4.2.2"
+                "source": "https://github.com/PrestaShop/productcomments/tree/v5.0.0"
             },
-            "time": "2021-06-10T07:45:49+00:00"
+            "time": "2021-11-29T09:55:29+00:00"
         },
         {
             "name": "prestashop/ps_banner",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Upgrade Smarty to 3.4.43. This protects us against https://github.com/smarty-php/smarty/security/advisories/GHSA-29gp-2c3m-3j6m and https://github.com/smarty-php/smarty/security/advisories/GHSA-4h9c-v5vg-5m6m. Backport from https://github.com/PrestaShop/PrestaShop/pull/27337. One commit added by @atomiix for the CI to pass.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI is green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27337)
<!-- Reviewable:end -->
