### PR TITLE
Product multi shop stock

### DIFF
--- a/admin-dev/themes/new-theme/js/components/modify-all-shops-checkbox/index.ts
+++ b/admin-dev/themes/new-theme/js/components/modify-all-shops-checkbox/index.ts
@@ -102,7 +102,7 @@ export default class ModifyAllShopsCheckbox {
           });
           // We check the event via JQuery as well because some components use internal JQuery event instead of native
           // ones (like select2) And it allows to check all children changes easily
-          $multiShopField.on('change', () => {
+          $multiShopField.on('change dp.change', () => {
             widget.classList.add(MultiShopModifyAllMap.updatedClass);
           });
           // Check for checkbox change also, in case it is modified programmatically

--- a/admin-dev/themes/new-theme/scss/components/_delta_quantity.scss
+++ b/admin-dev/themes/new-theme/scss/components/_delta_quantity.scss
@@ -42,4 +42,12 @@ $component-name: delta-quantity;
     margin: 0 0.3125rem;
     line-height: 39px;
   }
+
+  .modify-all-shops {
+    text-align: right;
+
+    label {
+      line-height: normal;
+    }
+  }
 }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1882,6 +1882,16 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     }
 
     /**
+     * Returns the shop ID used to fetch initial object data.
+     *
+     * @return int
+     */
+    public function getShopId(): int
+    {
+        return (int) $this->id_shop;
+    }
+
+    /**
      * Delete images associated with the object.
      *
      * @param bool $force_delete

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -788,6 +788,10 @@ class ProductCore extends ObjectModel
         }
 
         $id_shop_list = Shop::getContextListShopID();
+        if (count($this->id_shop_list)) {
+            $id_shop_list = $this->id_shop_list;
+        }
+
         if ($this->getType() == Product::PTYPE_VIRTUAL) {
             foreach ($id_shop_list as $value) {
                 StockAvailable::setProductOutOfStock((int) $this->id, OutOfStockType::OUT_OF_STOCK_AVAILABLE, $value);

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -35,7 +35,7 @@ use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Options\RedirectTargetProvider;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
-use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\Repository\VirtualProductFileRepository;
 use PrestaShop\PrestaShop\Adapter\Tax\TaxComputer;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\QueryResult\AttachmentInformation;
@@ -60,6 +60,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductStockInformatio
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\VirtualProductFileNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\QueryResult\VirtualProductFileForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor;
@@ -88,7 +89,7 @@ final class GetProductForEditingHandler implements GetProductForEditingHandlerIn
     private $categoryRepository;
 
     /**
-     * @var StockAvailableRepository
+     * @var StockAvailableMultiShopRepository
      */
     private $stockAvailableRepository;
 
@@ -131,7 +132,7 @@ final class GetProductForEditingHandler implements GetProductForEditingHandlerIn
      * @param NumberExtractor $numberExtractor
      * @param ProductMultiShopRepository $productRepository
      * @param CategoryRepository $categoryRepository
-     * @param StockAvailableRepository $stockAvailableRepository
+     * @param StockAvailableMultiShopRepository $stockAvailableRepository
      * @param VirtualProductFileRepository $virtualProductFileRepository
      * @param ProductImageRepository $productImageRepository
      * @param AttachmentRepository $attachmentRepository
@@ -144,7 +145,7 @@ final class GetProductForEditingHandler implements GetProductForEditingHandlerIn
         NumberExtractor $numberExtractor,
         ProductMultiShopRepository $productRepository,
         CategoryRepository $categoryRepository,
-        StockAvailableRepository $stockAvailableRepository,
+        StockAvailableMultiShopRepository $stockAvailableRepository,
         VirtualProductFileRepository $virtualProductFileRepository,
         ProductImageRepository $productImageRepository,
         AttachmentRepository $attachmentRepository,
@@ -435,10 +436,7 @@ final class GetProductForEditingHandler implements GetProductForEditingHandlerIn
      */
     private function getProductStockInformation(Product $product): ProductStockInformation
     {
-        //@todo: In theory StockAvailable is created for each product when Product::add is called,
-        //  but we should explore some multishop edgecases
-        //  (like shop ids might be missing and foreach loop won't start resulting in a missing StockAvailable for product)
-        $stockAvailable = $this->stockAvailableRepository->getForProduct(new ProductId($product->id));
+        $stockAvailable = $this->stockAvailableRepository->getForProduct(new ProductId($product->id), new ShopId($product->getShopId()));
 
         return new ProductStockInformation(
             (int) $product->pack_stock_type,

--- a/src/Adapter/Product/Stock/CommandHandler/UpdateProductStockInformationHandler.php
+++ b/src/Adapter/Product/Stock/CommandHandler/UpdateProductStockInformationHandler.php
@@ -74,6 +74,7 @@ final class UpdateProductStockInformationHandler implements UpdateProductStockIn
                 $this->movementReasonRepository->getIdForEmployeeEdition($command->getDeltaQuantity() > 0)
             );
         }
+
         $this->productStockUpdater->update(
             $command->getProductId(),
             new ProductStockProperties(
@@ -87,7 +88,8 @@ final class UpdateProductStockInformationHandler implements UpdateProductStockIn
                 $command->getLocalizedAvailableNowLabels(),
                 $command->getLocalizedAvailableLaterLabels(),
                 $command->getAvailableDate()
-            )
+            ),
+            $command->getShopConstraint()
         );
     }
 }

--- a/src/Adapter/Product/Stock/QueryHandler/GetEmployeesStockMovementsHandler.php
+++ b/src/Adapter/Product/Stock/QueryHandler/GetEmployeesStockMovementsHandler.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Stock\QueryHandler;
 
 use DateTime;
