### PR TITLE
Add check if the gift wrapping is disabled

### DIFF
--- a/mails/themes/classic/core/order_conf.html.twig
+++ b/mails/themes/classic/core/order_conf.html.twig
@@ -118,6 +118,7 @@
             </table>
           </td>
         </tr>
+        {% if giftWrapping == 1 %}
         <tr class="conf_body">
           <td bgcolor="#f8f8f8" colspan="4" style="border:1px solid #D6D4D4;">
             <table class="table">
@@ -146,7 +147,7 @@
             </table>
           </td>
         </tr>
-        {% if giftWrapping == 1 %}
+        {% endif %}
         <tr class="conf_body">
           <td bgcolor="#f8f8f8" colspan="4" style="border:1px solid #D6D4D4;">
             <table class="table">
@@ -175,7 +176,6 @@
             </table>
           </td>
         </tr>
-        {% endif %}
         <tr class="conf_body">
           <td bgcolor="#f8f8f8" colspan="4" style="border:1px solid #D6D4D4;">
             <table class="table">

--- a/mails/themes/classic/core/order_conf.html.twig
+++ b/mails/themes/classic/core/order_conf.html.twig
@@ -146,6 +146,7 @@
             </table>
           </td>
         </tr>
+        {% if giftWrapping == 1 %}
         <tr class="conf_body">
           <td bgcolor="#f8f8f8" colspan="4" style="border:1px solid #D6D4D4;">
             <table class="table">
@@ -174,6 +175,7 @@
             </table>
           </td>
         </tr>
+        {% endif %}
         <tr class="conf_body">
           <td bgcolor="#f8f8f8" colspan="4" style="border:1px solid #D6D4D4;">
             <table class="table">

--- a/mails/themes/modern/core/order_conf.html.twig
+++ b/mails/themes/modern/core/order_conf.html.twig
@@ -1,5 +1,5 @@
 {% extends '@MailThemes/modern/components/order_layout.html.twig' %}
-        
+
 {% block title %}{{ 'Order confirmation'|trans({}, 'Emails.Body', locale) }}{% endblock %}
 
 {% block content %}
@@ -179,17 +179,17 @@
                                       <th bgcolor="#FDFDFD">{{ 'Total price'|trans({}, 'Emails.Body', locale)|raw }}</th>
                                     </tr>
                                     {% if templateType == 'html' %}
-{products}
-{% endif %}
+                                      {products}
+                                    {% endif %}
                                     {% if templateType == 'txt' %}
-{products_txt}
-{% endif %}
+                                      {products_txt}
+                                    {% endif %}
                                     {% if templateType == 'html' %}
-{discounts}
-{% endif %}
+                                      {discounts}
+                                    {% endif %}
                                     {% if templateType == 'txt' %}
-{discounts_txt}
-{% endif %}
+                                      {discounts_txt}
+                                    {% endif %}
                                     <tr class="order_summary">
                                       <td bgcolor="#FDFDFD" colspan="3" align="right">
                                         {{ 'Products'|trans({}, 'Emails.Body', locale)|raw }}
@@ -202,12 +202,14 @@
                                       </td>
                                       <td bgcolor="#FDFDFD" colspan="3"> {total_discounts} </td>
                                     </tr>
+                                    {% if giftWrapping == 1 %}
                                     <tr class="order_summary">
                                       <td bgcolor="#FDFDFD" colspan="3" align="right">
                                         {{ 'Gift-wrapping'|trans({}, 'Emails.Body', locale)|raw }}
                                       </td>
                                       <td bgcolor="#FDFDFD" colspan="3"> {total_wrapping} </td>
                                     </tr>
+                                    {% endif %}
                                     <tr class="order_summary">
                                       <td bgcolor="#FDFDFD" colspan="3" align="right">
                                         {{ 'Shipping'|trans({}, 'Emails.Body', locale)|raw }}
@@ -371,11 +373,11 @@
                                                 </p>
                                                 <p style="border: 1px solid #DFDFDF;background-color: #FEFEFE;padding:20px;font-size:14px">
                                                   {% if templateType == 'html' %}
-{invoice_block_html}
-{% endif %}
+                                                    {invoice_block_html}
+                                                  {% endif %}
                                                   {% if templateType == 'txt' %}
-{invoice_block_txt}
-{% endif %}
+                                                    {invoice_block_txt}
+                                                  {% endif %}
                                                 </p>
                                               </td>
                                             </tr>
