### PR TITLE
Fix bad display of progress bar for bulk actions

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
@@ -42,8 +42,8 @@
                     <div class="float-right progress-details-text" default-value="{{ progressbar.label|default('Processing...'|trans({}, 'Admin.Global')) }}">
                         {{ progressbar.label|default('Processing...'|trans({}, 'Admin.Global')) }}
                     </div>
-                    <div class="progress active progress-striped" style="display: block; width: 100%">
-                        <div class="progress-bar progress-bar-success" role="progressbar" style="width: 0%">
+                    <div class="progress" style="width: 100%">
+                        <div class="progress-bar progress-bar-striped" role="progressbar" style="width: 0%">
                             <span>0 %</span>
                         </div>
                     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Make the progress bar percentage visible.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27386
| How to test?      | 1. Go to BO > Catalog > Products<br/>2. Select multiple products<br/>3. Try to duplicate with bulk actions menu 
| Possible impacts? | This fix impacts all modals with progress bar, I tried to gather the list of usages:<br>- import modal<br>- product bulk duplication modal<br>- product bulk activation modal<br>- product bulk deactivation modal<br>- product bulk deletion modal


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27389)
<!-- Reviewable:end -->
