### PR TITLE
Set the statistics controller as ajax

### DIFF
--- a/controllers/front/StatisticsController.php
+++ b/controllers/front/StatisticsController.php
@@ -25,10 +25,13 @@
  */
 class StatisticsControllerCore extends FrontController
 {
-    public $display_header = false;
-    public $display_footer = false;
-
     protected $param_token;
+
+    public function init()
+    {
+        $this->ajax = true;
+        parent::init();
+    }
 
     public function postProcess()
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The Statistics controller should be mark as ajax to prevent the unnecessary code execution and unnecessary logging as the core tries to process smarty templates for the requests.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27449.
| How to test?      | Navigating the frontend should collect the users information but shouldn't log errors nor warnings of invalid or unassigned templates on the server related to the statistics requests.
| Possible impacts? | No secondary impacts.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27448)
<!-- Reviewable:end -->
