### PR TITLE
Fix error when formatting null price

### DIFF
--- a/src/Core/Localization/Locale.php
+++ b/src/Core/Localization/Locale.php
@@ -138,7 +138,7 @@ class Locale implements LocaleInterface
     /**
      * Format a number as a price.
      *
-     * @param int|float|string $number
+     * @param int|float|string|null $number
      *                                 Number to be formatted as a price
      * @param string $currencyCode
      *                             Currency of the price
@@ -149,7 +149,10 @@ class Locale implements LocaleInterface
      */
     public function formatPrice($number, $currencyCode)
     {
-        if ( $number === null ) return null;
+        if ($number === null) {
+            return '';
+        }
+        
         return $this->numberFormatter->format(
             $number,
             $this->getPriceSpecification($currencyCode)

--- a/src/Core/Localization/Locale.php
+++ b/src/Core/Localization/Locale.php
@@ -149,6 +149,7 @@ class Locale implements LocaleInterface
      */
     public function formatPrice($number, $currencyCode)
     {
+        if ( $number === null ) return null;
         return $this->numberFormatter->format(
             $number,
             $this->getPriceSpecification($currencyCode)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  develop / 1.7.8.5
| Description?      | A null value throw an error, formatPrice() can simply return a null or empty string. 
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #27816 
| How to test?      | see issue above
| Possible impacts? | formated price

initially this is a fix for #27816 
i think is the best place to fix this otherwise it's can be fixed in getCatalogProductList() 
src/Adapter/Product/AdminProductDataProvider.php

may be also fix for #23970 and other issue with error: 
Invalid $number parameter: "" cannot be interpreted as a number

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27817)
<!-- Reviewable:end -->
