### PR TITLE
Fix: login page float buggy on latest chrome version and long shop name problem

### DIFF
--- a/admin-dev/themes/default/scss/controllers/_login.scss
+++ b/admin-dev/themes/default/scss/controllers/_login.scss
@@ -1,8 +1,3 @@
-@mixin background-image-with-ms($image) {
-  @include background-image($image)
-    background-image: -ms-$image;
-}
-
 #login {
   min-height: 100%;
   padding-bottom: 45px;
@@ -52,9 +47,7 @@
   }
 
   .flip-container {
-    height: 420px;
     margin-top: 115px;
-    transform-style: preserve-3d;
     @include perspective(1000px);
 
     &.flip {
@@ -70,21 +63,16 @@
 
   .flipper {
     position: relative;
-    transform-style: preserve-3d;
     @include transition-duration(0.6s);
     @include transform-style ();
   }
 
   .front,
   .back {
-    position: absolute;
-    top: 0;
     width: 100%;
     padding: 40px;
     transition: 0.6s;
-    transform-style: preserve-3d;
     @include backface-visibility(hidden);
-    @include left(0);
   }
 
   .front {

--- a/admin-dev/themes/default/template/controllers/login/content.tpl
+++ b/admin-dev/themes/default/template/controllers/login/content.tpl
@@ -74,14 +74,14 @@
 							</span>
 						</button>
 					</div>
-					<div class="form-group">
-						<div id="remind-me" class="checkbox pull-left">
+					<div class="form-group row">
+						<div id="remind-me" class="checkbox col-xs-6">
 							<label for="stay_logged_in">
 								<input name="stay_logged_in" type="checkbox" id="stay_logged_in" value="1"	tabindex="3"/>
 								{l s='Stay logged in' d='Admin.Login.Feature'}
 							</label>
 						</div>
-						<a href="#" id="forgot-password-link" class="show-forgot-password pull-right" >
+						<a href="#" id="forgot-password-link" class="show-forgot-password col-xs-6 text-right">
 							{l s='I forgot my password' d='Admin.Login.Feature'}
 						</a>
 					</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Some floats on stay logged in and lost password were buggy on the latest chrome version, it can be replaced by a bootstrap column system
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27835.
| How to test?      | Update to chrome 99, then go on the BO login page, the layout should be finely displayed and the issue should be fixed, try with a very long shop name too, it should work
| Possible impacts? | Login BO page


Closes #27800 too
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27843)
<!-- Reviewable:end -->
