### PR TITLE
Fix exception when associated file name in virtual product is empty

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
@@ -48,6 +48,7 @@ export default class VirtualProductManager {
   private init(): void {
     this.productFormModel.watch('stock.hasVirtualProductFile', () => this.toggleContentVisibility());
     this.toggleContentVisibility();
+    this.fillVirtualProductNameField();
   }
 
   private toggleContentVisibility(): void {
@@ -75,5 +76,20 @@ export default class VirtualProductManager {
    */
   private showContent(): void {
     this.$fileContentContainer.removeClass('d-none');
+  }
+
+  fillVirtualProductNameField() {
+    $(ProductMap.virtualProduct.fileUploadField).on('change', () => {
+      const fullPath = $(ProductMap.virtualProduct.fileUploadField).val();
+
+      // get file name from full path
+      const startIndex = (fullPath.indexOf('\\') >= 0 ? fullPath.lastIndexOf('\\') : fullPath.lastIndexOf('/'));
+      let filename = fullPath.substring(startIndex);
+
+      if (filename.indexOf('\\') === 0 || filename.indexOf('/') === 0) {
+        filename = filename.substring(1);
+      }
+      $(ProductMap.virtualProduct.fileNameField).val(filename);
+    });
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
@@ -88,13 +88,11 @@ export default class VirtualProductManager {
       let fullPath = $(ProductMap.virtualProduct.fileUploadField).val();
 
       if (Array.isArray(fullPath) || typeof fullPath === 'undefined') {
-        throw new Error('Full path of the file is not supposed to be an array');
+        console.error('Full path of the file is not supposed to be an array');
       } else {
         // Convert to string in any other case
         fullPath = fullPath.toString();
       }
-
-      alert(fullPath);
 
       // get file name from full path
       const startIndex = (fullPath.indexOf('\\') >= 0 ? fullPath.lastIndexOf('\\') : fullPath.lastIndexOf('/'));

--- a/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
@@ -78,9 +78,11 @@ export default class VirtualProductManager {
     this.$fileContentContainer.removeClass('d-none');
   }
 
-  fillVirtualProductNameField() {
+  private fillVirtualProductNameField(): void {
     $(ProductMap.virtualProduct.fileUploadField).on('change', () => {
-      const fullPath = $(ProductMap.virtualProduct.fileUploadField).val();
+      const fullPath = $(ProductMap.virtualProduct.fileUploadField).val()!;
+
+      if (typeof fullPath === 'undefined') return;
 
       // get file name from full path
       const startIndex = (fullPath.indexOf('\\') >= 0 ? fullPath.lastIndexOf('\\') : fullPath.lastIndexOf('/'));

--- a/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
@@ -80,15 +80,21 @@ export default class VirtualProductManager {
 
   private fillVirtualProductNameField(): void {
     $(ProductMap.virtualProduct.fileUploadField).on('change', () => {
-      let fullPath = $(ProductMap.virtualProduct.fileUploadField).val()!;
+      // do not fill the name field if it's not empty
+      if ($(ProductMap.virtualProduct.fileNameField).val() !== '') {
+        return;
+      }
 
-      if (Array.isArray(fullPath)) {
-        // Handle the error with the most appropriate way, here an error is just thrown
+      let fullPath = $(ProductMap.virtualProduct.fileUploadField).val();
+
+      if (Array.isArray(fullPath) || typeof fullPath === 'undefined') {
         throw new Error('Full path of the file is not supposed to be an array');
       } else {
         // Convert to string in any other case
         fullPath = fullPath.toString();
       }
+
+      alert(fullPath);
 
       // get file name from full path
       const startIndex = (fullPath.indexOf('\\') >= 0 ? fullPath.lastIndexOf('\\') : fullPath.lastIndexOf('/'));

--- a/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
@@ -83,11 +83,11 @@ export default class VirtualProductManager {
       const fullPath = $(ProductMap.virtualProduct.fileUploadField).val()!;
 
       if (Array.isArray(fullPath)) {
-          // Handle the error with the most appropriate way, here an error is just thrown
-          throw new Error('Full path of the file is not supposed to be an array');
+        // Handle the error with the most appropriate way, here an error is just thrown
+        throw new Error('Full path of the file is not supposed to be an array');
       } else {
-          // Convert to string in any other case
-          fullPath = fullPath.toString();
+        // Convert to string in any other case
+        fullPath = fullPath.toString();
       }
 
       // get file name from full path

--- a/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
@@ -80,7 +80,7 @@ export default class VirtualProductManager {
 
   private fillVirtualProductNameField(): void {
     $(ProductMap.virtualProduct.fileUploadField).on('change', () => {
-      const fullPath = $(ProductMap.virtualProduct.fileUploadField).val()!;
+      let fullPath = $(ProductMap.virtualProduct.fileUploadField).val()!;
 
       if (Array.isArray(fullPath)) {
         // Handle the error with the most appropriate way, here an error is just thrown

--- a/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/virtual-product-manager.ts
@@ -82,7 +82,13 @@ export default class VirtualProductManager {
     $(ProductMap.virtualProduct.fileUploadField).on('change', () => {
       const fullPath = $(ProductMap.virtualProduct.fileUploadField).val()!;
 
-      if (typeof fullPath === 'undefined') return;
+      if (Array.isArray(fullPath)) {
+          // Handle the error with the most appropriate way, here an error is just thrown
+          throw new Error('Full path of the file is not supposed to be an array');
+      } else {
+          // Convert to string in any other case
+          fullPath = fullPath.toString();
+      }
 
       // get file name from full path
       const startIndex = (fullPath.indexOf('\\') >= 0 ? fullPath.lastIndexOf('\\') : fullPath.lastIndexOf('/'));

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -173,6 +173,8 @@ export default {
   virtualProduct: {
     container: '.virtual-product-file-container',
     fileContentContainer: '.virtual-product-file-content',
+    fileUploadField: '#product_stock_virtual_product_file_file',
+    fileNameField: '#product_stock_virtual_product_file_name',
   },
   dropzone: {
     configuration: {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
@@ -90,7 +90,6 @@ class VirtualProductFileType extends TranslatorAwareType implements EventSubscri
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::PRE_SET_DATA => 'adaptSelf',
             FormEvents::PRE_SUBMIT => 'adaptSelf',
         ];
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/VirtualProductFileType.php
@@ -38,6 +38,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -48,7 +49,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 
 class VirtualProductFileType extends TranslatorAwareType
 {
-    const ASSOCIATED_FILE_VALIDATION_GROUP = 'associated_file';
+    private const ASSOCIATED_FILE_VALIDATION_GROUP = 'associated_file';
 
     /**
      * @var int
@@ -198,7 +199,7 @@ class VirtualProductFileType extends TranslatorAwareType
                 'class' => 'virtual-product-file-content',
             ],
             'columns_number' => 3,
-            'validation_groups' => function ($form) {
+            'validation_groups' => function (FormInterface $form): array {
                 $groups = ['Default'];
                 $data = $form->getData();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      |  The form constraint on the `name` field was canceled in formType . I also added auto-fill for the virtual product's name, like it was done on legacy product page.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25315
| How to test?      | See steps in issue
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27572)
<!-- Reviewable:end -->
