### PR TITLE
Fix an unclear alert

### DIFF
--- a/classes/form/AbstractForm.php
+++ b/classes/form/AbstractForm.php
@@ -138,6 +138,8 @@ abstract class AbstractFormCore implements FormInterface
                     $field->addError(
                         $this->constraintTranslator->translate('required')
                     );
+
+                    continue;
                 } elseif (!$this->checkFieldLength($field)) {
                     $field->addError(
                         $this->translator->trans(
@@ -147,8 +149,6 @@ abstract class AbstractFormCore implements FormInterface
                         )
                     );
                 }
-
-                continue;
             } elseif (!$field->isRequired()) {
                 if (!$field->getValue()) {
                     continue;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Unclear alert when we have invalid address
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26833.
| How to test?      | Go to FO > Sign in and try to add a new address. In the address field, add invalid data for example `address_`. Click on Save. See error
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27376)
<!-- Reviewable:end -->
