### PR TITLE
Simplify Product Preferences Form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPricePriorityType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
@@ -34,6 +35,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Class generates "General" form
@@ -42,31 +44,124 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class GeneralType extends TranslatorAwareType
 {
     /**
+     * @var LegacyContext
+     */
+    private $legacyContext;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param LegacyContext $legacyContext
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        LegacyContext $legacyContext
+    ) {
+        parent::__construct($translator, $locales);
+        $this->legacyContext = $legacyContext;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('catalog_mode', SwitchType::class)
-            ->add('catalog_mode_with_prices', SwitchType::class)
+            ->add('catalog_mode', SwitchType::class, [
+                'label' => $this->trans('Catalog mode', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans(
+                        'Catalog mode disables the shopping cart on your store. Visitors will be able to browse your products catalog, but not buy them.',
+                        'Admin.Shopparameters.Help'
+                    ),
+                'required' => false,
+            ])
+            ->add('catalog_mode_with_prices', SwitchType::class, [
+                'label' => $this->trans('Show prices', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans(
+                    'Display product prices when in catalog mode.',
+                    'Admin.Shopparameters.Help'
+                ) . '<br />' . $this->trans(
+                    'To hide prices for a specific group, go to [1]Customer Settings > Groups[/1].',
+                    'Admin.Shopparameters.Help',
+                        [
+                            '[1]' => sprintf(
+                                '<a target="_blank" href="%s">',
+                                $this->legacyContext->getAdminLink('AdminGroups')
+                            ),
+                            '[/1]' => '</a>',
+                        ]
+                ),
+                'row_attr' => [
+                    'class' => 'catalog-mode-option',
+                ],
+                'required' => false,
+            ])
             ->add('new_days_number', IntegerType::class, [
+                'label' => $this->trans(
+                    'Number of days for which the product is considered \'new\'',
+                    'Admin.Shopparameters.Feature'
+                ),
                 'required' => false,
             ])
             ->add('short_description_limit', TextWithUnitType::class, [
+                'label' => $this->trans(
+                    'Max size of product summary',
+                    'Admin.Shopparameters.Feature'
+                ),
                 'required' => false,
                 'unit' => $this->trans('characters', 'Admin.Shopparameters.Help'),
             ])
             ->add('quantity_discount', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Quantity discounts based on',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'How to calculate quantity discounts.',
+                    'Admin.Shopparameters.Help'
+                ),
                 'choices' => [
                     'Products' => 0,
                     'Combinations' => 1,
                 ],
                 'choice_translation_domain' => 'Admin.Global',
-                'required' => true,
+                'placeholder' => false,
+                'required' => false,
             ])
-            ->add('force_friendly_url', SwitchType::class)
-            ->add('default_status', SwitchType::class)
-            ->add('specific_price_priorities', SpecificPricePriorityType::class)
+            ->add('force_friendly_url', SwitchType::class, [
+                'label' => $this->trans(
+                    'Force update of friendly URL',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'When active, friendly URL will be updated on every save.',
+                    'Admin.Shopparameters.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('default_status', SwitchType::class, [
+                'label' => $this->trans(
+                    'Activate new products by default',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Enable this option if you want to activate by default all your manually created new products.',
+                    'Admin.Shopparameters.Help'
+                ),
+                'required' => false,
+            ])
+            ->add('specific_price_priorities', SpecificPricePriorityType::class, [
+                'label' => $this->trans(
+                    'Default order of priority for specific prices',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'If a customer meets multiple conditions, specific prices will be applied in this order of priority, unless a different order has been set for a particular product.',
+                    'Admin.Shopparameters.Help'
+                ),
+                'required' => false,
+            ])
         ;
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PageType.php
@@ -27,7 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -36,7 +36,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Class generates "Product page" form
  * in "Configure > Shop Parameters > Product Settings" page.
  */
-class PageType extends AbstractType
+class PageType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -44,17 +44,60 @@ class PageType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('display_quantities', SwitchType::class)
-            ->add('allow_add_variant_to_cart_from_listing', SwitchType::class)
+            ->add('display_quantities', SwitchType::class, [
+                'label' => $this->trans(
+                    'Display available quantities on the product page',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'required' => false,
+            ])
+            ->add('allow_add_variant_to_cart_from_listing', SwitchType::class, [
+                'label' => $this->trans(
+                    'Display the "%add_to_cart_label%" button when a product has attributes',
+                    'Admin.Shopparameters.Help',
+                    [
+                        '%add_to_cart_label%' => $this->trans(
+                            'Add to cart',
+                            'Shop.Theme.Actions'
+                        ),
+                    ]
+                ),
+                'help' => $this->trans(
+                    'Display or hide the "%add_to_cart_label%" button on category pages for products that have attributes forcing customers to see product details.',
+                    'Admin.Shopparameters.Help',
+                    [
+                        '%add_to_cart_label%' => $this->trans(
+                            'Add to cart',
+                            'Shop.Theme.Actions'
+                        ),
+                    ]
+                ),
+                'required' => false,
+            ])
             ->add('attribute_anchor_separator', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Separator of attribute anchor on the product links',
+                    'Admin.Shopparameters.Feature'
+                ),
                 'choices' => [
                     '-' => '-',
                     ',' => ',',
                 ],
-                'required' => true,
+                'placeholder' => false,
+                'required' => false,
                 'choice_translation_domain' => 'Admin.Global',
             ])
-            ->add('display_discount_price', SwitchType::class);
+            ->add('display_discount_price', SwitchType::class, [
+                'label' => $this->trans(
+                    'Display the discounted unit price',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'In the volume discount table on the product page, display the discounted unit price instead of the unit discount. E.g. If you sell a product for $10 with a discount of $2 from 3 items purchased, the discounted unit price ($8) will be displayed instead of the unit discount ($2).',
+                    'Admin.Shopparameters.Help'
+                ),
+                'required' => false,
+            ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
-use Symfony\Component\Form\AbstractType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -36,7 +36,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * Class generates "Pagination" form
  * in "Configure > Shop Parameters > Product Settings" page.
  */
-class PaginationType extends AbstractType
+class PaginationType extends TranslatorAwareType
 {
     /**
      * {@inheritdoc}
@@ -44,8 +44,22 @@ class PaginationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('products_per_page', IntegerType::class)
+            ->add('products_per_page', IntegerType::class, [
+                'label' => $this->trans(
+                    'Products per page',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'required' => false,
+            ])
             ->add('default_order_by', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Default order by',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'The order in which products are displayed in the product list.',
+                    'Admin.Shopparameters.Help'
+                ),
                 'choices' => [
                     'Product name' => 0,
                     'Product price' => 1,
@@ -56,15 +70,21 @@ class PaginationType extends AbstractType
                     'Product quantity' => 6,
                     'Product reference' => 7,
                 ],
-                'required' => true,
+                'required' => false,
+                'placeholder' => false,
             ])
             ->add('default_order_way', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Default order method',
+                    'Admin.Shopparameters.Feature'
+                ),
                 'choices' => [
                     'Ascending' => 0,
                     'Descending' => 1,
                 ],
-                'required' => true,
                 'choice_translation_domain' => 'Admin.Global',
+                'required' => false,
+                'placeholder' => false,
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/StockType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -47,69 +48,41 @@ class StockType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('allow_ordering_oos', SwitchType::class)
-            ->add('stock_management', SwitchType::class)
-            ->add('in_stock_label', TranslatableType::class, [
-                'type' => TextType::class,
-                'only_enabled_locales' => false,
-                'options' => [
-                    'attr' => [
-                        'placeholder' => $this->trans('In stock', 'Admin.Shopparameters.Help'),
-                    ],
-                ],
-            ])
-            ->add('oos_allowed_backorders', TranslatableType::class, [
-                'type' => TextType::class,
-                'only_enabled_locales' => false,
-                'options' => [
-                    'attr' => [
-                        'placeholder' => $this->trans('On backorder', 'Admin.Shopparameters.Help'),
-                    ],
-                ],
-            ])
-            ->add('oos_denied_backorders', TranslatableType::class, [
-                'type' => TextType::class,
-                'only_enabled_locales' => false,
-                'options' => [
-                    'attr' => [
-                        'placeholder' => $this->trans('Out of stock', 'Admin.Shopparameters.Help'),
-                    ],
-                ],
-            ])
-            ->add('delivery_time', TranslatableType::class, [
-                'type' => TextType::class,
-                'only_enabled_locales' => false,
-                'options' => [
-                    'attr' => [
-                        'placeholder' => $this->trans('Delivered within 3-4 days', 'Admin.Shopparameters.Help'),
-                    ],
-                ],
-            ])
-            ->add('oos_delivery_time', TranslatableType::class, [
-                'type' => TextType::class,
-                'only_enabled_locales' => false,
-                'options' => [
-                    'attr' => [
-                        'placeholder' => $this->trans('Delivered within 5-7 days', 'Admin.Shopparameters.Help'),
-                    ],
-                ],
+            ->add('stock_management', SwitchType::class, [
+                'label' => $this->trans(
+                    'Enable stock management',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'required' => false,
             ])
             ->add('pack_stock_management', ChoiceType::class, [
-                'choices' => [
-                    'Decrement pack only.' => 0,
-                    'Decrement products in pack only.' => 1,
-                    'Decrement both.' => 2,
-                ],
-            ])
-            ->add('oos_show_label_listing_pages', SwitchType::class, [
                 'label' => $this->trans(
-                    'Display out-of-stock label on product listing pages',
+                    'Default pack stock management',
                     'Admin.Shopparameters.Feature'
                 ),
                 'help' => $this->trans(
-                    'Note that the label will be displayed only if backorders are denied.',
+                    'When selling packs of products, how do you want your stock to be calculated?',
                     'Admin.Shopparameters.Help'
                 ),
+                'choices' => [
+                    'Decrement pack only.' => PackStockType::STOCK_TYPE_PACK_ONLY,
+                    'Decrement products in pack only.' => PackStockType::STOCK_TYPE_PRODUCTS_ONLY,
+                    'Decrement both.' => PackStockType::STOCK_TYPE_BOTH,
+                ],
+                'choice_translation_domain' => 'Admin.Catalog.Feature',
+                'required' => false,
+                'placeholder' => false,
+            ])
+            ->add('display_unavailable_attributes', SwitchType::class, [
+                'label' => $this->trans(
+                    'Display unavailable attributes on the product page',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'If an attribute is not available in every product combination, it will not be displayed.',
+                    'Admin.Shopparameters.Help'
+                ),
+                'required' => false,
             ])
             ->add('display_last_quantities', IntegerType::class, [
                 'label' => $this->trans(
@@ -120,8 +93,120 @@ class StockType extends TranslatorAwareType
                     'Set to "0" to disable this feature.',
                     'Admin.Shopparameters.Help'
                 ),
+                'required' => false,
             ])
-            ->add('display_unavailable_attributes', SwitchType::class);
+            ->add('allow_ordering_oos', SwitchType::class, [
+                'label' => $this->trans(
+                    'Allow ordering of out-of-stock products',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'By default, the "%add_to_cart_label%" button is hidden when a product is unavailable. You can choose to have it displayed in all cases.',
+                    'Admin.Shopparameters.Help',
+                    [
+                        '%add_to_cart_label%' => $this->trans(
+                            'Add to cart',
+                            'Shop.Theme.Actions'
+                        ),
+                    ]
+                ),
+                'required' => false,
+            ])
+            ->add('in_stock_label', TranslatableType::class, [
+                'label' => $this->trans(
+                    'Label of in-stock products',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'type' => TextType::class,
+                'only_enabled_locales' => false,
+                'options' => [
+                    'attr' => [
+                        'placeholder' => $this->trans('In stock', 'Admin.Shopparameters.Help'),
+                    ],
+                ],
+                'required' => false,
+            ])
+            ->add('oos_allowed_backorders', TranslatableType::class, [
+                'label' => $this->trans(
+                    'Label of out-of-stock products with allowed backorders',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'type' => TextType::class,
+                'only_enabled_locales' => false,
+                'options' => [
+                    'attr' => [
+                        'placeholder' => $this->trans('On backorder', 'Admin.Shopparameters.Help'),
+                    ],
+                ],
+                'required' => false,
+            ])
+            ->add('oos_denied_backorders', TranslatableType::class, [
+                'label' => $this->trans(
+                    'Label of out-of-stock products with denied backorders',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'type' => TextType::class,
+                'only_enabled_locales' => false,
+                'options' => [
+                    'attr' => [
+                        'placeholder' => $this->trans('Out of stock', 'Admin.Shopparameters.Help'),
+                    ],
+                ],
+                'required' => false,
+            ])
+            ->add('delivery_time', TranslatableType::class, [
+                'label' => $this->trans(
+                    'Delivery time of in-stock products',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                        'Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)',
+                        'Admin.Shopparameters.Help'
+                    ) . '<br />' . $this->trans(
+                        'Leave empty to disable',
+                        'Admin.Shopparameters.Feature'
+                    ),
+                'type' => TextType::class,
+                'only_enabled_locales' => false,
+                'options' => [
+                    'attr' => [
+                        'placeholder' => $this->trans('Delivered within 3-4 days', 'Admin.Shopparameters.Help'),
+                    ],
+                ],
+                'required' => false,
+            ])
+            ->add('oos_delivery_time', TranslatableType::class, [
+                'label' => $this->trans(
+                    'Delivery time of out-of-stock products with allowed backorders',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                        'Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)',
+                        'Admin.Shopparameters.Help'
+                    ) . '<br />' . $this->trans(
+                        'Leave empty to disable',
+                        'Admin.Shopparameters.Feature'
+                    ),
+                'type' => TextType::class,
+                'only_enabled_locales' => false,
+                'options' => [
+                    'attr' => [
+                        'placeholder' => $this->trans('Delivered within 5-7 days', 'Admin.Shopparameters.Help'),
+                    ],
+                ],
+                'required' => false,
+            ])
+            ->add('oos_show_label_listing_pages', SwitchType::class, [
+                'label' => $this->trans(
+                    'Display out-of-stock label on product listing pages',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'Note that the label will be displayed only if backorders are denied.',
+                    'Admin.Shopparameters.Help'
+                ),
+                'required' => false,
+            ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -405,12 +405,28 @@ services:
   form.type.product_preferences.general:
     class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences\GeneralType'
     parent: 'form.type.translatable.aware'
+    arguments:
+      - '@prestashop.adapter.legacy.context'
     public: true
     tags:
       - { name: form.type }
 
   form.type.product_preferences.stock:
     class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences\StockType'
+    parent: 'form.type.translatable.aware'
+    public: true
+    tags:
+      - { name: form.type }
+
+  form.type.product_preferences.page:
+    class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences\PageType'
+    parent: 'form.type.translatable.aware'
+    public: true
+    tags:
+      - { name: form.type }
+
+  form.type.product_preferences.pagination:
+    class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences\PaginationType'
     parent: 'form.type.translatable.aware'
     public: true
     tags:

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_general.html.twig
@@ -24,10 +24,9 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme generalForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block product_preferences_general %}
-
   <div class="card" id="configuration_fieldset_products">
     <h3 class="card-header">
       <i class="material-icons">settings</i>
@@ -35,69 +34,7 @@
     </h3>
     <div class="card-body">
       <div class="form-wrapper">
-        <div class="form-group row">
-          {{ ps.label_with_help(('Catalog mode'|trans), ('Catalog mode disables the shopping cart on your store. Visitors will be able to browse your products catalog, but not buy them.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(generalForm.catalog_mode) }}
-            {{ form_widget(generalForm.catalog_mode) }}
-            <small class="form-text">{{ 'Have specific needs? Edit particular groups to let them see prices or not.'|trans({}, 'Admin.Shopparameters.Help') }}</small>
-          </div>
-        </div>
-        <div class="form-group row catalog-mode-option">
-          {{ ps.label_with_help(('Show prices'|trans), ('Display product prices when in catalog mode.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(generalForm.catalog_mode_with_prices) }}
-            {{ form_widget(generalForm.catalog_mode_with_prices) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Number of days for which the product is considered \'new\''|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(generalForm.new_days_number) }}
-            {{ form_widget(generalForm.new_days_number) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Max size of product summary'|trans), ('Set the maximum size of the summary of your product description (in characters).'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(generalForm.short_description_limit) }}
-            {{ form_widget(generalForm.short_description_limit) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Quantity discounts based on'|trans), ('How to calculate quantity discounts.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(generalForm.quantity_discount) }}
-            {{ form_widget(generalForm.quantity_discount) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Force update of friendly URL'|trans), ('When active, friendly URL will be updated on every save.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(generalForm.force_friendly_url) }}
-            {{ form_widget(generalForm.force_friendly_url) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Default activation status'|trans), ('Enable this option if you want to activate by default all your manually created new products.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(generalForm.default_status) }}
-            {{ form_widget(generalForm.default_status) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Default order of priority for specific prices'|trans), ('If a customer meets multiple conditions, specific prices will be applied in this order of priority, unless a different order has been set for a particular product.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(generalForm.specific_price_priorities) }}
-            {{ form_widget(generalForm.specific_price_priorities) }}
-          </div>
-        </div>
-
-        {% block product_general_preferences_form_rest %}
-          {{ form_rest(generalForm) }}
-        {% endblock %}
+        {{ form_widget(generalForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_page.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme pageForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block product_preferences_page %}
   <div class="card" id="configuration_fieldset_fo_product_page">
@@ -34,46 +34,8 @@
     </h3>
     <div class="card-body">
       <div class="form-wrapper">
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Display available quantities on the product page'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(pageForm.display_quantities) }}
-            {{ form_widget(pageForm.display_quantities) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Display the "%add_to_cart_label%" button when a product has attributes'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help')), ('Display or hide the "%add_to_cart_label%" button on category pages for products that have attributes forcing customers to see product details.'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(pageForm.allow_add_variant_to_cart_from_listing) }}
-            {{ form_widget(pageForm.allow_add_variant_to_cart_from_listing) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Separator of attribute anchor on the product links'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(pageForm.attribute_anchor_separator) }}
-            {{ form_widget(pageForm.attribute_anchor_separator) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Display discounted price'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(pageForm.display_discount_price) }}
-            {{ form_widget(pageForm.display_discount_price) }}
-            <small class="form-text">{{ 'In the volume discounts board, display the new price with the applied discount instead of showing the discount (ie. "-5%").'|trans({}, 'Admin.Shopparameters.Help') }}</small>
-          </div>
-        </div>
+        {{ form_widget(pageForm) }}
       </div>
-
-      {% block product_page_preferences_form_rest %}
-        {{ form_rest(pageForm) }}
-      {% endblock %}
     </div>
     <div class="card-footer">
       <div class="d-flex justify-content-end">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_pagination.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme paginationForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block product_preferences_pagination %}
 
@@ -35,31 +35,7 @@
     </h3>
     <div class="card-body">
       <div class="form-wrapper">
-        <div class="form-group row">
-          {{ ps.label_with_help(('Products per page'|trans), ('Number of products displayed per page. Default is 10.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(paginationForm.products_per_page) }}
-            {{ form_widget(paginationForm.products_per_page) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Default order by'|trans), ('The order in which products are displayed in the product list.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(paginationForm.default_order_by) }}
-            {{ form_widget(paginationForm.default_order_by) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Default order method'|trans), ('Default order method for product list.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(paginationForm.default_order_way) }}
-            {{ form_widget(paginationForm.default_order_way) }}
-          </div>
-        </div>
-
-        {% block product_pagination_preferences_form_rest %}
-          {{ form_rest(paginationForm) }}
-        {% endblock %}
+        {{ form_widget(paginationForm) }}
       </div>
     </div>
     <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/product_preferences_stock.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {% trans_default_domain "Admin.Shopparameters.Feature" %}
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme stockForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block product_preferences_stock %}
   <div class="card" id="configuration_fieldset_stock">
@@ -34,91 +34,7 @@
     </h3>
     <div class="card-body">
       <div class="form-wrapper">
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Enable stock management'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(stockForm.stock_management) }}
-            {{ form_widget(stockForm.stock_management) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Default pack stock management'|trans), ('When selling packs of products, how do you want your stock to be calculated?'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(stockForm.pack_stock_management) }}
-            {{ form_widget(stockForm.pack_stock_management) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Display unavailable attributes on the product page'|trans), ('If an attribute is not available in every product combination, it will not be displayed.'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(stockForm.display_unavailable_attributes) }}
-            {{ form_widget(stockForm.display_unavailable_attributes) }}
-          </div>
-        </div>
-
-        {{ form_row(stockForm.display_last_quantities) }}
-
-        <div class="form-group row">
-          {{ ps.label_with_help(('Allow ordering of out-of-stock products'|trans), ('By default, the "%add_to_cart_label%" button is hidden when a product is unavailable. You can choose to have it displayed in all cases.'|trans({'%add_to_cart_label%': 'Add to cart'|trans({}, 'Shop.Theme.Actions')}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(stockForm.allow_ordering_oos) }}
-            {{ form_widget(stockForm.allow_ordering_oos) }}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Label of in-stock products'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(stockForm.stock_management) }}
-            {{ form_widget(stockForm.in_stock_label) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Label of out-of-stock products with allowed backorders'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(stockForm.oos_allowed_backorders) }}
-            {{ form_widget(stockForm.oos_allowed_backorders) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Label of out-of-stock products with denied backorders'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(stockForm.oos_denied_backorders) }}
-            {{ form_widget(stockForm.oos_denied_backorders) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Delivery time of in-stock products'|trans), ('Advised for European merchants to be legally compliant (eg: Delivered within 3-4 days)'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(stockForm.delivery_time) }}
-            {{ form_widget(stockForm.delivery_time) }}
-            <small class="form-text">{{ 'Leave empty to disable'|trans }}</small>
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help(('Delivery time of out-of-stock products with allowed backorders'|trans), ('Advised for European merchants to be legally compliant (eg: Delivered within 5-7 days)'|trans({}, 'Admin.Shopparameters.Help'))) }}
-          <div class="col-sm">
-            {{ form_errors(stockForm.oos_delivery_time) }}
-            {{ form_widget(stockForm.oos_delivery_time) }}
-            <small class="form-text">{{ 'Leave empty to disable'|trans }}</small>
-          </div>
-        </div>
-
-        {{ form_row(stockForm.oos_show_label_listing_pages) }}
-
-        {% block product_stock_preferences_form_rest %}
-          {{ form_rest(stockForm) }}
-        {% endblock %}
+        {{ form_widget(stockForm) }}
       </div>
     </div>
     <div class="card-footer">
@@ -127,5 +43,4 @@
       </div>
     </div>
   </div>
-
 {% endblock %}


### PR DESCRIPTION

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify Product Preferences Form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Configuration -> Shop Parameters -> Product Preferences. Everything must look the same aside for help now appearing under inputs instead as blue box, also some fields now will appear as required because they always were.

:notebook: **BC Break**
Backwards compatibility break introduced due to extension of TranslationAwareType by PageType and PaginationType. This means if any module extends those types they will get an exception upon upgrading to PS version containing changes in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27892)
<!-- Reviewable:end -->
