### PR TITLE
[FO]: Out of stock label displayed even stock management disabled

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -625,7 +625,11 @@ class ProductLazyArray extends AbstractLazyArray
         if (!$settings->showLabelOOSListingPages) {
             return false;
         }
-
+        
+        if (!$this->configuration->getBoolean('PS_STOCK_MANAGEMENT')) {
+            return false;
+        }
+        
         // Displayed only if the order of out of stock product is denied.
         if ($product['out_of_stock'] == OutOfStockType::OUT_OF_STOCK_AVAILABLE
             || (

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -625,11 +625,11 @@ class ProductLazyArray extends AbstractLazyArray
         if (!$settings->showLabelOOSListingPages) {
             return false;
         }
-        
+
         if (!$this->configuration->getBoolean('PS_STOCK_MANAGEMENT')) {
             return false;
         }
-        
+
         // Displayed only if the order of out of stock product is denied.
         if ($product['out_of_stock'] == OutOfStockType::OUT_OF_STOCK_AVAILABLE
             || (


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop /1.7.8.5
| Description?      | out of stock" label displayed with stock management disabled
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28097 
| How to test?      | - Go to product configuration and disable stock management<br> - Go to Catalogue Stocks<br>- Put the stock of some product in 0 or a negative value for example, <br>- Go to FO and see the bug (the out of stock flag is displayed on the product page & category list page)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28110)
<!-- Reviewable:end -->
