### PR TITLE
Hook getHookStatusByName should not be case-sensitive

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1277,7 +1277,7 @@ class HookCore extends ObjectModel
             $hook_names = Cache::retrieve('active_hooks');
         } else {
             $sql = new DbQuery();
-            $sql->select('name');
+            $sql->select('lower(name) as name');
             $sql->from('hook', 'h');
             $sql->where('h.active = 1');
             $active_hooks = Db::getInstance()->executeS($sql);
@@ -1289,6 +1289,6 @@ class HookCore extends ObjectModel
             }
         }
 
-        return in_array($hook_name, $hook_names);
+        return in_array(strtolower($hook_name), $hook_names);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This fixes a regression in 1.7.8.4 by which the hook names became case sensitive. Comparing the hook names all in lowercase solves the problem
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27854.
| How to test?      | Hooks are no longer case sensitive. See issue #27872 as an example. Issues #27872 or #27854 should be fixed
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27874)
<!-- Reviewable:end -->
