### PR TITLE
Handle empty outstanding_allow_amount field

### DIFF
--- a/src/Core/Grid/Data/Factory/OutstandingGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/OutstandingGridDataFactory.php
@@ -79,12 +79,14 @@ final class OutstandingGridDataFactory implements GridDataFactoryInterface
 
         foreach ($records as &$record) {
             $customer = new Customer((int) $record['id_customer']);
-            $record['outstanding'] = $locale->formatPrice(
-                Validate::isLoadedObject($customer) ? $customer->getOutstanding() : 0.00,
-                $record['iso_code']
-            );
+            $record['outstanding'] = Validate::isLoadedObject($customer)
+                ? $locale->formatPrice($customer->getOutstanding(), $record['iso_code'])
+                : null
+            ;
 
-            $record['outstanding_allow_amount'] = $locale->formatPrice($record['outstanding_allow_amount'], $record['iso_code']);
+            if ($record['outstanding_allow_amount'] !== null) {
+                $record['outstanding_allow_amount'] = $locale->formatPrice($record['outstanding_allow_amount'], $record['iso_code']);
+            }
 
             if (!$record['company']) {
                 $record['company'] = '--';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR aims to not try to format the `outstanding_allow_amount` if the value is `null`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27785
| How to test?      | Please see #27785
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28031)
<!-- Reviewable:end -->
