### PR TITLE
Better french translation for "new" product label

### DIFF
--- a/tests/Resources/translations/fr-FR/messages.fr-FR.xlf
+++ b/tests/Resources/translations/fr-FR/messages.fr-FR.xlf
@@ -1072,7 +1072,7 @@
       </trans-unit>
       <trans-unit id="03c2e7e41ffc181a4e84080b4710e81e" approved="yes">
         <source>New</source>
-        <target state="final">Neuf</target>
+        <target state="final">Nouveauté</target>
         <note>Line: 85</note>
       </trans-unit>
     </body>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      | The word "New" in english refers more naturally to the word "Nouveauté" rather than "Neuf" which could make think that the product not labelled as "New" could be repackaged
| Type?             | improvement
| Category?         | LO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | None.
| How to test?      | It is just a changed word. It should work immediatly.
| Possible impacts? | None.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27714)
<!-- Reviewable:end -->
