### PR TITLE
Update config.yml to follow Symfony3.4+ syntax

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -82,7 +82,7 @@ twig:
         '%mail_themes_dir%': MailThemes
     globals:
         webpack_server: false
-        multistore_field_prefix: !php/const:PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX
+        multistore_field_prefix: !php/const PrestaShopBundle\Service\Form\MultistoreCheckboxEnabler::MULTISTORE_FIELD_PREFIX
 
 # Swiftmailer Configuration
 swiftmailer:


### PR DESCRIPTION
Since Symfony 3.4, the YAML component uses the syntax without the colon.

https://symfony.com/doc/current/components/yaml.html#parsing-php-constants


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      | Since Symfony 3.4, the YAML component uses the syntax without the colon.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | yes
| Fixed ticket?     | Fixes #26884.
| How to test?      | There is no need to test as this is not a prestashop component and the syntax is already in use by prestashop code
| Possible impacts? | YAML parsing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28046)
<!-- Reviewable:end -->
