### PR TITLE
Fix stock page padding-left

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -23,7 +23,7 @@
   height: 100%;
   margin-top: $size-header-height;
   background: $gray-dark;
-  @include transition(all 0.5s ease-out);
+  @include transition(all 0.5s ease);
 
   &-overflow {
     height: 100%;

--- a/admin-dev/themes/new-theme/scss/pages/stock/stock_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/stock/stock_page.scss
@@ -5,11 +5,12 @@
 @import "@scss/config/_bootstrap";
 /* stylelint-enable */
 
-.stock-app {
+.adminstockmanagement .stock-app {
   padding: 0;
 
   .header-toolbar {
     z-index: 989;
+    padding-right: 0;
     padding-left: 0;
     margin: -($grid-gutter-width / 2);
     margin-bottom: 1rem;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR aim to fix the padding left of the header of the stock page by using a more precise css selector.<br>It also fix a "glitch" in the open/close left menu, more on that below.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27356
| How to test?      | Please see #27356
| Possible impacts? | 

### About the animation
Because the header animation is using `ease` while the left menu was using `ease-out`, both elements were not in sync.
By using `ease` everywhere, it solves it.

With `ease` and `ease-out` (note the white square when reopening the menu):

https://user-images.githubusercontent.com/2168836/149761503-a35a43e5-72e4-4025-bb70-e9b8790c20e5.mov

With `ease` only:

https://user-images.githubusercontent.com/2168836/149761545-fe1c3902-b283-4450-8da5-f173ad3c8774.mov


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27372)
<!-- Reviewable:end -->
