### PR TITLE
Fix the category dropdown on the module catalog page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories_catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/dropdown_categories_catalog.html.twig
@@ -33,14 +33,13 @@
     </div>
 
     <div class="ps-dropdown-menu dropdown-menu module-category-selector items-list js-items-list" aria-labelledby="{{refMenu}}">
-        <a class="dropdown-item module-category-reset">
+        <a class="dropdown-item module-category-menu module-category-reset">
           {{ 'All categories'|trans({}, 'Admin.Modules.Feature') }}
         </a>
 
         {% for subMenu in menu.subMenu %}
           <a 
-            class="dropdown-item" 
-            class="module-category-menu"
+            class="dropdown-item module-category-menu"
             {% if subMenu.tab %}data-category-tab="{{subMenu.tab}}"{% endif %}
             data-category-ref="{{subMenu.refMenu}}"
             data-category-display-name="{{subMenu.name}}"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | See #27747
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27747
| How to test?      | Go to Admin > Modules > Modules catalog, you'll have a list of recommended modules in different categories. In the top right corner, try to filter with a category in the dropdown, the list will be reduced to the modules matching this category
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27748)
<!-- Reviewable:end -->
