### PR TITLE
Proper guest management in backoffice

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
@@ -42,6 +42,15 @@ export default class CustomerForm {
     $(customerFormMap.customerGroupCheckboxes).on('change', (event) => {
       this.checkOrUpdateDefaultGroup($(event.currentTarget).is(':checked'));
     });
+
+    // Watch is_guest switch change and update other inputs accordingly
+    $(customerFormMap.isGuestRadios).on('change', (event) => {
+      if (Number($(event.currentTarget).val()) === 1) {
+        this.adaptFormForGuestCustomer();
+      } else {
+        this.adaptFormForRegisteredCustomer();
+      }
+    });
   }
 
   private checkOrUpdateDefaultGroup(wasChecked: boolean): void {
@@ -82,5 +91,69 @@ export default class CustomerForm {
     if (!checkedGroups.includes(currentDefaultGroup)) {
       $(customerFormMap.defaultGroupSelect).val(checkedGroups[0]).trigger('change');
     }
+  }
+
+  private adaptFormForGuestCustomer(): void {
+    // Disable password input and clean it
+    $(customerFormMap.passwordInput)
+      .prop('disabled', 'disabled')
+      .prop('required', false)
+      .val('')
+      .removeClass('border-danger')
+      .removeClass('border-success')
+      .popover('dispose');
+
+    // Hide password feedback
+    $(customerFormMap.passwordStrengthFeedbackContainer).toggleClass('d-none', true);
+
+    // Check groups and disable all checkboxes except guest group
+    $(customerFormMap.customerGroupCheckboxes).each((index, input) => {
+      if (Number($(input).val()) === window.data.guestGroupId) {
+        $(input).prop('checked', 'checked');
+      } else {
+        $(input).prop('checked', false);
+      }
+      $(input).prop('disabled', 'disabled');
+    });
+
+    // Disable select all selector
+    $('.js-choice-table-select-all').prop('disabled', 'disabled');
+
+    // Set guest default group and disable the field
+    $(customerFormMap.defaultGroupSelect).prop('disabled', 'disabled').val(window.data.guestGroupId).trigger('change');
+
+    // Disable "Enabled" input and set it to yes
+    $(customerFormMap.isEnabledRadios).prop('disabled', 'disabled');
+    $(customerFormMap.isEnabledRadiosOff).prop('checked', false);
+    $(customerFormMap.isEnabledRadiosOn).prop('checked', 'checked');
+  }
+
+  private adaptFormForRegisteredCustomer(): void {
+    // Enable password input
+    $(customerFormMap.passwordInput)
+      .prop('disabled', false)
+      .prop('required', 'required');
+
+    // Check default groups and enable all checkboxes
+    $(customerFormMap.customerGroupCheckboxes).each((index, input) => {
+      if (window.data.defaultGroups.includes(Number($(input).val()))) {
+        $(input).prop('checked', 'checked');
+      } else {
+        $(input).prop('checked', false);
+      }
+      $(input).prop('disabled', false);
+    });
+
+    // Enable select all selector
+    $('.js-choice-table-select-all').prop('disabled', false);
+
+    // Set customer group as default group and enable the field
+    $(customerFormMap.defaultGroupSelect).prop('disabled', false)
+      .val(window.data.customerGroupId).trigger('change');
+
+    // Enable "Enabled" input and set it to yes
+    $(customerFormMap.isEnabledRadios).prop('disabled', false);
+    $(customerFormMap.isEnabledRadiosOff).prop('checked', false);
+    $(customerFormMap.isEnabledRadiosOn).prop('checked', 'checked');
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/customer/customer-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/customer-form-map.ts
@@ -31,7 +31,17 @@ export default {
   passwordStrengthFeedbackContainer: '.password-strength-feedback',
   requiredFieldsFormAlertOptin: '#customerRequiredFieldsAlertMessageOptin',
   requiredFieldsFormCheckboxOptin: '#customerRequiredFieldsContainer input[type="checkbox"][value="optin"]',
+
+  // Customer group inputs
   customerGroupCheckboxes: 'input[type="checkbox"][name="customer[group_ids][]"]',
   defaultGroupSelect: '#customer_default_group_id',
   defaultGroupSelectedOption: '#customer_default_group_id option:selected',
+
+  // Is guest switch selector
+  isGuestRadios: 'input[name="customer[is_guest]"]',
+
+  // Is enabled switch and it's radios
+  isEnabledRadios: 'input[name="customer[is_enabled]"]',
+  isEnabledRadiosOn: 'input[name="customer[is_enabled]"][value="1"]',
+  isEnabledRadiosOff: 'input[name="customer[is_enabled]"][value="0"]',
 };

--- a/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
@@ -115,12 +115,12 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
             return (int) $groupId;
         }, $data['group_ids']);
         $isEnabled = (bool) $data['is_enabled'];