@@ -451,7 +453,7 @@
               </div>
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               <!-- SECOND TEXT ENDING -->
-              
+
 
 {% endblock %}
 

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationCollect
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationInterface;
 use Twig\Environment;
 use Twig\Error\LoaderError;
+use PrestaShop\PrestaShop\Adapter\Configuration as Configuration;
 
 /**
  * MailTemplateTwigRenderer is a basic implementation of MailTemplateRendererInterface
@@ -122,6 +123,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     ) {
         $layoutVariables = $this->variablesBuilder->buildVariables($layout, $language);
         $layoutVariables['templateType'] = $templateType;
+        $layoutVariables['giftWrapping'] = Configuration::get('PS_GIFT_WRAPPING');
         if (MailTemplateInterface::HTML_TYPE === $templateType) {
             $layoutPath = !empty($layout->getHtmlPath()) ? $layout->getHtmlPath() : $layout->getTxtPath();
         } else {

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\MailTemplate;
 
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Exception\TypeException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
@@ -38,7 +39,6 @@ use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationCollect
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationInterface;
 use Twig\Environment;
 use Twig\Error\LoaderError;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 
 /**
  * MailTemplateTwigRenderer is a basic implementation of MailTemplateRendererInterface

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter\MailTemplate;
 
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Exception\TypeException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -38,7 +38,7 @@ use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationCollect
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationInterface;
 use Twig\Environment;
 use Twig\Error\LoaderError;
-use PrestaShop\PrestaShop\Adapter\Configuration as Configuration;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 
 /**
  * MailTemplateTwigRenderer is a basic implementation of MailTemplateRendererInterface
@@ -58,6 +58,9 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     /** @var TransformationCollection */
     private $transformations;
 
+    /** @var ConfigurationInterface */
+    private $configuration;
+
     /**
      * @param Environment $twig
      * @param LayoutVariablesBuilderInterface $variablesBuilder
@@ -68,12 +71,14 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     public function __construct(
         Environment $twig,
         LayoutVariablesBuilderInterface $variablesBuilder,
-        HookDispatcherInterface $hookDispatcher
+        HookDispatcherInterface $hookDispatcher,
+        ConfigurationInterface $configuration
     ) {
         $this->twig = $twig;
         $this->variablesBuilder = $variablesBuilder;
         $this->hookDispatcher = $hookDispatcher;
         $this->transformations = new TransformationCollection();
+        $this->configuration = $configuration;
     }
 
     /**
@@ -123,7 +128,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     ) {
         $layoutVariables = $this->variablesBuilder->buildVariables($layout, $language);
         $layoutVariables['templateType'] = $templateType;
-        $layoutVariables['giftWrapping'] = Configuration::get('PS_GIFT_WRAPPING');
+        $layoutVariables['giftWrapping'] = $this->configuration->get('PS_GIFT_WRAPPING');
         if (MailTemplateInterface::HTML_TYPE === $templateType) {
             $layoutPath = !empty($layout->getHtmlPath()) ? $layout->getHtmlPath() : $layout->getTxtPath();
         } else {

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -64,6 +64,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
      * @param Environment $twig
      * @param LayoutVariablesBuilderInterface $variablesBuilder
      * @param HookDispatcherInterface $hookDispatcher
+     * @param bool $hasGiftWrapping
      *
      * @throws TypeException
      */

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -58,8 +58,8 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     /** @var TransformationCollection */
     private $transformations;
 
