### PR TITLE
Remove useless `sslRedirection` function default behavior

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -828,21 +828,12 @@ class FrontControllerCore extends Controller
 
     /**
      * Redirects to correct protocol if settings and request methods don't match.
+     *
+     * @deprecated since 8.0.0 to be removed in next major
+     * SSL redirection is managed properly by `canonicalRedirection` and `context->link` configuration
      */
     protected function sslRedirection()
     {
-        // If we call a SSL controller without SSL or a non SSL controller with SSL, we redirect with the right protocol
-        if (Configuration::get('PS_SSL_ENABLED') && $_SERVER['REQUEST_METHOD'] != 'POST' && $this->ssl != Tools::usingSecureMode()) {
-            $this->context->cookie->disallowWriting();
-            header('HTTP/1.1 301 Moved Permanently');
-            header('Cache-Control: no-cache');
-            if ($this->ssl) {
-                header('Location: ' . Tools::getShopDomainSsl(true) . $_SERVER['REQUEST_URI']);
-            } else {
-                header('Location: ' . Tools::getShopDomain(true) . $_SERVER['REQUEST_URI']);
-            }
-            exit();
-        }
     }
 
     /**

--- a/controllers/front/PageNotFoundController.php
+++ b/controllers/front/PageNotFoundController.php
@@ -48,11 +48,6 @@ class PageNotFoundControllerCore extends FrontController
         // 404 - no need to redirect to the canonical url
     }
 
-    protected function sslRedirection()
-    {
-        // 404 - no need to redirect
-    }
-
     public function getTemplateVarPage()
     {
         $page = parent::getTemplateVarPage();


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Double redirection called from server when you have ssl, specific language and `Friendly URL` configuration.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes #17095 .
| How to test?      | Fresh install; allow ssl; add language; configure `Friendly URL`; go to [http://{prestashop_hostname}]() with opened browser console and check that you have only one 302 redirection.
| Possible impacts? | Impacts may be observed on prestashop modules that inherit FrontController.

As we work on next major version, I recommend to remove sslRedirection method with proper comments and documentation to help modules maintainers to detect possible problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28002)
<!-- Reviewable:end -->
