### PR TITLE
Remove unused FrontController properties

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -76,6 +76,34 @@ class FrontControllerCore extends Controller
     /** @var string Language ISO code */
     public $iso;
 
+    /**
+     * @deprecated Since 8.0 and will be removed in the next major.
+     *
+     * @var string ORDER BY field
+     */
+    public $orderBy;
+
+    /**
+     * @deprecated Since 8.0 and will be removed in the next major.
+     *
+     * @var string Order way string ('ASC', 'DESC')
+     */
+    public $orderWay;
+
+    /**
+     * @deprecated Since 8.0 and will be removed in the next major.
+     *
+     * @var int Current page number
+     */
+    public $p;
+
+    /**
+     * @deprecated Since 8.0 and will be removed in the next major.
+     *
+     * @var int Items (products) per page
+     */
+    public $n;
+
     /** @var bool If set to true, will redirected user to login page during init function. */
     public $auth = false;
 
@@ -121,6 +149,13 @@ class FrontControllerCore extends Controller
      * @var array Holds current customer's groups
      */
     protected static $currentCustomerGroups;
+
+    /**
+     * @deprecated Since 8.0 and will be removed in the next major.
+     *
+     * @var int
+     */
+    public $nb_items_per_page;
 
     /**
      * @var ObjectPresenter

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -76,18 +76,6 @@ class FrontControllerCore extends Controller
     /** @var string Language ISO code */
     public $iso;
 
-    /** @var string ORDER BY field */
-    public $orderBy;
-
-    /** @var string Order way string ('ASC', 'DESC') */
-    public $orderWay;
-
-    /** @var int Current page number */
-    public $p;
-
-    /** @var int Items (products) per page */
-    public $n;
-
     /** @var bool If set to true, will redirected user to login page during init function. */
     public $auth = false;
 
@@ -133,11 +121,6 @@ class FrontControllerCore extends Controller
      * @var array Holds current customer's groups
      */
     protected static $currentCustomerGroups;
-
-    /**
-     * @var int
-     */
-    public $nb_items_per_page;
 
     /**
      * @var ObjectPresenter

--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -179,7 +179,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
 
     public function getTemplateVarManufacturers()
     {
-        $manufacturers = Manufacturer::getManufacturers(true, $this->context->language->id, true, $this->p, $this->n, false);
+        $manufacturers = Manufacturer::getManufacturers(true, $this->context->language->id);
         $manufacturers_for_display = [];
 
         foreach ($manufacturers as $manufacturer) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Some unused code cleanup to make it easier to manage
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | no
| How to test?      | CI green
| Possible impacts? | no


`$nb_items_per_page;` It seems that it was accidentally added in the next commit, because it was not used at that time.
https://github.com/PrestaShop/PrestaShop/commit/139bb84f872de217cfb3c738056cd2f2834441f4 (editado) 

`$p` & `$n` was used by old `pagination()` function that no longer exists.
https://github.com/PrestaShop/PrestaShop/blame/d7663195cfc582e1f1285ff03c90eac9859fa9c1/classes/controller/FrontController.php#L1116

`OrderBy` & `orderWay` were not deleted when `productSort()` function was removed/extracted.
https://github.com/PrestaShop/PrestaShop/blame/d7663195cfc582e1f1285ff03c90eac9859fa9c1/classes/controller/FrontController.php#L1079

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27644)
<!-- Reviewable:end -->
