### PR TITLE
Fix stock movement creation from new order

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -533,28 +533,45 @@ class OrderDetailCore extends ObjectModel
     }
 
     /**
-     * Check the order status.
+     * Updates product quantity in stock, according to order status.
      *
      * @param array $product
-     * @param int $id_order_state
+     * @param int $orderStateId
      */
-    protected function checkProductStock($product, $id_order_state)
+    protected function updateProductQuantityInStock($product, $orderStateId): void
     {
-        if ($id_order_state != Configuration::get('PS_OS_CANCELED') && $id_order_state != Configuration::get('PS_OS_ERROR')) {
-            $update_quantity = true;
-            if (!StockAvailable::dependsOnStock($product['id_product'])) {
-                $update_quantity = StockAvailable::updateQuantity($product['id_product'], $product['id_product_attribute'], -(int) $product['cart_quantity'], $product['id_shop'], true);
-            }
-
-            if ($update_quantity) {
-                $product['stock_quantity'] -= $product['cart_quantity'];
-            }
-
-            if ($product['stock_quantity'] < 0 && Configuration::get('PS_STOCK_MANAGEMENT')) {
-                $this->outOfStock = true;
-            }
-            Product::updateDefaultAttribute($product['id_product']);
+        $dismissOrderStateIds = Configuration::getMultiple([
+            'PS_OS_CANCELED',
+            'PS_OS_ERROR',
+        ]);
+        if (in_array($orderStateId, $dismissOrderStateIds)) {
+            return;
         }
+        if (!StockAvailable::dependsOnStock($product['id_product'])) {
+            $orderState = new OrderState($orderStateId, $this->id_lang);
+            $isQuantityUpdated = StockAvailable::updateQuantity(
+                $product['id_product'],
+                $product['id_product_attribute'],
+                -(int) $product['cart_quantity'],
+                $product['id_shop'],
+                // Add stock movement only if order state is flagged as shipped
+                true === (bool) $orderState->shipped,
+                [
+                    'id_order' => $this->id_order,
+                    // Only one stock movement reason fits a new order creation
+                    'id_stock_mvt_reason' => Configuration::get('PS_STOCK_CUSTOMER_ORDER_REASON'),
+                ]
+            );
+        } else {
+            $isQuantityUpdated = true;
+        }
+        if ($isQuantityUpdated === true) {
+            $product['stock_quantity'] -= $product['cart_quantity'];
+        }
+        if ($product['stock_quantity'] < 0 && Configuration::get('PS_STOCK_MANAGEMENT')) {
+            $this->outOfStock = true;
+        }
+        Product::updateDefaultAttribute($product['id_product']);
     }
 
     /**
@@ -763,7 +780,7 @@ class OrderDetailCore extends ObjectModel
             $product_quantity_in_stock : (int) $product['cart_quantity'];
 
         $this->setVirtualProductInformation($product);
-        $this->checkProductStock($product, $id_order_state);
+        $this->updateProductQuantityInStock($product, $id_order_state);
 
         if ($use_taxes) {
             $this->setProductTax($order, $product);

--- a/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockManagementRepository.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
+use Context;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\ORM\EntityManager;
@@ -78,21 +79,6 @@ abstract class StockManagementRepository
     /**
      * @var int
      */
-    protected $languageId;
-
-    /**
-     * @var int
-     */
-    protected $shopId;
-
-    /**
-     * @var \Context
-     */
-    protected $context;
-
-    /**
-     * @var int
-     */
     protected $foundRows = 0;
 
     /**
@@ -123,26 +109,65 @@ abstract class StockManagementRepository
         $this->contextAdapter = $contextAdapter;
         $this->imageManager = $imageManager;
         $this->tablePrefix = $tablePrefix;
+    }
 
-        $this->context = $contextAdapter->getContext();
+    /**
+     * Returns the current context
+     */
+    protected function getCurrentContext(): Context
+    {
+        return $this->contextAdapter->getContext();
+    }
 
-        if (!$this->context->employee instanceof Employee) {
+    /**
+     * Returns the employee set in current context
+     */
+    protected function getCurrentEmployee(): Employee
+    {
+        $employee = $this->getCurrentContext()->employee;
+
+        if (!$employee instanceof Employee) {
             throw new RuntimeException('Determining the active language requires a contextual employee instance.');
         }
 
-        $languageId = $this->context->employee->id_lang;
-        $this->languageId = (int) $languageId;
+        return $employee;
+    }
 
-        if (!$this->context->shop instanceof Shop) {
+    /**
+     * Returns the language ID of the employee in current context
+     */
+    protected function getCurrentLanguageId(): int
+    {
+        return (int) $this->getCurrentEmployee()->id_lang;
+    }
+
+    /**
+     * Returns the shop set in current context
+     *
+     * @throws NotImplementedException
+     */
+    protected function getCurrentShop(): Shop
+    {
+        $shop = $this->getCurrentContext()->shop;
+
+        if (!$shop instanceof Shop) {
             throw new RuntimeException('Determining the active shop requires a contextual shop instance.');
         }
-
-        $shop = $this->context->shop;
-        if ($shop->getContextType() !== $shop::CONTEXT_SHOP) {
+        if ($shop->getContextType() !== Shop::CONTEXT_SHOP) {
             throw new NotImplementedException('Shop context types other than "single shop" are not supported');
         }
 
-        $this->shopId = $shop->getContextualShopId();
+        return $shop;
+    }
+
+    /**
+     * Returns the contextual ID of the shop in current context
+     *
+     * @throws NotImplementedException
+     */
+    protected function getContextualShopId(): int
+    {
+        return $this->getCurrentShop()->getContextualShopId();
     }
 
     /**
@@ -342,18 +367,21 @@ abstract class StockManagementRepository
         QueryParamsCollection $queryParams = null,
         ProductIdentity $productIdentity = null
     ) {
-        $statement->bindValue('shop_id', $this->shopId, PDO::PARAM_INT);
-        $statement->bindValue('language_id', $this->languageId, PDO::PARAM_INT);
+        $shop = $this->getCurrentShop();
+        $shopId = $shop->getContextualShopId();
+        $shopGroup = $shop->getGroup();
+        $languageId = $this->getCurrentLanguageId();
+
+        $statement->bindValue('shop_id', $shopId, PDO::PARAM_INT);
+        $statement->bindValue('language_id', $languageId, PDO::PARAM_INT);
         $statement->bindValue('state', Product::STATE_SAVED, PDO::PARAM_INT);
 
         // if quantities are shared between shops of the group
-        $shop = $this->context->shop;
-        $shopGroup = $shop->getGroup();
         if ($shopGroup->share_stock) {
             $stockShopId = 0;
             $stockGroupId = $shopGroup->id;
         } else {
-            $stockShopId = $shop->getContextualShopId();
+            $stockShopId = $shopId;
             $stockGroupId = 0;
         }
 
@@ -503,7 +531,7 @@ abstract class StockManagementRepository
                         WHERE fv.custom = 0 AND fp.id_product=:id_product';
             $statement = $this->connection->prepare($query);
             $statement->bindValue('id_product', (int) $row['product_id'], \PDO::PARAM_INT);
-            $statement->bindValue('shop_id', $this->shopId, \PDO::PARAM_INT);
+            $statement->bindValue('shop_id', $this->getContextualShopId(), \PDO::PARAM_INT);
             $statement->execute();
             $this->productFeatures[$row['product_id']] = $statement->fetchColumn(0);
             $statement->closeCursor();

--- a/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
@@ -202,7 +202,7 @@ class StockMovementRepository extends StockManagementRepository
     {
         foreach ($rows as &$row) {
             if ($row['id_order']) {
-                $row['order_link'] = $this->contextAdapter->getContext()->link->getAdminLink(
+                $row['order_link'] = $this->getCurrentContext()->link->getAdminLink(
                     'AdminOrders',
                     true,
                     [],
@@ -235,7 +235,7 @@ class StockMovementRepository extends StockManagementRepository
         );
 
         $statement = $this->connection->prepare($query);
-        $statement->bindValue('shop_id', $this->shopId, PDO::PARAM_INT);
+        $statement->bindValue('shop_id', $this->getContextualShopId(), PDO::PARAM_INT);
         $statement->execute();
 
         $rows = $statement->fetchAll();
@@ -278,8 +278,8 @@ class StockMovementRepository extends StockManagementRepository
         );
 
         $statement = $this->connection->prepare($query);
-        $statement->bindValue('language_id', $this->languageId, PDO::PARAM_INT);
-        $statement->bindValue('shop_id', $this->shopId, PDO::PARAM_INT);
+        $statement->bindValue('language_id', $this->getCurrentLanguageId(), PDO::PARAM_INT);
+        $statement->bindValue('shop_id', $this->getContextualShopId(), PDO::PARAM_INT);
         $statement->execute();
 
         $rows = $statement->fetchAll();

--- a/src/PrestaShopBundle/Entity/Repository/StockRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockRepository.php
@@ -129,7 +129,7 @@ class StockRepository extends StockManagementRepository
                     $product,
                     $productIdentity->getCombinationId(),
                     $delta,
-                    $this->contextAdapter->getContext()->shop->id,
+                    $this->getCurrentShop()->id,
                     true,
                     [
                         'id_stock_mvt_reason' => ($delta >= 1 ? $configurationAdapter->get('PS_STOCK_MVT_INC_EMPLOYEE_EDITION') : $configurationAdapter->get('PS_STOCK_MVT_DEC_EMPLOYEE_EDITION')),
@@ -151,7 +151,7 @@ class StockRepository extends StockManagementRepository
     private function syncAllStock($idProduct)
     {
         (new StockManager())->updatePhysicalProductQuantity(
-            $this->contextAdapter->getContext()->shop->id,
+            $this->getCurrentShop()->id,
             $this->orderStates['error'],
             $this->orderStates['cancellation'],
             (int) $idProduct
@@ -195,7 +195,7 @@ class StockRepository extends StockManagementRepository
     public function getData(QueryParamsCollection $queryParams)
     {
         $this->stockManager->updatePhysicalProductQuantity(
-            $this->shopId,
+            $this->getContextualShopId(),
             $this->orderStates['error'],
             $this->orderStates['cancellation']
         );

--- a/tests/Integration/Behaviour/Features/Scenario/Order/order_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Order/order_stock.feature
@@ -1,0 +1,64 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s order --tags order-stock
+@restore-all-tables-before-feature
+@clear-cache-before-feature
+@order-stock
+Feature: Stock management of order from Back Office (BO)
+  In order to manage product stock quantities
+  As a BO user
+  I need to update stock quantities of ordered products
+
+  Background:
+    Given email sending is disabled
+    And the current currency is "USD"
+    And country "US" is enabled
+    And the module "dummy_payment" is installed
+    And I am logged in as "test@prestashop.com" employee
+    And there is customer "testCustomer" with email "pub@prestashop.com"
+    And customer "testCustomer" has address in "US" country
+    And a carrier "default_carrier" with name "My carrier" exists
+
+  Scenario Outline: Check no stock movement is added by new order without status flagged as shipped
+    Given there is a product in the catalog named "product<index>" with a price of 17.0 and 100 items in stock
+    When I create an empty cart "dummy_cart<index>" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart<index>"
+    And I add 2 products "product<index>" to the cart "dummy_cart<index>"
+    And I add order "bo_order<index>" with the following details:
+      | cart                | dummy_cart<index> |
+      | message             | test<index>       |
+      | payment module name | dummy_payment     |
+      | status              | <order_status>    |
+    Then product "product<index>" last employees stock movements should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 100            |
+    Examples:
+      | index | order_status                         |
+      | 1     | Awaiting check payment               |
+      | 2     | Payment accepted                     |
+      | 3     | Processing in progress               |
+      | 4     | Canceled                             |
+      | 5     | Refunded                             |
+      | 6     | Payment error                        |
+      | 7     | On backorder (paid)                  |
+      | 8     | On backorder (not paid)              |
+      | 9     | Awaiting bank wire payment           |
+      | 10    | Remote payment accepted              |
+      | 11    | Awaiting Cash On Delivery validation |
+
+  Scenario Outline: Check stock movement is added by new order with status flagged as shipped
+    Given there is a product in the catalog named "product<index>" with a price of 17.0 and 100 items in stock
+    When I create an empty cart "dummy_cart<index>" for customer "testCustomer"
+    And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart<index>"
+    And I add 2 products "product<index>" to the cart "dummy_cart<index>"
+    And I add order "bo_order<index>" with the following details:
+      | cart                | dummy_cart<index> |
+      | message             | test<index>       |
+      | payment module name | dummy_payment     |
+      | status              | <order_status>    |
+    Then product "product<index>" last employees stock movements should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | -2             |
+      | Puff       | Daddy     | 100            |
+    Examples:
+      | index | order_status |
+      | 1     | Shipped      |
+      | 2     | Delivered    |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | New order created from BO always add a new stock movement:<ul><li>from any order status, not only "delivered"</li><li>without any reference to order (id_order = NULL)</li></ul>This PR fixes the bug:<ul><li>stock movement is only created from an order with "delivered" status</li><li>this order is referenced in the newly created stock movement</li></ul>As required by initial specifications: https://forge.prestashop.com/browse/FF-1
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | <ul><li>Method `OrderDetail::checkProductStock()` has been renamed to `OrderDetail::updateProductQuantityInStock()`</li><li>Protected properties have been removed in abstract class `PrestaShopBundle\Entity\Repository\StockManagementRepository`:<ul><li>$languageId</li><li>$shopId</li><li>$context</li></ul>Use new methods instead:<ul><li>`getCurrentContext(): Context` Returns the current context</li><li>`getCurrentEmployee(): Employee` Returns the employee set in current context</li><li>`getCurrentLanguageId(): int` Returns the language ID of the employee in current context</li><li>`getCurrentShop(): Shop` Returns the shop set in current context</li><li>`getContextualShopId(): int` Returns the contextual ID of the shop in current context</li></ul></li></ul>
| Deprecations?     | no
| Fixed ticket?     | Fixes #27627.
| How to test?      | <ol><li>Create a new order from BO with "Waiting for payment" status</li><li>No stock movement has been inserted in database table ps_stock_mvt</li><li>Create a new order from BO with 'Shipped" or "Delivered" status</li><li>A new stock movement has been inserted in database table ps_stock_mvt with id_order != NULL</li></ol>
| Possible impacts? | Any feature related to stock management update by orders.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27626)
<!-- Reviewable:end -->
