### PR TITLE
Removed phpstan-ignore with use of `dynamicConstantNames`

### DIFF
--- a/admin-dev/index.php
+++ b/admin-dev/index.php
@@ -65,7 +65,6 @@ $apcLoader = new ApcClassLoader(sha1(__FILE__), $loader);
 $loader->unregister();
 $apcLoader->register(true);
 */
-/* @phpstan-ignore-next-line */
 if (_PS_MODE_DEV_) {
     Debug::enable();
 }

--- a/classes/Media.php
+++ b/classes/Media.php
@@ -136,7 +136,6 @@ class MediaCore
             try {
                 $jsContent = JSMin::minify($jsContent);
             } catch (Exception $e) {
-                /* @phpstan-ignore-next-line */
                 if (_PS_MODE_DEV_) {
                     echo $e->getMessage();
                 }

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -217,7 +217,6 @@ abstract class PaymentModuleCore extends Module
         Shop $shop = null,
         ?string $order_reference = null
     ) {
-        /* @phpstan-ignore-next-line */
         if (self::DEBUG_MODE) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Function called', 1, null, 'Cart', (int) $id_cart, true);
         }
@@ -369,7 +368,6 @@ abstract class PaymentModuleCore extends Module
             throw new PrestaShopException('The order address country is not active.');
         }
 
-        /* @phpstan-ignore-next-line */
         if (self::DEBUG_MODE) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - Payment is about to be added', 1, null, 'Cart', (int) $id_cart, true);
         }
@@ -412,7 +410,6 @@ abstract class PaymentModuleCore extends Module
             if (!empty($message)) {
                 $message = strip_tags($message, '<br>');
                 if (Validate::isCleanHtml($message)) {
-                    /* @phpstan-ignore-next-line */
                     if (self::DEBUG_MODE) {
                         PrestaShopLogger::addLog('PaymentModule::validateOrder - Message is about to be added', 1, null, 'Cart', (int) $id_cart, true);
                     }
@@ -546,7 +543,6 @@ abstract class PaymentModuleCore extends Module
                 }
             }
 
-            /* @phpstan-ignore-next-line */
             if (self::DEBUG_MODE) {
                 PrestaShopLogger::addLog('PaymentModule::validateOrder - Hook validateOrder is about to be called', 1, null, 'Cart', (int) $id_cart, true);
             }
@@ -566,7 +562,6 @@ abstract class PaymentModuleCore extends Module
                 }
             }
 
-            /* @phpstan-ignore-next-line */
             if (self::DEBUG_MODE) {
                 PrestaShopLogger::addLog('PaymentModule::validateOrder - Order Status is about to be added', 1, null, 'Cart', (int) $id_cart, true);
             }
@@ -622,7 +617,6 @@ abstract class PaymentModuleCore extends Module
                     $file_attachement = null;
                 }
 
-                /* @phpstan-ignore-next-line */
                 if (self::DEBUG_MODE) {
                     PrestaShopLogger::addLog('PaymentModule::validateOrder - Mail is about to be sent', 1, null, 'Cart', (int) $id_cart, true);
                 }
@@ -741,7 +735,6 @@ abstract class PaymentModuleCore extends Module
             $this->currentOrder = (int) $order->id;
         }
 
-        /* @phpstan-ignore-next-line */
         if (self::DEBUG_MODE) {
             PrestaShopLogger::addLog('PaymentModule::validateOrder - End of validateOrder', 1, null, 'Cart', (int) $id_cart, true);
         }

