### PR TITLE
Fix images for objects without name or rewrite

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -164,47 +164,62 @@ class ImageRetriever
 
         $urls = [];
         $image_types = ImageType::getImagesTypes($type, true);
-
+        $generateHighDpiImages = (bool) Configuration::get('PS_HIGHT_DPI');
         $ext = 'jpg';
 
-        $mainImagePath = implode(DIRECTORY_SEPARATOR, [
+        // Get path of original uploaded image we will use to get thumbnails
+        $originalImagePath = implode(DIRECTORY_SEPARATOR, [
             $imageFolderPath,
             $id_image . '.' . $ext,
         ]);
-        $generateHighDpiImages = (bool) Configuration::get('PS_HIGHT_DPI');
 
         foreach ($image_types as $image_type) {
-            $resizedImagePath = implode(DIRECTORY_SEPARATOR, [
+            // Final path thumbnail in our size
+            $thumbnailPath = implode(DIRECTORY_SEPARATOR, [
                 $imageFolderPath,
                 $id_image . '-' . $image_type['name'] . '.' . $ext,
             ]);
 
-            if (!file_exists($resizedImagePath)) {
+            // Check if the thumbnail exists, if not, create it automatically on the fly
+            if (!file_exists($thumbnailPath)) {
                 ImageManager::resize(
-                    $mainImagePath,
-                    $resizedImagePath,
+                    $originalImagePath,
+                    $thumbnailPath,
                     (int) $image_type['width'],
                     (int) $image_type['height']
                 );
             }
 
+            /* 
+            * If High-DPI images are enabled, we will also generate a thumbnail in
+            * double the size, so it can be used in src-sets.
+            */
             if ($generateHighDpiImages) {
-                $resizedImagePathHighDpi = implode(DIRECTORY_SEPARATOR, [
+                $thumbnailPathHighDpi = implode(DIRECTORY_SEPARATOR, [
                     $imageFolderPath,
                     $id_image . '-' . $image_type['name'] . '2x.' . $ext,
                 ]);
-                if (!file_exists($resizedImagePathHighDpi)) {
+                if (!file_exists($thumbnailPathHighDpi)) {
                     ImageManager::resize(
-                        $mainImagePath,
-                        $resizedImagePathHighDpi,
+                        $originalImagePath,
+                        $thumbnailPathHighDpi,
                         (int) $image_type['width'] * 2,
                         (int) $image_type['height'] * 2
                     );
                 }
             }
 
+            // Thumbnail done, now let's generate it's seo-friendly URL and add it to our output
+            // Primary (fake) image name is object rewrite, fallbacks are name and ID
+            if (!empty($object->link_rewrite)) {
+                $rewrite = $object->link_rewrite;
+            } elseif (!empty($object->name)) {
+                $rewrite = $object->name;
+            } else {
+                $rewrite = $id_image;
+            }
             $url = $this->link->$getImageURL(
-                isset($object->link_rewrite) ? $object->link_rewrite : $object->name,
+                $rewrite,
                 $id_image,
                 $image_type['name']
             );
@@ -216,12 +231,13 @@ class ImageRetriever
             ];
         }
 
+        // Sort thumbnails by size
         uasort($urls, function (array $a, array $b) {
             return $a['width'] * $a['height'] > $b['width'] * $b['height'] ? 1 : -1;
         });
 
+        // Resolve some basic sizes - the smallest, middle and largest
         $keys = array_keys($urls);
-
         $small = $urls[$keys[0]];
         $large = end($urls);
         $medium = $urls[$keys[ceil((count($keys) - 1) / 2)]];
@@ -231,7 +247,7 @@ class ImageRetriever
             'small' => $small,
             'medium' => $medium,
             'large' => $large,
-            'legend' => isset($object->meta_title) ? $object->meta_title : $object->name,
+            'legend' => !empty($object->meta_title) ? $object->meta_title : $object->name,
             'id_image' => $id_image,
         ];
     }

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -190,7 +190,7 @@ class ImageRetriever
                 );
             }
 
-            /* 
+            /*
             * If High-DPI images are enabled, we will also generate a thumbnail in
             * double the size, so it can be used in src-sets.
             */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If a product does not have `link _rewrite` or a `name`, it didn't work because of wrong URL. I use image ID as a fallback. Also, changed `isset` to `!empty` and renamed some variables to make it more understandable.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Resolves #27757, Resolves #30058
| How to test?      | Make a product, set name and link_rewrite in ps_product_lang to empty strings, check in FO that no images for that product are working. I managed to somehow reproduce a scenario where language addition failed and there was no data for single language, and whole shop was without images.
| Possible impacts? | No


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27758)
<!-- Reviewable:end -->
