### PR TITLE
Fixed Product.php getCountryAndState result handle

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4068,7 +4068,7 @@ class ProductCore extends ObjectModel
 
         $id_currency = (int) $context->currency->id;
         $ids = Address::getCountryAndState((int) $context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
-        $id_country = $ids['id_country'] ? (int) $ids['id_country'] : (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $id_country = isset($ids['id_country']) ? (int) $ids['id_country'] : (int) Configuration::get('PS_COUNTRY_DEFAULT');
 
         return (bool) SpecificPrice::getSpecificPrice((int) $id_product, $context->shop->id, $id_currency, $id_country, $id_group, $quantity, null, 0, 0, $quantity);
     }


### PR DESCRIPTION
After "getCountryAndState" use "isset" to check the result

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      | After "getCountryAndState" use "isset" to check the result to prevent the error "Trying to access array offset on value of type bool" on newer PHP versions
| Type?             | bug fix
| Category?             | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #27482
| How to test?      | open a Product page in Debug Mode
| Possible impacts? | none

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27480)
<!-- Reviewable:end -->
