### PR TITLE
Pin setup-gcloud to v0 instead of master (backport of #27974)

### DIFF
--- a/.github/workflows/cron_nightly.yml
+++ b/.github/workflows/cron_nightly.yml
@@ -33,7 +33,7 @@ jobs:
       -   name: Initialize GCloud Service Key
           run: echo $GC_SERVICE_KEY > $HOME/gcloud-service-key.json
 
-      -   uses: google-github-actions/setup-gcloud@master
+      -   uses: google-github-actions/setup-gcloud@v0
           with:
             service_account_key: ${{ env.GC_SERVICE_KEY }}
             project_id: ${{ env.GC_PROJECT_ID }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Backport of https://github.com/PrestaShop/PrestaShop/pull/27974. I could not cherry-pick because GitHub workflow files are different between develop and 1.7.8.x
| Type?             | improvement
| Category?         |  TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI should run correctly screen without the PR



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28044)
<!-- Reviewable:end -->
