### PR TITLE
Add the minimum required to the error message, when trying to apply a cart rule with a minimum

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -830,7 +830,7 @@ class CartRuleCore extends ObjectModel
             }
 
             if ($cartTotal < $minimum_amount) {
-                return (!$display_error) ? false : $this->trans('You have not reached the minimum amount required to use this voucher', [], 'Shop.Notifications.Error');
+                return (!$display_error) ? false : $this->trans('You have not reached the %s minimum amount required to use this voucher', [$context->getCurrentLocale()->formatPrice($minimum_amount, $context->currency->iso_code)], 'Shop.Notifications.Error');
             }
         }
 

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -830,7 +830,7 @@ class CartRuleCore extends ObjectModel
             }
 
             if ($cartTotal < $minimum_amount) {
-                return (!$display_error) ? false : $this->trans('You have not reached the %s minimum amount required to use this voucher', [Tools::getContextLocale($context)->formatPrice($minimum_amount, $context->currency->iso_code)], 'Shop.Notifications.Error');
+                return (!$display_error) ? false : $this->trans('The minimum amount to benefit from this promo code is %s.', [Tools::getContextLocale($context)->formatPrice($minimum_amount, $context->currency->iso_code)], 'Shop.Notifications.Error');
             }
         }
 

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -830,7 +830,7 @@ class CartRuleCore extends ObjectModel
             }
 
             if ($cartTotal < $minimum_amount) {
-                return (!$display_error) ? false : $this->trans('You have not reached the %s minimum amount required to use this voucher', [$context->getCurrentLocale()->formatPrice($minimum_amount, $context->currency->iso_code)], 'Shop.Notifications.Error');
+                return (!$display_error) ? false : $this->trans('You have not reached the %s minimum amount required to use this voucher', [Tools::getContextLocale($context)->formatPrice($minimum_amount, $context->currency->iso_code)], 'Shop.Notifications.Error');
             }
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add the minimum required to the error message, when trying to apply a cart rule with a minimum
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| How to test?      | 1. Create a voucher with a minimum amount.<br/>2. Add some product to the cart but with a cart total lower than the minimum of the voucher, so the voucher is not eligible.<br/>3. Try to apply the voucher to the cart.<br/>4. This PR adds an error message that tell the customer the minimum amount requested.
| Possible impacts? |
| Sponsor company   | Prestaplugins

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27397)
<!-- Reviewable:end -->
