### PR TITLE
Align checkboxes of multistore widget

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -38,6 +38,12 @@
     @extend .col-sm-10;
   }
 
+  .switch-widget {
+    .form-check-radio {
+      padding-top: calc(0.375rem + 1px);
+    }
+  }
+
   .form-group {
     > .alert {
       margin-top: 0.75rem;

--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -38,10 +38,8 @@
     @extend .col-sm-10;
   }
 
-  .switch-widget {
-    .form-check-radio {
-      padding-top: calc(0.375rem + 1px);
-    }
+  .form-check-radio {
+    padding-top: calc(0.375rem + 1px);
   }
 
   .form-group {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Multistore checkbox wasn't aligned with the right content
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26904.
| How to test?      | See issue
| Possible impacts? | Multistore checkbox


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27430)
<!-- Reviewable:end -->
