### PR TITLE
Remove special characters but keep accents with Accented URLs enabled

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -36,7 +36,7 @@ function str2url(str, encoding, ucfirst)
     str = str.replace(/[^a-z0-9\s\'\:\/\[\]-]\\u00A1-\\uFFFF/g,'');
    str = str.replace(/[\u00AC\uFFE2\u00AE\u2122\u00A9\u20AC\u0024\uFF04\uFE69\u00B0\u00B2\u00B3\u00B9\u02AF\u0670\u0711\u2121\u213B\u2207\u29B5\u2070\u2071\u2074-\u208E\u2090-\u209C\u17D2\u1D62-\u1D6A\u2A27]/g, '');
     /*List of replaced characters in the above line
-    * € ¬ ® ™ © $ ° ² ³ ¹ ʯ ٰ ܑ ℡ ℻ ∇ ⦵ 	⁰ ⁱ 	⁴ ₎ ₐ ₜ ្ ᵢ ᵪ ⨧
+    * € ¬ ® ™ © $ ° ² ³ ¹ ʯ ٰ ܑ ℡ ℻ ∇ ⦵ ⁰ ⁱ ⁴ ₎ ₐ ₜ ᵢ ᵪ ⨧
     *  */
   else
   {

--- a/js/admin.js
+++ b/js/admin.js
@@ -34,6 +34,8 @@ function str2url(str, encoding, ucfirst)
   str = str.toLowerCase();
   if (PS_ALLOW_ACCENTED_CHARS_URL)
     str = str.replace(/[^a-z0-9\s\'\:\/\[\]-]\\u00A1-\\uFFFF/g,'');
+    str = str.replace(/[\u00AC\uFFE2\u00AE\u2122\u00A9\u20AC\u0024\uFF04\uFE69\u00B0\u00B2\u00B3\u00B9\u02AF\u0670\u0711\u2121\u213B\u2207\u29B5\uFC5B-\uFC5D\uFC63\uFC90\uFCD9\u2070\u2071\u2074-\u208E\u2090-\u209C\u0345\u0656\u17D2\u1D62-\u1D6A\u2A27\u2C7C]/g, '');
+
   else
   {
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -34,8 +34,10 @@ function str2url(str, encoding, ucfirst)
   str = str.toLowerCase();
   if (PS_ALLOW_ACCENTED_CHARS_URL)
     str = str.replace(/[^a-z0-9\s\'\:\/\[\]-]\\u00A1-\\uFFFF/g,'');
-    str = str.replace(/[\u00AC\uFFE2\u00AE\u2122\u00A9\u20AC\u0024\uFF04\uFE69\u00B0\u00B2\u00B3\u00B9\u02AF\u0670\u0711\u2121\u213B\u2207\u29B5\uFC5B-\uFC5D\uFC63\uFC90\uFCD9\u2070\u2071\u2074-\u208E\u2090-\u209C\u0345\u0656\u17D2\u1D62-\u1D6A\u2A27\u2C7C]/g, '');
-
+   str = str.replace(/[\u00AC\uFFE2\u00AE\u2122\u00A9\u20AC\u0024\uFF04\uFE69\u00B0\u00B2\u00B3\u00B9\u02AF\u0670\u0711\u2121\u213B\u2207\u29B5\u2070\u2071\u2074-\u208E\u2090-\u209C\u17D2\u1D62-\u1D6A\u2A27]/g, '');
+    /*List of replaced characters in the above line
+    * € ¬ ® ™ © $ ° ² ³ ¹ ʯ ٰ ܑ ℡ ℻ ∇ ⦵ 	⁰ ⁱ 	⁴ ₎ ₐ ₜ ្ ᵢ ᵪ ⨧
+    *  */
   else
   {
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Remove special characters but keep accents in the "reset url" button on products pages when "Accented URLs" is enabled 
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes PrestaShop/Prestashop#21495
| How to test?      | Enable Accented URLs, go to products and select a product then write a title with an accent and special character, e.g. Camión m² and then in SEO tab click on Reset URL.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

We don't have Unicode range for special characters so we have to put unicode codes one by one (the most commons  ones)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28059)
<!-- Reviewable:end -->
