### PR TITLE
Adjust scss for long shop names on login page

### DIFF
--- a/admin-dev/themes/default/scss/controllers/_login.scss
+++ b/admin-dev/themes/default/scss/controllers/_login.scss
@@ -1,6 +1,6 @@
 @mixin background-image-with-ms($image) {
-  @include background-image($image)
-    background-image: -ms-$image;
+  @include background-image($image);
+  background-image: -ms-$image;
 }
 
 #login {

--- a/admin-dev/themes/default/scss/controllers/_login.scss
+++ b/admin-dev/themes/default/scss/controllers/_login.scss
@@ -52,7 +52,6 @@
   }
 
   .flip-container {
-    height: 420px;
     margin-top: 115px;
     transform-style: preserve-3d;
     @include perspective(1000px);
@@ -77,14 +76,11 @@
 
   .front,
   .back {
-    position: absolute;
     top: 0;
     width: 100%;
     padding: 40px;
     transition: 0.6s;
-    transform-style: preserve-3d;
     @include backface-visibility(hidden);
-    @include left(0);
   }
 
   .front {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Force max-height for shop name on login page and truncate if needed (more than 200 chars -> 2 full lines)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #27800
| How to test?      | check with a very long shop name (nb chars more than 150, and re-check with more than 200) 
| Possible impacts? | No


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27812)
<!-- Reviewable:end -->
