### PR TITLE
Remove duplicate by using distinct connection and also make sure carts are linked

### DIFF
--- a/classes/Guest.php
+++ b/classes/Guest.php
@@ -217,6 +217,11 @@ class GuestCore extends ObjectModel
             'id_guest' => (int) $idGuest,
         ], 'id_guest = ' . (int) $this->id);
 
+        // Since the guests are merged, the guest id in the cart table must be changed too
+        Db::getInstance()->update('cart', [
+            'id_guest' => (int) $idGuest,
+        ], 'id_guest = ' . (int) $this->id);
+
         // The existing guest is removed from the database
         $existingGuest = new Guest((int) $idGuest);
         $existingGuest->delete();

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -63,7 +63,7 @@ class AdminCartsControllerCore extends AdminController
 		LEFT JOIN ' . _DB_PREFIX_ . 'carrier ca ON (ca.id_carrier = a.id_carrier)
 		LEFT JOIN ' . _DB_PREFIX_ . 'orders o ON (o.id_cart = a.id_cart)
 		LEFT JOIN (
-            SELECT `id_guest`
+            SELECT DISTINCT `id_guest`
             FROM `' . _DB_PREFIX_ . 'connections`
             WHERE
                 TIME_TO_SEC(TIMEDIFF(\'' . pSQL(date('Y-m-d H:i:00', time())) . '\', `date_add`)) < 1800


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | There were two problems, see below.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27450
| How to test?      | Use the pub@prestashop.com account after a fresh install, just log in and log out multiple time, the Shopping Carts list in the BO should be ok.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


With the PR:
See the `Online` field, which is now ok, and also there are no more duplicates.
![image](https://user-images.githubusercontent.com/1462701/151013881-345d71f7-16f1-4863-9f2b-76640a4046c0.png)

Without the PR:
![image](https://user-images.githubusercontent.com/1462701/151016855-c7f00065-a75b-4d67-b8d5-dc7c841e7b2e.png)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27459)
<!-- Reviewable:end -->
