### PR TITLE
Added values and amounts with and without taxes #27652

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -507,12 +507,12 @@ class CartPresenter implements PresenterInterface
             'vouchers' => $vouchers,
             'discounts' => $discounts,
             'minimalPurchase' => $minimalPurchase,
-            'minimalPurchaseRequired' => ($products_total_including_tax < $minimalPurchase) ?
+            'minimalPurchaseRequired' => ($products_total_excluding_tax < $minimalPurchase) ?
                 $this->translator->trans(
                     'A minimum shopping cart total of %amount% (tax excl.) is required to validate your order. Current cart total is %total% (tax excl.).',
                     [
                         '%amount%' => $this->priceFormatter->format($minimalPurchase),
-                        '%total%' => $this->priceFormatter->format($products_total_including_tax),
+                        '%total%' => $this->priceFormatter->format($products_total_excluding_tax),
                     ],
                     'Shop.Theme.Checkout'
                 ) :

--- a/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
@@ -89,15 +89,23 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
                 $totalProducts,
                 Currency::getCurrencyInstance((int) $this->order->id_currency)
             ),
-            'amount_excl_tax' => $this->order->total_products,
-            'amount_incl_tax' => $this->order->total_products_wt,
-            'value_excl_tax' => $this->priceFormatter->format(
-                $this->order->total_products,
-                Currency::getCurrencyInstance((int) $this->order->id_currency)
+            'subtotal_including_tax' => array(
+                'type' => 'products_including_tax',
+                'label' => $this->translator->trans('Subtotal (tax incl.)', [], 'Shop.Theme.Checkout'),
+                'amount' => $this->order->total_products_wt,
+                'value' => $this->priceFormatter->format(
+                    $this->order->total_products_wt,
+                    Currency::getCurrencyInstance((int) $this->order->id_currency)
+                ),
             ),
-            'value_incl_tax' => $this->priceFormatter->format(
-                $this->order->total_products_wt,
-                Currency::getCurrencyInstance((int) $this->order->id_currency)
+            'subtotal_excluding_tax' => array(
+                'type' => 'products_excluding_tax',
+                'label' => $this->translator->trans('Subtotal (tax excl.)', [], 'Shop.Theme.Checkout'),
+                'amount' => $this->order->total_products,
+                'value' => $this->priceFormatter->format(
+                    $this->order->total_products,
+                    Currency::getCurrencyInstance((int) $this->order->id_currency)
+                ),
             ),
         ];
     }
@@ -151,18 +159,29 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
                 'value' => $shippingCost != 0 ? $this->priceFormatter->format(
                     $shippingCost,
                     Currency::getCurrencyInstance((int) $this->order->id_currency)
-                )
-                    : $this->translator->trans('Free', [], 'Shop.Theme.Checkout'),
-                'amount_excl_tax' => $this->order->total_shipping_tax_excl,
-                'amount_incl_tax' => $this->order->total_shipping_tax_incl,
-                'value_excl_tax' => $shippingCost != 0 ? $this->priceFormatter->format(
-                    $this->order->total_shipping_tax_excl,
-                    Currency::getCurrencyInstance((int) $this->order->id_currency)
                 ) : $this->translator->trans('Free', [], 'Shop.Theme.Checkout'),
-                'value_incl_tax' => $shippingCost != 0 ? $this->priceFormatter->format(
-                    $this->order->total_shipping_tax_incl,
-                    Currency::getCurrencyInstance((int) $this->order->id_currency)
-                ) : $this->translator->trans('Free', [], 'Shop.Theme.Checkout'),
+                'subtotal_including_tax' => array(
+                    'type' => 'shipping_including_tax',
+                    'label' => $this->translator->trans('Shipping and handling (tax incl.)', [], 'Shop.Theme.Checkout'),
+                    'amount' => $this->order->total_shipping_tax_incl,
+                    'value' => $this->priceFormatter->format(
+                        $this->order->total_products_wt,
+                        Currency::getCurrencyInstance((int) $this->order->id_currency)
+                    ),
+                    'value_incl_tax' => $shippingCost != 0 ? $this->priceFormatter->format(
+                        $this->order->total_shipping_tax_incl,
+                        Currency::getCurrencyInstance((int) $this->order->id_currency)
+                    ) : $this->translator->trans('Free', [], 'Shop.Theme.Checkout'),
+                ),
+                'subtotal_excluding_tax' => array(
+                    'type' => 'shipping_excluding_tax',
+                    'label' => $this->translator->trans('Shipping and handling (tax excl.)', [], 'Shop.Theme.Checkout'),
+                    'amount' => $this->order->total_shipping_tax_excl,
+                    'value' => $shippingCost != 0 ? $this->priceFormatter->format(
+                        $this->order->total_shipping_tax_excl,
+                        Currency::getCurrencyInstance((int) $this->order->id_currency)
+                    ) : $this->translator->trans('Free', [], 'Shop.Theme.Checkout'),
+                ),
             ];
         }
 

