### PR TITLE
Add scrollbar when changelog is too long

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/_modules.scss
+++ b/admin-dev/themes/new-theme/scss/pages/_modules.scss
@@ -166,6 +166,12 @@
 .module-modal-content {
   border: none;
   box-shadow: none;
+
+  .changelog-tab {
+    max-height: 300px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
 }
 
 .module-modal-close {

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_read_more_content.html.twig
@@ -179,7 +179,7 @@
             </p>
           </div>
 
-          <div id="changelog-{{ name }}" class="tab-pane fade">
+          <div id="changelog-{{ name }}" class="tab-pane fade changelog-tab">
             {% if changeLog %}
               <ul class="module-readmore-tab-content">
                 {% for version, lines in changeLog|arrayCast|reverse %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Adds a max-height for the module changelog tab and scrollbar when content is too long
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27752
| How to test?      | Go to Modules catalog in the Admin, search for colissimo (just an example) and click on the changelog tab. You will have a scollbar because the content is too long
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27750)
<!-- Reviewable:end -->
