### PR TITLE
Show confirmation modal before deleting order status and order return status

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order-states/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/order-states/index.ts
@@ -29,22 +29,31 @@ import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sq
 import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
 import SortingExtension from '@components/grid/extension/sorting-extension';
 import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
+import SubmitBulkActionExtension from '@components/grid/extension/submit-bulk-action-extension';
+import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
+import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
 
 const {$} = window;
 
 $(() => {
   const orderStatesGrid = new Grid('order_states');
 
-  orderStatesGrid.addExtension(new ReloadListActionExtension());
-  orderStatesGrid.addExtension(new ExportToSqlManagerExtension());
   orderStatesGrid.addExtension(new FiltersResetExtension());
   orderStatesGrid.addExtension(new SortingExtension());
+  orderStatesGrid.addExtension(new ExportToSqlManagerExtension());
+  orderStatesGrid.addExtension(new ReloadListActionExtension());
+  orderStatesGrid.addExtension(new BulkActionCheckboxExtension());
+  orderStatesGrid.addExtension(new SubmitBulkActionExtension());
+  orderStatesGrid.addExtension(new SubmitRowActionExtension());
   orderStatesGrid.addExtension(new ColumnTogglingExtension());
 
   const orderReturnStatusesGrid = new Grid('order_return_states');
 
-  orderReturnStatusesGrid.addExtension(new ReloadListActionExtension());
-  orderReturnStatusesGrid.addExtension(new ExportToSqlManagerExtension());
   orderReturnStatusesGrid.addExtension(new FiltersResetExtension());
   orderReturnStatusesGrid.addExtension(new SortingExtension());
+  orderReturnStatusesGrid.addExtension(new ExportToSqlManagerExtension());
+  orderReturnStatusesGrid.addExtension(new ReloadListActionExtension());
+  orderReturnStatusesGrid.addExtension(new BulkActionCheckboxExtension());
+  orderReturnStatusesGrid.addExtension(new SubmitBulkActionExtension());
+  orderReturnStatusesGrid.addExtension(new SubmitRowActionExtension());
 });

--- a/src/Adapter/OrderReturnState/CommandHandler/AbstractOrderReturnStateHandler.php
+++ b/src/Adapter/OrderReturnState/CommandHandler/AbstractOrderReturnStateHandler.php
@@ -29,8 +29,10 @@ namespace PrestaShop\PrestaShop\Adapter\OrderReturnState\CommandHandler;
 
 use OrderReturnState;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\MissingOrderReturnStateRequiredFieldsException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\ValueObject\OrderReturnStateId;
+use PrestaShopException;
 
 /**
  * Provides reusable methods for order return state command handlers.
@@ -60,6 +62,50 @@ abstract class AbstractOrderReturnStateHandler
             $missingFields = array_keys($errors);
 
             throw new MissingOrderReturnStateRequiredFieldsException($missingFields, sprintf('One or more required fields for order return state are missing. Missing fields are: %s', implode(',', $missingFields)));
+        }
+    }
+
+    /**
+     * @param OrderReturnStateId $orderReturnStateId
+     *
+     * @return OrderReturnState
+     *
+     * @throws OrderReturnStateException
+     * @throws OrderReturnStateNotFoundException
+     */
+    protected function getOrderReturnState(OrderReturnStateId $orderReturnStateId): OrderReturnState
+    {
+        try {
+            $OrderReturnState = new OrderReturnState($orderReturnStateId->getValue());
+        } catch (PrestaShopException $e) {
+            throw new OrderReturnStateException('Failed to create new order return state', 0, $e);
+        }
+
+        if ($OrderReturnState->id !== $orderReturnStateId->getValue()) {
+            throw new OrderReturnStateNotFoundException($orderReturnStateId);
+        }
+
+        return $OrderReturnState;
+    }
+
+    /**
+     * Deletes legacy Address
+     *
+     * @param OrderReturnState $orderReturnState
+     *
+     * @return bool
+     *
+     * @throws OrderReturnStateException
+     */
+    protected function deleteOrderReturnState(OrderReturnState $orderReturnState): bool
+    {
+        try {
+            return (bool) $orderReturnState->delete();
+        } catch (PrestaShopException $e) {
+            throw new OrderReturnStateException(sprintf(
+                'An error occurred when deleting OrderReturnState object with id "%s".',
+                $orderReturnState->id
+            ));
         }
     }
 }

--- a/src/Adapter/OrderReturnState/CommandHandler/BulkDeleteOrderReturnStateHandler.php
+++ b/src/Adapter/OrderReturnState/CommandHandler/BulkDeleteOrderReturnStateHandler.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\OrderReturnState\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\BulkDeleteOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\CommandHandler\BulkDeleteOrderReturnStateHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\BulkDeleteOrderReturnStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateException;
+
+/**
+ * Handles command which deletes OrderReturnStates in bulk action
+ */
+class BulkDeleteOrderReturnStateHandler extends AbstractOrderReturnStateHandler implements BulkDeleteOrderReturnStateHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws BulkDeleteOrderReturnStateException
+     */
+    public function handle(BulkDeleteOrderReturnStateCommand $command): void
+    {
+        $errors = [];
+
+        foreach ($command->getOrderReturnStateIds() as $orderReturnStateId) {
+            try {
+                $orderReturnState = $this->getOrderReturnState($orderReturnStateId);
+
+                if (!$this->deleteOrderReturnState($orderReturnState)) {
+                    $errors[] = $orderReturnState->id;
+                }
+            } catch (OrderReturnStateException $e) {
+                $errors[] = $orderReturnStateId->getValue();
+            }
+        }
+
+        if (!empty($errors)) {
+            throw new BulkDeleteOrderReturnStateException(
+                $errors,
+                'Failed to delete all of selected order return statuses'
+            );
+        }
+    }
+}

--- a/src/Adapter/OrderReturnState/CommandHandler/DeleteOrderReturnStateHandler.php
+++ b/src/Adapter/OrderReturnState/CommandHandler/DeleteOrderReturnStateHandler.php
@@ -24,34 +24,32 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Core\Grid\Column\Type\Common;
+declare(strict_types=1);
 
-use PrestaShop\PrestaShop\Core\Grid\Column\AbstractColumn;
-use Symfony\Component\OptionsResolver\OptionsResolver;
+namespace PrestaShop\PrestaShop\Adapter\OrderReturnState\CommandHandler;
 
