### PR TITLE
Replace usage of ModuleRepository with interface

### DIFF
--- a/src/Adapter/Module/Configuration/ModuleSelfConfigurator.php
+++ b/src/Adapter/Module/Configuration/ModuleSelfConfigurator.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter\Module\Configuration;
 use Doctrine\DBAL\Connection;
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepositoryInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Process\Exception\InvalidArgumentException;
@@ -67,7 +67,7 @@ class ModuleSelfConfigurator
     protected $defaultConfigFile = 'self_config.yml';
 
     /**
-     * @var ModuleRepository
+     * @var ModuleRepositoryInterface
      */
     protected $moduleRepository;
 
@@ -87,7 +87,7 @@ class ModuleSelfConfigurator
     protected $filesystem;
 
     public function __construct(
-        ModuleRepository $moduleRepository,
+        ModuleRepositoryInterface $moduleRepository,
         Configuration $configuration,
         Connection $connection,
         Filesystem $filesystem

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -225,7 +225,7 @@ class Module implements ModuleInterface
     /**
      * @return bool
      */
-    public function isActive()
+    public function isActive(): bool
     {
         return (bool) $this->database->get('active');
     }

--- a/src/Core/Addon/Module/ModuleInterface.php
+++ b/src/Core/Addon/Module/ModuleInterface.php
@@ -81,4 +81,11 @@ interface ModuleInterface extends AddonInterface
      * @return bool true for success
      */
     public function onUpgrade($version): bool;
+
+    /**
+     * Return is module is active
+     *
+     * @return bool
+     */
+    public function isActive(): bool;
 }

--- a/src/Core/Addon/Module/ModuleInterface.php
+++ b/src/Core/Addon/Module/ModuleInterface.php
@@ -87,5 +87,5 @@ interface ModuleInterface extends AddonInterface
      *
      * @return bool
      */
-    public function isActive();
+    public function isActive(): bool;
 }

--- a/src/Core/Addon/Module/ModuleInterface.php
+++ b/src/Core/Addon/Module/ModuleInterface.php
@@ -83,7 +83,7 @@ interface ModuleInterface extends AddonInterface
     public function onUpgrade($version): bool;
 
     /**
-     * Return is module is active
+     * Return true if module is active
      *
      * @return bool
      */

--- a/src/Core/Addon/Module/ModuleInterface.php
+++ b/src/Core/Addon/Module/ModuleInterface.php
@@ -87,5 +87,5 @@ interface ModuleInterface extends AddonInterface
      *
      * @return bool
      */
-    public function isActive(): bool;
+    public function isActive();
 }

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -41,6 +41,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class ModuleRepository implements ModuleRepositoryInterface
@@ -406,7 +407,14 @@ class ModuleRepository implements ModuleRepositoryInterface
         return $module;
     }
 
-    public function getModuleAttributes($name)
+    /**
+     * Get Module Attributes (name, displayName, etc.).
+     *
+     * @param string $name The technical name of the module
+     *
+     * @return \Symfony\Component\HttpFoundation\ParameterBag
+     */
+    public function getModuleAttributes($name): ParameterBag
     {
         $module = $this->getModule($name);
 

--- a/src/Core/Addon/Module/ModuleRepository.php
+++ b/src/Core/Addon/Module/ModuleRepository.php
@@ -408,11 +408,7 @@ class ModuleRepository implements ModuleRepositoryInterface
     }
 
     /**
-     * Get Module Attributes (name, displayName, etc.).
-     *
-     * @param string $name The technical name of the module
-     *
-     * @return \Symfony\Component\HttpFoundation\ParameterBag
+     * {@inheritDoc}
      */
     public function getModuleAttributes($name): ParameterBag
     {

--- a/src/Core/Addon/Module/ModuleRepositoryInterface.php
+++ b/src/Core/Addon/Module/ModuleRepositoryInterface.php
@@ -71,5 +71,5 @@ interface ModuleRepositoryInterface extends AddonRepositoryInterface
      *
      * @return \Symfony\Component\HttpFoundation\ParameterBag
      */
-    public function getModuleAttributes($name);
+    public function getModuleAttributes(string $name): ParameterBag;
 }