-        
+
         /*
          * If a guest is created, we will alter the data a bit.
          * The data should already come correct from the form, but we can't trust the JS.
-         * 
-         * Difference between a customer and a guest is not big:
+         *
+         * Difference between a customer and a guest:
          * - Password is randomly generated.
          * - He is always enabled.
          * - His default group is the default GUEST group and he should belong to this group.
@@ -148,6 +148,7 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
             (bool) $data['is_guest']
         );
 
+        // Optional data processed only if B2B mode is enabled
         if ($this->isB2bFeatureEnabled) {
             $command
                 ->setCompanyName((string) $data['company_name'])

--- a/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
@@ -31,6 +31,9 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Command\AddCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\EditCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Birthday;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
+use PrestaShop\PrestaShop\Core\Group\Provider\DefaultGroupsProviderInterface;
+use PrestaShop\PrestaShop\Core\Security\OpenSsl\OpenSSL;
+use PrestaShop\PrestaShop\Core\Security\PasswordGenerator;
 
 /**
  * Saves or updates customer data submitted in form
@@ -53,18 +56,26 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
     private $isB2bFeatureEnabled;
 
     /**
+     * @var DefaultGroupsProviderInterface
+     */
+    private $defaultGroupsProvider;
+
+    /**
      * @param CommandBusInterface $bus
      * @param int $contextShopId
      * @param bool $isB2bFeatureEnabled
+     * @param DefaultGroupsProviderInterface $defaultGroupsProvider
      */
     public function __construct(
         CommandBusInterface $bus,
         $contextShopId,
-        $isB2bFeatureEnabled
+        $isB2bFeatureEnabled,
+        DefaultGroupsProviderInterface $defaultGroupsProvider
     ) {
         $this->bus = $bus;
         $this->contextShopId = $contextShopId;
         $this->isB2bFeatureEnabled = $isB2bFeatureEnabled;
+        $this->defaultGroupsProvider = $defaultGroupsProvider;
     }
 
     /**
@@ -97,37 +108,57 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
      */
     private function buildCustomerAddCommandFromFormData(array $data)
     {
+        // Default data from the form
+        $password = $data['password'];
+        $defaultGroupId = (int) $data['default_group_id'];
         $groupIds = array_map(function ($groupId) {
             return (int) $groupId;
         }, $data['group_ids']);
+        $isEnabled = (bool) $data['is_enabled'];
+        
+        /*
+         * If a guest is created, we will alter the data a bit.
+         * The data should already come correct from the form, but we can't trust the JS.
+         * 
+         * Difference between a customer and a guest is not big:
+         * - Password is randomly generated.
+         * - He is always enabled.
+         * - His default group is the default GUEST group and he should belong to this group.
+         */
+        if ($data['is_guest']) {
+            $password = (new PasswordGenerator(new OpenSSL()))->generatePassword(16, 'RANDOM');
+            $guestGroupId = $this->defaultGroupsProvider->getGroups()->getGuestsGroup()->getId();
+            $defaultGroupId = $guestGroupId;
+            $groupIds = [$guestGroupId];
+            $isEnabled = true;
+        }
 
         $command = new AddCustomerCommand(
             $data['first_name'],
             $data['last_name'],
             $data['email'],
-            $data['password'],
-            (int) $data['default_group_id'],
+            $password,
+            $defaultGroupId,
             $groupIds,
             $this->contextShopId,
             (int) $data['gender_id'],
-            (bool) $data['is_enabled'],
+            $isEnabled,
             (bool) $data['is_partner_offers_subscribed'],
-            $data['birthday'] ?: Birthday::EMPTY_BIRTHDAY
+            $data['birthday'] ?: Birthday::EMPTY_BIRTHDAY,
+            (bool) $data['is_guest']
         );
 
-        if (!$this->isB2bFeatureEnabled) {
-            return $command;
+        if ($this->isB2bFeatureEnabled) {
+            $command
+                ->setCompanyName((string) $data['company_name'])
+                ->setSiretCode((string) $data['siret_code'])
+                ->setApeCode((string) $data['ape_code'])
+                ->setWebsite((string) $data['website'])
+                ->setAllowedOutstandingAmount((float) $data['allowed_outstanding_amount'])
+                ->setMaxPaymentDays((int) $data['max_payment_days'])
+                ->setRiskId((int) $data['risk_id'])
+            ;
         }
-
-        $command
-            ->setCompanyName((string) $data['company_name'])
-            ->setSiretCode((string) $data['siret_code'])
-            ->setApeCode((string) $data['ape_code'])
-            ->setWebsite((string) $data['website'])
-            ->setAllowedOutstandingAmount((float) $data['allowed_outstanding_amount'])
-            ->setMaxPaymentDays((int) $data['max_payment_days'])
-            ->setRiskId((int) $data['risk_id'])
-        ;
 
         return $command;
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -161,11 +161,12 @@ class CustomerController extends AbstractAdminController
         }
 
         $this->addGroupSelectionToRequest($request);
-        $customerFormOptions = [
-            'show_guest_field' => $this->get('prestashop.adapter.legacy.configuration')->get('PS_GUEST_CHECKOUT_ENABLED') == 1 ? true : false,
-        ];
-        $customerForm = $this->get('prestashop.core.form.identifiable_object.builder.customer_form_builder')
-            ->getForm([], $customerFormOptions);
+        $customerForm = $this->get('prestashop.core.form.identifiable_object.builder.customer_form_builder')->getForm(
+            [],
+            [
+                'show_guest_field' => (bool) $this->get('prestashop.adapter.legacy.configuration')->get('PS_GUEST_CHECKOUT_ENABLED'),
+            ]
+        );
         $customerForm->handleRequest($request);
 
         $customerFormHandler = $this->get('prestashop.core.form.identifiable_object.handler.customer_form_handler');

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -161,8 +161,11 @@ class CustomerController extends AbstractAdminController
         }
 
         $this->addGroupSelectionToRequest($request);
