### PR TITLE
Move notifications divs to the vuejs app

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/header/stock-header.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/header/stock-header.vue
@@ -52,7 +52,7 @@
   }
 
   function getNotificationsElements() {
-    return $(`#ajax_confirmation, #${ComponentsMap.contextualNotification.messageBoxId}`);
+    return $(`${ComponentsMap.ajaxConfirmation}, #${ComponentsMap.contextualNotification.messageBoxId}`);
   }
 
   export default Vue.extend({
@@ -61,12 +61,13 @@
       Tabs,
     },
     mounted() {
+      const $vueElement = $(this.$el);
       // move the toolbar buttons to this header
       const toolbarButtons = getOldHeaderToolbarButtons();
-      toolbarButtons.insertAfter($(this.$el).find('.title-row > .title'));
+      toolbarButtons.insertAfter($vueElement.find('.title-row > .title'));
 
       const notifications = getNotificationsElements();
-      notifications.insertAfter($(this.$el));
+      notifications.insertAfter($vueElement);
 
       // signal header change (so size can be updated)
       const event = $.Event('vueHeaderMounted', {

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/header/stock-header.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/header/stock-header.vue
@@ -39,6 +39,7 @@
 
 <script lang="ts">
   import Vue from 'vue';
+  import ComponentsMap from '@components/components-map';
   import Breadcrumb from './breadcrumb.vue';
   import Tabs from './tabs.vue';
 
@@ -50,6 +51,10 @@
       .find('.toolbar-icons');
   }
 
+  function getNotificationsElements() {
+    return $(`#ajax_confirmation, #${ComponentsMap.contextualNotification.messageBoxId}`);
+  }
+
   export default Vue.extend({
     components: {
       Breadcrumb,
@@ -59,6 +64,9 @@
       // move the toolbar buttons to this header
       const toolbarButtons = getOldHeaderToolbarButtons();
       toolbarButtons.insertAfter($(this.$el).find('.title-row > .title'));
+
+      const notifications = getNotificationsElements();
+      notifications.insertAfter($(this.$el));
 
       // signal header change (so size can be updated)
       const event = $.Event('vueHeaderMounted', {

--- a/admin-dev/themes/new-theme/js/components/components-map.ts
+++ b/admin-dev/themes/new-theme/js/components/components-map.ts
@@ -102,4 +102,5 @@ export default {
     messageBoxId: 'content-message-box',
     notificationClass: 'contextual-notification',
   },
+  ajaxConfirmation: '#ajax_confirmation',
 };

--- a/admin-dev/themes/new-theme/scss/pages/stock/stock_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/stock/stock_page.scss
@@ -14,6 +14,13 @@
   }
 }
 
+.content-div {
+  > #content-message-box,
+  > #ajax_confirmation {
+    display: none;
+  }
+}
+
 .adminstockmanagement .stock-app {
   padding: 0;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | As the stock page is a vuejs page, the contextual notification was displayed outside of the vuejs page. This PR aims to fix that by dynamically moving the element into the vuejs page.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27840
| How to test?      | Please see #27840 after compiling assets
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27850)
<!-- Reviewable:end -->
