### PR TITLE
In Stock Movement page, localize date & time

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/movement-line.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/movements/movement-line.vue
@@ -63,7 +63,7 @@
       </span>
     </td>
     <td class="text-sm-center">
-      {{ dateAdd }}
+      {{ product.date_add_formatted }}
     </td>
     <td>
       {{ employeeName }}
@@ -96,11 +96,6 @@
       },
       orderLink(): string | null {
         return this.product.order_link !== 'N/A' ? this.product.order_link : null;
-      },
-      dateAdd() {
-        const date = new Date(Date.parse(this.product.date_add));
-
-        return date.toLocaleDateString(window.data.locale, {});
       },
     },
     components: {

--- a/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/StockMovementRepository.php
@@ -37,6 +37,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class StockMovementRepository extends StockManagementRepository
 {
     /**
+     * @var string
+     */
+    protected $dateFormatFull;
+
+    /**
      * StockMovementRepository constructor.
      *
      * @param ContainerInterface $container
@@ -45,6 +50,7 @@ class StockMovementRepository extends StockManagementRepository
      * @param ContextAdapter $contextAdapter
      * @param ImageManager $imageManager
      * @param string $tablePrefix
+     * @param string $dateFormatFull
      */
     public function __construct(
         ContainerInterface $container,
@@ -52,7 +58,8 @@ class StockMovementRepository extends StockManagementRepository
         EntityManager $entityManager,
         ContextAdapter $contextAdapter,
         ImageManager $imageManager,
-        $tablePrefix
+        $tablePrefix,
+        string $dateFormatFull
     ) {
         parent::__construct(
             $container,
@@ -62,6 +69,8 @@ class StockMovementRepository extends StockManagementRepository
             $imageManager,
             $tablePrefix
         );
+
+        $this->dateFormatFull = $dateFormatFull;
     }
 
     /**
@@ -186,9 +195,9 @@ class StockMovementRepository extends StockManagementRepository
      */
     protected function addAdditionalData(array $rows)
     {
-        $rows = $this->addCombinationsAndFeatures($rows);
-        $rows = $this->addImageThumbnailPaths($rows);
+        $rows = parent::addAdditionalData($rows);
         $rows = $this->addOrderLink($rows);
+        $rows = $this->addFormattedDate($rows);
 
         return $rows;
     }
@@ -305,5 +314,17 @@ class StockMovementRepository extends StockManagementRepository
         $this->em->flush();
 
         return $stockMvt->getIdStockMvt();
+    }
+
+    protected function addFormattedDate(array $rows): array
+    {
+        foreach ($rows as &$row) {
+            $row['date_add_formatted'] = date(
+                $this->dateFormatFull,
+                strtotime($row['date_add'])
+            );
+        }
+
+        return $rows;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -63,6 +63,7 @@ services:
       - "@prestashop.adapter.legacy.context"
       - "@prestashop.adapter.image_manager"
       - "%database_prefix%"
+      - '@=service("prestashop.adapter.legacy.context").getLanguage().date_format_full'
 
   prestashop.core.api.supplier.repository:
     class: PrestaShopBundle\Entity\Repository\SupplierRepository


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In Stock Movement page, localize date & time
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26454 (and Relative to #9591)
| How to test?      | In Stock Movement, the time is now displayed and the datetime is now localized. The date take the full date time format from the language.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28001)
<!-- Reviewable:end -->
