### PR TITLE
Clean combinations behat step

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartRuleFeatureContext.php
@@ -53,7 +53,7 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
     protected $countryFeatureContext;
 
     /**
-     * @var ProductFeatureContext
+     * @var LegacyProductFeatureContext
      */
     protected $productFeatureContext;
 
@@ -92,8 +92,8 @@ class CartRuleFeatureContext extends AbstractPrestaShopFeatureContext
         $environment = $scope->getEnvironment();
         /** @var CountryFeatureContext $countryFeatureContext */
         $countryFeatureContext = $environment->getContext(CountryFeatureContext::class);
-        /** @var ProductFeatureContext $productFeatureContext */
-        $productFeatureContext = $environment->getContext(ProductFeatureContext::class);
+        /** @var LegacyProductFeatureContext $productFeatureContext */
+        $productFeatureContext = $environment->getContext(LegacyProductFeatureContext::class);
         /** @var CarrierFeatureContext $carrierFeatureContext */
         $carrierFeatureContext = $environment->getContext(CarrierFeatureContext::class);
         /** @var CustomerFeatureContext $customerFeatureContext */

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -34,6 +34,7 @@ use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use Configuration;
+use Currency;
 use Exception;
 use Language;
 use ObjectModel;
@@ -298,6 +299,16 @@ abstract class AbstractDomainFeatureContext implements Context
     protected function getDefaultLangId(): int
     {
         return (int) Configuration::get('PS_LANG_DEFAULT');
+    }
+
+    protected function getDefaultCurrencyId(): int
+    {
+        return (int) Configuration::get('PS_CURRENCY_DEFAULT');
+    }
+
+    protected function getDefaultCurrencyIsoCode(): string
+    {
+        return Currency::getIsoCodeById($this->getDefaultCurrencyId());
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CartFeatureContext.php
@@ -67,13 +67,13 @@ use Product;
 use RuntimeException;
 use SpecificPrice;
 use State;
-use Tests\Integration\Behaviour\Features\Context\ProductFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\LegacyProductFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 
 class CartFeatureContext extends AbstractDomainFeatureContext
 {
     /**
-     * @var ProductFeatureContext
+     * @var LegacyProductFeatureContext
      */
     protected $productFeatureContext;
 
@@ -82,8 +82,8 @@ class CartFeatureContext extends AbstractDomainFeatureContext
     {
         /** @var InitializedContextEnvironment $environment */
         $environment = $scope->getEnvironment();
-        /** @var ProductFeatureContext $productFeatureContext */
-        $productFeatureContext = $environment->getContext(ProductFeatureContext::class);
+        /** @var LegacyProductFeatureContext $productFeatureContext */
+        $productFeatureContext = $environment->getContext(LegacyProductFeatureContext::class);
 
         $this->productFeatureContext = $productFeatureContext;
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
-use Behat\Gherkin\Node\TableNode;
 use Language;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
@@ -38,8 +37,6 @@ use PrestaShopBundle\Install\DatabaseDump;
 use Product;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext;
-use Tests\Integration\Behaviour\Features\Context\Util\CombinationDetails;
-use Tests\Integration\Behaviour\Features\Context\Util\ProductCombinationFactory;
 use Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext;
 
 class CommonProductFeatureContext extends AbstractProductFeatureContext
@@ -113,40 +110,6 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
             'feature_product',
             'warehouse_product_location',
         ]);
-    }
-
-    /**
-     * @Given product :productReference has following combinations:
-     *
-     * @param string $productReference
-     * @param TableNode $tableNode
-     */
-    public function addCombinationsToProduct(string $productReference, TableNode $tableNode): void
-    {
-        $details = $tableNode->getColumnsHash();
-        $combinationsDetails = [];
-
-        foreach ($details as $combination) {
-            $combinationsDetails[] = new CombinationDetails(
-                $combination['reference'],
-                (int) $combination['quantity'],
-                explode(';', $combination['attributes'])
-            );
-        }
-
-        $combinations = ProductCombinationFactory::makeCombinations(
-            $this->getSharedStorage()->get($productReference),
-            $combinationsDetails
-        );
-
-        foreach ($combinations as $combination) {
-            $this->getSharedStorage()->set($combination->reference, (int) $combination->id);
-        }
-
-        // Product class has a lot of cache that is set as soon as the product is created, including for prices
-        // which are cached for each combinations. Since it was cached when the combinations did not exist we need
-        // to clear it so that the newly created combinations' prices are correctly computed next time they are needed.
-        Product::resetStaticCache();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProductFeatureContext.php
@@ -28,7 +28,6 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Cache;
 use Category;
-use Context;
 use Customer;
 use GroupReduction;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
@@ -125,7 +124,7 @@ class ProductFeatureContext extends AbstractDomainFeatureContext
     private function getProductIdByName(string $productName): int
     {
         /** @var FoundProduct[] */
-        $products = $this->getQueryBus()->handle(new SearchProducts($productName, 1, Context::getContext()->currency->iso_code));
+        $products = $this->getQueryBus()->handle(new SearchProducts($productName, 1, $this->getDefaultCurrencyIsoCode()));
 
         if (empty($products)) {
             throw new RuntimeException(sprintf('Product with name "%s" was not found', $productName));

--- a/tests/Integration/Behaviour/Features/Context/LegacyProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LegacyProductFeatureContext.php
@@ -46,7 +46,7 @@ use TaxRulesGroup;
 use Tests\Integration\Behaviour\Features\Context\Util\CombinationDetails;
 use Tests\Integration\Behaviour\Features\Context\Util\ProductCombinationFactory;
 
-class ProductFeatureContext extends AbstractPrestaShopFeatureContext
+class LegacyProductFeatureContext extends AbstractPrestaShopFeatureContext
 {
     use CartAwareTrait;
 

--- a/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ProductFeatureContext.php
@@ -659,6 +659,9 @@ class ProductFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
+     * This step was created when CQRS commands did not exist for product It shouldn't be used unless you want to force
+     * creating combinations in a "legacy way" and make sure they are consistent with the usage of new commands.
+     *
      * @Given /^product "(.+)" has combinations with following details:$/
      */
     public function productWithNameHasCombinationsWithFollowingDetails($productName, TableNode $table)

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -32,6 +32,7 @@ use Configuration;
 use Context;
 use Db;
 use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\SearchShopException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Query\SearchShops;
 use PrestaShop\PrestaShop\Core\Domain\Shop\QueryResult\FoundShop;
@@ -73,6 +74,13 @@ class ShopFeatureContext extends AbstractDomainFeatureContext
      */
     public function loadSingleShopContext(string $shopReference): void
     {
+        // If context shop has never been initialized we must do it here otherwise it will be done later automatically
+        // by LegacyContext with a shop context for ALL_SHOPS which will remove this override
+        /** @var LegacyContext $legacyContext */
+        $legacyContext = $this->getContainer()->get('prestashop.adapter.legacy.context');
+        // Just calling the getter initializes the context
+        $legacyContext->getContext();
+
         Shop::setContext(
             Shop::CONTEXT_SHOP,
             SharedStorage::getStorage()->get($shopReference)

--- a/tests/Integration/Behaviour/Features/Context/TaxFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/TaxFeatureContext.php
@@ -59,7 +59,7 @@ class TaxFeatureContext extends AbstractPrestaShopFeatureContext
     protected $carrierFeatureContext;
 
     /**
-     * @var ProductFeatureContext
+     * @var LegacyProductFeatureContext
      */
     protected $productFeatureContext;
 
@@ -70,8 +70,8 @@ class TaxFeatureContext extends AbstractPrestaShopFeatureContext
         $environment = $scope->getEnvironment();
         /** @var CarrierFeatureContext $carrierFeatureContext */
         $carrierFeatureContext = $environment->getContext(CarrierFeatureContext::class);
-        /** @var ProductFeatureContext $productFeatureContext */
-        $productFeatureContext = $environment->getContext(ProductFeatureContext::class);
+        /** @var LegacyProductFeatureContext $productFeatureContext */
+        $productFeatureContext = $environment->getContext(LegacyProductFeatureContext::class);
 
         $this->carrierFeatureContext = $carrierFeatureContext;
         $this->productFeatureContext = $productFeatureContext;

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -8,7 +8,8 @@ Feature: Legacy products have consistent product type through dynamic checking (
   I need to be sure that "legacy" products (created with page v1) have a correct product type (used for v2)
 
   Background:
-    Given language with iso code "en" is the default one
+    Given shop "shop1" with name "test_shop" exists
+    And language with iso code "en" is the default one
     And attribute group "Size" named "Size" in en language exists
     And attribute group "Color" named "Color" in en language exists
     And attribute "S" named "S" in en language exists
@@ -18,6 +19,7 @@ Feature: Legacy products have consistent product type through dynamic checking (
     And attribute "Black" named "Black" in en language exists
     And attribute "Blue" named "Blue" in en language exists
     And attribute "Red" named "Red" in en language exists
+    And single shop shop1 context is loaded
 
   Scenario: I create a standard product using legacy methods, its product type should be standard
     Given there is a product in the catalog named "Standard Product" with a price of 15.0 and 100 items in stock

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -9,7 +9,6 @@ Feature: Legacy products have consistent product type through dynamic checking (
 
   Background:
     Given language with iso code "en" is the default one
-    And the current currency is "USD"
     And attribute group "Size" named "Size" in en language exists
     And attribute group "Color" named "Color" in en language exists
     And attribute "S" named "S" in en language exists

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_pack.feature
@@ -6,6 +6,15 @@ Feature: Add product to pack from Back Office (BO)
   As a BO user
   I need to be able to add product to pack from BO
 
+  Background:
+    Given language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+
   Scenario: I cannot perform pack update on a standard product
     Given I add product "product1" with following information:
       | name[en-US] | weird sunglasses box |
@@ -150,74 +159,79 @@ Feature: Add product to pack from Back Office (BO)
     Given I add product "productSkirt1" with following information:
       | name[en-US] | regular skirt |
       | type        | combinations  |
-    And product "productSkirt1" has following combinations:
-      | reference | quantity | attributes         |
-      | whiteS    | 15       | Size:S;Color:White |
-      | whiteM    | 15       | Size:M;Color:White |
-      | blackM    | 13       | Size:M;Color:Black |
+    When I generate combinations for product productSkirt1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black] |
+    Then product "productSkirt1" should have following combinations:
+      | id reference        | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | productSkirt1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | productSkirt1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | productSkirt1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | productSkirt1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
     And product productSkirt1 type should be combinations
     And product "productPack4" type should be pack
     When I update pack productPack4 with following product quantities:
-      | product       | combination | quantity |
-      | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | whiteM      | 11       |
-      | productSkirt1 | blackM      | 12       |
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MWhite | 11       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following quantities:
-      | product       | combination | quantity |
-      | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | whiteM      | 11       |
-      | productSkirt1 | blackM      | 12       |
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MWhite | 11       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
 
   Scenario: Add combination & standard product to a pack
     Given product "product2" type should be standard
     And product productSkirt1 type should be combinations
-    And product "productSkirt1" has following combinations:
-      | reference | quantity | attributes         |
-      | whiteS    | 15       | Size:S;Color:White |
-      | whiteM    | 15       | Size:M;Color:White |
-      | blackM    | 13       | Size:M;Color:Black |
+    And product "productSkirt1" should have following combinations:
+      | id reference        | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | productSkirt1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | productSkirt1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | productSkirt1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | productSkirt1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
     When I update pack productPack4 with following product quantities:
-      | product       | combination | quantity |
-      | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | whiteM      | 11       |
-      | productSkirt1 | blackM      | 12       |
-      | product2      |             | 2        |
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MWhite | 11       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
+      | product2      |                     | 2        |
     Then product "productPack4" type should be pack
     And pack productPack4 should contain products with following quantities:
-      | product       | combination | quantity |
-      | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | whiteM      | 11       |
-      | productSkirt1 | blackM      | 12       |
-      | product2      |             | 2        |
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MWhite | 11       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
+      | product2      |                     | 2        |
 
   Scenario: I remove one combination of same product from existing pack and change another combination quantity
     Given product "productPack4" type should be pack
     And pack productPack4 should contain products with following quantities:
-      | product       | combination | quantity |
-      | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | whiteM      | 11       |
-      | productSkirt1 | blackM      | 12       |
-      | product2      |             | 2        |
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MWhite | 11       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
+      | product2      |                     | 2        |
     When I update pack productPack4 with following product quantities:
-      | product       | combination | quantity |
-      | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | blackM      | 9        |
-      | product2      |             | 2        |
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MBlack | 9        |
+      | product2      |                     | 2        |
     Then pack productPack4 should contain products with following quantities:
-      | product       | combination | quantity |
-      | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | blackM      | 9        |
-      | product2      |             | 2        |
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MBlack | 9        |
+      | product2      |                     | 2        |
     Then product "productPack4" type should be pack
 
   Scenario: I remove all products from existing pack when it contains combination and standard products
     Given product "productPack4" type should be pack
     And pack productPack4 should contain products with following quantities:
-      | product       | combination | quantity |
-      | productSkirt1 | whiteS      | 10       |
-      | productSkirt1 | blackM      | 9        |
-      | product2      |             | 2        |
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MBlack | 9        |
+      | product2      |                     | 2        |
     When I remove all products from pack productPack4
     Then product "productPack4" type should be pack
     And pack "productPack4" should be empty

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_related_products.feature
@@ -7,6 +7,12 @@ Feature: Update product related products from Back Office (BO)
   As an employee
   I need to be able to update related products of a product from Back Office
 
+  Background:
+    Given language with iso code "en" is the default one
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+
   Scenario: I set related products
     Given I add product "product1" with following information:
       | name[en-US] | book of law |
@@ -23,10 +29,12 @@ Feature: Update product related products from Back Office (BO)
     And I add product "product4" with following information:
       | name[en-US] | Reading glasses |
       | type        | combinations    |
-    And product "product4" has following combinations:
-      | reference   | quantity | attributes  |
-      | whiteFramed | 10       | Color:White |
-      | blackFramed | 10       | Color:Black |
+    When I generate combinations for product product4 using following attributes:
+      | Color | [White,Black] |
+    Then product "product4" should have following combinations:
+      | id reference | combination name | reference | attributes    | impact on price | quantity | is default |
+      | whiteFramed  | Color - White    |           | [Color:White] | 0               | 0        | true       |
+      | blackFramed  | Color - Black    |           | [Color:Black] | 0               | 0        | false      |
     And product product1 should have no related products
     And product product2 type should be standard
     And product "product3" type should be pack

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
@@ -9,6 +9,12 @@ Feature: Update product status from BO (Back Office)
     Given language "language1" with locale "en-US" exists
     And category "home" in default language named "Home" exists
     And category "home" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
 
   Scenario: I update standard product status
     Given I add product "product1" with following information:
@@ -41,11 +47,15 @@ Feature: Update product status from BO (Back Office)
     And I add product "product3" with following information:
       | name[en-US] | T-Shirt with listed values |
       | type        | combinations               |
-    And product "product3" has following combinations:
-      | reference | quantity | attributes         |
-      | whiteS    | 100      | Size:S;Color:White |
-      | whiteM    | 150      | Size:M;Color:White |
-      | blackM    | 130      | Size:M;Color:Black |
+    When I generate combinations for product product3 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black] |
+    Then product "product3" should have following combinations:
+      | id reference        | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product3SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product3SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product3MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product3MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
     And product product3 type should be combinations
     And product "product3" should be disabled
     When I enable product "product3"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -249,7 +249,6 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductTypeFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -249,66 +249,65 @@ default:
             contexts:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductTypeFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductShopFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateBasicInformationFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCategoriesFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateOptionsFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateDetailsFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePackFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePricesFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateShippingFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateTagsFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductSuppliersFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateSeoFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\SearchProductFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CategoryFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CarrierFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\ShopFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\SupplierFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\ManufacturerFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateAttachmentFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\AttachmentFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\SpecificPricePrioritiesFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\RelatedProductsFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\DuplicateProductFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\VirtualProductFileFeatureContext
-                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
-                - Tests\Integration\Behaviour\Features\Transform\StringToArrayTransformContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductImageFeatureContext
-                - Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\AttributeGroupFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\AttributeFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\AttributeGroupFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CarrierFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CategoryFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CountryFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\FeatureFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\FeatureValueFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\ManufacturerFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationListingFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\DeleteCombinationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SearchCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationDetailsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationPricesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationStockFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationSuppliersFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SearchCombinationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\DuplicateProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductImageFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductShopFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductTypeFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\RelatedProductsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\SearchProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\SpecificPriceContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\FeatureFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\FeatureValueFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\SpecificPricePrioritiesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateAttachmentFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateBasicInformationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCategoriesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateDetailsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateOptionsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePackFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePricesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductFeatureValuesFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CountryFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductSuppliersFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateSeoFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateShippingFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateTagsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\VirtualProductFileFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\ShopFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\SupplierFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToArrayTransformContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
         legacy_product:
             paths:
                 - "%paths.base%/Features/Scenario/Product"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -46,7 +46,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\ContextFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\SqlManagerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CartFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LegacyProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CartRuleFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\TaxFeatureContext
@@ -89,7 +89,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Configuration\EmailConfigurationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LegacyProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CarrierFeatureContext
@@ -317,7 +317,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LegacyProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\AttributeGroupFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\AttributeFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -244,10 +244,11 @@ default:
         product:
             paths:
                 - "%paths.base%/Features/Scenario/Product"
+            filters:
+                tags: "~@legacy-product-type"
             contexts:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
@@ -308,6 +309,21 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\CountryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
+        legacy_product:
+            paths:
+                - "%paths.base%/Features/Scenario/Product"
+            filters:
+                tags: "@legacy-product-type"
+            contexts:
+                - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\AttributeGroupFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\AttributeFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
         shop:
             paths:
                 - "%paths.base%/Features/Scenario/Shop"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Some behat tests in the product suite were using a legacy way to create combinations This was unstable (sometimes the shop context was blocking because of this) and not clean since the suite is supposed to test the domain and rely on it only They were all cleaned and replaced by actual use of the domain commands to generate combinations
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | CI tests green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27494)
<!-- Reviewable:end -->
