### PR TITLE
Multistore - Product on category page display out of stock flag instead of availlable on order

### DIFF
--- a/src/Core/Product/Search/ProductSearchContext.php
+++ b/src/Core/Product/Search/ProductSearchContext.php
@@ -50,10 +50,24 @@ class ProductSearchContext
      */
     private $idCustomer;
 
+    /**
+     * @var int the Shop Group id
+     */
+    private $idShopGroup;
+
+    /**
+     * @var bool if the sharing stock is enable
+     */
+    private $stockSharingBetweenShopGroupEnabled = false;
+
     public function __construct(Context $context = null)
     {
         if ($context) {
+            $shopGroup = $context->shop->getGroup();
+
             $this->idShop = $context->shop->id;
+            $this->idShopGroup = $shopGroup->id;
+            $this->stockSharingBetweenShopGroupEnabled = (bool) $shopGroup->share_stock;
             $this->idLang = $context->language->id;
             $this->idCurrency = $context->currency->id;
             $this->idCustomer = $context->customer->id;
@@ -63,7 +77,7 @@ class ProductSearchContext
     /**
      * @param int $idShop
      *
-     * @return $this
+     * @return self
      */
     public function setIdShop($idShop)
     {
@@ -83,7 +97,7 @@ class ProductSearchContext
     /**
      * @param int $idLang
      *
-     * @return $this
+     * @return self
      */
     public function setIdLang($idLang)
     {
@@ -103,7 +117,7 @@ class ProductSearchContext
     /**
      * @param int $idCurrency
      *
-     * @return $this
+     * @return self
      */
     public function setIdCurrency($idCurrency)
     {
@@ -123,7 +137,7 @@ class ProductSearchContext
     /**
      * @param int $idCustomer
      *
-     * @return $this
+     * @return self
      */
     public function setIdCustomer($idCustomer)
     {
@@ -138,5 +152,45 @@ class ProductSearchContext
     public function getIdCustomer()
     {
         return $this->idCustomer;
+    }
+
+    /**
+     * @return int the Shop Group Iid
+     */
+    public function getIdShopGroup(): int
+    {
+        return $this->idShopGroup;
+    }
+
+    /**
+     * @param int $idShopGroup
+     *
+     * @return self
+     */
+    public function setIdShopGroup(int $idShopGroup): self
+    {
+        $this->idShopGroup = $idShopGroup;
+
+        return $this;
+    }
+
+    /**
+     * @return bool if sharing stock is enable
+     */
+    public function isStockSharingBetweenShopGroupEnabled(): bool
+    {
+        return $this->stockSharingBetweenShopGroupEnabled;
+    }
+
+    /**
+     * @param bool $stockSharingBetweenShopGroupEnabled
+     *
+     * @return self
+     */
+    public function setStockSharingBetweenShopGroupEnabled(bool $stockSharingBetweenShopGroupEnabled): self
+    {
+        $this->stockSharingBetweenShopGroupEnabled = $stockSharingBetweenShopGroupEnabled;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Adding shop group id on ProductSearchContext and update sql query on  ProductAssembler.php

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Take account of the sharing stock in product assembler. Adding Shop Group Id and flag in SearchContext
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #27604
| How to test?      | As indicated in ticket, in multistore with stock sharing enable, adding product with allow order, the flag is correctly displayed
| Possible impacts? | Few impact. two proprerties in Search Context only used in productAssembler.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27841)
<!-- Reviewable:end -->

This PR could fix this issue: https://github.com/PrestaShop/PrestaShop/issues/28097