### PR TITLE
Use category ME instead of [merge] in PR title to allow merge commit

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,6 @@ on: pull_request
 
 jobs:
   message-check:
-    if: "!endsWith(github.event.pull_request.title, '[merge]')"
     name: Block Merge Commits
 
     runs-on: ubuntu-latest
@@ -15,7 +14,15 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+      - name: Check is merge PR
+        id: check-is-merge
+        run: |
+          if [[ """${{ github.event.pull_request.body }}""" =~ \|?[[:space:]]*Category\?[[:space:]]*\|[[:space:]]*ME[[:space:]]+ ]]; then
+              echo ::set-output name=isMerge::true
+          fi
+
       - name: Block Merge Commits
+        if: steps.check-is-merge.outputs.isMerge != 'true'
         uses: Morishiri/block-merge-commits-action@v1.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR aims to use the "Category?" section in the PR description table to allow merge commit only when the category is ME instead of adding [merge] in the PR title
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI is green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28007)
<!-- Reviewable:end -->
