### PR TITLE
Add hook to allow adding extra buttons in module configure toolbar

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/configure.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/configure.tpl
@@ -101,6 +101,7 @@
 					<div>{l s='Manage hooks' d='Admin.Modules.Feature'}</div>
 				</a>
 			</li>
+			{hook h="displayModuleConfigureExtraButtons"}
 		</ul>
 	</div>
 </div>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -281,6 +281,11 @@
       <title>Customer account creation form</title>
       <description>This hook displays some information on the form to create a customer account</description>
     </hook>
+    <hook id="displayModuleConfigureExtraButtons">
+      <name>displayModuleConfigureExtraButtons</name>
+      <title>Module configuration - After toolbar buttons</title>
+      <description>This hook allows to add toolbar's additional content on module configuration page</description>
+    </hook>
     <hook id="displayAdminStatsModules">
       <name>displayAdminStatsModules</name>
       <title>Stats - Modules</title>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | After removal of "module update" button in module configure page, we need to be able to add extra buttons in this page's toolbar
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #27578
| How to test?      | Create a module, use the hook to add a buton in the toolbar.<br>Here is an example module [prestashopexamplemodule.zip](https://github.com/PrestaShop/PrestaShop/files/7936179/prestashopexamplemodule.zip)
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27461)
<!-- Reviewable:end -->
