### PR TITLE
Rework of Webservice API

### DIFF
--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -26,17 +26,28 @@
  */
 class ApiNode
 {
+
     public const TYPE_VALUE = 'value';
     public const TYPE_LANGUAGE = 'language';
     public const TYPE_PARENT = 'parent';
     public const TYPE_LIST = 'list';
 
     public static $languages;
-    private string $type;
-    private ?string $name = null;
-    private ?string $value = null;
-    private array $attributes = [];
-    private array $nodes = [];
+
+    /** @var string */
+    private $type;
+
+    /** @var string|null */
+    private $name = null;
+
+    /** @var string|null */
+    private $value = null;
+
+    /** @var array */
+    private $attributes = [];
+
+    /** @var array */
+    private $nodes = [];
 
     private function __construct(string $type, ?string $name = null, ?string $value = null, array $attributes = [], array $nodes = [])
     {

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -328,7 +328,7 @@ class ApiNode
         }
 
         // display i18n fields
-        if (isset($field['i18n']) && $field['i18n']) {
+        if (!empty($field['i18n'])) {
             foreach (self::$languages as $language) {
                 $langAttributes = ['id' => $language];
 

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -299,7 +299,7 @@ class ApiNode
      *
      * @param array $field
      * @param string $schemaToDisplay
-     * 
+     *
      * @return self
      */
     public function addField(array $field, string $schemaToDisplay = ''): self

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -26,7 +26,6 @@
  */
 class ApiNode
 {
-
     public const TYPE_VALUE = 'value';
     public const TYPE_LANGUAGE = 'language';
     public const TYPE_PARENT = 'parent';
@@ -245,7 +244,7 @@ class ApiNode
      * Create new ApiNode of type "value" and appends it as child to current ApiNode
      *
      * @param string $name
-     * @param mixed $value
+     * @param string|null $value
      *
      * @return ApiNode Created child node
      */
@@ -261,7 +260,6 @@ class ApiNode
      * Create new ApiNode of type "lang" and appends it as child to current ApiNode
      *
      * @param string $name
-     * @param array $values
      *
      * @return ApiNode Created child node
      */

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -1,0 +1,369 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+class ApiNode
+{
+    public const TYPE_VALUE = 'value';
+    public const TYPE_LANGUAGE = 'language';
+    public const TYPE_PARENT = 'parent';
+    public const TYPE_LIST = 'list';
+
+    public static $languages;
+    private string $type;
+    private ?string $name = null;
+    private ?string $value = null;
+    private array $attributes = [];
+    private array $nodes = [];
+
+    private function __construct(string $type, ?string $name = null, ?string $value = null, array $attributes = [], array $nodes = [])
+    {
+        $this->type = $type;
+        $this->name = $name;
+        $this->value = $value;
+        $this->attributes = $attributes;
+        $this->nodes = $nodes;
+    }
+
+    /**
+     * Create new ApiNode instance of type "value"
+     *
+     * @param string $name
+     * @param string|null $value
+     *
+     * @return \ApiNode
+     */
+    private static function value(string $name, ?string $value = null): self
+    {
+        return new ApiNode(self::TYPE_VALUE, $name, $value);
+    }
+
+    /**
+     * Create new ApiNode instance of type "lang"
+     * Lang ApiNode serves as ApiNode with name. All the translated values are supposed to be children of that Node.
+     *
+     * @param string $name
+     *
+     * @return \ApiNode
+     */
+    private static function lang(string $name): self
+    {
+        return new ApiNode(self::TYPE_LANGUAGE, $name);
+    }
+
+    /**
+     * Create new ApiNode instance of type "parent"
+     * Parent ApiNode serves as ApiNode with name and array of child nodes (and potentionally array of attributes)
+     * Its children nodes are meant to be rendered as associative arrays
+     *
+     * @param string $name
+     * @param array $attributes
+     *
+     * @return \ApiNode
+     */
+    public static function parent(?string $name = null, array $attributes = []): self
+    {
+        return new ApiNode(self::TYPE_PARENT, $name, null, $attributes);
+    }
+
+    /**
+     * Create new ApiNode instance of type "list"
+     * List ApiNode serves as ApiNode with name and array of child nodes.
+     * Its children nodes are meant to be rendered as non-associative arrays
+     *
+     * @param string $name
+     * @param array $attributes
+     *
+     * @return \ApiNode
+     */
+    public static function list(?string $name = null, array $attributes = []): self
+    {
+        return new ApiNode(self::TYPE_LIST, $name, null, $attributes);
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    /**
+     * @return array
+     */
+    public function getNodes(): array
+    {
+        return $this->nodes;
+    }
+
+    /**
+     * @param string $type
+     *
+     * @return self
+     */
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $name
+     *
+     * @return self
+     */
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @param string|null $value
+     *
+     * @return self
+     */
+    public function setValue(?string $value): self
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param array $attributes
+     *
+     * @return self
+     */
+    public function setAttributes(array $attributes): self
+    {
+        $this->attributes = $attributes;
+
+        return $this;
+    }
+
+    /**
+     * @param array $nodes
+     *
+     * @return self
+     */
+    public function setNodes(array $nodes): self
+    {
+        $this->nodes = $nodes;
+
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @param string|null $value
+     *
+     * @return self
+     */
+    public function addAttribute(string $name, ?string $value = null): self
+    {
+        $this->attributes[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Appends $node as child to current ApiNode
+     *
+     * @param ApiNode $node
+     *
+     * @return ApiNode self
+     */
+    public function addApiNode(ApiNode $node): self
+    {
+        $this->nodes[] = $node;
+
+        return $this;
+    }
+
+    /**
+     * Create new ApiNode of type "value" and appends it as child to current ApiNode
+     *
+     * @param string $name
+     * @param mixed $value
+     *
+     * @return ApiNode Created child node
+     */
+    public function addNode(string $name, ?string $value = null): self
+    {
+        $newNode = self::value($name, $value);
+        $this->nodes[] = $newNode;
+
+        return $newNode;
+    }
+
+    /**
+     * Create new ApiNode of type "lang" and appends it as child to current ApiNode
+     *
+     * @param string $name
+     * @param array $values
+     *
+     * @return ApiNode Created child node
+     */
+    public function addLanguageNode(string $name): self
+    {
+        $newNode = self::lang($name);
+        $this->nodes[] = $newNode;
+
+        return $newNode;
+    }
+
+    /**
+     * Create new ApiNode of type "parent" and appends it as child to current ApiNode
+     *
+     * @param string $name
+     * @param array $attributes
+     *
+     * @return ApiNode Created child node
+     */
+    public function addParentNode(string $name = null, array $attributes = []): self
+    {
+        $newNode = self::parent($name, $attributes);
+        $this->nodes[] = $newNode;
+
+        return $newNode;
+    }
+
+    /**
+     * Create new ApiNode of type "list" and appends it as child to current ApiNode
+     *
+     * @param string $name
+     * @param array $attributes
+     *
+     * @return ApiNode Created child node
+     */
+    public function addListNode(string $name = null, array $attributes = [])
+    {
+        $newNode = self::list($name, $attributes);
+        $this->nodes[] = $newNode;
+
+        return $newNode;
+    }
+
+    /**
+     * Transform $field array into ApiNode and appends it as child to current node
+     *
+     * @param array $field
+     * @param string $schemaToDisplay
+     * 
+     * @return self
+     */
+    public function addField(array $field, string $schemaToDisplay = ''): self
+    {
+        $newNode = self::value($field['sqlId']);
+
+        if (isset($field['encode'])) {
+            $newNode->addAttribute('encode', $field['encode']);
+        }
+
+        if (!empty($field['synopsis_details']) && $schemaToDisplay !== 'blank') {
+            foreach ($field['synopsis_details'] as $name => $detail) {
+                $newNode->addAttribute($name, is_array($detail) ? implode(' ', $detail) : $detail);
+            }
+        }
+
+        // display i18n fields
+        if (isset($field['i18n']) && $field['i18n']) {
+            foreach (self::$languages as $language) {
+                $langAttributes = ['id' => $language];
+
+                if (isset($field['synopsis_details']) || (isset($field['value']) && is_array($field['value']))) {
+                    $langAttributes['xlink:href'] = WebserviceOutputBuilderCore::$wsUrl . 'languages/' . $language;
+                    if (isset($field['synopsis_details']) && $schemaToDisplay != 'blank') {
+                        $langAttributes['format'] = 'isUnsignedId';
+                    }
+                }
+
+                $newNode->setType(self::TYPE_LANGUAGE);
+                $newNode->addNode('language', $field['value'][$language] ?? '')
+                    ->setAttributes($langAttributes);
+            }
+        } else {
+            // display not i18n fields value
+            if (array_key_exists('xlink_resource', $field) && $schemaToDisplay != 'blank') {
+                if (!is_array($field['xlink_resource'])) {
+                    $xlink = WebserviceOutputBuilderCore::$wsUrl . $field['xlink_resource'] . '/' . $field['value'];
+                } else {
+                    $xlink = WebserviceOutputBuilderCore::$wsUrl . $field['xlink_resource']['resourceName'] . '/';
+
+                    if (isset($field['xlink_resource']['subResourceName'])) {
+                        $xlink .= $field['xlink_resource']['subResourceName'] . '/' . $field['object_id'] . '/';
+                    }
+
+                    $xlink .= $field['value'];
+                }
+                $newNode->addAttribute('xlink:href', $xlink);
+            }
+
+            if (isset($field['getter']) && $schemaToDisplay != 'blank') {
+                $newNode->addAttribute('notFilterable', 'true');
+            }
+
+            if (isset($field['setter']) && $field['setter'] == false && $schemaToDisplay == 'synopsis') {
+                $newNode->addAttribute('read_only', 'true');
+            }
+
+            if (array_key_exists('value', $field)) {
+                $newNode->setValue($field['value']);
+            }
+        }
+
+        $this->nodes[] = $newNode;
+
+        return $newNode;
+    }
+}

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -34,6 +34,7 @@ class ApiNode
     public const TYPE_PARENT = 'parent';
     public const TYPE_LIST = 'list';
 
+    /** @var int[] Ids of available languages  */
     public static $languages;
 
     /** @var string */

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -307,7 +307,29 @@ class ApiNode
      * Transform $field array into ApiNode and appends it as child to current node
      *
      * @param array $field
-     * @param string|null $schemaToDisplay
+     * <pre>
+     * $field = [
+     *  'sqlId' => (string) DB field name. Required.
+     *  'encode'    => (string) Field encoding. May contain 'base64' for displaying image content. Optional.
+     *  'synopsis_details'  => [
+     *      'required'  => (string) 'true' / 'false'. Added as an attribute.
+     *      'maxSize'   => (int) Maximum field size. Length for strings, digits for integers. Added as an attribute.
+     *      'format'    => (string) Field specific format. Added as an attribute.
+     *      'readOnly'  => (string) 'true' / 'false'. Added as an attribute.
+     *  ] (Optional)
+     *  'i18n'  => (bool) If this is international field. If set, this field is rendered with <strong>language</strong> sub-nodes. (Optional)
+     *  'value' => (mixed) Field value. Required.
+     *  'xlink_resource'    => (string) Url resource. If set to string, this field is rendered with <strong>xlink:href</strong> attribute, containing this url, prepended with language base url.
+     *  'xlink_resource'    => [
+     *      'resourceName'  => (string) Resource name, to url scheme: <i>'wsUrl/<strong>resourceName</strong>/<strong>subResourceName</strong>/<strong>object_id</strong>/<strong>value</strong>'</i>
+     *      'subResourceName'  => (string) Sub-Resource name, used to compose output url.
+     *  ]
+     *  'object_id' => (string|int) Sub resource id. Used to compose output url and only if xlink_resource contains subResourceName.
+     *  'getter'    => (string) Name of getter. If set, adds attribute <strong>notFilterable = true</strong>.
+     *  'setter'    => (bool) Name of setter. If set to <i>false</i> and <strong>$schemaToDisplay</strong> is set to synopsis, adds attribute <strong>read_only = true</strong>.
+     *]
+     * </pre>
+     * @param string|null $schemaToDisplay 'blank' / 'synopsis'. Optional
      *
      * @return self
      */

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -43,7 +43,7 @@ class ApiNode
     /** @var string|null */
     private $name = null;
 
-    /** @var string|null */
+    /** @var mixed */
     private $value = null;
 
     /** @var array */
@@ -134,9 +134,9 @@ class ApiNode
     }
 
     /**
-     * @return string|null
+     * @return mixed
      */
-    public function getValue(): ?string
+    public function getValue()
     {
         return $this->value;
     }
@@ -182,11 +182,11 @@ class ApiNode
     }
 
     /**
-     * @param string|null $value
+     * @param mixed $value
      *
      * @return self
      */
-    public function setValue(?string $value): self
+    public function setValue($value): self
     {
         $this->value = $value;
 

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -34,7 +34,7 @@ class ApiNode
     public const TYPE_PARENT = 'parent';
     public const TYPE_LIST = 'list';
 
-    /** @var int[] Ids of available languages  */
+    /** @var int[] Ids of available languages */
     public static $languages;
 
     /** @var string */

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -307,11 +307,11 @@ class ApiNode
      * Transform $field array into ApiNode and appends it as child to current node
      *
      * @param array $field
-     * @param string $schemaToDisplay
+     * @param string|null $schemaToDisplay
      *
      * @return self
      */
-    public function addField(array $field, string $schemaToDisplay = ''): self
+    public function addField(array $field, ?string $schemaToDisplay = null): self
     {
         $newNode = self::value($field['sqlId']);
 

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -24,6 +24,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+declare(strict_types=1);
+
 class ApiNode
 {
     public const TYPE_VALUE = 'value';

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -307,26 +307,26 @@ class ApiNode
      * Transform $field array into ApiNode and appends it as child to current node
      *
      * @param array $field
-     * <pre>
-     * $field = [
-     *  'sqlId' => (string) DB field name. Required.
-     *  'encode'    => (string) Field encoding. May contain 'base64' for displaying image content. Optional.
-     *  'synopsis_details'  => [
-     *      'required'  => (string) 'true' / 'false'. Added as an attribute.
-     *      'maxSize'   => (int) Maximum field size. Length for strings, digits for integers. Added as an attribute.
-     *      'format'    => (string) Field specific format. Added as an attribute.
-     *      'readOnly'  => (string) 'true' / 'false'. Added as an attribute.
-     *  ] (Optional)
-     *  'i18n'  => (bool) If this is international field. If set, this field is rendered with <strong>language</strong> sub-nodes. (Optional)
-     *  'value' => (mixed) Field value. Required.
-     *  'xlink_resource'    => (string) Url resource. If set to string, this field is rendered with <strong>xlink:href</strong> attribute, containing this url, prepended with language base url.
-     *  'xlink_resource'    => [
-     *      'resourceName'  => (string) Resource name, to url scheme: <i>'wsUrl/<strong>resourceName</strong>/<strong>subResourceName</strong>/<strong>object_id</strong>/<strong>value</strong>'</i>
-     *      'subResourceName'  => (string) Sub-Resource name, used to compose output url.
-     *  ]
-     *  'object_id' => (string|int) Sub resource id. Used to compose output url and only if xlink_resource contains subResourceName.
-     *  'getter'    => (string) Name of getter. If set, adds attribute <strong>notFilterable = true</strong>.
-     *  'setter'    => (bool) Name of setter. If set to <i>false</i> and <strong>$schemaToDisplay</strong> is set to synopsis, adds attribute <strong>read_only = true</strong>.
+     *                     <pre>
+     *                     $field = [
+     *                     'sqlId' => (string) DB field name. Required.
+     *                     'encode'    => (string) Field encoding. May contain 'base64' for displaying image content. Optional.
+     *                     'synopsis_details'  => [
+     *                     'required'  => (string) 'true' / 'false'. Added as an attribute.
+     *                     'maxSize'   => (int) Maximum field size. Length for strings, digits for integers. Added as an attribute.
+     *                     'format'    => (string) Field specific format. Added as an attribute.
+     *                     'readOnly'  => (string) 'true' / 'false'. Added as an attribute.
+     *                     ] (Optional)
+     *                     'i18n'  => (bool) If this is international field. If set, this field is rendered with <strong>language</strong> sub-nodes. (Optional)
+     *                     'value' => (mixed) Field value. Required.
+     *                     'xlink_resource'    => (string) Url resource. If set to string, this field is rendered with <strong>xlink:href</strong> attribute, containing this url, prepended with language base url.
+     *                     'xlink_resource'    => [
+     *                     'resourceName'  => (string) Resource name, to url scheme: <i>'wsUrl/<strong>resourceName</strong>/<strong>subResourceName</strong>/<strong>object_id</strong>/<strong>value</strong>'</i>
+     *                     'subResourceName'  => (string) Sub-Resource name, used to compose output url.
+     *                     ]
+     *                     'object_id' => (string|int) Sub resource id. Used to compose output url and only if xlink_resource contains subResourceName.
+     *                     'getter'    => (string) Name of getter. If set, adds attribute <strong>notFilterable = true</strong>.
+     *                     'setter'    => (bool) Name of setter. If set to <i>false</i> and <strong>$schemaToDisplay</strong> is set to synopsis, adds attribute <strong>read_only = true</strong>.
      *]
      * </pre>
      * @param string|null $schemaToDisplay 'blank' / 'synopsis'. Optional

--- a/classes/webservice/ApiNode.php
+++ b/classes/webservice/ApiNode.php
@@ -365,7 +365,7 @@ class ApiNode
             }
         } else {
             // display not i18n fields value
-            if (array_key_exists('xlink_resource', $field) && $schemaToDisplay != 'blank') {
+            if (array_key_exists('xlink_resource', $field) && $schemaToDisplay != 'blank' && isset($field['value'])) {
                 if (!is_array($field['xlink_resource'])) {
                     $xlink = WebserviceOutputBuilderCore::$wsUrl . $field['xlink_resource'] . '/' . $field['value'];
                 } else {

--- a/classes/webservice/SuperXMLElement.php
+++ b/classes/webservice/SuperXMLElement.php
@@ -24,9 +24,17 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-interface WebserviceOutputInterface
+class SuperXMLElement extends \SimpleXMLElement
 {
-    public function getContentType();
+    public function addChildCData(string $name, ?string $value = null): SuperXMLElement
+    {
+        $new = $this->addChild($name);
+        if ($value !== null) {
+            $base = dom_import_simplexml($new);
+            $docOwner = $base->ownerDocument;
+            $base->appendChild($docOwner->createCDATASection($value));
+        }
 
-    public function renderNode($apiNode);
+        return $new;
+    }
 }

--- a/classes/webservice/SuperXMLElement.php
+++ b/classes/webservice/SuperXMLElement.php
@@ -24,6 +24,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+declare(strict_types=1);
+
 class SuperXMLElement extends \SimpleXMLElement
 {
     public function addChildCData(string $name, ?string $value = null): SuperXMLElement

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -410,7 +410,7 @@ class WebserviceOutputBuilderCore
                     } else {
                         $this->renderEntity($this->output, $object);
                     }
-                } elseif ($key == 'empty' && $this->objectRender->getContentType() == 'application/json') {
+                } elseif ($this->objectRender->getContentType() == 'application/json') {
                     $this->renderEntity($this->output, $object);
                 }
             }

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -410,8 +410,6 @@ class WebserviceOutputBuilderCore
                     } else {
                         $this->renderEntity($this->output, $object);
                     }
-                } elseif ($this->objectRender->getContentType() == 'application/json') {
-                    $this->renderEntity($this->output, $object);
                 }
             }
         } else {

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -35,7 +35,14 @@ class WebserviceOutputBuilderCore
     const VIEW_LIST = 1;
     const VIEW_DETAILS = 2;
 
-    protected $wsUrl;
+    /**
+     * Base PrestaShop webservice URL.
+     *
+     * @var string
+     */
+    public static $wsUrl;
+
+    /** @var ApiNode */
     protected $output;
 
     /** @var WebserviceOutputInterface|WebserviceOutputXML|WebserviceOutputJSON|null */
@@ -68,8 +75,13 @@ class WebserviceOutputBuilderCore
     {
         $this->statusInt = 200;
         $this->status = $_SERVER['SERVER_PROTOCOL'] . ' 200 OK';
-        $this->wsUrl = $ws_url;
         $this->wsParamOverrides = [];
+        self::$wsUrl = $ws_url;
+    }
+
+    public function getOutput(): ApiNode
+    {
+        return $this->output;
     }
 
     /**
@@ -90,7 +102,7 @@ class WebserviceOutputBuilderCore
         }
 
         $this->objectRender = $obj_render;
-        $this->objectRender->setWsUrl($this->wsUrl);
+
         if ($this->objectRender->getContentType()) {
             $this->setHeaderParams('Content-Type', $this->objectRender->getContentType());
         }
@@ -278,25 +290,28 @@ class WebserviceOutputBuilderCore
      */
     public function getErrors($errors)
     {
-        $str_output = '';
-        if (!empty($errors)) {
-            if (isset($this->objectRender)) {
-                $str_output = $this->objectRender->renderErrorsHeader();
-                foreach ($errors as $error) {
-                    if (is_array($error)) {
-                        $str_output .= $this->objectRender->renderErrors($error[1], $error[0]);
-                    } else {
-                        $str_output .= $this->objectRender->renderErrors($error);
-                    }
+        if (empty($errors)) {
+            return '';
+        }
+
+        if (!isset($this->objectRender)) {
+            return '<pre>' . print_r($errors, true) . '</pre>';
+        }
+
+        $this->output = ApiNode::list('errors');
+        foreach ($errors as $error) {
+            $errorNode = $this->output->addParentNode('error');
+            if (is_array($error)) {
+                if ($error[0]) {
+                    $errorNode->addNode('code', $error[0]);
                 }
-                $str_output .= $this->objectRender->renderErrorsFooter();
-                $str_output = $this->objectRender->overrideContent($str_output);
+                $errorNode->addNode('message', $error[1]);
             } else {
-                $str_output = '<pre>' . print_r($errors, true) . '</pre>';
+                $errorNode->addNode('message', $error);
             }
         }
 
-        return $str_output;
+        return $this->objectRender->renderNode($this->output);
     }
 
     /**
@@ -311,44 +326,39 @@ class WebserviceOutputBuilderCore
         if (null === $this->wsResource) {
             throw new WebserviceException('You must set web service resource for get the resources list.', [82, 500]);
         }
-        $output = '';
-        $more_attr = ['shopName' => htmlspecialchars(Configuration::get('PS_SHOP_NAME'))];
-        $output .= $this->objectRender->renderNodeHeader('api', [], $more_attr);
+
+        $output = ApiNode::list('api')->setAttributes(['shopName' => htmlspecialchars(Configuration::get('PS_SHOP_NAME'))]);
+
         foreach ($this->wsResource as $resourceName => $resource) {
             if (in_array($resourceName, array_keys($key_permissions))) {
-                $more_attr = [
-                    'xlink_resource' => $this->wsUrl . $resourceName,
+                $resourceNode = $output->addParentNode($resourceName, [
+                    'xlink:href' => self::$wsUrl . $resourceName,
                     'get' => (in_array('GET', $key_permissions[$resourceName]) ? 'true' : 'false'),
                     'put' => (in_array('PUT', $key_permissions[$resourceName]) ? 'true' : 'false'),
                     'post' => (in_array('POST', $key_permissions[$resourceName]) ? 'true' : 'false'),
                     'delete' => (in_array('DELETE', $key_permissions[$resourceName]) ? 'true' : 'false'),
                     'head' => (in_array('HEAD', $key_permissions[$resourceName]) ? 'true' : 'false'),
-                ];
-                $output .= $this->objectRender->renderNodeHeader($resourceName, [], $more_attr);
+                ]);
 
-                $output .= $this->objectRender->renderNodeHeader('description', [], $more_attr);
-                $output .= $resource['description'];
-                $output .= $this->objectRender->renderNodeFooter('description', []);
+                $resourceNode->addNode('description', $resource['description']);
 
                 if (!isset($resource['specific_management']) || !$resource['specific_management']) {
-                    $more_attr_schema = [
-                        'xlink_resource' => $this->wsUrl . $resourceName . '?schema=blank',
+                    //add blank schema
+                    $resourceNode->addNode('schema')->setAttributes([
+                        'xlink:href' => self::$wsUrl . $resourceName . '?schema=blank',
                         'type' => 'blank',
-                    ];
-                    $output .= $this->objectRender->renderNodeHeader('schema', [], $more_attr_schema, false);
-                    $more_attr_schema = [
-                        'xlink_resource' => $this->wsUrl . $resourceName . '?schema=synopsis',
+                    ]);
+
+                    //add synopsis schema
+                    $resourceNode->addNode('schema')->setAttributes([
+                        'xlink:href' => self::$wsUrl . $resourceName . '?schema=synopsis',
                         'type' => 'synopsis',
-                    ];
-                    $output .= $this->objectRender->renderNodeHeader('schema', [], $more_attr_schema, false);
+                    ]);
                 }
-                $output .= $this->objectRender->renderNodeFooter($resourceName, []);
             }
         }
-        $output .= $this->objectRender->renderNodeFooter('api', []);
-        $output = $this->objectRender->overrideContent($output);
 
-        return $output;
+        return $this->objectRender->renderNode($output);
     }
 
     public function registerOverrideWSParameters($wsrObject, $method)
@@ -378,79 +388,52 @@ class WebserviceOutputBuilderCore
     {
         $this->fieldsToDisplay = $fields_to_display;
         $this->depth = $depth;
-        $output = '';
 
         if ($schema_to_display != null) {
             $this->schemaToDisplay = $schema_to_display;
-            $this->objectRender->setSchemaToDisplay($this->schemaToDisplay);
-
-            // If a shema is asked the view must be an details type
-            $type_of_view = self::VIEW_DETAILS;
+            $type_of_view = self::VIEW_DETAILS; // If a shema is asked the view must be an details type
         }
-
-        $class = get_class($objects['empty']);
-        if (!isset(WebserviceOutputBuilder::$_cache_ws_parameters[$class])) {
-            WebserviceOutputBuilder::$_cache_ws_parameters[$class] = $objects['empty']->getWebserviceParameters();
-        }
-        $ws_params = WebserviceOutputBuilder::$_cache_ws_parameters[$class];
+        $ws_params = $this->loadWsParams($objects['empty']);
 
         foreach ($this->wsParamOverrides as $p) {
             $object = $p['object'];
             $ws_params = $object->{$p['method']}($ws_params);
         }
 
-        // If a list is asked, need to wrap with a plural node
-        if ($type_of_view === self::VIEW_LIST) {
-            $output .= $this->setIndent($depth) . $this->objectRender->renderNodeHeader($ws_params['objectsNodeName'], $ws_params);
-        }
+        $this->output = $type_of_view == self::VIEW_DETAILS ? ApiNode::parent($ws_params['objectsNodeName']) : ApiNode::list($ws_params['objectsNodeName']);
 
         if (null === $this->schemaToDisplay) {
             foreach ($objects as $key => $object) {
                 if ($key !== 'empty') {
                     if ($this->fieldsToDisplay === 'minimum') {
-                        $output .= $this->renderEntityMinimum($object, $depth);
+                        $this->renderEntityMinimum($object);
                     } else {
-                        $output .= $this->renderEntity($object, $depth);
+                        $this->renderEntity($this->output, $object);
                     }
+                } elseif ($key == 'empty' && $this->objectRender->getContentType() == 'application/json') {
+                    $this->renderEntity($this->output, $object);
                 }
             }
         } else {
-            $output .= $this->renderSchema($objects['empty'], $ws_params);
+            $this->renderSchema($objects['empty'], $ws_params);
         }
 
-        // If a list is asked, need to wrap with a plural node
-        if ($type_of_view === self::VIEW_LIST) {
-            $output .= $this->setIndent($depth) . $this->objectRender->renderNodeFooter($ws_params['objectsNodeName'], $ws_params);
-        }
-
-        if ($override) {
-            $output = $this->objectRender->overrideContent($output);
-        }
-
-        return $output;
+        return $this->objectRender->renderNode($this->output);
     }
 
     /**
      * Create the tree diagram with no details.
      *
      * @param ObjectModel $object create by the entity
-     * @param int $depth the depth for the tree diagram
-     *
-     * @return string
      */
-    public function renderEntityMinimum($object, $depth)
+    public function renderEntityMinimum($object)
     {
-        $class = get_class($object);
-        if (!isset(WebserviceOutputBuilder::$_cache_ws_parameters[$class])) {
-            WebserviceOutputBuilder::$_cache_ws_parameters[$class] = $object->getWebserviceParameters();
-        }
-        $ws_params = WebserviceOutputBuilder::$_cache_ws_parameters[$class];
+        $ws_params = $this->loadWsParams($object);
 
         $more_attr['id'] = $object->id;
-        $more_attr['xlink_resource'] = $this->wsUrl . $ws_params['objectsNodeName'] . '/' . $object->id;
-        $output = $this->setIndent($depth) . $this->objectRender->renderNodeHeader($ws_params['objectNodeName'], $ws_params, $more_attr, false);
+        $more_attr['xlink:href'] = self::$wsUrl . $ws_params['objectsNodeName'] . '/' . $object->id;
 
-        return $output;
+        $this->output->addParentNode($ws_params['objectNodeName'], $more_attr);
     }
 
     /**
@@ -458,49 +441,39 @@ class WebserviceOutputBuilderCore
      *
      * @param ObjectModel $object create by the entity
      * @param array $ws_params webserviceParams from the entity
-     *
-     * @return string
      */
     protected function renderSchema($object, $ws_params)
     {
-        $output = $this->objectRender->renderNodeHeader($ws_params['objectNodeName'], $ws_params);
+        $parentNode = $this->output->addParentNode($ws_params['objectNodeName'], $ws_params);
+
         foreach ($ws_params['fields'] as $field_name => $field) {
-            $output .= $this->renderField($object, $ws_params, $field_name, $field, 0);
+            $this->renderField($parentNode, $object, $ws_params, $field_name, $field);
         }
         if (isset($ws_params['associations']) && count($ws_params['associations']) > 0) {
             $this->fieldsToDisplay = 'full';
-            $output .= $this->renderAssociations($object, 0, $ws_params['associations'], $ws_params);
+            $this->renderAssociations($parentNode, $object, $ws_params['associations'], $ws_params);
         }
-        $output .= $this->objectRender->renderNodeFooter($ws_params['objectNodeName'], $ws_params);
-
-        return $output;
     }
 
     /**
      * Build the entity detail.
      *
+     * @param ApiNode $parentNode node to which append entity
      * @param ObjectModel $object create by the entity
-     * @param int $depth the depth for the tree diagram
      *
-     * @return string
+     * @return void
      */
-    public function renderEntity($object, $depth)
+    public function renderEntity(ApiNode &$parentNode, ObjectModel $object): void
     {
-        $output = '';
-
-        $class = get_class($object);
-        if (!isset(WebserviceOutputBuilder::$_cache_ws_parameters[$class])) {
-            WebserviceOutputBuilder::$_cache_ws_parameters[$class] = $object->getWebserviceParameters();
-        }
-        $ws_params = WebserviceOutputBuilder::$_cache_ws_parameters[$class];
+        $ws_params = $this->loadWsParams($object);
 
         foreach ($this->wsParamOverrides as $p) {
             $o = $p['object'];
             $ws_params = $o->{$p['method']}($ws_params);
         }
-        $output .= $this->setIndent($depth) . $this->objectRender->renderNodeHeader($ws_params['objectNodeName'], $ws_params);
 
-        if (!empty($object->id)) {
+        $entityNode = $parentNode->addParentNode($ws_params['objectNodeName']);
+        if ($object->id != 0) {
             // This to add virtual Fields for a particular entity.
             $virtual_fields = $this->addVirtualFields($ws_params['objectsNodeName'], $object);
             if (!empty($virtual_fields)) {
@@ -512,7 +485,7 @@ class WebserviceOutputBuilderCore
                     $field['object_id'] = $object->id;
                     $field['entity_name'] = $ws_params['objectNodeName'];
                     $field['entities_name'] = $ws_params['objectsNodeName'];
-                    $output .= $this->renderField($object, $ws_params, $field_name, $field, $depth);
+                    $this->renderField($entityNode, $object, $ws_params, $field_name, $field);
                 }
             }
         }
@@ -521,39 +494,33 @@ class WebserviceOutputBuilderCore
             foreach ($this->fieldsToDisplay as $fields) {
                 if (is_array($fields)) {
                     $subexists = true;
+                    break;
                 }
             }
         }
 
-        if (isset($ws_params['associations'])
-            && ($this->fieldsToDisplay == 'full'
-            || $subexists)) {
-            $output .= $this->renderAssociations($object, $depth, $ws_params['associations'], $ws_params);
+        if (isset($ws_params['associations']) && ($this->fieldsToDisplay == 'full' || $subexists)) {
+            $this->renderAssociations($entityNode, $object, $ws_params['associations'], $ws_params);
         }
-
-        $output .= $this->setIndent($depth) . $this->objectRender->renderNodeFooter($ws_params['objectNodeName'], $ws_params);
-
-        return $output;
     }
 
     /**
      * Build a field and use recursivity depend on the depth parameter.
      *
+     * @param ApiNode $parentNode parent underneath which to create field nodes
      * @param ObjectModel $object create by the entity
      * @param array $ws_params webserviceParams from the entity
      * @param string $field_name
      * @param array $field
-     * @param int $depth
      *
-     * @return string
+     * @return void
      */
-    protected function renderField($object, $ws_params, $field_name, $field, $depth)
+    protected function renderField(ApiNode &$parentNode, ObjectModel $object, array $ws_params, string $field_name, array $field): void
     {
-        $output = '';
         $show_field = true;
 
         if (isset($ws_params['hidden_fields']) && in_array($field_name, $ws_params['hidden_fields'])) {
-            return '';
+            return;
         }
 
         if ($this->schemaToDisplay === 'synopsis') {
@@ -600,38 +567,30 @@ class WebserviceOutputBuilderCore
 
         // don't display the node id for a synopsis schema
         if ($show_field) {
-            $output .= $this->setIndent($depth - 1) . $this->objectRender->renderField($field);
+            $parentNode->addField($field, $this->schemaToDisplay);
         }
-
-        return $output;
     }
 
     /**
+     * Add associations nodes underneath parent node
+     *
+     * @param ApiNode $parentNode parent underneath which to create field nodes
      * @param ObjectModel $object
-     * @param int $depth
      * @param array $associations
      * @param array $ws_params
      *
-     * @return string
+     * @return void
      */
-    protected function renderAssociations($object, $depth, $associations, $ws_params)
+    protected function renderAssociations(ApiNode &$parentNode, ObjectModel $object, array $associations, array $ws_params): void
     {
-        $output = $this->objectRender->renderAssociationWrapperHeader();
+        $associationsWrapperNode = $parentNode->addParentNode('associations');
+
         foreach ($associations as $assoc_name => $association) {
             if ($this->fieldsToDisplay == 'full' || is_array($this->fieldsToDisplay) && array_key_exists($assoc_name, $this->fieldsToDisplay)) {
                 $getter = $association['getter'];
                 $objects_assoc = [];
 
-                $fields_assoc = [];
-                if (isset($association['fields'])) {
-                    $fields_assoc = $association['fields'];
-                }
-
-                $parent_details = [
-                    'object_id' => $object->id,
-                    'entity_name' => $ws_params['objectNodeName'],
-                    'entities_name' => $ws_params['objectsNodeName'],
-                ];
+                $fields_assoc = $association['fields'] ?? [];
 
                 if (is_array($getter)) {
                     $association_resources = call_user_func($getter, $object);
@@ -657,79 +616,111 @@ class WebserviceOutputBuilderCore
                 if (isset($this->wsResource[$assoc_name]['class']) && class_exists($this->wsResource[$assoc_name]['class'], true)) {
                     $class_name = $this->wsResource[$assoc_name]['class'];
                 }
-                $output_details = '';
-                foreach ($objects_assoc as $object_assoc) {
-                    if ($depth == 0 || $class_name === null) {
-                        $value = null;
-                        if (!empty($object_assoc)) {
-                            $value = $object_assoc;
-                        }
-                        if (empty($fields_assoc)) {
-                            $fields_assoc = [['id' => $value['id']]];
-                        }
-                        $output_details .= $this->renderFlatAssociation($object, $depth, $assoc_name, $association['resource'], $fields_assoc, $value, $parent_details);
-                    } else {
-                        foreach ($object_assoc as $id) {
-                            if ($class_name !== null) {
-                                $child_object = new $class_name($id);
-                                $output_details .= $this->renderEntity($child_object, ($depth - 2 ? 0 : $depth - 2));
-                            }
-                        }
-                    }
-                }
-                if ($output_details != '') {
-                    $output .= $this->setIndent($depth) . $this->objectRender->renderAssociationHeader($object, $ws_params, $assoc_name);
-                    $output .= $output_details;
-                    $output .= $this->setIndent($depth) . $this->objectRender->renderAssociationFooter($object, $ws_params, $assoc_name);
-                } else {
-                    $output .= $this->setIndent($depth) . $this->objectRender->renderAssociationHeader($object, $ws_params, $assoc_name, true);
-                }
+
+                $this->injectAssociation($associationsWrapperNode, $object, $assoc_name, $association, $ws_params, $objects_assoc, $fields_assoc);
             }
         }
-        $output .= $this->objectRender->renderAssociationWrapperFooter();
-
-        return $output;
     }
 
-    protected function renderFlatAssociation($object, $depth, $assoc_name, $resource_name, $fields_assoc, $object_assoc, $parent_details)
+    /**
+     * Inject one association section into parent node
+     *
+     * @param ApiNode $parentNode
+     * @param ObjectModel $object
+     * @param string $assoc_name
+     * @param array $association
+     * @param array $params
+     * @param array $objects_assoc
+     * @param array|null $fields_assoc
+     *
+     * @return void
+     */
+    private function injectAssociation(ApiNode &$parentNode, ObjectModel $object, string $assoc_name, array $association, array $params, array $objects_assoc, ?array $fields_assoc = null): void
     {
-        $output = '';
+        //1) add assocatiation node with attributes
+        $associationNode = $parentNode->addListNode($assoc_name);
+
+        if ($this->schemaToDisplay == 'blank') {//if this is blank schema, adding parent node is sufficient
+            return;
+        }
+
+        $associationNode->addAttribute('nodeType', $params['associations'][$assoc_name]['resource']);
+
+        if (array_key_exists('setter', $params['associations'][$assoc_name]) && !$params['associations'][$assoc_name]['setter']) {
+            $associationNode->addAttribute('readOnly', 'true');
+        }
+
+        if (isset($params['associations'][$assoc_name]['virtual_entity']) && $params['associations'][$assoc_name]['virtual_entity']) {
+            $associationNode->addAttribute('virtualEntity', 'true');
+        } else {
+            if (isset($params['associations'][$assoc_name]['api'])) {
+                $associationNode->addAttribute('api', $params['associations'][$assoc_name]['api']);
+            } else {
+                $associationNode->addAttribute('api', $assoc_name);
+            }
+        }
+
+        //2) Add details underneath association node
+
+        $parent_details = [
+            'object_id' => $object->id,
+            'entity_name' => $params['objectNodeName'],
+            'entities_name' => $params['objectsNodeName'],
+        ];
+
+        foreach ($objects_assoc as $object_assoc) {
+            $value = $object_assoc ?? null;
+            $fields_assoc = empty($fields_assoc) ? [['id' => $value['id']]] : $fields_assoc;
+            $this->injectFlatAssociation($associationNode, $object, $assoc_name, $association['resource'], $fields_assoc, $value, $parent_details);
+        }
+    }
+
+    /**
+     * @param ApiNode $parentNode
+     * @param ObjectModel $object
+     * @param string $assoc_name
+     * @param string $resource_name
+     * @param array $fields_assoc
+     * @param array $object_assoc
+     * @param array $parent_details
+     */
+    protected function injectFlatAssociation(ApiNode &$parentNode, ObjectModel $object, string $assoc_name, string $resource_name, array $fields_assoc, array $object_assoc, array $parent_details)
+    {
         $more_attr = [];
         if (isset($this->wsResource[$assoc_name]) && null === $this->schemaToDisplay) {
             if ($assoc_name == 'images') {
                 if ($parent_details['entities_name'] == 'combinations') {
-                    $more_attr['xlink_resource'] = $this->wsUrl . $assoc_name . '/products/' . $object->id_product . '/' . $object_assoc['id'];
+                    $more_attr['xlink:href'] = self::$wsUrl . $assoc_name . '/products/' . $object->id_product . '/' . $object_assoc['id'];
                 } else {
-                    $more_attr['xlink_resource'] = $this->wsUrl . $assoc_name . '/' . $parent_details['entities_name'] . '/' . $parent_details['object_id'] . '/' . $object_assoc['id'];
+                    $more_attr['xlink:href'] = self::$wsUrl . $assoc_name . '/' . $parent_details['entities_name'] . '/' . $parent_details['object_id'] . '/' . $object_assoc['id'];
                 }
             } else {
-                $more_attr['xlink_resource'] = $this->wsUrl . $assoc_name . '/' . $object_assoc['id'];
+                $more_attr['xlink:href'] = self::$wsUrl . $assoc_name . '/' . $object_assoc['id'];
             }
         }
-        $output .= $this->setIndent($depth - 1) . $this->objectRender->renderNodeHeader($resource_name, [], $more_attr);
+
+        $flatAssNode = $parentNode->addParentNode($resource_name, $more_attr);
 
         foreach ($fields_assoc as $field_name => $field) {
-            if (!is_array($this->fieldsToDisplay) || in_array($field_name, $this->fieldsToDisplay[$assoc_name])) {
-                if ($field_name == 'id' && !isset($field['sqlId'])) {
-                    $field['sqlId'] = 'id';
-                    $field['value'] = isset($object_assoc['id']) ? $object_assoc['id'] : null;
-                } elseif (!isset($field['sqlId'])) {
-                    $field['sqlId'] = $field_name;
-                    $field['value'] = isset($object_assoc[$field_name]) ? $object_assoc[$field_name] : null;
-                }
-                $field['entities_name'] = $assoc_name;
-                $field['entity_name'] = $resource_name;
-
-                if (null !== $this->schemaToDisplay) {
-                    $field['synopsis_details'] = $this->getSynopsisDetails($field);
-                }
-                $field['is_association'] = true;
-                $output .= $this->setIndent($depth - 1) . $this->objectRender->renderField($field);
+            if (is_array($this->fieldsToDisplay) && in_array($field_name, $this->fieldsToDisplay[$assoc_name])) {
+                continue;   //skip fields meant to be hidden
             }
-        }
-        $output .= $this->setIndent($depth - 1) . $this->objectRender->renderNodeFooter($resource_name, []);
+            if ($field_name == 'id' && !isset($field['sqlId'])) {
+                $field['sqlId'] = 'id';
+                $field['value'] = isset($object_assoc['id']) ? $object_assoc['id'] : null;
+            } elseif (!isset($field['sqlId'])) {
+                $field['sqlId'] = $field_name;
+                $field['value'] = isset($object_assoc[$field_name]) ? $object_assoc[$field_name] : null;
+            }
+            $field['entities_name'] = $assoc_name;
+            $field['entity_name'] = $resource_name;
 
-        return $output;
+            if (null !== $this->schemaToDisplay) {
+                $field['synopsis_details'] = $this->getSynopsisDetails($field);
+            }
+            $field['is_association'] = true;
+            $flatAssNode->addField($field, $this->schemaToDisplay);
+        }
     }
 
     public function setIndent($depth)
@@ -865,5 +856,15 @@ class WebserviceOutputBuilderCore
     public function setFieldsToDisplay($fields)
     {
         $this->fieldsToDisplay = $fields;
+    }
+
+    private function loadWsParams($object)
+    {
+        $class = get_class($object);
+        if (!isset(WebserviceOutputBuilder::$_cache_ws_parameters[$class])) {
+            WebserviceOutputBuilder::$_cache_ws_parameters[$class] = $object->getWebserviceParameters();
+        }
+
+        return WebserviceOutputBuilder::$_cache_ws_parameters[$class];
     }
 }

--- a/classes/webservice/WebserviceOutputInterface.php
+++ b/classes/webservice/WebserviceOutputInterface.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/classes/webservice/WebserviceOutputInterface.php
+++ b/classes/webservice/WebserviceOutputInterface.php
@@ -28,5 +28,5 @@ interface WebserviceOutputInterface
 {
     public function getContentType();
 
-    public function renderNode($apiNode);
+    public function renderNode(ApiNode $apiNode);
 }

--- a/classes/webservice/WebserviceOutputInterface.php
+++ b/classes/webservice/WebserviceOutputInterface.php
@@ -25,7 +25,7 @@
  */
 interface WebserviceOutputInterface
 {
-    public function getContentType();
+    public function getContentType(): string;
 
     public function renderNode(ApiNode $apiNode);
 }

--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -35,11 +35,10 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
      * Main function used to render node in desired format
      *
      * @param ApiNode $apiNode
-     * @param int $type_of_view Use constants WebserviceOutputBuilderCore::VIEW_DETAILS / WebserviceOutputBuilderCore::VIEW_LIST
      *
      * @return string json-encoded string
      */
-    public function renderNode($apiNode)
+    public function renderNode(ApiNode $apiNode): string
     {
         if ($apiNode->getType() == ApiNode::TYPE_LIST) {
             $jsonArray = [$apiNode->getName() => $this->toJsonArray($apiNode)];
@@ -47,7 +46,7 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
             $jsonArray = $this->toJsonArray($apiNode);
         }
 
-        return json_encode($jsonArray, JSON_UNESCAPED_UNICODE);
+        return \json_encode($jsonArray, JSON_UNESCAPED_UNICODE);
     }
 
     /**
@@ -60,7 +59,7 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
      *                      Node type ApiNode::TYPE_PARENT returns recursive array of underlying nodes in the form of [Name => [... subnodes ...]]
      *                      Node type ApiNode::TYPE_LIST returns recursive array of underlying nodes in the form of [[... subnodes ...]]
      */
-    private function toJsonArray($apiNode)
+    private function toJsonArray(ApiNode $apiNode)
     {
         switch ($apiNode->getType()) {
             case ApiNode::TYPE_VALUE:
@@ -89,6 +88,8 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
                 }
 
                 return $out;
+            default:    //unreachable
+                return '';
         }
     }
 }

--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -85,19 +85,22 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
                 if (empty($apiNode->getNodes())) {
                     $out = [];
                     foreach ($apiNode->getAttributes() as $attributeName => $attributeValue) {
-                        if(strpos($attributeName, "xlink:") === 0){ //do not display xlink:href xml templates uris in JSON output
+                        if (strpos($attributeName, 'xlink:') === 0) { //do not display xlink:href xml templates uris in JSON output
                             continue;
                         }
                         $out[$attributeName] = $attributeValue;
                     }
+
                     return $out;
                 } else {
                     $out = [];
                     foreach ($apiNode->getNodes() as $node) {
                         $out[$node->getName()] = $this->toJsonArray($node);
                     }
+
                     return $out;
                 }
+                // no break
             default:    //unreachable
                 return '';
         }

--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -82,12 +82,22 @@ class WebserviceOutputJSONCore implements WebserviceOutputInterface
 
                 return $out;
             case ApiNode::TYPE_PARENT:
-                $out = [];
-                foreach ($apiNode->getNodes() as $node) {
-                    $out[$node->getName()] = $this->toJsonArray($node);
+                if (empty($apiNode->getNodes())) {
+                    $out = [];
+                    foreach ($apiNode->getAttributes() as $attributeName => $attributeValue) {
+                        if(strpos($attributeName, "xlink:") === 0){ //do not display xlink:href xml templates uris in JSON output
+                            continue;
+                        }
+                        $out[$attributeName] = $attributeValue;
+                    }
+                    return $out;
+                } else {
+                    $out = [];
+                    foreach ($apiNode->getNodes() as $node) {
+                        $out[$node->getName()] = $this->toJsonArray($node);
+                    }
+                    return $out;
                 }
-
-                return $out;
             default:    //unreachable
                 return '';
         }

--- a/classes/webservice/WebserviceOutputJSON.php
+++ b/classes/webservice/WebserviceOutputJSON.php
@@ -26,7 +26,7 @@
  */
 class WebserviceOutputJSONCore implements WebserviceOutputInterface
 {
-    public function getContentType()
+    public function getContentType(): string
     {
         return 'application/json';
     }

--- a/classes/webservice/WebserviceOutputXML.php
+++ b/classes/webservice/WebserviceOutputXML.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/classes/webservice/WebserviceOutputXML.php
+++ b/classes/webservice/WebserviceOutputXML.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -25,216 +26,81 @@
  */
 class WebserviceOutputXMLCore implements WebserviceOutputInterface
 {
-    public $docUrl = '';
-    public $languages = [];
-    protected $wsUrl;
-    protected $schemaToDisplay;
-
-    public function setSchemaToDisplay($schema)
-    {
-        if (is_string($schema)) {
-            $this->schemaToDisplay = $schema;
-        }
-
-        return $this;
-    }
-
-    public function getSchemaToDisplay()
-    {
-        return $this->schemaToDisplay;
-    }
-
-    public function setWsUrl($url)
-    {
-        $this->wsUrl = $url;
-
-        return $this;
-    }
-
-    public function getWsUrl()
-    {
-        return $this->wsUrl;
-    }
+    private const XLINK_NS = 'http://www.w3.org/1999/xlink';
 
     public function getContentType()
     {
         return 'text/xml';
     }
 
-    public function __construct($languages = [])
+    /**
+     * Iterate over ApiNode tree and returns XML formatted output.
+     * If requested schema is DETAIL instead of node, parent resource is not being printed out (i.e. <strong>&lt;products/&gt;</strong> tag)
+     *
+     * @param Apinode $apiNode
+     * @param int $type_of_view Use constants WebserviceOutputBuilderCore::VIEW_DETAILS / WebserviceOutputBuilderCore::VIEW_LIST
+     *
+     * @return string Properly XML formatted string
+     */
+    public function renderNode($apiNode)
     {
-        $this->languages = $languages;
-    }
+        $xml = new SuperXMLElement("<?xml version='1.0' encoding='UTF-8'?><prestashop xmlns:xlink='" . self::XLINK_NS . "'/>");
 
-    public function setLanguages($languages)
-    {
-        $this->languages = $languages;
-
-        return $this;
-    }
-
-    public function renderErrorsHeader()
-    {
-        return '<errors>' . "\n";
-    }
-
-    public function renderErrorsFooter()
-    {
-        return '</errors>' . "\n";
-    }
-
-    public function renderErrors($message, $code = null)
-    {
-        $str_output = '<error>' . "\n";
-        if ($code !== null) {
-            $str_output .= '<code><![CDATA[' . $code . ']]></code>' . "\n";
-        }
-        $str_output .= '<message><![CDATA[' . $message . ']]></message>' . "\n";
-        $str_output .= '</error>' . "\n";
-
-        return $str_output;
-    }
-
-    public function renderField($field)
-    {
-        $ret = '';
-        $node_content = '';
-        $ret .= '<' . $field['sqlId'];
-        // display i18n fields
-        if (isset($field['i18n']) && $field['i18n']) {
-            foreach ($this->languages as $language) {
-                $more_attr = '';
-                if (isset($field['synopsis_details']) || (isset($field['value']) && is_array($field['value']))) {
-                    $more_attr .= ' xlink:href="' . $this->getWsUrl() . 'languages/' . $language . '"';
-                    if (isset($field['synopsis_details']) && $this->schemaToDisplay != 'blank') {
-                        $more_attr .= ' format="isUnsignedId" ';
-                    }
-                }
-                $node_content .= '<language id="' . $language . '"' . $more_attr . '>';
-                $node_content .= '<![CDATA[';
-                if (isset($field['value'][$language])) {
-                    $node_content .= $field['value'][$language];
-                }
-                $node_content .= ']]>';
-                $node_content .= '</language>';
-            }
+        /* @var $rootXml SuperXMLElement */
+        if ($apiNode->getType() == ApiNode::TYPE_LIST) {
+            $rootXml = $xml->addChild($apiNode->getName(), $apiNode->getValue());
         } else {
-            // display not i18n fields value
-            if (array_key_exists('xlink_resource', $field) && $this->schemaToDisplay != 'blank') {
-                if (!is_array($field['xlink_resource'])) {
-                    $ret .= ' xlink:href="' . $this->getWsUrl() . $field['xlink_resource'] . '/' . $field['value'] . '"';
-                } else {
-                    $ret .= ' xlink:href="' . $this->getWsUrl() . $field['xlink_resource']['resourceName'] . '/' .
-                    (isset($field['xlink_resource']['subResourceName']) ? $field['xlink_resource']['subResourceName'] . '/' . $field['object_id'] . '/' : '') . $field['value'] . '"';
+            $rootXml = $xml;
+    }
+
+        $this->injectAttributes($rootXml, $apiNode);
+        $this->injectChildren($rootXml, $apiNode);
+
+        return $xml->asXML();
+    }
+
+    /**
+     * Iterates over all attributes specified in ApiNode and injects them into $xml
+     *
+     * @param \SuperXMLElement $xml
+     * @param ApiNode $node
+     *
+     * @return void
+     */
+    private function injectAttributes(&$xml, $node)
+    {
+        if (empty($node->getAttributes()) || !is_array($node->getAttributes())) {
+            return;
+        }
+
+        foreach ($node->getAttributes() as $name => $value) {
+            if (strpos($name, 'xlink:') === 0) {    //when name begins on xlink, inject it underneath proper namespace
+                $xml->addAttribute($name, $value, self::XLINK_NS);
+        } else {
+                $xml->addAttribute($name, $value);
                 }
             }
-
-            if (isset($field['getter']) && $this->schemaToDisplay != 'blank') {
-                $ret .= ' notFilterable="true"';
             }
 
-            if (isset($field['setter']) && $field['setter'] == false && $this->schemaToDisplay == 'synopsis') {
-                $ret .= ' read_only="true"';
-            }
-
-            if (array_key_exists('value', $field)) {
-                $node_content .= '<![CDATA[' . $field['value'] . ']]>';
-            }
-        }
-
-        if (isset($field['encode'])) {
-            $ret .= ' encode="' . $field['encode'] . '"';
-        }
-
-        if (isset($field['synopsis_details']) && !empty($field['synopsis_details']) && $this->schemaToDisplay !== 'blank') {
-            foreach ($field['synopsis_details'] as $name => $detail) {
-                $ret .= ' ' . $name . '="' . (is_array($detail) ? implode(' ', $detail) : $detail) . '"';
-            }
-        }
-        $ret .= '>';
-        $ret .= $node_content;
-        $ret .= '</' . $field['sqlId'] . '>' . "\n";
-
-        return $ret;
-    }
-
-    public function renderNodeHeader($node_name, $params, $more_attr = null, $has_child = true)
+    /**
+     * Inject children node
+     *
+     * @param \SuperXMLElement $parentXml
+     * @param ApiNode $apiNode
+     *
+     * @return void
+     */
+    private function injectChildren(&$parentXml, $apiNode)
     {
-        $string_attr = '';
-        if (is_array($more_attr)) {
-            foreach ($more_attr as $key => $attr) {
-                if ($key === 'xlink_resource') {
-                    $string_attr .= ' xlink:href="' . $attr . '"';
-                } else {
-                    $string_attr .= ' ' . $key . '="' . $attr . '"';
+        if (empty($apiNode->getNodes())) {
+            return;
                 }
-            }
+
+        foreach ($apiNode->getNodes() as $node) {
+            /* @var $node ApiNode */
+            $childXml = $node->getType() == ApiNode::TYPE_VALUE ? $parentXml->addChildCData($node->getName(), $node->getValue()) : $parentXml->addChild($node->getName(), $node->getValue());
+            $this->injectAttributes($childXml, $node);
+            $this->injectChildren($childXml, $node);
+    }
         }
-        $end_tag = (!$has_child) ? '/>' : '>';
-
-        return '<' . $node_name . $string_attr . $end_tag . "\n";
     }
-
-    public function getNodeName($params)
-    {
-        $node_name = '';
-        if (isset($params['objectNodeName'])) {
-            $node_name = $params['objectNodeName'];
-        }
-
-        return $node_name;
-    }
-
-    public function renderNodeFooter($node_name, $params)
-    {
-        return '</' . $node_name . '>' . "\n";
-    }
-
-    public function overrideContent($content)
-    {
-        $xml = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
-        $xml .= '<prestashop xmlns:xlink="http://www.w3.org/1999/xlink">' . "\n";
-        $xml .= $content;
-        $xml .= '</prestashop>' . "\n";
-
-        return $xml;
-    }
-
-    public function renderAssociationWrapperHeader()
-    {
-        return '<associations>' . "\n";
-    }
-
-    public function renderAssociationWrapperFooter()
-    {
-        return '</associations>' . "\n";
-    }
-
-    public function renderAssociationHeader($obj, $params, $assoc_name, $closed_tags = false)
-    {
-        $end_tag = ($closed_tags) ? '/>' : '>';
-        $more = '';
-        if ($this->schemaToDisplay != 'blank') {
-            if (array_key_exists('setter', $params['associations'][$assoc_name]) && !$params['associations'][$assoc_name]['setter']) {
-                $more .= ' readOnly="true"';
-            }
-            $more .= ' nodeType="' . $params['associations'][$assoc_name]['resource'] . '"';
-            if (isset($params['associations'][$assoc_name]['virtual_entity']) && $params['associations'][$assoc_name]['virtual_entity']) {
-                $more .= ' virtualEntity="true"';
-            } else {
-                if (isset($params['associations'][$assoc_name]['api'])) {
-                    $more .= ' api="' . $params['associations'][$assoc_name]['api'] . '"';
-                } else {
-                    $more .= ' api="' . $assoc_name . '"';
-                }
-            }
-        }
-
-        return '<' . $assoc_name . $more . $end_tag . "\n";
-    }
-
-    public function renderAssociationFooter($obj, $params, $assoc_name)
-    {
-        return '</' . $assoc_name . '>' . "\n";
-    }
-}

--- a/classes/webservice/WebserviceOutputXML.php
+++ b/classes/webservice/WebserviceOutputXML.php
@@ -37,12 +37,11 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
      * Iterate over ApiNode tree and returns XML formatted output.
      * If requested schema is DETAIL instead of node, parent resource is not being printed out (i.e. <strong>&lt;products/&gt;</strong> tag)
      *
-     * @param Apinode $apiNode
-     * @param int $type_of_view Use constants WebserviceOutputBuilderCore::VIEW_DETAILS / WebserviceOutputBuilderCore::VIEW_LIST
+     * @param ApiNode $apiNode
      *
      * @return string Properly XML formatted string
      */
-    public function renderNode($apiNode)
+    public function renderNode(ApiNode $apiNode): string
     {
         $xml = new SuperXMLElement("<?xml version='1.0' encoding='UTF-8'?><prestashop xmlns:xlink='" . self::XLINK_NS . "'/>");
 
@@ -62,7 +61,7 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
     /**
      * Iterates over all attributes specified in ApiNode and injects them into $xml
      *
-     * @param \SuperXMLElement $xml
+     * @param SuperXMLElement $xml
      * @param ApiNode $node
      *
      * @return void
@@ -85,7 +84,7 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
     /**
      * Inject children node
      *
-     * @param \SuperXMLElement $parentXml
+     * @param SuperXMLElement $parentXml
      * @param ApiNode $apiNode
      *
      * @return void

--- a/classes/webservice/WebserviceOutputXML.php
+++ b/classes/webservice/WebserviceOutputXML.php
@@ -51,7 +51,7 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
             $rootXml = $xml->addChild($apiNode->getName(), $apiNode->getValue());
         } else {
             $rootXml = $xml;
-    }
+        }
 
         $this->injectAttributes($rootXml, $apiNode);
         $this->injectChildren($rootXml, $apiNode);
@@ -76,11 +76,11 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
         foreach ($node->getAttributes() as $name => $value) {
             if (strpos($name, 'xlink:') === 0) {    //when name begins on xlink, inject it underneath proper namespace
                 $xml->addAttribute($name, $value, self::XLINK_NS);
-        } else {
+            } else {
                 $xml->addAttribute($name, $value);
-                }
             }
-            }
+        }
+    }
 
     /**
      * Inject children node
@@ -94,13 +94,13 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
     {
         if (empty($apiNode->getNodes())) {
             return;
-                }
+        }
 
         foreach ($apiNode->getNodes() as $node) {
             /* @var $node ApiNode */
             $childXml = $node->getType() == ApiNode::TYPE_VALUE ? $parentXml->addChildCData($node->getName(), $node->getValue()) : $parentXml->addChild($node->getName(), $node->getValue());
             $this->injectAttributes($childXml, $node);
             $this->injectChildren($childXml, $node);
-    }
         }
     }
+}

--- a/classes/webservice/WebserviceOutputXML.php
+++ b/classes/webservice/WebserviceOutputXML.php
@@ -27,7 +27,7 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
 {
     private const XLINK_NS = 'http://www.w3.org/1999/xlink';
 
-    public function getContentType()
+    public function getContentType(): string
     {
         return 'text/xml';
     }
@@ -65,7 +65,7 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
      *
      * @return void
      */
-    private function injectAttributes(&$xml, $node)
+    private function injectAttributes(SuperXMLElement &$xml, ApiNode $node): void
     {
         if (empty($node->getAttributes()) || !is_array($node->getAttributes())) {
             return;
@@ -88,7 +88,7 @@ class WebserviceOutputXMLCore implements WebserviceOutputInterface
      *
      * @return void
      */
-    private function injectChildren(&$parentXml, $apiNode)
+    private function injectChildren(SuperXMLElement &$parentXml, ApiNode $apiNode): void
     {
         if (empty($apiNode->getNodes())) {
             return;

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -263,6 +263,8 @@ class WebserviceRequestCore
             $type = $_GET['io_format'];
         }
         $this->outputFormat = $type;
+        require_once __DIR__ . '/ApiNode.php';
+        require_once __DIR__ . '/SuperXMLElement.php';
         switch ($type) {
             case 'JSON':
                 require_once __DIR__ . '/WebserviceOutputJSON.php';
@@ -545,7 +547,7 @@ class WebserviceRequestCore
             // Need to set available languages for the render object.
             // Thus we can filter i18n field for the output
             // @see WebserviceOutputXML::renderField() method for example
-            $this->objOutput->objectRender->setLanguages($this->_available_languages);
+            ApiNode::$languages = $this->_available_languages;
 
             // check method and resource
             if (empty($this->errors) && $this->checkResource() && $this->checkHTTPMethod()) {

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -563,8 +563,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                         $this->output->addParentNode('declination')
                             ->setAttributes([
                                 'id' => $available_image_id,
-                                'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $object_id . '/' . $available_image_id
-                        ]);
+                                'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $object_id . '/' . $available_image_id,
+                            ]);
                     }
                 } else {
                     $this->objOutput->setStatus(404);

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -560,7 +560,11 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                     $this->output = ApiNode::list('image');
                     $this->output->addAttribute('id', $object_id);
                     foreach ($available_image_ids as $available_image_id) {
-                        $this->output->addNode('declination')->setAttributes(['id' => $available_image_id, 'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $object_id . '/' . $available_image_id]);
+                        $this->output->addParentNode('declination')
+                            ->setAttributes([
+                                'id' => $available_image_id,
+                                'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $object_id . '/' . $available_image_id
+                        ]);
                     }
                 } else {
                     $this->objOutput->setStatus(404);

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -28,7 +28,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
     /** @var WebserviceOutputBuilder */
     protected $objOutput;
 
-    /** @var ApiNode */
+    /** @var ApiNode|null */
     protected $output;
 
     /** @var WebserviceRequest */
@@ -168,7 +168,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 return file_get_contents($this->imgToDisplay);
             }
         }
-
+        
         return '';
     }
 
@@ -577,7 +577,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         }
 
         // in case of declinated images list of a product is get
-        if (!empty($this->output)) {
+        if (isset($this->output)) {
             return true;
         } elseif (isset($image_size) && $image_size != '' && isset($image_id)) {
             // If a size was given try to display it

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -128,7 +128,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
      */
     public function getContent()
     {
-        if ($this->output instanceof ApiNode) {
+        if (!empty($this->output)) {
             return $this->objOutput->getObjectRender()->renderNode($this->output);
         } elseif ($this->imgToDisplay) {
             // display image content if needed
@@ -294,8 +294,6 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
             // general images management : like header's logo, invoice logo, etc...
             case 'general':
                 return $this->manageGeneralImages();
-
-                break;
             // normal images management : like the most entity images (categories, manufacturers..)...
             case 'categories':
                 return $this->manageDeclinatedImages(_PS_CAT_IMG_DIR_);
@@ -412,8 +410,6 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 $this->imgToDisplay = is_file($path) ? $path : $alternative_path;
 
                 return true;
-
-                break;
             case 'PUT':
                 if ($this->writePostedImageOnDisk($path, null, null)) {
                     if ($this->wsObject->urlSegment[2] == 'header') {
@@ -428,8 +424,6 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 } else {
                     throw new WebserviceException('Error while copying image to the directory', [54, 400]);
                 }
-
-                break;
         }
     }
 
@@ -503,7 +497,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                     if ($this->imageType != 'products') {
                         preg_match('/^(\d+)\.jpg*$/Ui', $node, $matches);
                         if (isset($matches[1])) {
-                            $imagesNode->addNode('image', $image)->setAttributes(['id' => $matches[1], 'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $id]);
+                            $imagesNode->addNode('image')->setAttributes(['id' => $matches[1], 'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $matches[1]]);
                         }
                     }
                 }
@@ -583,7 +577,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         }
 
         // in case of declinated images list of a product is get
-        if ($this->output instanceof ApiNode) {
+        if (!empty($this->output)) {
             return true;
         } elseif (isset($image_size) && $image_size != '' && isset($image_id)) {
             // If a size was given try to display it
@@ -621,7 +615,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
      *
      * @return bool
      */
-    protected function manageDeclinatedImages($directory)
+    protected function manageDeclinatedImages(string $directory): bool
     {
         // Get available image sizes for the current image type
         $normal_image_sizes = ImageType::getImagesTypes($this->imageType);
@@ -629,14 +623,11 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
             // Match the default images
             case 'default':
                 return $this->manageDefaultDeclinatedImages($directory, $normal_image_sizes);
-                break;
             // Display the list of images
             case '':
-                $this->manageListDeclinatedImages($directory, $normal_image_sizes);
-                break;
+                return $this->manageListDeclinatedImages($directory, $normal_image_sizes);
             default:
                 return $this->manageEntityDeclinatedImages($directory, $normal_image_sizes);
-                break;
         }
     }
 
@@ -801,9 +792,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 } else {
                     throw new WebserviceException('This image does not exist on disk', [63, 500]);
                 }
-
-                break;
             // Delete the image
+            // no break
             case 'DELETE':
                 // Delete products image in DB
                 if ($this->imageType == 'products') {
@@ -822,9 +812,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 } else {
                     throw new WebserviceException('This image does not exist on disk', [64, 500]);
                 }
-
-                break;
             // Add the image
+            // no break
             case 'POST':
                 if ($filename_exists) {
                     throw new WebserviceException('This image already exists. To modify it, please use the PUT method', [65, 400]);
@@ -835,8 +824,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                         throw new WebserviceException('Unable to save this image', [66, 500]);
                     }
                 }
-
-                break;
+                // no break
             default:
                 throw new WebserviceException('This method is not allowed', [67, 405]);
         }
@@ -1192,7 +1180,5 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         }
 
         throw new WebserviceException('Method ' . $this->wsObject->method . ' is not allowed for an image resource', [77, 405]);
-
-        return false;
     }
 }

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -168,7 +168,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 return file_get_contents($this->imgToDisplay);
             }
         }
-        
+
         return '';
     }
 

--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -28,7 +28,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
     /** @var WebserviceOutputBuilder */
     protected $objOutput;
 
-    /** @var string */
+    /** @var ApiNode */
     protected $output;
 
     /** @var WebserviceRequest */
@@ -128,8 +128,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
      */
     public function getContent()
     {
-        if ($this->output != '') {
-            return $this->objOutput->getObjectRender()->overrideContent($this->output);
+        if ($this->output instanceof ApiNode) {
+            return $this->objOutput->getObjectRender()->renderNode($this->output);
         } elseif ($this->imgToDisplay) {
             // display image content if needed
             if (empty($this->imgExtension)) {
@@ -294,6 +294,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
             // general images management : like header's logo, invoice logo, etc...
             case 'general':
                 return $this->manageGeneralImages();
+
+                break;
             // normal images management : like the most entity images (categories, manufacturers..)...
             case 'categories':
                 return $this->manageDeclinatedImages(_PS_CAT_IMG_DIR_);
@@ -303,6 +305,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 return $this->manageDeclinatedImages(_PS_SUPP_IMG_DIR_);
             case 'stores':
                 return $this->manageDeclinatedImages(_PS_STORE_IMG_DIR_);
+
             // product image management : many image for one entity (product)
             case 'products':
                 return $this->manageProductImages();
@@ -310,16 +313,15 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 return $this->manageCustomizationImages();
             // images root node management : many image for one entity (product)
             case '':
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('image_types', []);
+                $this->output = ApiNode::list('image_types');
                 foreach (array_keys($this->imageTypes) as $image_type_name) {
                     $more_attr = [
-                        'xlink_resource' => $this->wsObject->wsUrl . $this->wsObject->urlSegment[0] . '/' . $image_type_name,
+                        'xlink:href' => $this->wsObject->wsUrl . $this->wsObject->urlSegment[0] . '/' . $image_type_name,
                         'get' => 'true', 'put' => 'false', 'post' => 'false', 'delete' => 'false', 'head' => 'true',
                         'upload_allowed_mimetypes' => implode(', ', $this->acceptedImgMimeTypes),
                     ];
-                    $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader($image_type_name, [], $more_attr, false);
+                    $this->output->addNode($image_type_name)->setAttributes($more_attr);
                 }
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeFooter('image_types', []);
 
                 return true;
             default:
@@ -386,19 +388,17 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 
             // List the general image types
             case '':
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('general_image_types', []);
+                $this->output = ApiNode::list('general_image_types');
                 foreach (array_keys($this->imageTypes['general']) as $general_image_type_name) {
                     $more_attr = [
-                        'xlink_resource' => $this->wsObject->wsUrl . $this->wsObject->urlSegment[0] . '/' . $this->wsObject->urlSegment[1] . '/' . $general_image_type_name,
+                        'xlink:href' => $this->wsObject->wsUrl . $this->wsObject->urlSegment[0] . '/' . $this->wsObject->urlSegment[1] . '/' . $general_image_type_name,
                         'get' => 'true', 'put' => 'true', 'post' => 'false', 'delete' => 'false', 'head' => 'true',
                         'upload_allowed_mimetypes' => implode(', ', $this->acceptedImgMimeTypes),
                     ];
-                    $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader($general_image_type_name, [], $more_attr, false);
+                    $this->output->addNode($general_image_type_name)->setAttributes($more_attr);
                 }
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeFooter('general_image_types', []);
 
                 return true;
-
             // If the image type does not exist...
             default:
                 $exception = new WebserviceException(sprintf('General image of type "%s" does not exist', $this->wsObject->urlSegment[2]), [53, 400]);
@@ -412,6 +412,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 $this->imgToDisplay = is_file($path) ? $path : $alternative_path;
 
                 return true;
+
+                break;
             case 'PUT':
                 if ($this->writePostedImageOnDisk($path, null, null)) {
                     if ($this->wsObject->urlSegment[2] == 'header') {
@@ -426,6 +428,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 } else {
                     throw new WebserviceException('Error while copying image to the directory', [54, 400]);
                 }
+
+                break;
         }
     }
 
@@ -444,19 +448,18 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         }
 
         // Display list of languages
+
         if ($this->wsObject->urlSegment[3] == '' && $this->wsObject->method == 'GET') {
-            $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('languages', []);
+            $this->output = ApiNode::list('languages');
             foreach ($lang_list as $lang) {
                 $more_attr = [
-                    'xlink_resource' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/default/' . $lang['iso_code'],
+                    'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/default/' . $lang['iso_code'],
                     'get' => 'true', 'put' => 'true', 'post' => 'true', 'delete' => 'true', 'head' => 'true',
                     'upload_allowed_mimetypes' => implode(', ', $this->acceptedImgMimeTypes),
                     'iso' => $lang['iso_code'],
                 ];
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('language', [], $more_attr, false);
+                $this->output->addNode('language')->setAttributes($more_attr);
             }
-
-            $this->output .= $this->objOutput->getObjectRender()->renderNodeFooter('languages', []);
 
             return true;
         } else {
@@ -480,23 +483,17 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
             throw new WebserviceException('This method is not allowed for listing category images.', [55, 405]);
         }
 
-        $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('image_types', []);
+        $this->output = ApiNode::parent();
+        $typesNode = $this->output->addListNode('image_types');
         foreach ($normal_image_sizes as $image_size) {
-            $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('image_type', [], ['id' => $image_size['id_image_type'], 'name' => $image_size['name'], 'xlink_resource' => $this->wsObject->wsUrl . 'image_types/' . $image_size['id_image_type']], false);
+            $typesNode->addParentNode('image_type', ['id' => $image_size['id_image_type'], 'name' => $image_size['name'], 'xlink:href' => $this->wsObject->wsUrl . 'image_types/' . $image_size['id_image_type']]);
         }
-        $this->output .= $this->objOutput->getObjectRender()->renderNodeFooter('image_types', []);
-        $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('images', []);
+
+        $imagesNode = $this->output->addListNode('images');
 
         if ($this->imageType == 'products') {
-            $ids = [];
-            $images = Image::getAllImages();
-            foreach ($images as $image) {
-                $ids[] = $image['id_product'];
-            }
-            $ids = array_unique($ids, SORT_NUMERIC);
-            asort($ids);
-            foreach ($ids as $id) {
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('image', [], ['id' => $id, 'xlink_resource' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $id], false);
+            foreach (Image::getAllImages() as $image) {
+                $imagesNode->addNode('image')->setAttributes(['id' => $image['id_image'], 'id_product' => $image['id_product'], 'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $image['id_product'] . '/' . $image['id_image']]);
             }
         } else {
             $nodes = scandir($directory, SCANDIR_SORT_NONE);
@@ -506,16 +503,12 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                     if ($this->imageType != 'products') {
                         preg_match('/^(\d+)\.jpg*$/Ui', $node, $matches);
                         if (isset($matches[1])) {
-                            $id = $matches[1];
-                            $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('image', [], ['id' => $id, 'xlink_resource' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $id], false);
+                            $imagesNode->addNode('image', $image)->setAttributes(['id' => $matches[1], 'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $id]);
                         }
                     }
                 }
             }
         }
-        $this->output .= $this->objOutput->getObjectRender()->renderNodeFooter('images', []);
-
-        return true;
     }
 
     protected function manageEntityDeclinatedImages($directory, $normal_image_sizes)
@@ -570,11 +563,11 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
             } elseif ($this->wsObject->method == 'GET' || $this->wsObject->method == 'HEAD') {
                 // display the list of declinated images
                 if ($available_image_ids) {
-                    $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('image', [], ['id' => $object_id]);
+                    $this->output = ApiNode::list('image');
+                    $this->output->addAttribute('id', $object_id);
                     foreach ($available_image_ids as $available_image_id) {
-                        $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('declination', [], ['id' => $available_image_id, 'xlink_resource' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $object_id . '/' . $available_image_id], false);
+                        $this->output->addNode('declination')->setAttributes(['id' => $available_image_id, 'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $object_id . '/' . $available_image_id]);
                     }
-                    $this->output .= $this->objOutput->getObjectRender()->renderNodeFooter('image', []);
                 } else {
                     $this->objOutput->setStatus(404);
                     $this->wsObject->setOutputEnabled(false);
@@ -590,7 +583,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         }
 
         // in case of declinated images list of a product is get
-        if ($this->output != '') {
+        if ($this->output instanceof ApiNode) {
             return true;
         } elseif (isset($image_size) && $image_size != '' && isset($image_id)) {
             // If a size was given try to display it
@@ -636,11 +629,14 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
             // Match the default images
             case 'default':
                 return $this->manageDefaultDeclinatedImages($directory, $normal_image_sizes);
+                break;
             // Display the list of images
             case '':
-                return $this->manageListDeclinatedImages($directory, $normal_image_sizes);
+                $this->manageListDeclinatedImages($directory, $normal_image_sizes);
+                break;
             default:
                 return $this->manageEntityDeclinatedImages($directory, $normal_image_sizes);
+                break;
         }
     }
 
@@ -677,20 +673,20 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 $ids[] = $result['id_cart'];
             }
             asort($ids);
-            $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('carts', []);
+            $this->output = ApiNode::list('carts');
             foreach ($ids as $id) {
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('cart', [], ['id' => $id, 'xlink_resource' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $id], false);
+                $this->output->addNode('cart')
+                    ->setAttributes(['id' => $id, 'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $id]);
             }
-            $this->output .= $this->objOutput->getObjectRender()->renderNodeFooter('carts', []);
 
             return true;
         } elseif (empty($this->wsObject->urlSegment[3])) {
-            $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('customizations', []);
+            $this->output = ApiNode::list('customizations');
             $customizations = $this->getCustomizations();
             foreach ($customizations as $id) {
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('customization', [], ['id' => $id, 'xlink_resource' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $id], false);
+                $this->output->addNode('customization')
+                    ->setAttributes(['id' => $id, 'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $id]);
             }
-            $this->output .= $this->objOutput->getObjectRender()->renderNodeFooter('customizations', []);
 
             return true;
         } elseif (empty($this->wsObject->urlSegment[4])) {
@@ -701,11 +697,11 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 					WHERE id_customization = ' . (int) $this->wsObject->urlSegment[3] . ' AND type = 0'
                 );
 
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('images', []);
+                $this->output = ApiNode::list('images');
                 foreach ($results as $result) {
-                    $this->output .= $this->objOutput->getObjectRender()->renderNodeHeader('image', [], ['id' => $result['index'], 'xlink_resource' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $result['index']], false);
+                    $this->output->addNode('image')
+                        ->setAttributes(['id' => $result['index'], 'xlink:href' => $this->wsObject->wsUrl . 'images/' . $this->imageType . '/' . $result['index']]);
                 }
-                $this->output .= $this->objOutput->getObjectRender()->renderNodeFooter('images', []);
 
                 return true;
             }
@@ -805,8 +801,9 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 } else {
                     throw new WebserviceException('This image does not exist on disk', [63, 500]);
                 }
+
+                break;
             // Delete the image
-            // no break
             case 'DELETE':
                 // Delete products image in DB
                 if ($this->imageType == 'products') {
@@ -825,8 +822,9 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 } else {
                     throw new WebserviceException('This image does not exist on disk', [64, 500]);
                 }
+
+                break;
             // Add the image
-            // no break
             case 'POST':
                 if ($filename_exists) {
                     throw new WebserviceException('This image already exists. To modify it, please use the PUT method', [65, 400]);
@@ -837,7 +835,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                         throw new WebserviceException('Unable to save this image', [66, 500]);
                     }
                 }
-                // no break
+
+                break;
             default:
                 throw new WebserviceException('This method is not allowed', [67, 405]);
         }
@@ -1143,9 +1142,11 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
 
                         $this->imgToDisplay = _PS_PRODUCT_IMG_DIR_ . $image->getExistingImgPath() . '.' . $image->image_format;
                         $this->objOutput->setFieldsToDisplay('full');
-                        $this->output = $this->objOutput->renderEntity($image, 1);
+                        $this->output = ApiNode::parent();
+
+                        $this->objOutput->renderEntity($this->output, $image);
                         $image_content = ['sqlId' => 'content', 'value' => base64_encode(file_get_contents($this->imgToDisplay)), 'encode' => 'base64'];
-                        $this->output .= $this->objOutput->objectRender->renderField($image_content);
+                        $this->output->addField($image_content);
                     } elseif (in_array($this->imageType, ['categories', 'manufacturers', 'suppliers', 'stores'])) {
                         if (!($tmp_name = tempnam(_PS_TMP_IMG_DIR_, 'PS')) || !move_uploaded_file($file['tmp_name'], $tmp_name)) {
                             throw new WebserviceException('An error occurred during the image upload', [76, 400]);
@@ -1191,5 +1192,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         }
 
         throw new WebserviceException('Method ' . $this->wsObject->method . ' is not allowed for an image resource', [77, 405]);
+
+        return false;
     }
 }

--- a/classes/webservice/WebserviceSpecificManagementSearch.php
+++ b/classes/webservice/WebserviceSpecificManagementSearch.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA

--- a/classes/webservice/WebserviceSpecificManagementSearch.php
+++ b/classes/webservice/WebserviceSpecificManagementSearch.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -28,7 +29,7 @@ class WebserviceSpecificManagementSearchCore implements WebserviceSpecificManage
     /** @var WebserviceOutputBuilder */
     protected $objOutput;
 
-    /** @var string */
+    /** @var ApiNode */
     protected $output;
 
     /** @var WebserviceRequest */
@@ -125,13 +126,16 @@ class WebserviceSpecificManagementSearchCore implements WebserviceSpecificManage
             $objects_categories[] = new Category($id);
         }
 
-        $this->output .= $this->objOutput->getContent($objects_products, null, $this->wsObject->fieldsToDisplay, $this->wsObject->depth, WebserviceOutputBuilder::VIEW_LIST, false);
+        $this->output = ApiNode::parent();
+        $this->objOutput->getContent($objects_products, null, $this->wsObject->fieldsToDisplay, $this->wsObject->depth, WebserviceOutputBuilder::VIEW_LIST, false);
+        $this->output->addApiNode($this->objOutput->getOutput());
         // @todo allow fields of type category and product
         // $this->_resourceConfiguration = $objects_categories['empty']->getWebserviceParameters();
         // if (!$this->setFieldsToDisplay())
         // return false;
 
-        $this->output .= $this->objOutput->getContent($objects_categories, null, $this->wsObject->fieldsToDisplay, $this->wsObject->depth, WebserviceOutputBuilder::VIEW_LIST, false);
+        $this->objOutput->getContent($objects_categories, null, $this->wsObject->fieldsToDisplay, $this->wsObject->depth, WebserviceOutputBuilder::VIEW_LIST, false);
+        $this->output->addApiNode($this->objOutput->getOutput());
     }
 
     /**
@@ -141,6 +145,6 @@ class WebserviceSpecificManagementSearchCore implements WebserviceSpecificManage
      */
     public function getContent()
     {
-        return $this->objOutput->getObjectRender()->overrideContent($this->output);
+        return $this->objOutput->getObjectRender()->renderNode($this->output);
     }
 }

--- a/webservice/index.php
+++ b/webservice/index.php
@@ -24,12 +24,12 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
-header("Cache-Control: no-store, no-cache, must-revalidate");
-header("Cache-Control: post-check=0, pre-check=0", false);
-header("Pragma: no-cache");
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
 
-header("Location: ../");
+header('Location: ../');
 exit;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below, its pretty huge
| Type?             | bug fix & improvement & new feature & refactor
| Category?         | WS
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #22675
| How to test?      | Using new WS autotest
| Possible impacts? | Composing API has been completely refactored, modernized and enlighted. Every file underneath classes/webservice has been changed, some now added. There is just one actual impact, which has brought me to refactor API completely - getting product images. Please see diff in ([ https://www.diffchecker.com/fisRdJ1l ],) what has been actually changed. This should be the only BC break, contained in this PR, everything else should stay the same (as for now)

**Note**:
This PR replaces pull-requests #23100 and #27297

**Description**:

WebService API was having historical troubles. Its XML output has been using string composing of headers / footers (instead of using modern SimpleXML PHP interface), which could cause troubles (well actually didnt, at least in modern versions of Prestashop). Troubles started after JSON output has been added into Prestashop - you can't correctly compose JSON output using header and footer rendering. That led to some custom overriding functions, leading to a bit of chaos on API Core structure.

I tried to solve this design trouble by creating a class called ApiNode and refactored WebServiceOutputBuilder to firstly build structure of ApiNode tree. Each ApiNode is basically an object, composing of name, type, array of attributes and array of subnodes. This ApiNode is then processed by XML / JSON rendering classes.

Then, WebServiceOutputJSON and WebServiceOutputXML are using simple function renderNode(ApiNode), which iterates over ApiNode (and its children) and composes output string.

WebServiceOutputXML uses SuperXMLElement (which is actually SimpleXMLElement, just extended with addCData() function) to create XML hierarchy. Output is then properly XML formatted into string. That makes XML API output easily extendable in the future. XML output is no more pretty printed (using deprecated $depth property), to avoid unneccessary overhead (XML is usually pretty printed by modern browsers automatically anyway and there is no need for pretty printing in actual API calls)

WebServiceOutputJSON iterates over ApiNode and its children to create a simple array of objects and its subobjects, then transforms it into string, using json_encode common PHP function. Due to nature of JSON, we cannot put attributes in it, as in XML. Either we have to accept complete BC break and add attributes into JSON request as well, or avoid working with attributes and treat important attributes as children nodes, thus creating another BC break in XML output.
(Working with attributes will definitely be neccessary on images requests - but they havent been working anyway in JSON, so I believe there is no BC break). Non-BC possibility would thus be to add attributes as subnodes only on Images requests. But this solution needs further analyze.

Consider this PR as a draft. I am going to process further tests. I have already tested few requests (mainly on products), ensuring that XML and JSON outputs stays the same, but more tests are neccessary. I am not sure whether there are any API autotests, which would come very handy.

Also, code-review from original creators of Prestashop WebService API would be very handy. I think that during the code examination I discovered every potential use-case, but one can never be sure.

:notebook: **BC Breaks :**

1. Change property `WebserviceOutputBuilderCore::$wsUrl` to `public static`
2. Change input parameters on `WebserviceOutputBuilderCore::renderEntity`
3. Change input parameters on `WebserviceOutputBuilderCore::renderField`
4. Change input parameters on `WebserviceOutputBuilderCore::renderAssociations`
5. Removed 2nd param `$depth` on method `WebserviceOutputBuilderCore::renderEntityMinimum`
6. Removed method `WebserviceOutputBuilderCore::renderFlatAssociation`
7. Removed method `WebServiceOutputInterface::__construct`
8. Removed method `WebServiceOutputInterface::setWsUrl`
9. Removed method `WebServiceOutputInterface::getWsUrl`
10. Removed method `WebServiceOutputInterface::getContentType`
11. Removed method `WebServiceOutputInterface::setSchemaToDisplay`
12. Removed method `WebServiceOutputInterface::getSchemaToDisplay`
13. Removed method `WebServiceOutputInterface::renderField`
14. Removed method `WebServiceOutputInterface::renderNodeHeader`
15. Removed method `WebServiceOutputInterface::renderNodeFooter`
16. Removed method `WebServiceOutputInterface::renderAssociationHeader`
17. Removed method `WebServiceOutputInterface::renderAssociationFooter`
18. Removed method `WebServiceOutputInterface::overrideContent`
19. Removed method `WebServiceOutputInterface::renderErrorsHeader`
20. Removed method `WebServiceOutputInterface::renderErrorsFooter`
21. Removed method `WebServiceOutputInterface::renderErrors`
22. Removed method `WebServiceOutputInterface::setLanguages`
23. Removed method `WebServiceOutputInterface::renderAssociationWrapperHeader`
24. Removed method `WebServiceOutputInterface::renderAssociationWrapperFooter`
25. Add output type to method `WebServiceOutputInterface::getContentType`
26. Removed method `WebserviceOutputJSONCore::renderAssociationField`
27. Removed method `WebserviceOutputJSONCore::renderi18nField`
28. Removed property `WebserviceOutputJSONCore::$docUrl`
29. Removed property `WebserviceOutputJSONCore::$languages`
30. Removed property `WebserviceOutputJSONCore::$wsUrl`
31. Removed property `WebserviceOutputJSONCore::$schemaToDisplay`
32. Removed property `WebserviceOutputJSONCore::$currentEntity`
33. Removed property `WebserviceOutputJSONCore::$currentAssociatedEntity`
34. Removed property `WebserviceOutputJSONCore::$content`
35. Removed method `WebserviceOutputXMLCore::renderAssociationField`
36. Removed method `WebserviceOutputXMLCore::renderi18nField`
37. Removed property `WebserviceOutputXMLCore::$docUrl`
38. Removed property `WebserviceOutputXMLCore::$languages`
39. Removed property `WebserviceOutputXMLCore::$wsUrl`
40. Removed property `WebserviceOutputXMLCore::$schemaToDisplay`
41. Add input & output types to method `WebserviceSpecificManagementImages::manageDeclinatedImages`

 (BC breaks of interface WebServiceOutputInterface applies also to its implementors `WebserviceOutputJSONCore` and `WebserviceOutputXMLCore`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27297)
<!-- Reviewable:end -->
