### PR TITLE
Make Shop Parameters > Customer Settings > Customers form multistore compatible

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -65,6 +65,7 @@ module.exports = {
     customer_form: './js/pages/customer/form',
     customer_address_form: './js/pages/address/form',
     customer_outstanding: './js/pages/outstanding',
+    customer_preferences: './js/pages/customer-preferences',
     customer_thread_view: './js/pages/customer-thread/view',
     email: './js/pages/email',
     employee: './js/pages/employee/index',

--- a/admin-dev/themes/new-theme/js/pages/customer-preferences/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-preferences/index.ts
@@ -23,8 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-const {$} = window;
-
 $(() => {
   window.prestashop.component.initComponents(
     [

--- a/admin-dev/themes/new-theme/js/pages/customer-preferences/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-preferences/index.ts
@@ -1,4 +1,4 @@
-{#**
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,18 +21,14 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
-{% trans_default_domain "Admin.Shopparameters.Feature" %}
+ */
 
-{% block content %}
-    {{ form_start(generalForm, {'attr': {'class': 'form', 'id': 'configuration_form'}}) }}
-      {% include '@PrestaShop/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig' %}
-    {{ form_end(generalForm) }}
-{% endblock %}
+const {$} = window;
 
-{% block javascripts %}
-  {{ parent() }}
-
-  <script src="{{ asset('themes/new-theme/public/customer_preferences.bundle.js') }}"></script>
-{% endblock %}
+$(() => {
+  window.prestashop.component.initComponents(
+    [
+      'MultistoreConfigField',
+    ],
+  );
+});

--- a/src/Adapter/Customer/CustomerConfiguration.php
+++ b/src/Adapter/Customer/CustomerConfiguration.php
@@ -56,7 +56,7 @@ class CustomerConfiguration extends AbstractMultistoreConfiguration
         return [
             'redisplay_cart_at_login' => (bool) $this->configuration->get('PS_CART_FOLLOWING', false, $shopConstraint),
             'send_email_after_registration' => (bool) $this->configuration->get('PS_CUSTOMER_CREATION_EMAIL', false, $shopConstraint),
-            'password_reset_delay' => (int) $this->configuration->get('PS_PASSWD_TIME_FRONT', null, $shopConstraint),
+            'password_reset_delay' => (int) $this->configuration->get('PS_PASSWD_TIME_FRONT', 0, $shopConstraint),
             'enable_b2b_mode' => (bool) $this->configuration->get('PS_B2B_ENABLE', false, $shopConstraint),
             'ask_for_birthday' => (bool) $this->configuration->get('PS_CUSTOMER_BIRTHDATE', false, $shopConstraint),
             'enable_offers' => (bool) $this->configuration->get('PS_CUSTOMER_OPTIN', false, $shopConstraint),

--- a/src/Adapter/Customer/CustomerConfiguration.php
+++ b/src/Adapter/Customer/CustomerConfiguration.php
@@ -26,36 +26,40 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Customer;
 
-use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class CustomerConfiguration is responsible for saving & loading customer configuration.
  */
-class CustomerConfiguration implements DataConfigurationInterface
+class CustomerConfiguration extends AbstractMultistoreConfiguration
 {
     /**
-     * @var Configuration
+     * @var array<int, string>
      */
-    private $configuration;
-
-    public function __construct(Configuration $configuration)
-    {
-        $this->configuration = $configuration;
-    }
+    private const CONFIGURATION_FIELDS = [
+        'redisplay_cart_at_login',
+        'send_email_after_registration',
+        'password_reset_delay',
+        'enable_b2b_mode',
+        'ask_for_birthday',
+        'enable_offers',
+    ];
 
     /**
      * {@inheritdoc}
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'redisplay_cart_at_login' => $this->configuration->getBoolean('PS_CART_FOLLOWING'),
-            'send_email_after_registration' => $this->configuration->getBoolean('PS_CUSTOMER_CREATION_EMAIL'),
-            'password_reset_delay' => $this->configuration->getInt('PS_PASSWD_TIME_FRONT'),
-            'enable_b2b_mode' => $this->configuration->getBoolean('PS_B2B_ENABLE'),
-            'ask_for_birthday' => $this->configuration->getBoolean('PS_CUSTOMER_BIRTHDATE'),
-            'enable_offers' => $this->configuration->getBoolean('PS_CUSTOMER_OPTIN'),
+            'redisplay_cart_at_login' => (bool) $this->configuration->get('PS_CART_FOLLOWING', false, $shopConstraint),
+            'send_email_after_registration' => (bool) $this->configuration->get('PS_CUSTOMER_CREATION_EMAIL', false, $shopConstraint),
+            'password_reset_delay' => (int) $this->configuration->get('PS_PASSWD_TIME_FRONT', null, $shopConstraint),
+            'enable_b2b_mode' => (bool) $this->configuration->get('PS_B2B_ENABLE', false, $shopConstraint),
+            'ask_for_birthday' => (bool) $this->configuration->get('PS_CUSTOMER_BIRTHDATE', false, $shopConstraint),
+            'enable_offers' => (bool) $this->configuration->get('PS_CUSTOMER_OPTIN', false, $shopConstraint),
         ];
     }
 
@@ -65,29 +69,33 @@ class CustomerConfiguration implements DataConfigurationInterface
     public function updateConfiguration(array $config)
     {
         if ($this->validateConfiguration($config)) {
-            $this->configuration->set('PS_CART_FOLLOWING', (int) $config['redisplay_cart_at_login']);
-            $this->configuration->set('PS_CUSTOMER_CREATION_EMAIL', (int) $config['send_email_after_registration']);
-            $this->configuration->set('PS_PASSWD_TIME_FRONT', (int) $config['password_reset_delay']);
-            $this->configuration->set('PS_B2B_ENABLE', (int) $config['enable_b2b_mode']);
-            $this->configuration->set('PS_CUSTOMER_BIRTHDATE', (int) $config['ask_for_birthday']);
-            $this->configuration->set('PS_CUSTOMER_OPTIN', (int) $config['enable_offers']);
+            $shopConstraint = $this->getShopConstraint();
+
+            $this->updateConfigurationValue('PS_CART_FOLLOWING', 'redisplay_cart_at_login', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_CUSTOMER_CREATION_EMAIL', 'send_email_after_registration', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_PASSWD_TIME_FRONT', 'password_reset_delay', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_B2B_ENABLE', 'enable_b2b_mode', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_CUSTOMER_BIRTHDATE', 'ask_for_birthday', $config, $shopConstraint);
+            $this->updateConfigurationValue('PS_CUSTOMER_OPTIN', 'enable_offers', $config, $shopConstraint);
         }
 
         return [];
     }
 
     /**
-     * {@inheritdoc}
+     * @return OptionsResolver
      */
-    public function validateConfiguration(array $config)
+    protected function buildResolver(): OptionsResolver
     {
-        return isset(
-            $config['redisplay_cart_at_login'],
-            $config['send_email_after_registration'],
-            $config['password_reset_delay'],
-            $config['enable_b2b_mode'],
-            $config['ask_for_birthday'],
-            $config['enable_offers']
-        );
+        $resolver = (new OptionsResolver())
+            ->setDefined(self::CONFIGURATION_FIELDS)
+            ->setAllowedTypes('redisplay_cart_at_login', 'bool')
+            ->setAllowedTypes('send_email_after_registration', 'bool')
+            ->setAllowedTypes('password_reset_delay', 'int')
+            ->setAllowedTypes('enable_b2b_mode', 'bool')
+            ->setAllowedTypes('ask_for_birthday', 'bool')
+            ->setAllowedTypes('enable_offers', 'bool');
+
+        return $resolver;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
@@ -92,13 +92,6 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
             $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
         }
 
-        $legacyController = $request->attributes->get('_legacy_controller');
-
-        return $this->render('@PrestaShop/Admin/Configure/ShopParameters/customer_preferences.html.twig', [
-            'layoutTitle' => $this->trans('Customers', 'Admin.Navigation.Menu'),
-            'enableSidebar' => true,
-            'help_link' => $this->generateSidebarLink($legacyController),
-            'generalForm' => $form->createView(),
-        ]);
+        return $this->redirectToRoute('admin_customer_preferences');
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
@@ -90,8 +90,17 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
             }
 
             $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+
+            return $this->redirectToRoute('admin_customer_preferences');
         }
 
-        return $this->redirectToRoute('admin_customer_preferences');
+        $legacyController = $request->attributes->get('_legacy_controller');
+
+        return $this->render('@PrestaShop/Admin/Configure/ShopParameters/customer_preferences.html.twig', [
+            'layoutTitle' => $this->trans('Customers', 'Admin.Navigation.Menu'),
+            'enableSidebar' => true,
+            'help_link' => $this->generateSidebarLink($legacyController),
+            'generalForm' => $form->createView(),
+        ]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\CustomerPreferences;
 
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -52,6 +53,7 @@ class GeneralType extends TranslatorAwareType
                     'After a customer logs in, you can recall and display the content of his/her last shopping cart.',
                     'Admin.Shopparameters.Help'
                 ),
+                'multistore_configuration_key' => 'PS_CART_FOLLOWING',
             ])
             ->add('send_email_after_registration', SwitchType::class, [
                 'label' => $this->trans(
@@ -62,6 +64,7 @@ class GeneralType extends TranslatorAwareType
                     'Send an email with a summary of the account information after registration.',
                     'Admin.Shopparameters.Help'
                 ),
+                'multistore_configuration_key' => 'PS_CUSTOMER_CREATION_EMAIL',
             ])
             ->add('password_reset_delay', IntegerType::class, [
                 'label' => $this->trans(
@@ -87,6 +90,7 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
                 'unit' => $this->trans('minutes', 'Admin.Shopparameters.Feature'),
+                'multistore_configuration_key' => 'PS_PASSWD_TIME_FRONT',
             ])
             ->add('enable_b2b_mode', SwitchType::class, [
                 'label' => $this->trans(
@@ -97,6 +101,7 @@ class GeneralType extends TranslatorAwareType
                     'Activate or deactivate B2B mode. When this option is enabled, B2B features will be made available.',
                     'Admin.Shopparameters.Help'
                 ),
+                'multistore_configuration_key' => 'PS_B2B_ENABLE',
             ])
             ->add('ask_for_birthday', SwitchType::class, [
                 'label' => $this->trans(
@@ -107,6 +112,7 @@ class GeneralType extends TranslatorAwareType
                     'Display or not the birth date field.',
                     'Admin.Shopparameters.Help'
                 ),
+                'multistore_configuration_key' => 'PS_CUSTOMER_BIRTHDATE',
             ])
             ->add('enable_offers', SwitchType::class, [
                 'label' => $this->trans(
@@ -117,6 +123,7 @@ class GeneralType extends TranslatorAwareType
                     'Display or not the partner offers tick box, to receive offers from the store\'s partners.',
                     'Admin.Shopparameters.Help'
                 ),
+                'multistore_configuration_key' => 'PS_CUSTOMER_OPTIN',
             ]);
     }
 
@@ -136,5 +143,15 @@ class GeneralType extends TranslatorAwareType
     public function getBlockPrefix()
     {
         return 'customer_preferences_general_block';
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -68,7 +68,7 @@ class GeneralType extends TranslatorAwareType
             ])
             ->add('password_reset_delay', IntegerType::class, [
                 'label' => $this->trans(
-                    'Password reset delay (in minutes)',
+                    'Password reset delay',
                     'Admin.Shopparameters.Feature'
                 ),
                 'constraints' => [
@@ -89,6 +89,7 @@ class GeneralType extends TranslatorAwareType
                     'Minimum time required between two requests for a password reset.',
                     'Admin.Shopparameters.Help'
                 ),
+                'unit' => $this->trans('minutes', 'Admin.Shopparameters.Feature'),
                 'multistore_configuration_key' => 'PS_PASSWD_TIME_FRONT',
             ])
             ->add('enable_b2b_mode', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -68,7 +68,7 @@ class GeneralType extends TranslatorAwareType
             ])
             ->add('password_reset_delay', IntegerType::class, [
                 'label' => $this->trans(
-                    'Password reset delay',
+                    'Password reset delay (in minutes)',
                     'Admin.Shopparameters.Feature'
                 ),
                 'constraints' => [
@@ -89,7 +89,6 @@ class GeneralType extends TranslatorAwareType
                     'Minimum time required between two requests for a password reset.',
                     'Admin.Shopparameters.Help'
                 ),
-                'unit' => $this->trans('minutes', 'Admin.Shopparameters.Feature'),
                 'multistore_configuration_key' => 'PS_PASSWD_TIME_FRONT',
             ])
             ->add('enable_b2b_mode', SwitchType::class, [

--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/customer_preferences.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/customer_preferences.yml
@@ -8,7 +8,7 @@ admin_customer_preferences:
 
 admin_customer_preferences_process:
   path: /
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\CustomerPreferencesController::processAction'
     _legacy_controller: AdminCustomerPreferences

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -27,6 +27,8 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Customer\CustomerConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
 
   prestashop.adapter.order_general.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\Order\GeneralConfiguration'

--- a/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
+++ b/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Customer;
+
+use PrestaShop\PrestaShop\Adapter\Customer\CustomerConfiguration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Tests\TestCase\AbstractConfigurationTestCase;
+
+class CustomerConfigurationTest extends AbstractConfigurationTestCase
+{
+    private const SHOP_ID = 42;
+
+    /**
+     * @dataProvider provideShopConstraints
+     *
+     * @param ShopConstraint $shopConstraint
+     */
+    public function testGetConfiguration(ShopConstraint $shopConstraint): void
+    {
+        $maintenanceConfiguration = new CustomerConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $this->mockShopConfiguration
+            ->method('getShopConstraint')
+            ->willReturn($shopConstraint);
+
+        $this->mockConfiguration
+            ->method('get')
+            ->willReturnMap(
+                [
+                    ['PS_CART_FOLLOWING', false, $shopConstraint, true],
+                    ['PS_CUSTOMER_CREATION_EMAIL', false, $shopConstraint, true],
+                    ['PS_PASSWD_TIME_FRONT', 0, $shopConstraint, 260],
+                    ['PS_B2B_ENABLE', false, $shopConstraint, true],
+                    ['PS_CUSTOMER_BIRTHDATE', false, $shopConstraint, true],
+                    ['PS_CUSTOMER_OPTIN', false, $shopConstraint, true],
+                ]
+            );
+
+        $result = $maintenanceConfiguration->getConfiguration();
+        $this->assertSame(
+            [
+                'redisplay_cart_at_login' => true,
+                'send_email_after_registration' => true,
+                'password_reset_delay' => 260,
+                'enable_b2b_mode' => true,
+                'ask_for_birthday' => true,
+                'enable_offers' => true,
+            ],
+            $result
+        );
+    }
+
+    /**
+     * @dataProvider provideInvalidConfiguration
+     *
+     * @param string $exception
+     * @param array $values
+     */
+    public function testUpdateConfigurationWithInvalidConfiguration(string $exception, array $values): void
+    {
+        $maintenanceConfiguration = new CustomerConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $this->expectException($exception);
+        $maintenanceConfiguration->updateConfiguration($values);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideInvalidConfiguration(): array
+    {
+        return [
+            [
+                UndefinedOptionsException::class,
+                [
+                    'does_not_exist' => 'does_not_exist',
+                ],
+            ],
+            [
+                InvalidOptionsException::class,
+                [
+                    'redisplay_cart_at_login' => 'wrong_type',
+                    'send_email_after_registration' => true,
+                    'password_reset_delay' => 120,
+                    'enable_b2b_mode' => true,
+                    'ask_for_birthday' => true,
+                    'enable_offers' => true,
+                ],
+            ],
+            [
+                InvalidOptionsException::class,
+                [
+                    'redisplay_cart_at_login' => true,
+                    'send_email_after_registration' => 'wrong_type',
+                    'password_reset_delay' => 120,
+                    'enable_b2b_mode' => true,
+                    'ask_for_birthday' => true,
+                    'enable_offers' => true,
+                ],
+            ],
+            [
+                InvalidOptionsException::class,
+                [
+                    'redisplay_cart_at_login' => true,
+                    'send_email_after_registration' => true,
+                    'password_reset_delay' => 'wrong_type',
+                    'enable_b2b_mode' => true,
+                    'ask_for_birthday' => true,
+                    'enable_offers' => true,
+                ],
+            ],
+            [
+                InvalidOptionsException::class,
+                [
+                    'redisplay_cart_at_login' => true,
+                    'send_email_after_registration' => true,
+                    'password_reset_delay' => 120,
+                    'enable_b2b_mode' => 'wrong_type',
+                    'ask_for_birthday' => true,
+                    'enable_offers' => true,
+                ],
+            ],
+            [
+                InvalidOptionsException::class,
+                [
+                    'redisplay_cart_at_login' => true,
+                    'send_email_after_registration' => true,
+                    'password_reset_delay' => 120,
+                    'enable_b2b_mode' => true,
+                    'ask_for_birthday' => 'wrong_type',
+                    'enable_offers' => true,
+                ],
+            ],
+            [
+                InvalidOptionsException::class,
+                [
+                    'redisplay_cart_at_login' => true,
+                    'send_email_after_registration' => true,
+                    'password_reset_delay' => 120,
+                    'enable_b2b_mode' => true,
+                    'ask_for_birthday' => true,
+                    'enable_offers' => 'wrong_type',
+                ],
+            ],
+        ];
+    }
+
+    public function testSuccessfulUpdate(): void
+    {
+        $maintenanceConfiguration = new CustomerConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+
+        $res = $maintenanceConfiguration->updateConfiguration([
+            'redisplay_cart_at_login' => true,
+            'send_email_after_registration' => true,
+            'password_reset_delay' => 120,
+            'enable_b2b_mode' => true,
+            'ask_for_birthday' => true,
+            'enable_offers' => true,
+        ]);
+
+        $this->assertSame([], $res);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideShopConstraints(): array
+    {
+        return [
+            [ShopConstraint::shop(self::SHOP_ID)],
+            [ShopConstraint::shopGroup(self::SHOP_ID)],
+            [ShopConstraint::allShops()],
+        ];
+    }
+}

--- a/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
+++ b/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
@@ -38,7 +38,14 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
 {
     private const SHOP_ID = 42;
 
-    private const PASSWORD_TIME_FRONT = 260;
+    private const VALID_CONFIGURATION = [
+        'redisplay_cart_at_login' => true,
+        'send_email_after_registration' => true,
+        'password_reset_delay' => 260,
+        'enable_b2b_mode' => true,
+        'ask_for_birthday' => true,
+        'enable_offers' => true,
+    ];
 
     /**
      * @dataProvider provideShopConstraints
@@ -47,7 +54,11 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
      */
     public function testGetConfiguration(ShopConstraint $shopConstraint): void
     {
-        $maintenanceConfiguration = new CustomerConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+        $maintenanceConfiguration = new CustomerConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
 
         $this->mockShopConfiguration
             ->method('getShopConstraint')
@@ -59,7 +70,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
                 [
                     ['PS_CART_FOLLOWING', false, $shopConstraint, true],
                     ['PS_CUSTOMER_CREATION_EMAIL', false, $shopConstraint, true],
-                    ['PS_PASSWD_TIME_FRONT', 0, $shopConstraint, self::PASSWORD_TIME_FRONT],
+                    ['PS_PASSWD_TIME_FRONT', 0, $shopConstraint, 260],
                     ['PS_B2B_ENABLE', false, $shopConstraint, true],
                     ['PS_CUSTOMER_BIRTHDATE', false, $shopConstraint, true],
                     ['PS_CUSTOMER_OPTIN', false, $shopConstraint, true],
@@ -67,17 +78,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
             );
 
         $result = $maintenanceConfiguration->getConfiguration();
-        $this->assertSame(
-            [
-                'redisplay_cart_at_login' => true,
-                'send_email_after_registration' => true,
-                'password_reset_delay' => self::PASSWORD_TIME_FRONT,
-                'enable_b2b_mode' => true,
-                'ask_for_birthday' => true,
-                'enable_offers' => true,
-            ],
-            $result
-        );
+        $this->assertSame(self::VALID_CONFIGURATION, $result);
     }
 
     /**
@@ -88,7 +89,11 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
      */
     public function testUpdateConfigurationWithInvalidConfiguration(string $exception, array $values): void
     {
-        $maintenanceConfiguration = new CustomerConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+        $maintenanceConfiguration = new CustomerConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
 
         $this->expectException($exception);
         $maintenanceConfiguration->updateConfiguration($values);
@@ -100,93 +105,25 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
     public function provideInvalidConfiguration(): array
     {
         return [
-            [
-                UndefinedOptionsException::class,
-                [
-                    'does_not_exist' => 'does_not_exist',
-                ],
-            ],
-            [
-                InvalidOptionsException::class,
-                [
-                    'redisplay_cart_at_login' => 'wrong_type',
-                    'send_email_after_registration' => true,
-                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
-                    'enable_b2b_mode' => true,
-                    'ask_for_birthday' => true,
-                    'enable_offers' => true,
-                ],
-            ],
-            [
-                InvalidOptionsException::class,
-                [
-                    'redisplay_cart_at_login' => true,
-                    'send_email_after_registration' => 'wrong_type',
-                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
-                    'enable_b2b_mode' => true,
-                    'ask_for_birthday' => true,
-                    'enable_offers' => true,
-                ],
-            ],
-            [
-                InvalidOptionsException::class,
-                [
-                    'redisplay_cart_at_login' => true,
-                    'send_email_after_registration' => true,
-                    'password_reset_delay' => 'wrong_type',
-                    'enable_b2b_mode' => true,
-                    'ask_for_birthday' => true,
-                    'enable_offers' => true,
-                ],
-            ],
-            [
-                InvalidOptionsException::class,
-                [
-                    'redisplay_cart_at_login' => true,
-                    'send_email_after_registration' => true,
-                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
-                    'enable_b2b_mode' => 'wrong_type',
-                    'ask_for_birthday' => true,
-                    'enable_offers' => true,
-                ],
-            ],
-            [
-                InvalidOptionsException::class,
-                [
-                    'redisplay_cart_at_login' => true,
-                    'send_email_after_registration' => true,
-                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
-                    'enable_b2b_mode' => true,
-                    'ask_for_birthday' => 'wrong_type',
-                    'enable_offers' => true,
-                ],
-            ],
-            [
-                InvalidOptionsException::class,
-                [
-                    'redisplay_cart_at_login' => true,
-                    'send_email_after_registration' => true,
-                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
-                    'enable_b2b_mode' => true,
-                    'ask_for_birthday' => true,
-                    'enable_offers' => 'wrong_type',
-                ],
-            ],
+            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['redisplay_cart_at_login' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['send_email_after_registration' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['password_reset_delay' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_b2b_mode' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['ask_for_birthday' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_offers' => 'wrong_type'])],
         ];
     }
 
     public function testSuccessfulUpdate(): void
     {
-        $maintenanceConfiguration = new CustomerConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature);
+        $maintenanceConfiguration = new CustomerConfiguration(
+            $this->mockConfiguration,
+            $this->mockShopConfiguration,
+            $this->mockMultistoreFeature
+        );
 
-        $res = $maintenanceConfiguration->updateConfiguration([
-            'redisplay_cart_at_login' => true,
-            'send_email_after_registration' => true,
-            'password_reset_delay' => self::PASSWORD_TIME_FRONT,
-            'enable_b2b_mode' => true,
-            'ask_for_birthday' => true,
-            'enable_offers' => true,
-        ]);
+        $res = $maintenanceConfiguration->updateConfiguration(self::VALID_CONFIGURATION);
 
         $this->assertSame([], $res);
     }

--- a/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
+++ b/tests/Unit/Adapter/Customer/CustomerConfigurationTest.php
@@ -38,6 +38,8 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
 {
     private const SHOP_ID = 42;
 
+    private const PASSWORD_TIME_FRONT = 260;
+
     /**
      * @dataProvider provideShopConstraints
      *
@@ -57,7 +59,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
                 [
                     ['PS_CART_FOLLOWING', false, $shopConstraint, true],
                     ['PS_CUSTOMER_CREATION_EMAIL', false, $shopConstraint, true],
-                    ['PS_PASSWD_TIME_FRONT', 0, $shopConstraint, 260],
+                    ['PS_PASSWD_TIME_FRONT', 0, $shopConstraint, self::PASSWORD_TIME_FRONT],
                     ['PS_B2B_ENABLE', false, $shopConstraint, true],
                     ['PS_CUSTOMER_BIRTHDATE', false, $shopConstraint, true],
                     ['PS_CUSTOMER_OPTIN', false, $shopConstraint, true],
@@ -69,7 +71,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
             [
                 'redisplay_cart_at_login' => true,
                 'send_email_after_registration' => true,
-                'password_reset_delay' => 260,
+                'password_reset_delay' => self::PASSWORD_TIME_FRONT,
                 'enable_b2b_mode' => true,
                 'ask_for_birthday' => true,
                 'enable_offers' => true,
@@ -109,7 +111,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
                 [
                     'redisplay_cart_at_login' => 'wrong_type',
                     'send_email_after_registration' => true,
-                    'password_reset_delay' => 120,
+                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
                     'enable_b2b_mode' => true,
                     'ask_for_birthday' => true,
                     'enable_offers' => true,
@@ -120,7 +122,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
                 [
                     'redisplay_cart_at_login' => true,
                     'send_email_after_registration' => 'wrong_type',
-                    'password_reset_delay' => 120,
+                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
                     'enable_b2b_mode' => true,
                     'ask_for_birthday' => true,
                     'enable_offers' => true,
@@ -142,7 +144,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
                 [
                     'redisplay_cart_at_login' => true,
                     'send_email_after_registration' => true,
-                    'password_reset_delay' => 120,
+                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
                     'enable_b2b_mode' => 'wrong_type',
                     'ask_for_birthday' => true,
                     'enable_offers' => true,
@@ -153,7 +155,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
                 [
                     'redisplay_cart_at_login' => true,
                     'send_email_after_registration' => true,
-                    'password_reset_delay' => 120,
+                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
                     'enable_b2b_mode' => true,
                     'ask_for_birthday' => 'wrong_type',
                     'enable_offers' => true,
@@ -164,7 +166,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
                 [
                     'redisplay_cart_at_login' => true,
                     'send_email_after_registration' => true,
-                    'password_reset_delay' => 120,
+                    'password_reset_delay' => self::PASSWORD_TIME_FRONT,
                     'enable_b2b_mode' => true,
                     'ask_for_birthday' => true,
                     'enable_offers' => 'wrong_type',
@@ -180,7 +182,7 @@ class CustomerConfigurationTest extends AbstractConfigurationTestCase
         $res = $maintenanceConfiguration->updateConfiguration([
             'redisplay_cart_at_login' => true,
             'send_email_after_registration' => true,
-            'password_reset_delay' => 120,
+            'password_reset_delay' => self::PASSWORD_TIME_FRONT,
             'enable_b2b_mode' => true,
             'ask_for_birthday' => true,
             'enable_offers' => true,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add multistore checkboxes/dropdowns on Customer settings page
| Type?             | new feature
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #19365. Fixes #19317.
| How to test?      | See issues
| Possible impacts? | -
| Sponsor company | @Creabilis

## BC BREAKS:

- `src/Adapter/Customer/CustomerConfiguration.php` (constructor)

This data configuration class now extend `AbstractMultistoreConfiguration`, which implies those BC break.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27608)
<!-- Reviewable:end -->
