### PR TITLE
Add getCanonicalURL to ManufacturerControllerCore

### DIFF
--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -42,6 +42,26 @@ class ManufacturerControllerCore extends ProductListingFrontController
             parent::canonicalRedirection($canonicalURL);
         }
     }
+    
+    public function getCanonicalURL()
+    {
+        $canonicalUrl = $this->context->link->getManufacturerLink($this->manufacturer);
+        $parsedUrl = parse_url($canonicalUrl);
+        if (isset($parsedUrl['query'])) {
+            parse_str($parsedUrl['query'], $params);
+        } else {
+            $params = [];
+        }
+        $page = (int) Tools::getValue('page');
+        if ($page > 1) {
+            $params['page'] = $page;
+        } else {
+            unset($params['page']);
+        }
+        $canonicalUrl = http_build_url($parsedUrl, ['query' => http_build_query($params)]);
+
+        return $canonicalUrl;
+    }
 
     /**
      * Initialize manufaturer controller.


### PR DESCRIPTION
The canonical url is missing in Manufacturer controller, add the method getCanonicalURL() to fix it.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Canonical url is missing in manufacturer pages
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #9503
| How to test?      | Just open any brand page and inspect the code to see that there is no canonical url.
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28037)
<!-- Reviewable:end -->
