### PR TITLE
Add the possibility to load PHP / XML files for modules services

### DIFF
--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -27,8 +27,11 @@
 namespace PrestaShopBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Finder\Finder;
 
@@ -67,7 +70,12 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
             if (in_array($modulePath->getFilename(), $activeModules)) {
                 $moduleConfigPath = $modulePath . $this->configPath;
                 if (file_exists($moduleConfigPath . 'services.yml')) {
-                    $loader = new YamlFileLoader($container, new FileLocator($moduleConfigPath));
+                    $fileLocator = new FileLocator($moduleConfigPath);
+                    $loader = new YamlFileLoader($container, $fileLocator);
+                    $loader->setResolver(new LoaderResolver([
+                        new PhpFileLoader($container, $fileLocator),
+                        new XmlFileLoader($container, $fileLocator),
+                    ]));
                     $loader->load('services.yml');
                 }
             }


### PR DESCRIPTION
…rvices

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Today, it's not possible for a module to have PHP or XML services files, and it can be useful sometimes to have them.
| Type?             | improvement
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27968 
| How to test?      | With this module unzipped in the `modules` repository, you will have an error on the Module Manager screen without the PR (the service file does not load). It will works well with the PR. [prestashopexamplemodule.zip](https://github.com/PrestaShop/PrestaShop/files/8305540/prestashopexamplemodule.zip)




<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27969)
<!-- Reviewable:end -->
