### PR TITLE
FO: Add page number in meta titles for new-products, best-sales, prices-drop

### DIFF
--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -531,9 +531,9 @@ class MetaCore extends ObjectModel
      */
     public static function paginateMetaTitle(&$meta_title)
     {
-        $page_num = (int)Tools::getValue('page');
+        $page_num = (int) Tools::getValue('page');
         if ($page_num > 1) {
-            $meta_title .= ' ('.$page_num.')';
+            $meta_title .= ' (' . $page_num . ')';
         }
     }
 

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -331,6 +331,7 @@ class MetaCore extends ObjectModel
         $ret['meta_description'] = (isset($metas['description']) && $metas['description']) ? $metas['description'] : '';
         $ret['meta_keywords'] = (isset($metas['keywords']) && $metas['keywords']) ? $metas['keywords'] : '';
         $ret = Meta::completeMetaTags($ret, $ret['meta_title']);
+
         return $ret;
     }
 

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -519,7 +519,7 @@ class MetaCore extends ObjectModel
             $metaTags['meta_title'] = $defaultValue;
         }
         if (!empty($context->controller) && method_exists($context->controller, 'getTemplateVarPagination')) {
-            Meta::paginateMetaTitle($metaTags['meta_title']);
+            $metaTags['meta_title'] = Meta::paginateMetaTitle($metaTags['meta_title']);
         }
 
         return $metaTags;

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -390,7 +390,7 @@ class MetaCore extends ObjectModel
                 if (!empty($title)) {
                     $row['meta_title'] = $title;
                 } else {
-                    $row['meta_title'] = ($row['meta_title'] ?: $row['name']);
+                    $row['meta_title'] = $row['meta_title'] ?: $row['name'];
                 }
 
                 $result = Meta::completeMetaTags($row, $row['name']);

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -536,6 +536,7 @@ class MetaCore extends ObjectModel
         if ($page_num > 1) {
             $meta_title .= ' (' . $page_num . ')';
         }
+        return $meta_title;
     }
 
     /**

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -530,7 +530,7 @@ class MetaCore extends ObjectModel
      *
      * @param string $meta_title
      */
-    public static function paginateMetaTitle(&$meta_title)
+    private static function paginateMetaTitle(string $meta_title): string
     {
         $page_num = (int) Tools::getValue('page');
         if ($page_num > 1) {

--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -424,7 +424,7 @@ class MetaCore extends ObjectModel
             if (!empty($row['meta_description'])) {
                 $row['meta_description'] = strip_tags($row['meta_description']);
             }
-            $row['meta_title'] = ($row['meta_title'] ?: $row['name']);
+            $row['meta_title'] = $row['meta_title'] ?: $row['name'];
 
             return Meta::completeMetaTags($row, $row['meta_title']);
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add page number in meta titles for listing pages that have pagination, like `new-products`, `best-sales`, `prices-drop`, etc.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27596.
| How to test?      | Go to 2nd page of any controller with pagination and check `meta_title`
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27598)
<!-- Reviewable:end -->