--- a/classes/Smarty/SmartyResourceModule.php
+++ b/classes/Smarty/SmartyResourceModule.php
@@ -58,7 +58,6 @@ class SmartyResourceModuleCore extends Smarty_Resource_Custom
     {
         foreach ($this->paths as $path) {
             if (Tools::file_exists_cache($file = $path . $name)) {
-                /* @phpstan-ignore-next-line */
                 if (_PS_MODE_DEV_) {
                     $source = implode('', [
                         '<!-- begin ' . $file . ' -->',

--- a/classes/Smarty/SmartyResourceParent.php
+++ b/classes/Smarty/SmartyResourceParent.php
@@ -52,7 +52,6 @@ class SmartyResourceParentCore extends Smarty_Resource_Custom
     {
         foreach ($this->paths as $path) {
             if (Tools::file_exists_cache($file = $path . $name)) {
-                /* @phpstan-ignore-next-line */
                 if (_PS_MODE_DEV_) {
                     $source = implode('', [
                         '<!-- begin ' . $file . ' -->',

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1121,7 +1121,6 @@ class ToolsCore
                 ->trans('Fatal error', [], 'Admin.Notifications.Error');
         }
 
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEV_) {
             throw new PrestaShopException($errorMessage);
         }
@@ -2109,7 +2108,6 @@ class ToolsCore
 
             $content = curl_exec($curl);
 
-            /* @phpstan-ignore-next-line */
             if (false === $content && _PS_MODE_DEV_) {
                 $errorMessage = sprintf('file_get_contents_curl failed to download %s : (error code %d) %s',
                     $url,
@@ -3058,7 +3056,6 @@ exit;
 
     protected static function throwDeprecated($error, $message, $class)
     {
-        /* @phpstan-ignore-next-line */
         if (_PS_DISPLAY_COMPATIBILITY_WARNING_) {
             @trigger_error($error, E_USER_DEPRECATED);
             PrestaShopLogger::addLog($message, 3, $class);
@@ -3328,7 +3325,6 @@ exit;
      */
     public static function dieOrLog($msg, $die = true)
     {
-        /* @phpstan-ignore-next-line */
         if ($die || (defined('_PS_MODE_DEV_') && _PS_MODE_DEV_)) {
             header('HTTP/1.1 500 Internal Server Error', true, 500);
             die($msg);

--- a/classes/cache/CacheMemcached.php
+++ b/classes/cache/CacheMemcached.php
@@ -43,7 +43,6 @@ class CacheMemcachedCore extends Cache
         $this->connect();
         if ($this->isConnected()) {
             $this->memcached->setOption(Memcached::OPT_PREFIX_KEY, _DB_PREFIX_);
-            /* @phpstan-ignore-next-line */
             if (Memcached::HAVE_IGBINARY) {
                 $this->memcached->setOption(Memcached::OPT_SERIALIZER, Memcached::SERIALIZER_IGBINARY);
             }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -187,7 +187,6 @@ abstract class ControllerCore
             ]
         );
 
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEV_ && $this->controller_type == 'admin' && !($this instanceof AdminLegacyLayoutControllerCore)) {
             set_error_handler([__CLASS__, 'myErrorHandler']);
         }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -808,7 +808,6 @@ class FrontControllerCore extends Controller
 
             // Don't send any cookie
             Context::getContext()->cookie->disallowWriting();
-            /* @phpstan-ignore-next-line */
             if (defined('_PS_MODE_DEV_') && _PS_MODE_DEV_ && $_SERVER['REQUEST_URI'] != __PS_BASE_URI__) {
                 die('[Debug] This page has moved<br />Please use the following URL instead: <a href="' . $final_url . '">' . $final_url . '</a>');
             }
@@ -1837,7 +1836,6 @@ class FrontControllerCore extends Controller
         } catch (PrestaShopException $e) {
             PrestaShopLogger::addLog($e->getMessage());
 
-            /* @phpstan-ignore-next-line */
             if (defined('_PS_MODE_DEV_') && _PS_MODE_DEV_) {
                 $this->warning[] = $e->getMessage();
                 $scope->assign(['notifications' => $this->prepareNotifications()]);

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -381,7 +381,6 @@ abstract class DbCore
             $this->result = $this->_query($sql);
         }
 
-        /* @phpstan-ignore-next-line */
         if (_PS_DEBUG_SQL_) {
             $this->displayError($sql);
         }
@@ -605,7 +604,6 @@ abstract class DbCore
 
         // This method must be used only with queries which display results
         if (!preg_match('#^\s*\(?\s*(select|show|explain|describe|desc|checksum)\s#i', $sql)) {
-            /* @phpstan-ignore-next-line */
             if (defined('_PS_MODE_DEV_') && _PS_MODE_DEV_) {
                 throw new PrestaShopDatabaseException('Db->executeS() must be used only with select, show, explain or describe queries');
             }
@@ -748,7 +746,6 @@ abstract class DbCore
             Cache::getInstance()->deleteQuery($sql);
         }
 
-        /* @phpstan-ignore-next-line */
         if (_PS_DEBUG_SQL_) {
             $this->displayError($sql);
         }
@@ -771,7 +768,7 @@ abstract class DbCore
         if ($webservice_call && $errno) {
             $dbg = debug_backtrace();
             WebserviceRequest::getInstance()->setError(500, '[SQL Error] ' . $this->getMsgError() . '. From ' . (isset($dbg[3]['class']) ? $dbg[3]['class'] : '') . '->' . $dbg[3]['function'] . '() Query was : ' . $sql, 97);
-        } elseif (_PS_DEBUG_SQL_ && $errno && !defined('PS_INSTALLATION_IN_PROGRESS')) { /* @phpstan-ignore-line */
+        } elseif (_PS_DEBUG_SQL_ && $errno && !defined('PS_INSTALLATION_IN_PROGRESS')) {
             if ($sql) {
                 throw new PrestaShopDatabaseException($this->getMsgError() . '<br /><br /><pre>' . $sql . '</pre>');
             }

--- a/classes/exception/PrestaShopException.php
+++ b/classes/exception/PrestaShopException.php
@@ -42,7 +42,7 @@ class PrestaShopExceptionCore extends Exception
         if (ToolsCore::isPHPCLI()) {
             echo get_class($this) . ' in ' . $this->getFile() . ' line ' . $this->getLine() . "\n";
             echo $this->getTraceAsString() . "\n";
-        } elseif (_PS_MODE_DEV_) { /* @phpstan-ignore-line */
+        } elseif (_PS_MODE_DEV_) {
             // Display error message
             echo '<style>
                 #psException{font-family: Verdana; font-size: 14px}

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1169,7 +1169,6 @@ abstract class ModuleCore implements ModuleInterface
     public static function getInstanceByName($module_name)
     {
         if (!Validate::isModuleName($module_name)) {
-            /* @phpstan-ignore-next-line */
             if (!_PS_MODE_DEV_) {
                 return false;
             }
@@ -2173,7 +2172,6 @@ abstract class ModuleCore implements ModuleInterface
     public function display($file, $template, $cache_id = null, $compile_id = null)
     {
         if (($overloaded = Module::_isTemplateOverloadedStatic(basename($file, '.php'), $template)) === null) {
-            /* @phpstan-ignore-next-line */
             return Context::getContext()->getTranslator()->trans('No template found for module', [], 'Admin.Modules.Notification') . ' ' . basename($file, '.php') . (_PS_MODE_DEV_ ? ' (' . $template . ')' : '');
         } else {
             $this->smarty->assign([

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -70,7 +70,6 @@ if (is_file(_PS_CUSTOM_CONFIG_FILE_)) {
     include_once _PS_CUSTOM_CONFIG_FILE_;
 }
 
-/* @phpstan-ignore-next-line */
 if (_PS_DEBUG_PROFILING_) {
     include_once _PS_TOOL_DIR_ . 'profiling/Profiler.php';
     include_once _PS_TOOL_DIR_ . 'profiling/Controller.php';

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -34,14 +34,13 @@ if (!defined('_PS_DISPLAY_COMPATIBILITY_WARNING_')) {
 }
 if (_PS_MODE_DEV_ === true) {
     $errorReportingLevel = E_ALL | E_STRICT;
-    /* @phpstan-ignore-next-line */
     if (_PS_DISPLAY_COMPATIBILITY_WARNING_ === false) {
         $errorReportingLevel = $errorReportingLevel & ~E_DEPRECATED & ~E_USER_DEPRECATED;
     }
     @ini_set('display_errors', 'on');
     @error_reporting($errorReportingLevel);
     define('_PS_DEBUG_SQL_', true);
-} else { /* @phpstan-ignore-line */
+} else {
     @ini_set('display_errors', 'off');
     define('_PS_DEBUG_SQL_', false);
 }
@@ -89,7 +88,6 @@ if ((defined('_PS_IN_TEST_') && _PS_IN_TEST_)
 ) {
     define('_PS_ENV_', 'test');
 } else {
-    /* @phpstan-ignore-next-line */
     define('_PS_ENV_', _PS_MODE_DEV_ ? 'dev': 'prod');
 }
 

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -27,7 +27,7 @@
 global $smarty;
 if (Configuration::get('PS_SMARTY_LOCAL')) {
     $smarty = new SmartyCustom();
-} elseif (_PS_MODE_DEV_ && !defined('_PS_ADMIN_DIR_')) { /* @phpstan-ignore-line */
+} elseif (_PS_MODE_DEV_ && !defined('_PS_ADMIN_DIR_')) {
     $smarty = new SmartyDev();
 } else {
     $smarty = new Smarty();

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -85,7 +85,6 @@ function smartyTranslate($params, $smarty)
                 $backTrace[0]['args'][1]->template_resource
             );
 
-            /* @phpstan-ignore-next-line */
             if (_PS_MODE_DEV_) {
                 throw new Exception($errorMessage);
             } else {
@@ -102,7 +101,6 @@ function smartyTranslate($params, $smarty)
                 $backTrace[0]['args'][1]->template_resource
             );
 
-            /* @phpstan-ignore-next-line */
             if (_PS_MODE_DEV_) {
                 throw new Exception($errorMessage);
             } else {

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -185,7 +185,6 @@ function smartyTranslate($params, $smarty)
                 $backTrace[0]['args'][1]->template_resource
             );
 
-            /* @phpstan-ignore-next-line */
             if (_PS_MODE_DEV_) {
                 throw new Exception($errorMessage);
             } else {
@@ -202,7 +201,6 @@ function smartyTranslate($params, $smarty)
                 $backTrace[0]['args'][1]->template_resource
             );
 
-            /* @phpstan-ignore-next-line */
             if (_PS_MODE_DEV_) {
                 throw new Exception($errorMessage);
             } else {

--- a/controllers/admin/AdminAccessController.php
+++ b/controllers/admin/AdminAccessController.php
@@ -137,7 +137,6 @@ class AdminAccessControllerCore extends AdminController
 
     public function ajaxProcessUpdateAccess()
     {
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEMO_) {
             throw new PrestaShopException($this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error'));
         }
@@ -163,7 +162,6 @@ class AdminAccessControllerCore extends AdminController
 
     public function ajaxProcessUpdateModuleAccess()
     {
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEMO_) {
             throw new PrestaShopException($this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error'));
         }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -4597,7 +4597,6 @@ class AdminImportControllerCore extends AdminController
     public function postProcess()
     {
         /* PrestaShop demo mode */
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEMO_) {
             $this->errors[] = $this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error');
 

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -298,7 +298,6 @@ class AdminLoginControllerCore extends AdminController
             ]
         );
 
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEMO_) {
             $this->errors[] = $this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error');
         } elseif (!$email) {
@@ -390,7 +389,6 @@ class AdminLoginControllerCore extends AdminController
             ]
         );
 
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEMO_) {
             $this->errors[] = $this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error');
         } elseif (!$reset_token_value) {

--- a/controllers/admin/AdminModulesController.php
+++ b/controllers/admin/AdminModulesController.php
@@ -453,7 +453,6 @@ class AdminModulesControllerCore extends AdminController
     public function postProcessDownload()
     {
         /* PrestaShop demo mode */
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEMO_ || ($this->context->mode == Context::MODE_HOST)) {
             $this->errors[] = $this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error');
 
@@ -569,7 +568,6 @@ class AdminModulesControllerCore extends AdminController
     public function postProcessDelete()
     {
         /* PrestaShop demo mode */
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEMO_) {
             $this->errors[] = $this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error');
 
@@ -615,7 +613,6 @@ class AdminModulesControllerCore extends AdminController
             }
 
             /* PrestaShop demo mode */
-            /* @phpstan-ignore-next-line */
             if (_PS_MODE_DEMO_) {
                 $this->errors[] = $this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error');
 

--- a/controllers/admin/AdminModulesPositionsController.php
+++ b/controllers/admin/AdminModulesPositionsController.php
@@ -502,7 +502,6 @@ class AdminModulesPositionsControllerCore extends AdminController
     {
         if ($this->access('view')) {
             /* PrestaShop demo mode */
-            /* @phpstan-ignore-next-line */
             if (_PS_MODE_DEMO_) {
                 die('{"hasError" : true, "errors" : ["Live Edit: This functionality has been disabled."]}');
             }
@@ -548,7 +547,6 @@ class AdminModulesPositionsControllerCore extends AdminController
     {
         if ($this->access('view')) {
             /* PrestaShop demo mode */
-            /* @phpstan-ignore-next-line */
             if (_PS_MODE_DEMO_) {
                 die('{"hasError" : true, "errors" : ["Live Edit: This functionality has been disabled."]}');
             }
@@ -579,7 +577,6 @@ class AdminModulesPositionsControllerCore extends AdminController
     {
         if ($this->access('edit')) {
             /* PrestaShop demo mode */
-            /* @phpstan-ignore-next-line */
             if (_PS_MODE_DEMO_) {
                 die('{"hasError" : true, "errors" : ["Live Edit: This functionality has been disabled."]}');
             }

--- a/controllers/admin/AdminRequestSqlController.php
+++ b/controllers/admin/AdminRequestSqlController.php
@@ -178,7 +178,6 @@ class AdminRequestSqlControllerCore extends AdminController
     public function postProcess()
     {
         /* PrestaShop demo mode */
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEMO_) {
             $this->errors[] = $this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error');
 
@@ -196,7 +195,6 @@ class AdminRequestSqlControllerCore extends AdminController
     public function ajaxProcess()
     {
         /* PrestaShop demo mode */
-        /* @phpstan-ignore-next-line  */
         if (_PS_MODE_DEMO_) {
             die($this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error'));
         }

--- a/controllers/admin/AdminTabsController.php
+++ b/controllers/admin/AdminTabsController.php
@@ -271,7 +271,6 @@ class AdminTabsControllerCore extends AdminController
     public function postProcess()
     {
         /* PrestaShop demo mode */
-        /* @phpstan-ignore-next-line */
         if (_PS_MODE_DEMO_) {
             $this->errors[] = $this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error');
 

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1498,7 +1498,6 @@ class AdminTranslationsControllerCore extends AdminController
         $this->getInformations();
 
         /* PrestaShop demo mode */
-        /* @phpstan-ignore-next-line  */
         if (_PS_MODE_DEMO_) {
             $this->errors[] = $this->trans('This functionality has been disabled.', [], 'Admin.Notifications.Error');
 
@@ -3303,7 +3302,6 @@ class AdminTranslationsControllerCore extends AdminController
 
     public static function getEmailHTML($email)
     {
-        /* @phpstan-ignore-next-line */
         if (__PS_BASE_URI__ != '/') {
             $email_file = str_replace(__PS_BASE_URI__, _PS_ROOT_DIR_ . '/', $email);
         } else {

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -110,7 +110,6 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
                 $this->processPostInstall();
             }
         } catch (\Exception $e) {
-            /** @phpstan-ignore-next-line */
             if (_PS_MODE_DEV_) {
                 // display stack trace
                 $message = (string) $e;

--- a/install-dev/controllers/http/welcome.php
+++ b/install-dev/controllers/http/welcome.php
@@ -65,7 +65,6 @@ class InstallControllerHttpWelcome extends InstallControllerHttp implements Http
     {
         $this->can_upgrade = false;
         if (file_exists(_PS_ROOT_DIR_ . '/config/settings.inc.php')) {
-            /** @phpstan-ignore-next-line */
             if (version_compare(_PS_VERSION_, _PS_INSTALL_VERSION_, '<')) {
                 $this->can_upgrade = true;
                 $this->ps_version = _PS_VERSION_;

--- a/install-dev/index.php
+++ b/install-dev/index.php
@@ -27,9 +27,9 @@
 require_once 'install_version.php';
 
 if (
-    !defined('PHP_VERSION_ID')  /** @phpstan-ignore-line */ // PHP_VERSION_ID is available since 5.2.7
-    || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_ /** @phpstan-ignore-line */
-    || PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_ /** @phpstan-ignore-line */
+    !defined('PHP_VERSION_ID') // PHP_VERSION_ID is available since 5.2.7
+    || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_
+    || PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_ 
     || !extension_loaded('SimpleXML') /** @phpstan-ignore-line */
     || !extension_loaded('zip') /** @phpstan-ignore-line */
     || !is_writable(
@@ -44,7 +44,6 @@ require_once dirname(__FILE__).DIRECTORY_SEPARATOR.'init.php';
 require_once(__DIR__).DIRECTORY_SEPARATOR.'autoload.php';
 
 try {
-    /* @phpstan-ignore-next-line */
     if (_PS_MODE_DEV_) {
         Symfony\Component\Debug\Debug::enable();
     }

--- a/install-dev/index_cli.php
+++ b/install-dev/index_cli.php
@@ -27,7 +27,6 @@
 require_once 'install_version.php';
 
 // Check PHP version
-/** @phpstan-ignore-next-line */
 if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_) {
     echo 'Your server is running PHP ' . PHP_VERSION . ', but PrestaShop requires PHP ' . _PS_INSTALL_MINIMUM_PHP_VERSION_ . ' or newer.';
     echo PHP_EOL;
@@ -35,7 +34,6 @@ if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSI
     echo PHP_EOL;
     die();
 }
-/** @phpstan-ignore-next-line */
 if (PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_) {
     echo 'Your server is running PHP ' . PHP_VERSION . ', but PrestaShop requires PHP ' . _PS_INSTALL_MAXIMUM_PHP_VERSION_ . ' or lower.';
     echo PHP_EOL;

--- a/install-dev/missing_requirement.php
+++ b/install-dev/missing_requirement.php
@@ -105,13 +105,13 @@
           PrestaShop installation requires the <b>Zip PHP extension</b> to be enabled.
       </li>
     <?php endif; ?>
-    <?php if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_): /** @phpstan-ignore-line */ ?>
+    <?php if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_): ?>
       <li>
           Your server is running PHP <?php echo PHP_VERSION ?>, but PrestaShop requires PHP <?php echo _PS_INSTALL_MINIMUM_PHP_VERSION_ ?> or newer.
           <i>To install PrestaShop <?php echo _PS_INSTALL_VERSION_ ?> you need to update your server's PHP version.</i>
       </li>
     <?php endif; ?>
-    <?php if (PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_): /** @phpstan-ignore-line */ ?>
+    <?php if (PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_): ?>
       <li>
           Your server is running PHP <?php echo PHP_VERSION ?>, but PrestaShop requires PHP <?php echo _PS_INSTALL_MAXIMUM_PHP_VERSION_ ?> or lower.
           <i>To install PrestaShop <?php echo _PS_INSTALL_VERSION_ ?> you need to downgrade your server's PHP version.</i>

--- a/js/retro-compat.js.php
+++ b/js/retro-compat.js.php
@@ -117,7 +117,6 @@ if (!array_key_exists($file, $plugins)) {
 } elseif ($file == 'jquery-ui-1.8.10.custom.min.js') {
     //jquery-ui cannot be call directly, now to include query UI, use Media::addJqueryUI('component_name');
     $html = '$(document).ready( function () {';
-    /** @phpstan-ignore-next-line */
     if (_PS_MODE_DEV_) {
         $html .= 'if (!$.browser.msie)console.log(\'MODE DEV : This file : "jquery-ui-1.8.10.custom.min.js" cannot be call directly please use Media::addJqueryUI("component_name")  \')';
     }
@@ -125,7 +124,6 @@ if (!array_key_exists($file, $plugins)) {
     $html .= file_get_contents($plugins[$file]['new_file']);
 } else {
     $html = '$(document).ready( function () {';
-    /** @phpstan-ignore-next-line */
     if (_PS_MODE_DEV_) {
         $html .= 'if (!$.browser.msie)console.log(\'MODE DEV : This file : "' . $file . '" has been moved to this folder ' . $plugins[$file]['new_file'] . '  To include this plugin use Media::addJqueryPlugin("' . $plugins[$file]['name'] . '")\')';
     }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -55,4 +55,18 @@ parameters:
     - OrderInvoice
     - Product
   dynamicConstantNames:
+    - _DB_PREFIX_
     - _PS_CREATION_DATE_
+    - _PS_DEBUG_PROFILING_
+    - _PS_DEBUG_SQL_
+    - _PS_DISPLAY_COMPATIBILITY_WARNING_
+    - _PS_INSTALL_MINIMUM_PHP_VERSION_ID_
+    - _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_
+    - _PS_INSTALL_VERSION_
+    - _PS_MODE_DEMO_
+    - _PS_MODE_DEV_
+    - _PS_VERSION_
+    - __PS_BASE_URI__
+    - PHP_VERSION_ID
+    - Memcached::HAVE_IGBINARY
+    - PaymentModuleCore::DEBUG_MODE

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -353,7 +353,6 @@ class Install extends AbstractInstall
         $instance->execute('SET FOREIGN_KEY_CHECKS=0');
         foreach ($instance->executeS('SHOW TABLES') as $row) {
             $table = current($row);
-            /* @phpstan-ignore-next-line */
             if (empty(_DB_PREFIX_) || preg_match('#^' . _DB_PREFIX_ . '#i', $table)) {
                 $instance->execute(($truncate ? 'TRUNCATE TABLE ' : 'DROP TABLE ') . '`' . $table . '`');
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed phpstan-ignore with use of `dynamicConstantNames`. Thanks @atomiix 
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #16471
| How to test?      | Github Actions are :green_circle:. No Need QA in this PR as I remove annotation `@phpstan-ignore(-next)-line`.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28060)
<!-- Reviewable:end -->
