### PR TITLE
Fix structured data availability

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -386,16 +386,13 @@ class ProductLazyArray extends AbstractLazyArray
      */
     public function getSeoAvailability()
     {
-        $seoAvailability = 'https://schema.org/';
-        if ($this->product['quantity'] > 0) {
-            $seoAvailability .= 'InStock';
-        } elseif ($this->product['quantity'] <= 0 && $this->product['allow_oosp']) {
-            $seoAvailability .= 'PreOrder';
+        if ($this->product['active'] === 0) {
+            return 'https://schema.org/Discontinued';
+        } elseif ($this->product['quantity'] > 0 || !$this->configuration->get('PS_STOCK_MANAGEMENT')) {
+            return 'https://schema.org/InStock';
         } else {
-            $seoAvailability .= 'OutOfStock';
+            return 'https://schema.org/OutOfStock';
         }
-
-        return $seoAvailability;
     }
 
     /**


### PR DESCRIPTION
Closed in favor of https://github.com/PrestaShop/PrestaShop/pull/29411/

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Structured data needed some tweaks, more info below. Everything is PM validated.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23534 and #23199
| How to test?      | Check source code on front office product page before and after the change.
| Possible impacts? | Better SEO. :-)

**What changed**
- Products out of stock should not have **Preorder** availability. Per google documentation: `Note: The preorder value should only be used for new products and shouldn't be used for existing products that are out of stock and will be back in stock at a later date.​`
  - Google doc: https://support.google.com/merchants/answer/6324448?hl=en
  - Discussion: https://github.com/PrestaShop/PrestaShop/issues/23534#issuecomment-796258724
- If stock management is disabled = we have everything, we should always return **In Stock**.
  - Discussion: https://github.com/PrestaShop/PrestaShop/pull/23248#issuecomment-813998975
  - Google doc: https://support.google.com/merchants/answer/6324448

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27759)
<!-- Reviewable:end -->
