### PR TITLE
Remove getCldr and array_replace

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -726,22 +726,6 @@ class ToolsCore
     }
 
     /**
-     * Return the CLDR associated with the context or given language_code.
-     *
-     * @see Tools::getContextLocale
-     * @deprecated since PrestaShop 1.7.6.0
-     *
-     * @param Context|null $context
-     * @param null $language_code
-     *
-     * @throws PrestaShopException
-     */
-    public static function getCldr(Context $context = null, $language_code = null)
-    {
-        throw new PrestaShopException('This CLDR library has been removed. See Tools::getContextLocale instead.');
-    }
-
-    /**
      * Return price with currency sign for a given product.
      *
      * @deprecated Since 1.7.6.0. Please use Locale::formatPrice() instead
@@ -890,38 +874,6 @@ class ToolsCore
         }
 
         return $price;
-    }
-
-    /**
-     * Implement array_replace for PHP <= 5.2.
-     *
-     * @return array|mixed|null
-     *
-     * @deprecated since version 1.7.4.0, to be removed.
-     */
-    public static function array_replace()
-    {
-        Tools::displayAsDeprecated('Use PHP\'s array_replace() instead');
-        if (!function_exists('array_replace')) {
-            $args = func_get_args();
-            $num_args = func_num_args();
-            $res = [];
-            for ($i = 0; $i < $num_args; ++$i) {
-                if (is_array($args[$i])) {
-                    foreach ($args[$i] as $key => $val) {
-                        $res[$key] = $val;
-                    }
-                } else {
-                    trigger_error(__FUNCTION__ . '(): Argument #' . ($i + 1) . ' is not an array', E_USER_WARNING);
-
-                    return null;
-                }
-            }
-
-            return $res;
-        } else {
-            return call_user_func_array('array_replace', func_get_args());
-        }
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes, Tools::getCldr and Tools::array_replace have been removed
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293
| How to test?      | CI is green
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27955)
<!-- Reviewable:end -->
