### PR TITLE
No more auto created carts on login

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -368,7 +368,7 @@ class ContextCore
                 $idCarrier = (int) $this->cart->id_carrier;
                 $this->cart->secure_key = $customer->secure_key;
                 $this->cart->id_carrier = 0;
-                if ($idCarrier) {
+                if (!empty($idCarrier)) {
                     $deliveryOption = [$this->cart->id_address_delivery => $idCarrier . ','];
                     $this->cart->setDeliveryOption($deliveryOption);
                 } else {

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -364,7 +364,7 @@ class ContextCore
             $this->cart = new Cart($idCart);
             $this->cart->secure_key = $customer->secure_key;
         } else {
-            if (!empty($this->cookie->id_cart) && Validate::isLoadedObject($this->cart)) {
+            if (Validate::isLoadedObject($this->cart)) {
                 $idCarrier = (int) $this->cart->id_carrier;
                 $this->cart->secure_key = $customer->secure_key;
                 $this->cart->id_carrier = 0;

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -364,25 +364,30 @@ class ContextCore
             $this->cart = new Cart($idCart);
             $this->cart->secure_key = $customer->secure_key;
         } else {
-            $idCarrier = (int) $this->cart->id_carrier;
-            $this->cart->secure_key = $customer->secure_key;
-            $this->cart->id_carrier = 0;
-            $this->cart->setDeliveryOption(null);
-            $this->cart->updateAddressId($this->cart->id_address_delivery, (int) Address::getFirstCustomerAddressId((int) ($customer->id)));
-            $this->cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
-            $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
+            if (!empty($this->cookie->id_cart) && Validate::isLoadedObject($this->cart)) {
+                $idCarrier = (int) $this->cart->id_carrier;
+                $this->cart->secure_key = $customer->secure_key;
+                $this->cart->id_carrier = 0;
+                if (isset($idCarrier) && $idCarrier) {
+                    $deliveryOption = [$this->cart->id_address_delivery => $idCarrier . ','];
+                    $this->cart->setDeliveryOption($deliveryOption);
+                } else {
+                    $this->cart->setDeliveryOption(null);
+                }
+                $this->cart->id_customer = (int) $customer->id;
+                $this->cart->updateAddressId($this->cart->id_address_delivery, (int) Address::getFirstCustomerAddressId((int) ($customer->id)));
+                $this->cart->id_address_delivery = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
+                $this->cart->id_address_invoice = (int) Address::getFirstCustomerAddressId((int) ($customer->id));
+            }
         }
-        $this->cart->id_customer = (int) $customer->id;
 
-        if (isset($idCarrier) && $idCarrier) {
-            $deliveryOption = [$this->cart->id_address_delivery => $idCarrier . ','];
-            $this->cart->setDeliveryOption($deliveryOption);
+        if (Validate::isLoadedObject($this->cart)) {
+            $this->cart->save();
+            $this->cart->autosetProductAddress();
+            $this->cookie->id_cart = (int) $this->cart->id;
         }
 
-        $this->cart->save();
-        $this->cookie->id_cart = (int) $this->cart->id;
         $this->cookie->write();
-        $this->cart->autosetProductAddress();
 
         $this->cookie->registerSession(new CustomerSession());
     }

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -368,7 +368,7 @@ class ContextCore
                 $idCarrier = (int) $this->cart->id_carrier;
                 $this->cart->secure_key = $customer->secure_key;
                 $this->cart->id_carrier = 0;
-                if (isset($idCarrier) && $idCarrier) {
+                if ($idCarrier) {
                     $deliveryOption = [$this->cart->id_address_delivery => $idCarrier . ','];
                     $this->cart->setDeliveryOption($deliveryOption);
                 } else {

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -519,10 +519,12 @@ class FrontControllerCore extends Controller
     protected function assignGeneralPurposeVariables()
     {
         if (Validate::isLoadedObject($this->context->cart)) {
-            $presentedCart = $this->cart_presenter->present($this->context->cart);
+            $cart = $this->context->cart;
         } else {
-            $presentedCart = $this->cart_presenter->present(new Cart());
+            $cart = new Cart();
         }
+        $templateVars = [
+            'cart' => $this->cart_presenter->present($cart),
 
         $templateVars = [
             'cart' => $presentedCart,

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -459,9 +459,8 @@ class FrontControllerCore extends Controller
             CartRule::autoAddToCart($this->context);
         } else {
             $this->context->cart = $cart;
+            $this->context->cart->checkAndUpdateAddresses();
         }
-
-        $this->context->cart->checkAndUpdateAddresses();
 
         $this->context->smarty->assign('request_uri', Tools::safeOutput(urldecode($_SERVER['REQUEST_URI'])));
 
@@ -519,8 +518,14 @@ class FrontControllerCore extends Controller
 
     protected function assignGeneralPurposeVariables()
     {
+        if (Validate::isLoadedObject($this->context->cart)) {
+            $cart_presentation = $this->cart_presenter->present($this->context->cart);
+        } else {
+            $cart_presentation = null;
+        }
+
         $templateVars = [
-            'cart' => $this->cart_presenter->present($this->context->cart),
+            'cart' => $cart_presentation,
             'currency' => $this->getTemplateVarCurrency(),
             'customer' => $this->getTemplateVarCustomer(),
             'language' => $this->objectPresenter->present($this->context->language),

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -525,7 +525,7 @@ class FrontControllerCore extends Controller
         }
 
         $templateVars = [
-            'cart' => $cart_presentation,
+            'cart' => $presentedCart,
             'currency' => $this->getTemplateVarCurrency(),
             'customer' => $this->getTemplateVarCustomer(),
             'language' => $this->objectPresenter->present($this->context->language),

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -521,7 +521,7 @@ class FrontControllerCore extends Controller
         if (Validate::isLoadedObject($this->context->cart)) {
             $cart_presentation = $this->cart_presenter->present($this->context->cart);
         } else {
-            $cart_presentation = null;
+            $cart_presentation = $this->cart_presenter->present(new Cart());
         }
 
         $templateVars = [

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -519,9 +519,9 @@ class FrontControllerCore extends Controller
     protected function assignGeneralPurposeVariables()
     {
         if (Validate::isLoadedObject($this->context->cart)) {
-            $cart_presentation = $this->cart_presenter->present($this->context->cart);
+            $presentedCart = $this->cart_presenter->present($this->context->cart);
         } else {
-            $cart_presentation = $this->cart_presenter->present(new Cart());
+            $presentedCart = $this->cart_presenter->present(new Cart());
         }
 
         $templateVars = [

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -523,11 +523,9 @@ class FrontControllerCore extends Controller
         } else {
             $cart = new Cart();
         }
-        $templateVars = [
-            'cart' => $this->cart_presenter->present($cart),
 
         $templateVars = [
-            'cart' => $presentedCart,
+            'cart' => $this->cart_presenter->present($cart),
             'currency' => $this->getTemplateVarCurrency(),
             'customer' => $this->getTemplateVarCustomer(),
             'language' => $this->objectPresenter->present($this->context->language),


### PR DESCRIPTION
Fix for issue 9589

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This will fix issue reported in 9589, where empty carts are created on login.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9589.
| How to test?      | Follow instructions in issue.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27803)
<!-- Reviewable:end -->
