### PR TITLE
Fix phpstan test with different php versions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.0'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
 
       - uses: actions/checkout@v2
@@ -73,7 +73,10 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Composer Install
-        run: composer install --ansi --prefer-dist --no-interaction --no-progress
+        run: |
+          composer install --ansi --prefer-dist --no-interaction --no-progress
+          rm composer.lock
+          composer config platform.php ${{ matrix.php }}
 
       - name: Run phpstan
         run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3296,7 +3296,8 @@ class CartCore extends ObjectModel
      */
     public static function desintifier($int, $delimiter = ',')
     {
-        $delimiter_len = $int[0];
+        /** @var positive-int $delimiter_len */
+        $delimiter_len = intval($int[0]);
         $int = strrev(substr($int, 1));
         $elm = explode(str_repeat('0', $delimiter_len + 1), $int);
 

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -3139,7 +3139,7 @@ class AdminImportControllerCore extends AdminController
         $customers_shop = [];
         $customers_shop['shared'] = [];
         $default_shop = new Shop((int) Configuration::get('PS_SHOP_DEFAULT'));
-        if ($shop_is_feature_active && $id_shop_list) {
+        if ($shop_is_feature_active && is_array($id_shop_list)) {
             foreach ($id_shop_list as $id_shop) {
                 if (empty($id_shop)) {
                     continue;

--- a/src/Adapter/Import/Handler/CategoryImportHandler.php
+++ b/src/Adapter/Import/Handler/CategoryImportHandler.php
@@ -528,7 +528,11 @@ final class CategoryImportHandler extends AbstractImportHandler
                 }
 
                 // Get shops for each attributes
-                $shopData = explode($importConfig->getMultipleValueSeparator(), $shopData);
+                $multipleValueSeparator = $importConfig->getMultipleValueSeparator();
+                if (empty($multipleValueSeparator)) {
+                    return;
+                }
+                $shopData = explode($multipleValueSeparator, $shopData);
 
                 foreach ($shopData as $shop) {
                     if (!empty($shop)) {

--- a/src/Adapter/Import/Handler/ProductImportHandler.php
+++ b/src/Adapter/Import/Handler/ProductImportHandler.php
@@ -452,7 +452,12 @@ final class ProductImportHandler extends AbstractImportHandler
 
         // link product to shops
         $product->id_shop_list = [];
-        $productShops = explode($importConfig->getMultipleValueSeparator(), $product->shop);
+
+        $multipleValueSeparator = $importConfig->getMultipleValueSeparator();
+        if (empty($multipleValueSeparator)) {
+            return;
+        }
+        $productShops = explode($multipleValueSeparator, $product->shop);
 
         if (is_array($productShops)) {
             foreach ($productShops as $shop) {
@@ -1006,7 +1011,7 @@ final class ProductImportHandler extends AbstractImportHandler
         if (isset($product->id) && $product->id) {
             $tags = Tag::getProductTags($product->id);
             if (is_array($tags) && count($tags)) {
-                if (is_string($product->tags)) {
+                if (is_string($product->tags) && !empty($multipleValueSeparator)) {
                     $product->tags = explode($multipleValueSeparator, $product->tags);
                 }
                 if (is_array($product->tags)) {
@@ -1179,7 +1184,7 @@ final class ProductImportHandler extends AbstractImportHandler
         $features = get_object_vars($product);
         $multipleValueSeparator = $importConfig->getMultipleValueSeparator();
 
-        if (empty($features['features'])) {
+        if (empty($features['features']) || empty($multipleValueSeparator)) {
             return;
         }
 

--- a/tests/TestCase/PhpErrorsCounter.php
+++ b/tests/TestCase/PhpErrorsCounter.php
@@ -43,7 +43,7 @@ class PhpErrorsCounter
         set_error_handler([$this, 'errorHandler'], E_ALL);
     }
 
-    public function errorHandler(int $errorType, string $errstr, string $errfile, int $errline, array $errcontext)
+    public function errorHandler(int $errorType): bool
     {
         switch ($errorType) {
             case E_WARNING:
@@ -62,6 +62,8 @@ class PhpErrorsCounter
             default:
                 // nothing to do.
         }
+
+        return false;
     }
 
     public function restoreErrorHandler()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Using different php version with phpstan is useless if `config.platform.php` is set in the `composer.json` file because as mentioned in [the phpstan documentation](https://phpstan.org/config-reference#phpversion):<br><br><blockquote>PHPStan will automatically infer the config.platform.php version from the last composer.json file it can find, if not configured in the PHPStan configuration file.</blockquote>This PR fixes it by overriding the `config.platform.php` entry of the `composer.json` file.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | CI should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28095)
<!-- Reviewable:end -->