--- a/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
@@ -89,6 +89,16 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
                 $totalProducts,
                 Currency::getCurrencyInstance((int) $this->order->id_currency)
             ),
+            'amount_excl_tax' => $this->order->total_products,
+            'amount_incl_tax' => $this->order->total_products_wt,
+            'value_excl_tax' => $this->priceFormatter->format(
+                $this->order->total_products,
+                Currency::getCurrencyInstance((int) $this->order->id_currency)
+            ),
+            'value_incl_tax' => $this->priceFormatter->format(
+                $this->order->total_products_wt,
+                Currency::getCurrencyInstance((int) $this->order->id_currency)
+            ),
         ];
     }
 
@@ -143,6 +153,16 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
                     Currency::getCurrencyInstance((int) $this->order->id_currency)
                 )
                     : $this->translator->trans('Free', [], 'Shop.Theme.Checkout'),
+                'amount_excl_tax' => $this->order->total_shipping_tax_excl,
+                'amount_incl_tax' => $this->order->total_shipping_tax_incl,
+                'value_excl_tax' => $shippingCost != 0 ? $this->priceFormatter->format(
+                    $this->order->total_shipping_tax_excl,
+                    Currency::getCurrencyInstance((int) $this->order->id_currency)
+                ) : $this->translator->trans('Free', [], 'Shop.Theme.Checkout'),
+                'value_incl_tax' => $shippingCost != 0 ? $this->priceFormatter->format(
+                    $this->order->total_shipping_tax_incl,
+                    Currency::getCurrencyInstance((int) $this->order->id_currency)
+                ) : $this->translator->trans('Free', [], 'Shop.Theme.Checkout'),
             ];
         }
 

--- a/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderSubtotalLazyArray.php
@@ -164,11 +164,7 @@ class OrderSubtotalLazyArray extends AbstractLazyArray
                     'type' => 'shipping_including_tax',
                     'label' => $this->translator->trans('Shipping and handling (tax incl.)', [], 'Shop.Theme.Checkout'),
                     'amount' => $this->order->total_shipping_tax_incl,
-                    'value' => $this->priceFormatter->format(
-                        $this->order->total_products_wt,
-                        Currency::getCurrencyInstance((int) $this->order->id_currency)
-                    ),
-                    'value_incl_tax' => $shippingCost != 0 ? $this->priceFormatter->format(
+                    'value' => $shippingCost != 0 ? $this->priceFormatter->format(
                         $this->order->total_shipping_tax_incl,
                         Currency::getCurrencyInstance((int) $this->order->id_currency)
                     ) : $this->translator->trans('Free', [], 'Shop.Theme.Checkout'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | To freely display all price values with or without taxes these ones are missing. <br> Seems to be common in other classes like Cart, Product and so on.
| Type?             | improvement / consistency
| Category?         | FO
| BC breaks?        | ?
| Deprecations?     | no
| Fixed ticket?     | Fixes #27652.
| How to test?      | In Classic Theme find `/templates/checkout/_partials/order-confirmation-table.tpl`. Inside the file find `{foreach $subtotals as $subtotal}`. Add `{$subtotal.amount_excl_tax\|var_dump}`, `{$subtotal.value_excl_tax\|var_dump}`, `{$subtotal.value_incl_tax\|var_dump}`, `{$subtotal.value_incl_tax\|var_dump}`. Purchase and see the Order Confirmation Table afterwards.
| Possible impacts? | There may be necessary adoptions to the variables at the Order Page because it includes the same tpl file with differing variables.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27653)
<!-- Reviewable:end -->
