### PR TITLE
Deprecate cleanNonUnicodeSupport function

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3859,7 +3859,7 @@ exit;
     /**
      * Delete unicode class from regular expression patterns.
      *
-     * @deprecated The use of cleanNonUnicodeSupport is not required
+     * @deprecated Since 8.0.0 and will be removed in the next major.
      *
      * @param string $pattern
      *
@@ -3869,7 +3869,13 @@ exit;
      */
     public static function cleanNonUnicodeSupport($pattern)
     {
-        Tools::displayAsDeprecated('The use of cleanNonUnicodeSupport is not required');
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.0.0. Its use is not required.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
 
         return $pattern;
     }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -26,12 +26,10 @@
 use Composer\CaBundle\CaBundle;
 use PHPSQLParser\PHPSQLParser;
 use PrestaShop\PrestaShop\Adapter\ContainerFinder;
-use PrestaShop\PrestaShop\Core\Exception\ContainerNotFoundException;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem as PsFileSystem;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
-use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
@@ -3861,7 +3859,7 @@ exit;
     /**
      * Delete unicode class from regular expression patterns.
      *
-     * @deprecated Use PrestaShop\PrestaShop\Core\String\CharacterCleaner::cleanNonUnicodeSupport() instead
+     * @deprecated The use of cleanNonUnicodeSupport is not required
      *
      * @param string $pattern
      *
@@ -3871,17 +3869,9 @@ exit;
      */
     public static function cleanNonUnicodeSupport($pattern)
     {
-        $context = Context::getContext();
-        $containerFinder = new ContainerFinder($context);
-        try {
-            $container = $containerFinder->getContainer();
-            $characterCleaner = $container->get('prestashop.core.string.character_cleaner');
-        } catch (ContainerNotFoundException $e) {
-            // Used when the container is not generated
-            $characterCleaner = new CharacterCleaner();
-        }
+        Tools::displayAsDeprecated('The use of cleanNonUnicodeSupport is not required');
 
-        return $characterCleaner->cleanNonUnicodeSupport($pattern);
+        return $pattern;
     }
 
     /**

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CustomerName;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Factory\CustomerNameValidatorFactory;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\NumericIsoCode;
 use PrestaShop\PrestaShop\Core\Email\SwiftMailerValidation;
-use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use Symfony\Component\Validator\Validation;
 
 class ValidateCore
@@ -170,7 +169,7 @@ class ValidateCore
      */
     public static function isCarrierName($name)
     {
-        return empty($name) || preg_match(Tools::cleanNonUnicodeSupport('/^[^<>;=#{}]*$/u'), $name);
+        return empty($name) || preg_match('/^[^<>;=#{}]*$/u', $name);
     }
 
     /**
@@ -195,9 +194,7 @@ class ValidateCore
     public static function isCustomerName($name)
     {
         $validatorBuilder = Validation::createValidatorBuilder();
-        $validatorBuilder->setConstraintValidatorFactory(
-            new CustomerNameValidatorFactory(new CharacterCleaner())
-        );
+        $validatorBuilder->setConstraintValidatorFactory(new CustomerNameValidatorFactory());
         $validator = $validatorBuilder->getValidator();
         $violations = $validator->validate($name, [
             new CustomerName(),
@@ -215,11 +212,7 @@ class ValidateCore
      */
     public static function isName($name)
     {
-        $validityPattern = Tools::cleanNonUnicodeSupport(
-            '/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u'
-        );
-
-        return preg_match($validityPattern, $name);
+        return preg_match('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u', $name);
     }
 
     /**
@@ -243,7 +236,7 @@ class ValidateCore
      */
     public static function isMailName($mail_name)
     {
-        return is_string($mail_name) && preg_match(Tools::cleanNonUnicodeSupport('/^[^<>;=#{}]*$/u'), $mail_name);
+        return is_string($mail_name) && preg_match('/^[^<>;=#{}]*$/u', $mail_name);
     }
 
     /**
@@ -255,7 +248,7 @@ class ValidateCore
      */
     public static function isMailSubject($mail_subject)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^<>]*$/u'), $mail_subject);
