### PR TITLE
Simplify CmpPrice functions

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1908,7 +1908,7 @@ class ToolsCore
     public static function orderbyPrice(&$array, $order_way)
     {
         foreach ($array as &$row) {
-            $row['price_tmp'] = Product::getPriceStatic($row['id_product'], true, ((isset($row['id_product_attribute']) && !empty($row['id_product_attribute'])) ? (int) $row['id_product_attribute'] : null), 2);
+            $row['price_tmp'] = (float) Product::getPriceStatic($row['id_product'], true, ((isset($row['id_product_attribute']) && !empty($row['id_product_attribute'])) ? (int) $row['id_product_attribute'] : null), 2);
         }
         unset($row);
 
@@ -4374,16 +4374,9 @@ exit;
  *
  * @return int
  */
-/* Externalized because of a bug in PHP 5.1.6 when inside an object */
 function cmpPriceAsc($a, $b)
 {
-    if ((float) $a['price_tmp'] < (float) $b['price_tmp']) {
-        return -1;
-    } elseif ((float) $a['price_tmp'] > (float) $b['price_tmp']) {
-        return 1;
-    }
-
-    return 0;
+    return $a['price_tmp'] <=> $b['price_tmp'];
 }
 
 /**
@@ -4394,11 +4387,5 @@ function cmpPriceAsc($a, $b)
  */
 function cmpPriceDesc($a, $b)
 {
-    if ((float) $a['price_tmp'] < (float) $b['price_tmp']) {
-        return 1;
-    } elseif ((float) $a['price_tmp'] > (float) $b['price_tmp']) {
-        return -1;
-    }
-
-    return 0;
+    return $b['price_tmp'] <=> $a['price_tmp'];
 }

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -231,7 +231,7 @@ class AdminProductsControllerCore extends AdminController
 
                 // convert price with the currency from context
                 $this->_list[$i]['price'] = Tools::convertPrice($this->_list[$i]['price'], $this->context->currency, true, $this->context);
-                $this->_list[$i]['price_tmp'] = Product::getPriceStatic(
+                $this->_list[$i]['price_tmp'] = (float) Product::getPriceStatic(
                     $this->_list[$i]['id_product'],
                     true,
                     null,

--- a/tests/Resources/modules_tests/override/AdminProductsController.php
+++ b/tests/Resources/modules_tests/override/AdminProductsController.php
@@ -126,7 +126,7 @@ class AdminProductsController extends AdminProductsControllerCore
                     $context->shop = new Shop((int) $this->_list[$i]['id_shop_default']);
                 }
                 $this->_list[$i]['price'] = Tools::convertPrice($this->_list[$i]['price'], $this->context->currency, true, $this->context);
-                $this->_list[$i]['price_tmp'] = Product::getPriceStatic($this->_list[$i]['id_product'], true, null, 2, null, false, true, 1, true, null, null, null, $nothing, true, true, $context);
+                $this->_list[$i]['price_tmp'] = (float) Product::getPriceStatic($this->_list[$i]['id_product'], true, null, 2, null, false, true, 1, true, null, null, null, $nothing, true, true, $context);
             }
         }
         if ($orderByPriceFinal == 'price_final') {

--- a/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -135,7 +135,7 @@ class AdminProductsController extends AdminProductsControllerCore
 
                 // convert price with the currency from context
                 $this->_list[$i]['price'] = Tools::convertPrice($this->_list[$i]['price'], $this->context->currency, true, $this->context);
-                $this->_list[$i]['price_tmp'] = Product::getPriceStatic($this->_list[$i]['id_product'], true, null, 2, null, false, true, 1, true, null, null, null, $nothing, true, true, $context);
+                $this->_list[$i]['price_tmp'] = (float) Product::getPriceStatic($this->_list[$i]['id_product'], true, null, 2, null, false, true, 1, true, null, null, null, $nothing, true, true, $context);
             }
         }
 

--- a/tests/Unit/Classes/ToolsTest.php
+++ b/tests/Unit/Classes/ToolsTest.php
@@ -571,4 +571,42 @@ class ToolsTest extends TestCase
             [null, 'http://'],
         ];
     }
+
+    /**
+     * @param int $expectedReturn
+     * @param array{"price_tmp": float} $a
+     * @param array{"price_tmp": float} $b
+     *
+     * @dataProvider providerCmpPriceAsc
+     */
+    public function testCmpPriceAsc(int $expectedReturn, $a, $b): void
+    {
+        $this->assertSame($expectedReturn, cmpPriceAsc($a, $b));
+    }
+
+    public function providerCmpPriceAsc(): iterable
+    {
+        yield [-1, ['price_tmp' => -0.001], ['price_tmp' => 0]];
+        yield [0, ['price_tmp' => 0], ['price_tmp' => 0]];
+        yield [1, ['price_tmp' => 0.001], ['price_tmp' => 0]];
+    }
+
+    /**
+     * @param int $expectedReturn
+     * @param array{"price_tmp": float} $a
+     * @param array{"price_tmp": float} $b
+     *
+     * @dataProvider providerCmpPriceDesc
+     */
+    public function testCmpPriceDesc(int $expectedReturn, $a, $b): void
+    {
+        $this->assertSame($expectedReturn, cmpPriceDesc($a, $b));
+    }
+
+    public function providerCmpPriceDesc(): iterable
+    {
+        yield [1, ['price_tmp' => -0.001], ['price_tmp' => 0]];
+        yield [0, ['price_tmp' => 0], ['price_tmp' => 0]];
+        yield [-1, ['price_tmp' => 0.001], ['price_tmp' => 0]];
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since PHP 7.0 we have `<=>` operator that does the same.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Unit test included.
| Possible impacts? | Despite the fact that the function documentation states that it only admits floats, previously, we do a conversion to float on each comparison.<br>Now, the values are converted to float before and the function no longer works as before with null values.<br>My advice is to be strict with this. <br>Previously around 4NlogN conversions to float were done, now only N.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27360)
<!-- Reviewable:end -->
