### PR TITLE
Refactor layout of add-to-cart modal

### DIFF
--- a/themes/classic/_dev/css/components/products.scss
+++ b/themes/classic/_dev/css/components/products.scss
@@ -413,8 +413,24 @@
 #blockcart-modal {
   color: $gray-darker;
 
+  .modal-dialog {
+    width: calc(100% - 20px);
+    max-width: 850px;
+  }
+
   .modal-header {
     background: $white;
+
+    .modal-title {
+      font-size: 1rem;
+      font-weight: 400;
+      color: $gray-dark;
+
+      i.material-icons {
+        margin-right: $large-space;
+        color: $brand-success;
+      }
+    }
 
     .close {
       opacity: 1;
@@ -425,46 +441,69 @@
     }
   }
 
-  .modal-body {
-    padding: 3.125rem 1.875rem;
-    background: $btn-warning-color;
+  .flex-grid {
+    display: flex;
+    flex-flow: row wrap;
+    justify-content: space-between;
+    padding: 0;
 
-    .divide-right span {
-      display: inline-block;
-      margin-bottom: 0.3125rem;
+    @include media-breakpoint-down(sm) {
+      flex-flow: column nowrap;
+    }
+
+    & > * {
+      padding: 1rem;
 
       @include media-breakpoint-down(sm) {
-        display: block;
-        padding: 0 0.5rem;
+        flex-basis: 100%;
+        padding: 0.5rem 0;
       }
+    }
+
+    & > .flex-grid {
+      padding: 0;
     }
   }
 
-  .modal-dialog {
-    width: 100%;
-    max-width: 1140px;
+  .flex-row {
+    flex-basis: 100%;
+    flex-wrap: nowrap;
+  }
+
+  .modal-body {
+    padding: 1rem;
+    background: $btn-warning-color;
+  }
+
+  .divide-right {
+    @include media-breakpoint-up(md) {
+      border-right: 1px solid $gray-light-second;
+    }
   }
 
   .product-image {
     display: block;
-    width: 100%;
-    max-width: 9.375rem;
-    margin: 0 0 0 auto;
+    max-width: 9rem;
 
-    @include media-breakpoint-down(md) {
+    @include media-breakpoint-down(sm) {
       max-width: 70%;
-      margin: 0 auto 1rem;
+      margin: 0 auto;
     }
   }
 
-  .modal-title {
-    font-size: 1rem;
-    font-weight: 400;
-    color: #353943;
+  .product-details {
+    flex-grow: 2;
 
-    i.material-icons {
-      margin-right: $large-space;
-      color: $brand-success;
+    div {
+      margin-bottom: 0.375rem;
+
+      @include media-breakpoint-down(sm) {
+        padding: 0 0.5rem;
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   }
 
@@ -480,30 +519,18 @@
   .product-price {
     display: block;
     color: $gray-dark;
+
     @include media-breakpoint-down(sm) {
       padding: 0 0.5rem;
     }
   }
 
   .cart-content {
-    @include media-breakpoint-up(md) {
-      padding-left: $extra-large-space;
-    }
-
-    .btn {
-      margin-bottom: $small-space;
-    }
-
     p {
       display: flex;
       justify-content: space-between;
       padding: 0 0.5rem;
       color: $gray-dark;
-
-      &.product-total {
-        padding: 0.5rem;
-        background-color: $gray-light;
-      }
 
       &.cart-products-count {
         font-size: 1rem;
@@ -516,28 +543,40 @@
         font-size: 0.875rem;
       }
 
+      &.product-total {
+        padding: 0.5rem;
+        background-color: $gray-light;
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+
       .label,
       .value {
         font-weight: 600;
       }
     }
-
-    .cart-content-btn {
-      display: inline-flex;
-      justify-content: space-between;
-
-      button {
-        margin-right: 0.9rem;
-      }
-
-      .btn {
-        white-space: inherit;
-      }
-    }
   }
 
-  .divide-right {
-    border-right: 1px solid $gray-light-second;
+  @include media-breakpoint-down(sm) {
+    .cart-content-btn {
+      .btn {
+        width: 100%;
+      }
+    }
+
+    .cart-details {
+      order: 1;
+    }
+
+    .checkout-action {
+      order: 2;
+    }
+
+    .continue-action {
+      order: 3;
+    }
   }
 }
 
@@ -900,29 +939,7 @@
     width: 100%;
   }
 
-  #blockcart-modal {
-    .modal-dialog {
-      width: calc(100% - 20px);
-    }
-
-    .modal-body {
-      padding: 1.875rem;
-    }
-  }
-
   .product-images > li.thumb-container > .thumb:not(.selected) {
     border: none;
-  }
-}
-
-@include media-breakpoint-down(sm) {
-  #blockcart-modal {
-    .divide-right {
-      border-right: none;
-    }
-
-    .modal-body {
-      padding: 1rem;
-    }
   }
 }

--- a/themes/classic/modules/ps_shoppingcart/modal.tpl
+++ b/themes/classic/modules/ps_shoppingcart/modal.tpl
@@ -31,41 +31,36 @@
         </button>
         <h4 class="modal-title h6 text-sm-center" id="myModalLabel"><i class="material-icons rtl-no-flip">&#xE876;</i>{l s='Product successfully added to your shopping cart' d='Shop.Theme.Checkout'}</h4>
       </div>
-      <div class="modal-body">
-        <div class="row">
-          <div class="col-md-5 divide-right">
-            <div class="row">
-              <div class="col-md-6">
-                {if $product.default_image}
-                  <img
-                    src="{$product.default_image.medium.url}"
-                    data-full-size-image-url="{$product.default_image.large.url}"
-                    title="{$product.default_image.legend}"
-                    alt="{$product.default_image.legend}"
-                    loading="lazy"
-                    class="product-image"
-                  >
-                {else}
-                  <img
-                    src="{$urls.no_picture_image.bySize.medium_default.url}"
-                    loading="lazy"
-                    class="product-image"
-                  />
-                {/if}
-              </div>
-              <div class="col-md-6">
-                <h6 class="h6 product-name">{$product.name}</h6>
-                <p class="product-price">{$product.price}</p>
-                {hook h='displayProductPriceBlock' product=$product type="unit_price"}
-                {foreach from=$product.attributes item="property_value" key="property"}
-                <span class="{$property|lower}">{l s='%label%:' sprintf=['%label%' => $property] d='Shop.Theme.Global'}<strong> {$property_value}</strong></span><br>
-                {/foreach}
-                <span class="product-quantity">{l s='Quantity:' d='Shop.Theme.Checkout'}&nbsp;<strong>{$product.cart_quantity}</strong></span>
-              </div>
-            </div>
+      <div class="modal-body flex-grid">
+        <div class="flex-row flex-grid cart-details">
+          <div>
+              {if $product.default_image}
+                <img
+                  src="{$product.default_image.medium.url}"
+                  data-full-size-image-url="{$product.default_image.large.url}"
+                  title="{$product.default_image.legend}"
+                  alt="{$product.default_image.legend}"
+                  loading="lazy"
+                  class="product-image"
+                />
+              {else}
+                <img
+                  src="{$urls.no_picture_image.bySize.medium_default.url}"
+                  loading="lazy"
+                  class="product-image"
+                />
+              {/if}
           </div>
-          <div class="col-md-7">
-            <div class="cart-content">
+          <div class="product-details divide-right">
+            <h6 class="h6 product-name">{$product.name}</h6>
+            <p class="product-price">{$product.price}</p>
+              {hook h='displayProductPriceBlock' product=$product type="unit_price"}
+              {foreach from=$product.attributes item="property_value" key="property"}
+                <div class="{$property|lower}">{l s='%label%:' sprintf=['%label%' => $property] d='Shop.Theme.Global'}<strong> {$property_value}</strong></div>
+              {/foreach}
+            <div class="product-quantity">{l s='Quantity:' d='Shop.Theme.Checkout'}&nbsp;<strong>{$product.cart_quantity}</strong></div>
+          </div>
+          <div class="cart-content">
               {if $cart.products_count > 1}
                 <p class="cart-products-count">{l s='There are %products_count% items in your cart.' sprintf=['%products_count%' => $cart.products_count] d='Shop.Theme.Checkout'}</p>
               {else}
@@ -75,27 +70,25 @@
               {if $cart.subtotals.shipping.value}
                 <p><span>{l s='Shipping:' d='Shop.Theme.Checkout'}</span>&nbsp;<span class="shipping value">{$cart.subtotals.shipping.value} {hook h='displayCheckoutSubtotalDetails' subtotal=$cart.subtotals.shipping}</span></p>
               {/if}
-
               {if !$configuration.display_prices_tax_incl && $configuration.taxes_enabled}
                 <p><span>{$cart.totals.total.label}{if $configuration.display_taxes_label}&nbsp;{$cart.labels.tax_short}{/if}</span>&nbsp;<span>{$cart.totals.total.value}</span></p>
                 <p class="product-total"><span class="label">{$cart.totals.total_including_tax.label}</span>&nbsp;<span class="value">{$cart.totals.total_including_tax.value}</span></p>
               {else}
                 <p class="product-total"><span class="label">{$cart.totals.total.label}&nbsp;{if $configuration.taxes_enabled && $configuration.display_taxes_label}{$cart.labels.tax_short}{/if}</span>&nbsp;<span class="value">{$cart.totals.total.value}</span></p>
               {/if}
-
               {if $cart.subtotals.tax}
                 <p class="product-tax">{l s='%label%:' sprintf=['%label%' => $cart.subtotals.tax.label] d='Shop.Theme.Global'}&nbsp;<span class="value">{$cart.subtotals.tax.value}</span></p>
               {/if}
               {hook h='displayCartModalContent' product=$product}
-              <div class="cart-content-btn">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal">{l s='Continue shopping' d='Shop.Theme.Actions'}</button>
-                <a href="{$cart_url}" class="btn btn-primary"><i class="material-icons rtl-no-flip">&#xE876;</i>{l s='Proceed to checkout' d='Shop.Theme.Actions'}</a>
-              </div>
-            </div>
           </div>
         </div>
-      </div>
-      {hook h='displayCartModalFooter' product=$product}
+        <div class="cart-content-btn continue-action">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">{l s='Continue shopping' d='Shop.Theme.Actions'}</button>
+        </div>
+        <div class="cart-content-btn checkout-action">
+          <a href="{$cart_url}" class="btn btn-primary">{l s='Proceed to checkout' d='Shop.Theme.Actions'}</a>
+        </div>
+        {hook h='displayCartModalFooter' product=$product}
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | New responsive layout of add-to-cart modal with flex design. Checkout button is moved on top in mobile display.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26642.
| How to test?      | <ol><li>Open product page on mobile or dev tools responsive mode</li><li>Add product to cart and wait for the modal to pop up</li></ol>
| Possible impacts? | Cart modal and navigation to order page.

# BC Break
The layout and style of the quickview model has changed, peoples using some selectors or overriding the style may have some issues

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27548)
<!-- Reviewable:end -->
