### PR TITLE
Fixed profiler in PHP8.0 in migrated page

### DIFF
--- a/tools/profiling/Profiler.php
+++ b/tools/profiling/Profiler.php
@@ -283,14 +283,14 @@ class Profiler
             $formattedOutput[$moduleName] = [
                 'total_time' => array_reduce(
                     $perfs,
-                    function (&$res, $item) {
+                    function ($res, $item) {
                         return $res + $item['time'];
                     },
                     0
                 ),
                 'total_memory' => array_reduce(
                     $perfs,
-                    function (&$res, $item) {
+                    function ($res, $item) {
                         return $res + $item['memory'];
                     },
                     0


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed profiler in PHP8.0 in migrated page : Removed call by reference for a callable for `array_reduce`
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28061
| How to test?      | Cf. #28061


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28103)
<!-- Reviewable:end -->