-    /** @var ConfigurationInterface */
-    private $configuration;
+    /** @var bool */
+    private $hasGiftWrapping;
 
     /**
      * @param Environment $twig
@@ -72,13 +72,13 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
         Environment $twig,
         LayoutVariablesBuilderInterface $variablesBuilder,
         HookDispatcherInterface $hookDispatcher,
-        ConfigurationInterface $configuration
+        bool $hasGiftWrapping
     ) {
         $this->twig = $twig;
         $this->variablesBuilder = $variablesBuilder;
         $this->hookDispatcher = $hookDispatcher;
         $this->transformations = new TransformationCollection();
-        $this->configuration = $configuration;
+        $this->hasGiftWrapping = $hasGiftWrapping;
     }
 
     /**
@@ -128,7 +128,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     ) {
         $layoutVariables = $this->variablesBuilder->buildVariables($layout, $language);
         $layoutVariables['templateType'] = $templateType;
-        $layoutVariables['giftWrapping'] = $this->configuration->get('PS_GIFT_WRAPPING');
+        $layoutVariables['giftWrapping'] = $this->hasGiftWrapping;
         if (MailTemplateInterface::HTML_TYPE === $templateType) {
             $layoutPath = !empty($layout->getHtmlPath()) ? $layout->getHtmlPath() : $layout->getTxtPath();
         } else {

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -93,7 +93,7 @@ class GiftOptionsType extends TranslatorAwareType
             ->add('enable_gift_wrapping', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Offer gift wrapping', 'Admin.Shopparameters.Feature'),
-                'help' => $this->trans('Remember to regenerate email templates after enabling or disabling this option in [1]Design > Email theme[/1].',
+                'help' => $this->trans('Remember to regenerate email templates in [1]Design > Email theme[/1] after enabling or disabling this feature.',
                     'Admin.Shopparameters.Help',
                     [
                         '[1]' => '<a href="' . $this->router->generate('admin_mail_theme_index') . '" target="_blank">',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -61,7 +61,7 @@ class GiftOptionsType extends TranslatorAwareType
     /**
      * @param TranslatorInterface $translator
      * @param array $locales
-     * @param $defaultCurrencyIsoCode
+     * @param string $defaultCurrencyIsoCode
      * @param array $taxChoices
      * @param RouterInterface $router
      */

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -34,6 +34,7 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 /**
@@ -52,16 +53,30 @@ class GiftOptionsType extends TranslatorAwareType
      */
     private $taxChoices;
 
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param $defaultCurrencyIsoCode
+     * @param array $taxChoices
+     * @param RouterInterface $router
+     */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
         $defaultCurrencyIsoCode,
-        array $taxChoices
+        array $taxChoices,
+        RouterInterface $router
     ) {
         parent::__construct($translator, $locales);
 
         $this->defaultCurrencyIsoCode = $defaultCurrencyIsoCode;
         $this->taxChoices = $taxChoices;
+        $this->router = $router;
     }
 
     /**
@@ -78,6 +93,13 @@ class GiftOptionsType extends TranslatorAwareType
             ->add('enable_gift_wrapping', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Offer gift wrapping', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Remember to regenerate email templates after enabling or disabling this option in [1]Design > Email theme[/1].',
+                    'Admin.Shopparameters.Help',
+                    [
+                        '[1]' => '<a href="' . $this->router->generate('admin_mail_theme_index') . '" target="_blank">',
+                        '[/1]' => '</a>',
+                    ]
+                ),
                 'multistore_configuration_key' => 'PS_GIFT_WRAPPING',
             ])
             ->add('gift_wrapping_price', MoneyWithSuffixType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -78,7 +78,6 @@ class GiftOptionsType extends TranslatorAwareType
             ->add('enable_gift_wrapping', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Offer gift wrapping', 'Admin.Shopparameters.Feature'),
-                'help' => $this->trans('Suggest gift-wrapping to customers.', 'Admin.Shopparameters.Help'),
                 'multistore_configuration_key' => 'PS_GIFT_WRAPPING',
             ])
             ->add('gift_wrapping_price', MoneyWithSuffixType::class, [

--- a/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
@@ -8,6 +8,7 @@ services:
       - '@twig'
       - '@prestashop.core.mail_template.variables_builder'
       - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.adapter.legacy.configuration'
     calls:
       - method: 'addTransformation'
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
@@ -8,7 +8,7 @@ services:
       - '@twig'
       - '@prestashop.core.mail_template.variables_builder'
       - '@prestashop.core.hook.dispatcher'
-      - '@prestashop.adapter.legacy.configuration'
+      - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_GIFT_WRAPPING')"
     calls:
       - method: 'addTransformation'
         arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -440,6 +440,7 @@ services:
     arguments:
       - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrencyIsoCode()'
       - '@=service("prestashop.adapter.data_provider.tax").getTaxRulesGroupChoices()'
+      - "@router"
     tags:
       - { name: form.type }
 

--- a/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
+++ b/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
@@ -61,12 +61,7 @@ class MailTemplateTwigRendererTest extends TestCase
             ->getMock()
         ;
 
-        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $generator = new MailTemplateTwigRenderer($engineMock, $builderMock, $dispatcherMock, $configurationMock);
+        $generator = new MailTemplateTwigRenderer($engineMock, $builderMock, $dispatcherMock, false);
         $this->assertNotNull($generator);
     }
 
@@ -94,18 +89,13 @@ class MailTemplateTwigRendererTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
-        /** @var ConfigurationInterface $configurationMock */
-        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
 
         /** @var Environment $engineMock */
         $generator = new MailTemplateTwigRenderer(
             $engineMock,
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
             $dispatcherMock,
-            $configurationMock
+            false
         );
         $this->assertNotNull($generator);
 
