### PR TITLE
Fix responsive CSS in add-to-cart modal

### DIFF
--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -446,6 +446,11 @@
     width: 100%;
     max-width: 9.375rem;
     margin: 0 0 0 auto;
+
+    @include media-breakpoint-down(md) {
+      max-width: 70%;
+      margin: 0 auto 1rem;
+    }
   }
 
   .modal-title {
@@ -477,7 +482,9 @@
   }
 
   .cart-content {
-    padding-left: $extra-large-space;
+    @include media-breakpoint-up(md) {
+      padding-left: $extra-large-space;
+    }
 
     .btn {
       margin-bottom: $small-space;
@@ -513,6 +520,7 @@
 
     .cart-content-btn {
       display: inline-flex;
+      justify-content: space-between;
 
       button {
         margin-right: 0.9rem;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Mobile display was messed up in add-to-cart modal. Responsive margins are now fixed.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26642
| How to test?      | <ol><li>Open product page on mobile or dev tools responsive mode</li><li>Add product to cart and wait for the modal to pop up</li></ol>
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27501)
<!-- Reviewable:end -->
