### PR TITLE
BO Bugfix - Add new order - Cart rule description is not correct

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -533,6 +533,7 @@ class CartCore extends ObjectModel
             $row['obj'] = new CartRule($row['id_cart_rule'], (int) $this->id_lang);
             $row['value_real'] = $row['obj']->getContextualValue(true, $virtual_context, $filter);
             $row['value_tax_exc'] = $row['obj']->getContextualValue(false, $virtual_context, $filter);
+            $row['id_discount'] = $row['id_cart_rule'];
         }
 
         return $result;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -534,8 +534,10 @@ class CartCore extends ObjectModel
             $row['value_real'] = $row['obj']->getContextualValue(true, $virtual_context, $filter);
             $row['value_tax_exc'] = $row['obj']->getContextualValue(false, $virtual_context, $filter);
             // Retro compatibility < 1.5.0.2
-            $row['id_discount'] = $row['id_cart_rule'];
-            $row['description'] = $row['name'];
+            if(Tools::version_compare(_PS_VERSION_, '1.5.0.2', '<') === true){
+              $row['id_discount'] = $row['id_cart_rule'];
+              $row['description'] = $row['name'];
+            }
         }
 
         return $result;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -533,11 +533,6 @@ class CartCore extends ObjectModel
             $row['obj'] = new CartRule($row['id_cart_rule'], (int) $this->id_lang);
             $row['value_real'] = $row['obj']->getContextualValue(true, $virtual_context, $filter);
             $row['value_tax_exc'] = $row['obj']->getContextualValue(false, $virtual_context, $filter);
-            // Retro compatibility < 1.5.0.2
-            if(Tools::version_compare(_PS_VERSION_, '1.5.0.2', '<') === true){
-              $row['id_discount'] = $row['id_cart_rule'];
-              $row['description'] = $row['name'];
-            }
         }
 
         return $result;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR fix a bug in cart rule description field, was showed the same "name" value in the description field while you apply the rule during backoffice order creation.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27951 
| How to test?      | In the BO > Orders > Add new order > Voucher application, the description of the voucher is now correct.
| Possible impacts? | Backoffice order creation and cart rule application


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

BEFORE:

![158851555-67de363c-ff31-4d7b-ab1e-e35e43e8d72a](https://user-images.githubusercontent.com/14024456/159594716-a50699f1-a597-4c6a-b967-9b8142dbf552.png)

AFTER:

<img width="1049" alt="Schermata 2022-03-23 alle 00 42 05" src="https://user-images.githubusercontent.com/14024456/159594736-5d99b8ec-eea1-4b7d-841e-5431b242059d.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28011)
<!-- Reviewable:end -->
