### PR TITLE
Product page v2 accessible in menu

### DIFF
--- a/install-dev/data/xml/tab.xml
+++ b/install-dev/data/xml/tab.xml
@@ -69,6 +69,11 @@
                     <wording>Products</wording>
                     <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
+                <tab id="Products_v2" id_parent="Catalog" active="1" enabled="1" icon="science" route_name="admin_products_v2_index">
+                  <class_name>AdminProducts</class_name>
+                  <wording>Products (experimental)</wording>
+                  <wording_domain>Admin.Navigation.Menu</wording_domain>
+                </tab>
                 <tab id="Categories" id_parent="Catalog" active="1" enabled="1">
                     <class_name>AdminCategories</class_name>
                     <wording>Categories</wording>
@@ -268,9 +273,9 @@
                     <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                     <tab id="Mail_Theme" id_parent="Mail_Theme_Parent" active="1" enabled="1">
-                      <class_name>AdminMailTheme</class_name>
-                      <wording>Email Theme</wording>
-                      <wording_domain>Admin.Navigation.Menu</wording_domain>
+                        <class_name>AdminMailTheme</class_name>
+                        <wording>Email Theme</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
 
                 <tab id="Pages" id_parent="Look_feel" active="1" enabled="1">
@@ -363,9 +368,9 @@
                     <wording_domain>Admin.Navigation.Menu</wording_domain>
                 </tab>
                     <tab id="Zones" id_parent="Locations" active="1" enabled="1">
-                      <class_name>AdminZones</class_name>
-                      <wording>Zones</wording>
-                      <wording_domain>Admin.Navigation.Menu</wording_domain>
+                        <class_name>AdminZones</class_name>
+                        <wording>Zones</wording>
+                        <wording_domain>Admin.Navigation.Menu</wording_domain>
                     </tab>
                     <tab id="Countries" id_parent="Locations" active="1" enabled="1">
                         <class_name>AdminCountries</class_name>
@@ -647,22 +652,22 @@
 
       <!--QUICK ACCESS-->
       <tab id="Quick_Access" id_parent="-1" active="1" enabled="1">
-        <class_name>AdminQuickAccesses</class_name>
-        <wording>Quick Access</wording>
-        <wording_domain>Admin.Navigation.Menu</wording_domain>
+          <class_name>AdminQuickAccesses</class_name>
+          <wording>Quick Access</wording>
+          <wording_domain>Admin.Navigation.Menu</wording_domain>
       </tab>
 
       <!--DEFAULT-->
       <tab id="DEFAULT" id_parent="" active="1" enabled="1">
-        <class_name>DEFAULT</class_name>
-        <wording>More</wording>
-        <wording_domain>Admin.Navigation.Menu</wording_domain>
+          <class_name>DEFAULT</class_name>
+          <wording>More</wording>
+          <wording_domain>Admin.Navigation.Menu</wording_domain>
       </tab>
 
       <tab id="Patterns" id_parent="-1" active="1" enabled="1">
-        <class_name>AdminPatterns</class_name>
-        <wording/>
-        <wording_domain/>
+          <class_name>AdminPatterns</class_name>
+          <wording/>
+          <wording_domain/>
       </tab>
     </entities>
 </entity_tab>

--- a/install-dev/langs/en/data/tab.xml
+++ b/install-dev/langs/en/data/tab.xml
@@ -95,6 +95,7 @@
     <tab id="Price_Rules" name="Discounts" />
     <tab id="Products_1" name="Product Settings" />
     <tab id="Products" name="Products" />
+    <tab id="Products_v2" name="Products (experimental)" />
     <tab id="Profiles" name="Profiles" />
     <tab id="Quick_Access" name="Quick Access" />
     <tab id="Referrers" name="Referrers" />

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -36,7 +36,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductExcep
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductIsEnabled;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcher;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Entity\AdminFilter;
@@ -344,7 +343,6 @@ class ProductController extends FrameworkBundleAdminController
             'last_sql_query' => $lastSql,
             'has_category_filter' => $productProvider->isCategoryFiltered(),
             'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
