### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -53,7 +53,7 @@ jobs:
         run: today=`date +%Y-%m-%d-`; for i in *; do mv $i $today$GH_BRANCH-$i; done
         working-directory: ${{ env.RELEASE_DIR }}
 
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         name: Setup Cloud Sdk
         with:
           service_account_key: ${{ env.GC_SERVICE_KEY }}

--- a/.github/workflows/cron_nightly_gcp.yml
+++ b/.github/workflows/cron_nightly_gcp.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Initialize GCloud Service Key
         run: echo $GC_SERVICE_KEY > $HOME/gcloud-service-key.json
 
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ env.GC_SERVICE_KEY }}
           project_id: ${{ env.GC_PROJECT_ID }}

--- a/.github/workflows/cron_nightly_tests.yml
+++ b/.github/workflows/cron_nightly_tests.yml
@@ -155,7 +155,7 @@ jobs:
           REPORT_NAME="$(date +%Y-%m-%d)-${{ env.GH_BRANCH }}"
           npx mochawesome-merge "${{ env.REPORTS_DIR_PATH }}/*.json" -o "${{ env.COMBINED_REPORT_DIR_PATH }}/${REPORT_NAME}.json"
 
-      - uses: google-github-actions/setup-gcloud@master
+      - uses: google-github-actions/setup-gcloud@v0
         name: Setup Cloud Sdk
         with:
           service_account_key: ${{ env.GC_SERVICE_KEY }}


### PR DESCRIPTION


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | setup-gcloud will be updating the branch name from master to main in a future release. Even though GitHub will establish redirects, this will break any GitHub Actions workflows that pin to master. This PR updates your GitHub Actions workflows to pin to v0, which is the recommended best practice.
| Type?             | improvement
| Category?         |  TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should run correctly screen without the PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27974)
<!-- Reviewable:end -->
