### PR TITLE
Remove OrderHistory getLastOrderState deprecated function

### DIFF
--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -426,34 +426,6 @@ class OrderHistoryCore extends ObjectModel
     }
 
     /**
-     * Returns the last order status.
-     *
-     * @param int $id_order
-     *
-     * @return OrderState|bool
-     *
-     * @deprecated 1.5.0.4
-     * @see Order->current_state
-     */
-    public static function getLastOrderState($id_order)
-    {
-        Tools::displayAsDeprecated();
-        $id_order_state = Db::getInstance()->getValue('
-        SELECT `id_order_state`
-        FROM `' . _DB_PREFIX_ . 'order_history`
-        WHERE `id_order` = ' . (int) $id_order . '
-        ORDER BY `date_add` DESC, `id_order_history` DESC');
-
-        // returns false if there is no state
-        if (!$id_order_state) {
-            return false;
-        }
-
-        // else, returns an OrderState object
-        return new OrderState((int) $id_order_state, (int) Configuration::get('PS_LANG_DEFAULT'));
-    }
-
-    /**
      * @param bool $autodate Optional
      * @param array|bool $template_vars Optional
      * @param Context|null $context Deprecated


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR remove the function getLastOrderState of class OrderHistory which is deprecated since prestashop 1.5.04
| Type?             | improvement 
| Category?         |  BO
| BC breaks?        | yes but as it's a very old function i'm not sur that it is still in use.
| Deprecations?     | yes 
| Fixed ticket?     | Relative to #26293
| How to test?      | Global tests should not fail
| Possible impacts? | Old modules using the function OrderHistory::getLastOrderState need to be upgraded


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28009)
<!-- Reviewable:end -->