-            'productPageV2IsEnabled' => $this->isProductPageV2Enabled(),
         ];
         if ($view !== 'full') {
             return $this->render(
@@ -378,21 +376,19 @@ class ProductController extends FrameworkBundleAdminController
             'help' => $this->trans('Create a new product: CTRL+P', 'Admin.Catalog.Help'),
         ];
 
-        if ($this->isProductPageV2Enabled()) {
-            $toolbarButtons['add_v2'] = [
-                'href' => $this->generateUrl('admin_products_v2_create'),
-                'desc' => $this->trans('New product on experimental page', 'Admin.Catalog.Feature'),
-                'icon' => 'add_circle_outline',
-                'class' => 'btn-outline-primary new-product',
-                'floating_class' => 'new-product',
-            ];
+        $toolbarButtons['add_v2'] = [
+            'href' => $this->generateUrl('admin_products_v2_create'),
+            'desc' => $this->trans('New product on experimental page', 'Admin.Catalog.Feature'),
+            'icon' => 'add_circle_outline',
+            'class' => 'btn-outline-primary new-product',
+            'floating_class' => 'new-product',
+        ];
 
-            $toolbarButtons['list_v2'] = [
-                'href' => $this->generateUrl('admin_products_v2_index'),
-                'desc' => $this->trans('List on experimental page', 'Admin.Catalog.Feature'),
-                'class' => 'btn-outline-primary',
-            ];
-        }
+        $toolbarButtons['list_v2'] = [
+            'href' => $this->generateUrl('admin_products_v2_index'),
+            'desc' => $this->trans('List on experimental page', 'Admin.Catalog.Feature'),
+            'class' => 'btn-outline-primary',
+        ];
 
         return $toolbarButtons;
     }
@@ -676,7 +672,6 @@ class ProductController extends FrameworkBundleAdminController
             'editable' => $this->isGranted(PageVoter::UPDATE, self::PRODUCT_OBJECT),
             'drawerModules' => $drawerModules,
             'layoutTitle' => $this->trans('Product', 'Admin.Global'),
-            'isProductPageV2Enabled' => ($this->isProductPageV2Enabled()),
             'isCreationMode' => (int) $product->state === Product::STATE_TEMP,
         ];
     }
@@ -1347,19 +1342,5 @@ class ProductController extends FrameworkBundleAdminController
             'error_code' => $error_code,
             'allow_duplicate' => $allow_duplicate,
         ];
-    }
-
-    /**
-     * @return bool
-     */
-    private function isProductPageV2Enabled(): bool
-    {
-        $productPageV2FeatureFlag = $this->get('prestashop.core.feature_flags.modifier')->getOneFeatureFlagByName(FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2);
-
-        if (null === $productPageV2FeatureFlag) {
-            return false;
-        }
-
-        return $productPageV2FeatureFlag->isEnabled();
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -39,7 +39,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProductsForAssociation
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForAssociation;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
 use PrestaShop\PrestaShop\Core\Exception\ProductException;
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductFilters;
@@ -108,11 +107,6 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function createAction(Request $request): Response
     {
-        if (!$this->isProductPageV2Enabled()) {
-            $this->addFlashMessageProductV2IsDisabled();
-
-            return $this->redirectToRoute('admin_product_new');
-        }
         if (!$this->get('prestashop.adapter.shop.context')->isSingleShopContext()) {
             return $this->renderDisableMultistorePage();
         }
@@ -146,12 +140,6 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function editAction(Request $request, int $productId): Response
     {
-        if (!$this->isProductPageV2Enabled()) {
-            $this->addFlashMessageProductV2IsDisabled();
-
-            return $this->redirectToRoute('admin_product_form', ['id' => $productId]);
-        }
-
         if (!$this->get('prestashop.adapter.shop.context')->isSingleShopContext()) {
             return $this->renderDisableMultistorePage($productId);
         }
@@ -452,36 +440,6 @@ class ProductController extends FrameworkBundleAdminController
                 'Admin.Notifications.Error'
             ),
         ];
-    }
-
-    /**
-     * @return bool
-     */
-    private function isProductPageV2Enabled(): bool
-    {
-        $productPageV2FeatureFlag = $this->get('prestashop.core.feature_flags.modifier')
-            ->getOneFeatureFlagByName(FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2);
-
-        if (null === $productPageV2FeatureFlag) {
-            return false;
-        }
-
-        return $productPageV2FeatureFlag->isEnabled();
-    }
-
-    private function addFlashMessageProductV2IsDisabled(): void
-    {
-        $this->addFlash(
-            'warning',
-            $this->trans(
-                'The experimental product page is not enabled. To enable it, go to the %sExperimental Features%s page.',
-                'Admin.Catalog.Notification',
-                [
-                    sprintf('<a href="%s">', $this->get('router')->generate('admin_feature_flags_index')),
-                    '</a>',
-                ]
-            )
-        );
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/list.html.twig
@@ -125,15 +125,13 @@
                     }
                 ]) %}
 