+        return preg_match('/^[^<>]*$/u', $mail_subject);
     }
 
     /**
@@ -366,7 +359,7 @@ class ValidateCore
      */
     public static function isDiscountName($voucher)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^!<>,;?=+()@"°{}_$%:]{3,32}$/u'), $voucher);
+        return preg_match('/^[^!<>,;?=+()@"°{}_$%:]{3,32}$/u', $voucher);
     }
 
     /**
@@ -378,7 +371,7 @@ class ValidateCore
      */
     public static function isCatalogName($name)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^<>;=#{}]*$/u'), $name);
+        return preg_match('/^[^<>;=#{}]*$/u', $name);
     }
 
     /**
@@ -415,7 +408,7 @@ class ValidateCore
     public static function isLinkRewrite($link)
     {
         if (Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL')) {
-            return preg_match(Tools::cleanNonUnicodeSupport('/^[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]+$/u'), $link);
+            return preg_match('/^[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]+$/u', $link);
         }
 
         return preg_match('/^[_a-zA-Z0-9\-]+$/', $link);
@@ -431,7 +424,7 @@ class ValidateCore
     public static function isRoutePattern($pattern)
     {
         if (Configuration::get('PS_ALLOW_ACCENTED_CHARS_URL')) {
-            return preg_match(Tools::cleanNonUnicodeSupport('/^[_a-zA-Z0-9\x{0600}-\x{06FF}\(\)\.{}:\/\pL\pS-]+$/u'), $pattern);
+            return preg_match('/^[_a-zA-Z0-9\x{0600}-\x{06FF}\(\)\.{}:\/\pL\pS-]+$/u', $pattern);
         }
 
         return preg_match('/^[_a-zA-Z0-9\(\)\.{}:\/\-]+$/', $pattern);
@@ -446,7 +439,7 @@ class ValidateCore
      */
     public static function isAddress($address)
     {
-        return empty($address) || preg_match(Tools::cleanNonUnicodeSupport('/^[^!<>?=+@{}_$%]*$/u'), $address);
+        return empty($address) || preg_match('/^[^!<>?=+@{}_$%]*$/u', $address);
     }
 
     /**
@@ -458,7 +451,7 @@ class ValidateCore
      */
     public static function isCityName($city)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^!<>;?=+@#"°{}_$%]*$/u'), $city);
+        return preg_match('/^[^!<>;?=+@#"°{}_$%]*$/u', $city);
     }
 
     /**
@@ -470,7 +463,7 @@ class ValidateCore
      */
     public static function isValidSearch($search)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^<>;=#{}]{0,64}$/u'), $search);
+        return preg_match('/^[^<>;=#{}]{0,64}$/u', $search);
     }
 
     /**
@@ -482,7 +475,7 @@ class ValidateCore
      */
     public static function isGenericName($name)
     {
-        return empty($name) || preg_match(Tools::cleanNonUnicodeSupport('/^[^<>={}]*$/u'), $name);
+        return empty($name) || preg_match('/^[^<>={}]*$/u', $name);
     }
 
     /**
@@ -522,7 +515,7 @@ class ValidateCore
      */
     public static function isReference($reference)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^<>;={}]*$/u'), $reference);
+        return preg_match('/^[^<>;={}]*$/u', $reference);
     }
 
     /**
@@ -799,7 +792,7 @@ class ValidateCore
      */
     public static function isTagsList($list)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^!<>;?=+#"°{}_$%]*$/u'), $list);
