### PR TITLE
Avoid use of unasigned ps_versions_compliancy

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -295,6 +295,10 @@ abstract class ModuleCore implements ModuleInterface
             Tools::displayParameterAsDeprecated('name');
         }
 
+        if (!isset($this->ps_versions_compliancy)) {
+            $this->ps_versions_compliancy = [];
+        }
+
         if (isset($this->ps_versions_compliancy) && !isset($this->ps_versions_compliancy['min'])) {
             $this->ps_versions_compliancy['min'] = '1.4.0.0';
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The ps_versions_compliancy property of the modules is set to default when min OR max are not defined, but when ps_versions_compliancy is not defined at all by the module, no default are set. This causes the a null to be used as array along the rest of the code. By default, PHP only logs this and no error is visible at prod, but in lower environments, when you see all the logs, is pretty noisy.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27434.
| How to test?      | 1.- Install a module that doesn't completes the ps_versions_compliancy property. 2.- Enable debuging for PS and for PHP 3.- Navigate the front end. (No extra logging should appear)
| Possible impacts? | No secondary impacts


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27435)
<!-- Reviewable:end -->
