### PR TITLE
Fix delete action in customer address view consistency.

### DIFF
--- a/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactory.php
@@ -54,7 +54,22 @@ final class CustomerAddressGridDefinitionFactory extends AbstractGridDefinitionF
     public function __construct(HookDispatcherInterface $hookDispatcher, ?Request $currentRequest)
     {
         parent::__construct($hookDispatcher);
-        $this->backUrl = $currentRequest ? $currentRequest->getUri() : '';
+
+        // Remove query parameters to ensure behavior of "customer address grid" is consistent with `AddressGridDefinitionFactory`
+        if ($currentRequest) {
+            $requestCopy = clone $currentRequest;
+
+            $query = $requestCopy->query;
+            $query->remove('customer_address');
+            $qs = http_build_query($query->all(), '', '&');
+
+            $server = $requestCopy->server;
+            $server->set('QUERY_STRING', $qs);
+
+            $this->backUrl = $requestCopy->getUri();
+        } else {
+            $this->backUrl = '';
+        }
     }
 
     /**

--- a/tests/Unit/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactoryTest.php
+++ b/tests/Unit/Core/Grid/Definition/Factory/CustomerAddressGridDefinitionFactoryTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Grid\Definition\Factory;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerAddressGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class CustomerAddressGridDefinitionFactoryTest extends TestCase
+{
+    public function testItSetsProperBackURLToEditAndDeleteActions()
+    {
+        $hookDispatcherMock = $this->createMock(HookDispatcherInterface::class);
+
+        $translatorMock = $this->createMock(TranslatorInterface::class);
+        $translatorMock->method('trans')->willReturn('Translated String');
+
+        $uri = 'http://localhost/admin-dev/index.php/sell/customers/1/view?_route=0&customer_address%5Boffset%5D=10&customer_address%5Blimit%5D=10&_token=my_super_token';
+        $expected_uri = 'http://localhost/admin-dev/index.php/sell/customers/1/view?_route=0&_token=my_super_token';
+        $request = Request::create($uri);
+
+        $grid_definition_factory = new CustomerAddressGridDefinitionFactory($hookDispatcherMock, $request);
+        $grid_definition_factory->setTranslator($translatorMock);
+
+        $definitions = $grid_definition_factory->getDefinition();
+        /** @var \PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection $columns */
+        $columns = $definitions->getColumns();
+        $array_columns = $columns->move('actions', 0)->toArray();
+        $actions = reset($array_columns)['options']['actions'];
+
+        $this->assertEquals(count($actions), 2);
+
+        $edit_action = $actions->current();
+        $this->assertEquals($actions->key(), 'edit');
+        $this->assertEquals($edit_action->getOptions()['extra_route_params']['back'], $expected_uri);
+
+        $delete_action = $actions->next();
+        $this->assertEquals($actions->key(), 'delete');
+        $this->assertEquals($delete_action->getOptions()['extra_route_params']['back'], $expected_uri);
+    }
+
+    public function testItCreatesWithNullRequest()
+    {
+        $hookDispatcherMock = $this->createMock(HookDispatcherInterface::class);
+
+        $this->expectNotToPerformAssertions();
+        new CustomerAddressGridDefinitionFactory($hookDispatcherMock, null);
+    }
+
+    public function testItDoesntChangeGivenHttpRequest()
+    {
+        $hookDispatcherMock = $this->createMock(HookDispatcherInterface::class);
+
+        $initial_query = '_route=0&customer_address%5Boffset%5D=10&customer_address%5Blimit%5D=10&_token=my_super_token';
+        $uri = 'http://localhost/admin-dev/index.php/sell/customers/1/view?' . $initial_query;
+
+        $request = Request::create($uri);
+        $this->assertEquals($request->server->get('QUERY_STRING'), $initial_query);
+        new CustomerAddressGridDefinitionFactory($hookDispatcherMock, $request);
+        $this->assertEquals($request->server->get('QUERY_STRING'), $initial_query);
+    }
+}


### PR DESCRIPTION
AddressGridDefinitionFactory and CustomerAddressGridDefinitionFactory default
pagination and redirection conventions weren't consistent.
We want the grid data list reset to first page after a delete action.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?          | develop
| Description?   | Fix <a href='https://github.com/PrestaShop/PrestaShop/issues/26218'> View customer page - No records found after deleting the last item of the second page</a> <br /> We want the grid data list reset to first page after a delete action.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26218.
| How to test?      | <ul> <li>Create 11 addresses for a customer.</li><li>Change pagination to 10.</li><li>Delete last element (should be the only one on the second page.)</li><li>Fix Ok if success message displayed and address view back to first page.</li></ul> 
| Possible impacts? | Test properly combined filter / sorting parameters on View customer page (using different blocks) 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27879)
<!-- Reviewable:end -->
