### PR TITLE
Add hook to display custom content before checkout confirmation

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3535,5 +3535,10 @@
       <title>Modify delivery option list result</title>
       <description>This hook allows you to modify delivery option list</description>
     </hook>
+    <hook id="displayCheckoutBeforeConfirmation">
+      <name>displayCheckoutBeforeConfirmation</name>
+      <title>Show custom content before checkout confirmation</title>
+      <description>This hook allows you to display custom content at the end of checkout process</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/themes/classic/templates/checkout/_partials/steps/payment.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/payment.tpl
@@ -121,6 +121,8 @@
     </form>
   {/if}
 
+  {hook h='displayCheckoutBeforeConfirmation'}
+
   {if $show_final_summary}
     {include file='checkout/_partials/order-final-summary.tpl'}
   {/if}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allows to display custom optional checkboxes or other content at the end of checkout process.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26800
| How to test?      | Add something to this hook and check its displayed in checkout.
| Possible impacts? | No


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27437)
<!-- Reviewable:end -->
