### PR TITLE
deprecate pending _PS_PRICE_COMPUTE_PRECISION_

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1157,7 +1157,7 @@ abstract class PaymentModuleCore extends Module
                 );
             }
             $remainingValue = $cartRuleReductionAmountConverted - $values[$cartRule->reduction_tax ? 'tax_incl' : 'tax_excl'];
-            $remainingValue = Tools::ps_round($remainingValue, _PS_PRICE_COMPUTE_PRECISION_);
+            $remainingValue = Tools::ps_round($remainingValue, $computingPrecision);
             if (count($order_list) == 1 && $remainingValue > 0 && $cartRule->partial_use == 1 && $cartRuleReductionAmountConverted > 0) {
                 // Create a new voucher from the original
                 $voucher = new CartRule((int) $cartRule->id); // We need to instantiate the CartRule without lang parameter to allow saving it


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The _PS_PRICE_COMPUTE_PRECISION_ constant from the config file was deprecated son years ago and is generating issues when mixing it with the new precision method if they are not equal. This PR extends the PR https://github.com/PrestaShop/PrestaShop/pull/26824 to a cart rules portion of the code.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes #26553
| How to test?      | Create a currency with decimal values different than "2". Create some cart rules that affect the price of the products partially (like by a percentage). Create an order from the FE that will apply the cart rule created in the currency that requieres a precision different than 2. The order should have the correct round applied for the currency.
| Possible impacts? | No secondary impacts.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27436)
<!-- Reviewable:end -->
