### PR TITLE
Add text nowrap to link btn inside grids

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/link.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/link.html.twig
@@ -37,7 +37,7 @@
 
 {% block link %}
 <a 
-  class="{{ class }}"
+  class="{{ class }} text-nowrap"
   href="{{ path(column.options.route, { (column.options.route_param_name) : record[column.options.route_param_field]}) }}"
   {% if column.options.target is defined %}
     target="{{ column.options.target }}"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Buttons shouldn't wrap when the window size is reduced, prefer having an horizontal scroll 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26779.
| How to test?      | Generate a credit slip, go to credit slip grid and see if the button is fine when you're on mobile
| Possible impacts? | Grid link elements btn


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27429)
<!-- Reviewable:end -->
