### PR TITLE
Remove PSWS-Version header as it's added after and only if we are authenticated

### DIFF
--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -1790,7 +1790,6 @@ class WebserviceRequestCore
         $this->objOutput
             ->setHeaderParams('Access-Time', (string) time())
             ->setHeaderParams('X-Powered-By', 'PrestaShop Webservice')
-            ->setHeaderParams('PSWS-Version', _PS_VERSION_)
             ->setHeaderParams('Execution-Time', (string) round(microtime(true) - $this->_startTime, 3))
         ;
 


### PR DESCRIPTION
…thenticated

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove an information header api returns.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below

### How to test

Perform a HTTP request against web service
- if you are not authentificated the PSWS-Version header should not be set
- if you are authentificated the PSWS-Version header should be set

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27741)
<!-- Reviewable:end -->