--- a/src/Core/Addon/Module/ModuleRepositoryInterface.php
+++ b/src/Core/Addon/Module/ModuleRepositoryInterface.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Addon\Module;
 use PrestaShop\PrestaShop\Core\Addon\AddonInterface;
 use PrestaShop\PrestaShop\Core\Addon\AddonListFilter;
 use PrestaShop\PrestaShop\Core\Addon\AddonRepositoryInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 interface ModuleRepositoryInterface extends AddonRepositoryInterface
 {
@@ -44,10 +45,11 @@ interface ModuleRepositoryInterface extends AddonRepositoryInterface
 
     /**
      * @param AddonListFilter $filter
+     * @param bool $skip_main_class_attributes
      *
      * @return AddonInterface[] retrieve a list of addons, regarding the $filter used
      */
-    public function getFilteredList(AddonListFilter $filter);
+    public function getFilteredList(AddonListFilter $filter, $skip_main_class_attributes = false);
 
     /**
      * @return AddonInterface[] retrieve a list of addons, regardless any $filter

--- a/src/Core/Addon/Module/ModuleRepositoryInterface.php
+++ b/src/Core/Addon/Module/ModuleRepositoryInterface.php
@@ -63,4 +63,13 @@ interface ModuleRepositoryInterface extends AddonRepositoryInterface
      * @return ModuleInterface
      */
     public function getModule($name);
+
+    /**
+     * Get Module Attributes (name, displayName, etc.).
+     *
+     * @param string $name The technical name of the module
+     *
+     * @return \Symfony\Component\HttpFoundation\ParameterBag
+     */
+    public function getModuleAttributes($name);
 }

--- a/src/Core/Addon/Module/ModuleRepositoryInterface.php
+++ b/src/Core/Addon/Module/ModuleRepositoryInterface.php
@@ -49,7 +49,7 @@ interface ModuleRepositoryInterface extends AddonRepositoryInterface
      *
      * @return AddonInterface[] retrieve a list of addons, regarding the $filter used
      */
-    public function getFilteredList(AddonListFilter $filter, $skip_main_class_attributes = false);
+    public function getFilteredList(AddonListFilter $filter, bool $skip_main_class_attributes = false);
 
     /**
      * @return AddonInterface[] retrieve a list of addons, regardless any $filter

--- a/src/PrestaShopBundle/EventListener/ModuleActivatedListener.php
+++ b/src/PrestaShopBundle/EventListener/ModuleActivatedListener.php
@@ -29,7 +29,7 @@ namespace PrestaShopBundle\EventListener;
 use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Util\ClassUtils;
-use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepositoryInterface;
 use PrestaShopBundle\Security\Annotation\ModuleActivated;
 use ReflectionClass;
 use ReflectionObject;
@@ -66,7 +66,7 @@ class ModuleActivatedListener
     private $annotationReader;
 
     /**
-     * @var ModuleRepository
+     * @var ModuleRepositoryInterface
      */
     private $moduleRepository;
 
@@ -75,14 +75,14 @@ class ModuleActivatedListener
      * @param TranslatorInterface $translator
      * @param Session $session
      * @param Reader $annotationReader
-     * @param ModuleRepository $moduleRepository
+     * @param ModuleRepositoryInterface $moduleRepository
      */
     public function __construct(
         RouterInterface $router,
         TranslatorInterface $translator,
         Session $session,
         Reader $annotationReader,
-        ModuleRepository $moduleRepository
+        ModuleRepositoryInterface $moduleRepository
     ) {
         $this->router = $router;
         $this->translator = $translator;

--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -27,7 +27,7 @@
 namespace PrestaShopBundle\Twig;
 
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
-use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository;
+use PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepositoryInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -49,7 +49,7 @@ class HookExtension extends AbstractExtension
     private $moduleDataProvider;
 
     /**
-     * @var ModuleRepository
+     * @var ModuleRepositoryInterface
      */
     private $moduleRepository;
 
@@ -62,7 +62,7 @@ class HookExtension extends AbstractExtension
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
         ModuleDataProvider $moduleDataProvider,
-        ModuleRepository $moduleRepository = null
+        ModuleRepositoryInterface $moduleRepository = null
     ) {
         $this->hookDispatcher = $hookDispatcher;
         $this->moduleDataProvider = $moduleDataProvider;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  For some internal needs i want to decorate the class \PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository .  <br />Unfortunately it is not possible with current code as some classes depends on the concrete class rather than on the interface \PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepositoryInterface .<br />This PR will fix it
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  yes
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      |  1. You can find a demo module in attachment which decorate the class \PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepository <br />2. Install it<br />3. On current develop branch it should raise an exception once you try to login to the BO<br />4. With the fix it works as expected<br />5. ( If you want to test the module behavior you will need to create an admin restricted role with authorized access to modules management and to modules contactform, ps_checkpayment, hhdemoinstance. With this user you should only show this modules in the list )
| Possible impacts? |  If the affected classes call functions that are not in the interface the code will break.


**BC Breaks :**
* Added method `public function isActive(): bool` to the interface `\PrestaShop\PrestaShop\Core\Addon\Module\ModuleInterface `
* Modified method `public function getFilteredList(AddonListFilter $filter, bool $skip_main_class_attributes = false);` to `\PrestaShop\PrestaShop\Core\Addon\Module\ModuleRepositoryInterface`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27802)
<!-- Reviewable:end -->
