### PR TITLE
Remove call of action*ListingFieldsModifier hook inside processFilter()

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -851,10 +851,6 @@ class AdminControllerCore extends Controller
 
     public function processFilter()
     {
-        Hook::exec('action' . $this->controller_name . 'ListingFieldsModifier', [
-            'fields' => &$this->fields_list,
-        ]);
-
         if (!isset($this->list_id)) {
             $this->list_id = $this->table;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This hook call is also made, with more parameters, inside https://github.com/PrestaShop/PrestaShop/blob/develop/classes/controller/AdminController.php#L3139 and inside `processFilter()`, there is no use of `$this->fields_list` at all..
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue number here}.
| How to test?      | Not sure there is something to test here.
| Possible impacts? | Make module reliable on this hook without checking if it's a lite or advanced usage.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27463)
<!-- Reviewable:end -->
