### PR TITLE
Option to configure displaying of copyright in the footer

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1585,6 +1585,7 @@ class FrontControllerCore extends Controller
             'voucher_enabled' => (int) CartRule::isFeatureActive(),
             'return_enabled' => (int) Configuration::get('PS_ORDER_RETURN'),
             'number_of_days_for_return' => (int) Configuration::get('PS_ORDER_RETURN_NB_DAYS'),
+            'display_footer_copyright' => (bool) Configuration::get('PS_DISPLAY_FOOTER_COPYRIGHT'),
         ];
     }
 

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -317,6 +317,9 @@
   <configuration id="PS_DISPLAY_BEST_SELLERS" name="PS_DISPLAY_BEST_SELLERS">
     <value>1</value>
   </configuration>
+  <configuration id="PS_DISPLAY_FOOTER_COPYRIGHT" name="PS_DISPLAY_FOOTER_COPYRIGHT">
+    <value>1</value>
+  </configuration>
   <configuration id="PS_CATALOG_MODE" name="PS_CATALOG_MODE">
     <value>0</value>
   </configuration>

--- a/src/Adapter/Preferences/PreferencesConfiguration.php
+++ b/src/Adapter/Preferences/PreferencesConfiguration.php
@@ -61,6 +61,7 @@ class PreferencesConfiguration implements DataConfigurationInterface
             'display_suppliers' => $this->configuration->getBoolean('PS_DISPLAY_SUPPLIERS'),
             'display_manufacturers' => $this->configuration->getBoolean('PS_DISPLAY_MANUFACTURERS'),
             'display_best_sellers' => $this->configuration->getBoolean('PS_DISPLAY_BEST_SELLERS'),
+            'display_footer_copyright' => $this->configuration->getBoolean('PS_DISPLAY_FOOTER_COPYRIGHT'),
             'multishop_feature_active' => $this->configuration->getBoolean('PS_MULTISHOP_FEATURE_ACTIVE'),
             'shop_activity' => $this->configuration->get('PS_SHOP_ACTIVITY'),
         ];
@@ -101,6 +102,7 @@ class PreferencesConfiguration implements DataConfigurationInterface
         $this->configuration->set('PS_DISPLAY_SUPPLIERS', $configuration['display_suppliers']);
         $this->configuration->set('PS_DISPLAY_MANUFACTURERS', $configuration['display_manufacturers']);
         $this->configuration->set('PS_DISPLAY_BEST_SELLERS', $configuration['display_best_sellers']);
+        $this->configuration->set('PS_DISPLAY_FOOTER_COPYRIGHT', $configuration['display_footer_copyright']);
         $this->configuration->set('PS_MULTISHOP_FEATURE_ACTIVE', $configuration['multishop_feature_active']);
         $this->configuration->set('PS_SHOP_ACTIVITY', $configuration['shop_activity']);
 
@@ -140,6 +142,7 @@ class PreferencesConfiguration implements DataConfigurationInterface
             $configuration['display_suppliers'],
             $configuration['display_manufacturers'],
             $configuration['display_best_sellers'],
+            $configuration['display_footer_copyright'],
             $configuration['multishop_feature_active']
         );
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -196,6 +196,14 @@ class PreferencesType extends TranslatorAwareType
                         'Admin.Shopparameters.Help'
                     ),
                 ])
+            ->add(
+                'display_footer_copyright', SwitchType::class, [
+                    'label' => $this->trans('Display PrestaShop copyright in the footer', 'Admin.Shopparameters.Feature'),
+                    'help' => $this->trans(
+                        'If you want to hide PrestaShop copyright information in the footer leave this option disabled.',
+                        'Admin.Shopparameters.Help'
+                    ),
+                ])
             ->add('multishop_feature_active', SwitchType::class, [
                 'disabled' => !$this->isContextDependantOptionEnabled(),
                 'label' => $this->trans('Enable Multistore', 'Admin.Shopparameters.Feature'),

--- a/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
+++ b/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
@@ -80,6 +80,7 @@ class PreferencesConfigurationTest extends TestCase
                     ['PS_DISPLAY_SUPPLIERS', false, false],
                     ['PS_DISPLAY_MANUFACTURERS', false, true],
                     ['PS_DISPLAY_BEST_SELLERS', false, false],
+                    ['PS_DISPLAY_FOOTER_COPYRIGHT', false, true],
                     ['PS_MULTISHOP_FEATURE_ACTIVE', false, true],
                 ]
             );
@@ -97,6 +98,7 @@ class PreferencesConfigurationTest extends TestCase
                 'display_suppliers' => false,
                 'display_manufacturers' => true,
                 'display_best_sellers' => false,
+                'display_footer_copyright' => true,
                 'multishop_feature_active' => true,
                 'shop_activity' => 'test',
             ],
@@ -149,6 +151,7 @@ class PreferencesConfigurationTest extends TestCase
                     'display_suppliers' => false,
                     'display_manufacturers' => true,
                     'display_best_sellers' => false,
+                    'display_footer_copyright' => false,
                     'multishop_feature_active' => true,
                     'shop_activity' => 'test',
                 ]
@@ -177,6 +180,7 @@ class PreferencesConfigurationTest extends TestCase
                     ['PS_DISPLAY_SUPPLIERS', false],
                     ['PS_DISPLAY_MANUFACTURERS', true],
                     ['PS_DISPLAY_BEST_SELLERS', false],
+                    ['PS_DISPLAY_FOOTER_COPYRIGHT', false],
                     ['PS_MULTISHOP_FEATURE_ACTIVE', true],
                     ['PS_PRICE_ROUND_MODE', 'test'],
                     ['PS_ROUND_TYPE', 'test'],
@@ -205,6 +209,7 @@ class PreferencesConfigurationTest extends TestCase
                     'display_suppliers' => false,
                     'display_manufacturers' => true,
                     'display_best_sellers' => false,
+                    'display_footer_copyright' => false,
                     'multishop_feature_active' => true,
                     'shop_activity' => 'test',
                 ]


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This is a new option in the back office to allow merchants to hide PrestaShop copyright information from the footer
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Partially Fixes PrestaShop/hummingbird#502. - PR for the theme and autoupgrade module are coming
| How to test?      | Instruction below
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

Install PrestaShop, use `{$configuration|dump}` somewhere in `footer.tpl`, you should see a configuration related to copyrights `display_footer_copyright`, hiding it will be implemented in the theme repository

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27963)
<!-- Reviewable:end -->
