### PR TITLE
Be able to skip CSV Header in CSV export

### DIFF
--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -178,7 +178,7 @@ class CsvResponse extends StreamedResponse
      */
     public function setExportHeader($exportHeader)
     {
-        $this->exportHeader = (boolean) $exportHeader;
+        $this->exportHeader = $exportHeader;
 
         return $this;
     }

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -94,7 +94,7 @@ class CsvResponse extends StreamedResponse
     /**
      * Returns true, if the header line should be exported.
      *
-     * @return boolean
+     * @return bool
      */
     public function getIncludeHeaderRow()
     {

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -96,7 +96,7 @@ class CsvResponse extends StreamedResponse
      *
      * @return bool
      */
-    public function getIncludeHeaderRow()
+    public function isHeaderRowIncluded(): bool
     {
         return $this->includeHeaderRow;
     }

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -68,9 +68,9 @@ class CsvResponse extends StreamedResponse
     private $limit = 1000;
 
     /**
-     * @var bool exportHeader
+     * @var bool includeHeaderRow
      */
-    private $exportHeader = true;
+    private $includeHeaderRow = true;
 
     /**
      * Constructor.
@@ -89,6 +89,16 @@ class CsvResponse extends StreamedResponse
 
         $this->setFileName('export_' . date('Y-m-d_His') . '.csv');
         $this->headers->set('Content-Type', 'text/csv; charset=utf-8');
+    }
+    
+    /**
+     * Returns true, if the header line should be exported.
+     *
+     * @return boolean
+     */
+    public function getIncludeHeaderRow()
+    {
+        return $this->includeHeaderRow;
     }
 
     /**
@@ -172,13 +182,13 @@ class CsvResponse extends StreamedResponse
     }
 
     /**
-     * @param bool $exportHeader
+     * @param bool $includeHeaderRow
      *
      * @return $this
      */
-    public function setExportHeader(bool $exportHeader): self
+    public function setIncludeHeaderRow(bool $includeHeaderRow): self
     {
-        $this->exportHeader = $exportHeader;
+        $this->includeHeaderRow = $includeHeaderRow;
 
         return $this;
     }
@@ -214,7 +224,7 @@ class CsvResponse extends StreamedResponse
     {
         $handle = tmpfile();
 
-        if ($this->exportHeader) {
+        if ($this->includeHeaderRow) {
             fputcsv($handle, $this->headersData, ';');
         }
 
@@ -232,7 +242,7 @@ class CsvResponse extends StreamedResponse
     {
         $handle = tmpfile();
 
-        if ($this->exportHeader) {
+        if ($this->includeHeaderRow) {
             fputcsv($handle, $this->headersData, ';');
         }
 

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -172,7 +172,7 @@ class CsvResponse extends StreamedResponse
     }
 
     /**
-     * @param boolean $exportHeader
+     * @param bool $exportHeader
      *
      * @return $this
      */

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -176,7 +176,7 @@ class CsvResponse extends StreamedResponse
      *
      * @return $this
      */
-    public function setExportHeader($exportHeader)
+    public function setExportHeader(bool $exportHeader): self
     {
         $this->exportHeader = $exportHeader;
 

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -90,7 +90,7 @@ class CsvResponse extends StreamedResponse
         $this->setFileName('export_' . date('Y-m-d_His') . '.csv');
         $this->headers->set('Content-Type', 'text/csv; charset=utf-8');
     }
-    
+
     /**
      * Returns true, if the header line should be exported.
      *

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -68,7 +68,7 @@ class CsvResponse extends StreamedResponse
     private $limit = 1000;
 
     /**
-     * @var boolean exportHeader
+     * @var bool exportHeader
      */
     private $exportHeader = true;
 

--- a/src/PrestaShopBundle/Component/CsvResponse.php
+++ b/src/PrestaShopBundle/Component/CsvResponse.php
@@ -68,6 +68,11 @@ class CsvResponse extends StreamedResponse
     private $limit = 1000;
 
     /**
+     * @var boolean exportHeader
+     */
+    private $exportHeader = true;
+
+    /**
      * Constructor.
      *
      * @param callable|null $callback A valid PHP callback or null to set it later
@@ -167,6 +172,18 @@ class CsvResponse extends StreamedResponse
     }
 
     /**
+     * @param boolean $exportHeader
+     *
+     * @return $this
+     */
+    public function setExportHeader($exportHeader)
+    {
+        $this->exportHeader = (boolean) $exportHeader;
+
+        return $this;
+    }
+
+    /**
      * Callback function for StreamedResponse.
      *
      * @throws \LogicException
@@ -196,7 +213,10 @@ class CsvResponse extends StreamedResponse
     private function processDataArray()
     {
         $handle = tmpfile();
-        fputcsv($handle, $this->headersData, ';');
+
+        if ($this->exportHeader) {
+            fputcsv($handle, $this->headersData, ';');
+        }
 
         foreach ($this->data as $line) {
             fputcsv($handle, $line, ';');
@@ -211,7 +231,10 @@ class CsvResponse extends StreamedResponse
     private function processDataCallback()
     {
         $handle = tmpfile();
-        fputcsv($handle, $this->headersData, ';');
+
+        if ($this->exportHeader) {
+            fputcsv($handle, $this->headersData, ';');
+        }
 
         do {
             $data = call_user_func_array($this->data, [$this->start, $this->limit]);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | To give the CSVResponse functionality a bit more flexibility, this PR add the possibility to skip header rows.
| Type?         | improvement
| Category?     |  CO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | Fixes #28073
| How to test?  | create a module which uses CSVResponse Class to create CSV File and call setExportHeader(false). This should skip adding the header row. Module [csvexporttest.zip](https://github.com/PrestaShop/PrestaShop/files/8408816/csvexporttest.zip)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28072)
<!-- Reviewable:end -->
