### PR TITLE
Avoid Notice: Trying to access array offset on value of type bool

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4090,7 +4090,7 @@ class ProductCore extends ObjectModel
 
         $id_currency = (int) $context->currency->id;
         $ids = Address::getCountryAndState((int) $context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
-        $id_country = ($ids && $ids['id_country']) ? (int) $ids['id_country'] : (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $id_country = (int) ($ids['id_country'] ?? Configuration::get('PS_COUNTRY_DEFAULT'));
 
         return (bool) SpecificPrice::getSpecificPrice((int) $id_product, $context->shop->id, $id_currency, $id_country, $id_group, $quantity, null, 0, 0, $quantity);
     }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4090,7 +4090,7 @@ class ProductCore extends ObjectModel
 
         $id_currency = (int) $context->currency->id;
         $ids = Address::getCountryAndState((int) $context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')});
-        $id_country = $ids['id_country'] ? (int) $ids['id_country'] : (int) Configuration::get('PS_COUNTRY_DEFAULT');
+        $id_country = ($ids && $ids['id_country']) ? (int) $ids['id_country'] : (int) Configuration::get('PS_COUNTRY_DEFAULT');
 
         return (bool) SpecificPrice::getSpecificPrice((int) $id_product, $context->shop->id, $id_currency, $id_country, $id_group, $quantity, null, 0, 0, $quantity);
     }


### PR DESCRIPTION
When you don't have a cart already yet, any module or script that uses this function raises a Notice: Trying to access array offset on value of type bool

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?          | develop
| Description?      | When you don't have a cart already yet, any module or script that uses this function raises a Notice: Trying to access array offset on value of type bool, because Address::getCountryAndState could return an array with the id_country, or if the cart is false, the address also and the function return a false, that is not correct evaluated into the next line (only take account that is returning an array)
| Type?           | bug fix
| Category         | FO
| BC breaks        |  no
| Deprecations     |  no
| Fixed ticket?    | Fixes #27774.
| How to test      | On the issue #27774 is explained how to test it.
| Possible impacts | None, with that simple behaviour is only applying more correctly the condition if the above function returns false when a cart doesn't have a address initialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27775)
<!-- Reviewable:end -->
