### PR TITLE
Refactor localisation & update language repository base path 

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -18,6 +18,8 @@ parameters:
   mail_themes_uri: "/mails/themes"
   mail_themes_dir: "%kernel.project_dir%%mail_themes_uri%"
   modules_translation_paths: [ ]
+  lang_repository_base_path: https://i18n.prestashop-project.org
+
 
 # Autowires Core controllers
 services:

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -23,6 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\DataLangFactory;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\EntityTranslatorFactory;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\Exception\DataLangClassNameNotFoundException;
@@ -34,6 +35,7 @@ use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
+use PrestaShop\PrestaShop\Core\Language\Pack\Loader\RemoteLanguagePackLoader;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
 use PrestaShop\PrestaShop\Core\Localization\RTL\Processor as RtlStylesheetProcessor;
 use Symfony\Component\Intl\Intl;
@@ -41,10 +43,6 @@ use Symfony\Component\Intl\Intl;
 class LanguageCore extends ObjectModel implements LanguageInterface
 {
     const ALL_LANGUAGES_FILE = '/app/Resources/all_languages.json';
-    const SF_LANGUAGE_PACK_URL = 'https://i18n.prestashop-project.org/translations/%version%/%locale%/%locale%.zip';
-    const EMAILS_LANGUAGE_PACK_URL = 'https://i18n.prestashop-project.org/mails/%version%/%locale%/%locale%.zip';
-    public const PACK_TYPE_EMAILS = 'emails';
-    public const PACK_TYPE_SYMFONY = 'sf';
 
     /**
      * Timeout for downloading a translation pack, in seconds
@@ -598,7 +596,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     {
         if (!$this->hasMultishopEntries() || Shop::getContext() == Shop::CONTEXT_ALL) {
             if (empty($this->iso_code)) {
-                $this->iso_code = Language::getIsoById($this->id);
+                $this->iso_code = Language::getIsoById($this->getId());
             }
 
             // Database translations deletion
@@ -607,17 +605,17 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
             foreach ($result as $row) {
                 if (isset($row[$tableNameKey]) && !empty($row[$tableNameKey]) && preg_match('/_lang$/', $row[$tableNameKey])) {
-                    if (!Db::getInstance()->execute('DELETE FROM `' . $row[$tableNameKey] . '` WHERE `id_lang` = ' . (int) $this->id)) {
+                    if (!Db::getInstance()->execute('DELETE FROM `' . $row[$tableNameKey] . '` WHERE `id_lang` = ' . $this->getId())) {
                         return false;
                     }
                 }
             }
 
             // Delete tags
-            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'tag WHERE id_lang = ' . (int) $this->id);
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'tag WHERE id_lang = ' . $this->getId());
 
             // Delete search words
-            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'search_word WHERE id_lang = ' . (int) $this->id);
+            Db::getInstance()->execute('DELETE FROM ' . _DB_PREFIX_ . 'search_word WHERE id_lang = ' . $this->getId());
 
             // Files deletion
             foreach (Language::getFilesList($this->iso_code, _THEME_NAME_, false, false, false, true, true) as $key => $file) {
@@ -653,7 +651,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
                 Tools::deleteDirectory(_PS_TRANSLATIONS_DIR_ . $this->iso_code);
             }
 
-            (new LanguageImageManager())->deleteImages($this->id, $this->iso_code);
+            (new LanguageImageManager())->deleteImages($this->getId(), $this->iso_code);
         }
 
         if (!parent::delete()) {
@@ -817,6 +815,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         if (!Validate::isLanguageIsoCode($iso_code)) {
             throw new PrestaShopException(sprintf('Invalid language ISO code: %s', $iso_code));
         }
+        $iso_code = (string) $iso_code;
 
         $key = 'Language::getIdByIso_' . $iso_code;
         if ($no_cache || !Cache::isStored($key)) {
@@ -1138,7 +1137,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         }
 
         $languageManager = new LanguageImageManager();
-        $languageManager->setupLanguageFlag($lang->locale, $lang->id, $lang_pack['flag'] ?? null);
+        $languageManager->setupLanguageFlag($lang->locale, $lang->getId(), $lang_pack['flag'] ?? null);
         $languageManager->setupDefaultImagePlaceholder($lang->iso_code);
 
         static::loadLanguages();
@@ -1189,7 +1188,10 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         return static::$countActiveLanguages[$id_shop];
     }
 
-    public static function downloadAndInstallLanguagePack($iso, $version = _PS_VERSION_, $params = null, $install = true)
+    /**
+     * @param mixed $version Unused parameter @deprecated since 8.0.0 and will be removed in next major version.
+     */
+    public static function downloadAndInstallLanguagePack($iso, $version = null, $params = null, $install = true)
     {
         if (!Validate::isLanguageIsoCode((string) $iso)) {
             return false;
@@ -1197,7 +1199,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         $errors = [];
 
-        if (Language::downloadLanguagePack($iso, $version, $errors)) {
+        if (Language::downloadLanguagePack($iso, null, $errors)) {
             if ($install) {
                 Language::installLanguagePack($iso, $params, $errors);
             } else {
@@ -1208,7 +1210,10 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         return count($errors) ? $errors : true;
     }
 
-    public static function downloadLanguagePack($iso, $version, &$errors = [])
+    /**
+     * @param mixed $version Unused parameter. @deprecated since 8.0.0 and will be removed in next major version.
+     */
+    public static function downloadLanguagePack($iso, $version = null, &$errors = [])
     {
         $iso = (string) $iso; // $iso often comes from xml and is a SimpleXMLElement
 
@@ -1219,7 +1224,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             return false;
         }
 
-        return static::downloadXLFLanguagePack($lang_pack['locale'], $errors, self::PACK_TYPE_SYMFONY);
+        return static::downloadXLFLanguagePack($lang_pack['locale'], $errors);
     }
 
     /**
@@ -1227,25 +1232,12 @@ class LanguageCore extends ObjectModel implements LanguageInterface
      *
      * @param string $locale IETF language tag
      * @param array $errors
-     * @param string $type self:PACK_TYPE_SYMFONY|self::PACK_TYPE_EMAILS
      *
      * @return bool
      */
-    public static function downloadXLFLanguagePack($locale, &$errors = [], $type = self::PACK_TYPE_SYMFONY)
+    public static function downloadXLFLanguagePack($locale, &$errors = [])
     {
-        $file = self::getPathToCachedTranslationPack($locale, $type);
-        $url = (self::PACK_TYPE_EMAILS === $type) ? self::EMAILS_LANGUAGE_PACK_URL : self::SF_LANGUAGE_PACK_URL;
-        $url = str_replace(
-            [
-                '%version%',
-                '%locale%',
-            ],
-            [
-                _PS_VERSION_,
-                $locale,
-            ],
-            $url
-        );
+        $file = self::getPathToCachedTranslationPack($locale);
 
         if (!is_writable(dirname($file))) {
             // @todo Throw exception
@@ -1253,6 +1245,9 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
             return false;
         }
+
+        $language_pack_loader = RemoteLanguagePackLoader::build();
+        $url = $language_pack_loader->getLanguagePackUrl($locale);
 
         $content = Tools::file_get_contents($url, false, null, static::PACK_DOWNLOAD_TIMEOUT);
 
@@ -1428,8 +1423,8 @@ class LanguageCore extends ObjectModel implements LanguageInterface
                 continue;
             }
 
-            $names[$language->id] = $currencyCLDR->getDisplayName();
-            $symbols[$language->id] = $currencyCLDR->getSymbol();
+            $names[$language->getId()] = $currencyCLDR->getDisplayName();
+            $symbols[$language->getId()] = $currencyCLDR->getSymbol();
 
             $currency->setLocalizedNames($names);
             $currency->setLocalizedSymbols($symbols);
@@ -1444,7 +1439,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         if (!empty($lang_pack['locale'])) {
             //Update locale field if empty (manually created, or imported without it)
             $language = new Language(Language::getIdByIso($iso));
-            if ($language->id && empty($language->locale)) {
+            if ($language->getId() && empty($language->locale)) {
                 $language->locale = $lang_pack['locale'];
                 $language->save();
             }
@@ -1565,7 +1560,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         // Fetch all countries from DB in specified locale
         $sql = 'SELECT c.`iso_code`, cl.* FROM `' . _DB_PREFIX_ . 'country` c
                 INNER JOIN `' . _DB_PREFIX_ . 'country_lang` cl ON c.`id_country` = cl.`id_country`
-                WHERE cl.`id_lang` = "' . (int) $lang->id . '" ';
+                WHERE cl.`id_lang` = "' . $lang->getId() . '" ';
         $translatableCountries = Db::getInstance()->executeS($sql, true, false);
 
         if (empty($translatableCountries)) {
@@ -1583,7 +1578,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             $sql = 'UPDATE `' . _DB_PREFIX_ . 'country_lang`
                     SET `name` = "' . pSQL($langCountries[$isoCode]) . '"
                     WHERE `id_country` = "' . (int) $country['id_country'] . '"
-                    AND `id_lang` = "' . (int) $lang->id . '" LIMIT 1;';
+                    AND `id_lang` = "' . $lang->getId() . '" LIMIT 1;';
             Db::getInstance()->execute($sql);
         }
     }
@@ -1645,7 +1640,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         (new EntityTranslatorFactory($translator))
             ->build($classObject)
-            ->translate($lang->id, $shop->id);
+            ->translate($lang->getId(), $shop->id);
     }
 
     /**
@@ -1674,27 +1669,25 @@ class LanguageCore extends ObjectModel implements LanguageInterface
     /**
      * Indicates if a given translation pack exists in cache
      *
-     * @param string $type IETF language tag
-     * @param string $locale self::PACK_TYPE_SYMFONY|self::PACK_TYPE_EMAILS
+     * @param string $locale IETF language tag
      *
      * @return bool
      */
-    public static function translationPackIsInCache(string $locale, string $type = self::PACK_TYPE_SYMFONY): bool
+    public static function translationPackIsInCache(string $locale): bool
     {
-        return file_exists(self::getPathToCachedTranslationPack($locale, $type));
+        return file_exists(self::getPathToCachedTranslationPack($locale));
     }
 
     /**
      * Returns the path to the local translation pack file
      *
      * @param string $locale IETF language tag
-     * @param string $type self::PACK_TYPE_SYMFONY|self::PACK_TYPE_EMAILS
      *
      * @return string Local path
      */
-    private static function getPathToCachedTranslationPack(string $locale, string $type = self::PACK_TYPE_SYMFONY): string
+    private static function getPathToCachedTranslationPack(string $locale): string
     {
-        return self::TRANSLATION_PACK_CACHE_DIR . $type . '-' . $locale . '.zip';
+        return self::TRANSLATION_PACK_CACHE_DIR . 'sf-' . $locale . '.zip';
     }
 
     /**

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Foundation\Version;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use PrestaShop\PrestaShop\Core\Language\Pack\Loader\RemoteLanguagePackLoader;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
@@ -1246,7 +1247,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             return false;
         }
 
-        $language_pack_loader = RemoteLanguagePackLoader::build();
+        $language_pack_loader = new RemoteLanguagePackLoader(Version::buildFromString(_PS_VERSION_));
         $url = $language_pack_loader->getLanguagePackUrl($locale);
 
         $content = Tools::file_get_contents($url, false, null, static::PACK_DOWNLOAD_TIMEOUT);

--- a/classes/LocalizationPack.php
+++ b/classes/LocalizationPack.php
@@ -408,7 +408,7 @@ class LocalizationPackCore
                 }
 
                 $freshInstall = empty(Language::getIdByIso($attributes['iso_code']));
-                $errors = Language::downloadAndInstallLanguagePack($attributes['iso_code'], $attributes['version'], $attributes, $freshInstall);
+                $errors = Language::downloadAndInstallLanguagePack($attributes['iso_code'], null, $attributes, $freshInstall);
                 if ($errors !== true && is_array($errors)) {
                     $this->_errors = array_merge($this->_errors, $errors);
                 }

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -23,9 +23,11 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem;
+use PrestaShop\PrestaShop\Core\Language\Pack\Loader\RemoteLanguagePackLoader;
 
 class AdminTranslationsControllerCore extends AdminController
 {
@@ -33,8 +35,8 @@ class AdminTranslationsControllerCore extends AdminController
     const DEFAULT_THEME_NAME = _PS_DEFAULT_THEME_NAME_;
     const TEXTAREA_SIZED = 70;
 
-    /** @var string : Link which list all pack of language */
-    protected $link_lang_pack = 'http://i18n.prestashop-project.org/translations/%ps_version%/available_languages.json';
+    /** @var string : URL for available language pack list */
+    protected $link_lang_pack;
 
     /** @var int : number of sentence which can be translated */
     protected $total_expression = 0;
@@ -83,7 +85,8 @@ class AdminTranslationsControllerCore extends AdminController
 
         parent::__construct();
 
-        $this->link_lang_pack = str_replace('%ps_version%', _PS_VERSION_, $this->link_lang_pack);
+        $language_pack_loader = RemoteLanguagePackLoader::build();
+        $this->link_lang_pack = $language_pack_loader->getLanguagePackListUrl();
 
         $this->themes = (new ThemeManagerBuilder($this->context, Db::getInstance()))
             ->buildRepository()
@@ -931,7 +934,7 @@ class AdminTranslationsControllerCore extends AdminController
         $isoCode = $languageDetails['iso_code'];
 
         if (Validate::isLangIsoCode($isoCode)) {
-            $success = Language::downloadAndInstallLanguagePack($isoCode, _PS_VERSION_, null, true);
+            $success = Language::downloadAndInstallLanguagePack($isoCode);
             if ($success === true) {
                 Language::loadLanguages();
                 Tools::clearAllCache();

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -27,7 +27,6 @@
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem;
-use PrestaShop\PrestaShop\Core\Language\Pack\Loader\RemoteLanguagePackLoader;
 
 class AdminTranslationsControllerCore extends AdminController
 {
@@ -85,7 +84,7 @@ class AdminTranslationsControllerCore extends AdminController
 
         parent::__construct();
 
-        $language_pack_loader = RemoteLanguagePackLoader::build();
+        $language_pack_loader = $this->container->get('prestashop.core.language.pack.loader.remote');
         $this->link_lang_pack = $language_pack_loader->getLanguagePackListUrl();
 
         $this->themes = (new ThemeManagerBuilder($this->context, Db::getInstance()))

--- a/install-dev/controllers/http/welcome.php
+++ b/install-dev/controllers/http/welcome.php
@@ -49,7 +49,7 @@ class InstallControllerHttpWelcome extends InstallControllerHttp implements Http
 
         $locale = $this->language->getLanguage($this->session->lang)->locale;
         if (!empty($this->session->lang) && !is_file(_PS_ROOT_DIR_ . '/translations/' . $locale . '/Install.' . $locale . '.xlf')) {
-            Language::downloadLanguagePack($this->session->lang, _PS_VERSION_);
+            Language::downloadLanguagePack($this->session->lang);
             Language::installSfLanguagePack($locale);
             $this->clearCache();
         }

--- a/src/Adapter/Language/LanguagePackInstaller.php
+++ b/src/Adapter/Language/LanguagePackInstaller.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Language;
 
 use Language;
-use PrestaShop\PrestaShop\Core\Foundation\Version;
 use PrestaShop\PrestaShop\Core\Language\Pack\LanguagePackInstallerInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -37,11 +36,6 @@ use Symfony\Component\Translation\TranslatorInterface;
 final class LanguagePackInstaller implements LanguagePackInstallerInterface
 {
     /**
-     * @var Version
-     */
-    private $version;
-
-    /**
      * @var TranslatorInterface
      */
     private $translator;
@@ -50,11 +44,9 @@ final class LanguagePackInstaller implements LanguagePackInstallerInterface
      * LanguagePackInstaller constructor.
      *
      * @param TranslatorInterface $translator
-     * @param Version $version
      */
-    public function __construct(TranslatorInterface $translator, Version $version)
+    public function __construct(TranslatorInterface $translator)
     {
-        $this->version = $version;
         $this->translator = $translator;
     }
 
@@ -64,7 +56,7 @@ final class LanguagePackInstaller implements LanguagePackInstallerInterface
     public function downloadAndInstallLanguagePack($iso)
     {
         $freshInstall = empty(Language::getIdByIso($iso));
-        $result = Language::downloadAndInstallLanguagePack($iso, $this->version->getSemVersion(), null, $freshInstall);
+        $result = Language::downloadAndInstallLanguagePack($iso, null, null, $freshInstall);
 
         if (false === $result) {
             return [

--- a/src/Adapter/Tools.php
+++ b/src/Adapter/Tools.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter;
 
-use PrestaShop\PrestaShop\Adapter\File\HtaccessFileGenerator;
 use Tools as LegacyTools;
 
 /**
@@ -80,7 +79,7 @@ class Tools
     }
 
     /**
-     * @see HtaccessFileGenerator::generateFile()
+     * @see PrestaShop\PrestaShop\Adapter\File\HtaccessFileGenerator::generateFile()
      *
      * @return bool
      */
@@ -96,7 +95,7 @@ class Tools
     }
 
     /**
-     * @see HtaccessFileGenerator::generateFile()
+     * @see PrestaShop\PrestaShop\Adapter\File\HtaccessFileGenerator::generateFile()
      *
      * @return bool
      */

--- a/src/Core/Configuration/IniConfiguration.php
+++ b/src/Core/Configuration/IniConfiguration.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace  PrestaShop\PrestaShop\Core\Configuration;
+namespace PrestaShop\PrestaShop\Core\Configuration;
 
 /**
  * Gets ini configuration.

--- a/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
+++ b/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
@@ -68,7 +68,7 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
      *
      * @return string requested URL
      */
-    public function getLanguagePackUrl(string $locale = null): string
+    public function getLanguagePackUrl(string $locale): string
     {
         $stringVersion = $this->version->getSemVersion();
 
@@ -91,8 +91,14 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
     public function getLanguagePackList()
     {
         $normalizedLink = $this->getLanguagePackListUrl();
+        // TODO : Don't trust network, remove direct `file_get_contents` call.
+        //        cf. https://github.com/PrestaShop/PrestaShop/issues/28766
         $jsonResponse = file_get_contents($normalizedLink);
-        $result = json_decode($jsonResponse, true) ?? [];
+
+        $result = [];
+        if ($jsonResponse) {
+            $result = json_decode($jsonResponse, true);
+        }
 
         return $result;
     }

--- a/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
+++ b/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
@@ -40,7 +40,7 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
      *
      * @TODO : add this to {prestashop_repository}/app/config/config.yml
      */
-    private const LANG_REPOSITORY_BASE_PATH = 'http://i18n.prestashop.com';
+    private const LANG_REPOSITORY_BASE_PATH = 'http://i18n.prestashop-project.org';
 
     /**
      * @var string Prestashop version

--- a/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
+++ b/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
@@ -38,22 +38,29 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
     /**
      * The languages repository base path
      *
-     * @TODO : add this to {prestashop_repository}/app/config/config.yml
+     * @TODO : duplicated from {prestashop_repository}/app/config/config.yml;
+     *         used for install context or other cases where no Symfony container is available
      */
-    private const LANG_REPOSITORY_BASE_PATH = 'http://i18n.prestashop-project.org';
+    private const LANG_REPOSITORY_BASE_PATH = 'https://i18n.prestashop-project.org';
 
     /**
-     * @var string Prestashop version
+     * @var Version Prestashop version
      */
     private $version;
 
     /**
-     * @param string $version Prestashop version
+     * @var string represents the language repository base path
      */
-    public function __construct(string $version)
+    private $langRepositoryBasePath;
+
+    /**
+     * @param Version $version Prestashop version
+     * @param string $langRepositoryBasePath should become mandatory in future release
+     */
+    public function __construct(Version $version, string $langRepositoryBasePath = self::LANG_REPOSITORY_BASE_PATH)
     {
-        // Ensure version format
-        $this->version = Version::buildFromString($version)->getSemVersion();
+        $this->version = $version;
+        $this->langRepositoryBasePath = $langRepositoryBasePath;
     }
 
     /**
@@ -63,7 +70,9 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
      */
     public function getLanguagePackUrl(string $locale = null): string
     {
-        return self::LANG_REPOSITORY_BASE_PATH . "/translations/{$this->version}/{$locale}/{$locale}.zip";
+        $stringVersion = $this->version->getSemVersion();
+
+        return "{$this->langRepositoryBasePath}/translations/{$stringVersion}/{$locale}/{$locale}.zip";
     }
 
     /**
@@ -71,7 +80,9 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
      */
     public function getLanguagePackListUrl(): string
     {
-        return self::LANG_REPOSITORY_BASE_PATH . "/translations/{$this->version}/available_languages.json";
+        $stringVersion = $this->version->getSemVersion();
+
+        return "{$this->langRepositoryBasePath}/translations/{$stringVersion}/available_languages.json";
     }
 
     /**
@@ -84,15 +95,5 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
         $result = json_decode($jsonResponse, true) ?? [];
 
         return $result;
-    }
-
-    /**
-     * Builds an instance from version defined in environment (`_PS_VERSION_`) _
-     *
-     * @return self
-     */
-    public static function build()
-    {
-        return new self(_PS_VERSION_);
     }
 }

--- a/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
+++ b/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Language\Pack\Loader;
 
 use PrestaShop\PrestaShop\Core\Foundation\Version;
@@ -34,21 +36,42 @@ use PrestaShop\PrestaShop\Core\Foundation\Version;
 final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
 {
     /**
-     * The link from which available languages are retrieved.
+     * The languages repository base path
+     *
+     * @TODO : add this to {prestashop_repository}/app/config/config.yml
      */
-    public const PACK_LINK = 'http://i18n.prestashop-project.org/translations/%ps_version%/available_languages.json';
+    private const LANG_REPOSITORY_BASE_PATH = 'http://i18n.prestashop.com';
 
     /**
-     * @var Version
+     * @var string Prestashop version
      */
     private $version;
 
     /**
-     * @param Version $version
+     * @param string $version Prestashop version
      */
-    public function __construct(Version $version)
+    public function __construct(string $version)
     {
-        $this->version = $version;
+        // Ensure version format
+        $this->version = Version::buildFromString($version)->getSemVersion();
+    }
+
+    /**
+     * @param string $locale
+     *
+     * @return string requested URL
+     */
+    public function getLanguagePackUrl(string $locale = null): string
+    {
+        return self::LANG_REPOSITORY_BASE_PATH . "/translations/{$this->version}/{$locale}/{$locale}.zip";
+    }
+
+    /**
+     * @return string requested URL
+     */
+    public function getLanguagePackListUrl(): string
+    {
+        return self::LANG_REPOSITORY_BASE_PATH . "/translations/{$this->version}/available_languages.json";
     }
 
     /**
@@ -56,14 +79,20 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
      */
     public function getLanguagePackList()
     {
-        $normalizedLink = str_replace('%ps_version%', $this->version->getSemVersion(), self::PACK_LINK);
+        $normalizedLink = $this->getLanguagePackListUrl();
         $jsonResponse = file_get_contents($normalizedLink);
-
-        $result = [];
-        if ($jsonResponse) {
-            $result = json_decode($jsonResponse, true);
-        }
+        $result = json_decode($jsonResponse, true) ?? [];
 
         return $result;
+    }
+
+    /**
+     * Builds an instance from version defined in environment (`_PS_VERSION_`) _
+     *
+     * @return self
+     */
+    public static function build()
+    {
+        return new self(_PS_VERSION_);
     }
 }

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -621,7 +621,7 @@ class Install extends AbstractInstall
             ];
 
             if (file_exists(_PS_TRANSLATIONS_DIR_ . (string) $iso . '.gzip') == false) {
-                $language = EntityLanguage::downloadLanguagePack($iso, _PS_INSTALL_VERSION_);
+                $language = EntityLanguage::downloadLanguagePack($iso);
 
                 if ($language == false) {
                     throw new PrestashopInstallerException($this->translator->trans('Cannot download language pack "%iso%"', ['%iso%' => $iso], 'Install'));

--- a/src/PrestaShopBundle/Resources/config/services/core/language.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/language.yml
@@ -6,6 +6,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Language\Pack\Loader\RemoteLanguagePackLoader'
     arguments:
       - '@prestashop.core.foundation.version'
+      - '%lang_repository_base_path%'
 
   prestashop.core.language.language_default_fonts_catalog:
     class: 'PrestaShop\PrestaShop\Core\Language\LanguageDefaultFontsCatalog'

--- a/tests/Unit/Core/Language/Pack/Loader/RemoteLanguagePackLoaderTest.php
+++ b/tests/Unit/Core/Language/Pack/Loader/RemoteLanguagePackLoaderTest.php
@@ -34,10 +34,10 @@ use PrestaShop\PrestaShop\Core\Language\Pack\Loader\RemoteLanguagePackLoader;
 
 final class RemoteLanguagePackLoaderTest extends TestCase
 {
-    public function testGetLanguagePackUrl()
+    public function testGetLanguagePackUrl(): void
     {
         $version = '8.0.0';
-        $basePath = 'http://i18n.mekey.com';
+        $basePath = 'http://i18n.domain.tld';
         $packLoader = new RemoteLanguagePackLoader(Version::buildFromString($version), $basePath);
 
         $locale = 'fr-FR';
@@ -48,10 +48,10 @@ final class RemoteLanguagePackLoaderTest extends TestCase
         $this->assertTrue(filter_var($languagePackLangLocaleUrl, FILTER_VALIDATE_URL) !== false);
     }
 
-    public function testGetLanguagePackListUrl()
+    public function testGetLanguagePackListUrl(): void
     {
         $version = '8.0.0';
-        $basePath = 'http://i18n.mekey.com';
+        $basePath = 'http://i18n.domain.tld';
         $packLoader = new RemoteLanguagePackLoader(Version::buildFromString($version), $basePath);
 
         $languagePackLangListUrl = $packLoader->getLanguagePackListUrl();
@@ -61,7 +61,7 @@ final class RemoteLanguagePackLoaderTest extends TestCase
         $this->assertTrue(filter_var($languagePackLangListUrl, FILTER_VALIDATE_URL) !== false, "Invalid URL found for {$languagePackLangListUrl}");
     }
 
-    public function testGetLanguagePackUrlWithoutBasePath()
+    public function testGetLanguagePackUrlWithoutBasePath(): void
     {
         $version = '8.0.0';
         $packLoader = new RemoteLanguagePackLoader(Version::buildFromString($version));

--- a/tests/Unit/Core/Language/Pack/Loader/RemoteLanguagePackLoaderTest.php
+++ b/tests/Unit/Core/Language/Pack/Loader/RemoteLanguagePackLoaderTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Language\Pack\Loader;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Language\Pack\Loader\RemoteLanguagePackLoader;
+
+final class RemoteLanguagePackLoaderTest extends TestCase
+{
+    public function testGetLanguagePackUrl()
+    {
+        $version_str = '8.0.0';
+        $locale = 'fr-FR';
+        $packLoader = new RemoteLanguagePackLoader($version_str);
+
+        $language_pack_locale_url = $packLoader->getLanguagePackUrl($locale);
+        $this->assertStringEndsWith("{$version_str}/{$locale}/{$locale}.zip", $language_pack_locale_url);
+        $this->assertTrue(filter_var($language_pack_locale_url, FILTER_VALIDATE_URL) !== false);
+    }
+
+    public function testGetLanguagePackListUrl()
+    {
+        $version_str = '8.0.0';
+        $packLoader = new RemoteLanguagePackLoader($version_str);
+
+        $language_pack_lang_list_url = $packLoader->getLanguagePackListUrl();
+        $this->assertStringEndsWith("{$version_str}/available_languages.json", $language_pack_lang_list_url);
+        $this->assertTrue(filter_var($language_pack_lang_list_url, FILTER_VALIDATE_URL) !== false);
+    }
+}

--- a/tests/Unit/Core/Language/Pack/Loader/RemoteLanguagePackLoaderTest.php
+++ b/tests/Unit/Core/Language/Pack/Loader/RemoteLanguagePackLoaderTest.php
@@ -29,28 +29,46 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Language\Pack\Loader;
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Foundation\Version;
 use PrestaShop\PrestaShop\Core\Language\Pack\Loader\RemoteLanguagePackLoader;
 
 final class RemoteLanguagePackLoaderTest extends TestCase
 {
     public function testGetLanguagePackUrl()
     {
-        $version_str = '8.0.0';
-        $locale = 'fr-FR';
-        $packLoader = new RemoteLanguagePackLoader($version_str);
+        $version = '8.0.0';
+        $basePath = 'http://i18n.mekey.com';
+        $packLoader = new RemoteLanguagePackLoader(Version::buildFromString($version), $basePath);
 
-        $language_pack_locale_url = $packLoader->getLanguagePackUrl($locale);
-        $this->assertStringEndsWith("{$version_str}/{$locale}/{$locale}.zip", $language_pack_locale_url);
-        $this->assertTrue(filter_var($language_pack_locale_url, FILTER_VALIDATE_URL) !== false);
+        $locale = 'fr-FR';
+        $languagePackLangLocaleUrl = $packLoader->getLanguagePackUrl($locale);
+
+        $this->assertStringStartsWith($basePath, $languagePackLangLocaleUrl);
+        $this->assertStringEndsWith("{$version}/{$locale}/{$locale}.zip", $languagePackLangLocaleUrl);
+        $this->assertTrue(filter_var($languagePackLangLocaleUrl, FILTER_VALIDATE_URL) !== false);
     }
 
     public function testGetLanguagePackListUrl()
     {
-        $version_str = '8.0.0';
-        $packLoader = new RemoteLanguagePackLoader($version_str);
+        $version = '8.0.0';
+        $basePath = 'http://i18n.mekey.com';
+        $packLoader = new RemoteLanguagePackLoader(Version::buildFromString($version), $basePath);
 
-        $language_pack_lang_list_url = $packLoader->getLanguagePackListUrl();
-        $this->assertStringEndsWith("{$version_str}/available_languages.json", $language_pack_lang_list_url);
-        $this->assertTrue(filter_var($language_pack_lang_list_url, FILTER_VALIDATE_URL) !== false);
+        $languagePackLangListUrl = $packLoader->getLanguagePackListUrl();
+
+        $this->assertStringEndsWith("{$version}/available_languages.json", $languagePackLangListUrl);
+        $this->assertStringStartsWith($basePath, $languagePackLangListUrl);
+        $this->assertTrue(filter_var($languagePackLangListUrl, FILTER_VALIDATE_URL) !== false, "Invalid URL found for {$languagePackLangListUrl}");
+    }
+
+    public function testGetLanguagePackUrlWithoutBasePath()
+    {
+        $version = '8.0.0';
+        $packLoader = new RemoteLanguagePackLoader(Version::buildFromString($version));
+
+        $languagePackLangListUrl = $packLoader->getLanguagePackListUrl();
+
+        $this->assertStringEndsWith("{$version}/available_languages.json", $languagePackLangListUrl);
+        $this->assertTrue(filter_var($languagePackLangListUrl, FILTER_VALIDATE_URL) !== false, "Invalid URL found for {$languagePackLangListUrl}");
     }
 }


### PR DESCRIPTION
Avoid duplication by making `RemoteLanguagePackLoader` central service for localisation parameters / requests.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Replace use of `i18n.prestashop.com` inside the software by `i18n.prestashop-project.org`. Take this opportunity to refactor language management.
| Type?             | refacto
| Category?         | PM
| BC breaks?        | yes
| Deprecations?     | yes
| Fixed ticket?     | Fixes #25888.
| How to test?      | Install Prestashop and check default lang is Ok; Fresh install, check language list available; Fresh install, try to install and use a new one. 
| Possible impacts? | Can break install. Can break language install.

add
```php
 declare(strict_types=1);
```
to `src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php`

```php
RemoteLanguagePackLoader::PACK_LINK
LanguageCore::SF_LANGUAGE_PACK_URL
LanguageCore::EMAILS_LANGUAGE_PACK_URL
LanguageCore::PACK_TYPE_EMAILS
LanguageCore::PACK_TYPE_SYMFONY
```
Removed. Please use `RemoteLanguagePackLoader::getLanguagePackUrl(...)`.

```php
LanguageCore::downloadXLFLanguagePack(...)
LanguageCore::translationPackIsInCache(...)
LanguagePackInstaller::__construct(...)
```
signatures changed ("version" and "pack_type" parameters removed or deprecated)

AdminTranslationsControllerCore::link_lang_pack default value changed but still set during `__construct` call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28057)
<!-- Reviewable:end -->