-use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockMovementRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Query\GetEmployeesStockMovements;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\QueryHandler\GetEmployeesStockMovementsHandlerInterface;
@@ -38,7 +38,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\QueryResult\EmployeeStockMov
 class GetEmployeesStockMovementsHandler implements GetEmployeesStockMovementsHandlerInterface
 {
     /**
-     * @var StockAvailableRepository
+     * @var StockAvailableMultiShopRepository
      */
     private $stockAvailableRepository;
 
@@ -48,7 +48,7 @@ class GetEmployeesStockMovementsHandler implements GetEmployeesStockMovementsHan
     private $stockMovementRepository;
 
     public function __construct(
-        StockAvailableRepository $stockAvailableRepository,
+        StockAvailableMultiShopRepository $stockAvailableRepository,
         StockMovementRepository $stockMovementRepository
     ) {
         $this->stockAvailableRepository = $stockAvailableRepository;
@@ -60,7 +60,7 @@ class GetEmployeesStockMovementsHandler implements GetEmployeesStockMovementsHan
      */
     public function handle(GetEmployeesStockMovements $query): array
     {
-        $stockId = $this->stockAvailableRepository->getStockIdByProduct($query->getProductId());
+        $stockId = $this->stockAvailableRepository->getStockIdByProduct($query->getProductId(), $query->getShopId());
         $movementsData = $this->stockMovementRepository->getLastEmployeeStockMovements(
             $stockId,
             $query->getOffset(),

--- a/src/Adapter/Product/Stock/Repository/StockAvailableMultiShopRepository.php
+++ b/src/Adapter/Product/Stock/Repository/StockAvailableMultiShopRepository.php
@@ -1,0 +1,290 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Stock\Repository;
+
+use Doctrine\DBAL\Connection;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Validate\StockAvailableValidator;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\NoCombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\CannotAddStockAvailableException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\CannotUpdateStockAvailableException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\StockAvailableNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\InvalidShopConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Repository\AbstractMultiShopObjectModelRepository;
+use PrestaShopException;
+use StockAvailable;
+
+/**
+ * @todo: This class has been added while we progressively migrate each domain to multishop It is used for product
+ *        commands for now it wille need to be integrated in combination commands later At that point both repositories
+ *        can be merged into one (with StockAvailableRepository) which is used everywhere and we can clean the double repositories.
+ */
+class StockAvailableMultiShopRepository extends AbstractMultiShopObjectModelRepository
+{
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
+    /**
+     * @var StockAvailableValidator
+     */
+    private $stockAvailableValidator;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param StockAvailableValidator $stockAvailableValidator
+     */
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        StockAvailableValidator $stockAvailableValidator
+    ) {
+        $this->connection = $connection;
+        $this->dbPrefix = $dbPrefix;
+        $this->stockAvailableValidator = $stockAvailableValidator;
+    }
+
+    /**
+     * @param StockAvailable $stockAvailable
+     * @param ShopConstraint $shopConstraint
+     *
+     * @throws CoreException
+     */
+    public function update(StockAvailable $stockAvailable, ShopConstraint $shopConstraint): void
+    {
+        $this->stockAvailableValidator->validate($stockAvailable);
+
+        $shopIds = $this->getShopIdsByConstraint($stockAvailable, $shopConstraint);
+
+        $this->updateObjectModelForShops(
+            $stockAvailable,
+            $shopIds,
+            CannotUpdateStockAvailableException::class
+        );
+    }
+
+    /**
+     * @param ProductId $productId
+     * @param ShopId $shopId
+     *
+     * @return StockId
+     *
+     * @throws StockAvailableNotFoundException
+     */
+    public function getStockIdByProduct(ProductId $productId, ShopId $shopId): StockId
+    {
+        $stockAvailableId = StockAvailable::getStockAvailableIdByProductId($productId->getValue(), null, $shopId->getValue());
+        if ($stockAvailableId <= 0) {
+            throw new StockAvailableNotFoundException(sprintf(
+                    'Cannot find StockAvailable for product #%d',
+                    $productId->getValue()
+                )
+            );
+        }
+
+        return new StockId($stockAvailableId);
+    }
+
+    /**
+     * @param ProductId $productId
+     * @param ShopId $shopId
+     *
+     * @return StockAvailable
+     *
+     * @throws CoreException
+     * @throws StockAvailableNotFoundException
+     */
+    public function getForProduct(ProductId $productId, ShopId $shopId): StockAvailable
+    {
+        $stockId = $this->getStockIdByProduct($productId, $shopId);
+
+        return $this->getStockAvailable($stockId);
+    }
+
+    /**
+     * @param CombinationId $combinationId
+     *
+     * @return StockAvailable
+     *
+     * @throws CoreException
+     * @throws StockAvailableNotFoundException
+     */
+    public function getForCombination(CombinationId $combinationId, ShopId $shopId): StockAvailable
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('id_stock_available')
+            ->from($this->dbPrefix . 'stock_available')
+            ->where('id_product_attribute = :combinationId')
+            ->andWhere('id_shop = :shopId')
+            ->setParameter('combinationId', $combinationId->getValue())
+            ->setParameter('shopId', $shopId->getValue())
+        ;
+
+        $result = $qb->execute()->fetch();
+
+        if (!$result) {
+            throw new StockAvailableNotFoundException(sprintf(
+                    'Cannot find StockAvailable for combination #%d',
+                    $combinationId->getValue()
+                )
+            );
+        }
+
+        return $this->getStockAvailable(new StockId((int) $result['id_stock_available']));
+    }
+
+    /**
+     * @param ProductId $productId
+     *
+     * @return StockAvailable
+     *
+     * @throws CoreException
+     * @throws StockAvailableNotFoundException
+     */
+    public function createProductStock(ProductId $productId, ShopId $shopId): StockAvailable
+    {
+        $stockAvailable = new StockAvailable();
+        $stockAvailable->id_product = $productId->getValue();
+        $stockAvailable->id_product_attribute = NoCombinationId::NO_COMBINATION_ID;
+
+        // Use legacy method, it checks if the shop belongs to a ShopGroup that shares stock, in which case the StockAvailable
+        // must be assigned to the group not the shop
+        $shopParams = [];
+        try {
+            StockAvailable::addSqlShopParams($shopParams, $shopId->getValue());
+        } catch (PrestaShopException $e) {
+            throw new CoreException(
+                sprintf('Error occurred when trying to add StockAvailable shop params #%d', $productId->getValue()),
+                0,
+                $e
+            );
+        }
+
+        $stockAvailable->id_shop = $shopParams['id_shop'] ?? 0;
+        $stockAvailable->id_shop_group = $shopParams['id_shop_group'] ?? 0;
+        $this->addObjectModel($stockAvailable, CannotAddStockAvailableException::class);
+
+        return $stockAvailable;
+    }
+
+    /**
+     * @param StockId $stockId
+     *
+     * @return ShopId[]
+     */
+    public function getAssociatedShopIds(StockId $stockId): array
+    {
+        $subQb = $this->connection->createQueryBuilder();
+        $subQb
+            ->select('CONCAT(sa.id_product, "-", sa.id_product_attribute)')
+            ->from($this->dbPrefix . 'stock_available', 'sa')
+            ->where('sa.id_stock_available = :stockId')
+            ->setParameter('stockId', $stockId->getValue())
+        ;
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb
+            ->select('id_shop')
+            ->from($this->dbPrefix . 'stock_available')
+            ->where($qb->expr()->eq(
+                'CONCAT(sa.id_product, "-", sa.id_product_attribute)',
+                $subQb->getSQL()
+            ))
+        ;
+
+        $result = $qb->execute()->fetchAll();
+        if (empty($result)) {
+            return [];
+        }
+
+        $shops = [];
+        foreach ($result as $shop) {
+            $shops[] = new ShopId((int) $shop['id_shop']);
+        }
+
+        return $shops;
+    }
+
+    /**
+     * @param StockAvailable $stockAvailable
+     * @param ShopConstraint $shopConstraint
+     *
+     * @return int[]
+     */
+    private function getShopIdsByConstraint(StockAvailable $stockAvailable, ShopConstraint $shopConstraint): array
+    {
+        if ($shopConstraint->getShopGroupId()) {
+            throw new InvalidShopConstraintException('Product has no features related with shop group use single shop and all shops constraints');
+        }
+
+        $shopIds = [];
+        if ($shopConstraint->forAllShops()) {
+            $shops = $this->getAssociatedShopIds(new StockId((int) $stockAvailable->id));
+            foreach ($shops as $shopId) {
+                $shopIds[] = $shopId->getValue();
+            }
+        } else {
+            $shopIds = [$shopConstraint->getShopId()->getValue()];
+        }
+
+        return $shopIds;
+    }
+
+    /**
+     * @param StockId $stockId
+     *
+     * @return StockAvailable
+     *
+     * @throws CoreException
+     * @throws StockAvailableNotFoundException
+     */
+    private function getStockAvailable(StockId $stockId): StockAvailable
+    {
+        /** @var StockAvailable $stockAvailable */
+        $stockAvailable = $this->getObjectModel(
+            $stockId->getValue(),
+            StockAvailable::class,
+            StockAvailableNotFoundException::class
+        );
+
+        return $stockAvailable;
+    }
+}

--- a/src/Adapter/Product/Stock/Repository/StockAvailableRepository.php
+++ b/src/Adapter/Product/Stock/Repository/StockAvailableRepository.php
@@ -31,14 +31,11 @@ namespace PrestaShop\PrestaShop\Adapter\Product\Stock\Repository;
 use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Validate\StockAvailableValidator;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
-use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\CannotAddStockAvailableException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\CannotUpdateStockAvailableException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\StockAvailableNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockId;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
-use PrestaShopException;
 use StockAvailable;
 
 /**
@@ -88,42 +85,6 @@ class StockAvailableRepository extends AbstractObjectModelRepository
     }
 
     /**
-     * @param ProductId $productId
-     *
-     * @return StockId
-     *
-     * @throws StockAvailableNotFoundException
-     */
-    public function getStockIdByProduct(ProductId $productId): StockId
-    {
-        $stockAvailableId = StockAvailable::getStockAvailableIdByProductId($productId->getValue());
-        if ($stockAvailableId <= 0) {
-            throw new StockAvailableNotFoundException(sprintf(
-                    'Cannot find StockAvailable for product #%d',
-                    $productId->getValue()
-                )
-            );
-        }
-
-        return new StockId($stockAvailableId);
-    }
-
-    /**
-     * @param ProductId $productId
-     *
-     * @return StockAvailable
-     *
-     * @throws CoreException
-     * @throws StockAvailableNotFoundException
-     */
-    public function getForProduct(ProductId $productId): StockAvailable
-    {
-        $stockId = $this->getStockIdByProduct($productId);
-
-        return $this->getStockAvailable($stockId);
-    }
-
-    /**
      * @param CombinationId $combinationId
      *
      * @return StockAvailable
@@ -152,36 +113,6 @@ class StockAvailableRepository extends AbstractObjectModelRepository
         }
 
         return $this->getStockAvailable(new StockId((int) $result['id_stock_available']));
-    }
-
-    /**
-     * @param ProductId $productId
-     *
-     * @return StockAvailable
-     *
-     * @throws CoreException
-     * @throws StockAvailableNotFoundException
-     */
-    public function create(ProductId $productId): StockAvailable
-    {
-        $stockAvailable = new StockAvailable();
-        $stockAvailable->id_product = $productId->getValue();
-        $shopParams = [];
-        try {
-            StockAvailable::addSqlShopParams($shopParams);
-        } catch (PrestaShopException $e) {
-            throw new CoreException(
-                sprintf('Error occurred when trying to add StockAvailable shop params #%d', $productId->getValue()),
-                0,
-                $e
-            );
-        }
-
-        $stockAvailable->id_shop = $shopParams['id_shop'] ?? 0;
-        $stockAvailable->id_shop_group = $shopParams['id_shop_group'] ?? 0;
-        $this->addObjectModel($stockAvailable, CannotAddStockAvailableException::class);
-
-        return $stockAvailable;
     }
 
     /**

--- a/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
+++ b/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
@@ -240,6 +240,7 @@ class ProductStockUpdater
             $stockModification->getDeltaQuantity(),
             [
                 'id_stock_mvt_reason' => $stockModification->getMovementReasonId()->getValue(),
+                'id_shop' => (int) $stockAvailable->id_shop,
             ]
         );
     }

--- a/src/Adapter/Product/Update/ProductShopUpdater.php
+++ b/src/Adapter/Product/Update/ProductShopUpdater.php
@@ -116,9 +116,6 @@ class ProductShopUpdater
         // $targetStock->physical_quantity = $sourceStock->physical_quantity;
         // $targetStock->reserved_quantity = $sourceStock->reserved_quantity;
 
-        $this->stockAvailableRepository->update(
-            $targetStock,
-            ShopConstraint::shop($targetShopId->getValue())
-        );
+        $this->stockAvailableRepository->update($targetStock);
     }
 }

--- a/src/Core/Domain/Product/Stock/Command/UpdateProductStockInformationCommand.php
+++ b/src/Core/Domain/Product/Stock/Command/UpdateProductStockInformationCommand.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Class UpdateProductStockInformationCommand update a given product stock
@@ -96,11 +97,20 @@ class UpdateProductStockInformationCommand
     private $availableDate;
 
     /**
-     * @param int $productId
+     * @var ShopConstraint
      */
-    public function __construct(int $productId)
-    {
+    private $shopConstraint;
+
+    /**
+     * @param int $productId
+     * @param ShopConstraint $shopConstraint
+     */
+    public function __construct(
+        int $productId,
+        ShopConstraint $shopConstraint
+    ) {
         $this->productId = new ProductId($productId);
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -109,6 +119,14 @@ class UpdateProductStockInformationCommand
     public function getProductId(): ProductId
     {
         return $this->productId;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 
     /**

--- a/src/Core/Domain/Product/Stock/Query/GetEmployeesStockMovements.php
+++ b/src/Core/Domain/Product/Stock/Query/GetEmployeesStockMovements.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Stock\Query;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 class GetEmployeesStockMovements
 {
@@ -38,6 +39,11 @@ class GetEmployeesStockMovements
      * @var ProductId
      */
     private $productId;
+
+    /**
+     * @var ShopId
+     */
+    private $shopId;
 
     /**
      * @var int
@@ -56,10 +62,12 @@ class GetEmployeesStockMovements
      */
     public function __construct(
         int $productId,
+        int $shopId,
         int $offset = 0,
         int $limit = self::DEFAULT_LIMIT
     ) {
         $this->productId = new ProductId($productId);
+        $this->shopId = new ShopId($shopId);
         $this->offset = $offset;
         $this->limit = $limit;
     }
@@ -70,6 +78,14 @@ class GetEmployeesStockMovements
     public function getProductId(): ProductId
     {
         return $this->productId;
+    }
+
+    /**
+     * @return ShopId
+     */
+    public function getShopId(): ShopId
+    {
+        return $this->shopId;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilder.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder;
 
-use DateTimeImmutable;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -222,7 +222,7 @@ class CommandBuilder
             case CommandField::TYPE_ARRAY:
                 return (array) $value;
             case CommandField::TYPE_DATETIME:
-                return new DateTimeImmutable($value);
+                return DateTime::buildNullableDateTime($value);
             default:
                 return $value;
         }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilder.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder;
 
+use DateTimeImmutable;
 use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -220,6 +221,8 @@ class CommandBuilder
                 return (int) $value;
             case CommandField::TYPE_ARRAY:
                 return (array) $value;
+            case CommandField::TYPE_DATETIME:
+                return new DateTimeImmutable($value);
             default:
                 return $value;
         }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/CommandField.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/CommandField.php
@@ -36,12 +36,14 @@ class CommandField
     public const TYPE_BOOL = 'bool';
     public const TYPE_INT = 'int';
     public const TYPE_ARRAY = 'array';
+    public const TYPE_DATETIME = 'datetime';
 
     public const ACCEPTED_TYPES = [
         self::TYPE_STRING,
         self::TYPE_BOOL,
         self::TYPE_INT,
         self::TYPE_ARRAY,
+        self::TYPE_DATETIME,
     ];
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -141,7 +141,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
             'header' => $this->extractHeaderData($productForEditing),
             'description' => $this->extractDescriptionData($productForEditing),
             'specifications' => $this->extractSpecificationsData($productForEditing),
-            'stock' => $this->extractStockData($productForEditing),
+            'stock' => $this->extractStockData($productForEditing, $shopConstraint),
             'pricing' => $this->extractPricingData($productForEditing),
             'seo' => $this->extractSEOData($productForEditing),
             'shipping' => $this->extractShippingData($productForEditing),
@@ -395,10 +395,11 @@ class ProductFormDataProvider implements FormDataProviderInterface
 
     /**
      * @param ProductForEditing $productForEditing
+     * @param ShopConstraint $shopConstraint
      *
      * @return array<string, mixed>
      */
-    private function extractStockData(ProductForEditing $productForEditing): array
+    private function extractStockData(ProductForEditing $productForEditing, ShopConstraint $shopConstraint): array
     {
         $stockInformation = $productForEditing->getStockInformation();
         $availableDate = $stockInformation->getAvailableDate();
@@ -409,7 +410,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
                     'quantity' => $stockInformation->getQuantity(),
                     'delta' => 0,
                 ],
-                'stock_movements' => $this->getStockMovements($productForEditing->getProductId()),
+                'stock_movements' => $this->getStockMovements($productForEditing->getProductId(), $shopConstraint),
                 'minimal_quantity' => $stockInformation->getMinimalQuantity(),
             ],
             'options' => [
@@ -433,10 +434,10 @@ class ProductFormDataProvider implements FormDataProviderInterface
      *
      * @return array
      */
-    private function getStockMovements(int $productId): array
+    private function getStockMovements(int $productId, ShopConstraint $shopConstraint): array
     {
         /** @var EmployeeStockMovement[] $stockMovements */
-        $stockMovements = $this->queryBus->handle(new GetEmployeesStockMovements($productId));
+        $stockMovements = $this->queryBus->handle(new GetEmployeesStockMovements($productId, $shopConstraint->getShopId()->getValue()));
 
         $movementData = [];
         foreach ($stockMovements as $stockMovement) {

--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -382,7 +382,7 @@ class StockManager
 
         if ($product->id) {
             $stockManager = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\StockManager');
-            $stockAvailable = $stockManager->getStockAvailableByProduct($product, $productAttributeId);
+            $stockAvailable = $stockManager->getStockAvailableByProduct($product, $productAttributeId, $params['id_shop'] ?? null);
 
             if ($stockAvailable->id) {
                 $stockMvt = new StockMvt();

--- a/src/Core/Util/DateTime/NullDateTime.php
+++ b/src/Core/Util/DateTime/NullDateTime.php
@@ -80,7 +80,7 @@ class NullDateTime extends DateTimeImmutable
      */
     public function add($interval)
     {
-        throw $this::buildUnusableMethodException('add');
+        return $this;
     }
 
     /**
@@ -152,7 +152,7 @@ class NullDateTime extends DateTimeImmutable
      */
     public function setTimezone($timezone)
     {
-        throw $this::buildUnusableMethodException('setTimezone');
+        return $this;
     }
 
     /**
@@ -164,7 +164,7 @@ class NullDateTime extends DateTimeImmutable
      */
     public function sub($interval)
     {
-        throw $this::buildUnusableMethodException('sub');
+        return $this;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -70,11 +70,13 @@ class AvailabilityType extends TranslatorAwareType
                 'label' => $this->trans('Behavior when out of stock', 'Admin.Catalog.Feature'),
                 'expanded' => true,
                 'column_breaker' => true,
+                'modify_all_shops' => true,
             ])
             ->add('available_now_label', TranslatableType::class, [
                 'type' => TextType::class,
                 'label' => $this->trans('Label when in stock', 'Admin.Catalog.Feature'),
                 'required' => false,
+                'modify_all_shops' => true,
             ])
             ->add('available_later_label', TranslatableType::class, [
                 'type' => TextType::class,
@@ -83,6 +85,7 @@ class AvailabilityType extends TranslatorAwareType
                     'Admin.Catalog.Feature'
                 ),
                 'required' => false,
+                'modify_all_shops' => true,
             ])
             ->add('available_date', DatePickerType::class, [
                 'label' => $this->trans('Availability date', 'Admin.Catalog.Feature'),
@@ -90,6 +93,7 @@ class AvailabilityType extends TranslatorAwareType
                 'attr' => [
                     'placeholder' => 'YYYY-MM-DD',
                 ],
+                'modify_all_shops' => true,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -111,6 +111,7 @@ class QuantityType extends TranslatorAwareType
                 ],
                 'required' => false,
                 'default_empty_data' => 0,
+                'modify_all_shops' => true,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockOptionsType.php
@@ -68,6 +68,7 @@ class StockOptionsType extends TranslatorAwareType
             ->add('stock_location', TextType::class, [
                 'label' => $this->trans('Stock location', 'Admin.Catalog.Feature'),
                 'required' => false,
+                'modify_all_shops' => true,
             ])
             ->add('low_stock_threshold', NumberType::class, [
                 'label' => $this->trans('Low stock level', 'Admin.Catalog.Feature'),
@@ -79,6 +80,7 @@ class StockOptionsType extends TranslatorAwareType
                 'default_empty_data' => 0,
                 // Using null here allows to keep the field empty in the page instead of 0
                 'empty_view_data' => null,
+                'modify_all_shops' => true,
             ])
             ->add('low_stock_alert', SwitchType::class, [
                 'required' => false,
@@ -97,6 +99,7 @@ class StockOptionsType extends TranslatorAwareType
                         '[/1]' => '</a>',
                     ]
                 ),
+                'modify_all_shops' => true,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -74,6 +74,7 @@ class StockType extends TranslatorAwareType
                 'label' => $this->trans('Pack quantities', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h2',
                 'required' => false,
+                'modify_all_shops' => true,
             ])
             ->add('availability', AvailabilityType::class)
         ;

--- a/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/DeltaQuantityType.php
@@ -58,6 +58,7 @@ class DeltaQuantityType extends TranslatorAwareType
                     new Type(['type' => 'numeric']),
                     new NotBlank(),
                 ],
+                'modify_all_shops' => true,
             ]);
 
         $builder->get('quantity')->addViewTransformer(new NumberToLocalizedStringTransformer(0, false));

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -101,7 +101,7 @@ services:
       - '@prestashop.core.util.number.number_extractor'
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@prestashop.adapter.category.repository.category_repository'
-      - '@prestashop.adapter.product.stock.repository.stock_available_repository'
+      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
       - '@prestashop.adapter.product.virtual_product.repository.virtual_product_file_repository'
       - '@prestashop.adapter.product.image.repository.product_image_repository'
       - '@prestashop.adapter.attachment.attachment_repository'
@@ -442,4 +442,5 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductShopUpdater
     arguments:
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
+      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
       - '@prestashop.adapter.shop.repository.shop_repository'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
@@ -12,6 +12,13 @@ services:
       - '%database_prefix%'
       - '@prestashop.adapter.product.stock.validate.stock_available_validator'
 
+  prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository:
+    class: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository
+    arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'
+      - '@prestashop.adapter.product.stock.validate.stock_available_validator'
+
   prestashop.adapter.product.stock.repository.stock_movement_repository:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockMovementRepository
     arguments:
@@ -45,6 +52,6 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\Update\ProductStockUpdater
     arguments:
       - '@prestashop.core.stock.stock_manager'
-      - '@prestashop.adapter.product.repository.product_repository'
-      - '@prestashop.adapter.product.stock.repository.stock_available_repository'
+      - '@prestashop.adapter.product.repository.product_multi_shop_repository'
+      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
       - '@prestashop.adapter.legacy.configuration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
@@ -42,7 +42,7 @@ services:
   prestashop.adapter.product.stock.query_handler.get_product_stock_movement_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\QueryHandler\GetEmployeesStockMovementsHandler
     arguments:
-      - '@prestashop.adapter.product.stock.repository.stock_available_repository'
+      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
       - '@prestashop.adapter.product.stock.repository.stock_movement_repository'
     tags:
       - name: tactician.handler

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -50,6 +50,8 @@ services:
 
   prestashop.core.form.command_builder.product.stock_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\StockCommandsBuilder
+    arguments:
+      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
     tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.product.product_suppliers_commands_builder:

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -566,7 +566,7 @@
 {% block switch_widget %}
   {% apply spaceless %}
   <div class="input-group">
-    <span class="ps-switch">
+    <span class="ps-switch" id="{{ form.vars.id }}">
         {% for choice in choices %}
           {% set inputId = id ~'_' ~ choice.value %}
           <input id="{{inputId}}"
@@ -1294,6 +1294,7 @@
       {{- block('form_append_external_link') -}}
     </div>
     {{- form_errors(form) -}}
+    {{- block('form_modify_all_shops') -}}
   </div>
 {% endblock %}
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
@@ -152,8 +152,9 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
      * @param ProductForEditing $productForEditing
      * @param array $data
      * @param string $propertyName
+     * @param string $extraMessage
      */
-    protected function assertBoolProperty(ProductForEditing $productForEditing, array &$data, string $propertyName): void
+    protected function assertBoolProperty(ProductForEditing $productForEditing, array &$data, string $propertyName, string $extraMessage = ''): void
     {
         if (isset($data[$propertyName])) {
             $expectedValue = PrimitiveUtils::castStringBooleanIntoBoolean($data[$propertyName]);
@@ -164,7 +165,7 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
             Assert::assertSame(
                 $expectedValue,
                 $actualValue,
-                sprintf('Expected %s "%s". Got "%s".', $propertyName, $expectedValue, $actualValue)
+                sprintf('Expected %s "%s". Got "%s"%s', $propertyName, $expectedValue, $actualValue, $extraMessage)
             );
 
             // Unset the checked field from array so we can validate they havel all been asserted
@@ -176,8 +177,9 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
      * @param ProductForEditing $productForEditing
      * @param array $data
      * @param string $propertyName
+     * @param string $extraMessage
      */
-    protected function assertStringProperty(ProductForEditing $productForEditing, array &$data, string $propertyName): void
+    protected function assertStringProperty(ProductForEditing $productForEditing, array &$data, string $propertyName, string $extraMessage = ''): void
     {
         if (isset($data[$propertyName])) {
             $expectedValue = $data[$propertyName];
@@ -188,7 +190,7 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
             Assert::assertSame(
                 $expectedValue,
                 $actualValue,
-                sprintf('Expected %s "%s". Got "%s".', $propertyName, $expectedValue, $actualValue)
+                sprintf('Expected %s "%s". Got "%s"%s', $propertyName, $expectedValue, $actualValue, $extraMessage)
             );
 
             // Unset the checked field from array so we can validate they havel all been asserted
@@ -200,8 +202,9 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
      * @param ProductForEditing $productForEditing
      * @param array $data
      * @param string $propertyName
+     * @param string $extraMessage
      */
-    protected function assertIntegerProperty(ProductForEditing $productForEditing, array &$data, string $propertyName): void
+    protected function assertIntegerProperty(ProductForEditing $productForEditing, array &$data, string $propertyName, string $extraMessage = ''): void
     {
         if (isset($data[$propertyName])) {
             $expectedValue = (int) $data[$propertyName];
@@ -212,7 +215,7 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
             Assert::assertSame(
                 $expectedValue,
                 $actualValue,
-                sprintf('Expected %s "%s". Got "%s".', $propertyName, $expectedValue, $actualValue)
+                sprintf('Expected %s "%s". Got "%s"%s', $propertyName, $expectedValue, $actualValue, $extraMessage)
             );
 
             // Unset the checked field from array so we can validate they havel all been asserted
@@ -224,8 +227,9 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
      * @param ProductForEditing $productForEditing
      * @param array $data
      * @param string $propertyName
+     * @param string $extraMessage
      */
-    protected function assertDateTimeProperty(ProductForEditing $productForEditing, array &$data, string $propertyName): void
+    protected function assertDateTimeProperty(ProductForEditing $productForEditing, array &$data, string $propertyName, string $extraMessage = ''): void
     {
         if (!isset($data[$propertyName])) {
             return;
@@ -237,7 +241,7 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
             Assert::assertEquals(
                 null,
                 $actualValue,
-                sprintf('Unexpected available_date. Expected NULL, got "%s"', var_export($actualValue, true))
+                sprintf('Unexpected available_date. Expected NULL, got "%s"%s', var_export($actualValue, true), $extraMessage)
             );
         } else {
             $expectedDateTime = new DateTime($data[$propertyName]);
@@ -250,7 +254,7 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
             Assert::assertSame(
                 $formattedExpectedDate,
                 $formattedActualDate,
-                sprintf('Expected %s "%s". Got "%s".', $propertyName, $formattedExpectedDate, $formattedActualDate)
+                sprintf('Expected %s "%s". Got "%s"%s', $propertyName, $formattedExpectedDate, $formattedActualDate, $extraMessage)
             );
         }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
@@ -78,10 +78,9 @@ class UpdateStockFeatureContext extends AbstractProductFeatureContext
     /**
      * @When I update product :productReference stock for all shops with following information:
      *
-     * @param string $productReference
      * @param TableNode $table
      */
-    public function updateProductStockForAllShops(string $productReference, string $shopReference, TableNode $table): void
+    public function updateProductStockForAllShops(string $productReference, TableNode $table): void
     {
         $this->updateProductStock($productReference, $table, ShopConstraint::allShops());
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
@@ -43,6 +43,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\QueryResult\EmployeeStockMov
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\QueryResult\StockMovement;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShopBundle\Api\QueryStockMovementParamsCollection;
 use PrestaShopBundle\Entity\Repository\StockMovementRepository;
 use RuntimeException;
@@ -56,13 +57,46 @@ class UpdateStockFeatureContext extends AbstractProductFeatureContext
      * @param string $productReference
      * @param TableNode $table
      */
-    public function updateProductStock(string $productReference, TableNode $table): void
+    public function updateProductStockForDefaultShop(string $productReference, TableNode $table): void
+    {
+        $this->updateProductStock($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
+    }
+
+    /**
+     * @When I update product :productReference stock for shop :shopReference with following information:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductStockForShop(string $productReference, string $shopReference, TableNode $table): void
+    {
+        $shopId = $this->getSharedStorage()->get(trim($shopReference));
+        $shopConstraint = ShopConstraint::shop($shopId);
+        $this->updateProductStock($productReference, $table, $shopConstraint);
+    }
+
+    /**
+     * @When I update product :productReference stock for all shops with following information:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductStockForAllShops(string $productReference, string $shopReference, TableNode $table): void
+    {
+        $this->updateProductStock($productReference, $table, ShopConstraint::allShops());
+    }
+
+    /**
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    private function updateProductStock(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
     {
         $data = $this->localizeByRows($table);
         $productId = $this->getSharedStorage()->get($productReference);
 
         try {
-            $command = new UpdateProductStockInformationCommand($productId);
+            $command = new UpdateProductStockInformationCommand($productId, $shopConstraint);
             $unhandledData = $this->setUpdateStockCommandData($data, $command);
             Assert::assertEmpty(
                 $unhandledData,
@@ -109,9 +143,34 @@ class UpdateStockFeatureContext extends AbstractProductFeatureContext
      * @param string $productReference
      * @param TableNode $table
      */
-    public function assertStockInformation(string $productReference, TableNode $table): void
+    public function assertStockInformationForDefaultShop(string $productReference, TableNode $table): void
     {
-        $productForEditing = $this->getProductForEditing($productReference);
+        $this->assertStockInformation($productReference, $table, $this->getDefaultShopId());
+    }
+
+    /**
+     * @Then product :productReference should have following stock information for shops :shopReferences:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function assertStockInformationForShops(string $productReference, string $shopReferences, TableNode $table): void
+    {
+        $shopReferences = explode(',', $shopReferences);
+        foreach ($shopReferences as $shopReference) {
+            $shopId = $this->getSharedStorage()->get(trim($shopReference));
+            $this->assertStockInformation($productReference, $table, $shopId);
+        }
+    }
+
+    /**
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    private function assertStockInformation(string $productReference, TableNode $table, int $shopId): void
+    {
+        $shopErrorMessage = !empty($shopId) ? sprintf(' for shop %s', $shopId) : '';
+        $productForEditing = $this->getProductForEditing($productReference, $shopId);
         $data = $table->getRowsHash();
 
         if (isset($data['out_of_stock_type'])) {
@@ -121,14 +180,14 @@ class UpdateStockFeatureContext extends AbstractProductFeatureContext
             $data['pack_stock_type'] = $this->convertPackStockTypeToInt($data['pack_stock_type']);
         }
 
-        $this->assertStringProperty($productForEditing, $data, 'pack_stock_type');
-        $this->assertIntegerProperty($productForEditing, $data, 'out_of_stock_type');
-        $this->assertIntegerProperty($productForEditing, $data, 'quantity');
-        $this->assertIntegerProperty($productForEditing, $data, 'minimal_quantity');
-        $this->assertStringProperty($productForEditing, $data, 'location');
-        $this->assertIntegerProperty($productForEditing, $data, 'low_stock_threshold');
-        $this->assertBoolProperty($productForEditing, $data, 'low_stock_alert');
-        $this->assertDateTimeProperty($productForEditing, $data, 'available_date');
+        $this->assertStringProperty($productForEditing, $data, 'pack_stock_type', $shopErrorMessage);
+        $this->assertIntegerProperty($productForEditing, $data, 'out_of_stock_type', $shopErrorMessage);
+        $this->assertIntegerProperty($productForEditing, $data, 'quantity', $shopErrorMessage);
+        $this->assertIntegerProperty($productForEditing, $data, 'minimal_quantity', $shopErrorMessage);
+        $this->assertStringProperty($productForEditing, $data, 'location', $shopErrorMessage);
+        $this->assertIntegerProperty($productForEditing, $data, 'low_stock_threshold', $shopErrorMessage);
+        $this->assertBoolProperty($productForEditing, $data, 'low_stock_alert', $shopErrorMessage);
+        $this->assertDateTimeProperty($productForEditing, $data, 'available_date', $shopErrorMessage);
 
         // Assertions checking isset() can hide some errors if it doesn't find array key,
         // to make sure all provided fields were checked we need to unset every asserted field

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -63,6 +63,20 @@ class ShopFeatureContext extends AbstractDomainFeatureContext
             'shop_url',
         ]);
         DatabaseDump::restoreMatchingTables('/.*_shop$/');
+
+        // We need to restore lang tables that are also multi-shop
+        DatabaseDump::restoreTables([
+            'carrier_lang',
+            'category_lang',
+            'cms_category_lang',
+            'cms_lang',
+            'cms_role_lang',
+            'customization_field_lang',
+            'info_lang',
+            'linksmenutop_lang',
+            'meta_lang',
+            'product_lang',
+        ]);
         Shop::setContext(Shop::CONTEXT_SHOP, 1);
         Shop::resetStaticCache();
     }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
@@ -16,25 +16,36 @@ Feature: Copy product from shop to shop.
     And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
     And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
     And single shop context is loaded
+    And language "french" with locale "fr-FR" exists
 
   Scenario: Add products in specific shop
-    Given I add product "product1" to shop "shop2" with following information:
+    Given I add product "createdProduct" to shop "shop2" with following information:
       | name[en-US] | magic staff |
       | type        | standard    |
-    Then product product1 is associated to shop shop2
-    And default shop for product product1 is shop2
-    And product product1 is not associated to shop shop1
-    And product product1 is not associated to shop shop3
-    And product product1 is not associated to shop shop4
+    Then product createdProduct is associated to shop shop2
+    And default shop for product createdProduct is shop2
+    And product createdProduct is not associated to shop shop1
+    And product createdProduct is not associated to shop shop3
+    And product createdProduct is not associated to shop shop4
+    # Assert stock has correctly been created for the appropriate shop
+    Then product "createdProduct" should have following stock information for shops "shop2":
+      | pack_stock_type     | default |
+      | out_of_stock_type   | default |
+      | quantity            | 0       |
+      | minimal_quantity    | 1       |
+      | location            |         |
+      | low_stock_threshold | 0       |
+      | low_stock_alert     | false   |
+      | available_date      |         |
 
   Scenario: I copy product to another shop that was not associated, prices are copied
     # By default the product is created for default shop
-    Given I add product "product2" with following information:
+    Given I add product "productWithPrices" with following information:
       | name[en-US] | magic staff |
       | type        | standard    |
-    Then product product2 is associated to shop shop1
-    And default shop for product product2 is shop1
-    When I update product "product2" prices with following information:
+    Then product productWithPrices is associated to shop shop1
+    And default shop for product productWithPrices is shop1
+    When I update product "productWithPrices" prices with following information:
       | price              | 100.99          |
       | ecotax             | 0               |
       | tax rules group    | US-AL Rate (4%) |
@@ -42,7 +53,7 @@ Feature: Copy product from shop to shop.
       | wholesale_price    | 70              |
       | unit_price         | 10              |
       | unity              | bag of ten      |
-    Then product product2 should have following prices information for shops "shop1":
+    Then product productWithPrices should have following prices information for shops "shop1":
       | price              | 100.99          |
       | price_tax_included | 105.0296        |
       | ecotax             | 0               |
@@ -52,15 +63,15 @@ Feature: Copy product from shop to shop.
       | unit_price         | 10              |
       | unity              | bag of ten      |
       | unit_price_ratio   | 10.099          |
-    And product product2 is not associated to shop shop2
-    And product product2 is not associated to shop shop3
-    And product product2 is not associated to shop shop4
+    And product productWithPrices is not associated to shop shop2
+    And product productWithPrices is not associated to shop shop3
+    And product productWithPrices is not associated to shop shop4
     # Copy values to another shop which was not associated yet
-    When I copy product product2 from shop shop1 to shop shop2
-    Then product product2 is associated to shop shop2
-    And product product2 is associated to shop shop1
-    And default shop for product product2 is shop1
-    And product product2 should have following prices information for shops "shop1,shop2":
+    When I copy product productWithPrices from shop shop1 to shop shop2
+    Then product productWithPrices is associated to shop shop2
+    And product productWithPrices is associated to shop shop1
+    And default shop for product productWithPrices is shop1
+    And product productWithPrices should have following prices information for shops "shop1,shop2":
       | price              | 100.99          |
       | price_tax_included | 105.0296        |
       | ecotax             | 0               |
@@ -70,10 +81,10 @@ Feature: Copy product from shop to shop.
       | unit_price         | 10              |
       | unity              | bag of ten      |
       | unit_price_ratio   | 10.099          |
-    And product product2 is not associated to shop shop3
-    And product product2 is not associated to shop shop4
+    And product productWithPrices is not associated to shop shop3
+    And product productWithPrices is not associated to shop shop4
     # Now modify and copy the values but this time the shop is already associated so it is an update
-    When I update product "product2" prices with following information:
+    When I update product "productWithPrices" prices with following information:
       | price              | 200.99            |
       | ecotax             | 2                 |
       | tax rules group    | US-AZ Rate (6.6%) |
@@ -81,7 +92,7 @@ Feature: Copy product from shop to shop.
       | wholesale_price    | 60                |
       | unit_price         | 20                |
       | unity              | bag of twenty     |
-    Then product product2 should have following prices information for shops "shop1":
+    Then product productWithPrices should have following prices information for shops "shop1":
       | price              | 200.99            |
       | price_tax_included | 214.25534         |
       | ecotax             | 2                 |
@@ -91,7 +102,7 @@ Feature: Copy product from shop to shop.
       | unit_price         | 20                |
       | unity              | bag of twenty     |
       | unit_price_ratio   | 10.0495           |
-    But product product2 should have following prices information for shops "shop2":
+    But product productWithPrices should have following prices information for shops "shop2":
       | price              | 100.99          |
       | price_tax_included | 105.0296        |
       | ecotax             | 0               |
@@ -102,9 +113,9 @@ Feature: Copy product from shop to shop.
       | unity              | bag of ten      |
       | unit_price_ratio   | 10.099          |
     # Copy values to a shop which is already associated
-    When I copy product product2 from shop shop1 to shop shop2
-    Then product product2 is associated to shop shop2
-    And product product2 should have following prices information for shops "shop1,shop2":
+    When I copy product productWithPrices from shop shop1 to shop shop2
+    Then product productWithPrices is associated to shop shop2
+    And product productWithPrices should have following prices information for shops "shop1,shop2":
       | price              | 200.99            |
       | price_tax_included | 214.25534         |
       | ecotax             | 2                 |
@@ -114,82 +125,214 @@ Feature: Copy product from shop to shop.
       | unit_price         | 20                |
       | unity              | bag of twenty     |
       | unit_price_ratio   | 10.0495           |
-    And product product2 is not associated to shop shop3
-    And product product2 is not associated to shop shop4
+    And product productWithPrices is not associated to shop shop3
+    And product productWithPrices is not associated to shop shop4
 
   Scenario: I copy product to another shop that was not associated, basic information are copied
     # By default the product is created for default shop
-    Given I add product "product3" with following information:
+    Given I add product "productWithBasic" with following information:
       | name[en-US] | funny mug |
       | type        | standard  |
-    Then product product3 is associated to shop shop1
-    And default shop for product product3 is shop1
-    When I update product "product3" basic information with following values:
+    Then product productWithBasic is associated to shop shop1
+    And default shop for product productWithBasic is shop1
+    When I update product "productWithBasic" basic information with following values:
       | name[en-US]              | photo of funny mug |
       | description[en-US]       | nice mug           |
       | description_short[en-US] | Just a nice mug    |
-    Then product "product3" localized "name" should be:
+    Then product "productWithBasic" localized "name" should be:
       | locale     | value              |
       | en-US      | photo of funny mug |
-    And product "product3" localized "description" should be:
+    And product "productWithBasic" localized "description" should be:
       | locale | value    |
       | en-US  | nice mug |
-    And product "product3" localized "description_short" should be:
+    And product "productWithBasic" localized "description_short" should be:
       | locale | value           |
       | en-US  | Just a nice mug |
-    And product product3 is not associated to shop shop2
-    And product product3 is not associated to shop shop3
-    And product product3 is not associated to shop shop4
+    And product productWithBasic is not associated to shop shop2
+    And product productWithBasic is not associated to shop shop3
+    And product productWithBasic is not associated to shop shop4
     # Copy values to another shop which was not associated yet
-    When I copy product product3 from shop shop1 to shop shop2
-    Then product product3 is associated to shop shop2
-    And product product3 is associated to shop shop1
-    And default shop for product product3 is shop1
-    Then product "product3" localized "name" for shops "shop1,shop2" should be:
+    When I copy product productWithBasic from shop shop1 to shop shop2
+    Then product productWithBasic is associated to shop shop2
+    And product productWithBasic is associated to shop shop1
+    And default shop for product productWithBasic is shop1
+    Then product "productWithBasic" localized "name" for shops "shop1,shop2" should be:
       | locale     | value              |
       | en-US      | photo of funny mug |
-    And product "product3" localized "description" for shops "shop1,shop2" should be:
+    And product "productWithBasic" localized "description" for shops "shop1,shop2" should be:
       | locale | value    |
       | en-US  | nice mug |
-    And product "product3" localized "description_short" for shops "shop1,shop2" should be:
+    And product "productWithBasic" localized "description_short" for shops "shop1,shop2" should be:
       | locale | value           |
       | en-US  | Just a nice mug |
-    And product product3 is not associated to shop shop3
-    And product product3 is not associated to shop shop4
+    And product productWithBasic is not associated to shop shop3
+    And product productWithBasic is not associated to shop shop4
     # Now modify and copy the values but this time the shop is already associated so it is an update
-    When I update product "product3" basic information with following values:
+    When I update product "productWithBasic" basic information with following values:
       | name[en-US]              | photo of super mug |
       | description[en-US]       | super mug          |
       | description_short[en-US] | Just a super mug   |
-    Then product "product3" localized "name" for shops "shop1" should be:
+    Then product "productWithBasic" localized "name" for shops "shop1" should be:
       | locale     | value              |
       | en-US      | photo of super mug |
-    And product "product3" localized "description" for shops "shop1" should be:
+    And product "productWithBasic" localized "description" for shops "shop1" should be:
       | locale | value     |
       | en-US  | super mug |
-    And product "product3" localized "description_short" for shops "shop1" should be:
+    And product "productWithBasic" localized "description_short" for shops "shop1" should be:
       | locale | value            |
       | en-US  | Just a super mug |
-    But product "product3" localized "name" for shops "shop2" should be:
+    But product "productWithBasic" localized "name" for shops "shop2" should be:
       | locale     | value              |
       | en-US      | photo of funny mug |
-    And product "product3" localized "description" for shops "shop2" should be:
+    And product "productWithBasic" localized "description" for shops "shop2" should be:
       | locale | value    |
       | en-US  | nice mug |
-    And product "product3" localized "description_short" for shops "shop2" should be:
+    And product "productWithBasic" localized "description_short" for shops "shop2" should be:
       | locale | value           |
       | en-US  | Just a nice mug |
     # Copy values to a shop which is already associated
-    When I copy product product3 from shop shop1 to shop shop2
-    Then product product3 is associated to shop shop2
-    And product "product3" localized "name" for shops "shop1,shop2" should be:
+    When I copy product productWithBasic from shop shop1 to shop shop2
+    Then product productWithBasic is associated to shop shop2
+    And product "productWithBasic" localized "name" for shops "shop1,shop2" should be:
       | locale     | value              |
       | en-US      | photo of super mug |
-    And product "product3" localized "description" for shops "shop1,shop2" should be:
+    And product "productWithBasic" localized "description" for shops "shop1,shop2" should be:
       | locale | value     |
       | en-US  | super mug |
-    And product "product3" localized "description_short" for shops "shop1,shop2" should be:
+    And product "productWithBasic" localized "description_short" for shops "shop1,shop2" should be:
       | locale | value            |
       | en-US  | Just a super mug |
-    And product product3 is not associated to shop shop3
-    And product product3 is not associated to shop shop4
+    And product productWithBasic is not associated to shop shop3
+    And product productWithBasic is not associated to shop shop4
+
+  Scenario: I copy product to another shop that was not associated, stock data are copied
+    # By default the product is created for default shop
+    Given I add product "productWithStock" with following information:
+      | name[en-US] | magic staff |
+      | type        | standard    |
+    Then product productWithStock is associated to shop shop1
+    And default shop for product productWithStock is shop1
+    # First modify data for default shop
+    When I update product "productWithStock" stock with following information:
+      | pack_stock_type               | pack_only    |
+      | out_of_stock_type             | available    |
+      | delta_quantity                | 42           |
+      | minimal_quantity              | 12           |
+      | location                      | dtc          |
+      | low_stock_threshold           | 42           |
+      | low_stock_alert               | true         |
+      | available_now_labels[en-US]   | get it now   |
+      | available_later_labels[en-US] | too late bro |
+      | available_date                | 1969-07-16   |
+    Then product "productWithStock" should have following stock information for shops "shop1":
+      | pack_stock_type     | pack_only  |
+      | out_of_stock_type   | available  |
+      | quantity            | 42         |
+      | minimal_quantity    | 12         |
+      | location            | dtc        |
+      | low_stock_threshold | 42         |
+      | low_stock_alert     | true       |
+      | available_date      | 1969-07-16 |
+    And product "productWithStock" localized "available_now_labels" for shops "shop1" should be:
+      | locale | value      |
+      | en-US  | get it now |
+      | fr-FR  |            |
+    And product "productWithStock" localized "available_later_labels" for shops "shop1" should be:
+      | locale | value        |
+      | en-US  | too late bro |
+      | fr-FR  |              |
+    And product productWithStock is not associated to shop shop2
+    And product productWithStock is not associated to shop shop3
+    And product productWithStock is not associated to shop shop4
+    # Copy values to another shop which was not associated yet
+    When I copy product productWithStock from shop shop1 to shop shop2
+    Then product productWithStock is associated to shop shop2
+    And product productWithStock is associated to shop shop1
+    And default shop for product productWithStock is shop1
+    Then product "productWithStock" should have following stock information for shops "shop1,shop2":
+      | pack_stock_type     | pack_only  |
+      | out_of_stock_type   | available  |
+      | quantity            | 42         |
+      | minimal_quantity    | 12         |
+      | location            | dtc        |
+      | low_stock_threshold | 42         |
+      | low_stock_alert     | true       |
+      | available_date      | 1969-07-16 |
+    And product "productWithStock" localized "available_now_labels" for shops "shop1,shop2" should be:
+      | locale | value      |
+      | en-US  | get it now |
+      | fr-FR  |            |
+    And product "productWithStock" localized "available_later_labels" for shops "shop1,shop2" should be:
+      | locale | value        |
+      | en-US  | too late bro |
+      | fr-FR  |              |
+    And product productWithStock is not associated to shop shop3
+    And product productWithStock is not associated to shop shop4
+    # Now modify and copy the values but this time the shop is already associated so it is an update
+    When I update product "productWithStock" stock for shop shop1 with following information:
+      | pack_stock_type               | products_only |
+      | out_of_stock_type             | not_available |
+      | delta_quantity                | 69            |
+      | minimal_quantity              | 24            |
+      | location                      | upa           |
+      | low_stock_threshold           | 51            |
+      | low_stock_alert               | false         |
+      | available_now_labels[en-US]   | hurry up      |
+      | available_later_labels[en-US] | too slow...   |
+      | available_date                | 1969-09-16    |
+    # First only one shop is updated
+    Then product "productWithStock" should have following stock information for shops "shop1":
+      | pack_stock_type     | products_only |
+      | out_of_stock_type   | not_available |
+      | quantity            | 111           |
+      | minimal_quantity    | 24            |
+      | location            | upa           |
+      | low_stock_threshold | 51            |
+      | low_stock_alert     | false         |
+      | available_date      | 1969-09-16    |
+    And product "productWithStock" localized "available_now_labels" for shops "shop1" should be:
+      | locale | value    |
+      | en-US  | hurry up |
+      | fr-FR  |          |
+    And product "productWithStock" localized "available_later_labels" for shops "shop1" should be:
+      | locale | value       |
+      | en-US  | too slow... |
+      | fr-FR  |             |
+    But product "productWithStock" should have following stock information for shops "shop2":
+      | pack_stock_type     | pack_only  |
+      | out_of_stock_type   | available  |
+      | quantity            | 42         |
+      | minimal_quantity    | 12         |
+      | location            | dtc        |
+      | low_stock_threshold | 42         |
+      | low_stock_alert     | true       |
+      | available_date      | 1969-07-16 |
+    And product "productWithStock" localized "available_now_labels" for shops "shop2" should be:
+      | locale | value      |
+      | en-US  | get it now |
+      | fr-FR  |            |
+    And product "productWithStock" localized "available_later_labels" for shops "shop2" should be:
+      | locale | value        |
+      | en-US  | too late bro |
+      | fr-FR  |              |
+    And product productWithStock is not associated to shop shop3
+    And product productWithStock is not associated to shop shop4
+    # Now copy new values to the other shop
+    When I copy product productWithStock from shop shop1 to shop shop2
+    Then product "productWithStock" should have following stock information for shops "shop1,shop2":
+      | pack_stock_type     | products_only |
+      | out_of_stock_type   | not_available |
+      | quantity            | 111           |
+      | minimal_quantity    | 24            |
+      | location            | upa           |
+      | low_stock_threshold | 51            |
+      | low_stock_alert     | false         |
+      | available_date      | 1969-09-16    |
+    And product "productWithStock" localized "available_now_labels" for shops "shop1,shop2" should be:
+      | locale | value    |
+      | en-US  | hurry up |
+      | fr-FR  |          |
+    And product "productWithStock" localized "available_later_labels" for shops "shop1,shop2" should be:
+      | locale | value       |
+      | en-US  | too slow... |
+      | fr-FR  |             |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_stock.feature
@@ -2,6 +2,7 @@
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
+@restore-languages-after-feature
 @clear-cache-after-feature
 @product-multi-shop
 @update-multi-shop-stock

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_stock.feature
@@ -20,6 +20,7 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
     Given I add product "product1" with following information:
       | name[en-US] | magic staff |
       | type        | standard    |
+    Then product "product1" should have no stock movements
     When I update product "product1" stock with following information:
       | pack_stock_type               | pack_only    |
       | out_of_stock_type             | available    |
@@ -49,6 +50,11 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | locale | value        |
       | en-US  | too late bro |
       | fr-FR  |              |
+    And product "product1" last employees stock movements should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 42             |
+    And product "product1" last stock movement increased by 42
+    And product "product1" should have no stock movements for shop "shop2"
     And product product1 is not associated to shop shop3
     And product product1 is not associated to shop shop4
 
@@ -81,6 +87,10 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | locale | value       |
       | en-US  | too slow... |
       | fr-FR  |             |
+    And product "product1" last employees stock movements for shop "shop2" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 69             |
+    And product "product1" last stock movement for shop "shop2" increased by 69
     But product "product1" should have following stock information for shops "shop1":
       | pack_stock_type     | pack_only  |
       | out_of_stock_type   | available  |
@@ -98,10 +108,14 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | locale | value        |
       | en-US  | too late bro |
       | fr-FR  |              |
+    And product "product1" last employees stock movements for shop "shop1" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 42             |
+    And product "product1" last stock movement for shop "shop1" increased by 42
     And product product1 is not associated to shop shop3
     And product product1 is not associated to shop shop4
 
-  Scenario: I update product stock for all associated shop (except quantity)
+  Scenario: I update product stock for all associated shop (quantity not handled)
     When I update product "product1" stock for all shops with following information:
       | pack_stock_type               | products_only |
       | out_of_stock_type             | not_available |
@@ -131,7 +145,7 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
     And product product1 is not associated to shop shop3
     And product product1 is not associated to shop shop4
 
-  Scenario: I update some fields for single shop and after for all shops
+  Scenario: I update some fields for single shop and after for all shops (quantity not handled)
     When I update product "product1" stock for shop shop2 with following information:
       | pack_stock_type               | products_only |
       | out_of_stock_type             | not_available |
@@ -181,7 +195,7 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
     And product product1 is not associated to shop shop3
     And product product1 is not associated to shop shop4
 
-  Scenario: I update some fields for all shops and after for single shop
+  Scenario: I update some fields for all shops and after for single shop (quantity not handled)
     When I update product "product1" stock for all shops with following information:
       | pack_stock_type               | default  |
       | out_of_stock_type             | default  |
@@ -233,14 +247,32 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | delta_quantity | 51 |
     Then product "product1" should have following stock information for shops "shop2":
       | quantity | 111 |
+    And product "product1" last employees stock movements for shop "shop2" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 69             |
+    And product "product1" last stock movement for shop "shop2" increased by 69
     And product "product1" should have following stock information for shops "shop1":
       | quantity | 93 |
+    And product "product1" last employees stock movements for shop "shop1" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 51             |
+      | Puff       | Daddy     | 42             |
+    And product "product1" last stock movement for shop "shop1" increased by 51
 
   Scenario: I can update stock quantity independently for all shops at once
     When I update product "product1" stock for all shops with following information:
       | delta_quantity | 69 |
     Then product "product1" should have following stock information for shops "shop1,shop2":
       | quantity | 111 |
+    And product "product1" last employees stock movements for shop "shop2" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 69             |
+    And product "product1" last stock movement for shop "shop2" increased by 69
+    And product "product1" last employees stock movements for shop "shop1" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 69             |
+      | Puff       | Daddy     | 42             |
+    And product "product1" last stock movement for shop "shop1" increased by 69
 
   Scenario: I can update stock quantity for single and/or al shops but since it's a delta modification their values are not necessarily synced
     When I update product "product1" stock for shop shop2 with following information:
@@ -251,8 +283,19 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | delta_quantity | -10 |
     Then product "product1" should have following stock information for shops "shop2":
       | quantity | 101 |
+    And product "product1" last employees stock movements for shop "shop2" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | -10            |
+      | Puff       | Daddy     | 69             |
+    And product "product1" last stock movement for shop "shop2" decreased by 10
     And product "product1" should have following stock information for shops "shop1":
       | quantity | 83 |
+    And product "product1" last employees stock movements for shop "shop1" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | -10            |
+      | Puff       | Daddy     | 51             |
+      | Puff       | Daddy     | 42             |
+    And product "product1" last stock movement for shop "shop1" decreased by 10
 
   Scenario: I can update stock quantity for single and/or al shops but since it's a delta modification their values are not necessarily synced
     When I update product "product1" stock for all shops with following information:
@@ -263,5 +306,16 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | delta_quantity | 51 |
     Then product "product1" should have following stock information for shops "shop2":
       | quantity | 101 |
+    And product "product1" last employees stock movements for shop "shop2" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 69             |
+      | Puff       | Daddy     | -10            |
+    And product "product1" last stock movement for shop "shop2" increased by 69
     And product "product1" should have following stock information for shops "shop1":
       | quantity | 83 |
+    And product "product1" last employees stock movements for shop "shop1" should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 51             |
+      | Puff       | Daddy     | -10            |
+      | Puff       | Daddy     | 42             |
+    And product "product1" last stock movement for shop "shop1" increased by 51

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_stock.feature
@@ -225,3 +225,43 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | fr-FR  |          |
     And product product1 is not associated to shop shop3
     And product product1 is not associated to shop shop4
+
+  Scenario: I can update stock quantity independently for each shop
+    When I update product "product1" stock for shop shop2 with following information:
+      | delta_quantity | 69 |
+    And I update product "product1" stock for shop shop1 with following information:
+      | delta_quantity | 51 |
+    Then product "product1" should have following stock information for shops "shop2":
+      | quantity | 111 |
+    And product "product1" should have following stock information for shops "shop1":
+      | quantity | 93 |
+
+  Scenario: I can update stock quantity independently for all shops at once
+    When I update product "product1" stock for all shops with following information:
+      | delta_quantity | 69 |
+    Then product "product1" should have following stock information for shops "shop1,shop2":
+      | quantity | 111 |
+
+  Scenario: I can update stock quantity for single and/or al shops but since it's a delta modification their values are not necessarily synced
+    When I update product "product1" stock for shop shop2 with following information:
+      | delta_quantity | 69 |
+    And I update product "product1" stock for shop shop1 with following information:
+      | delta_quantity | 51 |
+    When I update product "product1" stock for all shops with following information:
+      | delta_quantity | -10 |
+    Then product "product1" should have following stock information for shops "shop2":
+      | quantity | 101 |
+    And product "product1" should have following stock information for shops "shop1":
+      | quantity | 83 |
+
+  Scenario: I can update stock quantity for single and/or al shops but since it's a delta modification their values are not necessarily synced
+    When I update product "product1" stock for all shops with following information:
+      | delta_quantity | -10 |
+    And I update product "product1" stock for shop shop2 with following information:
+      | delta_quantity | 69 |
+    And I update product "product1" stock for shop shop1 with following information:
+      | delta_quantity | 51 |
+    Then product "product1" should have following stock information for shops "shop2":
+      | quantity | 101 |
+    And product "product1" should have following stock information for shops "shop1":
+      | quantity | 83 |

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilderTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilder;
@@ -66,11 +67,13 @@ class CommandBuilderTest extends TestCase
             ->addField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
             ->addField('[_number]', 'setCount', CommandField::TYPE_INT)
             ->addField('[parent][children]', 'setChildren', CommandField::TYPE_ARRAY)
+            ->addField('[date_time]', 'setDate', CommandField::TYPE_DATETIME)
         ;
         $children = [
             'bob',
             'steve',
         ];
+        $dateTime = new DateTimeImmutable('2022-10-10 15:34:45');
 
         $command = new CommandBuilderTestCommand(ShopConstraint::shop(self::SHOP_ID));
         $command
@@ -79,6 +82,7 @@ class CommandBuilderTest extends TestCase
             ->setIsValid(true)
             ->setCount(42)
             ->setChildren($children)
+            ->setDate($dateTime)
         ;
 
         yield [
@@ -93,6 +97,7 @@ class CommandBuilderTest extends TestCase
                 'parent' => [
                     'children' => $children,
                 ],
+                'date_time' => '2022-10-10 15:34:45',
             ],
             [$command],
         ];
@@ -105,6 +110,7 @@ class CommandBuilderTest extends TestCase
             ->addField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
             ->addField('[_number]', 'setCount', CommandField::TYPE_INT)
             ->addField('[parent][children]', 'setChildren', CommandField::TYPE_ARRAY)
+            ->addField('[date_time]', 'setDate', CommandField::TYPE_DATETIME)
         ;
 
         yield [
@@ -119,6 +125,7 @@ class CommandBuilderTest extends TestCase
                 'parent' => [
                     'children' => $children,
                 ],
+                'date_time' => '2022-10-10 15:34:45',
             ],
             [$command],
         ];
@@ -148,6 +155,7 @@ class CommandBuilderTest extends TestCase
             ->addMultiShopField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
             ->addField('[_number]', 'setCount', CommandField::TYPE_INT)
             ->addField('[parent][children]', 'setChildren', CommandField::TYPE_ARRAY)
+            ->addMultiShopField('[date_time]', 'setDate', CommandField::TYPE_DATETIME)
         ;
 
         $command = new CommandBuilderTestCommand(ShopConstraint::shop(self::SHOP_ID));
@@ -156,6 +164,7 @@ class CommandBuilderTest extends TestCase
             ->setName('toto')
             ->setIsValid(true)
             ->setCount(42)
+            ->setDate($dateTime)
         ;
 
         // Same test but now some fields are multishop, since no multishop command is provided it shouldn't change the final result
@@ -169,6 +178,7 @@ class CommandBuilderTest extends TestCase
                 ],
                 '_number' => 42,
                 'unknown' => 45,
+                'date_time' => '2022-10-10 15:34:45',
             ],
             [$command],
         ];
@@ -202,11 +212,13 @@ class CommandBuilderTest extends TestCase
             ->addMultiShopField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
             ->addMultiShopField('[_number]', 'setCount', CommandField::TYPE_INT)
             ->addMultiShopField('[parent][children]', 'setChildren', CommandField::TYPE_ARRAY)
+            ->addMultiShopField('[date_time]', 'setDate', CommandField::TYPE_DATETIME)
         ;
         $children = [
             'bob',
             'steve',
         ];
+        $dateTime = new DateTimeImmutable('2022-10-10 15:34:45');
 
         $command = new CommandBuilderTestCommand(ShopConstraint::shop(self::SHOP_ID));
         $command
@@ -215,6 +227,7 @@ class CommandBuilderTest extends TestCase
             ->setIsValid(true)
             ->setCount(42)
             ->setChildren($children)
+            ->setDate($dateTime)
         ;
 
         yield [
@@ -229,6 +242,7 @@ class CommandBuilderTest extends TestCase
                 'parent' => [
                     'children' => $children,
                 ],
+                'date_time' => '2022-10-10 15:34:45',
             ],
             [$command],
         ];
@@ -244,6 +258,7 @@ class CommandBuilderTest extends TestCase
         $allShopsCommand
             ->setCount(42)
             ->setChildren($children)
+            ->setDate($dateTime)
         ;
 
         yield [
@@ -260,6 +275,8 @@ class CommandBuilderTest extends TestCase
                     'children' => $children,
                     self::MULTI_SHOP_PREFIX . 'children' => true,
                 ],
+                'date_time' => '2022-10-10 15:34:45',
+                self::MULTI_SHOP_PREFIX . 'date_time' => true,
             ],
             [$command, $allShopsCommand],
         ];
@@ -273,6 +290,8 @@ class CommandBuilderTest extends TestCase
                     'children' => $children,
                     self::MULTI_SHOP_PREFIX . 'children' => true,
                 ],
+                'date_time' => '2022-10-10 15:34:45',
+                self::MULTI_SHOP_PREFIX . 'date_time' => true,
             ],
             [$allShopsCommand],
         ];
@@ -284,6 +303,7 @@ class CommandBuilderTest extends TestCase
             ->setName('toto')
             ->setCount(42)
             ->setIsValid(false)
+            ->setDate($dateTime)
         ;
 
         $allShopsCommand = new CommandBuilderTestCommand(ShopConstraint::allShops());
@@ -306,6 +326,8 @@ class CommandBuilderTest extends TestCase
                     'children' => $children,
                     self::MULTI_SHOP_PREFIX . 'children' => true,
                 ],
+                'date_time' => '2022-10-10 15:34:45',
+                self::MULTI_SHOP_PREFIX . 'date_time' => false,
             ],
             [$command, $allShopsCommand],
         ];
@@ -318,6 +340,7 @@ class CommandBuilderTest extends TestCase
             ->addMultiShopField('[command][isValid]', 'setIsValid', CommandField::TYPE_BOOL)
             ->addMultiShopField('[_number]', 'setCount', CommandField::TYPE_INT)
             ->addMultiShopField('[parent][children]', 'setChildren', CommandField::TYPE_ARRAY)
+            ->addField('[date_time]', 'setDate', CommandField::TYPE_DATETIME)
         ;
 
         $command = new CommandBuilderTestCommand(ShopConstraint::shop(self::SHOP_ID));
@@ -325,6 +348,7 @@ class CommandBuilderTest extends TestCase
             ->setName('toto')
             ->setCount(42)
             ->setIsValid(false)
+            ->setDate($dateTime)
         ;
 
         $allShopsCommand = new CommandBuilderTestCommand(ShopConstraint::allShops());
@@ -348,6 +372,8 @@ class CommandBuilderTest extends TestCase
                     'children' => $children,
                     self::MULTI_SHOP_PREFIX . 'children' => true,
                 ],
+                'date_time' => '2022-10-10 15:34:45',
+                self::MULTI_SHOP_PREFIX . 'date_time' => true,
             ],
             [$command, $allShopsCommand],
         ];

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilderTest.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilder;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilderConfig;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandField;
+use PrestaShop\PrestaShop\Core\Util\DateTime\NullDateTime;
 
 class CommandBuilderTest extends TestCase
 {
@@ -179,6 +180,35 @@ class CommandBuilderTest extends TestCase
                 '_number' => 42,
                 'unknown' => 45,
                 'date_time' => '2022-10-10 15:34:45',
+            ],
+            [$command],
+        ];
+
+        // Handle empty date time
+        $config = new CommandBuilderConfig(self::MULTI_SHOP_PREFIX);
+        $config
+            ->addField('[date_time]', 'setDate', CommandField::TYPE_DATETIME)
+        ;
+
+        $command = new CommandBuilderTestCommand(ShopConstraint::shop(self::SHOP_ID));
+        $command
+            ->setDate(new NullDateTime())
+        ;
+
+        // Test empty datetime
+        yield [
+            $config,
+            [
+                'date_time' => '',
+            ],
+            [$command],
+        ];
+
+        // Test empty datetime
+        yield [
+            $config,
+            [
+                'date_time' => null,
             ],
             [$command],
         ];

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilderTestCommand.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/CommandBuilderTestCommand.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder;
 
+use DateTimeImmutable;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 class CommandBuilderTestCommand
@@ -56,6 +57,11 @@ class CommandBuilderTestCommand
      * @var array
      */
     private $children;
+
+    /**
+     * @var DateTimeImmutable
+     */
+    private $date;
 
     /**
      * @var ShopConstraint
@@ -176,5 +182,25 @@ class CommandBuilderTestCommand
     public function getShopConstraint(): ShopConstraint
     {
         return $this->shopConstraint;
+    }
+
+    /**
+     * @return DateTimeImmutable
+     */
+    public function getDate(): DateTimeImmutable
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param DateTimeImmutable $date
+     *
+     * @return static
+     */
+    public function setDate(DateTimeImmutable $date): self
+    {
+        $this->date = $date;
+
+        return $this;
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/CommandFieldTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/CommandFieldTest.php
@@ -75,6 +75,20 @@ class CommandFieldTest extends TestCase
             CommandField::TYPE_INT,
             true,
         ];
+
+        yield [
+            'localized_field',
+            'setLocalizedField',
+            CommandField::TYPE_ARRAY,
+            true,
+        ];
+
+        yield [
+            'date_time',
+            'setDate',
+            CommandField::TYPE_DATETIME,
+            true,
+        ];
     }
 
     /**

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/StockCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/StockCommandsBuilderTest.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\UpdateProductStockIn
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\StockCommandsBuilder;
+use PrestaShop\PrestaShop\Core\Util\DateTime\NullDateTime;
 
 class StockCommandsBuilderTest extends AbstractProductCommandBuilderTest
 {
@@ -194,6 +195,32 @@ class StockCommandsBuilderTest extends AbstractProductCommandBuilderTest
                 'stock' => [
                     'availability' => [
                         'available_date' => '2022-10-10',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setAvailableDate(new NullDateTime());
+        yield [
+            [
+                'stock' => [
+                    'availability' => [
+                        'available_date' => '',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setAvailableDate(new NullDateTime());
+        yield [
+            [
+                'stock' => [
+                    'availability' => [
+                        'available_date' => null,
                     ],
                 ],
             ],

--- a/tests/Unit/Core/Util/DateTime/NullDateTimeTest.php
+++ b/tests/Unit/Core/Util/DateTime/NullDateTimeTest.php
@@ -75,11 +75,11 @@ class NullDateTimeTest extends TestCase
         $nullDateTime->format($format);
     }
 
-    public function testMethodAddShouldThrowException(): void
+    public function testMethodAddChangesNothing(): void
     {
-        $this->expectUnusableMethodException('add');
         $nullDateTime = new NullDateTime();
-        $nullDateTime->add('+1 day');
+        $modifiedDateTime = $nullDateTime->add('+1 day');
+        $this->assertEquals($nullDateTime, $modifiedDateTime);
     }
 
     public function testMethodCreateFromFormatShouldThrowException(): void
@@ -137,16 +137,16 @@ class NullDateTimeTest extends TestCase
 
     public function testMethodSetTimezoneShouldThrowException(): void
     {
-        $this->expectUnusableMethodException('setTimezone');
         $nullDateTime = new NullDateTime();
-        $nullDateTime->setTimezone(new DateTimeZone('UTC'));
+        $modifiedDateTime = $nullDateTime->setTimezone(new DateTimeZone('UTC'));
+        $this->assertEquals($nullDateTime, $modifiedDateTime);
     }
 
     public function testMethodSubShouldThrowException(): void
     {
-        $this->expectUnusableMethodException('sub');
         $nullDateTime = new NullDateTime();
-        $nullDateTime->sub('-1 day');
+        $modifiedDateTime = $nullDateTime->sub('-1 day');
+        $this->assertEquals($nullDateTime, $modifiedDateTime);
     }
 
     public function testMethodDiffShouldThrowException(): void


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle product stock data in a multishop context CommandBuilder can now handle `ImmutableDateTime` type
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | ~
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27719)
<!-- Reviewable:end -->

### Breaking Changes

- `StockAvailableRepository` has been cleaned from several methods, even if it will be merged with `StockAvailableMultiShopRepository` later it might not meet exactly the interfaces from 178
- `UpdateProductStockInformationCommand` now requires a shop constraint parameter
- `GetEmployeesStockMovements` now requires a `shopId` parameter
- `StockCommandsBuilder` now implements the `MultiShopProductCommandsBuilderInterface`
- `NulDateTime` now authorizes the use of a few methods instead of throwing an exception, it remains unchanged though (the methods have no effect)
