### PR TITLE
Added hooks for blockwishlist in classic theme

### DIFF
--- a/themes/classic/config/theme.yml
+++ b/themes/classic/config/theme.yml
@@ -60,6 +60,12 @@ global_settings:
       #  - blockreassurance
       # displayNavFullWidth:
       #  - blockreassurance
+      displayAdminCustomers:
+        - blockwishlist
+      displayCustomerAccount:
+        - blockwishlist
+      displayMyAccountBlock:
+        - blockwishlist
       displayNav1:
         - ps_contactinfo
       displayNav2:
@@ -85,6 +91,7 @@ global_settings:
         - ps_linklist
         - ps_customeraccountlinks
         - ps_contactinfo
+        - blockwishlist
       # displayFooterAfter:
       #  - blockreassurance
       displayLeftColumn:
@@ -98,6 +105,8 @@ global_settings:
       #  - blockreassurance
       displayOrderConfirmation2:
         - ps_featuredproducts
+      displayProductActions:
+        - blockwishlist
 
   image_types:
     cart_default:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Added hooks for blockwishlist in classic theme
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27478 : the child theme should have the same changes in its theme.yml else the hook `displayFooter` is unlinked from `blockwishlist`
| How to test?      | Cf. #27478


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27860)
<!-- Reviewable:end -->
