### PR TITLE
Add select2 in large select options

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -88,14 +88,26 @@
   .select-status {
     position: relative;
     max-width: 280px;
-    color: $white;
     background: $white;
     border: none;
     @include border-radius(4px);
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
     @include transition(0.2s ease-out);
 
-    .select-status-colored {
+    .select2-container,
+    .select2-selection {
+      height: 100%;
+    }
+
+    .select2-selection__rendered,
+    .select2-selection__arrow b::after {
+      color: $white;
+    }
+
+    .select-status-colored,
+    .select2-selection {
+      display: flex;
+      align-items: center;
       padding: 0.375rem 2.2rem 0.375rem 0.4375rem;
       color: $white;
       background: none;
@@ -107,21 +119,8 @@
       }
     }
 
-    &::after {
-      position: absolute;
-      top: 50%;
-      right: 10px;
-      font-family: "Material Icons", Arial, sans-serif;
-      font-size: 1.25rem;
-      color: $white;
-      pointer-events: none;
-      cursor: pointer;
-      content: "keyboard_arrow_down";
-      transform: translateY(-50%);
-    }
-
-    &.is-bright .select-status-colored,
-    &.is-bright::after {
+    &.is-bright .select2-selection__rendered,
+    &.is-bright .select2-selection__arrow b::after {
       color: $bright-status-text;
     }
   }
@@ -461,7 +460,8 @@
       .select-status {
         max-width: 206px;
 
-        .select-status-colored {
+        .select-status-colored,
+        .select2-selection {
           max-width: inherit;
           padding-right: 2.5rem;
           text-overflow: ellipsis;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -231,6 +231,10 @@ class PreferencesType extends TranslatorAwareType
                 ],
                 'label' => $this->trans('Main Shop Activity', 'Admin.Shopparameters.Feature'),
                 'choice_translation_domain' => 'Install',
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -136,6 +136,10 @@ class GeneralType extends TranslatorAwareType
                 'placeholder' => $this->trans('None', 'Admin.Global'),
                 'choices' => $this->tosCmsChoices,
                 'multistore_configuration_key' => 'PS_CONDITIONS_CMS_ID',
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/CarrierOptionsType.php
@@ -90,6 +90,10 @@ class CarrierOptionsType extends TranslatorAwareType
                     'Admin.Shipping.Help'
                 ),
                 'multistore_configuration_key' => 'PS_CARRIER_DEFAULT',
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ])
             ->add('carrier_default_order_by', ChoiceType::class, [
                 'choices' => $this->orderByChoices,

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -329,6 +329,10 @@ class ProductInformation extends CommonAbstractType
                 'multiple' => false,
                 'required' => true,
                 'label' => $this->translator->trans('Default category', [], 'Admin.Catalog.Feature'),
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ])
             ->add('new_category', SimpleCategory::class, [
                 'ajax' => true,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -374,6 +374,8 @@ class CustomerAddressType extends TranslatorAwareType
                 ],
                 'attr' => [
                     'data-states-url' => $this->router->generate('admin_country_states'),
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
                 ],
             ])->add('id_state', ChoiceType::class, [
                 'label' => $this->trans('State', 'Admin.Global'),
@@ -389,6 +391,8 @@ class CustomerAddressType extends TranslatorAwareType
                 ],
                 'attr' => [
                     'visible' => $showStates,
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
                 ],
             ])->add('phone', TextType::class, [
                 'label' => $this->trans('Phone', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/ManufacturerAddressType.php
@@ -230,6 +230,8 @@ class ManufacturerAddressType extends TranslatorAwareType
                 'attr' => [
                     'class' => 'js-manufacturer-country-select',
                     'data-states-url' => $this->router->generate('admin_country_states'),
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
                 ],
                 'required' => true,
                 'with_dni_attr' => true,
@@ -249,6 +251,10 @@ class ManufacturerAddressType extends TranslatorAwareType
                     new AddressStateRequired([
                         'id_country' => $countryId,
                     ]),
+                ],
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
                 ],
             ])
             ->add('dni', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -257,6 +257,10 @@ class CustomerType extends TranslatorAwareType
                 'required' => false,
                 'placeholder' => null,
                 'choices' => $this->groupChoices,
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ])
         ;
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/CartSummaryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/CartSummaryType.php
@@ -89,6 +89,10 @@ class CartSummaryType extends AbstractType
                     [],
                     'Admin.Actions'
                 ),
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ])
             ->add('order_state', ChoiceType::class, [
                 'choices' => $this->orderStatesChoiceProvider->getChoices(),
@@ -98,6 +102,10 @@ class CartSummaryType extends AbstractType
                     [],
                     'Admin.Actions'
                 ),
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderShippingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderShippingType.php
@@ -59,6 +59,10 @@ class UpdateOrderShippingType extends AbstractType
                 'choices' => $this->carrierForOrderChoiceProvider->getChoices([
                     'order_id' => $options['order_id'],
                 ]),
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ])
             ->add('current_order_carrier_id', HiddenType::class)
             ->add('tracking_number', TextType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/UpdateOrderStatusType.php
@@ -68,6 +68,10 @@ class UpdateOrderStatusType extends AbstractType
                 'choices' => $this->statusChoiceProvider->getChoices($choiceProviderParams),
                 'choice_attr' => $this->statusChoiceAttributes,
                 'translation_domain' => false,
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
@@ -78,6 +78,10 @@ class CategoriesType extends TranslatorAwareType
                 'choices' => $this->defaultCategoryChoiceProvider->getChoices(['product_id' => $options['product_id']]),
                 //@todo: wording - default or main?
                 'label' => $this->trans('Default category', 'Admin.Catalog.Feature'),
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
+                ],
             ])
             ->add('add_categories_btn', ButtonType::class, [
                 'label' => $this->trans('Add categories', 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Supplier/SupplierType.php
@@ -232,6 +232,8 @@ class SupplierType extends TranslatorAwareType
                 'attr' => [
                     'class' => 'js-supplier-country-select',
                     'data-states-url' => $this->router->generate('admin_country_states'),
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
                 ],
             ])
             ->add('id_state', ChoiceType::class, [
@@ -242,6 +244,10 @@ class SupplierType extends TranslatorAwareType
                     new AddressStateRequired([
                         'id_country' => $countryId,
                     ]),
+                ],
+                'attr' => [
+                    'data-toggle' => 'select2',
+                    'data-minimumResultsForSearch' => '7',
                 ],
             ])
             ->add('dni', TextType::class, [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | add select2 in large select options.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28065.
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/28065.
| Possible impacts? | All pages BO described here https://github.com/PrestaShop/PrestaShop/issues/28065.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28066)
<!-- Reviewable:end -->