-final class BulkActionColumn extends AbstractColumn
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\DeleteOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\CommandHandler\DeleteOrderReturnStateHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\DeleteOrderReturnStateException;
+
+/**
+ * Handles command which deletes order states
+ */
+class DeleteOrderReturnStateHandler extends AbstractOrderReturnStateHandler implements DeleteOrderReturnStateHandlerInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function handle(DeleteOrderReturnStateCommand $command): void
     {
-        return 'bulk_action';
-    }
+        $orderReturnStateId = $command->getOrderReturnStateId();
+        $orderReturnState = $this->getOrderReturnState($orderReturnStateId);
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function configureOptions(OptionsResolver $resolver)
-    {
-        $resolver
-            ->setRequired([
-                'bulk_field',
-            ])
-            ->setDefaults([
-                'disabled_field' => null,
-            ])
-            ->setAllowedTypes('bulk_field', 'string')
-            ->setAllowedTypes('disabled_field', ['string', 'null']);
+        if (!$this->deleteOrderReturnState($orderReturnState)) {
+            throw new DeleteOrderReturnStateException(
+                sprintf('Cannot delete OrderReturnState object with id "%d".', $orderReturnStateId->getValue()),
+                DeleteOrderReturnStateException::FAILED_DELETE
+            );
+        }
     }
 }

--- a/src/Adapter/OrderState/CommandHandler/AbstractOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/AbstractOrderStateHandler.php
@@ -29,8 +29,10 @@ namespace PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler;
 
 use OrderState;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\MissingOrderStateRequiredFieldsException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
+use PrestaShopException;
 
 /**
  * Provides reusable methods for order state command handlers.
@@ -60,6 +62,52 @@ abstract class AbstractOrderStateHandler
             $missingFields = array_keys($errors);
 
             throw new MissingOrderStateRequiredFieldsException($missingFields, sprintf('One or more required fields for order state are missing. Missing fields are: %s', implode(',', $missingFields)));
+        }
+    }
+
+    /**
+     * @param OrderStateId $orderStateId
+     *
+     * @return OrderState
+     *
+     * @throws OrderStateException
+     * @throws OrderStateNotFoundException
+     */
+    protected function getOrderState(OrderStateId $orderStateId): OrderState
+    {
+        try {
+            $orderState = new OrderState($orderStateId->getValue());
+        } catch (PrestaShopException $e) {
+            throw new OrderStateException('Failed to create new order state', 0, $e);
+        }
+
+        if ($orderState->id !== $orderStateId->getValue()) {
+            throw new OrderStateNotFoundException($orderStateId);
+        }
+
+        return $orderState;
+    }
+
+    /**
+     * Deletes legacy Address
+     *
+     * @param OrderState $orderState
+     *
+     * @return bool
+     *
+     * @throws OrderStateException
+     */
+    protected function deleteOrderState(OrderState $orderState): bool
+    {
+        try {
+            $orderState->deleted = true;
+
+            return (bool) $orderState->update();
+        } catch (PrestaShopException $e) {
+            throw new OrderStateException(sprintf(
+                'An error occurred when deleting OrderState object with id "%s".',
+                $orderState->id
+            ));
         }
     }
 }

--- a/src/Adapter/OrderState/CommandHandler/BulkDeleteOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/BulkDeleteOrderStateHandler.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\BulkDeleteOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\CommandHandler\BulkDeleteOrderStateHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\BulkDeleteOrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
+
+/**
+ * Handles command which deletes OrderStatees in bulk action
+ */
+class BulkDeleteOrderStateHandler extends AbstractOrderStateHandler implements BulkDeleteOrderStateHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws BulkDeleteOrderStateException
+     */
+    public function handle(BulkDeleteOrderStateCommand $command): void
+    {
+        $errors = [];
+
+        foreach ($command->getOrderStateIds() as $orderStateId) {
+            try {
+                $orderState = $this->getOrderState($orderStateId);
+
+                if (!$this->deleteOrderState($orderState)) {
+                    $errors[] = $orderState->id;
+                }
+            } catch (OrderStateException $e) {
+                $errors[] = $orderStateId->getValue();
+            }
+        }
+
+        if (!empty($errors)) {
+            throw new BulkDeleteOrderStateException(
+                $errors,
+                'Failed to delete all of selected order statuses'
+            );
+        }
+    }
+}

--- a/src/Adapter/OrderState/CommandHandler/DeleteOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/DeleteOrderStateHandler.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\DeleteOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\CommandHandler\DeleteOrderStateHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\DeleteOrderStateException;
+
+/**
+ * Handles command which deletes order states
+ */
+class DeleteOrderStateHandler extends AbstractOrderStateHandler implements DeleteOrderStateHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(DeleteOrderStateCommand $command): void
+    {
+        $orderStateId = $command->getOrderStateId();
+        $orderState = $this->getOrderState($orderStateId);
+
+        if (!$orderState->isRemovable()) {
+            throw new DeleteOrderStateException(
+                sprintf('Cannot delete unremovable OrderState object with id "%d".', $orderStateId->getValue()),
+                DeleteOrderStateException::FAILED_DELETE
+            );
+        }
+
+        if (!$this->deleteOrderState($orderState)) {
+            throw new DeleteOrderStateException(
+                sprintf('Cannot delete OrderState object with id "%d".', $orderStateId->getValue()),
+                DeleteOrderStateException::FAILED_DELETE
+            );
+        }
+    }
+}

--- a/src/Adapter/OrderState/QueryHandler/GetOrderStateForEditingHandler.php
+++ b/src/Adapter/OrderState/QueryHandler/GetOrderStateForEditingHandler.php
@@ -65,7 +65,8 @@ final class GetOrderStateForEditingHandler implements GetOrderStateForEditingHan
             (bool) $orderState->shipped,
             (bool) $orderState->paid,
             (bool) $orderState->delivery,
-            $orderState->template
+            $orderState->template,
+            (bool) $orderState->deleted
         );
     }
 }

--- a/src/Core/Domain/OrderReturnState/Command/BulkDeleteOrderReturnStateCommand.php
+++ b/src/Core/Domain/OrderReturnState/Command/BulkDeleteOrderReturnStateCommand.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,47 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\ValueObject\OrderReturnStateId;
+
+/**
+ * Deletes order return statuses in bulk action
+ */
+class BulkDeleteOrderReturnStateCommand
+{
+    /**
+     * @var OrderReturnStateId[]
+     */
+    private $orderReturnStateIds;
+
+    /**
+     * @param int[] $orderReturnStateIds
+     */
+    public function __construct(array $orderReturnStateIds)
+    {
+        $this->setOrderReturnStateIds($orderReturnStateIds);
+    }
+
+    /**
+     * @return OrderReturnStateId[]
+     */
+    public function getOrderReturnStateIds(): array
+    {
+        return $this->orderReturnStateIds;
+    }
+
+    /**
+     * @param int[] $orderReturnStateIds
+     */
+    private function setOrderReturnStateIds(array $orderReturnStateIds): void
+    {
+        foreach ($orderReturnStateIds as $orderReturnStateId) {
+            $this->orderReturnStateIds[] = new OrderReturnStateId($orderReturnStateId);
+        }
+    }
+}

