### PR TITLE
Fix css specificity issue in mobile menu

### DIFF
--- a/admin-dev/themes/default/scss/partials/_nav.scss
+++ b/admin-dev/themes/default/scss/partials/_nav.scss
@@ -1,16 +1,18 @@
-.js-mobile-menu {
-  display: none;
-  flex-direction: column;
-  justify-content: center;
-  float: left;
-  padding-top: 0;
-  margin-right: 0.6rem;
-  margin-left: 0.6rem;
-  font-size: 1.8rem;
-  cursor: pointer;
+#header_infos {
+  .js-mobile-menu {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    float: left;
+    padding-top: 0;
+    margin-right: 0.6rem;
+    margin-left: 0.6rem;
+    font-size: 1.8rem;
+    cursor: pointer;
 
-  @include media-breakpoint-down(md) {
-    display: inline-flex;
+    @include media-breakpoint-down(md) {
+      display: inline-flex;
+    }
   }
 }
 

--- a/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_nav_bar.scss
@@ -1,16 +1,18 @@
-.js-mobile-menu {
-  display: none;
-  flex-direction: column;
-  justify-content: center;
-  float: left;
-  padding-top: 0;
-  margin-right: 0.6rem;
-  margin-left: 0.6rem;
-  font-size: 1.8rem;
-  cursor: pointer;
+#header_infos {
+  .js-mobile-menu {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    float: left;
+    padding-top: 0;
+    margin-right: 0.6rem;
+    margin-left: 0.6rem;
+    font-size: 1.8rem;
+    cursor: pointer;
 
-  @include media-breakpoint-down(md) {
-    display: inline-flex;
+    @include media-breakpoint-down(md) {
+      display: inline-flex;
+    }
   }
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch           | develop
| Description      | Increase selector specificity `.js-mobile-menu` becomes `#header_infos .js-mobile-menu`.
| Type             | bug fix 
| Category         | BO 
| BC breaks        |  no
| Deprecations     | no
| Fixed ticket     | Fixes #22892 .
| How to test      | Open any page loading it's own material-icons.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27813)
<!-- Reviewable:end -->
