### PR TITLE
Remove NotBlank constraint on CreditSlipOptionsType

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CreditSlip/CreditSlipOptionsType.php
@@ -30,7 +30,6 @@ use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * Backwards compatibility break introduced in 1.7.8.0 due to extension of TranslationAwareType instead of using translator as dependency.
@@ -47,11 +46,6 @@ final class CreditSlipOptionsType extends TranslatorAwareType
         $builder->add('slip_prefix', TranslatableType::class, [
             'label' => $this->trans('Credit slip prefix', 'Admin.Orderscustomers.Feature'),
             'help' => $this->trans('Prefix used for credit slips.', 'Admin.Orderscustomers.Help'),
-            'options' => [
-                'constraints' => [
-                    new NotBlank(),
-                ],
-            ],
             'required' => false,
             'error_bubbling' => true,
             'type' => TextType::class,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove NotBlank constraint on CreditSlipOptionsType.<br/><br/>This constraint was introduced in https://github.com/PrestaShop/PrestaShop/commit/60f9492638375e062c424cf1e014cb73593e3551 but the behavior stated in https://github.com/PrestaShop/PrestaShop/issues/27451 informs us it was not valid. A credit slip prefix can be blank.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27451
| How to test?      | See ticket https://github.com/PrestaShop/PrestaShop/issues/27451
| Possible impacts? | No side impacts expected outside of the Credit Slip form


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27457)
<!-- Reviewable:end -->
