### PR TITLE
Fixes php notice because $result maybe false value

### DIFF
--- a/classes/Guest.php
+++ b/classes/Guest.php
@@ -199,7 +199,7 @@ class GuestCore extends ObjectModel
 		FROM `' . _DB_PREFIX_ . 'guest`
 		WHERE `id_customer` = ' . (int) ($idCustomer));
 
-        return $result['id_guest'];
+        return $result['id_guest'] ?? false;
     }
 
     /**


### PR DESCRIPTION
If $result is false we got a notice because we are assuming that id_guest is present.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | With debug mode activated, while creating a new backoffice order and open a generated link, php notice is triggered.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Activate debug mode, create new customer, new backoffice order, copy and paste generated link to checkout in anonymous navigation.
| Possible impacts? | Customers thats want to checkout after getting a link to order

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27830)
<!-- Reviewable:end -->
