### PR TITLE
Refactor gelocation configuration form before it can be migrated as multistore compatible

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsFormDataProvider.php
@@ -72,7 +72,13 @@ final class GeolocationOptionsFormDataProvider implements FormDataProviderInterf
      */
     public function getData()
     {
-        return $this->dataConfiguration->getConfiguration();
+        $configuration = $this->dataConfiguration->getConfiguration();
+
+        if (!empty($configuration['geolocation_countries'])) {
+            $configuration['geolocation_countries'] = explode(';', $configuration['geolocation_countries']);
+        }
+
+        return $configuration;
     }
 
     /**
@@ -93,6 +99,8 @@ final class GeolocationOptionsFormDataProvider implements FormDataProviderInterf
         if (!empty($errors)) {
             return $errors;
         }
+
+        $data['geolocation_countries'] = implode(';', $data['geolocation_countries']);
 
         return $this->dataConfiguration->updateConfiguration($data);
     }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsFormDataProvider.php
@@ -76,6 +76,8 @@ final class GeolocationOptionsFormDataProvider implements FormDataProviderInterf
 
         if (!empty($configuration['geolocation_countries'])) {
             $configuration['geolocation_countries'] = explode(';', $configuration['geolocation_countries']);
+        } else {
+            $configuration['geolocation_countries'] = [];
         }
 
         return $configuration;

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
@@ -105,14 +105,5 @@ class GeolocationOptionsType extends TranslatorAwareType
                 'choices' => $this->countryChoices,
                 'choice_translation_domain' => false,
             ]);
-
-        $builder->get('geolocation_countries')->addModelTransformer(new CallbackTransformer(
-            function ($countriesAsString) {
-                return explode(';', $countriesAsString);
-            },
-            function ($countriesAsArray) {
-                return implode(';', $countriesAsArray);
-            }
-        ));
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Geolocation/GeolocationOptionsType.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Form\Admin\Improve\International\Geolocation;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -81,6 +81,7 @@ services:
       - '@prestashop.adapter.legacy.configuration'
       - '@prestashop.adapter.shop.context'
       - '@prestashop.core.admin.multistore'
+      - '@form.form_cloner'
 
   form.extension.downloadable_file:
     class: 'PrestaShopBundle\Form\Admin\Extension\DownloadFileExtension'

--- a/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
+++ b/src/PrestaShopBundle/Service/Form/MultistoreCheckboxEnabler.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Controller\Admin\MultistoreController;
+use PrestaShopBundle\Form\FormCloner;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormInterface;
 
@@ -76,23 +77,31 @@ class MultistoreCheckboxEnabler
     private $multistoreController;
 
     /**
+     * @var FormCloner
+     */
+    private $formCloner;
+
+    /**
      * MultistoreCheckboxEnabler constructor.
      *
      * @param FeatureInterface $multistoreFeature
      * @param ShopConfigurationInterface $configuration
      * @param Context $multiStoreContext
      * @param MultistoreController $multistoreController
+     * @param FormCloner $formCloner
      */
     public function __construct(
         FeatureInterface $multistoreFeature,
         ShopConfigurationInterface $configuration,
         Context $multiStoreContext,
-        MultistoreController $multistoreController
+        MultistoreController $multistoreController,
+        FormCloner $formCloner
     ) {
         $this->multistoreFeature = $multistoreFeature;
         $this->configuration = $configuration;
         $this->multiStoreContext = $multiStoreContext;
         $this->multistoreController = $multistoreController;
+        $this->formCloner = $formCloner;
     }
 
     /**
@@ -166,12 +175,10 @@ class MultistoreCheckboxEnabler
             )->getContent();
         }
 
-        // update field
-        $form->add(
-            $childElement->getName(),
-            get_class($childElement->getConfig()->getType()->getInnerType()),
-            $options
-        );
+        // clone the field so that we keep all existing options, model transformers, listeners, etc...
+        $clonedField = $this->formCloner->cloneForm($form->get($childElement->getName()), $options);
+
+        $form->add($clonedField);
     }
 
     /**

--- a/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Form/MultistoreCheckboxEnablerTest.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Controller\Admin\MultistoreController;
 use PrestaShopBundle\Form\Admin\Extension\MultistoreExtension;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\FormCloner;
 use PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Forms;
@@ -60,7 +61,8 @@ class MultistoreCheckboxEnablerTest extends TypeTestCase
             $this->createMultistoreFeatureMock($isMultistoreUsed),
             $this->mockedShopConfiguration,
             $this->createMultistoreContextMock($isAllShopContext),
-            $this->createMultistoreControllerMock()
+            $this->createMultistoreControllerMock(),
+            new FormCloner()
         );
 
         $this->assertEquals($expectedValue, $checkboxEnabler->shouldAddMultistoreElements());
@@ -89,7 +91,8 @@ class MultistoreCheckboxEnablerTest extends TypeTestCase
             $this->createMultistoreFeatureMock(),
             $this->mockedShopConfiguration,
             $this->createMultistoreContextMock(),
-            $this->createMultistoreControllerMock()
+            $this->createMultistoreControllerMock(),
+            new FormCloner()
         );
 
         $checkboxEnabler->addMultistoreElements($form);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the `GeolocationOptionsType` form type, there was a model transformer that would transform a list of country codes into an array (for frontend) and vice versa (for saving in DB). In a multistore context, this model transformer would be canceled. To circumvent this issue I cloned the fields instead of simply overriding them inside `MultistoreCheckboxEnabler', I also moved the data transformation logic into the data provider, which is better than doing this in the form type...
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #27540
| How to test?      | Check that the configuration form in Localization -> Geolocation still works as usual, especially the country list field. There is no bug to check because it fixes an issue that will only happen once this PR is merged: #27538
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27700)
<!-- Reviewable:end -->
