### PR TITLE
Add hooks to retrieve module on install/upgrade from external source

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/configure.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/configure.tpl
@@ -101,7 +101,7 @@
 					<div>{l s='Manage hooks' d='Admin.Modules.Feature'}</div>
 				</a>
 			</li>
-			{hook h="displayModuleConfigureExtraButtons"}
+			{hook h="displayModuleConfigureExtraButtons" name={$module_name}}
 		</ul>
 	</div>
 </div>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3555,5 +3555,15 @@
       <title>Show custom content before checkout confirmation</title>
       <description>This hook allows you to display custom content at the end of checkout process</description>
     </hook>
+    <hook id="actionAdminModuleInstallRetrieveSource">
+      <name>actionAdminModuleInstallRetrieveSource</name>
+      <title>Module Install - Get source from other module</title>
+      <description>This hook retrieves a module zip on install process in the BackOffice</description>
+    </hook>
+    <hook id="actionAdminModuleUpgradeRetrieveSource">
+      <name>actionAdminModuleUpgradeRetrieveSource</name>
+      <title>Module Upgrade - Get source from other module</title>
+      <description>This hook retrieves a module zip on upgrade process in the BackOffice</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -296,7 +296,7 @@ class ModuleManager implements AddonManagerInterface
             return $this->upgrade($name, 'latest', $source);
         }
 
-        // The module is not in PS modules folder and no ZIP is given as source
+        // The module is not in modules folder and no ZIP is given as source
         // We try to retrieve the module's zip from another module (marketplace)
         if (!$this->moduleProvider->isOnDisk($name) && empty($source)) {
             // Give a chance to the other modules (like marketplace) to download the module

--- a/src/Core/Addon/Module/ModuleManager.php
+++ b/src/Core/Addon/Module/ModuleManager.php
@@ -304,8 +304,14 @@ class ModuleManager implements AddonManagerInterface
                 'actionAdminModuleInstallRetrieveSource',
                 [
                     'name' => $name,
-                ]
+                ],
+                null,
+                true
             );
+
+            if (is_array($sourceZip)) {
+                $sourceZip = array_values($sourceZip)[0];
+            }
 
             // We need to check that the file is actually a module's ZIP and the same module as the one expected
             if (is_file($sourceZip)) {
@@ -413,13 +419,27 @@ class ModuleManager implements AddonManagerInterface
 
         if ($source === null) {
             // Give a chance to the other modules (like marketplace) to retrieve the module source
-            $source = $this->hookManager->exec(
+            $sourceZip = $this->hookManager->exec(
                 'actionAdminModuleUpgradeRetrieveSource',
                 [
                     'name' => $name,
                     'current_version' => $module->get('version'),
-                ]
+                ],
+                null,
+                true
             );
+
+            if (is_array($sourceZip)) {
+                $sourceZip = array_values($sourceZip)[0];
+            }
+
+            // We need to check that the file is actually a module's ZIP and the same module as the one expected
+            if (is_file($sourceZip)) {
+                $moduleInZipName = $this->moduleZipManager->getName($sourceZip);
+                if ($name === $moduleInZipName) {
+                    $source = $sourceZip;
+                }
+            }
         }
 
         if (empty($source)) {

--- a/src/Core/Addon/Module/ModuleManagerBuilder.php
+++ b/src/Core/Addon/Module/ModuleManagerBuilder.php
@@ -31,6 +31,7 @@ use Context;
 use Db;
 use PrestaShop\PrestaShop\Adapter\Cache\Clearer;
 use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
@@ -112,7 +113,8 @@ class ModuleManagerBuilder
                     self::$moduleZipManager,
                     self::$translator,
                     new NullDispatcher(),
-                    new Clearer\SymfonyCacheClearer()
+                    new Clearer\SymfonyCacheClearer(),
+                    new HookManager()
                 );
             }
         }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/hook.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/hook.yml
@@ -13,3 +13,6 @@ services:
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetHookStatus
+
+  prestashop.adapter.hook.manager:
+    class: PrestaShop\PrestaShop\Adapter\HookManager

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -49,6 +49,8 @@ services:
       - "@translator"
       - "@event_dispatcher"
       - "@prestashop.adapter.cache.clearer.symfony_cache_clearer"
+      - '@prestashop.adapter.hook.manager'
+
 
   prestashop.module.zip.manager:
     class: PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -28,27 +28,79 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Core\Addon\Module;
 
