### PR TITLE
Specific Price Form : Changing currency change the symbol

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/currency-symbol-updater.ts
+++ b/admin-dev/themes/new-theme/js/components/form/currency-symbol-updater.ts
@@ -23,31 +23,40 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-const {$} = window;
-
 /**
- * Shows/hides 'include_tax' field depending from 'reduction_type' field value
+ * Change symbol when the currency select is changed
  */
-export default class IncludeTaxFieldToggle {
-  $reductionTypeSelector: JQuery;
+export default class CurrencySymbolUpdater {
+  currencySymbolSelect: string;
 
-  $taxInclusionInputs: JQuery;
+  callbackChange: (symbol: string) => void;
 
-  constructor(reductionTypeSelector: string, taxInclusionInputs: string) {
-    this.$reductionTypeSelector = $(reductionTypeSelector);
-    this.$taxInclusionInputs = $(taxInclusionInputs);
-    this.handle();
-    this.$reductionTypeSelector.on('change', () => this.handle());
+  constructor(
+    currencySymbolSelect: string,
+    callbackChange: (symbol: string) => void,
+  ) {
+    this.currencySymbolSelect = currencySymbolSelect;
+    this.callbackChange = callbackChange;
+
+    this.init();
   }
 
-  /**
-   * When source value is 'percentage', target field is shown, else hidden
-   */
-  private handle(): void {
-    if (this.$reductionTypeSelector.val() === 'percentage') {
-      this.$taxInclusionInputs.fadeOut();
-    } else {
-      this.$taxInclusionInputs.fadeIn();
+  private init(): void {
+    const selectCurrency = document.querySelector<HTMLSelectElement>(this.currencySymbolSelect);
+
+    if (selectCurrency) {
+      this.callbackChange(this.getSymbol(selectCurrency));
+
+      selectCurrency.addEventListener('change', () => this.callbackChange(this.getSymbol(selectCurrency)));
     }
+  }
+
+  private getSymbol(select: HTMLSelectElement): string {
+    const selectItem = select.item(select.selectedIndex);
+
+    if (!selectItem) {
+      return '';
+    }
+    return selectItem.getAttribute('symbol') ?? '';
   }
 }

--- a/admin-dev/themes/new-theme/js/components/form/reduction-tax-field-toggle.ts
+++ b/admin-dev/themes/new-theme/js/components/form/reduction-tax-field-toggle.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+const {$} = window;
+
+/**
+ * Shows/hides 'include_tax' field depending from 'reduction_type' field value
+ */
+export default class ReductionTaxFieldToggle {
+  $reductionTypeSelector: JQuery;
+
+  $taxInclusionInputs: JQuery;
+
+  currencySymbolSelect: string;
+
+  reductionAmountSymbolSelector: string;
+
+  constructor(
+    reductionTypeSelector: string,
+    taxInclusionInputs: string,
+    currencySymbolSelect: string,
+    reductionAmountSymbolSelector:string,
+  ) {
+    this.$reductionTypeSelector = $(reductionTypeSelector);
+    this.$taxInclusionInputs = $(taxInclusionInputs);
+    this.currencySymbolSelect = currencySymbolSelect;
+    this.reductionAmountSymbolSelector = reductionAmountSymbolSelector;
+    this.handle();
+    this.$reductionTypeSelector.on('change', () => this.handle());
+  }
+
+  /**
+   * When source value is 'percentage', target field is shown, else hidden
+   */
+  private handle(): void {
+    const isPercentage = this.$reductionTypeSelector.val() === 'percentage';
+
+    if (isPercentage) {
+      this.$taxInclusionInputs.fadeOut();
+    } else {
+      this.$taxInclusionInputs.fadeIn();
+    }
+
+    if (this.reductionAmountSymbolSelector !== '') {
+      const reductionTypeAmountSymbols = document.querySelectorAll(this.reductionAmountSymbolSelector);
+
+      if (reductionTypeAmountSymbols.length) {
+        reductionTypeAmountSymbols.forEach((value: Element) => {
+          const elt = value;
+          elt.innerHTML = isPercentage ? '%' : this.getSymbol(value.innerHTML);
+        });
+      }
+    }
+  }
+
+  private getSymbol(defaultValue: string): string {
+    const select = document.querySelector<HTMLSelectElement>(this.currencySymbolSelect);
+
+    if (!select) {
+      return defaultValue;
+    }
+
+    const selectItem = select.item(select.selectedIndex);
+
+    if (!selectItem) {
+      return defaultValue;
+    }
+    return selectItem.getAttribute('symbol') ?? defaultValue;
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/catalog-price-rule/form/catalog-price-rule-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog-price-rule/form/catalog-price-rule-form-map.ts
@@ -30,6 +30,10 @@ export default {
   // mapping for price-field-availability-handler
   initialPrice: '#catalog_price_rule_leave_initial_price',
   price: '#catalog_price_rule_price',
+  currencyId: '#catalog_price_rule_id_currency',
+  reductionTypeSelect: '#catalog_price_rule_reduction_type',
+  reductionTypeAmountSymbol: '.js-reduction-row .input-group .input-group-append .input-group-text, '
+    + '.js-reduction-row .input-group .input-group-prepend .input-group-text',
 
   // mapping for include-tax-field-visibility-handler
   reductionType: '.js-reduction-type-source',

--- a/admin-dev/themes/new-theme/js/pages/catalog-price-rule/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog-price-rule/form/index.ts
@@ -23,7 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import IncludeTaxFieldToggle from '@components/form/include-tax-field-toggle';
+import ReductionTaxFieldToggle from '@components/form/reduction-tax-field-toggle';
+import CurrencySymbolUpdater from '@components/form/currency-symbol-updater';
 import PriceFieldAvailabilityHandler from './price-field-availability-handler';
 
 import CatalogPriceRuleFormMap from './catalog-price-rule-form-map';
@@ -31,12 +32,38 @@ import CatalogPriceRuleFormMap from './catalog-price-rule-form-map';
 const {$} = window;
 
 $(() => {
+  new CurrencySymbolUpdater(
+    CatalogPriceRuleFormMap.currencyId,
+    ((symbol: string): void => {
+      if (symbol === '') {
+        return;
+      }
+
+      // Reduction Amount
+      const reductionTypeSelect = document.querySelector<HTMLSelectElement>(CatalogPriceRuleFormMap.reductionTypeSelect);
+
+      if (reductionTypeSelect?.options[reductionTypeSelect.selectedIndex].value === 'amount') {
+        const reductionTypeAmountSymbols = document.querySelectorAll(
+          CatalogPriceRuleFormMap.reductionTypeAmountSymbol,
+        );
+
+        if (reductionTypeAmountSymbols.length) {
+          reductionTypeAmountSymbols.forEach((value: Element) => {
+            const elt = value;
+            elt.innerHTML = symbol;
+          });
+        }
+      }
+    }),
+  );
   new PriceFieldAvailabilityHandler(
     CatalogPriceRuleFormMap.initialPrice,
     CatalogPriceRuleFormMap.price,
   );
-  new IncludeTaxFieldToggle(
+  new ReductionTaxFieldToggle(
     CatalogPriceRuleFormMap.reductionType,
     CatalogPriceRuleFormMap.includeTax,
+    CatalogPriceRuleFormMap.currencyId,
+    CatalogPriceRuleFormMap.reductionTypeAmountSymbol,
   );
 });

--- a/admin-dev/themes/new-theme/js/pages/specific-price/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/specific-price/form/index.ts
@@ -24,14 +24,52 @@
  */
 import EntitySearchInput from '@components/entity-search-input';
 import PriceInputToggle from '@pages/specific-price/form/price-input-toggle';
+import CurrencySymbolUpdater from '@components/form/currency-symbol-updater';
 import SpecificPriceMap from '@pages/specific-price/specific-price-map';
-import IncludeTaxFieldToggle from '@components/form/include-tax-field-toggle';
+import ReductionTaxFieldToggle from '@components/form/reduction-tax-field-toggle';
 
 const {$} = window;
 
 $(() => {
   new PriceInputToggle();
-  new IncludeTaxFieldToggle(SpecificPriceMap.reductionTypeSelect, SpecificPriceMap.includeTaxInputContainer);
+  new CurrencySymbolUpdater(
+    SpecificPriceMap.currencyId,
+    ((symbol: string): void => {
+      if (symbol === '') {
+        return;
+      }
+
+      // Specific Price
+      const priceSymbols = document.querySelectorAll(SpecificPriceMap.priceSymbol);
+
+      if (priceSymbols.length) {
+        priceSymbols.forEach((value: Element) => {
+          const elt = value;
+          elt.innerHTML = symbol;
+        });
+      }
+
+      // Reduction Amount
+      const reductionTypeSelect = document.querySelector<HTMLSelectElement>(SpecificPriceMap.reductionTypeSelect);
+
+      if (reductionTypeSelect?.options[reductionTypeSelect.selectedIndex].value === 'amount') {
+        const reductionTypeAmountSymbols = document.querySelectorAll(SpecificPriceMap.reductionTypeAmountSymbol);
+
+        if (reductionTypeAmountSymbols.length) {
+          reductionTypeAmountSymbols.forEach((value: Element) => {
+            const elt = value;
+            elt.innerHTML = symbol;
+          });
+        }
+      }
+    }),
+  );
+  new ReductionTaxFieldToggle(
+    SpecificPriceMap.reductionTypeSelect,
+    SpecificPriceMap.includeTaxInputContainer,
+    SpecificPriceMap.currencyId,
+    SpecificPriceMap.reductionTypeAmountSymbol,
+  );
   new EntitySearchInput($(SpecificPriceMap.customerSearchContainer), {
     responseTransformer: (response: any) => {
       if (!response || response.customers.length === 0) {

--- a/admin-dev/themes/new-theme/js/pages/specific-price/specific-price-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/specific-price/specific-price-map.ts
@@ -24,9 +24,14 @@
  */
 
 export default {
+  currencyId: '#specific_price_currency_id',
   customerSearchContainer: '#specific_price_customer',
   priceInput: '#specific_price_fixed_price',
+  priceSymbol: '.js-fixed_price-row .input-group.money-type .input-group-append .input-group-text, '
+    + '.js-fixed_price-row .input-group.money-type .input-group-prepend .input-group-text',
   leaveInitialPriceCheckbox: '#specific_price_leave_initial_price',
   reductionTypeSelect: '#specific_price_reduction_type',
+  reductionTypeAmountSymbol: '#specific_price_reduction .input-group .input-group-append .input-group-text, '
+    + '#specific_price_reduction .input-group .input-group-prepend .input-group-text',
   includeTaxInputContainer: '.js-include-tax-row',
 };

--- a/src/Adapter/Product/SpecificPrice/QueryHandler/GetSpecificPriceListHandler.php
+++ b/src/Adapter/Product/SpecificPrice/QueryHandler/GetSpecificPriceListHandler.php
@@ -131,6 +131,7 @@ class GetSpecificPriceListHandler implements GetSpecificPriceListHandlerInterfac
                 $combinationId ? $this->combinationNameBuilder->buildName($attributesInfo[$combinationId]) : null,
                 $specificPrice['shop_name'],
                 $specificPrice['currency_name'],
+                $specificPrice['currency_iso_code'],
                 $specificPrice['country_name'],
                 $specificPrice['group_name'],
                 $this->buildCustomerFullName($specificPrice)

--- a/src/Adapter/Product/SpecificPrice/Repository/SpecificPriceRepository.php
+++ b/src/Adapter/Product/SpecificPrice/Repository/SpecificPriceRepository.php
@@ -161,6 +161,7 @@ class SpecificPriceRepository extends AbstractObjectModelRepository
                 sp.*,
                 shop.name as shop_name,
                 currency_lang.name as currency_name,
+                currency.iso_code as currency_iso_code,
                 customer.firstname as customer_firstname,
                 customer.lastname as customer_lastname,
                 country_lang.name as country_name,
@@ -307,6 +308,11 @@ class SpecificPriceRepository extends AbstractObjectModelRepository
                 'sp',
                 $this->dbPrefix . 'currency_lang', 'currency_lang',
                 'sp.id_currency = currency_lang.id_currency AND currency_lang.id_lang = :langId'
+            )
+            ->leftJoin(
+                'currency_lang',
+                $this->dbPrefix . 'currency', 'currency',
+                'currency.id_currency = currency_lang.id_currency'
             )
             ->leftJoin(
                 'sp',

--- a/src/Core/Domain/Product/SpecificPrice/QueryResult/SpecificPriceForListing.php
+++ b/src/Core/Domain/Product/SpecificPrice/QueryResult/SpecificPriceForListing.php
@@ -76,6 +76,11 @@ class SpecificPriceForListing
     /**
      * @var string|null
      */
+    private $currencyISOCode;
+
+    /**
+     * @var string|null
+     */
     private $countryName;
 
     /**
@@ -114,7 +119,8 @@ class SpecificPriceForListing
      * @param DateTimeInterface $dateTimeTo
      * @param string|null $combinationName
      * @param string|null $shop
-     * @param string|null $currency
+     * @param string|null $currencyName
+     * @param string|null $currencyISOCode
      * @param string|null $country
      * @param string|null $group
      * @param string|null $customer
@@ -130,7 +136,8 @@ class SpecificPriceForListing
         DateTimeInterface $dateTimeTo,
         ?string $combinationName,
         ?string $shop,
-        ?string $currency,
+        ?string $currencyName,
+        ?string $currencyISOCode,
         ?string $country,
         ?string $group,
         ?string $customer
@@ -145,7 +152,8 @@ class SpecificPriceForListing
         $this->dateTimeTo = $dateTimeTo;
         $this->combinationName = $combinationName;
         $this->shopName = $shop;
-        $this->currencyName = $currency;
+        $this->currencyName = $currencyName;
+        $this->currencyISOCode = $currencyISOCode;
         $this->countryName = $country;
         $this->groupName = $group;
         $this->customerName = $customer;
@@ -221,6 +229,14 @@ class SpecificPriceForListing
     public function getCurrencyName(): ?string
     {
         return $this->currencyName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCurrencyISOCode(): ?string
+    {
+        return $this->currencyISOCode;
     }
 
     /**

--- a/src/Core/Form/ChoiceProvider/CurrencyByIdChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CurrencyByIdChoiceProvider.php
@@ -27,12 +27,13 @@
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 
 /**
  * Class CurrencyByIdChoiceProvider provides currency choices with ID values.
  */
-final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface
+final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface, FormChoiceAttributeProviderInterface
 {
     /**
      * @var CurrencyDataProvider
@@ -54,13 +55,32 @@ final class CurrencyByIdChoiceProvider implements FormChoiceProviderInterface
      */
     public function getChoices()
     {
-        $currencies = $this->currencyDataProvider->getCurrencies(false, true, true);
+        $currencies = $this->getCurrencies();
         $choices = [];
 
         foreach ($currencies as $currency) {
-            $choices[sprintf('%s (%s)', $currency['name'], $currency['iso_code'])] = $currency['id_currency'];
+            $currencyLabel = sprintf('%s (%s)', $currency['name'], $currency['iso_code']);
+            $choices[$currencyLabel] = $currency['id_currency'];
         }
 
         return $choices;
+    }
+
+    public function getChoicesAttributes()
+    {
+        $currencies = $this->getCurrencies();
+        $choicesAttributes = [];
+
+        foreach ($currencies as $currency) {
+            $currencyLabel = sprintf('%s (%s)', $currency['name'], $currency['iso_code']);
+            $choicesAttributes[$currencyLabel]['symbol'] = $currency['symbol'];
+        }
+
+        return $choicesAttributes;
+    }
+
+    private function getCurrencies(): array
+    {
+        return $this->currencyDataProvider->getCurrencies(false, true, true);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/SpecificPriceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/SpecificPriceController.php
@@ -182,8 +182,15 @@ class SpecificPriceController extends FrameworkBundleAdminController
                 'country' => $specificPrice->getCountryName() ?? $this->trans('All countries', 'Admin.Global'),
                 'group' => $specificPrice->getGroupName() ?? $this->trans('All groups', 'Admin.Global'),
                 'customer' => $specificPrice->getCustomerName() ?? $this->trans('All customers', 'Admin.Global'),
-                'price' => $this->formatPrice($specificPrice->getFixedPrice()),
-                'impact' => $this->formatImpact($specificPrice->getReductionType(), $specificPrice->getReductionValue()),
+                'price' => $this->formatPrice(
+                    $specificPrice->getFixedPrice(),
+                    $specificPrice->getCurrencyISOCode() ?: $this->getContextCurrencyIso()
+                ),
+                'impact' => $this->formatImpact(
+                    $specificPrice->getReductionType(),
+                    $specificPrice->getReductionValue(),
+                    $specificPrice->getCurrencyISOCode() ?: $this->getContextCurrencyIso()
+                ),
                 'period' => $this->formatPeriod($specificPrice->getDateTimeFrom(), $specificPrice->getDateTimeTo()),
                 'fromQuantity' => $specificPrice->getFromQuantity(),
             ];
@@ -194,25 +201,27 @@ class SpecificPriceController extends FrameworkBundleAdminController
 
     /**
      * @param FixedPriceInterface $fixedPrice
+     * @param string $currencyIsoCode
      *
      * @return string
      */
-    private function formatPrice(FixedPriceInterface $fixedPrice): string
+    private function formatPrice(FixedPriceInterface $fixedPrice, string $currencyIsoCode): string
     {
         if (InitialPrice::isInitialPriceValue((string) $fixedPrice->getValue())) {
             return self::UNSPECIFIED_VALUE_FORMAT;
         }
 
-        return $this->getContextLocale()->formatPrice((string) $fixedPrice->getValue(), $this->getContextCurrencyIso());
+        return $this->getContextLocale()->formatPrice((string) $fixedPrice->getValue(), $currencyIsoCode);
     }
 
     /**
      * @param string $reductionType
      * @param DecimalNumber $reductionValue
+     * @param string $currencyIsoCode
      *
      * @return string
      */
-    private function formatImpact(string $reductionType, DecimalNumber $reductionValue): string
+    private function formatImpact(string $reductionType, DecimalNumber $reductionValue, string $currencyIsoCode): string
     {
         if ($reductionValue->equalsZero()) {
             return self::UNSPECIFIED_VALUE_FORMAT;
@@ -222,7 +231,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
 
         $locale = $this->getContextLocale();
         if ($reductionType === Reduction::TYPE_AMOUNT) {
-            return sprintf('%s', $locale->formatPrice((string) $reductionValue, $this->getContextCurrencyIso()));
+            return sprintf('%s', $locale->formatPrice((string) $reductionValue, $currencyIsoCode));
         }
 
         return sprintf('%s %%', (string) $reductionValue);

--- a/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/CatalogPriceRule/CatalogPriceRuleType.php
@@ -64,6 +64,11 @@ class CatalogPriceRuleType extends AbstractType
     /**
      * @var array
      */
+    private $currencyByIdChoicesAttributes;
+
+    /**
+     * @var array
+     */
     private $countryByIdChoices;
 
     /**
@@ -89,6 +94,7 @@ class CatalogPriceRuleType extends AbstractType
      * @param array $groupByIdChoices
      * @param array $shopByIdChoices
      * @param array $taxInclusionChoices
+     * @param array $currencyByIdChoicesAttributes
      */
     public function __construct(
         TranslatorInterface $translator,
@@ -97,11 +103,13 @@ class CatalogPriceRuleType extends AbstractType
         array $countryByIdChoices,
         array $groupByIdChoices,
         array $shopByIdChoices,
-        array $taxInclusionChoices
+        array $taxInclusionChoices,
+        array $currencyByIdChoicesAttributes
     ) {
         $this->translator = $translator;
         $this->isMultishopEnabled = $isMultishopEnabled;
         $this->currencyByIdChoices = $currencyByIdChoices;
+        $this->currencyByIdChoicesAttributes = $currencyByIdChoicesAttributes;
         $this->countryByIdChoices = $countryByIdChoices;
         $this->groupByIdChoices = $groupByIdChoices;
         $this->shopByIdChoices = $shopByIdChoices;
@@ -123,6 +131,7 @@ class CatalogPriceRuleType extends AbstractType
                 'required' => false,
                 'placeholder' => false,
                 'choices' => $this->getModifiedCurrencyChoices(),
+                'choice_attr' => $this->currencyByIdChoicesAttributes,
             ])
             ->add('id_country', ChoiceType::class, [
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/SpecificPriceType.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Reduction;
 use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Exception\SpecificPriceException;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Reduction as ReductionVO;
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Sell\Customer\SearchedCustomerType;
 use PrestaShopBundle\Form\Admin\Type\DateRangeType;
@@ -59,7 +60,7 @@ class SpecificPriceType extends TranslatorAwareType
     private $defaultCurrencyIso;
 
     /**
-     * @var FormChoiceProviderInterface
+     * @var FormChoiceProviderInterface|FormChoiceAttributeProviderInterface
      */
     private $currencyByIdChoiceProvider;
 
@@ -102,7 +103,7 @@ class SpecificPriceType extends TranslatorAwareType
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param string $defaultCurrencyIso
-     * @param FormChoiceProviderInterface $currencyByIdChoiceProvider
+     * @param FormChoiceProviderInterface|FormChoiceAttributeProviderInterface $currencyByIdChoiceProvider
      * @param FormChoiceProviderInterface $countryByIdChoiceProvider
      * @param FormChoiceProviderInterface $groupByIdChoiceProvider
      * @param FormChoiceProviderInterface $shopByIdChoiceProvider
@@ -115,7 +116,7 @@ class SpecificPriceType extends TranslatorAwareType
         TranslatorInterface $translator,
         array $locales,
         string $defaultCurrencyIso,
-        FormChoiceProviderInterface $currencyByIdChoiceProvider,
+        $currencyByIdChoiceProvider,
         FormChoiceProviderInterface $countryByIdChoiceProvider,
         FormChoiceProviderInterface $groupByIdChoiceProvider,
         FormChoiceProviderInterface $shopByIdChoiceProvider,
@@ -149,6 +150,7 @@ class SpecificPriceType extends TranslatorAwareType
                 'label' => $this->trans('Currency', 'Admin.Global'),
                 'placeholder' => $this->trans('All currencies', 'Admin.Global'),
                 'choices' => $this->currencyByIdChoiceProvider->getChoices(),
+                'choice_attr' => $this->currencyByIdChoiceProvider->getChoicesAttributes(),
                 'required' => false,
             ])
             ->add('country_id', ChoiceType::class, [
@@ -199,6 +201,9 @@ class SpecificPriceType extends TranslatorAwareType
                 'required' => false,
                 'label' => $this->trans('Set specific price (tax excl.)', 'Admin.Catalog.Feature'),
                 'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'row_attr' => [
+                    'class' => 'js-fixed_price-row',
+                ],
                 'currency' => $this->defaultCurrencyIso,
                 'constraints' => [
                     new NotBlank(),

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1059,6 +1059,7 @@ services:
       - '@=service("prestashop.core.form.choice_provider.group_by_id").getChoices()'
       - '@=service("prestashop.adapter.form.choice_provider.shop_name_by_id").getChoices()'
       - '@=service("prestashop.core.form.choice_provider.tax_inclusion").getChoices()'
+      - '@=service("prestashop.core.form.choice_provider.currency_by_id").getChoicesAttributes()'
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/CatalogPriceRule/Blocks/form.html.twig
@@ -83,9 +83,11 @@
         }) }}
       </div>
 
-      {{ ps.form_group_row(catalogPriceRuleForm.reduction.value, {}, {
-        'label': 'Reduction'|trans({}, 'Admin.Catalog.Feature'),
-      }) }}
+      <div class="js-reduction-row">
+        {{ ps.form_group_row(catalogPriceRuleForm.reduction.value, {}, {
+          'label': 'Reduction'|trans({}, 'Admin.Catalog.Feature'),
+        }) }}
+      </div>
 
       {% block catalog_price_rule_form_rest %}
         {{ form_rest(catalogPriceRuleForm) }}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPriceContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPriceContext.php
@@ -104,7 +104,7 @@ class SpecificPriceContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Transform table:id reference,combination,reduction type,reduction value,includes tax,fixed price,from quantity,shop,currency,country,group,customer,from,to
+     * @Transform table:id reference,combination,reduction type,reduction value,includes tax,fixed price,from quantity,shop,currency,currencyISOCode,country,group,customer,from,to
      *
      * @param TableNode $tableNode
      *
@@ -129,6 +129,7 @@ class SpecificPriceContext extends AbstractProductFeatureContext
                 $dataRow['combination'] ?: null,
                 $dataRow['shop'] ?: null,
                 $dataRow['currency'] ?: null,
+                $dataRow['currencyISOCode'] ?: null,
                 $dataRow['country'] ?: null,
                 $dataRow['group'] ?: null,
                 $dataRow['customer'] ?: null
@@ -289,7 +290,7 @@ class SpecificPriceContext extends AbstractProductFeatureContext
 
             $scalarPropertyNames = [
                 'specificPriceId', 'reductionType', 'includesTax',
-                'fromQuantity', 'shopName', 'currencyName', 'countryName',
+                'fromQuantity', 'shopName', 'currencyName', 'currencyISOCode', 'countryName',
                 'groupName', 'customerName', 'combinationName',
             ];
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_prices_listing.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_prices_listing.feature
@@ -67,7 +67,7 @@ Feature: List specific prices for product in Back Office (BO)
       | combination     | product1SWhite |
     And product "product1" should have 3 specific prices
     Then product "product1" should have following list of specific prices in "en" language:
-      | id reference | combination             | reduction type | reduction value | includes tax | fixed price | from quantity | shop      | currency | country       | group   | customer | from                | to                  |
-      | price1       |                         | amount         | 111.50          | true         | 400         | 1             |           |          |               |         |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
-      | price2       |                         | amount         | 12.56           | true         | 45.78       | 1             | test_shop | USD      | United States | Visitor | John DOE | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
-      | price3       | Size - S, Color - White | percentage     | 30              | false        | 0           | 1             |           |          |               |         |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+      | id reference | combination             | reduction type | reduction value | includes tax | fixed price | from quantity | shop      | currency | currencyISOCode | country       | group   | customer | from                | to                  |
+      | price1       |                         | amount         | 111.50          | true         | 400         | 1             |           |          |                 |               |         |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+      | price2       |                         | amount         | 12.56           | true         | 45.78       | 1             | test_shop | USD      | USD             | United States | Visitor | John DOE | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+      | price3       | Size - S, Color - White | percentage     | 30              | false        | 0           | 1             |           |          |                 |               |         |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Specific Price Form : Changing currency change the symbol
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26482
| How to test?      | Cf. #26482 (Only on the Product Page v2) <br><br>Check the same behavior on the page `sell/catalog/catalog-price-rules/new` (Migrated but not totally)

**:notebook: BC Breaks**
* Parameter 4 of the class `PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPriceType` has changed from  `FormChoiceProviderInterface $currencyByIdChoiceProvider` to `$currencyByIdChoiceProvider`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28068)
<!-- Reviewable:end -->
