### PR TITLE
Remove useless sensio/distribution-bundle composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -161,15 +161,8 @@
     ]
   },
   "scripts": {
-    "post-install-cmd": [
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
-    ],
     "post-update-cmd": [
-      "PrestaShopBundle\\Install\\Upgrade::migrateSettingsFile",
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-      "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
+      "PrestaShopBundle\\Install\\Upgrade::migrateSettingsFile"
     ],
     "create-test-db": [
       "@php ./tests-legacy/create-test-db.php"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Since the [release of composer 2.3.0](https://github.com/composer/composer/blob/main/CHANGELOG.md#230-rc1-2022-03-16), some commands of the package `sensio/distribution-bundle` are not compatible with composer anymore. However, it looks like these commands where useless for us:<br>1. The `buildBootstrap` command generates the file `var/bootstrap.php.cache` that is not used anywhere.<br>2. The `clearCache` command is optional, we can clear the cache in PrestaShop directly or `rm -rf var/cache/*` if needed.<br>3. The `prepareDeploymentTarget` command is only useful in a Heroku environment and we're not using it.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | CI should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28083)
<!-- Reviewable:end -->
