### PR TITLE
Don't check if an invalid address exists over and over again

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -442,9 +442,13 @@ class AddressCore extends ObjectModel
      */
     public static function addressExists($id_address)
     {
+        if ($id_address <= 0) {
+            return false;
+        }
+
         return (bool) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
-            'SELECT `id_address` 
-            FROM ' . _DB_PREFIX_ . 'address a 
+            'SELECT `id_address`
+            FROM ' . _DB_PREFIX_ . 'address a
             WHERE a.`id_address` = ' . (int) $id_address,
             false
         );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | It's no use checking if an id_address <= 0 exists.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26754 (only when not logged in)
| How to test?      | Enable profiling mode, look for the query described in the issue, see it's not there.
| Possible impacts? | Nothing I can think of

Note: I wanted to add a local cache in the Cart class for the part that verifies if an address exists, but I found a weird thing with tax address during cart calculation. 

- If the shop is configured to use the **invoice address** for tax purposes, then the calculation will try to figure out the invoice address. 
- If the shop is configured to use the **shipping address** for tax, however, it will use whatever is stored as delivery address for each product in the cart (in `ps_cart_product`).

I don't really understand why does the cart hold the shipping address for each product. Is it to support different shipping addresses for the same order? But then, why is this attached to the cart, if it depends on the order?

Also, this is set to zero when you're a guest, and to your default address when you're logged in. So if you add a product to the cart while unlogged, and then you add another product when logged, they will have different shipping addresses stored, so the tax calculation will be different. Is this expected? Shouldn't the tax calculation be homogeneous within an order and therefore only use the shipping/invoice/inferred (if not logged) address? /cc @PrestaShop/product-team 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27406)
<!-- Reviewable:end -->
