### PR TITLE
Remove HookExtension::hookCount method

### DIFF
--- a/src/PrestaShopBundle/Twig/HookExtension.php
+++ b/src/PrestaShopBundle/Twig/HookExtension.php
@@ -93,7 +93,6 @@ class HookExtension extends AbstractExtension
         return [
             new TwigFunction('renderhook', [$this, 'renderHook'], ['is_safe' => ['html']]),
             new TwigFunction('renderhooksarray', [$this, 'renderHooksArray'], ['is_safe' => ['html']]),
-            new TwigFunction('hookcount', [$this, 'hookCount']),
             new TwigFunction('hooksarraycontent', [$this, 'hooksArrayContent']),
         ];
     }
@@ -190,22 +189,5 @@ class HookExtension extends AbstractExtension
         }
 
         return $content;
-    }
-
-    /**
-     * Count how many listeners will respond to the hook name.
-     * Does not trigger the hook, so maybe some listeners could not add a response to the result.
-     *
-     * @deprecated since 1.7.7.0
-     *
-     * @param string $hookName
-     *
-     * @return number the listeners count that will respond to the hook name
-     */
-    public function hookCount($hookName)
-    {
-        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 1.7.7.0.', E_USER_DEPRECATED);
-
-        return count($this->hookDispatcher->getListeners(strtolower($hookName)));
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove HookExtension::hookCount method
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293
| How to test?      | Tests are green, because methods are no longer used.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

## BC breaks

`HookExtension::hookCount` is no longer available

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28021)
<!-- Reviewable:end -->