--- a/src/Core/Domain/OrderReturnState/Command/DeleteOrderReturnStateCommand.php
+++ b/src/Core/Domain/OrderReturnState/Command/DeleteOrderReturnStateCommand.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,37 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\ValueObject\OrderReturnStateId;
+
+/**
+ * Deletes Order Return States
+ */
+class DeleteOrderReturnStateCommand
+{
+    /**
+     * @var OrderReturnStateId
+     */
+    private $orderReturnStateId;
+
+    /**
+     * @param int $orderReturnStateId
+     */
+    public function __construct(int $orderReturnStateId)
+    {
+        $this->orderReturnStateId = new OrderReturnStateId($orderReturnStateId);
+    }
+
+    /**
+     * @return OrderReturnStateId
+     */
+    public function getOrderReturnStateId(): OrderReturnStateId
+    {
+        return $this->orderReturnStateId;
+    }
+}

--- a/src/Core/Domain/OrderReturnState/CommandHandler/BulkDeleteOrderReturnStateHandlerInterface.php
+++ b/src/Core/Domain/OrderReturnState/CommandHandler/BulkDeleteOrderReturnStateHandlerInterface.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,19 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+namespace PrestaShop\PrestaShop\Core\Domain\OrderReturnState\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\BulkDeleteOrderReturnStateCommand;
+
+/**
+ * Defines contract for BulkDeleteOrderStateHandler
+ */
+interface BulkDeleteOrderReturnStateHandlerInterface
+{
+    /**
+     * @param BulkDeleteOrderReturnStateCommand $command
+     */
+    public function handle(BulkDeleteOrderReturnStateCommand $command): void;
+}

--- a/src/Core/Domain/OrderReturnState/CommandHandler/DeleteOrderReturnStateHandlerInterface.php
+++ b/src/Core/Domain/OrderReturnState/CommandHandler/DeleteOrderReturnStateHandlerInterface.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,19 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+namespace PrestaShop\PrestaShop\Core\Domain\OrderReturnState\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\DeleteOrderReturnStateCommand;
+
+/**
+ * Defines contract for DeleteOrderStateHandler
+ */
+interface DeleteOrderReturnStateHandlerInterface
+{
+    /**
+     * @param DeleteOrderReturnStateCommand $command
+     */
+    public function handle(DeleteOrderReturnStateCommand $command): void;
+}

--- a/src/Core/Domain/OrderReturnState/Exception/BulkDeleteOrderReturnStateException.php
+++ b/src/Core/Domain/OrderReturnState/Exception/BulkDeleteOrderReturnStateException.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,42 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception;
+
+use Exception;
+
+/**
+ * Thrown on failure to delete all selected order return states without errors
+ */
+class BulkDeleteOrderReturnStateException extends OrderReturnStateException
+{
+    /**
+     * @var int[]
+     */
+    private $orderReturnStatesId;
+
+    /**
+     * @param int[] $orderReturnStatesId
+     * @param string $message
+     * @param int $code
+     * @param Exception|null $previous
+     */
+    public function __construct(array $orderReturnStatesId, string $message = '', int $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->orderReturnStatesId = $orderReturnStatesId;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getOrderReturnStatesIds(): array
+    {
+        return $this->orderReturnStatesId;
+    }
+}

--- a/src/Core/Domain/OrderReturnState/Exception/DeleteOrderReturnStateException.php
+++ b/src/Core/Domain/OrderReturnState/Exception/DeleteOrderReturnStateException.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,24 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception;
+
+/**
+ * Is thrown when order return state cannot be deleted
+ */
+class DeleteOrderReturnStateException extends OrderReturnStateException
+{
+    /**
+     * When fails to delete single order return state
+     */
+    public const FAILED_DELETE = 10;
+
+    /**
+     * When fails to delete order return states in bulk action
+     */
+    public const FAILED_BULK_DELETE = 20;
+}

--- a/src/Core/Domain/OrderState/Command/AddOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/AddOrderStateCommand.php
@@ -23,6 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\OrderState\Command;

--- a/src/Core/Domain/OrderState/Command/BulkDeleteOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/BulkDeleteOrderStateCommand.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,52 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\OrderState\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
+
+/**
+ * Deletes addresses in bulk action
+ */
+class BulkDeleteOrderStateCommand
+{
+    /**
+     * @var OrderStateId[]
+     */
+    private $orderStateIds;
+
+    /**
+     * @param int[] $orderStateIds
+     *
+     * @throws OrderStateException
+     */
+    public function __construct(array $orderStateIds)
+    {
+        $this->setOrderStateIds($orderStateIds);
+    }
+
+    /**
+     * @return OrderStateId[]
+     */
+    public function getOrderStateIds(): array
+    {
+        return $this->orderStateIds;
+    }
+
+    /**
+     * @param int[] $orderStateIds
+     *
+     * @throws OrderStateException
+     */
+    private function setOrderStateIds(array $orderStateIds)
+    {
+        foreach ($orderStateIds as $orderStateId) {
+            $this->orderStateIds[] = new OrderStateId($orderStateId);
+        }
+    }
+}

--- a/src/Core/Domain/OrderState/Command/DeleteOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/DeleteOrderStateCommand.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,40 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\OrderState\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
+
+/**
+ * Deletes Address
+ */
+class DeleteOrderStateCommand
+{
+    /**
+     * @var OrderStateId
+     */
+    private $orderStateId;
+
+    /**
+     * @param int $orderStateId
+     *
+     * @throws OrderStateException
+     */
+    public function __construct(int $orderStateId)
+    {
+        $this->orderStateId = new OrderStateId($orderStateId);
+    }
+
+    /**
+     * @return OrderStateId
+     */
+    public function getOrderStateId(): OrderStateId
+    {
+        return $this->orderStateId;
+    }
+}

--- a/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
@@ -23,6 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\OrderState\Command;

--- a/src/Core/Domain/OrderState/CommandHandler/BulkDeleteOrderStateHandlerInterface.php
+++ b/src/Core/Domain/OrderState/CommandHandler/BulkDeleteOrderStateHandlerInterface.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,19 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+namespace PrestaShop\PrestaShop\Core\Domain\OrderState\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\BulkDeleteOrderStateCommand;
+
+/**
+ * Defines contract for BulkDeleteOrderStateHandler
+ */
+interface BulkDeleteOrderStateHandlerInterface
+{
+    /**
+     * @param BulkDeleteOrderStateCommand $command
+     */
+    public function handle(BulkDeleteOrderStateCommand $command): void;
+}

--- a/src/Core/Domain/OrderState/CommandHandler/DeleteOrderStateHandlerInterface.php
+++ b/src/Core/Domain/OrderState/CommandHandler/DeleteOrderStateHandlerInterface.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,19 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+namespace PrestaShop\PrestaShop\Core\Domain\OrderState\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\DeleteOrderStateCommand;
+
+/**
+ * Defines contract for DeleteOrderStateHandler
+ */
+interface DeleteOrderStateHandlerInterface
+{
+    /**
+     * @param DeleteOrderStateCommand $command
+     */
+    public function handle(DeleteOrderStateCommand $command): void;
+}

--- a/src/Core/Domain/OrderState/Exception/BulkDeleteOrderStateException.php
+++ b/src/Core/Domain/OrderState/Exception/BulkDeleteOrderStateException.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,42 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\OrderState\Exception;
+
+use Exception;
+
+/**
+ * Thrown on failure to delete all selected order states without errors
+ */
+class BulkDeleteOrderStateException extends OrderStateException
+{
+    /**
+     * @var int[]
+     */
+    private $orderStatesId;
+
+    /**
+     * @param int[] $orderStatesId
+     * @param string $message
+     * @param int $code
+     * @param Exception|null $previous
+     */
+    public function __construct(array $orderStatesId, $message = '', $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->orderStatesId = $orderStatesId;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getOrderStatesIds(): array
+    {
+        return $this->orderStatesId;
+    }
+}

--- a/src/Core/Domain/OrderState/Exception/DeleteOrderStateException.php
+++ b/src/Core/Domain/OrderState/Exception/DeleteOrderStateException.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,24 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\OrderState\Exception;
+
+/**
+ * Is thrown when order state cannot be deleted
+ */
+class DeleteOrderStateException extends OrderStateException
+{
+    /**
+     * When fails to delete single order state
+     */
+    public const FAILED_DELETE = 10;
+
+    /**
+     * When fails to delete order states in bulk action
+     */
+    public const FAILED_BULK_DELETE = 20;
+}

--- a/src/Core/Domain/OrderState/QueryResult/EditableOrderState.php
+++ b/src/Core/Domain/OrderState/QueryResult/EditableOrderState.php
@@ -86,6 +86,10 @@ class EditableOrderState
      * @var array
      */
     private $localizedTemplates;
+    /**
+     * @var bool
+     */
+    private $isDeleted;
 
     public function __construct(
         OrderStateId $orderStateId,
@@ -100,7 +104,8 @@ class EditableOrderState
         bool $shipped,
         bool $paid,
         bool $delivery,
-        array $localizedTemplates
+        array $localizedTemplates,
+        bool $isDeleted
     ) {
         $this->orderStateId = $orderStateId;
         $this->localizedNames = $name;
@@ -115,6 +120,7 @@ class EditableOrderState
         $this->paid = $paid;
         $this->delivery = $delivery;
         $this->localizedTemplates = $localizedTemplates;
+        $this->isDeleted = $isDeleted;
     }
 
     /**
@@ -139,6 +145,14 @@ class EditableOrderState
     public function getColor()
     {
         return $this->color;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDeleted(): bool
+    {
+        return $this->isDeleted;
     }
 
     /**

--- a/src/Core/Grid/Action/Row/AccessibilityChecker/DeleteOrderReturnStatesAccessibilityChecker.php
+++ b/src/Core/Grid/Action/Row/AccessibilityChecker/DeleteOrderReturnStatesAccessibilityChecker.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,26 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker;
+
+/**
+ * Class DeleteOrderReturnStatesAccessibilityChecker
+ */
+class DeleteOrderReturnStatesAccessibilityChecker implements AccessibilityCheckerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isGranted(array $record)
+    {
+        if (isset($record['unremovable'])) {
+            return !$record['unremovable'];
+        }
+
+        return false;
+    }
+}

--- a/src/Core/Grid/Action/Row/AccessibilityChecker/DeleteOrderStatesAccessibilityChecker.php
+++ b/src/Core/Grid/Action/Row/AccessibilityChecker/DeleteOrderStatesAccessibilityChecker.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +22,26 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
-<div class="md-checkbox">
-  <label>
-    <input type="checkbox"
-           title="{{ column.name }}"
-           class="js-bulk-action-checkbox"
-           name="{{ grid.id~'_'~column.id }}[]"
-           value="{{ record[column.options.bulk_field] }}"
-    >
-    <i class="md-checkbox-control"></i>
-  </label>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker;
+
+/**
+ * Class DeleteOrderStatesAccessibilityChecker
+ */
+class DeleteOrderStatesAccessibilityChecker implements AccessibilityCheckerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isGranted(array $record)
+    {
+        if (isset($record['unremovable'])) {
+            return !$record['unremovable'];
+        }
+
+        return false;
+    }
+}

