### PR TITLE
filterCategoryContent hook not working

### DIFF
--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -120,7 +120,7 @@ class CategoryControllerCore extends ProductListingFrontController
             $check_exceptions = true,
             $use_push = false,
             $id_shop = null,
-            $chain = true
+            $chain = false
         );
         if (!empty($filteredCategory['object'])) {
             $categoryVar = $filteredCategory['object'];

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -116,7 +116,7 @@ class CategoryControllerCore extends ProductListingFrontController
             'filterCategoryContent',
             ['object' => $categoryVar],
             $id_module = null,
-            $array_return = false,
+            $array_return = true,
             $check_exceptions = true,
             $use_push = false,
             $id_shop = null,


### PR DESCRIPTION
The hook returns an array but the function in line 115 is configured for a hook that does not return an array.
So using this hook returns an error.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      | Using the filterCategoryContent hook causes an error as the hook is misconfigured in the controller
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixe     | Fixes #27487
| How to test?      | Create a module and test with filterCategoryContent hook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27486)
<!-- Reviewable:end -->
