### PR TITLE
Remove duplicate error messages in account and address creation

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -106,17 +106,16 @@ class CustomerAddressFormCore extends AbstractForm
     {
         $is_valid = true;
 
-        if (($postcode = $this->getField('postcode'))) {
-            if ($postcode->isRequired()) {
-                $country = $this->formatter->getCountry();
-                if (!$country->checkZipCode($postcode->getValue())) {
-                    $postcode->addError($this->translator->trans(
-                        'Invalid postcode - should look like "%zipcode%"',
-                        ['%zipcode%' => $country->zip_code_format],
-                        'Shop.Forms.Errors'
-                    ));
-                    $is_valid = false;
-                }
+        $postcode = $this->getField('postcode');
+        if ($postcode && $postcode->isRequired()) {
+            $country = $this->formatter->getCountry();
+            if (!$country->checkZipCode($postcode->getValue())) {
+                $postcode->addError($this->translator->trans(
+                    'Invalid postcode - should look like "%zipcode%"',
+                    ['%zipcode%' => $country->zip_code_format],
+                    'Shop.Forms.Errors'
+               ));
+                $is_valid = false;
             }
         }
 

--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -104,7 +104,21 @@ class CustomerAddressFormCore extends AbstractForm
 
     public function validate()
     {
-        $is_valid = $this->validateFieldsValues();
+        $is_valid = true;
+
+        if (($postcode = $this->getField('postcode'))) {
+            if ($postcode->isRequired()) {
+                $country = $this->formatter->getCountry();
+                if (!$country->checkZipCode($postcode->getValue())) {
+                    $postcode->addError($this->translator->trans(
+                        'Invalid postcode - should look like "%zipcode%"',
+                        ['%zipcode%' => $country->zip_code_format],
+                        'Shop.Forms.Errors'
+                    ));
+                    $is_valid = false;
+                }
+            }
+        }
 
         if (($hookReturn = Hook::exec('actionValidateCustomerAddressForm', ['form' => $this])) !== '') {
             $is_valid &= (bool) $hookReturn;
@@ -140,16 +154,10 @@ class CustomerAddressFormCore extends AbstractForm
 
         $this->setAddress($address);
 
-        try {
-            return $this->getPersister()->save(
-                $address,
-                $this->getValue('token')
-            );
-        } catch (PrestaShopException $e) {
-            $this->errors[''][] = $this->translator->trans('Could not update your information, please check your data.', [], 'Shop.Notifications.Error');
-        }
-
-        return false;
+        return $this->getPersister()->save(
+            $address,
+            $this->getValue('token')
+        );
     }
 
     /**
@@ -208,83 +216,5 @@ class CustomerAddressFormCore extends AbstractForm
             'errors' => $this->getErrors(),
             'formFields' => $formFields,
         ];
-    }
-
-    /**
-     * Performs validation on field values.
-     * Returns true if all field values are correct, false otherwise.
-     *
-     * @return bool
-     */
-    private function validateFieldsValues(): bool
-    {
-        $isValid = true;
-
-        $isValid &= $this->validatePostcode();
-        $isValid &= $this->validateField('firstname', 'isName', $this->translator->trans(
-            'Invalid name',
-            [],
-            'Shop.Forms.Errors'
-        ));
-        $isValid &= $this->validateField('lastname', 'isName', $this->translator->trans(
-            'Invalid name',
-            [],
-            'Shop.Forms.Errors'
-        ));
-        $isValid &= $this->validateField('city', 'isCityName', $this->translator->trans(
-            'Invalid format.',
-            [],
-            'Shop.Forms.Errors'
-        ));
-
-        return (bool) $isValid;
-    }
-
-    /**
-     * @return bool
-     */
-    private function validatePostcode(): bool
-    {
-        $postcode = $this->getField('postcode');
-        if ($postcode && $postcode->isRequired()) {
-            $country = $this->formatter->getCountry();
-            if (!$country->checkZipCode($postcode->getValue())) {
-                $postcode->addError($this->translator->trans(
-                    'Invalid postcode - should look like "%zipcode%"',
-                    ['%zipcode%' => $country->zip_code_format],
-                    'Shop.Forms.Errors'
-                ));
-
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * @param string $fieldName
-     * @param string $validationFunction
-     * @param string $validationFailMessage
-     *
-     * @return bool
-     */
-    private function validateField(string $fieldName, string $validationFunction, string $validationFailMessage): bool
-    {
-        $field = $this->getField($fieldName);
-        if (null === $field) {
-            return true;
-        }
-        $value = $field->getValue();
-        if ($field->isRequired() && empty($value)) {
-            return false;
-        }
-        if (!empty($value) && false === (bool) Validate::$validationFunction($value)) {
-            $field->addError($validationFailMessage);
-
-            return false;
-        }
-
-        return true;
     }
 }

--- a/classes/form/CustomerForm.php
+++ b/classes/form/CustomerForm.php
@@ -149,9 +149,7 @@ class CustomerFormCore extends AbstractForm
                 'Shop.Notifications.Error'
             ));
         }
-
         $this->validateFieldsLengths();
-        $this->validateFieldsValues();
         $this->validateByModules();
 
         return parent::validate();
@@ -213,17 +211,12 @@ class CustomerFormCore extends AbstractForm
             $clearTextPassword = $this->getValue('password');
             $newPassword = $this->getValue('new_password');
 
-            try {
-                $ok = $this->customerPersister->save(
-                    $this->getCustomer(),
-                    $clearTextPassword,
-                    $newPassword,
-                    $this->passwordRequired
-                );
-            } catch (PrestaShopException $e) {
-                $this->errors[''][] = $this->translator->trans('Could not update your information, please check your data.', [], 'Shop.Notifications.Error');
-                $ok = false;
-            }
+            $ok = $this->customerPersister->save(
+                $this->getCustomer(),
+                $clearTextPassword,
+                $newPassword,
+                $this->passwordRequired
+            );
 
             if (!$ok) {
                 foreach ($this->customerPersister->getErrors() as $field => $errors) {
@@ -280,37 +273,6 @@ class CustomerFormCore extends AbstractForm
                     array_merge($this->formFields, $validatedCustomerFormFields);
                 }
             }
-        }
-    }
-
-    /**
-     * Performs validation on field values.
-     * Adds error to the field object if value is not as expected.
-     */
-    private function validateFieldsValues(): void
-    {
-        $this->validateFieldIsCustomerName('firstname');
-        $this->validateFieldIsCustomerName('lastname');
-    }
-
-    /**
-     * Checks whether a field's value is a valid customer(person) name.
-     *
-     * @param string $fieldName
-     */
-    private function validateFieldIsCustomerName(string $fieldName): void
-    {
-        $field = $this->getField($fieldName);
-        if (null === $field) {
-            return;
-        }
-        $value = $field->getValue();
-        if (!empty($value) && false === (bool) Validate::isCustomerName($value)) {
-            $field->addError($this->translator->trans(
-                'Invalid format.',
-                [],
-                'Shop.Forms.Errors'
-            ));
         }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR is a revert of the PR #24600 as the "real" fix was #27376 that as been merged later. When keeping both, the validation happens twice leading to a duplicate of the error messages.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27876
| How to test?      | Please see #27876 & #24464
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28028)
<!-- Reviewable:end -->