+        return preg_match('/^[^!<>;?=+#"°{}_$%]*$/u', $list);
     }
 
     /**
@@ -904,7 +897,7 @@ class ValidateCore
      */
     public static function isUrl($url)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[~:#,$%&_=\(\)\.\? \+\-@\/a-zA-Z0-9\pL\pS-]+$/u'), $url);
+        return preg_match('/^[~:#,$%&_=\(\)\.\? \+\-@\/a-zA-Z0-9\pL\pS-]+$/u', $url);
     }
 
     /**
@@ -954,13 +947,13 @@ class ValidateCore
 
     public static function isUnixName($data)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[a-z0-9\._-]+$/ui'), $data);
+        return preg_match('/^[a-z0-9\._-]+$/ui', $data);
     }
 
     public static function isTablePrefix($data)
     {
         // Even if "-" is theorically allowed, it will be considered a syntax error if you do not add backquotes (`) around the table name
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[a-z0-9_]+$/ui'), $data);
+        return preg_match('/^[a-z0-9_]+$/ui', $data);
     }
 
     /**
@@ -996,7 +989,7 @@ class ValidateCore
      */
     public static function isTabName($name)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^<>]+$/u'), $name);
+        return preg_match('/^[^<>]+$/u', $name);
     }
 
     public static function isWeightUnit($unit)
