### PR TITLE
Fixes error which occurred when you try to modify any customer information after the import

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -401,6 +401,7 @@ class AdminImportControllerCore extends AdminController
 
                 self::$default_values = [
                     'active' => '1',
+                    'date_upd' => date('Y-m-d H:i:s'),
                     'id_shop' => Configuration::get('PS_SHOP_DEFAULT'),
                 ];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix issue : https://github.com/PrestaShop/PrestaShop/issues/24583 - Add default value for customer 'date_upd' while importing new customers. - Please note that to reproduce this bug you must import customers and have "Registration date" in the columns.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24583
| How to test?      | 1) Import customer(s) with "Registration date" filled.  <br /> 2) Edit customer in back office (with or without modification)<br />3) Save customer<br />-------------------------------------------------------<br />Before fix  : An unexpected error occurred. [CustomerException code 0]: Customer contains invalid field values<br />-------------------------------------------------------<br />After fix : Customer is saved without errors
| Possible impacts? | None : only one new default value for customer entity before import (date_upd)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27781)
<!-- Reviewable:end -->
