### PR TITLE
Add check if the gift wrapping is disabled (1.7.8.x)

### DIFF
--- a/mails/themes/modern/core/order_conf.html.twig
+++ b/mails/themes/modern/core/order_conf.html.twig
@@ -1,5 +1,5 @@
 {% extends '@MailThemes/modern/components/order_layout.html.twig' %}
-        
+
 {% block title %}{{ 'Order confirmation'|trans({}, 'Emails.Body', locale) }}{% endblock %}
 
 {% block content %}
@@ -179,17 +179,17 @@
                                       <th bgcolor="#FDFDFD">{{ 'Total price'|trans({}, 'Emails.Body', locale)|raw }}</th>
                                     </tr>
                                     {% if templateType == 'html' %}
-{products}
-{% endif %}
+                                      {products}
+                                    {% endif %}
                                     {% if templateType == 'txt' %}
-{products_txt}
-{% endif %}
+                                      {products_txt}
+                                    {% endif %}
                                     {% if templateType == 'html' %}
-{discounts}
-{% endif %}
+                                      {discounts}
+                                    {% endif %}
                                     {% if templateType == 'txt' %}
-{discounts_txt}
-{% endif %}
+                                      {discounts_txt}
+                                    {% endif %}
                                     <tr class="order_summary">
                                       <td bgcolor="#FDFDFD" colspan="3" align="{{ align_right }}">
                                         {{ 'Products'|trans({}, 'Emails.Body', locale)|raw }}
@@ -202,12 +202,14 @@
                                       </td>
                                       <td bgcolor="#FDFDFD" colspan="3"> {total_discounts} </td>
                                     </tr>
+                                    {% if giftWrapping == 1 %}
                                     <tr class="order_summary">
                                       <td bgcolor="#FDFDFD" colspan="3" align="{{ align_right }}">
                                         {{ 'Gift-wrapping'|trans({}, 'Emails.Body', locale)|raw }}
                                       </td>
                                       <td bgcolor="#FDFDFD" colspan="3"> {total_wrapping} </td>
                                     </tr>
+                                    {% endif %}
                                     <tr class="order_summary">
                                       <td bgcolor="#FDFDFD" colspan="3" align="{{ align_right }}">
                                         {{ 'Shipping'|trans({}, 'Emails.Body', locale)|raw }}
@@ -348,11 +350,11 @@
                                                 </p>
                                                 <p style="border: 1px solid #DFDFDF;background-color: #FEFEFE;padding:20px;font-size:14px">
                                                   {% if templateType == 'html' %}
-{delivery_block_html}
-{% endif %}
+                                                    {delivery_block_html}
+                                                  {% endif %}
                                                   {% if templateType == 'txt' %}
-{delivery_block_txt}
-{% endif %}
+                                                    {delivery_block_txt}
+                                                  {% endif %}
                                                 </p>
                                               </td>
                                               <td width="10" class="space" style="padding:7px 0"> </td>
@@ -371,11 +373,11 @@
                                                 </p>
                                                 <p style="border: 1px solid #DFDFDF;background-color: #FEFEFE;padding:20px;font-size:14px">
                                                   {% if templateType == 'html' %}
-{invoice_block_html}
-{% endif %}
+                                                    {invoice_block_html}
+                                                  {% endif %}
                                                   {% if templateType == 'txt' %}
-{invoice_block_txt}
-{% endif %}
+                                                    {invoice_block_txt}
+                                                  {% endif %}
                                                 </p>
                                               </td>
                                             </tr>
@@ -451,7 +453,6 @@
               </div>
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               <!-- SECOND TEXT ENDING -->
-              
 
 {% endblock %}
 

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -37,7 +37,7 @@ use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateRendererInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationCollection;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationInterface;
 use Symfony\Component\Templating\EngineInterface;
-use PrestaShop\PrestaShop\Adapter\Configuration as Configuration;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 
 /**
  * MailTemplateTwigRenderer is a basic implementation of MailTemplateRendererInterface
@@ -57,22 +57,28 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     /** @var TransformationCollection */
     private $transformations;
 
