### PR TITLE
Simply Delivery Slip Form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipOptionsType.php
@@ -29,7 +29,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Order\Delivery;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
-use Symfony\Component\Form\Extension\Core\Type as FormType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -49,15 +49,31 @@ class SlipOptionsType extends TranslatorAwareType
                 TranslatableType::class,
                 [
                     'type' => TextType::class,
+                    'label' => $this->trans('Delivery prefix', 'Admin.Orderscustomers.Feature'),
+                    'help' => $this->trans('Prefix used for delivery slips.', 'Admin.Orderscustomers.Help'),
                 ]
             )
             ->add(
                 'number',
-                FormType\NumberType::class
+                NumberType::class,
+                [
+                    'label' => $this->trans('Delivery number', 'Admin.Orderscustomers.Feature'),
+                    'help' => $this->trans(
+                        'The next delivery slip will begin with this number and then increase with each additional slip.',
+                        'Admin.Orderscustomers.Help'
+                    ),
+                ]
             )
             ->add(
                 'enable_product_image',
-                SwitchType::class
+                SwitchType::class,
+                [
+                    'label' => $this->trans('Enable product image', 'Admin.Orderscustomers.Feature'),
+                    'help' => $this->trans(
+                        'Add an image before the product name on delivery slips.',
+                        'Admin.Orderscustomers.Help'
+                    ),
+                ]
             );
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Delivery/SlipPdfType.php
@@ -27,14 +27,14 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Order\Delivery;
 
 use DateTime;
-use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
  * This form class generates the "Pdf" form in Delivery slips page.
  */
-class SlipPdfType extends CommonAbstractType
+class SlipPdfType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -51,6 +51,12 @@ class SlipPdfType extends CommonAbstractType
                     'attr' => ['placeholder' => 'YYYY-MM-DD'],
                     'data' => $now,
                     'empty_data' => $now,
+                    'label' => $this->trans('From', 'Admin.Global'),
+                    'help' => $this->trans(
+                        'Format: %s (inclusive).',
+                        'Admin.Orderscustomers.Help',
+                        [date('Y-m-d')]
+                    ),
                 ]
             )
             ->add(
@@ -61,6 +67,12 @@ class SlipPdfType extends CommonAbstractType
                     'attr' => ['placeholder' => 'YYYY-MM-DD'],
                     'data' => $now,
                     'empty_data' => $now,
+                    'label' => $this->trans('To', 'Admin.Global'),
+                    'help' => $this->trans(
+                        'Format: %s (inclusive).',
+                        'Admin.Orderscustomers.Help',
+                        [date('Y-m-d')]
+                    ),
                 ]
             );
     }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -460,6 +460,13 @@ services:
     tags:
       - { name: form.type }
 
+  form.type.order.delivery.slip_pdf:
+    class: 'PrestaShopBundle\Form\Admin\Sell\Order\Delivery\SlipPdfType'
+    parent: 'form.type.translatable.aware'
+    public: true
+    tags:
+      - { name: form.type }
+
   form.type.order.delivery.slip.options:
     class: 'PrestaShopBundle\Form\Admin\Sell\Order\Delivery\SlipOptionsType'
     parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Delivery/slip.html.twig
@@ -23,6 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
+{% form_theme pdfForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+{% form_theme optionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
@@ -38,23 +41,7 @@
         {{ 'Print PDF'|trans }}
       </h3>
       <div class="card-body">
-        <div class="form-wrapper">
-          <div class="form-group row">
-            {{ ps.label_with_help('From'|trans({}, 'Admin.Global'), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(pdfForm.date_from) }}
-              {{ form_widget(pdfForm.date_from) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help('To'|trans({}, 'Admin.Global'), ('Format: 2011-12-31 (inclusive).'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(pdfForm.date_to) }}
-              {{ form_widget(pdfForm.date_to) }}
-            </div>
-          </div>
-          {{ form_rest(pdfForm) }}
-        </div>
+        {{ form_widget(pdfForm) }}
       </div>
       <div class="card-footer">
         <div class="d-flex justify-content-end">
@@ -73,30 +60,7 @@
         {{ 'Delivery slip options'|trans }}
       </h3>
       <div class="card-body">
-        <div class="form-wrapper">
-          <div class="form-group row">
-            {{ ps.label_with_help(('Delivery prefix'|trans), ('Prefix used for delivery slips.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(optionsForm.prefix) }}
-              {{ form_widget(optionsForm.prefix) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Delivery number'|trans), ('The next delivery slip will begin with this number and then increase with each additional slip.'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(optionsForm.number) }}
-              {{ form_widget(optionsForm.number) }}
-            </div>
-          </div>
-          <div class="form-group row">
-            {{ ps.label_with_help(('Enable product image'|trans), ('Add an image before product name on delivery slip'|trans({}, 'Admin.Orderscustomers.Help'))) }}
-            <div class="col-sm">
-              {{ form_errors(optionsForm.enable_product_image) }}
-              {{ form_widget(optionsForm.enable_product_image) }}
-            </div>
-          </div>
-          {{ form_rest(optionsForm) }}
-        </div>
+        {{ form_widget(optionsForm) }}
       </div>
       <div class="card-footer">
         <div class="d-flex justify-content-end">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Simply Delivery Slip Form. Began by @JevgenijVisockij in #22139.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Relative to #16482
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Simplifying Sell -> Order -> Delivery Slips. Everything must look the same aside for help now appearing under inputs instead as blue box, also some fields now will appear as required because they always were.

**:notebook: BC Breaks :**
Backwards compatibility break introduced due to extension of TranslationAwareType by SlipPdfType. This means if any module extends this type they will get an exception upon upgrading to PS version containing changes in this PR.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27851)
<!-- Reviewable:end -->
