### PR TITLE
Fixed wording and color button on exit button for the bulk delete

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
@@ -54,7 +54,13 @@
                 {% if actions is defined %}
                     <div class="modal-footer">
                         {% if closable is defined and closable == true %}
-                            <button type="button" class="btn btn-outline-secondary btn-lg" data-dismiss="modal">{{ 'Close'|trans({}, 'Admin.Actions') }}</button>
+                            <button type="button" class="btn btn-outline-secondary btn-lg" data-dismiss="modal">
+                              {% if closeLabel is defined %}
+                                {{ closeLabel }}
+                              {% else %}
+                                {{ 'Close'|trans({}, 'Admin.Actions') }}
+                              {% endif %}
+                            </button>
                         {% endif %}
                         {% for action in actions %}
                             {% if action.type is defined and action.type == 'link' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
@@ -190,13 +190,14 @@
   {# Confirmation deletion product modal #}
   {% embed '@PrestaShop/Admin/Helpers/bootstrap_popup.html.twig' with {
     'id': "catalog_deletion_modal",
-    'title': "Delete products?"|trans({}, 'Admin.Catalog.Feature'),
+    'title': 'Delete products?'|trans({}, 'Admin.Catalog.Feature'),
     'closable': true,
+    'closeLabel': 'Cancel'|trans({}, 'Admin.Actions'),
     'actions': [{
       'type': 'button',
-      'label': "Delete now"|trans({}, 'Admin.Actions'),
+      'label': 'Delete'|trans({}, 'Admin.Actions'),
       'value': 'confirm',
-      'class': 'btn btn-primary btn-lg',
+      'class': 'btn btn-danger btn-lg',
     }],
   }%}
     {% block content %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/delete_categories_modal.html.twig
@@ -27,6 +27,7 @@
   'id': grid.id ~ '_grid_delete_categories_modal',
   'title': "What do you want to do with the products associated with this category?"|trans({}, 'Admin.Catalog.Notification'),
   'closable': true,
+  'closeLabel': "Cancel"|trans({}, 'Admin.Actions'),
   'actions': [{
     'type': 'button',
     'label': "Delete"|trans({}, 'Admin.Actions'),

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/delete_modal.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/delete_modal.html.twig
@@ -27,6 +27,7 @@
   'id': grid.id ~ '_grid_delete_customers_modal',
   'title': "How do you want to delete the selected customers?"|trans({}, 'Admin.Orderscustomers.Notification'),
   'closable': true,
+  'closeLabel': "Cancel"|trans({}, 'Admin.Actions'),
   'actions': [{
     'type': 'button',
     'label': "Delete"|trans({}, 'Admin.Actions'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed wording and color button on exit button for the bulk delete
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27836
| How to test?      | Cf #27836<br><br>Catalog > Products<br>![image](https://user-images.githubusercontent.com/1533248/159663614-b1b0ed35-c097-4f5f-a006-4c77caedfa8b.png)<br><br>Catalog > Categories<br>![image](https://user-images.githubusercontent.com/1533248/159663667-b4804a64-de15-41f7-b603-5af9b0db6460.png)<br><br>Customers > Customers<br>![image](https://user-images.githubusercontent.com/1533248/159663772-dc1faa2f-7c43-470b-9cd2-fdc30f38d0be.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28003)
<!-- Reviewable:end -->
