### PR TITLE
Fix displayHeader is not available when transplanting modules/hooks

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3280,6 +3280,8 @@ abstract class ModuleCore implements ModuleInterface
 
         if ($this instanceof WidgetInterface) {
             $possible_hooks_list = array_merge($this->getWidgetHooks(), $possible_hooks_list);
+            $name_column = array_column($possible_hooks_list, 'name');
+            array_multisort($name_column, SORT_ASC, $possible_hooks_list);
         }
 
         return $possible_hooks_list;

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3281,6 +3281,7 @@ abstract class ModuleCore implements ModuleInterface
         if ($this instanceof WidgetInterface) {
             $possible_hooks_list = array_merge($this->getWidgetHooks(), $possible_hooks_list);
         }
+
         return $possible_hooks_list;
     }
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2426,7 +2426,9 @@ abstract class ModuleCore implements ModuleInterface
     public function isHookableOn($hook_name)
     {
         if ($this instanceof WidgetInterface) {
-            return Hook::isDisplayHookName($hook_name);
+            if (Hook::isDisplayHookName($hook_name)) {
+                return true;
+            }
         }
 
         return is_callable([$this, 'hook' . ucfirst($hook_name)]);
@@ -3259,10 +3261,6 @@ abstract class ModuleCore implements ModuleInterface
      */
     public function getPossibleHooksList()
     {
-        if ($this instanceof WidgetInterface) {
-            return $this->getWidgetHooks();
-        }
-
         $hooks_list = Hook::getHooks();
         $possible_hooks_list = [];
         $registeredHookList = Hook::getHookModuleList();
@@ -3280,6 +3278,9 @@ abstract class ModuleCore implements ModuleInterface
             }
         }
 
+        if ($this instanceof WidgetInterface) {
+            $possible_hooks_list = array_merge($this->getWidgetHooks(), $possible_hooks_list);
+        }
         return $possible_hooks_list;
     }
 


### PR DESCRIPTION
Merge displayhooks with other hooks from module.
Possible to hooks to non display hooks with widget modules if hook function exists.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR fixes the issue descripbed in ticket 10405 where widget modules could only be hooked to display hooks.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #10405.
| How to test?      | Please follow instructions in ticket.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28094)
<!-- Reviewable:end -->
