### PR TITLE
Fix wrong array_slice arguments

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3084,7 +3084,7 @@ class ProductCore extends ObjectModel
 
         if ($order_by === 'price') {
             Tools::orderbyPrice($result, $order_way);
-            $result = array_slice($result, (int) (($nb_products - 1) * $page_number), (int) $page_number);
+            $result = array_slice($result, (int) (($page_number - 1) * $nb_products), (int) $nb_products);
         }
         $products_ids = [];
         foreach ($result as $row) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Because of wrong argument in the method `array_slice` in charge of getting the right amount of products when ordering by price, the list of product returned was wrong. This PR fixes it by using the right arguments.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27146
| How to test?      | Please see #27146
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27374)
<!-- Reviewable:end -->