+    /** @var ConfigurationInterface */
+    private $configuration;
+
     /**
      * @param EngineInterface $engine
      * @param LayoutVariablesBuilderInterface $variablesBuilder
      * @param HookDispatcherInterface $hookDispatcher
+     * @param ConfigurationInterface $configuration
      *
      * @throws TypeException
      */
     public function __construct(
         EngineInterface $engine,
         LayoutVariablesBuilderInterface $variablesBuilder,
-        HookDispatcherInterface $hookDispatcher
+        HookDispatcherInterface $hookDispatcher,
+        ConfigurationInterface $configuration
     ) {
         $this->engine = $engine;
         $this->variablesBuilder = $variablesBuilder;
         $this->hookDispatcher = $hookDispatcher;
         $this->transformations = new TransformationCollection();
+        $this->configuration = $configuration;
     }
 
     /**
@@ -122,7 +128,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     ) {
         $layoutVariables = $this->variablesBuilder->buildVariables($layout, $language);
         $layoutVariables['templateType'] = $templateType;
-        $layoutVariables['giftWrapping'] = Configuration::get('PS_GIFT_WRAPPING');
+        $layoutVariables['giftWrapping'] = $this->configuration->get('PS_GIFT_WRAPPING');
         if (MailTemplateInterface::HTML_TYPE === $templateType) {
             $layoutPath = !empty($layout->getHtmlPath()) ? $layout->getHtmlPath() : $layout->getTxtPath();
         } else {

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateRendererInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationCollection;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationInterface;
 use Symfony\Component\Templating\EngineInterface;
+use PrestaShop\PrestaShop\Adapter\Configuration;
 
 /**
  * MailTemplateTwigRenderer is a basic implementation of MailTemplateRendererInterface
@@ -121,6 +122,7 @@ class MailTemplateTwigRenderer implements MailTemplateRendererInterface
     ) {
         $layoutVariables = $this->variablesBuilder->buildVariables($layout, $language);
         $layoutVariables['templateType'] = $templateType;
+        $layoutVariables['giftWrapping'] = Configuration::get('PS_GIFT_WRAPPING');
         if (MailTemplateInterface::HTML_TYPE === $templateType) {
             $layoutPath = !empty($layout->getHtmlPath()) ? $layout->getHtmlPath() : $layout->getTxtPath();
         } else {

--- a/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
+++ b/src/Adapter/MailTemplate/MailTemplateTwigRenderer.php
@@ -37,7 +37,7 @@ use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateRendererInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationCollection;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\TransformationInterface;
 use Symfony\Component\Templating\EngineInterface;
-use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Adapter\Configuration as Configuration;
 
 /**
  * MailTemplateTwigRenderer is a basic implementation of MailTemplateRendererInterface

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -77,7 +77,7 @@ class GiftOptionsType extends TranslatorAwareType
             ->add('enable_gift_wrapping', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Offer gift wrapping', 'Admin.Shopparameters.Feature'),
-                'help' => $this->trans('Suggest gift-wrapping to customers.', 'Admin.Shopparameters.Help'),
+                'help' => $this->trans('Suggest gift-wrapping to customers. Remember to regenerate e-mails template if you activate or deactivate this option', 'Admin.Shopparameters.Help'),
             ])
             ->add('gift_wrapping_price', MoneyWithSuffixType::class, [
                 'required' => false,

--- a/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
@@ -8,6 +8,7 @@ services:
       - '@templating.engine.twig'
       - '@prestashop.core.mail_template.variables_builder'
       - '@prestashop.core.hook.dispatcher'
+      - 'prestashop.adapter.legacy.configuration'
     calls:
       - method: 'addTransformation'
         arguments:


### PR DESCRIPTION
Don't show the line in the order summary. I've added a reminder hint in the BO form

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | If you disable the Gift Option, in the order summary the gift wrapping line is still present. It will be confusing.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22825.
| How to test?      | Apply edits, regenerate e-mails.
| Possible impacts? | If the merchant enable or disable _Gift Wrapping_ option he/she needs to re-generate e-mails template. In this PR I've added a small hint in the BO as help text near the option

If this PR will be approved, I will made a PR in https://github.com/PrestaShop/mjml-theme-converter

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27891)
<!-- Reviewable:end -->