-
-        $customerForm = $this->get('prestashop.core.form.identifiable_object.builder.customer_form_builder')->getForm();
+        $customerFormOptions = [
+            'show_guest_field' => $this->get('prestashop.adapter.legacy.configuration')->get('PS_GUEST_CHECKOUT_ENABLED') == 1 ? true : false,
+        ];
+        $customerForm = $this->get('prestashop.core.form.identifiable_object.builder.customer_form_builder')
+            ->getForm([], $customerFormOptions);
         $customerForm->handleRequest($request);
 
         $customerFormHandler = $this->get('prestashop.core.form.identifiable_object.handler.customer_form_handler');
@@ -189,6 +192,9 @@ class CustomerController extends AbstractAdminController
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages($e)));
         }
 
+        // Get default groups for JS purposes
+        $defaultGroups = $this->get('prestashop.adapter.group.provider.default_groups_provider')->getGroups();
+
         return $this->render('@PrestaShop/Admin/Sell/Customer/create.html.twig', [
             'customerForm' => $customerForm->createView(),
             'isB2bFeatureActive' => $this->get('prestashop.core.b2b.b2b_feature')->isActive(),
@@ -197,6 +203,13 @@ class CustomerController extends AbstractAdminController
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'enableSidebar' => true,
             'layoutTitle' => $this->trans('New customer', 'Admin.Navigation.Menu'),
+            'defaultGroups' => [
+                $defaultGroups->getVisitorsGroup()->getId(),
+                $defaultGroups->getGuestsGroup()->getId(),
+                $defaultGroups->getCustomersGroup()->getId(),
+            ],
+            'customerGroupId' => $defaultGroups->getCustomersGroup()->getId(),
+            'guestGroupId' => $defaultGroups->getGuestsGroup()->getId(),
         ]);
     }
 
