### PR TITLE
Add hook to allow adding content after themes list in the BO

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3608,7 +3608,7 @@
     <hook id="displayAdminThemesListAfter">
       <name>displayAdminThemesListAfter</name>
       <title>BO themes list extra content</title>
-      <description>This hook displays content after the themes list in the BackOffice</description>
+      <description>This hook displays content after the themes list in the back office</description>
     </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3605,5 +3605,10 @@
       <title>Before a module is reset</title>
       <description>This hook is called just before a module is reset</description>
     </hook>
+    <hook id="displayAdminThemesListAfter">
+      <name>displayAdminThemesListAfter</name>
+      <title>BO themes list extra content</title>
+      <description>This hook displays content after the themes list in the BackOffice</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Theme/index.html.twig
@@ -139,6 +139,8 @@
           {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/delete_theme_modal.html.twig' %}
         {% endif %}
 
+        {{ renderhook('displayAdminThemesListAfter', { 'current_theme_name': currentlyUsedTheme.get('name') }) }}
+
         {% include '@PrestaShop/Admin/Improve/Design/Theme/Blocks/layouts_configuration.html.twig' %}
       </div>
     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This hook will allow to add extra content after the themes list like a CTA to recommend themes. This feature was removed by https://github.com/PrestaShop/PrestaShop/pull/26917
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27865
| How to test?      | Create an example module which calls the hook and add any HTML content. This content will appear after the themes list. Example module [prestashopexamplemodule.zip](https://github.com/PrestaShop/PrestaShop/files/7941378/prestashopexamplemodule.zip)<br> You can also test with https://github.com/PrestaShopCorp/ps_mbo/pull/126. The autoupgrade PR is https://github.com/PrestaShop/autoupgrade/pull/462.
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27469)
<!-- Reviewable:end -->
