### PR TITLE
The delivery slip date in the template must be the delivery date and not the invoice creation date

### DIFF
--- a/classes/pdf/HTMLTemplateDeliverySlip.php
+++ b/classes/pdf/HTMLTemplateDeliverySlip.php
@@ -61,7 +61,9 @@ class HTMLTemplateDeliverySlipCore extends HTMLTemplate
         }
 
         // header informations
-        $this->date = Tools::displayDate($order_invoice->date_add);
+        // The date MUST be the delivery slip date and not the invoice date …
+        // In case of empty date, use the old one …
+        $this->date = Tools::displayDate($order_invoice->delivery_date) ?: Tools::displayDate($order_invoice->date_add);
         $prefix = Configuration::get('PS_DELIVERY_PREFIX', Context::getContext()->language->id);
         $this->title = sprintf(HTMLTemplateDeliverySlip::l('%1$s%2$06d'), $prefix, $this->order_invoice->delivery_number);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      |  The delivery slip date is not correct in the PDF template.
| Type?             | bug fix
| Category?         |   CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27867 .
| How to test?      | All is in the bug ticket.
| Possible impacts? | The already printed delivery slips could have a different date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27868)
<!-- Reviewable:end -->