@@ -217,6 +230,7 @@ class CustomerController extends AbstractAdminController
         $customerInformation = $this->getQueryBus()->handle(new GetCustomerForEditing((int) $customerId));
         $customerFormOptions = [
             'is_password_required' => false,
+            'show_guest_field' => false,
         ];
         try {
             $customerForm = $this->get('prestashop.core.form.identifiable_object.builder.customer_form_builder')

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -136,9 +136,9 @@ class CustomerType extends TranslatorAwareType
         if ($options['show_guest_field'] === true) {
             $builder
                 ->add('is_guest', SwitchType::class, [
-                    'label' => $this->trans('Register as guest', 'Admin.Global'),
+                    'label' => $this->trans('Guest account', 'Admin.Global'),
                     'help' => $this->trans(
-                        'Adds a one-time guest customer with no password.',
+                        'Quick customers with no password, who don\'t have access to the privileges of registered ones. You can create as many guests as needed using the same email. It could be helpful if you take phone call orders.',
                         'Admin.Orderscustomers.Help'
                     ),
                     'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -384,13 +384,12 @@ class CustomerType extends TranslatorAwareType
             ;
         }
 
-        // A listener that will make password field not required, if we want to create a guest
+        // We add a listener that will make password field not required, if we want to create a guest
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
             $form = $event->getForm();
             $formData = $event->getData();
 
-            // If is_guest was provided and it's Yes, we change the field to NOT required
-            // and remove the validation constraints
+            // If is_guest was provided and it's yes, we make the field optional (removing the constraints)
             if (isset($formData['is_guest']) && $formData['is_guest'] == 1) {
                 $form->add($this->formCloner->cloneForm($form->get('password'), [
                     'required' => false,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -336,6 +336,7 @@ services:
       $riskChoices: '@=service("prestashop.adapter.form.choice_provider.risk_by_id_choice_provider").getChoices()'
       $isB2bFeatureEnabled: '@=service("prestashop.core.b2b.b2b_feature").isActive()'
       $isPartnerOffersEnabled: '@=service("prestashop.adapter.legacy.configuration").get("PS_CUSTOMER_OPTIN")'
+      $formCloner: '@form.form_cloner'
 
   PrestaShopBundle\Form\Admin\Improve\International\Currencies\CurrencyType:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -13,6 +13,7 @@ services:
       - '@prestashop.core.command_bus'
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
       - '@=service("prestashop.core.b2b.b2b_feature").isActive()'
+      - '@prestashop.adapter.group.provider.default_groups_provider'
 
   prestashop.core.form.identifiable_object.data_handler.language_form_data_handler:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\LanguageFormDataHandler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/create.html.twig
@@ -32,4 +32,11 @@
   {{ parent() }}
 
   <script src="{{ asset('themes/new-theme/public/customer_form.bundle.js') }}"></script>
+  <script>
+    var data = {
+      defaultGroups: {{ defaultGroups|json_encode() }},
+      customerGroupId: {{ customerGroupId }},
+      guestGroupId: {{ guestGroupId }},
+    }
+  </script>
 {% endblock %}


### PR DESCRIPTION
**Could be improved**
- 🚧 Group selectors have absolutely no selector and targeting select all checkbox is not very clean, it could disable other inputs by accident. More precise selector would be better.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22645 and #25355
| How to test?      | See below
| Possible impacts? | No

### Description
- This PR allows you to create a guest customer from backoffice.
- There is a new field when creating a customer, allows you to quickly create a guest. 
- If guest is checked, password field, enable field and group fields are greyed out to behave the same as in FO. And they get changed to proper groups so the merchant knows what will happen after saving.
- Once you save this customer, the same logic as in front office is processed - the guest has a random password and his group is default guest group from PS configuration. No matter what was sent in the form.
- The field is not shown for existing customers. If converting a customer, we have separate functions for that. And we don't want people to be able to mess up a registered customer by changing him back to guest. We can work on this in separate PR.
- This field shows up only if guest checkout is enabled, because Customer class does not allow to create a guest if guest checkout is disabled.
![guest](https://user-images.githubusercontent.com/6097524/155132322-7ce4a258-cd8f-4d73-a5d9-bca9cd2e9b86.png)

### Technical changes
- I added some JS that, depending on guest field, disables and clears password input, sets groups, sets them disabled, disables "is enabled" switch. They are overriden anyway in FormHandler, but so that the visual experience matches what is done later internally. And for security.
- I pass default groups to template so when switching guest ON/OFF I can re-check those 3 default groups. Their IDs are configurable so you can't use just 1,2,3.
- Added a parameter coming to Customer form which shows the guest field only when creating a customer.
- Added a `FormEvents::PRE_SUBMIT` listener that removes constraints from password field if the is_guest was sent and is true. Standard formCloner class is used for this - I got inspired in other places in the code. Added a missing NotBlank constraint, because it was validated in the ValueObject only.
- Adjusted the command in FormHandler before sending it further into the handler. It sets a random password, guest group, sets enabled to true.

### Video
https://user-images.githubusercontent.com/6097524/219753944-37e4603c-fa60-4b1c-a3d1-cf8c7126afa3.mp4

https://user-images.githubusercontent.com/6097524/219767560-09ebcf92-0a66-4b32-9d6b-ac5f813698b9.mp4

### Manual tests
 - Create guest through front office and back office and check that they are the same data-wise.
 - Make a registered customer A first@prestashop.com. Check that you can create a new customer with the same email ONLY if you are creating a guest.

### Automatic behavior tests
- Everything is already automatically tested - implemented in previous PRs.
- OK to create a guest customer with existing email.
- FAIL to create a duplicate customer with existing email
- OK to change guest's email to already existing email.
- FAIL to change registered customer's email to already existing email.

### Preparations for this PR
I have extracted the majority of this PR to separate PRs, so it's easier to review.
- https://github.com/PrestaShop/PrestaShop/pull/31375
- https://github.com/PrestaShop/PrestaShop/pull/31386
- https://github.com/PrestaShop/PrestaShop/pull/31363
- https://github.com/PrestaShop/PrestaShop/pull/25353
- https://github.com/PrestaShop/PrestaShop/pull/31461
- https://github.com/PrestaShop/PrestaShop/pull/31462