### PR TITLE
Use core translations sources for themes in addition to the translations of the theme itself

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -182,11 +182,7 @@ function smartyTranslate($params, $smarty)
     $basename = basename($filename, '.tpl');
 
     if (!isset($params['d'])) {
-        if ($params['mod']) {
-            $params['d'] = DomainHelper::buildModuleDomainFromLegacySource($params['mod'], $basename);
-        } else {
-            $params['d'] = null;
-        }
+        $params['d'] = $params['mod'] ? DomainHelper::buildModuleDomainFromLegacySource($params['mod'], $basename) : null;
     }
 
     if (!empty($params['d'])) {

--- a/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
+++ b/src/Core/Translation/Builder/TranslationCatalogueBuilder.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CatalogueProviderFac
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
+use PrestaShopBundle\Translation\Provider\AbstractProvider;
 
 /**
  * This class provides the catalogue represented as an array.
@@ -190,6 +191,9 @@ class TranslationCatalogueBuilder
             foreach ($messages as $translationKey => $translationValue) {
                 $translationKey = (string) $translationKey;
                 $message = new Message($translationKey);
+                if ($locale === AbstractProvider::DEFAULT_LOCALE) {
+                    $message->setFileTranslation($translationKey);
+                }
                 if ($fileTranslatedCatalogue->defines($translationKey, $domainName)) {
                     $message->setFileTranslation($fileTranslatedCatalogue->get($translationKey, $domainName));
                 }

--- a/src/Core/Translation/Storage/Provider/CatalogueProviderFactory.php
+++ b/src/Core/Translation/Storage/Provider/CatalogueProviderFactory.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoa
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\AbstractCoreProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\FrontofficeProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModulesProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
 use Symfony\Component\Filesystem\Filesystem;
@@ -206,11 +207,18 @@ class CatalogueProviderFactory
     {
         if (!isset($this->providers[$providerDefinition->getType()])) {
             $coreFrontProviderDefinition = new FrontofficeProviderDefinition();
+            $modulesProviderDefinition = new ModulesProviderDefinition();
             $coreFrontProvider = new CoreCatalogueLayersProvider(
                 $this->databaseTranslationLoader,
                 $this->translationsDirectory,
-                $coreFrontProviderDefinition->getFilenameFilters(),
-                $coreFrontProviderDefinition->getTranslationDomains()
+                array_merge(
+                    $coreFrontProviderDefinition->getFilenameFilters(),
+                    $modulesProviderDefinition->getFilenameFilters()
+                ),
+                array_merge(
+                    $coreFrontProviderDefinition->getTranslationDomains(),
+                    $modulesProviderDefinition->getTranslationDomains()
+                )
             );
 
             $this->providers[$providerDefinition->getType()] = new ThemeCatalogueLayersProvider(

--- a/src/Core/Translation/Storage/Provider/Definition/ModulesProviderDefinition.php
+++ b/src/Core/Translation/Storage/Provider/Definition/ModulesProviderDefinition.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition;
+
+/**
+ * Properties container for Modules translation provider.
+ */
+class ModulesProviderDefinition extends AbstractCoreProviderDefinition
+{
+    private const FILENAME_FILTERS_REGEX = ['#^Modules*#'];
+
+    private const TRANSLATION_DOMAINS_REGEX = ['^Modules*'];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): string
+    {
+        return ProviderDefinitionInterface::TYPE_MODULES;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilenameFilters(): array
+    {
+        return self::FILENAME_FILTERS_REGEX;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTranslationDomains(): array
+    {
+        return self::TRANSLATION_DOMAINS_REGEX;
+    }
+}

--- a/src/Core/Translation/Storage/Provider/ModuleCatalogueProviderFactory.php
+++ b/src/Core/Translation/Storage/Provider/ModuleCatalogueProviderFactory.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Storage\Provider;
+
+use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\LegacyModuleExtractorInterface;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
+use Symfony\Component\Translation\Loader\LoaderInterface;
+
+class ModuleCatalogueProviderFactory
+{
+    /**
+     * @var DatabaseTranslationLoader
+     */
+    private $databaseTranslationLoader;
+
+    /**
+     * @var LegacyModuleExtractorInterface
+     */
+    private $legacyModuleExtractor;
+
+    /**
+     * @var LoaderInterface
+     */
+    private $legacyFileLoader;
+
+    /**
+     * @var string
+     */
+    private $modulesDirectory;
+
+    /**
+     * @var string
+     */
+    private $translationsDirectory;
+
+    public function __construct(
+        DatabaseTranslationLoader $databaseTranslationLoader,
+        LegacyModuleExtractorInterface $legacyModuleExtractor,
+        LoaderInterface $legacyFileLoader,
+        string $modulesDirectory,
+        string $translationsDirectory
+    ) {
+        $this->databaseTranslationLoader = $databaseTranslationLoader;
+        $this->legacyModuleExtractor = $legacyModuleExtractor;
+        $this->legacyFileLoader = $legacyFileLoader;
+        $this->modulesDirectory = $modulesDirectory;
+        $this->translationsDirectory = $translationsDirectory;
+    }
+
+    public function getModuleCatalogueProvider(ModuleProviderDefinition $providerDefinition): CatalogueLayersProviderInterface
+    {
+        return new ModuleCatalogueLayersProvider(
+            $this->databaseTranslationLoader,
+            $this->legacyModuleExtractor,
+            $this->legacyFileLoader,
+            $this->modulesDirectory,
+            $this->translationsDirectory,
+            $providerDefinition->getModuleName(),
+            $providerDefinition->getFilenameFilters(),
+            $providerDefinition->getTranslationDomains()
+        );
+    }
+}

--- a/src/Core/Translation/Storage/Provider/ThemeCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ThemeCatalogueLayersProvider.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Translation\Exception\InvalidThemeException;
 use PrestaShop\PrestaShop\Core\Translation\Exception\TranslationFilesNotFoundException;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\ThemeExtractor;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Loader\DatabaseTranslationLoader;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\FileTranslatedCatalogueFinder;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Finder\UserTranslatedCatalogueFinder;
 use RuntimeException;
@@ -93,6 +94,17 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
     private $theme;
 
     /**
+     * @var MessageCatalogue|null
+     */
+    private $defaultCatalogue;
+
+    /**
+     * @var ModuleCatalogueProviderFactory
+     */
+    private $moduleCatalogueProviderFactory;
+
+    /**
+     * @param ModuleCatalogueProviderFactory $moduleCatalogueProviderFactory
      * @param CatalogueLayersProviderInterface $coreFrontProvider
      * @param DatabaseTranslationLoader $databaseTranslationLoader
      * @param ThemeExtractor $themeExtractor
@@ -102,6 +114,7 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
      * @param string $themeName
      */
     public function __construct(
+        ModuleCatalogueProviderFactory $moduleCatalogueProviderFactory,
         CatalogueLayersProviderInterface $coreFrontProvider,
         DatabaseTranslationLoader $databaseTranslationLoader,
         ThemeExtractor $themeExtractor,
@@ -111,6 +124,7 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
         string $themeName
     ) {
         $this->databaseTranslationLoader = $databaseTranslationLoader;
+        $this->moduleCatalogueProviderFactory = $moduleCatalogueProviderFactory;
         $this->coreFrontProvider = $coreFrontProvider;
         $this->themeExtractor = $themeExtractor;
         $this->themeRepository = $themeRepository;
@@ -129,7 +143,11 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
         bool $refreshCache = false
     ): MessageCatalogue {
         // Extracts wordings from the theme's templates
-        return $this->themeExtractor->extract($this->theme, $locale);
+        if ($this->defaultCatalogue === null) {
+            $this->defaultCatalogue = $this->themeExtractor->extract($this->theme, $locale);
+        }
+
+        return $this->defaultCatalogue;
     }
 
     /**
@@ -144,16 +162,8 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
     public function getFileTranslatedCatalogue(string $locale): MessageCatalogue
     {
         // load front office catalogue
-        $coreCatalogue = $this->coreFrontProvider->getFileTranslatedCatalogue($locale);
-
-        // load core user-translated catalogue
-        $coreUserTranslatedCatalogue = (new UserTranslatedCatalogueFinder(
-            $this->databaseTranslationLoader,
-            ['*']
-        ))
-            ->getCatalogue($locale);
-
-        $coreCatalogue->addCatalogue($coreUserTranslatedCatalogue);
+        $coreCatalogue = $this->getCoreCatalogue($locale);
+        $coreCatalogue->addCatalogue($this->getModulesTranslations($locale));
 
         try {
             $fileTranslatedCatalogue = (new FileTranslatedCatalogueFinder(
@@ -215,5 +225,57 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
         $this->filesystem->mkdir($resourceDirectory);
 
         return $resourceDirectory;
+    }
+
+    private function getCoreCatalogue(string $locale): MessageCatalogue
+    {
+        $coreCatalogue = $this->coreFrontProvider->getFileTranslatedCatalogue($locale);
+
+        // load core user-translated catalogue
+        $coreUserTranslatedCatalogue = (new UserTranslatedCatalogueFinder(
+            $this->databaseTranslationLoader,
+            ['*']
+        ))
+            ->getCatalogue($locale);
+
+        $coreCatalogue->addCatalogue($coreUserTranslatedCatalogue);
+
+        return $coreCatalogue;
+    }
+
+    private function getModulesTranslations(string $locale): MessageCatalogue
+    {
+        $moduleCatalogue = new MessageCatalogue($locale);
+        $modules = $this->getModulesFromTranslations($locale);
+
+        foreach ($modules as $module) {
+            $moduleProvider = $this->moduleCatalogueProviderFactory->getModuleCatalogueProvider(
+                new ModuleProviderDefinition($module)
+            );
+            try {
+                $moduleCatalogue->addCatalogue($moduleProvider->getFileTranslatedCatalogue($locale));
+            } catch (Exception $e) {
+                // no translations found
+            }
+        }
+
+        return $moduleCatalogue;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getModulesFromTranslations(string $locale): array
+    {
+        $modules = [];
+
+        $catalogue = $this->getDefaultCatalogue($locale);
+        foreach ($catalogue->getDomains() as $domain) {
+            if (preg_match('/^Modules([A-Z]([^A-Z]+))/', $domain, $matches)) {
+                $modules[] = strtolower($matches[1]);
+            }
+        }
+
+        return $modules;
     }
 }

--- a/src/Core/Translation/Storage/Provider/ThemeCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ThemeCatalogueLayersProvider.php
@@ -138,7 +138,7 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
      * @return MessageCatalogue
      *
      * The **file** translated catalogue for a theme other than classic corresponds
-     * to the core files, overwrite by the user-translated core wordings (if any), overwrite
+     * to the core files, overwritten by the user-translated core wordings (if any), overwritten
      * by the theme files (if any)
      */
     public function getFileTranslatedCatalogue(string $locale): MessageCatalogue

--- a/src/Core/Translation/Storage/Provider/ThemeCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ThemeCatalogueLayersProvider.php
@@ -147,13 +147,13 @@ class ThemeCatalogueLayersProvider implements CatalogueLayersProviderInterface
         $coreCatalogue = $this->coreFrontProvider->getFileTranslatedCatalogue($locale);
 
         // load core user-translated catalogue
-        $coreUserTranslatedCalalogue = (new UserTranslatedCatalogueFinder(
+        $coreUserTranslatedCatalogue = (new UserTranslatedCatalogueFinder(
             $this->databaseTranslationLoader,
             ['*']
         ))
             ->getCatalogue($locale);
 
-        $coreCatalogue->addCatalogue($coreUserTranslatedCalalogue);
+        $coreCatalogue->addCatalogue($coreUserTranslatedCatalogue);
 
         try {
             $fileTranslatedCatalogue = (new FileTranslatedCatalogueFinder(

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -164,11 +164,6 @@ services:
             - "@prestashop.core.admin.lang.repository"
             - "@prestashop.core.admin.translation.repository"
 
-    prestashop.translation.sql_loader:
-        class: PrestaShopBundle\Translation\Loader\SqlTranslationLoader
-        tags:
-            - {name: translation.loader, alias: db}
-
     prestashop.translation.reader.legacy_file:
         class: PrestaShop\PrestaShop\Core\Translation\Storage\Loader\LegacyFileReader
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -164,6 +164,9 @@ services:
             - "@prestashop.core.admin.lang.repository"
             - "@prestashop.core.admin.translation.repository"
 
+    prestashop.translation.sql_loader:
+        class: PrestaShopBundle\Translation\Loader\SqlTranslationLoader
+
     prestashop.translation.reader.legacy_file:
         class: PrestaShop\PrestaShop\Core\Translation\Storage\Loader\LegacyFileReader
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -57,7 +57,7 @@ services:
             - '@prestashop.translation.extractor.theme'
             - '@prestashop.core.addon.theme.repository'
             - '@filesystem'
-            - '%themes_translations_dir%'
+            - '%themes_dir%'
             - '%modules_dir%'
             - "%translations_dir%"
 

--- a/src/PrestaShopBundle/Service/TranslationService.php
+++ b/src/PrestaShopBundle/Service/TranslationService.php
@@ -220,7 +220,7 @@ class TranslationService
      * @param string $domain
      * @param string $key
      * @param string $translationValue
-     * @param null $theme
+     * @param string|null $theme
      *
      * @return bool
      */
@@ -238,14 +238,18 @@ class TranslationService
         $translation = null;
 
         try {
-            $translation = $entityManager->getRepository('PrestaShopBundle:Translation')
+            $queryBuilder = $entityManager->getRepository('PrestaShopBundle:Translation')
                 ->createQueryBuilder('t')
                 ->where('t.lang = :lang')->setParameter('lang', $lang)
                 ->andWhere('t.domain = :domain')->setParameter('domain', $domain)
                 ->andWhere('t.key LIKE :key')->setParameter('key', $key)
-                ->andWhere('t.theme = :theme OR t.theme is NULL')->setParameter('theme', $theme)
-                ->getQuery()
-                ->getSingleResult();
+            ;
+            if ($theme !== null) {
+                $queryBuilder->andWhere('t.theme = :theme')->setParameter('theme', $theme);
+            } else {
+                $queryBuilder->andWhere('t.theme IS NULL');
+            }
+            $translation = $queryBuilder->getQuery()->getSingleResult();
         } catch (Exception $exception) {
             $logger->error($exception->getMessage(), $log_context);
         }

--- a/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/DatabaseTranslationLoader.php
@@ -72,6 +72,10 @@ class DatabaseTranslationLoader implements LoaderInterface
             $langs[$locale] = $this->entityManager->getRepository('PrestaShopBundle:Lang')->findOneBy(['locale' => $locale]);
         }
 
+        if ($langs[$locale] === null) {
+            return $catalogue;
+        }
+
         /** @var EntityRepository $translationRepository */
         $translationRepository = $this->entityManager->getRepository('PrestaShopBundle:Translation');
 

--- a/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
+++ b/src/PrestaShopBundle/Translation/Loader/SqlTranslationLoader.php
@@ -77,19 +77,13 @@ class SqlTranslationLoader implements LoaderInterface
         $selectTranslationsQuery = '
             SELECT `key`, `translation`, `domain`
             FROM `' . _DB_PREFIX_ . 'translation`
-            WHERE `id_lang` = ' . $localeResults[$locale]['id_lang'];
+            WHERE `id_lang` = ' . $localeResults[$locale]['id_lang'] . '
+            AND theme ' . ($this->theme !== null ? '= "' . $this->theme->getName() . '"' : 'IS NULL');
+
         $translations = Db::getInstance()->executeS($selectTranslationsQuery) ?: [];
 
         $catalogue = new MessageCatalogue($locale);
         $this->addTranslationsToCatalogue($translations, $catalogue);
-
-        if (null !== $this->theme) {
-            $selectThemeTranslationsQuery =
-                $selectTranslationsQuery . "\n" .
-                "AND theme = '" . $this->theme->getName() . "'";
-            $themeTranslations = Db::getInstance()->executeS($selectThemeTranslationsQuery) ?: [];
-            $this->addTranslationsToCatalogue($themeTranslations, $catalogue);
-        }
 
         return $catalogue;
     }

--- a/tests/Integration/Core/Translation/Storage/Provider/ThemeCatalogueLayersProviderTest.php
+++ b/tests/Integration/Core/Translation/Storage/Provider/ThemeCatalogueLayersProviderTest.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Translation\Storage\Extractor\ThemeExtractor;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\CoreCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\FrontofficeProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ThemeProviderDefinition;
+use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\ModuleCatalogueProviderFactory;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\ThemeCatalogueLayersProvider;
 use PrestaShop\PrestaShop\Core\Translation\TranslationRepositoryInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -133,6 +134,7 @@ class ThemeCatalogueLayersProviderTest extends AbstractCatalogueLayersProviderTe
         );
 
         $provider = new ThemeCatalogueLayersProvider(
+            $this->createMock(ModuleCatalogueProviderFactory::class),
             $coreFrontProvider,
             $databaseTranslationLoader,
             $this->themeExtractor,
@@ -272,6 +274,7 @@ class ThemeCatalogueLayersProviderTest extends AbstractCatalogueLayersProviderTe
         );
 
         return new ThemeCatalogueLayersProvider(
+            $this->createMock(ModuleCatalogueProviderFactory::class),
             $coreFrontProvider,
             $databaseTranslationLoader,
             $this->themeExtractor,

--- a/tests/Unit/Core/Translation/Builder/TranslationTreeBuilderTest.php
+++ b/tests/Unit/Core/Translation/Builder/TranslationTreeBuilderTest.php
@@ -39,6 +39,7 @@ use Symfony\Component\Translation\MessageCatalogue;
 class TranslationTreeBuilderTest extends TestCase
 {
     private const LOCALE = 'en-US';
+    private const FRENCH_LOCALE = 'fr-FR';
 
     private static $defaultTranslations = [
         'AdminFirstDomain' => [
@@ -146,7 +147,7 @@ class TranslationTreeBuilderTest extends TestCase
     {
         $tree = $this->treeBuilder->getTree(
             new BackofficeProviderDefinition(),
-            self::LOCALE,
+            self::FRENCH_LOCALE,
             []
         );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Since #23296, one of the path given to `PrestaShop\PrestaShop\Core\Translation\Provider\CatalogueProviderFactory` was wrong, this PR fixes it. Also, core translations where not take into account when translating a theme (other than classic) that uses core wordings. This PR fixes it by loading core translations first, then overwrite them with theme translations (if present).
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #27410 & #26549
| How to test?      | Please see #27410 & #26549
| Possible impacts? | 

#### Deprecation
The constructor of `PrestaShop\PrestaShop\Core\Translation\Storage\Provider\ThemeCatalogueLayersProvider` takes now a `PrestaShop\PrestaShop\Core\Translation\Storage\Provider\ModuleCatalogueProviderFactory` as first argument

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27422)
<!-- Reviewable:end -->