@@ -126,7 +116,7 @@ class MailTemplateTwigRendererTest extends TestCase
             $this->createEngineMock($templatePaths[MailTemplateInterface::HTML_TYPE], $expectedVariables, $expectedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
             $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE),
-            $this->createConfigurationMock()
+            true
         );
         $this->assertNotNull($generator);
 
@@ -149,7 +139,7 @@ class MailTemplateTwigRendererTest extends TestCase
             $this->createEngineMock($templatePaths[MailTemplateInterface::TXT_TYPE], $expectedVariables, $expectedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
             $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE),
-            $this->createConfigurationMock()
+            true
         );
         $this->assertNotNull($generator);
 
@@ -171,7 +161,7 @@ class MailTemplateTwigRendererTest extends TestCase
             $this->createEngineMock($templatePaths[MailTemplateInterface::TXT_TYPE], $expectedVariables, $expectedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
             $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::TXT_TYPE),
-            $this->createConfigurationMock()
+            true
         );
         $this->assertNotNull($generator);
 
@@ -194,7 +184,7 @@ class MailTemplateTwigRendererTest extends TestCase
             $this->createEngineMock($templatePaths[MailTemplateInterface::HTML_TYPE], $expectedVariables, $expectedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
             $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::TXT_TYPE),
-            $this->createConfigurationMock()
+            true
         );
         $this->assertNotNull($generator);
 
@@ -217,7 +207,7 @@ class MailTemplateTwigRendererTest extends TestCase
             $this->createEngineMock($templatePaths[MailTemplateInterface::HTML_TYPE], $expectedVariables, $generatedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
             $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE, 1),
-            $this->createConfigurationMock()
+            true
         );
         $this->assertNotNull($generator);
 
@@ -394,22 +384,5 @@ class MailTemplateTwigRendererTest extends TestCase
         }
 
         return $mailLayoutMock;
-    }
-
-    /**
-     * @return MockObject|ConfigurationInterface
-     */
-    private function createConfigurationMock()
-    {
-        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $configurationMock
-            ->method('get')
-            ->willReturn(1);
-
-        return $configurationMock;
     }
 }

--- a/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
+++ b/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
@@ -29,6 +29,7 @@ namespace Tests\Unit\Adapter\MailTemplate;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\MailTemplate\MailTemplateTwigRenderer;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
@@ -60,7 +61,12 @@ class MailTemplateTwigRendererTest extends TestCase
             ->getMock()
         ;
 
-        $generator = new MailTemplateTwigRenderer($engineMock, $builderMock, $dispatcherMock);
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $generator = new MailTemplateTwigRenderer($engineMock, $builderMock, $dispatcherMock, $configurationMock);
         $this->assertNotNull($generator);
     }
 
@@ -88,12 +94,18 @@ class MailTemplateTwigRendererTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock()
         ;
+        /** @var ConfigurationInterface $configurationMock */
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
 
         /** @var Environment $engineMock */
         $generator = new MailTemplateTwigRenderer(
             $engineMock,
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
-            $dispatcherMock
+            $dispatcherMock,
+            $configurationMock
         );
         $this->assertNotNull($generator);
 
@@ -106,14 +118,15 @@ class MailTemplateTwigRendererTest extends TestCase
             MailTemplateInterface::HTML_TYPE => '@Resources/mails/templates/account.html.twig',
         ];
         $expectedTemplate = 'mail_template';
-        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::HTML_TYPE];
+        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::HTML_TYPE, 'giftWrapping' => 1];
         $expectedLanguage = $this->createLanguageMock();
         $mailLayout = $this->createMailLayoutMock($templatePaths);
 
         $generator = new MailTemplateTwigRenderer(
             $this->createEngineMock($templatePaths[MailTemplateInterface::HTML_TYPE], $expectedVariables, $expectedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
-            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE)
+            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE),
+            $this->createConfigurationMock()
         );
         $this->assertNotNull($generator);
 
@@ -128,14 +141,15 @@ class MailTemplateTwigRendererTest extends TestCase
             MailTemplateInterface::TXT_TYPE => '@Resources/mails/templates/account.html.twig',
         ];
         $expectedTemplate = 'mail_template';
