### PR TITLE
Fixed the wording translation for Enable/Disable Mobile in Modules page

### DIFF
--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -49,21 +49,45 @@ class AdminModuleDataProvider implements ModuleInterface
      * @const array giving a translation domain key for each module action
      */
     public const _ACTIONS_TRANSLATION_DOMAINS_ = [
-        'install' => 'Admin.Actions',
-        'uninstall' => 'Admin.Actions',
-        'enable' => 'Admin.Actions',
-        'disable' => 'Admin.Actions',
-        'enableMobile' => 'Admin.Modules.Feature',
-        'disableMobile' => 'Admin.Modules.Feature',
-        'reset' => 'Admin.Actions',
-        'upgrade' => 'Admin.Actions',
-        'configure' => 'Admin.Actions',
+        Module::ACTION_INSTALL => 'Admin.Actions',
+        Module::ACTION_UNINSTALL => 'Admin.Actions',
+        Module::ACTION_ENABLE => 'Admin.Actions',
+        Module::ACTION_DISABLE => 'Admin.Actions',
+        Module::ACTION_ENABLE_MOBILE => 'Admin.Modules.Feature',
+        Module::ACTION_DISABLE_MOBILE => 'Admin.Modules.Feature',
+        Module::ACTION_RESET => 'Admin.Actions',
+        Module::ACTION_UPGRADE => 'Admin.Actions',
+        Module::ACTION_CONFIGURE => 'Admin.Actions',
+    ];
+
+    /**
+     * @const array giving a translation label for each module action
+     */
+    public const ACTIONS_TRANSLATION_LABELS = [
+        Module::ACTION_INSTALL => 'Install',
+        Module::ACTION_UNINSTALL => 'Uninstall',
+        Module::ACTION_ENABLE => 'Enable',
+        Module::ACTION_DISABLE => 'Disable',
+        Module::ACTION_ENABLE_MOBILE => 'Enable mobile',
+        Module::ACTION_DISABLE_MOBILE => 'Disable mobile',
+        Module::ACTION_RESET => 'Reset',
+        Module::ACTION_UPGRADE => 'Upgrade',
+        Module::ACTION_CONFIGURE => 'Configure',
     ];
 
     /**
      * @var array of defined and callable module actions
      */
-    protected $moduleActions = ['install', 'uninstall', 'enable', 'disable', 'enableMobile', 'disableMobile', 'reset', 'upgrade'];
+    protected $moduleActions = [
+        Module::ACTION_INSTALL,
+        Module::ACTION_UNINSTALL,
+        Module::ACTION_ENABLE,
+        Module::ACTION_DISABLE,
+        Module::ACTION_ENABLE_MOBILE,
+        Module::ACTION_DISABLE_MOBILE,
+        Module::ACTION_RESET,
+        Module::ACTION_UPGRADE,
+    ];
 
     /**
      * @var Router|null
@@ -255,6 +279,7 @@ class AdminModuleDataProvider implements ModuleInterface
             $urls = $this->filterAllowedActions($urls, $addon->attributes->get('name'));
             $addon->attributes->set('urls', $urls);
             $addon->attributes->set('actionTranslationDomains', self::_ACTIONS_TRANSLATION_DOMAINS_);
+            $addon->attributes->set('actionTranslationLabels', self::ACTIONS_TRANSLATION_LABELS);
             if ($specific_action && array_key_exists($specific_action, $urls)) {
                 $addon->attributes->set('url_active', $specific_action);
             } elseif ($url_active === 'buy' || array_key_exists($url_active, $urls)) {

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -47,6 +47,7 @@ class Module implements ModuleInterface
     public const ACTION_DISABLE_MOBILE = 'disableMobile';
     public const ACTION_RESET = 'reset';
     public const ACTION_UPGRADE = 'upgrade';
+    public const ACTION_CONFIGURE = 'configure';
 
     /**
      * @var LegacyModule Module The instance of the legacy module

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Command;
 
 use Employee;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Configuration\ModuleSelfConfigurator;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManager;
 use Symfony\Component\Console\Command\Command;
@@ -190,7 +191,7 @@ class ModuleCommand extends Command
                 $this->translator->trans(
                     '%action% action on module %module% succeeded.',
                     [
-                        '%action%' => ucfirst(str_replace('_', ' ', $action)),
+                        '%action%' => ucfirst(AdminModuleDataProvider::ACTIONS_TRANSLATION_LABELS[$action]),
                         '%module%' => $moduleName, ],
                     'Admin.Modules.Notification'
                 )

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -224,7 +224,7 @@ class ModuleController extends ModuleAbstractController
             return new JsonResponse($response);
         }
 
-        $actionTitle = str_replace('_', ' ', $action);
+        $actionTitle = AdminModuleDataProvider::ACTIONS_TRANSLATION_LABELS[$action];
 
         try {
             $response[$module]['status'] = $moduleManager->{$action}($module);

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_button.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% set displayAction = action|title|replace({'_': " "})|trans({}, transDomain[action]) %}
+{% set displayAction = transLabels[action]|title|trans({}, transDomain[action]) %}
 
 {% if (action == 'configure') %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/action_menu.html.twig
@@ -22,13 +22,14 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-{% set url, priceRaw, priceDisplay, url_active, urls, name, transDomains =
+{% set url, priceRaw, priceDisplay, url_active, urls, name, transLabels, transDomains =
   module.attributes.url,
   module.attributes.price.raw,
   module.attributes.price.displayPrice,
   module.attributes.url_active,
   module.attributes.urls,
   module.attributes.name,
+  module.attributes.actionTranslationLabels,
   module.attributes.actionTranslationDomains
 %}
  <div class="btn-group module-actions">
@@ -43,14 +44,15 @@
         'classes' : 'btn btn-primary-reverse btn-outline-primary',
         'url': urls[url_active],
         'action': url_active,
+        'transLabels': transLabels,
         'transDomain': transDomains}
     %}
     {% if (urls|length > 1) %}
-        <input type="hidden" class="btn" /> 
-        <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"> 
-          <span class="caret"></span> 
+        <input type="hidden" class="btn" />
+        <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <span class="caret"></span>
         </button>
-        <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span> 
+        <span class="sr-only">{{ 'Toggle Dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
         <div class="dropdown-menu">
           {% for module_action, module_url in urls %}
             {% if module_action != url_active %}
@@ -60,6 +62,7 @@
                       'classes' : 'dropdown-item',
                       'url': module_url,
                       'action': module_action,
+                      'transLabels': transLabels,
                       'transDomain': transDomains}
                   %}
                 </li>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed the wording translation for Enable/Disable Mobile in Modules page (Bug inherited from #27527 (ping @PrestaEdit))
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28000
| How to test?      | Cf. #28000

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28023)
<!-- Reviewable:end -->
