### PR TITLE
Fix theme translation: The correct location of the xlf files is the theme dir

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -2,7 +2,7 @@ parameters:
   ps_root_dir: "%kernel.root_dir%/../"
   ps_config_dir: "%ps_root_dir%config"
   translations_dir: "%kernel.root_dir%/../translations"
-  themes_translations_dir: "%kernel.cache_dir%/themes"
+  themes_translations_dir: "%kernel.root_dir%/../themes"
   modules_dir: "%kernel.root_dir%/../modules"
   themes_dir: "%kernel.root_dir%/../themes"
   translation_catalogues_export_dir: "%kernel.cache_dir%/export"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This fix allows to translate the missing wording for a theme. It allows to load the core translations.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27410 (and its duplicate #27970)
| How to test?      | Se issue #27970 for a way to reproduce the error and the correct behavior after applying the fix.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27971)
<!-- Reviewable:end -->
