### PR TITLE
Make Advanced Parameters > Logs configuration form multistore compatible

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/logs/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/logs/index.ts
@@ -44,3 +44,11 @@ $(() => {
   grid.addExtension(new SubmitGridActionExtension());
   grid.addExtension(new FiltersSubmitButtonEnablerExtension());
 });
+
+$(() => {
+  window.prestashop.component.initComponents(
+    [
+      'MultistoreConfigField',
+    ],
+  );
+});

--- a/src/Adapter/Configuration/LogsConfiguration.php
+++ b/src/Adapter/Configuration/LogsConfiguration.php
@@ -28,17 +28,52 @@ namespace PrestaShop\PrestaShop\Adapter\Configuration;
 
 use PrestaShop\PrestaShop\Adapter\Validate;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
-use Context;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 
 /**
  * This class will manage Logs configuration for a Shop.
  */
 class LogsConfiguration extends AbstractMultistoreConfiguration
 {
+
+    /**
+     * @var Configuration
+     */
+    protected $configuration;
+
+    /**
+     * @var Context
+     */
+    protected $shopContext;
+
+     /**
+     * @var FeatureInterface
+     */
+    protected $multistoreFeature;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var Validate
+     */
+    private $validate;
+
+    public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature, TranslatorInterface $translator, Validate $validate)
+    {
+        $this->configuration = $configuration;
+        $this->shopContext = $shopContext;
+        $this->multistoreFeature = $multistoreFeature;
+        $this->translator = $translator;
+        $this->validate = $validate;
+    }
 
     /**
      * {@inheritdoc}
@@ -57,16 +92,12 @@ class LogsConfiguration extends AbstractMultistoreConfiguration
     public function updateConfiguration(array $configuration)
     {
         if ($this->validateConfiguration($configuration)) {
-
-            $validate = new Validate();
-            $context = Context::getContext();
-            $translator = $context->getTranslator();
             $checkEmails = explode(',', $configuration['logs_email_receivers']);
             $errors = [];
             $invalidEmails = [];
 
             foreach ($checkEmails as $email) {
-                if (!$validate->isEmail($email)) {
+                if (!$this->validate->isEmail($email)) {
                     $invalidEmails[] = $email;
                 }
             }
@@ -75,13 +106,13 @@ class LogsConfiguration extends AbstractMultistoreConfiguration
                 $nbInvalidEmails = count($invalidEmails);
 
                 if ($nbInvalidEmails > 1) {
-                    $errors[] = $translator->trans(
+                    $errors[] = $this->translator->trans(
                         'Invalid emails: %invalid_emails%.',
                         ['%invalid_emails%' => implode(',', $invalidEmails)],
                         'Admin.Notifications.Error'
                     );
                 } else {
-                    $errors[] = $translator->trans(
+                    $errors[] = $this->translator->trans(
                         'Invalid email: %invalid_email%.',
                         ['%invalid_email%' => implode(',', $invalidEmails)],
                         'Admin.Notifications.Error'

--- a/src/Adapter/Configuration/LogsConfiguration.php
+++ b/src/Adapter/Configuration/LogsConfiguration.php
@@ -40,22 +40,6 @@ use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
  */
 class LogsConfiguration extends AbstractMultistoreConfiguration
 {
-
-    /**
-     * @var Configuration
-     */
-    protected $configuration;
-
-    /**
-     * @var Context
-     */
-    protected $shopContext;
-
-     /**
-     * @var FeatureInterface
-     */
-    protected $multistoreFeature;
-
     /**
      * @var TranslatorInterface
      */
@@ -68,11 +52,9 @@ class LogsConfiguration extends AbstractMultistoreConfiguration
 
     public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature, TranslatorInterface $translator, Validate $validate)
     {
-        $this->configuration = $configuration;
-        $this->shopContext = $shopContext;
-        $this->multistoreFeature = $multistoreFeature;
         $this->translator = $translator;
-        $this->validate = $validate;
+        $this->validate = $validate; 
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Logs/LogsByEmailType.php
@@ -31,6 +31,7 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 
 /**
  * This form class generates the "Logs by email" form in Logs page.
@@ -52,6 +53,7 @@ final class LogsByEmailType extends TranslatorAwareType
                     'Minimum severity level',
                     'Admin.Advparameters.Feature'
                 ),
+                'multistore_configuration_key' => 'PS_LOGS_BY_EMAIL',
                 'help' => $this->trans(
                     'Click on "None" to disable log alerts by email or enter the recipients of these emails in the following field.',
                     'Admin.Advparameters.Help'
@@ -62,6 +64,7 @@ final class LogsByEmailType extends TranslatorAwareType
                     'Send emails to',
                     'Admin.Advparameters.Feature'
                 ),
+                'multistore_configuration_key' => 'PS_LOGS_EMAIL_RECEIVERS',
                 'help' => $this->trans(
                     'Log alerts will be sent to these emails. Please use a comma to separate them (e.g. pub@prestashop.com, anonymous@psgdpr.com).',
                     'Admin.Advparameters.Help'
@@ -86,4 +89,15 @@ final class LogsByEmailType extends TranslatorAwareType
     {
         return 'logs_by_email_block';
     }
+
+     /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
+    }
+    
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/logs.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/advanced_parameters/logs.yml
@@ -8,7 +8,7 @@ admin_logs_index:
 
 admin_logs_save_settings:
   path: /settings
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\LogsController::saveSettingsAction'
     _legacy_controller: AdminLogs

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -109,6 +109,8 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Configuration\LogsConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
       - '@translator'
       - '@prestashop.adapter.validate'
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR add checkboxes and specifics settings drop-downs list to  BO > Advanced Parameters > Logs page to make it multistore compatible
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19358 and #19311 
| Original PR?      | https://github.com/PrestaShop/PrestaShop/pull/25645
| How to test?      | See issue
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/25645)
<!-- Reviewable:end -->
