### PR TITLE
Removed double escape for Tree Node template

### DIFF
--- a/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_node_folder_radio.tpl
+++ b/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_node_folder_radio.tpl
@@ -29,6 +29,6 @@
 		<label class="tree-toggler">{$node['name']|escape:'html':'UTF-8'}</label>
 	</span>
 	<ul class="tree">
-		{$children|escape:'UTF-8'}
+		{$children}
 	</ul>
 </li>

--- a/admin-dev/themes/default/template/controllers/scenes/helpers/tree/tree_node_folder_checkbox.tpl
+++ b/admin-dev/themes/default/template/controllers/scenes/helpers/tree/tree_node_folder_checkbox.tpl
@@ -29,6 +29,6 @@
 		<label class="tree-toggler">{$node['name']|escape:'html':'UTF-8'}</label>
 	</span>
 	<ul class="tree">
-		{$children|escape:'UTF-8'}
+		{$children}
 	</ul>
 </li>

--- a/admin-dev/themes/default/template/controllers/shop/helpers/tree/shop_tree_node_folder.tpl
+++ b/admin-dev/themes/default/template/controllers/shop/helpers/tree/shop_tree_node_folder.tpl
@@ -28,6 +28,6 @@
 		<label class="tree-toggler"><a href="{$url_shop_group|escape:'html':'UTF-8'}&amp;id_shop_group={$node['id']}">{$node['name']|escape:'html':'UTF-8'}</a></label>
 	</span>
 	<ul class="tree">
-		{$children|escape:'UTF-8'}
+		{$children}
 	</ul>
 </li>

--- a/admin-dev/themes/default/template/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/helpers/options/options.tpl
@@ -184,7 +184,7 @@
 										</div>
 									{elseif $field['type'] == 'text'}
 										<div class="col-lg-9">{if isset($field['suffix'])}<div class="input-group{if isset($field.class)} {$field.class}{/if}">{/if}
-											<input class="form-control {if isset($field['class'])}{$field['class']}{/if}" type="{$field['type']}"{if isset($field['id'])} id="{$field['id']}"{/if} size="{if isset($field['size'])}{$field['size']|intval}{else}5{/if}" name="{$key}" value="{if isset($field['no_escape']) && $field['no_escape']}{$field['value']|escape:'UTF-8'}{else}{$field['value']|escape:'html':'UTF-8'}{/if}" {if isset($field['autocomplete']) && !$field['autocomplete']}autocomplete="off"{/if}/>
+											<input class="form-control {if isset($field['class'])}{$field['class']}{/if}" type="{$field['type']}"{if isset($field['id'])} id="{$field['id']}"{/if} size="{if isset($field['size'])}{$field['size']|intval}{else}5{/if}" name="{$key}" value="{if isset($field['no_escape']) && $field['no_escape']}{$field['value']}{else}{$field['value']|escape:'html':'UTF-8'}{/if}" {if isset($field['autocomplete']) && !$field['autocomplete']}autocomplete="off"{/if}/>
 											{if isset($field['suffix'])}
 											<span class="input-group-addon">
 												{$field['suffix']|strval}

--- a/admin-dev/themes/default/template/helpers/tree/tree_node_folder.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_node_folder.tpl
@@ -28,6 +28,6 @@
 		<label class="tree-toggler">{$node['name']|escape:'html':'UTF-8'}</label>
 	</span>
 	<ul class="tree">
-		{$children|escape:'UTF-8'}
+		{$children}
 	</ul>
 </li>

--- a/admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox.tpl
@@ -31,6 +31,6 @@
 		<label class="tree-toggler">{if isset($node['name'])}{$node['name']|escape:'html':'UTF-8'}{/if}{if isset($node['selected_childs']) && (int)$node['selected_childs'] > 0} {l s='(%s selected)' sprintf=[$node['selected_childs']]}{/if}</label>
 	</span>
 	<ul class="tree">
-		{$children|escape:'UTF-8'}
+		{$children}
 	</ul>
 </li>

--- a/admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox_shops.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_node_folder_checkbox_shops.tpl
@@ -29,6 +29,6 @@
 		<label class="tree-toggler">{l s='Group: %s' sprintf=[$node['name']|escape:'html':'UTF-8']}</label>
 	</span>
 	<ul class="tree">
-		{$children|escape:'UTF-8'}
+      {$children}
 	</ul>
 </li>

--- a/admin-dev/themes/default/template/helpers/tree/tree_node_folder_radio.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_node_folder_radio.tpl
@@ -31,6 +31,6 @@
 		<label class="tree-toggler">{$node['name']|escape:'html':'UTF-8'}</label>
 	</span>
 	<ul class="tree">
-		{$children|escape:'UTF-8'}
+		{$children}
 	</ul>
 </li>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed double escape for Tree Node template
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27348
| How to test?      | Cf #27348


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27381)
<!-- Reviewable:end -->
