### PR TITLE
Add UTF-8 BOM to every CSV exported from backoffice

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1069,6 +1069,11 @@ class AdminControllerCore extends Controller
         header('Content-disposition: attachment; filename="' . $this->table . '_' . date('Y-m-d_His') . '.csv"');
 
         $fd = fopen('php://output', 'wb');
+
+        // Write BOM - for proper recognition of the encoding
+        fwrite($fd, (chr(0xEF) . chr(0xBB) . chr(0xBF)));
+
+        // Write first row of CSV - the header
         $headers = [];
         foreach ($this->fields_list as $key => $datas) {
             if ('PDF' === $datas['title']) {
@@ -1083,6 +1088,7 @@ class AdminControllerCore extends Controller
         }
         fputcsv($fd, $headers, ';', $text_delimiter);
 
+        // Write other rows of CSV - the content
         foreach ($this->_list as $i => $row) {
             $content = [];
             $path_to_image = false;

--- a/src/Core/Export/FileWriter/ExportCsvFileWriter.php
+++ b/src/Core/Export/FileWriter/ExportCsvFileWriter.php
@@ -65,8 +65,13 @@ final class ExportCsvFileWriter implements FileWriterInterface
             throw new FileWritingException(sprintf('Cannot open export file for writing'), FileWritingException::CANNOT_OPEN_FILE_FOR_WRITING);
         }
 
+        // Write BOM - for proper recognition of the encoding
+        $exportFile->fwrite(chr(0xEF) . chr(0xBB) . chr(0xBF));
+
+        // Write first row of CSV - the header
         $exportFile->fputcsv($data->getTitles(), ';');
 
+        // Write other rows of CSV - the content
         foreach ($data->getRows() as $row) {
             $exportFile->fputcsv($row, ';');
         }

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -196,8 +196,14 @@ class CsvResponse extends StreamedResponse
     private function processDataArray()
     {
         $handle = tmpfile();
+
+        // Write BOM - for proper recognition of the encoding
+        fwrite($handle, (chr(0xEF) . chr(0xBB) . chr(0xBF)));
+
+        // Write first row of CSV - the header
         fputcsv($handle, $this->headersData, ';');
 
+        // Write other rows of CSV - the content
         foreach ($this->data as $line) {
             fputcsv($handle, $line, ';');
         }
@@ -211,8 +217,14 @@ class CsvResponse extends StreamedResponse
     private function processDataCallback()
     {
         $handle = tmpfile();
+
+        // Write BOM - for proper recognition of the encoding
+        fwrite($handle, (chr(0xEF) . chr(0xBB) . chr(0xBF)));
+
+        // Write first row of CSV - the header
         fputcsv($handle, $this->headersData, ';');
 
+        // Write other rows of CSV - the content
         do {
             $data = call_user_func_array($this->data, [$this->start, $this->limit]);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds a BOM to every CSV exported from backoffice, for software to properly recognize that it's using UTF-8 encoding. (0xEF,0xBB,0xBF) More information - https://en.wikipedia.org/wiki/Byte_order_mark
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19807
| How to test?      | Get a Windows PC with Excel, open any backoffice listing (legacy and migrated) and try using the Export function. Before this change, the file is a mess.
| Possible impacts? | no

### Problem

When you use Prestashop export function, the data looks like this in latest Excel... It cannot properly recognize UTF-8 encoded CSVs. (unless you go through the data import process)
![export](https://user-images.githubusercontent.com/6097524/151335651-68f9f2e2-ccea-41b0-aacb-bc7906050e2c.png)

### Solution
Excel does not recognize the CSV format properly because it's missing BOM in the header of the CSV file. You can test this by opening the file in VS code > click UTF-8 in the bottom > save with encoding > UTF-8 with BOM. Then open it in Excel and see it works fine. Or test before and after this PR.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27495)
<!-- Reviewable:end -->