@@ -1040,7 +1033,7 @@ class ValidateCore
      */
     public static function isLabel($label)
     {
-        return preg_match(Tools::cleanNonUnicodeSupport('/^[^{}<>]*$/u'), $label);
+        return preg_match('/^[^{}<>]*$/u', $label);
     }
 
     /**
@@ -1259,7 +1252,7 @@ class ValidateCore
 
     public static function isControllerName($name)
     {
-        return (bool) (is_string($name) && preg_match(Tools::cleanNonUnicodeSupport('/^[0-9a-zA-Z-_]*$/u'), $name));
+        return (bool) (is_string($name) && preg_match('/^[0-9a-zA-Z-_]*$/u', $name));
     }
 
     public static function isPrestaShopVersion($version)

--- a/controllers/admin/AdminCustomerThreadsController.php
+++ b/controllers/admin/AdminCustomerThreadsController.php
@@ -1078,7 +1078,7 @@ class AdminCustomerThreadsControllerCore extends AdminController
                         // parse from attribute and fix it if needed
                         $from_parsed = [];
                         if (!isset($overview->from)
-                            || (!preg_match('/<(' . Tools::cleanNonUnicodeSupport('[a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+[._a-z\p{L}0-9-]*\.[a-z0-9]+') . ')>/', $overview->from, $from_parsed)
+                            || (!preg_match('/<([a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]+[.a-z\p{L}0-9!#$%&\'*+\/=?^`{}|~_-]*@[a-z\p{L}0-9]+[._a-z\p{L}0-9-]*\.[a-z0-9]+)>/', $overview->from, $from_parsed)
                             && !Validate::isEmail($overview->from))) {
                             $message_errors[] = $this->trans('Cannot create message in a new thread.', [], 'Admin.Orderscustomers.Notification');
 

--- a/src/Adapter/Tools.php
+++ b/src/Adapter/Tools.php
@@ -248,6 +248,8 @@ class Tools
     /**
      * Delete unicode class from regular expression patterns.
      *
+     * @deprecated since version 8.0.0, to be removed.
+     *
      * @param string $pattern
      *
      * @return string pattern

--- a/src/Adapter/Tools.php
+++ b/src/Adapter/Tools.php
@@ -248,7 +248,7 @@ class Tools
     /**
      * Delete unicode class from regular expression patterns.
      *
-     * @deprecated since version 8.0.0, to be removed.
+     * @deprecated Since 8.0.0 and will be removed in the next major.
      *
      * @param string $pattern
      *

--- a/src/Core/ConstraintValidator/CustomerNameValidator.php
+++ b/src/Core/ConstraintValidator/CustomerNameValidator.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\ConstraintValidator;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CustomerName;
-use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -39,19 +38,6 @@ class CustomerNameValidator extends ConstraintValidator
 {
     public const PATTERN_NAME = '/^(?!\s*$)(?:[^0-9!<>,;?=+()\/\\\\@#"°*`{}_^$%:¤\[\]|\.。]|[。\.](?:\s|$))*$/u';
     public const PATTERN_DOT_SPACED = '/[\.。](\s{1}[^\ ]|$)/';
-
-    /**
-     * @var CharacterCleaner
-     */
-    private $characterCleaner;
-
-    /**
-     * @param CharacterCleaner $characterCleaner
-     */
-    public function __construct(CharacterCleaner $characterCleaner)
-    {
-        $this->characterCleaner = $characterCleaner;
-    }
 
     /**
      * {@inheritdoc}
@@ -82,9 +68,7 @@ class CustomerNameValidator extends ConstraintValidator
      */
     private function isNameValid($name)
     {
-        $pattern = $this->characterCleaner->cleanNonUnicodeSupport(self::PATTERN_NAME);
-
-        return (bool) preg_match($pattern, $name);
+        return (bool) preg_match(self::PATTERN_NAME, $name);
     }
 
     /**
@@ -99,8 +83,7 @@ class CustomerNameValidator extends ConstraintValidator
         if (mb_strpos($name, '.') === false && mb_strpos($name, '。') === false) {
             return true;
         }
-        $pattern = $this->characterCleaner->cleanNonUnicodeSupport(self::PATTERN_DOT_SPACED);
 
-        return (bool) preg_match($pattern, $name);
+        return (bool) preg_match(self::PATTERN_DOT_SPACED, $name);
     }
 }

--- a/src/Core/ConstraintValidator/CustomerNameValidator.php
+++ b/src/Core/ConstraintValidator/CustomerNameValidator.php
@@ -32,7 +32,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
- * Class CustomerNameValidator is responsilbe for doing the actual validation under CustomerName constraint.
+ * Class CustomerNameValidator is responsible for doing the actual validation under the CustomerName constraint.
  */
 class CustomerNameValidator extends ConstraintValidator
 {

--- a/src/Core/ConstraintValidator/CustomerNameValidator.php
+++ b/src/Core/ConstraintValidator/CustomerNameValidator.php
@@ -68,7 +68,7 @@ class CustomerNameValidator extends ConstraintValidator
      */
     private function isNameValid($name)
     {
-        return (bool) preg_match(self::PATTERN_NAME, $name);
+        return (bool) preg_match(static::PATTERN_NAME, $name);
     }
 
     /**
@@ -84,6 +84,6 @@ class CustomerNameValidator extends ConstraintValidator
             return true;
         }
 
-        return (bool) preg_match(self::PATTERN_DOT_SPACED, $name);
+        return (bool) preg_match(static::PATTERN_DOT_SPACED, $name);
     }
 }

--- a/src/Core/ConstraintValidator/Factory/CustomerNameValidatorFactory.php
+++ b/src/Core/ConstraintValidator/Factory/CustomerNameValidatorFactory.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\ConstraintValidator\Factory;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\CustomerNameValidator;
-use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
@@ -35,27 +34,12 @@ use Symfony\Component\Validator\ConstraintValidatorInterface;
 class CustomerNameValidatorFactory implements ConstraintValidatorFactoryInterface
 {
     /**
-     * @var CharacterCleaner
-     */
-    private $characterCleaner;
-
-    /**
-     * CustomerNameValidatorFactory constructor.
-     *
-     * @param CharacterCleaner $characterCleaner
-     */
-    public function __construct(CharacterCleaner $characterCleaner)
-    {
-        $this->characterCleaner = $characterCleaner;
-    }
-
-    /**
      * @param Constraint $constraint
      *
      * @return ConstraintValidatorInterface
      */
     public function getInstance(Constraint $constraint)
     {
-        return new CustomerNameValidator($this->characterCleaner);
+        return new CustomerNameValidator();
     }
 }

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Upc;
-use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use ReflectionClass;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -50,19 +49,6 @@ class TypedRegexValidator extends ConstraintValidator
     public const GENERIC_NAME_CHARS = '<>={}';
     public const MESSAGE_CHARS = '<>{}';
     public const NAME_CHARS = '0-9!<>,;?=+()@#"�{}_$%:';
