### PR TITLE
Change the way that smarty is escaped to avoid exception when parsing

### DIFF
--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -213,7 +213,12 @@ EOF;
             $useRegularH1Structure
         );
 
-        //test if legacy template from "content.tpl" has '{$content}'
+        // There is nothing to display no legacy layout are generated
+        if ($layout === '') {
+            return '';
+        }
+
+        // Test if legacy template from "content.tpl" has '{$content}'
         if (false === strpos($layout, '{$content}')) {
             throw new Exception('PrestaShopBundle\Twig\LayoutExtension cannot find the {$content} string in legacy layout template', 1);
         }

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -236,7 +236,7 @@ EOF;
 
     private function escapeSmarty(string $template): string
     {
-        return '{{ \'' . addslashes($template) . '\' | raw }}';
+        return '{{ \'' . addcslashes($template, "\\'\0") . '\' | raw }}';
     }
 
     /**

--- a/src/PrestaShopBundle/Twig/LayoutExtension.php
+++ b/src/PrestaShopBundle/Twig/LayoutExtension.php
@@ -241,7 +241,15 @@ EOF;
 
     private function escapeSmarty(string $template): string
     {
-        return '{{ \'' . addcslashes($template, "\\'\0") . '\' | raw }}';
+        // Hard limit of twig filter at 8191 characters (2^13 - 1)
+        // Split the string in multiple chunks
+        $strings = str_split($template, 2000);
+        $return = '';
+        foreach ($strings as $string) {
+            $return .= '{{ \'' . addcslashes($string, "\\'\0") . '\' | raw }}';
+        }
+
+        return $return;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | change the way that smarty is escaped to avoid exception when parsing
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27684
| How to test?      | Run the scenario
| Possible impacts? | No


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27806)
<!-- Reviewable:end -->
