### PR TITLE
AdminCarts infinite loop fix

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -214,8 +214,10 @@ class CartCore extends ObjectModel
             Cart::$_customer = $customer;
 
             if ((!$this->secure_key || $this->secure_key == '-1') && $customer->secure_key) {
-                $this->secure_key = $customer->secure_key;
-                $this->save();
+                if ($this->secure_key !== $customer->secure_key) {
+                    $this->secure_key = $customer->secure_key;
+                    $this->save();
+                }
             }
         }
 


### PR DESCRIPTION
Hello, 
First of all, I don't really have much experience with Prestshop Core, so please review this twice before anything :)
We had a problem in our Prestashop installation where AdminCarts controller was killing the server, because of infinite loop. The culprit was that `classes/Cart.php` was trying to update the same `secret_key` column for customer over and over again.
The problem was happening also without overrides or any 3rd party modules enabled.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Prevents infinite loop when updating customer's `secure_key`. If the new and old secure_keys match, we skip the update.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | Not really sure how to test this as it doesn't happen in every installation
| Possible impacts? | unknown

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27965)
<!-- Reviewable:end -->
