### PR TITLE
Do not pad ps_versions_compliancy for PrestaShop >= 8

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -303,20 +303,16 @@ abstract class ModuleCore implements ModuleInterface
             $this->ps_versions_compliancy['max'] = _PS_VERSION_;
         }
 
-        if (strlen($this->ps_versions_compliancy['min']) == 3) {
-            $this->ps_versions_compliancy['min'] .= '.0.0';
-        }
+        $minParts = explode('.', $this->ps_versions_compliancy['min']);
+        $maxParts = explode('.', $this->ps_versions_compliancy['max']);
 
-        if (strlen($this->ps_versions_compliancy['min']) == 5) {
-            $this->ps_versions_compliancy['min'] .= '.0';
+        // Since v8, we don't pad versions
+        if ((int) current($minParts) < 8) {
+            $this->ps_versions_compliancy['min'] = str_pad($this->ps_versions_compliancy['min'], 7, '.0');
         }
-
-        if (strlen($this->ps_versions_compliancy['max']) == 5) {
-            $this->ps_versions_compliancy['max'] .= '.999';
-        }
-
-        if (strlen($this->ps_versions_compliancy['max']) == 3) {
-            $this->ps_versions_compliancy['max'] .= '.999.999';
+        if ((int) current($maxParts) < 8) {
+            $padLength = strlen($this->ps_versions_compliancy['max']) + (4 - count($maxParts)) * 4;
+            $this->ps_versions_compliancy['max'] = str_pad($this->ps_versions_compliancy['max'], $padLength, '.999');
         }
 
         // Load context and smarty


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When the constructor of a module is called, the `ps_versions_compliancy` property gets padded with missings `.0` or `.999` (`1.7.3` becomes `1.7.3.0` for min and `1.7.3.999` for max). Since PrestaShop 8 get rid of the first `1`, the implemented logic doesn't work and add a missing `.0` or `.999` when it shouldn't. This PR fixes the issue by not padding the `ps_versions_compliancy` property when the version starts with `8` or above.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26968
| How to test?      | Please see #26968
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27355)
<!-- Reviewable:end -->
