### PR TITLE
Remove OrderSlip::createOrderSlip deprecated function

### DIFF
--- a/classes/order/OrderSlip.php
+++ b/classes/order/OrderSlip.php
@@ -261,29 +261,6 @@ class OrderSlipCore extends ObjectModel
         return $slips;
     }
 
-    /**
-     * @deprecated since 1.6.0.10 use OrderSlip::create() instead
-     */
-    public static function createOrderSlip($order, $productList, $qtyList, $shipping_cost = false)
-    {
-        Tools::displayAsDeprecated('Use OrderSlip::create() instead');
-
-        $product_list = [];
-        foreach ($productList as $id_order_detail) {
-            $order_detail = new OrderDetail((int) $id_order_detail);
-            $product_list[$id_order_detail] = [
-                'id_order_detail' => $id_order_detail,
-                'quantity' => $qtyList[$id_order_detail],
-                'unit_price' => $order_detail->unit_price_tax_excl,
-                'amount' => $order_detail->unit_price_tax_incl * $qtyList[$id_order_detail],
-            ];
-
-            $shipping_cost = $shipping_cost ? null : false;
-        }
-
-        return OrderSlip::create($order, $product_list, $shipping_cost);
-    }
-
     public static function create(Order $order, $product_list, $shipping_cost = false, $amount = 0, $amount_choosen = false, $add_tax = true)
     {
         $currency = new Currency((int) $order->id_currency);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | This PR remove the function createOrderSlip of class OrderSlip which is deprecated since prestashop 1.6.0.10
| Type?             | improvement
| Category?         |  BO 
| BC breaks?        | yes but as it's a very old function i'm not sur that it is still in use.
| Deprecations?     | yes
| Fixed ticket?     | Relative to #26293
| How to test?      | Global tests should not fail
| Possible impacts? | Old modules using the function OrderSlip::createOrderSlip need to be upgraded

BC Break: `OrderSlip::createOrderSlip()` has been removed

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28010)
<!-- Reviewable:end -->
