### PR TITLE
Fixed a problem that prevent customer address save

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -111,7 +111,7 @@ class CustomerAddressFormCore extends AbstractForm
     {
         $is_valid = $this->validateFieldsValues();
 
-        if (($hookReturn = Hook::exec('actionValidateCustomerAddressForm', ['form' => $this])) !== '') {
+        if (!is_null($hookReturn = Hook::exec('actionValidateCustomerAddressForm', ['form' => $this]))) {
             $is_valid &= (bool) $hookReturn;
         }
 

--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -112,7 +112,7 @@ class CustomerAddressFormCore extends AbstractForm
         $is_valid = $this->validateFieldsValues();
 
         $hookReturn = Hook::exec('actionValidateCustomerAddressForm', ['form' => $this]);
-        if (!is_null($hookReturn) && $hookReturn !== '') {
+        if ($hookReturn !== null && $hookReturn !== '') {
             $is_valid &= (bool) $hookReturn;
         }
 

--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -111,7 +111,8 @@ class CustomerAddressFormCore extends AbstractForm
     {
         $is_valid = $this->validateFieldsValues();
 
-        if (!is_null($hookReturn = Hook::exec('actionValidateCustomerAddressForm', ['form' => $this]))) {
+        $hookReturn = Hook::exec('actionValidateCustomerAddressForm', ['form' => $this]);
+        if (!is_null($hookReturn) && $hookReturn !== '') {
             $is_valid &= (bool) $hookReturn;
         }
 


### PR DESCRIPTION
If the hook::exec method returns "null" value the customer address can't be saved.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete them:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      | If the hook::exec method returns "null" value the customer address can't be saved.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/29030
| How to test?      | Upgrade Prestashop from 1.6 to 1.7.8.4 and try to add a customer address. PHP version was 7.3.3 in my case if it is matters.
| Possible impacts? | Registered addresses  must be shown on addresses pages both BO and FO


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27976)
<!-- Reviewable:end -->
