### PR TITLE
Deprecate Tools::redirectLink

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -195,7 +195,7 @@ class ToolsCore
             $link = Context::getContext()->link;
         }
 
-        if (strpos($url, 'http://') === false && strpos($url, 'https://') === false && $link) {
+        if (!preg_match('@^https?://@i', $url) && $link) {
             if (strpos($url, $base_uri) === 0) {
                 $url = substr($url, strlen($base_uri));
             }
@@ -234,24 +234,13 @@ class ToolsCore
      * Warning: uses exit
      *
      * @param string $url Desired URL
+     *
+     * @deprecated since PrestaShop 8.0.0
      */
     public static function redirectLink($url)
     {
-        if (!preg_match('@^https?://@i', $url)) {
-            if (strpos($url, __PS_BASE_URI__) !== false && strpos($url, __PS_BASE_URI__) == 0) {
-                $url = substr($url, strlen(__PS_BASE_URI__));
-            }
-            if (strpos($url, 'index.php?controller=') !== false && strpos($url, 'index.php/') == 0) {
-                $url = substr($url, strlen('index.php?controller='));
-            }
-            $explode = explode('?', $url);
-            $url = Context::getContext()->link->getPageLink($explode[0]);
-            if (isset($explode[1])) {
-                $url .= '?' . $explode[1];
-            }
-        }
-        header('Location: ' . $url);
-        exit;
+        Tools::displayAsDeprecated('Use Tools::redirect() instead');
+        static::redirect($url);
     }
 
     /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -199,7 +199,7 @@ class ToolsCore
             if (strpos($url, $base_uri) === 0) {
                 $url = substr($url, strlen($base_uri));
             }
-            if (strpos($url, 'index.php?controller=') !== false && strpos($url, 'index.php/') == 0) {
+            if (strpos($url, 'index.php?controller=') === 0) {
                 $url = substr($url, strlen('index.php?controller='));
                 if (Configuration::get('PS_REWRITING_SETTINGS')) {
                     $url = Tools::strReplaceFirst('&', '?', $url);

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -664,7 +664,7 @@ class FrontControllerCore extends Controller
      */
     protected function redirect()
     {
-        Tools::redirectLink($this->redirect_after);
+        Tools::redirect($this->redirect_after);
     }
 
     public function redirectWithNotifications()
@@ -854,7 +854,7 @@ class FrontControllerCore extends Controller
             $redirect_type = Configuration::get('PS_CANONICAL_REDIRECT') == 2 ? '301' : '302';
             header('HTTP/1.0 ' . $redirect_type . ' Moved');
             header('Cache-Control: no-cache');
-            Tools::redirectLink($final_url);
+            Tools::redirect($final_url);
         }
     }
 

--- a/tools/profiling/Tools.php
+++ b/tools/profiling/Tools.php
@@ -31,7 +31,7 @@ class Tools extends ToolsCore
             $link = Context::getContext()->link;
         }
 
-        if (strpos($url, 'http://') === false && strpos($url, 'https://') === false) {
+        if (!preg_match('@^https?://@i', $url) && $link) {
             if (strpos($url, $base_uri) === 0) {
                 $url = substr($url, strlen($base_uri));
             }
@@ -43,8 +43,7 @@ class Tools extends ToolsCore
             }
 
             $explode = explode('?', $url);
-            // don't use ssl if url is home page
-            // used when logout for example
+            // don't use ssl if url is home page, used when logout for example
             $use_ssl = !empty($url);
             $url = $link->getPageLink($explode[0], $use_ssl);
             if (isset($explode[1])) {
@@ -85,16 +84,7 @@ class Tools extends ToolsCore
 
     public static function redirectLink($url)
     {
-        if (!preg_match('@^https?://@i', $url)) {
-            if (strpos($url, __PS_BASE_URI__) !== false && strpos($url, __PS_BASE_URI__) == 0) {
-                $url = substr($url, strlen(__PS_BASE_URI__));
-            }
-            $explode = explode('?', $url);
-            $url = Context::getContext()->link->getPageLink($explode[0]);
-            if (isset($explode[1])) {
-                $url .= '?' . $explode[1];
-            }
-        }
+        static::redirect($url);
     }
 
     public static function redirectAdmin($url)

--- a/tools/profiling/Tools.php
+++ b/tools/profiling/Tools.php
@@ -35,7 +35,7 @@ class Tools extends ToolsCore
             if (strpos($url, $base_uri) === 0) {
                 $url = substr($url, strlen($base_uri));
             }
-            if (strpos($url, 'index.php?controller=') !== false && strpos($url, 'index.php/') == 0) {
+            if (strpos($url, 'index.php?controller=') === 0) {
                 $url = substr($url, strlen('index.php?controller='));
                 if (Configuration::get('PS_REWRITING_SETTINGS')) {
                     $url = static::strReplaceFirst('&', '?', $url);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `Tools::redirectLink` and `Tools::redirect` do the same and they have bugs.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | no
| How to test?      | ¿?
| Possible impacts? | `PS_REWRITING_SETTINGS` was not handled in `Tools::redirect`. Was it a bug or intentional?


Change to discuss:
```diff
-if (strpos($url, 'index.php?controller=') !== false && strpos($url, 'index.php/') == 0) {
+if (strpos($url, 'index.php?controller=') === 0) {
    $url = substr($url, strlen('index.php?controller='));
}
```

#### Other notes:
- `preg_match('@^https?://@i', $url)` is better than `strpos($url, 'http://') === false && strpos($url, 'https://') === false` because it is not case sensitive.
- `strpos($url, __PS_BASE_URI__) !== false && strpos($url, __PS_BASE_URI__) == 0` is the same as `strpos($url, __PS_BASE_URI__) === 0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27364)
<!-- Reviewable:end -->
