### PR TITLE
BO - Customer Page - Allow only positive number for Maximum number of payment days

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -36,6 +36,12 @@ use Symfony\Component\Validator\Validation;
 class ValidateCore
 {
     public const ORDER_BY_REGEXP = '/^(?:(`?)[\w!_-]+\1\.)?(?:(`?)[\w!_-]+\2)$/';
+    /**
+     * Maximal 32 bits value: (2^32)-1
+     *
+     * @var int
+     */
+    public const MYSQL_UNSIGNED_INT_MAX = 4294967295;
 
     const ADMIN_PASSWORD_LENGTH = 8;
     const PASSWORD_LENGTH = 5;
@@ -821,7 +827,10 @@ class ValidateCore
      */
     public static function isUnsignedInt($value)
     {
-        return (is_numeric($value) || is_string($value)) && (string) (int) $value === (string) $value && $value < 4294967296 && $value >= 0;
+        return (is_numeric($value) || is_string($value))
+            && (string) (int) $value === (string) $value
+            && $value < (static::MYSQL_UNSIGNED_INT_MAX + 1)
+            && $value >= 0;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -46,7 +46,9 @@ use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Type;
+use Validate;
 
 /**
  * Type is used to created form for customer add/edit actions
@@ -306,6 +308,24 @@ class CustomerType extends TranslatorAwareType
                     ),
                     'required' => false,
                     'invalid_message' => $this->trans('This field is invalid.', 'Admin.Notifications.Error'),
+                    'constraints' => [
+                        new Range([
+                            'min' => 0,
+                            'max' => Validate::MYSQL_UNSIGNED_INT_MAX,
+                            'minMessage' => $this->trans(
+                                '%s is invalid. Please enter an integer greater than or equal to 0.',
+                                'Admin.Notifications.Error'
+                            ),
+                            'maxMessage' => $this->trans(
+                                '%s is invalid. Please enter an integer lower than or equal to %s.',
+                                'Admin.Notifications.Error',
+                                [
+                                    '{{ value }}',
+                                    '{{ max }}',
+                                ]
+                            ),
+                        ]),
+                    ],
                 ])
                 ->add('risk_id', ChoiceType::class, [
                     'label' => $this->trans('Risk rating', 'Admin.Orderscustomers.Feature'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | BO - Customer Page - Allow only positive number for Maximum number of payment days
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27784
| How to test?      | 1. Enable B2B in the BO > Shop Parameters > Customer Settings page<br>2. Go to BO > Customers > Customers page<br>2. Add/Edit a customer<br>3. Add the "Maximum number of payment days" field with a negative number<br>4. Save<br>5. **BEFORE :** See error<br>5. **AFTER :** A constraint is added if lower than 0.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27793)
<!-- Reviewable:end -->
