### PR TITLE
Stock field must be empty and still be considered as zero

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/spinner.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/spinner.vue
@@ -82,7 +82,7 @@
       getQuantity() {
         if (!this.product.qty) {
           this.isEnabled = false;
-          this.value = 0;
+          this.value = '';
         }
         return parseInt(this.value, 10);
       },

--- a/admin-dev/themes/new-theme/js/app/widgets/ps-number.vue
+++ b/admin-dev/themes/new-theme/js/app/widgets/ps-number.vue
@@ -58,7 +58,7 @@
   export default {
     props: {
       value: {
-        type: Number,
+        type: [Number, String],
         default: 0,
       },
       danger: {
@@ -85,7 +85,7 @@
         this.$emit('blur', $event);
       },
       increment() {
-        const value = parseInt(this.value === '' ? 0 : this.value, 10);
+        const value = parseInt(this.value === '' || isNaN(this.value) ? 0 : this.value, 10);
         this.$emit('change', Number.isNaN(value) ? 0 : value + 1);
       },
       decrement() {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fix bug for the empty state in stock delta component, it should be displayed as zero when value is empty But avoid empty to be considered as NaN so that the increment works properly
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27736
| How to test?      | See issue but TLDR; stock delta input is empty by default (no more 0 value in the field) but the incrementation still works as expected
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27776)
<!-- Reviewable:end -->
