### PR TITLE
Fix: prestashop event functions are overwritten in the "classic" theme

### DIFF
--- a/themes/_core/js/theme.js
+++ b/themes/_core/js/theme.js
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 
-
 import './migrate-mute';
 import 'jquery-migrate';
 import 'jquery.browser';

--- a/themes/_core/js/theme.js
+++ b/themes/_core/js/theme.js
@@ -1,8 +1,5 @@
 import $ from 'jquery';
 
-import prestashop from 'prestashop';
-// eslint-disable-next-line
-import EventEmitter from "events";
 
 import './migrate-mute';
 import 'jquery-migrate';
@@ -20,13 +17,6 @@ import './address';
 import {psShowHide} from './common';
 import initEmailFields from './email-idn';
 
-/* eslint-disable */
-// "inherit" EventEmitter
-for (const i in EventEmitter.prototype) {
-  prestashop[i] = EventEmitter.prototype[i];
-}
-/* expose jQuery for modules */
-/* eslint-enable */
 window.$ = $;
 window.jQuery = $;
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix event handling on `prestashop` variable
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27473
| How to test?      | Create an event JavaScript in a module or in the theme
| Possible impacts? | Prestashop theme events

Create an event JavaScript in a module or in the theme:
```jsx
prestashop.on('selectorsInit', () => {
	...
});
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27475)
<!-- Reviewable:end -->
