### PR TITLE
Deprecate Tools::arrayReplaceRecursive()

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4208,35 +4208,14 @@ exit;
      *
      * @param array $base the array in which elements are replaced
      * @param array $replacements the array from which elements will be extracted
+     *
+     * @deprecated since version 8.0.0, to be removed.
      */
     public static function arrayReplaceRecursive($base, $replacements)
     {
-        if (function_exists('array_replace_recursive')) {
-            return array_replace_recursive($base, $replacements);
-        }
+        Tools::displayAsDeprecated('Use PHP\'s array_replace_recursive() instead');
 
-        foreach (array_slice(func_get_args(), 1) as $replacements) {
-            $bref_stack = [&$base];
-            $head_stack = [$replacements];
-
-            do {
-                end($bref_stack);
-
-                $bref = &$bref_stack[key($bref_stack)];
-                $head = array_pop($head_stack);
-                unset($bref_stack[key($bref_stack)]);
-                foreach (array_keys($head) as $key) {
-                    if (is_array($bref[$key]) && is_array($head[$key])) {
-                        $bref_stack[] = &$bref[$key];
-                        $head_stack[] = $head[$key];
-                    } else {
-                        $bref[$key] = $head[$key];
-                    }
-                }
-            } while (count($head_stack));
-        }
-
-        return $base;
+        return array_replace_recursive($base, $replacements);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Deprecate `Tools::arrayReplaceRecursive()` because we have `array_replace_recursive()` since PHP 5 >= 5.3.0
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | no
| How to test?      | No needed / CI green
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27361)
<!-- Reviewable:end -->
