### PR TITLE
FO:  Remove Front controller deprecated properties

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -33,34 +33,6 @@ use Symfony\Component\HttpFoundation\IpUtils;
 
 class FrontControllerCore extends Controller
 {
-    /**
-     * @deprecated Deprecated shortcuts as of 1.5.0.1 - Use $context->smarty instead
-     *
-     * @var Smarty
-     */
-    protected static $smarty;
-
-    /**
-     * @deprecated Deprecated shortcuts as of 1.5.0.1 - Use $context->cookie instead
-     *
-     * @var Cookie
-     */
-    protected static $cookie;
-
-    /**
-     * @deprecated Deprecated shortcuts as of 1.5.0.1 - Use $context->link instead
-     *
-     * @var Link
-     */
-    protected static $link;
-
-    /**
-     * @deprecated Deprecated shortcuts as of 1.5.0.1 - Use $context->cart instead
-     *
-     * @var Cart
-     */
-    protected static $cart;
-
     /** @var array Controller errors */
     public $errors = [];
 
@@ -263,17 +235,6 @@ class FrontControllerCore extends Controller
      * class properties, redirects depending on context, etc.
      *
      * @global bool     $useSSL           SSL connection flag
-     * @global Cookie   $cookie           Visitor's cookie
-     * @global Smarty   $smarty
-     * @global Cart     $cart             Visitor's cart
-     * @global string   $iso              Language ISO
-     * @global Country  $defaultCountry   Visitor's country object
-     * @global string   $protocol_link
-     * @global string   $protocol_content
-     * @global Link     $link
-     * @global array    $css_files
-     * @global array    $js_files
-     * @global Currency $currency         Visitor's selected currency
      *
      * @throws PrestaShopException
      */
@@ -291,7 +252,7 @@ class FrontControllerCore extends Controller
          * Use the Context object to access objects instead.
          * Example: $this->context->cart
          */
-        global $useSSL, $cookie, $smarty, $cart, $iso, $defaultCountry, $protocol_link, $protocol_content, $link, $css_files, $js_files, $currency;
+        global $useSSL;
 
         if (self::$initialized) {
             return;
@@ -305,10 +266,6 @@ class FrontControllerCore extends Controller
         if (Tools::usingSecureMode()) {
             $useSSL = true;
         }
-
-        // For compatibility with globals, DEPRECATED as of version 1.5.0.1
-        $css_files = $this->css_files;
-        $js_files = $this->js_files;
 
         $this->sslRedirection();
 
@@ -478,24 +435,12 @@ class FrontControllerCore extends Controller
             $this->context->country = $country;
         }
 
-        /*
-         * These shortcuts are DEPRECATED as of version 1.5.0.1
-         * Use the Context to access objects instead.
-         * Example: $this->context->cart
-         */
-        self::$cookie = $this->context->cookie;
-        self::$cart = $cart;
-        self::$smarty = $this->context->smarty;
-        self::$link = $link;
-        $defaultCountry = $this->context->country;
-
         $this->displayMaintenancePage();
 
         if (Country::GEOLOC_FORBIDDEN == $this->restrictedCountry) {
             $this->displayRestrictedCountryPage();
         }
 
-        $this->iso = $iso;
         $this->context->cart = $cart;
         $this->context->currency = $currency;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Remove deprecated class attributes and global variables from front controller (except $useSSL )
| Type?             |  improvement
| Category?         | FO
| BC breaks?        | Old modules which relies on usages of the global variables : $cookie, $smarty, $cart, $iso, $defaultCountry, $protocol_link, $protocol_content, $link, $css_files, $js_files, $currency should change to use variables from the context instead.
| Deprecations?     | yes / no
| Fixed ticket?     | Relative to  #26293
| How to test?      |  Global tests should not fail
| Possible impacts? | Old modules relying on globals will not works anymore ( but usage is discouraged since the release of prestashop 1.5.0.1 ... ) As discussed in this PR the useSSL var can have impacts and will be treated in another PR.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27756)
<!-- Reviewable:end -->
