### PR TITLE
Fix translations installation broken by prefix

### DIFF
--- a/src/Adapter/EntityTranslation/DataLangFactory.php
+++ b/src/Adapter/EntityTranslation/DataLangFactory.php
@@ -119,7 +119,7 @@ class DataLangFactory
     {
         $length = strlen($this->dbPrefix);
         if (substr($tableName, 0, $length) === $this->dbPrefix) {
-            $tableName = substr($tableName, $length - 1) ?? '';
+            $tableName = substr($tableName, $length) ?: '';
         }
 
         return $tableName;

--- a/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
+++ b/tests/Unit/Adapter/Translations/DataLangFactoryTest.php
@@ -33,28 +33,27 @@ use PrestaShopBundle\Translation\TranslatorInterface;
 
 class DataLangFactoryTest extends TestCase
 {
-    const DB_PREFIX = 'ps_';
-
     /**
-     * @param string $tableName
-     * @param string $expected
-     *
      * @dataProvider provideTableNames
      */
-    public function testItCreatesClassNamesFromTableNames(string $tableName, string $expected)
+    public function testItCreatesClassNamesFromTableNames(string $databasePrefix, string $tableName, string $expected)
     {
-        $factory = new DataLangFactory(self::DB_PREFIX, $this->getMockBuilder(TranslatorInterface::class)->getMock());
+        $factory = new DataLangFactory(
+            $databasePrefix,
+            $this->getMockBuilder(TranslatorInterface::class)->getMock()
+        );
         $this->assertSame($expected, $factory->getClassNameFromTable($tableName));
     }
 
     public function provideTableNames()
     {
         return [
-            [self::DB_PREFIX . 'tab_lang', 'TabLang'],
-            [self::DB_PREFIX . 'cart_rule_lang', 'CartRuleLang'],
-            ['cart_rule_lang', 'CartRuleLang'],
-            [self::DB_PREFIX . 'tab_lang', 'TabLang'],
-            ['tab', 'TabLang'],
+            ['ps_', 'ps_tab_lang', 'TabLang'],
+            ['ps_', 'ps_cart_rule_lang', 'CartRuleLang'],
+            ['ps_', 'cart_rule_lang', 'CartRuleLang'],
+            ['ps_', 'tab', 'TabLang'],
+            ['ps', 'pstab_lang', 'TabLang'],
+            ['ps', 'ps_tab_lang', 'TabLang'],
         ];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Installation using `ps` instead of `ps_` as database prefix fails to translate `_lang` tables.<br/>Bug went unnoticed because underscore character is removed when table name gets converted in camel case.<br/>ps_tab_lang => _tab_lang => TabLang => OK<br/>pstab_lang => stab_lang => StabLang => Class not found
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27029.
| How to test?      | <ol><li>Install docker image from https://hub.docker.com/r/prestashop/prestashop<br/>(i installed with this command `docker run -ti --name some-prestashop --network prestashop-net -e DB_SERVER=some-mysql -e PS_DEV_MODE=0 -e DB_USER=root -e DB_PASSWD=admin -e DB_PREFIX=ps -e DB_NAME=testdocker -e PS_INSTALL_AUTO=0 -e PS_ERASE_DB=1 -e PS_INSTALL_DB=1 -e PS_DOMAIN=localhost -e PS_LANGUAGE=fr -e PS_COUNTRY=fr -e PS_ALL_LANGUAGES=0 -e PS_FOLDER_ADMIN=admin-dev -e PS_FOLDER_INSTALL=install-dev -e PS_ENABLE_SSL=0 -e ADMIN_MAIL=demo@prestashop.com -e ADMIN_PASSWD=prestashop_demo -p 8181:80 -d prestashop/prestashop`)</li><li>Install shop in manual (install in fr and country in fr) or with CLI<br/>(i installed with this command `runuser -g www-data -u www-data -- php -d memory_limit=1 /var/www/html/$PS_FOLDER_INSTALL/index_cli.php --domain=localhost:8181 --db_server=some-mysql --db_name="$DB_NAME" --db_user=root --db_password=admin --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY --all_languages=0 --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL`)</li><li>Go to the BO of your shop and login</li><li>See error => side menu is in english but should be in french</li><li>See error => translation tables `*_lang` in database are not translated to french</li></ol>
| Possible impacts? | Installation CLI and Web, with unusual database prefix like `ps`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27722)
<!-- Reviewable:end -->
