### PR TITLE
Fix for attributes not listed on product page

### DIFF
--- a/src/PrestaShopBundle/Entity/Repository/AttributeRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AttributeRepository.php
@@ -68,7 +68,7 @@ class AttributeRepository extends \Doctrine\ORM\EntityRepository
 
         foreach ($result as $attribute) {
             if (isset($attributeGroups[$attribute['attributeGroupPosition']])) {
-                $attributeGroups[$attribute['attributeGroupPosition']]['attributes'][$attribute['attributePosition']] = $this->getAttributeRow($attribute);
+                array_push($attributeGroups[$attribute['attributeGroupPosition']]['attributes'], $this->getAttributeRow($attribute));
             } else {
                 $attributeGroups[$attribute['attributeGroupPosition']] = [
                     'id' => $attribute['attributeGroupId'],


### PR DESCRIPTION
Sometimes after migration position of attributes might be messed up. This change fixes that issue and shows all attributes on combinations screen of the product.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue number here}.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27905)
<!-- Reviewable:end -->