--- a/src/Core/Grid/Query/OrderReturnStatesQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderReturnStatesQueryBuilder.php
@@ -70,7 +70,12 @@ final class OrderReturnStatesQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $searchQueryBuilder = $this->getOrderReturnStatesQueryBuilder($searchCriteria)
-            ->select('ors.id_order_return_state, orsl.name, ors.color');
+            ->select(
+                'ors.id_order_return_state',
+                'orsl.name',
+                'ors.color',
+                'IF(ors.id_order_return_state IN (1,2,3,4,5),1,0) AS unremovable'
+            );
 
         $this->applySorting($searchQueryBuilder, $searchCriteria);
 

--- a/src/Core/Grid/Query/OrderStatesQueryBuilder.php
+++ b/src/Core/Grid/Query/OrderStatesQueryBuilder.php
@@ -70,7 +70,16 @@ final class OrderStatesQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria)
     {
         $searchQueryBuilder = $this->getOrderStatesQueryBuilder($searchCriteria)
-            ->select('os.id_order_state, osl.name, os.send_email, os.delivery, os.invoice, osl.template, os.color');
+            ->select(
+                'os.id_order_state',
+                'osl.name',
+                'os.send_email',
+                'os.delivery',
+                'os.invoice',
+                'osl.template',
+                'os.color',
+                'os.unremovable'
+            );
 
         $this->applySorting($searchQueryBuilder, $searchCriteria);
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
@@ -27,8 +27,12 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\BulkDeleteOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\DeleteOrderReturnStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Query\GetOrderReturnStateForEditing;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\BulkDeleteOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\DeleteOrderStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\EditOrderStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\DuplicateOrderStateNameException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\MissingOrderStateRequiredFieldsException;
@@ -273,6 +277,62 @@ class OrderStateController extends FrameworkBundleAdminController
     }
 
     /**
+     * Deletes order return state
+     *
+     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_order_states")
+     *
+     * @param int $orderReturnStateId
+     *
+     * @return RedirectResponse
+     */
+    public function deleteOrderReturnStateAction(Request $request, int $orderReturnStateId): RedirectResponse
+    {
+        try {
+            $this->getCommandBus()->handle(new DeleteOrderReturnStateCommand($orderReturnStateId));
+            $this->addFlash(
+                'success',
+                $this->trans('Successful deletion', 'Admin.Notifications.Success')
+            );
+        } catch (OrderReturnStateException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        }
+
+        return $request->query->has('redirectUrl') ?
+            $this->redirect($request->query->get('redirectUrl')) :
+            $this->redirectToRoute('admin_order_states');
+    }
+
+    /**
+     * Delete order return states in bulk action.
+     *
+     * @AdminSecurity(
+     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_order_states",
+     *     message="You do not have permission to delete this."
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function deleteOrderReturnStateBulkAction(Request $request): RedirectResponse
+    {
+        $orderReturnStateIds = $this->getBulkOrderReturnStatesFromRequest($request);
+
+        try {
+            $this->getCommandBus()->handle(new BulkDeleteOrderReturnStateCommand($orderReturnStateIds));
+            $this->addFlash(
+                'success',
+                $this->trans('Successful deletion', 'Admin.Notifications.Success')
+            );
+        } catch (OrderReturnStateException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        }
+
+        return $this->redirectToRoute('admin_order_states');
+    }
+
+    /**
      * Toggle order state delivery option.
      *
      * @AdminSecurity(
@@ -375,6 +435,98 @@ class OrderStateController extends FrameworkBundleAdminController
         }
 
         return $this->redirectToRoute('admin_order_states');
+    }
+
+    /**
+     * Deletes order state
+     *
+     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_order_states")
+     *
+     * @param int $orderStateId
+     *
+     * @return RedirectResponse
+     */
+    public function deleteAction(Request $request, int $orderStateId): RedirectResponse
+    {
+        try {
+            $this->getCommandBus()->handle(new DeleteOrderStateCommand($orderStateId));
+            $this->addFlash(
+                'success',
+                $this->trans('Successful deletion', 'Admin.Notifications.Success')
+            );
+        } catch (OrderStateException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        }
+
+        return $request->query->has('redirectUrl') ?
+            $this->redirect($request->query->get('redirectUrl')) :
+            $this->redirectToRoute('admin_order_states');
+    }
+
+    /**
+     * Delete order states in bulk action.
+     *
+     * @AdminSecurity(
+     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     redirectRoute="admin_order_states",
+     *     message="You do not have permission to delete this."
+     * )
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function deleteBulkAction(Request $request): RedirectResponse
+    {
+        $orderStateIds = $this->getBulkOrderStatesFromRequest($request);
+
+        try {
+            $this->getCommandBus()->handle(new BulkDeleteOrderStateCommand($orderStateIds));
+            $this->addFlash(
+                'success',
+                $this->trans('Successful deletion', 'Admin.Notifications.Success')
+            );
+        } catch (OrderStateException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
+        }
+
+        return $this->redirectToRoute('admin_order_states');
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return array
+     */
+    private function getBulkOrderStatesFromRequest(Request $request): array
+    {
+        $orderStateIds = $request->request->get('order_states_order_states_bulk');
+
+        if (!is_array($orderStateIds)) {
+            return [];
+        }
+
+        return array_map(function (string $orderStateId): int {
+            return (int) $orderStateId;
+        }, $orderStateIds);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return array
+     */
+    private function getBulkOrderReturnStatesFromRequest(Request $request): array
+    {
+        $orderReturnStateIds = $request->request->get('order_return_states_order_return_states_bulk');
+
+        if (!is_array($orderReturnStateIds)) {
+            return [];
+        }
+
+        return array_map(static function (string $orderReturnStateId) {
+            return (int) $orderReturnStateId;
+        }, $orderReturnStateIds);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/order_return_states.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/order_return_states.yml
@@ -15,3 +15,23 @@ admin_order_return_states_edit:
     _legacy_link: AdminStatuses:updateorderreturnstate
     _legacy_parameters:
       id_order_return_state: orderReturnStateId
+
+admin_order_return_states_delete:
+  path: /{orderReturnStateId}/delete
+  methods: [ POST, DELETE ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderStateController::deleteOrderReturnStateAction
+    _legacy_controller: AdminStatuses
+    _legacy_link: AdminStatuses:deleteorderreturnstate
+    _legacy_parameters:
+      id_order_return_state: orderReturnStateId
+  requirements:
+    addressId: \d+
+
+admin_order_return_states_delete_bulk:
+  path: /delete-bulk
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderStateController::deleteOrderReturnStateBulkAction
+    _legacy_controller: AdminStatuses
+    _legacy_link: AdminStatuses:submitBulkdeleteorderreturnstate

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/order_states.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/order_states.yml
@@ -69,3 +69,23 @@ admin_order_states_toggle_send_email:
       id_order_state: orderStateId
   requirements:
     orderStateId: \d+
+
+admin_order_states_delete:
+  path: /{orderStateId}/delete
+  methods: [ POST, DELETE ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderStateController::deleteAction
+    _legacy_controller: AdminStatuses
+    _legacy_link: AdminStatuses:deleteorderstate
+    _legacy_parameters:
+      id_order_state: orderStateId
+  requirements:
+    addressId: \d+
+
+admin_order_states_delete_bulk:
+  path: /delete-bulk
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Configure\ShopParameters\OrderStateController::deleteBulkAction
+    _legacy_controller: AdminStatuses
+    _legacy_link: AdminStatuses:submitBulkdeleteorderstate

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order_return_state.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order_return_state.yml
@@ -19,3 +19,15 @@ services:
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\EditOrderReturnStateCommand'
+
+  prestashop.adapter.order_return_state.command_handler.delete_order_return_state_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\OrderReturnState\CommandHandler\DeleteOrderReturnStateHandler'
+    tags:
+      - name: 'tactician.handler'
+        command: 'PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\DeleteOrderReturnStateCommand'
+
+  prestashop.adapter.order_return_state.command_handler.bulk_delete_order_return_state_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\OrderReturnState\CommandHandler\BulkDeleteOrderReturnStateHandler'
+    tags:
+      - name: 'tactician.handler'
+        command: 'PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\BulkDeleteOrderReturnStateCommand'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order_state.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order_state.yml
@@ -19,3 +19,13 @@ services:
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\OrderState\Command\EditOrderStateCommand'
+
+  prestashop.adapter.order_state.command_handler.delete_order_state_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler\DeleteOrderStateHandler'
+    tags:
+      - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\OrderState\Command\DeleteOrderStateCommand' }
+
+  prestashop.adapter.order_state.command_handler.bulk_delete_order_state_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler\BulkDeleteOrderStateHandler'
+    tags:
+      - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\OrderState\Command\BulkDeleteOrderStateCommand' }

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
@@ -12,3 +12,9 @@ services:
 
   prestashop.core.grid.action.row.accessibility_checker.print_delivery_slip:
     class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintDeliverySlipAccessibilityChecker'
+
+  prestashop.core.grid.action.row.accessibility_checker.delete_order_return_states:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderReturnStatesAccessibilityChecker'
+
+  prestashop.core.grid.action.row.accessibility_checker.delete_order_states:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteOrderStatesAccessibilityChecker'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -253,11 +253,15 @@ services:
   prestashop.core.grid.definition.factory.order_states:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderStatesGridDefinitionFactory'
     parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+    arguments:
+      - '@prestashop.core.grid.action.row.accessibility_checker.delete_order_states'
     public: true
 
   prestashop.core.grid.definition.factory.order_return_states:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderReturnStatesGridDefinitionFactory'
     parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+    arguments:
+      - '@prestashop.core.grid.action.row.accessibility_checker.delete_order_return_states'
     public: true
 
   prestashop.core.grid.definition.factory.outstanding:

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/action.html.twig
@@ -30,10 +30,12 @@
     {% set regularActions = [] %}
 
     {% for action in actions %}
-      {% if action.options['use_inline_display'] == true %}
-          {% set inlineActions = inlineActions|merge([action]) %}
-        {% else %}
-          {% set regularActions = regularActions|merge([action]) %}
+      {% if action.isApplicable(record) %}
+        {% if action.options['use_inline_display'] == true %}
+            {% set inlineActions = inlineActions|merge([action]) %}
+          {% else %}
+            {% set regularActions = regularActions|merge([action]) %}
+        {% endif %}
       {% endif %}
     {% endfor %}
 
@@ -41,8 +43,6 @@
       {% if inlineActions is not empty %}
         <div class="btn-group d-flex justify-content-between text-right">
           {% for inlineAction in inlineActions -%}
-            {% if inlineAction.isApplicable(record) %}
-
               {% set class = 'dropdown-item inline-dropdown-item' %}
 
               {{ include('@PrestaShop/Admin/Common/Grid/Actions/Row/'~inlineAction.type~'.html.twig', {
@@ -52,7 +52,6 @@
                 'record': record,
                 'action': inlineAction
               }) }}
-            {% endif %}
           {% endfor %}
         </div>
       {% endif %}
@@ -67,7 +66,7 @@
               {% set skippedActions = skippedActions + 1 %}
             {% endif %}
 
-            {% if action.isApplicable(record) and not isFirstRendered %}
+            {% if not isFirstRendered %}
               {{ include('@PrestaShop/Admin/Common/Grid/Actions/Row/'~action.type~'.html.twig', {
                 'grid': grid,
                 'column': column,
@@ -90,7 +89,7 @@
             </a>
 
             <div class="dropdown-menu dropdown-menu-right">
-              {% for action in regularActions|slice(skippedActions)|filter(action => action.isApplicable(record)) %}
+              {% for action in regularActions|slice(skippedActions) %}
                 {{ include('@PrestaShop/Admin/Common/Grid/Actions/Row/'~action.type~'.html.twig', {
                   'grid': grid,
                   'column': column,

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderReturnStateFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderReturnStateFeatureContext.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain;
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert as Assert;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\AddOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\BulkDeleteOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\DeleteOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\EditOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\BulkDeleteOrderReturnStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\DeleteOrderReturnStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Query\GetOrderReturnStateForEditing;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\QueryResult\EditableOrderReturnState;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\ValueObject\OrderReturnStateId;
+use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\SharedStorage;
+
+class OrderReturnStateFeatureContext extends AbstractDomainFeatureContext
+{
+    /**
+     * @var int default language id from configs
+     */
+    private $defaultLangId;
+
+    public function __construct()
+    {
+        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
+        $this->defaultLangId = $configuration->get('PS_LANG_DEFAULT');
+    }
+
+    /**
+     * @Given I add a new order return state :orderReturnStateReference with the following details:
+     *
+     * @param string $orderReturnStateReference
+     * @param TableNode $table
+     */
+    public function addNewOrderReturnState(string $orderReturnStateReference, TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+
+        try {
+            /** @var OrderReturnStateId $orderReturnStateId */
+            $orderReturnStateId = $this->getCommandBus()->handle(new AddOrderReturnStateCommand(
+                [
+                    $this->defaultLangId => $data['name'],
+                ],
+                $data['color']
+            ));
+
+            SharedStorage::getStorage()->set($orderReturnStateReference, $orderReturnStateId->getValue());
+        } catch (OrderReturnStateException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Given I update the order return state :orderReturnStateReference with the following details:
+     *
+     * @param string $orderReturnStateReference
+     * @param TableNode $table
+     */
+    public function updateOrderReturnState(string $orderReturnStateReference, TableNode $table): void
+    {
+        $orderReturnStateId = SharedStorage::getStorage()->get($orderReturnStateReference);
+
+        $editableOrderReturnState = new EditOrderReturnStateCommand((int) $orderReturnStateId);
+
+        $data = $table->getRowsHash();
+        if (isset($data['name'])) {
+            $editableOrderReturnState->setName([
+                $this->defaultLangId => $data['name'],
+            ]);
+        }
+        if (isset($data['color'])) {
+            $editableOrderReturnState->setColor($data['color']);
+        }
+
+        try {
+            $this->getCommandBus()->handle($editableOrderReturnState);
+        } catch (OrderReturnStateException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I delete the order return state :orderReturnStateReference
+     *
+     * @param string $orderReturnStateReference
+     */
+    public function deleteOrderReturnState(string $orderReturnStateReference): void
+    {
+        $orderReturnStateId = SharedStorage::getStorage()->get($orderReturnStateReference);
+
+        try {
+            $this->getCommandBus()->handle(new DeleteOrderReturnStateCommand($orderReturnStateId));
+        } catch (DeleteOrderReturnStateException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I bulk delete order return states :orderReturnStateReferences
+     *
+     * @param string $orderReturnStateReferences
+     */
+    public function bulkDeleteOrderReturnState(string $orderReturnStateReferences): void
+    {
+        $orderReturnStateReferences = explode(',', $orderReturnStateReferences);
+        $orderReturnStatesId = [];
+        foreach ($orderReturnStateReferences as $orderReturnStateReference) {
+            $orderReturnStatesId[] = SharedStorage::getStorage()->get($orderReturnStateReference);
+        }
+
+        try {
+            $this->getCommandBus()->handle(new BulkDeleteOrderReturnStateCommand($orderReturnStatesId));
+        } catch (BulkDeleteOrderReturnStateException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then the order return state :orderReturnStateReference should have the following details:
+     *
+     * @param string $orderReturnStateReference
+     * @param TableNode $table
+     */
+    public function checkOrderReturnStateDetails(string $orderReturnStateReference, TableNode $table): void
+    {
+        $editableOrderReturnState = $this->getOrderReturnState($orderReturnStateReference);
+
+        $this->assertLastErrorIsNull();
+
+        $data = $table->getRowsHash();
+
+        $localizedNames = $editableOrderReturnState->getLocalizedNames();
+        Assert::assertIsArray($localizedNames);
+        Assert::assertArrayHasKey($this->defaultLangId, $localizedNames);
+        Assert::assertEquals($data['name'], $localizedNames[$this->defaultLangId]);
+        Assert::assertEquals($data['color'], $editableOrderReturnState->getColor());
+    }
+
+    /**
+     * @Then the order return state :orderReturnStateReference should exist
+     *
+     * @param string $orderReturnStateReference
+     */
+    public function checkOrderReturnStateExists(string $orderReturnStateReference): void
+    {
+        $this->getOrderReturnState($orderReturnStateReference);
+
+        $this->assertLastErrorIsNull();
+    }
+
+    /**
+     * @Then the order return state :orderReturnStateReference shouldn't exist
+     *
+     * @param string $orderReturnStateReference
+     */
+    public function checkOrderReturnStateNotExists(string $orderReturnStateReference): void
+    {
+        $this->getOrderReturnState($orderReturnStateReference);
+
+        $this->assertLastErrorIs(OrderReturnStateNotFoundException::class);
+    }
+
+    /**
+     * @param string $orderReturnStateReference
+     *
+     * @return EditableOrderReturnState|null
+     */
+    private function getOrderReturnState(string $orderReturnStateReference): ?EditableOrderReturnState
+    {
+        try {
+            return $this->getQueryBus()->handle(
+                new GetOrderReturnStateForEditing(SharedStorage::getStorage()->get($orderReturnStateReference))
+            );
+        } catch (OrderReturnStateNotFoundException $e) {
+            $this->setLastException($e);
+        }
+
+        return null;
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderStateFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderStateFeatureContext.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain;
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert as Assert;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\AddOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\BulkDeleteOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\DeleteOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\EditOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\BulkDeleteOrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\DeleteOrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Query\GetOrderStateForEditing;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\QueryResult\EditableOrderState;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
+use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\SharedStorage;
+
+class OrderStateFeatureContext extends AbstractDomainFeatureContext
+{
+    /**
+     * @var int default language id from configs
+     */
+    private $defaultLangId;
+
+    public function __construct()
+    {
+        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
+        $this->defaultLangId = $configuration->get('PS_LANG_DEFAULT');
+    }
+
+    /**
+     * @Given I add a new order state :orderStateReference with the following details:
+     *
+     * @param string $orderStateReference
+     * @param TableNode $table
+     */
+    public function addNewOrderState(string $orderStateReference, TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+
+        try {
+            /** @var OrderStateId $orderStateId */
+            $orderStateId = $this->getCommandBus()->handle(new AddOrderStateCommand(
+                [
+                    $this->defaultLangId => $data['name'],
+                ],
+                $data['color'],
+                (bool) $data['isLoggable'],
+                (bool) $data['isInvoice'],
+                (bool) $data['isHidden'],
+                (bool) $data['hasSendMail'],
+                (bool) $data['hasPdfInvoice'],
+                (bool) $data['hasPdfDelivery'],
+                (bool) $data['isShipped'],
+                (bool) $data['isPaid'],
+                (bool) $data['isDelivery'],
+                []
+            ));
+
+            SharedStorage::getStorage()->set($orderStateReference, $orderStateId->getValue());
+        } catch (OrderStateException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Given I update the order state :orderStateReference with the following details:
+     *
+     * @param string $orderStateReference
+     * @param TableNode $table
+     */
+    public function updateOrderState(string $orderStateReference, TableNode $table): void
+    {
+        $orderStateId = SharedStorage::getStorage()->get($orderStateReference);
+
+        $editableOrderState = new EditOrderStateCommand((int) $orderStateId);
+
+        $data = $table->getRowsHash();
+        if (isset($data['name'])) {
+            $editableOrderState->setName([
+                $this->defaultLangId => $data['name'],
+            ]);
+        }
+        if (isset($data['color'])) {
+            $editableOrderState->setColor($data['color']);
+        }
+        if (isset($data['isLoggable'])) {
+            $editableOrderState->setLoggable((bool) $data['isLoggable']);
+        }
+        if (isset($data['isInvoice'])) {
+            $editableOrderState->setInvoice((bool) $data['isInvoice']);
+        }
+        if (isset($data['isHidden'])) {
+            $editableOrderState->setHidden((bool) $data['isHidden']);
+        }
+        if (isset($data['hasSendMail'])) {
+            $editableOrderState->setSendEmail((bool) $data['hasSendMail']);
+        }
+        if (isset($data['hasPdfInvoice'])) {
+            $editableOrderState->setPdfInvoice((bool) $data['hasPdfInvoice']);
+        }
+        if (isset($data['isShipped'])) {
+            $editableOrderState->setShipped((bool) $data['isShipped']);
+        }
+        if (isset($data['isPaid'])) {
+            $editableOrderState->setPaid((bool) $data['isPaid']);
+        }
+        if (isset($data['isDelivery'])) {
+            $editableOrderState->setDelivery((bool) $data['isDelivery']);
+        }
+
+        try {
+            $this->getCommandBus()->handle($editableOrderState);
+        } catch (OrderStateException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I delete the order state :orderStateReference
+     *
+     * @param string $orderStateReference
+     */
+    public function deleteOrderState(string $orderStateReference): void
+    {
+        $orderStateId = SharedStorage::getStorage()->get($orderStateReference);
+
+        try {
+            $this->getCommandBus()->handle(new DeleteOrderStateCommand($orderStateId));
+        } catch (DeleteOrderStateException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @When I bulk delete order states :orderStateReferences
+     *
+     * @param string $orderStateReferences
+     */
+    public function bulkDeleteOrderState(string $orderStateReferences): void
+    {
+        $orderStateReferences = explode(',', $orderStateReferences);
+        $orderStatesId = [];
+        foreach ($orderStateReferences as $orderStateReference) {
+            $orderStatesId[] = SharedStorage::getStorage()->get($orderStateReference);
+        }
+
+        try {
+            $this->getCommandBus()->handle(new BulkDeleteOrderStateCommand($orderStatesId));
+        } catch (BulkDeleteOrderStateException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Then the order state :orderStateReference should have the following details:
+     *
+     * @param string $orderStateReference
+     * @param TableNode $table
+     */
+    public function checkOrderStateDetails(string $orderStateReference, TableNode $table): void
+    {
+        $editableOrderState = $this->getOrderState($orderStateReference);
+
+        $this->assertLastErrorIsNull();
+
+        $data = $table->getRowsHash();
+
+        $localizedNames = $editableOrderState->getLocalizedNames();
+        Assert::assertIsArray($localizedNames);
+        Assert::assertArrayHasKey($this->defaultLangId, $localizedNames);
+        Assert::assertEquals($data['name'], $localizedNames[$this->defaultLangId]);
+        Assert::assertEquals($data['color'], $editableOrderState->getColor());
+    }
+
+    /**
+     * @Then the order state :orderStateReference should exist
+     *
+     * @param string $orderStateReference
+     */
+    public function checkOrderStateExists(string $orderStateReference): void
+    {
+        $this->getOrderState($orderStateReference);
+
+        $this->assertLastErrorIsNull();
+    }
+
+    /**
+     * @Then the order state :orderStateReference should be deleted
+     *
+     * @param string $orderStateReference
+     */
+    public function checkOrderStateIsDeleted(string $orderStateReference): void
+    {
+        $orderState = $this->getOrderState($orderStateReference);
+
+        Assert::assertTrue($orderState->isDeleted());
+    }
+
+    /**
+     * @Then the order state :orderStateReference shouldn't exist
+     *
+     * @param string $orderStateReference
+     */
+    public function checkOrderStateNotExists(string $orderStateReference): void
+    {
+        $this->getOrderState($orderStateReference);
+
+        $this->assertLastErrorIs(OrderStateNotFoundException::class);
+    }
+
+    /**
+     * @Then the order state :orderStateReference shouldn't be deleted
+     *
+     * @param string $orderStateReference
+     */
+    public function checkOrderStateIsNotDeleted(string $orderStateReference): void
+    {
+        $orderState = $this->getOrderState($orderStateReference);
+
+        Assert::assertFalse($orderState->isDeleted());
+    }
+
+    /**
+     * @param string $orderStateReference
+     *
+     * @return EditableOrderState|null
+     */
+    private function getOrderState(string $orderStateReference): ?EditableOrderState
+    {
+        try {
+            return $this->getQueryBus()->handle(
+                new GetOrderStateForEditing(SharedStorage::getStorage()->get($orderStateReference))
+            );
+        } catch (OrderStateNotFoundException $e) {
+            $this->setLastException($e);
+        }
+
+        return null;
+    }
+}

--- a/tests/Integration/Behaviour/Features/Scenario/OrderReturnState/order_return_state.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/OrderReturnState/order_return_state.feature
@@ -1,0 +1,39 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order_return_state
+@restore-order-return-states-after-feature
+Feature: OrderState
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    And I add a new order return state "order_return_state_1st" with the following details:
+      | name            | The 1st Order Return State |
+      | color           | #123456                    |
+    And the order return state "order_return_state_1st" should exist
+    And I add a new order return state "order_return_state_2nd" with the following details:
+      | name            | The 2nd Order Return State |
+      | color           | #7890AB                    |
+    And the order return state "order_return_state_2nd" should exist
+
+  Scenario: Add new order return state
+    When I add a new order return state "order_return_state_3rd" with the following details:
+      | name            | The 3rd Order Return State |
+      | color           | #CDEF12                    |
+    And the order return state "order_return_state_3rd" should have the following details:
+      | name            | The 3rd Order Return State |
+      | color           | #CDEF12                    |
+    ## Reset
+    When I delete the order return state "order_return_state_3rd"
+
+  Scenario: Edit order return state
+    When I update the order return state "order_return_state_1st" with the following details:
+      | color           | #345678                    |
+    And the order return state "order_return_state_1st" should have the following details:
+      | name            | The 1st Order Return State |
+      | color           | #345678                    |
+
+  Scenario: Delete order return state
+    When I delete the order return state "order_return_state_1st"
+    And the order return state "order_return_state_1st" shouldn't exist
+
+  Scenario: Bulk Delete
+    When I bulk delete order return states "order_return_state_1st,order_return_state_2nd"
+    And the order return state "order_return_state_1st" shouldn't exist
+    And the order return state "order_return_state_2nd" shouldn't exist

--- a/tests/Integration/Behaviour/Features/Scenario/OrderState/order_state.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/OrderState/order_state.feature
@@ -1,0 +1,70 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order_state
+@restore-order-states-after-feature
+Feature: OrderState
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    And I add a new order state "order_state_1st" with the following details:
+      | name            | The 1st Order State |
+      | color           | #123456             |
+      | isLoggable      | 0                   |
+      | isInvoice       | 0                   |
+      | isHidden        | 0                   |
+      | hasSendMail     | 0                   |
+      | hasPdfInvoice   | 0                   |
+      | hasPdfDelivery  | 0                   |
+      | isShipped       | 0                   |
+      | isPaid          | 0                   |
+      | isDelivery      | 0                   |
+    And the order state "order_state_1st" should exist
+    And I add a new order state "order_state_2nd" with the following details:
+      | name            | The 2nd Order State |
+      | color           | #7890AB             |
+      | isLoggable      | 0                   |
+      | isInvoice       | 0                   |
+      | isHidden        | 0                   |
+      | hasSendMail     | 0                   |
+      | hasPdfInvoice   | 0                   |
+      | hasPdfDelivery  | 0                   |
+      | isShipped       | 0                   |
+      | isPaid          | 0                   |
+      | isDelivery      | 0                   |
+    And the order state "order_state_2nd" should exist
+
+  Scenario: Add new order state
+    When I add a new order state "order_state_3rd" with the following details:
+      | name            | The 3rd Order State |
+      | color           | #CDEF12             |
+      | isLoggable      | 0                   |
+      | isInvoice       | 0                   |
+      | isHidden        | 0                   |
+      | hasSendMail     | 0                   |
+      | hasPdfInvoice   | 0                   |
+      | hasPdfDelivery  | 0                   |
+      | isShipped       | 0                   |
+      | isPaid          | 0                   |
+      | isDelivery      | 0                   |
+    And the order state "order_state_3rd" should have the following details:
+      | name            | The 3rd Order State |
+      | color           | #CDEF12             |
+    ## Reset
+    When I delete the order state "order_state_3rd"
+    And the order state "order_state_3rd" should be deleted
+
+  Scenario: Edit order state
+    When I update the order state "order_state_1st" with the following details:
+      | color           | #345678             |
+    And the order state "order_state_1st" should have the following details:
+      | name            | The 1st Order State |
+      | color           | #345678             |
+
+  Scenario: Delete order state
+    When I delete the order state "order_state_1st"
+    And the order state "order_state_1st" should be deleted
+    And the order state "order_state_1st" should exist
+
+  Scenario: Bulk Delete
+    When I bulk delete order states "order_state_1st,order_state_2nd"
+    And the order state "order_state_1st" should be deleted
+    And the order state "order_state_1st" should exist
+    And the order state "order_state_2nd" should be deleted
+    And the order state "order_state_2nd" should exist

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -135,6 +135,20 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateDetailsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
+        order_return_state:
+          paths:
+            - "%paths.base%/Features/Scenario/OrderReturnState"
+          contexts:
+            - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\OrderReturnStateFeatureContext
+        order_state:
+          paths:
+            - "%paths.base%/Features/Scenario/OrderState"
+          contexts:
+            - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\OrderStateFeatureContext
         currency:
             paths:
                 - "%paths.base%/Features/Scenario/Currency"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Show confirmation modal before deleting order status
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Relative to #10619 : Build assets, and Go to `/admin-dev/index.php/configure/shop/order-states/` and check bulk delete on Order States Grid & Order Return States Grid
| How to test?      | On the migrated page "Order State", you can now delete & bulk delete order states with modal.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27606)
<!-- Reviewable:end -->
