### PR TITLE
In Import Page, allow all languages (active and inactive)

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -453,8 +453,10 @@ services:
 
   form.type.import.import:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Import\ImportType'
-    parent: 'form.type.translatable.aware'
     public: true
+    arguments:
+      - '@translator'
+      - '@=service("prestashop.adapter.legacy.context").getLanguages(false)'
     tags:
       - { name: form.type }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In Import Page, allow all languages (active and inactive)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #15334
| How to test?      | * Turn off some of the languages installed on the shop<br>* Go to Advanced Parameters -> Import<br>* **BEFORE:** See error - only active languages are available to select<br>* **AFTER:** All languages are available

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27697)
<!-- Reviewable:end -->
