### PR TITLE
Check href exists before replacing it in multistore header

### DIFF
--- a/admin-dev/themes/new-theme/js/components/multistore-header.ts
+++ b/admin-dev/themes/new-theme/js/components/multistore-header.ts
@@ -100,6 +100,9 @@ const initMultistoreHeader = () => {
    */
   function updateLinksAnchor(): void {
     function updateLinkAnchor(shopLink: HTMLLinkElement) {
+      if (!shopLink.hasAttribute('href')) {
+        return;
+      }
       const updatedLink = shopLink.href.replace(/#(.*)$/, '') + window.location.hash;
       shopLink.setAttribute('href', updatedLink);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | To make the link disabled, the `href` attribute should not be present. This was the case from the php side but the JS part was adding it even if it was empty. This PR fixes it by checking if the `href` attribute is present before trying to replace it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27844
| How to test?      | Please see #27844
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27848)
<!-- Reviewable:end -->
