### PR TITLE
Improve mail order message

### DIFF
--- a/mails/themes/classic/core/order_customer_comment.html.twig
+++ b/mails/themes/classic/core/order_customer_comment.html.twig
@@ -26,8 +26,10 @@
             
 {% endif %}
             <span>
-              {{ 'You have received a new message regarding order with the reference'|trans({}, 'Emails.Body', locale)|raw }} <span><strong>{order_name}</strong></span>.<br/><br/>
-              <span><strong>{{ 'Customer:'|trans({}, 'Emails.Body', locale)|raw }}</strong></span> {firstname} {lastname} ({email})<br/><br/>
+              {{ 'You have received a new message.'|trans({}, 'Emails.Body', locale)|raw }}<br/><br/>
+              <span><strong>{{ 'Customer:'|trans({}, 'Emails.Body', locale)|raw }}</strong></span> {firstname} {lastname} ({email})<br/>
+              <span><strong>{{ 'Order reference:'|trans({}, 'Emails.Body', locale)|raw }}</strong></span> {order_name}<br/>
+              <span><strong>{{ 'Product:'|trans({}, 'Emails.Body', locale)|raw }}</strong></span> {product_name}<br/><br/>
               {message}
             </span>
           </font>

--- a/mails/themes/modern/core/order_customer_comment.html.twig
+++ b/mails/themes/modern/core/order_customer_comment.html.twig
@@ -120,12 +120,14 @@
                                     <tbody>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">{{ 'You have received a new message regarding order with the reference'|trans({}, 'Emails.Body', locale)|raw }} <span class="label">{order_name}</span>.</div>
+                                          <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;">{{ 'You have received a new message.'|trans({}, 'Emails.Body', locale)|raw }}</div>
                                         </td>
                                       </tr>
                                       <tr>
                                         <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
                                           <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;"><span style=" font-size:16px" class="label">{{ 'Customer:'|trans({}, 'Emails.Body', locale)|raw }}</span> {firstname} {lastname} ({email})</div>
+                                          <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;"><span style=" font-size:16px" class="label">{{ 'Order reference:'|trans({}, 'Emails.Body', locale)|raw }}</span> {order_name}</div>
+                                          <div style="font-family:Open sans, arial, sans-serif;font-size:14px;line-height:25px;text-align:left;color:#363A41;"><span style=" font-size:16px" class="label">{{ 'Product:'|trans({}, 'Emails.Body', locale)|raw }}</span> {product_name}</div>
                                         </td>
                                       </tr>
                                     </tbody>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add the {product_name} to the content of the mail, it's already loaded by the controller but missing in the mail and improve wording
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27581 .
| How to test?      | Send a mail from an order detail in front-end, check the message received by the admin
| Possible impacts? |
| Sponsor company   | Prestaplugins

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27643)
<!-- Reviewable:end -->
