### PR TITLE
Hook displayOverrideTemplate not executed on checkout page due to naming issue.

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1410,7 +1410,7 @@ class FrontControllerCore extends Controller
         }
 
         if ($overridden_template = Hook::exec(
-            'DisplayOverrideTemplate',
+            'displayOverrideTemplate',
             [
                 'controller' => $this,
                 'template_file' => $template,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | displayOverrideTemplate hook was not spelled correctly. This PR modifies it for consistency with other hooks.
| Type?             | improvement
| BC Breaks | Yes, hook name modified
| Category?         | FO 
| How to test?      | Check with a module which uses the hook displayOverrideTemplate that is works as before
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27941)
<!-- Reviewable:end -->