-        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::HTML_TYPE];
+        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::HTML_TYPE, 'giftWrapping' => 1];
         $expectedLanguage = $this->createLanguageMock();
         $mailLayout = $this->createMailLayoutMock($templatePaths);
 
         $generator = new MailTemplateTwigRenderer(
             $this->createEngineMock($templatePaths[MailTemplateInterface::TXT_TYPE], $expectedVariables, $expectedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
-            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE)
+            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE),
+            $this->createConfigurationMock()
         );
         $this->assertNotNull($generator);
 
@@ -149,14 +163,15 @@ class MailTemplateTwigRendererTest extends TestCase
             MailTemplateInterface::TXT_TYPE => '@Resources/mails/templates/account.html.twig',
         ];
         $expectedTemplate = 'mail_template';
-        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::TXT_TYPE];
+        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::TXT_TYPE, 'giftWrapping' => 1];
         $expectedLanguage = $this->createLanguageMock();
         $mailLayout = $this->createMailLayoutMock($templatePaths);
 
         $generator = new MailTemplateTwigRenderer(
             $this->createEngineMock($templatePaths[MailTemplateInterface::TXT_TYPE], $expectedVariables, $expectedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
-            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::TXT_TYPE)
+            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::TXT_TYPE),
+            $this->createConfigurationMock()
         );
         $this->assertNotNull($generator);
 
@@ -171,14 +186,15 @@ class MailTemplateTwigRendererTest extends TestCase
             MailTemplateInterface::TXT_TYPE => '',
         ];
         $expectedTemplate = 'mail_template';
-        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::TXT_TYPE];
+        $expectedVariables = ['locale' => null, 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::TXT_TYPE, 'giftWrapping' => 1];
         $expectedLanguage = $this->createLanguageMock();
         $mailLayout = $this->createMailLayoutMock($templatePaths);
 
         $generator = new MailTemplateTwigRenderer(
             $this->createEngineMock($templatePaths[MailTemplateInterface::HTML_TYPE], $expectedVariables, $expectedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
-            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::TXT_TYPE)
+            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::TXT_TYPE),
+            $this->createConfigurationMock()
         );
         $this->assertNotNull($generator);
 
@@ -193,14 +209,15 @@ class MailTemplateTwigRendererTest extends TestCase
         ];
         $generatedTemplate = 'mail_template';
         $transformedTemplate = 'mail_template_transformed_fr';
-        $expectedVariables = ['locale' => 'fr', 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::HTML_TYPE];
+        $expectedVariables = ['locale' => 'fr', 'url' => 'http://test.com', 'templateType' => MailTemplateInterface::HTML_TYPE, 'giftWrapping' => 1];
         $expectedLanguage = $this->createLanguageMock();
         $mailLayout = $this->createMailLayoutMock($templatePaths);
 
         $generator = new MailTemplateTwigRenderer(
             $this->createEngineMock($templatePaths[MailTemplateInterface::HTML_TYPE], $expectedVariables, $generatedTemplate),
             $this->createVariablesBuilderMock($expectedVariables, $expectedLanguage),
-            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE, 1)
+            $this->createHookDispatcherMock($mailLayout, MailTemplateInterface::HTML_TYPE, 1),
+            $this->createConfigurationMock()
         );
         $this->assertNotNull($generator);
 
@@ -377,5 +394,22 @@ class MailTemplateTwigRendererTest extends TestCase
         }
 
         return $mailLayoutMock;
+    }
+
+    /**
+     * @return MockObject|ConfigurationInterface
+     */
+    private function createConfigurationMock()
+    {
+        $configurationMock = $this->getMockBuilder(ConfigurationInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $configurationMock
+            ->method('get')
+            ->willReturn(1);
+
+        return $configurationMock;
     }
 }

--- a/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
+++ b/tests/Unit/Adapter/MailTemplate/MailTemplateTwigRendererTest.php
@@ -29,7 +29,6 @@ namespace Tests\Unit\Adapter\MailTemplate;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\MailTemplate\MailTemplateTwigRenderer;
-use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Exception\FileNotFoundException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;


### PR DESCRIPTION
Don't show the line in the order summary. I've added a reminder hint in the BO form

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If you disable the Gift Option, in the order summary the gift wrapping line is still present. It will be confusing.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22825.
| How to test?      | Apply edits, regenerate e-mails.
| Possible impacts? | If the merchant enable or disable _Gift Wrapping_ option he/she needs to re-generate e-mails template. In this PR I've added a small hint in the BO as help text near the option

If this PR will be approved, I will made a PR in https://github.com/PrestaShop/mjml-theme-converter

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27890)
<!-- Reviewable:end -->