-                {% if productPageV2IsEnabled == true %}
-                    {% set buttons_action = buttons_action|merge([
-                        {
-                          "href": product.url_v2|default('#'),
-                          "icon": "mode_edit",
-                          "label": "Edit on experimental page"|trans({}, 'Admin.Catalog.Feature')
-                        }
-                    ]) %}
-                {% endif %}
+                {% set buttons_action = buttons_action|merge([
+                  {
+                    "href": product.url_v2|default('#'),
+                    "icon": "mode_edit",
+                    "label": "Edit on experimental page"|trans({}, 'Admin.Catalog.Feature')
+                  }
+                ]) %}
 
                 {% include '@Product/CatalogPage/Forms/form_edit_dropdown.html.twig' with {
                     'button_id': "product_list_id_" ~ product.id_product ~ "_menu",

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Blocks/footer.html.twig
@@ -106,22 +106,18 @@
       >
         {{ 'Add new product'|trans({}, 'Admin.Catalog.Feature')|raw }}
       </button>
-      {% if isProductPageV2Enabled == true %}
-        <a
-          class="btn btn-outline-primary ml-3 new-product"
-          href="{{ path('admin_products_v2_create') }}"
-        >
-          {{ 'New product on experimental page'|trans({}, 'Admin.Catalog.Feature')|raw }}
-        </a>
-      {% endif %}
-      {% if isProductPageV2Enabled == true and isCreationMode is same as(false) %}
-        <a
-          class="btn btn-outline-primary ml-3"
-          href="{{ path('admin_products_v2_edit', {'productId': productId}) }}"
-        >
-          {{ 'Edit on experimental page'|trans({}, 'Admin.Catalog.Feature')|raw }}
-        </a>
-      {% endif %}
+      <a
+        class="btn btn-outline-primary ml-3 new-product"
+        href="{{ path('admin_products_v2_create') }}"
+      >
+        {{ 'New product on experimental page'|trans({}, 'Admin.Catalog.Feature')|raw }}
+      </a>
+      <a
+        class="btn btn-outline-primary ml-3"
+        href="{{ path('admin_products_v2_edit', {'productId': productId}) }}"
+      >
+        {{ 'Edit on experimental page'|trans({}, 'Admin.Catalog.Feature')|raw }}
+      </a>
 
       <div class="js-spinner spinner hide btn-primary-reverse onclick mr-1 btn"></div>
       <div class="btn-group hide dropdown">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | To ease the starting work on automated tests and QA for product page v2 a link is added in the menu to access the new list page directly Also the feature flag for products is now ignored meaning the page is always enabled even if the product flag is not This PR does NOT clean the feature flag code, this will have to be done in another PR
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | Make a fresh install, the menu should have a new entry after "Products" which is "Products (experimental)" The experimental page is now always accessible regardless of the feature flag values along with all buttons related to it
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27481)
<!-- Reviewable:end -->
