### PR TITLE
Fix update attachment webservice

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementAttachments.php
+++ b/classes/webservice/WebserviceSpecificManagementAttachments.php
@@ -327,7 +327,7 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
         try {
             $file = $uploader->upload($fileToUpload);
             if (!empty($attachment->id)) {
-                unlink(PS_DOWNLOAD_DIR . $attachment->file);
+                unlink(_PS_DOWNLOAD_DIR_ . $attachment->file);
             }
 
             $attachment->file = $file['id'];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Updating an attachment via the webservice does not delete the old file
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27690.
| How to test?      | Go to BO, Add an attachment, The file appears in the `/download` directory, Update this attachment via webservice, The file is still in the `/download` directory
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27555)
<!-- Reviewable:end -->
