### PR TITLE
Add header for maintenance context

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -774,6 +774,7 @@ class FrontControllerCore extends Controller
             if (!IpUtils::checkIp(Tools::getRemoteAddr(), $allowed_ips)) {
                 header('HTTP/1.1 503 Service Unavailable');
                 header('Retry-After: 3600');
+                header('Shop-Status: maintenance');
 
                 $this->registerStylesheet('theme-error', '/assets/css/error.css', ['media' => 'all', 'priority' => 50]);
                 $this->context->smarty->assign([

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -774,6 +774,7 @@ class FrontControllerCore extends Controller
             if (!IpUtils::checkIp(Tools::getRemoteAddr(), $allowed_ips)) {
                 header('HTTP/1.1 503 Service Unavailable');
                 header('Retry-After: 3600');
+                header('Shop-Status: Maintenance');
 
                 $this->registerStylesheet('theme-error', '/assets/css/error.css', ['media' => 'all', 'priority' => 50]);
                 $this->context->smarty->assign([


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      |  The targer is to know when a shop is in maintenance. Currently, when a shop is in maintenance we have just 503. Like that, we can't know if the shop is maintenance or there are an issue. With this specific header (Shop-Status: Maintenance) we can know if the shop have an issue or not. It's very import for monitoring
| Type?             | improvement 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | No
| How to test?      | Turn the shop on maintenance and look for the header "Shop-status" is "Maintenance"
| Possible impacts? | We just add an new header only for maintenance page.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27518)
<!-- Reviewable:end -->
