### PR TITLE
Reproduce the same behavior as PHP7.3 if currency name doesn't exist

### DIFF
--- a/src/Core/Form/ChoiceProvider/CurrencyNameByIsoCodeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CurrencyNameByIsoCodeChoiceProvider.php
@@ -61,7 +61,7 @@ final class CurrencyNameByIsoCodeChoiceProvider implements FormChoiceProviderInt
             }
             $currencyNames = $cldrCurrency->getDisplayNames();
             $isoCode = $cldrCurrency->getIsoCode();
-            $displayName = sprintf('%s (%s)', $currencyNames['default'], $isoCode);
+            $displayName = sprintf('%s (%s)', $currencyNames['default'] ?? null, $isoCode);
 
             $result[$displayName] = $isoCode;
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Reproduce the same behavior as PHP7.3 if currency names doesn't exists. On the develop branch, it could be cool (maybe) to retrieve english or default language names if they are not available in the CLDR ressources.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27921
| How to test?      | Follow ticket instruction.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28081)
<!-- Reviewable:end -->
