### PR TITLE
Disable toggle switch 'show out of stock label' based on stock management

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
@@ -86,6 +86,7 @@ class StockManagementOptionHandler {
   */
   handleDisplayOutOfStockLabelOption(isStockManagementEnabled) {
     const displayLabelRadio = $('input[name="stock[oos_show_label_listing_pages]"]');
+
     if (isStockManagementEnabled) {
       displayLabelRadio.removeAttr('disabled');
     } else {

--- a/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-const {$} = window;
+const { $ } = window;
 
 class StockManagementOptionHandler {
   constructor() {
@@ -38,6 +38,7 @@ class StockManagementOptionHandler {
 
     this.handleAllowOrderingOutOfStockOption(isStockManagementEnabled);
     this.handleDisplayAvailableQuantitiesOption(isStockManagementEnabled);
+    this.handleDisplayOutOfStockLabelOption(isStockManagementEnabled);
   }
 
   /**
@@ -73,6 +74,23 @@ class StockManagementOptionHandler {
     } else {
       displayQuantitiesRadio.val([0]);
       displayQuantitiesRadio.attr('disabled', 'disabled');
+    }
+  }
+  /**
+  * If stock managament is disabled
+  * then 'Display out-of-stock label on product listing pages' option must be No and disabled
+  * otherwise it should be enabled
+  *
+  * @param {int} isStockManagementEnabled
+  */
+  handleDisplayOutOfStockLabelOption(isStockManagementEnabled) {
+    const displayLabelRadio = $('input[name="stock[oos_show_label_listing_pages]"]');
+    console.log(isStockManagementEnabled);
+    if (isStockManagementEnabled) {
+      displayLabelRadio.removeAttr('disabled');
+    } else {
+      displayLabelRadio.val([0]);
+      displayLabelRadio.attr('disabled', 'disabled');
     }
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-const { $ } = window;
+const {$} = window;
 
 class StockManagementOptionHandler {
   constructor() {
@@ -85,7 +85,6 @@ class StockManagementOptionHandler {
   */
   handleDisplayOutOfStockLabelOption(isStockManagementEnabled) {
     const displayLabelRadio = $('input[name="stock[oos_show_label_listing_pages]"]');
-    console.log(isStockManagementEnabled);
     if (isStockManagementEnabled) {
       displayLabelRadio.removeAttr('disabled');
     } else {

--- a/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
+++ b/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.js
@@ -76,6 +76,7 @@ class StockManagementOptionHandler {
       displayQuantitiesRadio.attr('disabled', 'disabled');
     }
   }
+
   /**
   * If stock managament is disabled
   * then 'Display out-of-stock label on product listing pages' option must be No and disabled


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  1.7.8.x
| Description?      | I think that if stock management is disabled, the "show out of stock label" option should not be able to be modified in the same way as the "allow sale of products that are out of stock" option does. check this issue : https://github.com/PrestaShop/PrestaShop/issues/28098
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #28098

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28123)
<!-- Reviewable:end -->