### PR TITLE
Removed old constants (for removed directories)

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -129,10 +129,6 @@ if (!defined('_PS_GEOIP_CITY_FILE_')) {
 }
 
 define('_PS_VENDOR_DIR_', _PS_CORE_DIR_.'/vendor/');
-define('_PS_PEAR_XML_PARSER_PATH_', _PS_TOOL_DIR_.'pear_xml_parser/');
-define('_PS_SWIFT_DIR_', _PS_TOOL_DIR_.'swift/');
-define('_PS_TAASC_PATH_', _PS_TOOL_DIR_.'taasc/');
-define('_PS_TCPDF_PATH_', _PS_TOOL_DIR_.'tcpdf/');
 
 define('_PS_IMG_SOURCE_DIR_', _PS_ROOT_DIR_.'/img/');
 if (!defined('_PS_IMG_DIR_')) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed old constants (for removed directories)
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Relative to #26293
| How to test?      | N/A

**:notebook: BC Breaks**
* Removed constant `_PS_PEAR_XML_PARSER_PATH_` (Directory removed in 1.7.0.0-rc.1.0 : #6106)
* Removed constant `_PS_SWIFT_DIR_` (Directory removed in 1.7.0.0 : #5233)
* Removed constant `_PS_TAASC_PATH_` (Directory removed in 1.6.0.4)
* Removed constant `_PS_TCPDF_PATH_` (Directory removed between 1.6.1.24 and 1.7.0.0-beta.1.0)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27797)
<!-- Reviewable:end -->
