### PR TITLE
Debug multishop category

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -320,7 +320,7 @@ const formCategory = (function () {
             <label>
               <input type="checkbox" name="form[step1][categories][tree][]" checked value="${response.category.id}">
               ${response.category.name[1]}
-              <input type="radio" value="${response.category.id}" name="ignore" class="default-category">
+              <input type="checkbox" value="${response.category.id}" name="ignore" class="default-category">
             </label>
           </div>
           </li>`;

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -94,7 +94,8 @@ class CategoryControllerCore extends ProductListingFrontController
 
         parent::init();
 
-        if (!Validate::isLoadedObject($this->category) || !$this->category->active) {
+        if (!Validate::isLoadedObject($this->category) || !$this->category->active || !$this->category->isAssociatedToShop(Context::getContext()->shop->id)) {
+            $this->category->active = false;
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
             $this->setTemplate('errors/404');

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -194,13 +194,13 @@
                         {{ child.name }}
                     {% endif %}
                     {% if defaultCategory is defined %}
-                        <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
+                        <input type="checkbox" value="{{ child.id_category }}" name="ignore" class="default-category" />
                     {% endif %}
                 </label>
             </div>
         {%- else -%}
             <div class="radio">
-              <label>
+                <label>
                 <input type="radio" name="form[{{ form.vars.id }}][tree]" value="{{ child.id_category }}"{% if checked %} checked="checked"{% endif %} class="category"{% if required %} required{% endif %}>
                     {{ child.name }}
                     {% if defaultCategory is defined %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -374,7 +374,7 @@
             {{ child.name }}
           {% endif %}
           {% if defaultCategory is defined %}
-            <input type="radio" value="{{ child.id_category }}" name="ignore" class="default-category" />
+            <input type="checkbox" value="{{ child.id_category }}" name="ignore" class="default-category" />
           {% endif %}
         </label>
       </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the case of a Prestashop Multishop, with shared products, it is impossible to define a default store category per store. We should be able to define a default category for each shop and categories assigned to a store should not be accessible on FO.
| Type?             | bug fix
| Category?         | FO and BO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22610 
| How to test?      | Steps to reproduce Create a Prestashop with two stores with shared stock <br>Create a category for each store <br>Create a product, assign it to the two shops, and to the two categories. <br>Try to put a default category for each store <br>On the detail of the product sheet on the Front Office side, in the store that does not have a default category, check the category link in the breadcrumb
| Possible impacts? | Default Category

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27732)
<!-- Reviewable:end -->