+use Employee;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\HookManager;
+use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
+use PrestaShop\PrestaShop\Adapter\Module\Module;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater;
+use PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManager;
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
+use Symfony\Component\Translation\Translator;
 
 class ModuleManagerTest extends TestCase
 {
     const UNINSTALLED_MODULE = 'uninstalled-module';
     const INSTALLED_MODULE = 'installed-module';
 
+    /**
+     * @var ModuleManager|null
+     */
     private $moduleManager;
-    private $adminModuleProviderS;
-    private $moduleProviderS; // S means "Stub"
+
+    /**
+     * @var AdminModuleDataProvider|MockObject|null
+     */
+    private $adminModuleProviderS; // S means "Stub"
+
+    /**
+     * @var ModuleDataProvider|MockObject|null
+     */
+    private $moduleProviderS;
+
+    /**
+     * @var ModuleDataUpdater|MockObject|null
+     */
     private $moduleUpdaterS;
+
+    /**
+     * @var ModuleRepository|MockObject|null
+     */
     private $moduleRepositoryS;
+
+    /**
+     * @var ModuleZipManager|MockObject|null
+     */
     private $moduleZipManagerS;
+
+    /**
+     * @var Translator|MockObject|null
+     */
     private $translatorS;
+
+    /**
+     * @var NullDispatcher|MockObject|null
+     */
     private $dispatcherS;
+
+    /**
+     * @var Employee|MockObject|null
+     */
     private $employeeS;
+
+    /**
+     * @var CacheClearerInterface|MockObject|null
+     */
     private $cacheClearerS;
+
+    /**
+     * @var HookManager|MockObject|null
+     */
     private $hookManagerS;
 
     protected function setUp(): void
@@ -179,7 +231,7 @@ class ModuleManagerTest extends TestCase
 
     private function mockAdminModuleProvider(): void
     {
-        $this->adminModuleProviderS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider')
+        $this->adminModuleProviderS = $this->getMockBuilder(AdminModuleDataProvider::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -204,7 +256,7 @@ class ModuleManagerTest extends TestCase
                 'configure', self::UNINSTALLED_MODULE, false,
             ],
         ];
-        $this->moduleProviderS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider')
+        $this->moduleProviderS = $this->getMockBuilder(ModuleDataProvider::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -240,7 +292,7 @@ class ModuleManagerTest extends TestCase
 
     private function mockModuleUpdater(): void
     {
-        $this->moduleUpdaterS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\ModuleDataUpdater')
+        $this->moduleUpdaterS = $this->getMockBuilder(ModuleDataUpdater::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->moduleUpdaterS
@@ -253,7 +305,7 @@ class ModuleManagerTest extends TestCase
 
     private function mockModuleRepository(): void
     {
-        $moduleS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\Module')
+        $moduleS = $this->getMockBuilder(Module::class)
             ->setConstructorArgs([[], [], []])
             ->getMock();
         $moduleS
@@ -284,7 +336,7 @@ class ModuleManagerTest extends TestCase
             ->method('onMobileEnable')
             ->willReturn(true);
 
-        $this->moduleRepositoryS = $this->getMockBuilder('PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository')
+        $this->moduleRepositoryS = $this->getMockBuilder(ModuleRepository::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -295,7 +347,7 @@ class ModuleManagerTest extends TestCase
 
     private function mockModuleZipManager(): void
     {
-        $this->moduleZipManagerS = $this->getMockBuilder('PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager')
+        $this->moduleZipManagerS = $this->getMockBuilder(ModuleZipManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -309,7 +361,7 @@ class ModuleManagerTest extends TestCase
 
     private function mockTranslator(): void
     {
-        $this->translatorS = $this->getMockBuilder('Symfony\Component\Translation\Translator')
+        $this->translatorS = $this->getMockBuilder(Translator::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -338,7 +390,7 @@ class ModuleManagerTest extends TestCase
     private function mockEmployee(): void
     {
         /* this is a super admin */
-        $this->employeeS = $this->getMockBuilder('Employee')
+        $this->employeeS = $this->getMockBuilder(Employee::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -357,5 +409,6 @@ class ModuleManagerTest extends TestCase
         $this->translatorS = null;
         $this->dispatcherS = null;
         $this->employeeS = null;
+        $this->hookManagerS = null;
     }
 }

--- a/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Addon/Module/ModuleManagerTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Addon\Module;
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManager;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
@@ -48,6 +49,7 @@ class ModuleManagerTest extends TestCase
     private $dispatcherS;
     private $employeeS;
     private $cacheClearerS;
+    private $hookManagerS;
 
     protected function setUp(): void
     {
@@ -61,7 +63,8 @@ class ModuleManagerTest extends TestCase
             $this->moduleZipManagerS,
             $this->translatorS,
             $this->dispatcherS,
-            $this->cacheClearerS
+            $this->cacheClearerS,
+            $this->hookManagerS
         );
     }
 
@@ -171,6 +174,7 @@ class ModuleManagerTest extends TestCase
         $this->mockDispatcher();
         $this->mockEmployee();
         $this->mockCacheClearer();
+        $this->mockHookManager();
     }
 
     private function mockAdminModuleProvider(): void
@@ -322,6 +326,12 @@ class ModuleManagerTest extends TestCase
     private function mockCacheClearer(): void
     {
         $this->cacheClearerS = $this->getMockBuilder(CacheClearerInterface::class)
+            ->getMock();
+    }
+
+    private function mockHookManager(): void
+    {
+        $this->hookManagerS = $this->getMockBuilder(HookManager::class)
             ->getMock();
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add hooks to allow modules (marketplace) to retrieve source when installing or upgrading a specific module.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27856 and [#MBO-46](https://forge.prestashop.com/browse/MBO-46)
| How to test?      | Can be tested with https://github.com/PrestaShopCorp/ps_mbo/pull/132
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27703)
<!-- Reviewable:end -->


## Breaking changes

- ModuleManager now have an extra parameter HookManager to execute hooks