### PR TITLE
Remove AdminController deprecated

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2245,43 +2245,9 @@ class AdminControllerCore extends Controller
         ]);
     }
 
-    /**
-     * Init tab modules list and add button in toolbar.
-     *
-     * @deprecated since 1.7.7.0
-     */
-    protected function initTabModuleList()
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated and has no effect since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
-    }
-
-    /**
-     * @deprecated since 1.7.7.0
-     */
-    protected function addPageHeaderToolBarModulesListButton()
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated and has no effect since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
-    }
-
-    /**
-     * @deprecated since 1.7.7.0
-     */
-    protected function addToolBarModulesListButton()
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated and has no effect since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
-    }
-
     protected function getAdminModulesUrl()
     {
         return $this->context->link->getAdminLink('AdminModulesCatalog');
-    }
-
-    /**
-     * @deprecated since 1.7.7.0
-     */
-    protected function filterTabModuleList()
-    {
-        @trigger_error(sprintf('The "%s()" method is deprecated and has no effect since 1.7.7.0', __METHOD__), E_USER_DEPRECATED);
     }
 
     /**
@@ -2625,13 +2591,6 @@ class AdminControllerCore extends Controller
         $helper->list_skip_actions = $this->list_skip_actions;
 
         $this->helper = $helper;
-    }
-
-    /**
-     * @deprecated 1.6.0
-     */
-    public function setDeprecatedMedia()
-    {
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | AdminController::initTabModuleList, AdminController::addPageHeaderToolBarModulesListButton, AdminController::addToolBarModulesListButton, AdminController::filterTabModuleList, AdminController::setDeprecatedMedia
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes - AdminController::initTabModuleList, AdminController::addPageHeaderToolBarModulesListButton, AdminController::addToolBarModulesListButton, AdminController::filterTabModuleList, AdminController::setDeprecatedMedia
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293
| How to test?      | Tests are green.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27959)
<!-- Reviewable:end -->