-
-    /**
-     * @var CharacterCleaner
-     */
-    private $characterCleaner;
-
-    /**
-     * @param CharacterCleaner $characterCleaner
-     */
-    public function __construct(CharacterCleaner $characterCleaner)
-    {
-        $this->characterCleaner = $characterCleaner;
-    }
 
     /**
      * {@inheritdoc}
@@ -104,15 +90,15 @@ class TypedRegexValidator extends ConstraintValidator
     {
         switch ($type) {
             case TypedRegex::TYPE_NAME:
-                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u');
+                return '/^[^0-9!<>,;?=+()@#"°{}_$%:¤|]*$/u';
             case TypedRegex::TYPE_CATALOG_NAME:
-                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^<>;=#{}]*$/u');
+                return '/^[^<>;=#{}]*$/u';
             case TypedRegex::TYPE_GENERIC_NAME:
-                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^<>={}]*$/u');
+                return '/^[^<>={}]*$/u';
             case TypedRegex::TYPE_CITY_NAME:
-                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^!<>;?=+@#"°{}_$%]*$/u');
+                return '/^[^!<>;?=+@#"°{}_$%]*$/u';
             case TypedRegex::TYPE_ADDRESS:
-                return $this->characterCleaner->cleanNonUnicodeSupport('/^[^!<>?=+@{}_$%]*$/u');
+                return '/^[^!<>?=+@{}_$%]*$/u';
             case TypedRegex::TYPE_POST_CODE:
                 return '/^[a-zA-Z 0-9-]+$/';
             case TypedRegex::TYPE_PHONE_NUMBER:
@@ -140,7 +126,7 @@ class TypedRegexValidator extends ConstraintValidator
             case TypedRegex::TYPE_MODULE_NAME:
                 return '/^[a-zA-Z0-9_-]+$/';
             case TypedRegex::TYPE_URL:
-                return $this->characterCleaner->cleanNonUnicodeSupport('/^[~:#,$%&_=\(\)\.\? \+\-@\/a-zA-Z0-9\pL\pS-]+$/u');
+                return '/^[~:#,$%&_=\(\)\.\? \+\-@\/a-zA-Z0-9\pL\pS-]+$/u';
             default:
                 $definedTypes = implode(', ', array_values((new ReflectionClass(TypedRegex::class))->getConstants()));
                 throw new InvalidArgumentException(sprintf('Type "%s" is not defined. Defined types are: %s', $type, $definedTypes));

--- a/src/Core/String/CharacterCleaner.php
+++ b/src/Core/String/CharacterCleaner.php
@@ -31,7 +31,7 @@ class CharacterCleaner
     /**
      * Delete unicode class from regular expression patterns.
      *
-     * @deprecated since version 8.0.0, to be removed.
+     * @deprecated Since 8.0.0 and will be removed in the next major.
      *
      * @param string $pattern
      *
@@ -39,7 +39,13 @@ class CharacterCleaner
      */
     public function cleanNonUnicodeSupport($pattern)
     {
-        \Tools::displayAsDeprecated('The use of cleanNonUnicodeSupport is not required');
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.0.0. Its use is not required.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
 
         return $pattern;
     }

