### PR TITLE
Multishop product basic

### DIFF
--- a/admin-dev/themes/new-theme/js/components/components-map.ts
+++ b/admin-dev/themes/new-theme/js/components/components-map.ts
@@ -92,4 +92,8 @@ export default {
   inputNotCheckbox: ':input:not(.multistore-checkbox)',
   inputContainer: '.input-container',
   formControlLabel: '.form-control-label',
+  tineMceEditor: {
+    selector: '.autoload_rte',
+    selectorClass: 'autoload_rte',
+  },
 };

--- a/admin-dev/themes/new-theme/js/components/tinymce-editor.js
+++ b/admin-dev/themes/new-theme/js/components/tinymce-editor.js
@@ -22,6 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+import ComponentsMap from '@components/components-map';
 import {EventEmitter} from './event-emitter';
 
 const {$} = window;
@@ -109,7 +110,7 @@ class TinyMCEEditor {
       valid_children: '+*[*]',
       valid_elements: '*[*]',
       rel_list: [{title: 'nofollow', value: 'nofollow'}],
-      editor_selector: 'autoload_rte',
+      editor_selector: ComponentsMap.tineMceEditor.selectorClass,
       init_instance_callback: () => {
         this.changeToMaterial();
       },

--- a/src/Adapter/Product/Repository/ProductMultiShopRepository.php
+++ b/src/Adapter/Product/Repository/ProductMultiShopRepository.php
@@ -46,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ProductTaxRulesGroupSettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\InvalidShopConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupException;
@@ -169,6 +170,10 @@ class ProductMultiShopRepository extends AbstractMultiShopObjectModelRepository
      */
     public function getByShopConstraint(ProductId $productId, ShopConstraint $shopConstraint): Product
     {
+        if ($shopConstraint->getShopGroupId()) {
+            throw new InvalidShopConstraintException('Product has no features related with shop group use single shop and all shops constraints');
+        }
+
         if ($shopConstraint->forAllShops()) {
             return $this->getProductByDefaultShop($productId);
         }
@@ -210,6 +215,10 @@ class ProductMultiShopRepository extends AbstractMultiShopObjectModelRepository
      */
     public function partialUpdate(Product $product, array $propertiesToUpdate, ShopConstraint $shopConstraint, int $errorCode): void
     {
+        if ($shopConstraint->getShopGroupId()) {
+            throw new InvalidShopConstraintException('Product has no features related with shop group use single shop and all shops constraints');
+        }
+
         $this->validateProduct($product, $propertiesToUpdate);
         $shopIds = $this->getShopIdsByConstraint($product, $shopConstraint);
 
@@ -229,6 +238,10 @@ class ProductMultiShopRepository extends AbstractMultiShopObjectModelRepository
      */
     public function update(Product $product, ShopConstraint $shopConstraint, int $errorCode): void
     {
+        if ($shopConstraint->getShopGroupId()) {
+            throw new InvalidShopConstraintException('Product has no features related with shop group use single shop and all shops constraints');
+        }
+
         $this->validateProduct($product);
         $shopIds = $this->getShopIdsByConstraint($product, $shopConstraint);
 
@@ -311,6 +324,10 @@ class ProductMultiShopRepository extends AbstractMultiShopObjectModelRepository
      */
     private function getShopIdsByConstraint(Product $product, ShopConstraint $shopConstraint): array
     {
+        if ($shopConstraint->getShopGroupId()) {
+            throw new InvalidShopConstraintException('Product has no features related with shop group use single shop and all shops constraints');
+        }
+
         $shopIds = [];
         if ($shopConstraint->forAllShops()) {
             $shops = $this->getAssociatedShopIds(new ProductId((int) $product->id));

--- a/src/Core/Domain/Product/Command/UpdateProductBasicInformationCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductBasicInformationCommand.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Command to update some basic properties of product
@@ -56,11 +57,20 @@ class UpdateProductBasicInformationCommand
     private $localizedShortDescriptions;
 
     /**
-     * @param int $productId
+     * @var ShopConstraint
      */
-    public function __construct(int $productId)
-    {
+    private $shopConstraint;
+
+    /**
+     * @param int $productId
+     * @param ShopConstraint $shopConstraint
+     */
+    public function __construct(
+        int $productId,
+        ShopConstraint $shopConstraint
+    ) {
         $this->productId = new ProductId($productId);
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -129,5 +139,13 @@ class UpdateProductBasicInformationCommand
         $this->localizedShortDescriptions = $localizedShortDescriptions;
 
         return $this;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 }

--- a/src/Core/Domain/Shop/Exception/InvalidShopConstraintException.php
+++ b/src/Core/Domain/Shop/Exception/InvalidShopConstraintException.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Shop\Exception;
 
 /**
- * Exception thrown when a shop constraint is built or used with in valid values.
+ * Exception thrown when a shop constraint is built or used with invalid values.
  */
 class InvalidShopConstraintException extends ShopException
 {

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/BasicInformationCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/BasicInformationCommandsBuilder.php
@@ -30,34 +30,49 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Prod
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilder;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilderConfig;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandField;
 
 /**
  * Builder used to build UpdateProductBasicInformationCommand
  */
-class BasicInformationCommandsBuilder implements ProductCommandsBuilderInterface
+class BasicInformationCommandsBuilder implements MultiShopProductCommandsBuilderInterface
 {
+    /**
+     * @var string
+     */
+    private $modifyAllNamePrefix;
+
+    /**
+     * @param string $modifyAllNamePrefix
+     */
+    public function __construct(string $modifyAllNamePrefix)
+    {
+        $this->modifyAllNamePrefix = $modifyAllNamePrefix;
+    }
+
     /**
      * {@inheritdoc}
      */
-    public function buildCommands(ProductId $productId, array $formData): array
+    public function buildCommands(ProductId $productId, array $formData, ShopConstraint $singleShopConstraint): array
     {
         if (empty($formData['description']) && empty($formData['header']['name'])) {
             return [];
         }
 
-        $descriptionData = $formData['description'] ?? [];
-        $command = new UpdateProductBasicInformationCommand($productId->getValue());
+        $config = new CommandBuilderConfig($this->modifyAllNamePrefix);
+        $config
+            ->addMultiShopField('[header][name]', 'setLocalizedNames', CommandField::TYPE_ARRAY)
+            ->addMultiShopField('[description][description]', 'setLocalizedDescriptions', CommandField::TYPE_ARRAY)
+            ->addMultiShopField('[description][description_short]', 'setLocalizedShortDescriptions', CommandField::TYPE_ARRAY)
+        ;
 
-        if (isset($formData['header']['name'])) {
-            $command->setLocalizedNames($formData['header']['name']);
-        }
-        if (isset($descriptionData['description'])) {
-            $command->setLocalizedDescriptions($descriptionData['description']);
-        }
-        if (isset($descriptionData['description_short'])) {
-            $command->setLocalizedShortDescriptions($descriptionData['description_short']);
-        }
+        $commandBuilder = new CommandBuilder($config);
+        $shopCommand = new UpdateProductBasicInformationCommand($productId->getValue(), $singleShopConstraint);
+        $allShopsCommand = new UpdateProductBasicInformationCommand($productId->getValue(), ShopConstraint::allShops());
 
-        return [$command];
+        return $commandBuilder->buildCommands($formData, $shopCommand, $allShopsCommand);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
@@ -111,6 +111,7 @@ class DescriptionType extends TranslatorAwareType
                     ],
                 ],
                 'label_tag_name' => 'h2',
+                'modify_all_shops' => true,
             ])
             ->add('description', TranslatableType::class, [
                 'required' => false,
@@ -132,6 +133,7 @@ class DescriptionType extends TranslatorAwareType
                     ],
                 ],
                 'label_tag_name' => 'h2',
+                'modify_all_shops' => true,
             ])
             ->add('categories', CategoriesType::class, [
                 'label' => $this->trans('Categories', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -62,6 +62,7 @@ class HeaderType extends TranslatorAwareType
                 'row_attr' => [
                     'class' => 'header-name',
                 ],
+                'modify_all_shops' => true,
             ])
             ->add('type', ChoiceType::class, [
                 'choices' => [

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -124,7 +124,7 @@ services:
   prestashop.adapter.product.command_handler.update_product_basic_information_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductBasicInformationHandler
     arguments:
-      - '@prestashop.adapter.product.repository.product_repository'
+      - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@=service("prestashop.adapter.legacy.configuration").get("PS_LANG_DEFAULT")'
     tags:
       - name: tactician.handler

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -30,6 +30,8 @@ services:
 
   prestashop.core.form.command_builder.product.basic_information:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\BasicInformationCommandsBuilder
+    arguments:
+      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
     tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.product.prices:

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -402,7 +402,7 @@
 
 {% block translatefields_widget %}
   {{ form_errors(form) }}
-  <div class="translations tabbable" id="{{ form.vars.id }}">
+  <div class="translations tabbable" id="{{ form.vars.id }}" tabindex="1">
     {% if hideTabs == false and form|length > 1 %}
       <ul class="translationsLocales nav nav-pills">
         {% for translationsFields in form %}
@@ -879,7 +879,7 @@
 
 {# Copied translatablefields_widget made to be compatible with TranslatableType.php and to be used in translatable widget#}
 {% block translatable_fields_with_tabs %}
-  <div class="translations tabbable" id="{{ form.vars.id }}">
+  <div class="translations tabbable" id="{{ form.vars.id }}" tabindex="1">
     {% if hide_locales == false and form|length > 1 %}
       <ul class="translationsLocales nav nav-pills">
         {% for translationsFields in form %}
@@ -904,7 +904,7 @@
 
 {% block translatable_fields_with_dropdown -%}
     {% set formClass = (form.vars.attr.class|default('') ~ ' input-group locale-input-group js-locale-input-group d-flex')|trim %}
-    <div class="{{ formClass }}">
+    <div class="{{ formClass }}" id="{{ form.vars.id }}" tabindex="1">
       {% for translateField in form %}
         {% set classes = translateField.vars.attr.class|default('') ~ ' js-locale-input'%}
         {% set classes = classes ~ ' js-locale-' ~ translateField.vars.label %}
@@ -925,11 +925,11 @@
             {% endif %}
                   aria-haspopup="true"
                   aria-expanded="false"
-                  id="{{ form.vars.id }}"
+                  id="{{ form.vars.id }}_dropdown"
           >
             {{ form.vars.default_locale.iso_code }}
           </button>
-          <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+          <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}_dropdown">
             {% for locale in locales %}
               <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
             {% endfor %}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateBasicInformationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateBasicInformationFeatureContext.php
@@ -31,20 +31,55 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 use Behat\Gherkin\Node\TableNode;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 class UpdateBasicInformationFeatureContext extends AbstractProductFeatureContext
 {
+    /**
+     * @When I update product :productReference basic information for shop :shopReference with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductBasicInfoForShop(string $productReference, string $shopReference, TableNode $table): void
+    {
+        $shopId = $this->getSharedStorage()->get(trim($shopReference));
+        $shopConstraint = ShopConstraint::shop($shopId);
+        $this->updateProductBasicInfo($productReference, $table, $shopConstraint);
+    }
+
+    /**
+     * @When I update product :productReference basic information for all shops with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductBasicInfoForAllShops(string $productReference, TableNode $table): void
+    {
+        $this->updateProductBasicInfo($productReference, $table, ShopConstraint::allShops());
+    }
+
     /**
      * @When I update product :productReference basic information with following values:
      *
      * @param string $productReference
      * @param TableNode $table
      */
-    public function updateProductBasicInfo(string $productReference, TableNode $table): void
+    public function updateProductBasicInfoWithDefaultShop(string $productReference, TableNode $table): void
+    {
+        $this->updateProductBasicInfo($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
+    }
+
+    /**
+     * @param string $productReference
+     * @param TableNode $table
+     * @param ShopConstraint $shopConstraint
+     */
+    private function updateProductBasicInfo(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
     {
         $data = $this->localizeByRows($table);
         $productId = $this->getSharedStorage()->get($productReference);
-        $command = new UpdateProductBasicInformationCommand($productId);
+        $command = new UpdateProductBasicInformationCommand($productId, $shopConstraint);
 
         if (isset($data['name'])) {
             $command->setLocalizedNames($data['name']);

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
@@ -17,40 +17,32 @@ Feature: Copy product from shop to shop.
     And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
     And single shop context is loaded
 
-  Scenario: I copy product to another shop that was not associated
-    # By default the product is created for default shop
-    Given I add product "product1" with following information:
+  Scenario: Add products in specific shop
+    Given I add product "product1" to shop "shop2" with following information:
       | name[en-US] | magic staff |
       | type        | standard    |
-    Then product product1 is associated to shop shop1
-    And default shop for product product1 is shop1
-    When I update product "product1" prices with following information:
-      | price              | 100.99          |
-      | ecotax             | 0               |
-      | tax rules group    | US-AL Rate (4%) |
-      | on_sale            | true            |
-      | wholesale_price    | 70              |
-      | unit_price         | 10              |
-      | unity              | bag of ten      |
-    Then product product1 should have following prices information for shops "shop1":
-      | price              | 100.99          |
-      | price_tax_included | 105.0296        |
-      | ecotax             | 0               |
-      | tax rules group    | US-AL Rate (4%) |
-      | on_sale            | true            |
-      | wholesale_price    | 70              |
-      | unit_price         | 10              |
-      | unity              | bag of ten      |
-      | unit_price_ratio   | 10.099          |
-    And product product1 is not associated to shop shop2
-    And product product1 is not associated to shop shop3
-    And product product1 is not associated to shop shop4
-    # Copy values to another shop which was not associated yet
-    When I copy product product1 from shop shop1 to shop shop2
     Then product product1 is associated to shop shop2
-    And product product1 is associated to shop shop1
-    And default shop for product product1 is shop1
-    And product product1 should have following prices information for shops "shop1,shop2":
+    And default shop for product product1 is shop2
+    And product product1 is not associated to shop shop1
+    And product product1 is not associated to shop shop3
+    And product product1 is not associated to shop shop4
+
+  Scenario: I copy product to another shop that was not associated, prices are copied
+    # By default the product is created for default shop
+    Given I add product "product2" with following information:
+      | name[en-US] | magic staff |
+      | type        | standard    |
+    Then product product2 is associated to shop shop1
+    And default shop for product product2 is shop1
+    When I update product "product2" prices with following information:
+      | price              | 100.99          |
+      | ecotax             | 0               |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | true            |
+      | wholesale_price    | 70              |
+      | unit_price         | 10              |
+      | unity              | bag of ten      |
+    Then product product2 should have following prices information for shops "shop1":
       | price              | 100.99          |
       | price_tax_included | 105.0296        |
       | ecotax             | 0               |
@@ -60,10 +52,28 @@ Feature: Copy product from shop to shop.
       | unit_price         | 10              |
       | unity              | bag of ten      |
       | unit_price_ratio   | 10.099          |
-    And product product1 is not associated to shop shop3
-    And product product1 is not associated to shop shop4
+    And product product2 is not associated to shop shop2
+    And product product2 is not associated to shop shop3
+    And product product2 is not associated to shop shop4
+    # Copy values to another shop which was not associated yet
+    When I copy product product2 from shop shop1 to shop shop2
+    Then product product2 is associated to shop shop2
+    And product product2 is associated to shop shop1
+    And default shop for product product2 is shop1
+    And product product2 should have following prices information for shops "shop1,shop2":
+      | price              | 100.99          |
+      | price_tax_included | 105.0296        |
+      | ecotax             | 0               |
+      | tax rules group    | US-AL Rate (4%) |
+      | on_sale            | true            |
+      | wholesale_price    | 70              |
+      | unit_price         | 10              |
+      | unity              | bag of ten      |
+      | unit_price_ratio   | 10.099          |
+    And product product2 is not associated to shop shop3
+    And product product2 is not associated to shop shop4
     # Now modify and copy the values but this time the shop is already associated so it is an update
-    When I update product "product1" prices with following information:
+    When I update product "product2" prices with following information:
       | price              | 200.99            |
       | ecotax             | 2                 |
       | tax rules group    | US-AZ Rate (6.6%) |
@@ -71,7 +81,7 @@ Feature: Copy product from shop to shop.
       | wholesale_price    | 60                |
       | unit_price         | 20                |
       | unity              | bag of twenty     |
-    Then product product1 should have following prices information for shops "shop1":
+    Then product product2 should have following prices information for shops "shop1":
       | price              | 200.99            |
       | price_tax_included | 214.25534         |
       | ecotax             | 2                 |
@@ -81,7 +91,7 @@ Feature: Copy product from shop to shop.
       | unit_price         | 20                |
       | unity              | bag of twenty     |
       | unit_price_ratio   | 10.0495           |
-    Given product product1 should have following prices information for shops "shop2":
+    But product product2 should have following prices information for shops "shop2":
       | price              | 100.99          |
       | price_tax_included | 105.0296        |
       | ecotax             | 0               |
@@ -92,9 +102,9 @@ Feature: Copy product from shop to shop.
       | unity              | bag of ten      |
       | unit_price_ratio   | 10.099          |
     # Copy values to a shop which is already associated
-    When I copy product product1 from shop shop1 to shop shop2
-    Then product product1 is associated to shop shop2
-    And product product1 should have following prices information for shops "shop1,shop2":
+    When I copy product product2 from shop shop1 to shop shop2
+    Then product product2 is associated to shop shop2
+    And product product2 should have following prices information for shops "shop1,shop2":
       | price              | 200.99            |
       | price_tax_included | 214.25534         |
       | ecotax             | 2                 |
@@ -104,15 +114,82 @@ Feature: Copy product from shop to shop.
       | unit_price         | 20                |
       | unity              | bag of twenty     |
       | unit_price_ratio   | 10.0495           |
-    And product product1 is not associated to shop shop3
-    And product product1 is not associated to shop shop4
-
-  Scenario: Add products in specific shop
-    Given I add product "product2" to shop "shop2" with following information:
-      | name[en-US] | magic staff |
-      | type        | standard    |
-    Then product product2 is associated to shop shop2
-    And default shop for product product2 is shop2
-    And product product2 is not associated to shop shop1
     And product product2 is not associated to shop shop3
     And product product2 is not associated to shop shop4
+
+  Scenario: I copy product to another shop that was not associated, basic information are copied
+    # By default the product is created for default shop
+    Given I add product "product3" with following information:
+      | name[en-US] | funny mug |
+      | type        | standard  |
+    Then product product3 is associated to shop shop1
+    And default shop for product product3 is shop1
+    When I update product "product3" basic information with following values:
+      | name[en-US]              | photo of funny mug |
+      | description[en-US]       | nice mug           |
+      | description_short[en-US] | Just a nice mug    |
+    Then product "product3" localized "name" should be:
+      | locale     | value              |
+      | en-US      | photo of funny mug |
+    And product "product3" localized "description" should be:
+      | locale | value    |
+      | en-US  | nice mug |
+    And product "product3" localized "description_short" should be:
+      | locale | value           |
+      | en-US  | Just a nice mug |
+    And product product3 is not associated to shop shop2
+    And product product3 is not associated to shop shop3
+    And product product3 is not associated to shop shop4
+    # Copy values to another shop which was not associated yet
+    When I copy product product3 from shop shop1 to shop shop2
+    Then product product3 is associated to shop shop2
+    And product product3 is associated to shop shop1
+    And default shop for product product3 is shop1
+    Then product "product3" localized "name" for shops "shop1,shop2" should be:
+      | locale     | value              |
+      | en-US      | photo of funny mug |
+    And product "product3" localized "description" for shops "shop1,shop2" should be:
+      | locale | value    |
+      | en-US  | nice mug |
+    And product "product3" localized "description_short" for shops "shop1,shop2" should be:
+      | locale | value           |
+      | en-US  | Just a nice mug |
+    And product product3 is not associated to shop shop3
+    And product product3 is not associated to shop shop4
+    # Now modify and copy the values but this time the shop is already associated so it is an update
+    When I update product "product3" basic information with following values:
+      | name[en-US]              | photo of super mug |
+      | description[en-US]       | super mug          |
+      | description_short[en-US] | Just a super mug   |
+    Then product "product3" localized "name" for shops "shop1" should be:
+      | locale     | value              |
+      | en-US      | photo of super mug |
+    And product "product3" localized "description" for shops "shop1" should be:
+      | locale | value     |
+      | en-US  | super mug |
+    And product "product3" localized "description_short" for shops "shop1" should be:
+      | locale | value            |
+      | en-US  | Just a super mug |
+    But product "product3" localized "name" for shops "shop2" should be:
+      | locale     | value              |
+      | en-US      | photo of funny mug |
+    And product "product3" localized "description" for shops "shop2" should be:
+      | locale | value    |
+      | en-US  | nice mug |
+    And product "product3" localized "description_short" for shops "shop2" should be:
+      | locale | value           |
+      | en-US  | Just a nice mug |
+    # Copy values to a shop which is already associated
+    When I copy product product3 from shop shop1 to shop shop2
+    Then product product3 is associated to shop shop2
+    And product "product3" localized "name" for shops "shop1,shop2" should be:
+      | locale     | value              |
+      | en-US      | photo of super mug |
+    And product "product3" localized "description" for shops "shop1,shop2" should be:
+      | locale | value     |
+      | en-US  | super mug |
+    And product "product3" localized "description_short" for shops "shop1,shop2" should be:
+      | locale | value            |
+      | en-US  | Just a super mug |
+    And product product3 is not associated to shop shop3
+    And product product3 is not associated to shop shop4

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_basic_information.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_basic_information.feature
@@ -1,0 +1,126 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-basic-information
+@restore-products-before-feature
+@clear-cache-before-feature
+@restore-shops-after-feature
+@clear-cache-after-feature
+@product-multi-shop
+@update-multi-shop-basic-information
+Feature: Update product basic information from Back Office (BO)
+  As a BO user
+  I need to be able to update product basic information from BO
+
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And I add a shop group "shopGroup2" with name "test_second_shop_group" and color "green"
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And single shop context is loaded
+    Given I add product "product1" with following information:
+      | name[en-US] | magic staff |
+      | type        | standard    |
+    When I update product "product1" basic information with following values:
+      | name[en-US]              | magic staff              |
+      | description[en-US]       | such a super magic staff |
+      | description_short[en-US] | super magic staff        |
+    And I copy product product1 from shop shop1 to shop shop2
+    Then product "product1" localized "name" for shops "shop1,shop2" should be:
+      | locale | value       |
+      | en-US  | magic staff |
+    And product "product1" localized "description" for shops "shop1,shop2" should be:
+      | locale | value                    |
+      | en-US  | such a super magic staff |
+    And product "product1" localized "description_short" for shops "shop1,shop2" should be:
+      | locale | value             |
+      | en-US  | super magic staff |
+    And product product1 is not associated to shop shop3
+    And product product1 is not associated to shop shop4
+
+  Scenario: I update product basic information for specific shop
+    When I update product "product1" basic information for shop "shop2" with following values:
+      | name[en-US]              | cool magic staff        |
+      | description[en-US]       | such a cool magic staff |
+      | description_short[en-US] | cool magic staff        |
+    Then product "product1" localized "name" for shops "shop1" should be:
+      | locale | value       |
+      | en-US  | magic staff |
+    And product "product1" localized "description" for shops "shop1" should be:
+      | locale | value                    |
+      | en-US  | such a super magic staff |
+    And product "product1" localized "description_short" for shops "shop1" should be:
+      | locale | value             |
+      | en-US  | super magic staff |
+    But product "product1" localized "name" for shops "shop2" should be:
+      | locale | value            |
+      | en-US  | cool magic staff |
+    And product "product1" localized "description" for shops "shop2" should be:
+      | locale | value                   |
+      | en-US  | such a cool magic staff |
+    And product "product1" localized "description_short" for shops "shop2" should be:
+      | locale | value            |
+      | en-US  | cool magic staff |
+    And product product1 is not associated to shop shop3
+    And product product1 is not associated to shop shop4
+
+  Scenario: I update product basic information for all associated shop
+    When I update product "product1" basic information for all shops with following values:
+      | name[en-US]              | cool magic staff        |
+      | description[en-US]       | such a cool magic staff |
+      | description_short[en-US] | cool magic staff        |
+    Then product "product1" localized "name" for shops "shop1,shop2" should be:
+      | locale | value            |
+      | en-US  | cool magic staff |
+    And product "product1" localized "description" for shops "shop1,shop2" should be:
+      | locale | value                   |
+      | en-US  | such a cool magic staff |
+    And product "product1" localized "description_short" for shops "shop1,shop2" should be:
+      | locale | value            |
+      | en-US  | cool magic staff |
+    And product product1 is not associated to shop shop3
+    And product product1 is not associated to shop shop4
+
+  Scenario: I update some fields for single shop and right after for all shops
+    When I update product "product1" basic information for shop "shop2" with following values:
+      | name[en-US]              | cool magic staff        |
+      | description[en-US]       | such a cool magic staff |
+    And I update product "product1" basic information for all shops with following values:
+      | description_short[en-US] | weird magic staff       |
+    Then product "product1" localized "name" for shops "shop2" should be:
+      | locale | value            |
+      | en-US  | cool magic staff |
+    And product "product1" localized "description" for shops "shop2" should be:
+      | locale | value                   |
+      | en-US  | such a cool magic staff |
+    And product "product1" localized "name" for shops "shop1" should be:
+      | locale | value       |
+      | en-US  | magic staff |
+    And product "product1" localized "description" for shops "shop1" should be:
+      | locale | value                    |
+      | en-US  | such a super magic staff |
+    And product "product1" localized "description_short" for shops "shop1,shop2" should be:
+      | locale | value             |
+      | en-US  | weird magic staff |
+    And product product1 is not associated to shop shop3
+    And product product1 is not associated to shop shop4
+
+  Scenario: I update some fields for all shops and right after for single shops
+    When I update product "product1" basic information for all shops with following values:
+      | name[en-US]              | cool magic staff        |
+      | description[en-US]       | such a cool magic staff |
+    And I update product "product1" basic information for shop "shop2" with following values:
+      | description_short[en-US] | weird magic staff       |
+    Then product "product1" localized "name" for shops "shop1,shop2" should be:
+      | locale | value            |
+      | en-US  | cool magic staff |
+    And product "product1" localized "description" for shops "shop1,shop2" should be:
+      | locale | value                   |
+      | en-US  | such a cool magic staff |
+    And product "product1" localized "description_short" for shops "shop1" should be:
+      | locale | value             |
+      | en-US  | super magic staff |
+    And product "product1" localized "description_short" for shops "shop2" should be:
+      | locale | value             |
+      | en-US  | weird magic staff |
+    And product product1 is not associated to shop shop3
+    And product product1 is not associated to shop shop4


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle multishop modification for basic inputs
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | ~
| Possible impacts? | The button id in dropdown translatable widget needed to be modified If some JS code targets it the selector will not work anymore


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

### Breaking Change

In the translatable widget, the form ID was assigned on the dropdown button, which made impossible to target the div container (which is the element that should have this ID). The ID was moved to the widget div and the button ID has been modified by appending `_dropdown` to the form ID. Which means if some js code was targeting this button (or a CSS rule) the selector won't work as expected anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27584)
<!-- Reviewable:end -->
