### PR TITLE
Remove z-index and overflow of product description of product list

### DIFF
--- a/themes/classic/_dev/css/components/featuredproducts.scss
+++ b/themes/classic/_dev/css/components/featuredproducts.scss
@@ -160,11 +160,9 @@ $product-description-height: 70px;
   .product-description {
     position: relative;
     bottom: 0;
-    z-index: 3;
     height: auto;
     padding: 0.25rem;
     padding-bottom: 0.7rem;
-    overflow: hidden;
     background: $white;
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | There is a problem where you can't see the rating of productcomments because of some styles on product lists
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27252.
| How to test?      | To be tested with https://github.com/PrestaShop/productcomments/pull/130 at the same time, see issue in order to have some more test informations
| Possible impacts? | Product list description


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27387)
<!-- Reviewable:end -->