--- a/src/Core/String/CharacterCleaner.php
+++ b/src/Core/String/CharacterCleaner.php
@@ -31,16 +31,16 @@ class CharacterCleaner
     /**
      * Delete unicode class from regular expression patterns.
      *
+     * @deprecated since version 8.0.0, to be removed.
+     *
      * @param string $pattern
      *
      * @return string pattern
      */
     public function cleanNonUnicodeSupport($pattern)
     {
-        if (!defined('PREG_BAD_UTF8_OFFSET')) {
-            return $pattern;
-        }
+        \Tools::displayAsDeprecated('The use of cleanNonUnicodeSupport is not required');
 
-        return preg_replace('/\\\[px]\{[a-z]{1,2}\}|(\/[a-z]*)u([a-z]*)$/i', '$1$2', $pattern);
+        return $pattern;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/core/constraint_validator.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/constraint_validator.yml
@@ -18,15 +18,11 @@ services:
 
   prestashop.core.constraint_validator.customer_name_validator:
     class: 'PrestaShop\PrestaShop\Core\ConstraintValidator\CustomerNameValidator'
-    arguments:
-      - '@prestashop.core.string.character_cleaner'
     tags:
       - { name: validator.constraint_validator }
 
   prestashop.core.constraint_validator.typed_regex_validator:
     class: 'PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator'
-    arguments:
-      - '@prestashop.core.string.character_cleaner'
     tags:
       - { name: validator.constraint_validator }
 

--- a/tests/Unit/Core/ConstraintValidator/CustomerNameValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/CustomerNameValidatorTest.php
@@ -26,10 +26,8 @@
 
 namespace Tests\Unit\Core\ConstraintValidator;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CustomerName;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\CustomerNameValidator;
-use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class CustomerNameValidatorTest extends ConstraintValidatorTestCase
@@ -162,21 +160,6 @@ class CustomerNameValidatorTest extends ConstraintValidatorTestCase
 
     protected function createValidator()
     {
-        return new CustomerNameValidator($this->createCharacterCleanerMock());
-    }
-
-    /**
-     * @return MockObject|CharacterCleaner
-     */
-    private function createCharacterCleanerMock()
-    {
-        $toolsMock = $this->getMockBuilder(CharacterCleaner::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $toolsMock
-            ->method('cleanNonUnicodeSupport')
-            ->will($this->returnArgument(0));
-
-        return $toolsMock;
+        return new CustomerNameValidator();
     }
 }

--- a/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
@@ -27,10 +27,8 @@
 namespace Tests\Unit\Core\ConstraintValidator;
 
 use Generator;
-use PHPUnit\Framework\MockObject\MockObject;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
-use PrestaShop\PrestaShop\Core\String\CharacterCleaner;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class TypedRegexValidatorTest extends ConstraintValidatorTestCase
@@ -603,22 +601,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
      */
     protected function createValidator(): TypedRegexValidator
     {
-        return new TypedRegexValidator($this->createCharacterCleanersMock());
-    }
-
-    /**
-     * @return MockObject|CharacterCleaner
-     */
-    private function createCharacterCleanersMock()
-    {
-        $toolsMock = $this->getMockBuilder(CharacterCleaner::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $toolsMock
-            ->method('cleanNonUnicodeSupport')
-            ->will($this->returnArgument(0));
-
-        return $toolsMock;
+        return new TypedRegexValidator();
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Deprecate cleanNonUnicodeSupport() because it does nothing, it always returns $pattern argument without being modified. It uses a undefined constant: PREG_BAD_UTF8_OFFSET so the behavior is always the same.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | yes
| Fixed ticket?     | Fixes #27362
| How to test?      | CI green
| Possible impacts? | NO

BC Breaks :
- `CustomerNameValidator` constructor no longer has params.
  - 1º param `CharacterCleaner $characterCleaner` and `private $characterCleaner;` property removed.
- `CustomerNameValidatorFactory` constructor no longer has params.
  - 1º param `CharacterCleaner $characterCleaner` and `private $characterCleaner;` property removed.
- `TypedRegexValidator` constructor no longer has params.
  - 1º param `CharacterCleaner $characterCleaner` and `private $characterCleaner;` property removed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27657)
<!-- Reviewable:end -->
