### PR TITLE
Integrate legacy classes autoloader to composer

### DIFF
--- a/.github/workflows/phpstan/autoload.php
+++ b/.github/workflows/phpstan/autoload.php
@@ -11,7 +11,6 @@ define('_PS_ADMIN_DIR_', _PS_ROOT_DIR_ . '/admin-dev/');
 define('PS_ADMIN_DIR', _PS_ADMIN_DIR_);
 
 require_once _PS_ROOT_DIR_ . '/config/defines.inc.php';
-require_once _PS_ROOT_DIR_ . '/config/autoload.php';
 require_once _PS_ROOT_DIR_ . '/config/bootstrap.php';
 require_once _PS_ROOT_DIR_ . '/install-dev/classes/exception.php';
 require_once _PS_ROOT_DIR_ . '/install-dev/classes/session.php';
@@ -151,27 +150,6 @@ foreach ($constantsToDefine as $key => $value) {
             default:
                 define($key, 'DUMMY_VALUE');
                 break;
-        }
-    }
-}
-
-/*
- * At this time if _PS_VERSION_ is still undefined, this is likely because
- * - we are on a old PrestaShop (below 1.7.0.0),
- * - the shop hasn't been installed yet.
- *
- * In that case, the constant can be set from another one in the installation folder.
- */
-if (!defined('_PS_VERSION_')) {
-    $legacyInstallationFileDefiningConstant = [
-        '/install-dev/install_version.php',
-        '/install/install_version.php',
-    ];
-    foreach ($legacyInstallationFileDefiningConstant as $file) {
-        if (file_exists(_PS_ROOT_DIR_ . $file)) {
-            require_once _PS_ROOT_DIR_ . $file;
-            define('_PS_VERSION_', _PS_INSTALL_VERSION_);
-            break;
         }
     }
 }

--- a/autoload.php
+++ b/autoload.php
@@ -28,5 +28,5 @@
  * Allow call of Legacy classes from classes in /src and /tests
  * @see composer.json "files" property for custom autoloading
  */
+require_once __DIR__.'/vendor/autoload.php';
 require_once __DIR__.'/config/defines.inc.php';
-require_once __DIR__.'/classes/PrestaShopAutoload.php';

--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -57,11 +57,11 @@ class PrestaShopAutoload
 
     protected function __construct()
     {
-        $this->root_dir = _PS_CORE_DIR_ . '/';
+        $this->root_dir = dirname(__DIR__);
         $file = static::getCacheFileIndex();
         $stubFile = static::getStubFileIndex();
         if (@filemtime($file) && is_readable($file) && @filemtime($stubFile) && is_readable($stubFile)) {
-            $this->index = include $file;
+            $this->index = require $file;
         } else {
             $this->generateIndex();
         }
@@ -82,13 +82,23 @@ class PrestaShopAutoload
     }
 
     /**
+     * Get cache directory.
+     *
+     * @return string
+     */
+    protected static function getCacheDir()
+    {
+        return dirname(__DIR__) . '/var/cache';
+    }
+
+    /**
      * Get Class index cache file.
      *
      * @return string
      */
     public static function getCacheFileIndex()
     {
-        return _PS_CACHE_DIR_ . 'class_index.php';
+        return static::getCacheDir() . '/class_index.php';
     }
 
     /**
@@ -98,7 +108,7 @@ class PrestaShopAutoload
      */
     public static function getNamespacedStubFileIndex()
     {
-        return _PS_CACHE_DIR_ . 'namespaced_class_stub.php';
+        return static::getCacheDir() . '/namespaced_class_stub.php';
     }
 
     /**
@@ -108,7 +118,7 @@ class PrestaShopAutoload
      */
     public static function getStubFileIndex()
     {
-        return _PS_CACHE_DIR_ . 'class_stub.php';
+        return static::getCacheDir() . '/class_stub.php';
     }
 
     /**
@@ -124,20 +134,17 @@ class PrestaShopAutoload
         }
 
         // regenerate the class index if the requested file doesn't exists
-        if ((isset($this->index[$className]) && $this->index[$className]['path'] && !is_file($this->root_dir . $this->index[$className]['path']))
-            || (isset($this->index[$className . 'Core']) && $this->index[$className . 'Core']['path'] && !is_file($this->root_dir . $this->index[$className . 'Core']['path']))
+        if ((isset($this->index[$className]) && $this->index[$className]['path'] && !is_file($this->root_dir . '/' . $this->index[$className]['path']))
+            || (isset($this->index[$className . 'Core']) && $this->index[$className . 'Core']['path'] && !is_file($this->root_dir . '/' . $this->index[$className . 'Core']['path']))
             || !file_exists(static::getNamespacedStubFileIndex())) {
             $this->generateIndex();
         }
 
         // If $classname has not core suffix (E.g. Shop, Product)
         if (substr($className, -4) != 'Core' && !class_exists($className, false)) {
-            $classDir = (isset($this->index[$className]['override'])
-                && $this->index[$className]['override'] === true) ? $this->normalizeDirectory(_PS_ROOT_DIR_) : $this->root_dir;
-
             // If requested class does not exist, load associated core class
             if (isset($this->index[$className]) && !$this->index[$className]['path']) {
-                require_once $classDir . $this->index[$className . 'Core']['path'];
+                require_once $this->root_dir . '/' . $this->index[$className . 'Core']['path'];
 
                 if ($this->index[$className . 'Core']['type'] != 'interface') {
                     eval($this->index[$className . 'Core']['type'] . ' ' . $className . ' extends ' . $className . 'Core {}');
@@ -145,16 +152,16 @@ class PrestaShopAutoload
             } else {
                 // request a non Core Class load the associated Core class if exists
                 if (isset($this->index[$className . 'Core'])) {
-                    require_once $this->root_dir . $this->index[$className . 'Core']['path'];
+                    require_once $this->root_dir . '/' . $this->index[$className . 'Core']['path'];
                 }
 
                 if (isset($this->index[$className])) {
-                    require_once $classDir . $this->index[$className]['path'];
+                    require_once $this->root_dir . '/' . $this->index[$className]['path'];
                 }
             }
         } elseif (isset($this->index[$className]['path']) && $this->index[$className]['path']) {
             // Call directly ProductCore, ShopCore class
-            require_once $this->root_dir . $this->index[$className]['path'];
+            require_once $this->root_dir . '/' . $this->index[$className]['path'];
         }
         if (strpos($className, 'PrestaShop\PrestaShop\Adapter\Entity') !== false) {
             require_once static::getNamespacedStubFileIndex();
@@ -175,11 +182,11 @@ class PrestaShopAutoload
             }
         }
 
-        $coreClasses = $this->getClassesFromDir('classes/');
+        $coreClasses = $this->getClassesFromDir('classes');
 
         $classes = array_merge(
             $coreClasses,
-            $this->getClassesFromDir('controllers/')
+            $this->getClassesFromDir('controllers')
         );
 
         $contentNamespacedStub = '<?php ' . "\n" . 'namespace PrestaShop\\PrestaShop\\Adapter\\Entity;' . "\n\n";
@@ -194,13 +201,13 @@ class PrestaShopAutoload
         }
 
         if ($this->_include_override_path) {
-            $coreOverrideClasses = $this->getClassesFromDir('override/classes/');
+            $coreOverrideClasses = $this->getClassesFromDir('override/classes');
             $coreClassesWOOverrides = array_diff_key($coreClasses, $coreOverrideClasses);
 
             $classes = array_merge(
                 $classes,
                 $coreOverrideClasses,
-                $this->getClassesFromDir('override/controllers/')
+                $this->getClassesFromDir('override/controllers')
             );
         } else {
             $coreClassesWOOverrides = $coreClasses;
@@ -222,7 +229,7 @@ class PrestaShopAutoload
 
         // Write classes index on disc to cache it
         $filename = static::getCacheFileIndex();
-        @mkdir(_PS_CACHE_DIR_, 0777, true);
+        @mkdir(static::getCacheDir(), 0777, true);
 
         if (!$this->dumpFile($filename, $content)) {
             Tools::error_log('Cannot write temporary file ' . $filename);
@@ -275,18 +282,17 @@ class PrestaShopAutoload
      */
     protected function getClassesFromDir($path)
     {
-        $rootDir = $this->root_dir;
-        if (!is_dir($rootDir . $path)) {
+        if (!is_dir($this->root_dir . '/' . $path)) {
             return [];
         }
 
         $classes = [];
-        foreach (scandir($rootDir . $path, SCANDIR_SORT_NONE) as $file) {
+        foreach (scandir($this->root_dir . '/' . $path, SCANDIR_SORT_NONE) as $file) {
             if ($file[0] != '.') {
-                if (is_dir($rootDir . $path . $file)) {
-                    $classes = array_merge($classes, $this->getClassesFromDir($path . $file . '/'));
+                if (is_dir($this->root_dir . '/' . $path . '/' . $file)) {
+                    $classes = array_merge($classes, $this->getClassesFromDir($path . '/' . $file));
                 } elseif (substr($file, -4) == '.php') {
-                    $content = file_get_contents($rootDir . $path . $file);
+                    $content = file_get_contents($this->root_dir . '/' . $path . '/' . $file);
 
                     $namePattern = '[a-z_\x7f-\xff][a-z0-9_\x7f-\xff]*';
                     $nameWithNsPattern = '(?:\\\\?(?:' . $namePattern . '\\\\)*' . $namePattern . ')';
@@ -305,7 +311,7 @@ class PrestaShopAutoload
 
                     if (!$usesNamespace && preg_match($pattern, $content, $m)) {
                         $classes[$m['classname']] = [
-                            'path' => $path . $file,
+                            'path' => $path . '/' . $file,
                             'type' => trim($m[1]),
                             'override' => false,
                         ];
@@ -333,18 +339,6 @@ class PrestaShopAutoload
     public function getClassPath($classname)
     {
         return (isset($this->index[$classname]['path'])) ? $this->index[$classname]['path'] : null;
-    }
-
-    /**
-     * Normalize directory.
-     *
-     * @param string $directory
-     *
-     * @return string
-     */
-    private function normalizeDirectory($directory)
-    {
-        return rtrim($directory, '/\\') . DIRECTORY_SEPARATOR;
     }
 }
 

--- a/composer.json
+++ b/composer.json
@@ -177,6 +177,9 @@
         "classmap": [
             "app/AppKernel.php",
             "app/AppCache.php"
+        ],
+        "files": [
+            "config/autoload.php"
         ]
     },
     "autoload-dev": {

--- a/config/autoload.php
+++ b/config/autoload.php
@@ -23,10 +23,15 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-require_once __DIR__.'/../vendor/autoload.php';
+
+// **************************************************************************************
+// * This file is included by composer vendor/autoload.php, do NOT include it manually. *
+// **************************************************************************************
+
+require_once __DIR__ . '/../classes/PrestaShopAutoload.php';
+spl_autoload_register([PrestaShopAutoload::getInstance(), 'load']);
+
+// Include some alias functions
+require_once __DIR__ . '/alias.php';
 
 define('_PS_VERSION_', AppKernel::VERSION);
-
-require_once _PS_CONFIG_DIR_.'alias.php';
-require_once _PS_CLASS_DIR_.'PrestaShopAutoload.php';
-spl_autoload_register(array(PrestaShopAutoload::getInstance(), 'load'));

--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -26,14 +26,14 @@
 
 use PrestaShop\PrestaShop\Core\Session\SessionHandler;
 
+require_once __DIR__ . '/../vendor/autoload.php';
+
 /* Custom defines made by users */
 if (is_file(__DIR__ . '/defines_custom.inc.php')) {
     include_once __DIR__ . '/defines_custom.inc.php';
 }
 
 require_once __DIR__ . '/defines.inc.php';
-
-require_once _PS_CONFIG_DIR_ . 'autoload.php';
 
 $start_time = microtime(true);
 
@@ -54,7 +54,7 @@ if (!file_exists(_PS_ROOT_DIR_ . '/app/config/parameters.yml') && !file_exists(_
     Tools::redirectToInstall();
 }
 
-require_once __DIR__ . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once __DIR__ . '/bootstrap.php';
 
 if (defined('_PS_CREATION_DATE_')) {
     $creationDate = _PS_CREATION_DATE_;

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -52,19 +52,17 @@ if (!defined('_PS_MODE_DEMO_')) {
     define('_PS_MODE_DEMO_', false);
 }
 
-$currentDir = dirname(__FILE__);
-
 if (!defined('_PS_ROOT_DIR_') && (getenv('_PS_ROOT_DIR_') || getenv('REDIRECT__PS_ROOT_DIR_'))) {
     define('_PS_ROOT_DIR_', getenv('_PS_ROOT_DIR_') ? getenv('_PS_ROOT_DIR_') : getenv('REDIRECT__PS_ROOT_DIR_'));
 }
 
 /* Directories */
 if (!defined('_PS_ROOT_DIR_')) {
-    define('_PS_ROOT_DIR_', realpath($currentDir.'/..'));
+    define('_PS_ROOT_DIR_', dirname(__DIR__));
 }
 
 if (!defined('_PS_CORE_DIR_')) {
-    define('_PS_CORE_DIR_', realpath($currentDir.'/..'));
+    define('_PS_CORE_DIR_', dirname(__DIR__));
 }
 
 define('_PS_ALL_THEMES_DIR_', _PS_ROOT_DIR_.'/themes/');

--- a/install-dev/index.php
+++ b/install-dev/index.php
@@ -36,12 +36,12 @@ if (
         __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'cache'
     )
 ) {
-    require_once dirname(__FILE__).'/missing_requirement.php';
+    require_once __DIR__.'/missing_requirement.php';
     exit();
 }
 /** @phpstan-ignore-next-line */
-require_once dirname(__FILE__).DIRECTORY_SEPARATOR.'init.php';
-require_once(__DIR__).DIRECTORY_SEPARATOR.'autoload.php';
+require_once __DIR__.DIRECTORY_SEPARATOR.'init.php';
+require_once __DIR__.DIRECTORY_SEPARATOR.'autoload.php';
 
 try {
     if (_PS_MODE_DEV_) {

--- a/install-dev/index_cli.php
+++ b/install-dev/index_cli.php
@@ -56,8 +56,8 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'classes/datas.php';
  */
 Datas::getInstance()->getAndCheckArgs($argv);
 
-require_once dirname(__FILE__).'/init.php';
-require_once(__DIR__).DIRECTORY_SEPARATOR.'autoload.php';
+require_once __DIR__.'/init.php';
+require_once __DIR__.DIRECTORY_SEPARATOR.'autoload.php';
 
 try {
     require_once _PS_INSTALL_PATH_.'classes/controllerConsole.php';

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -86,8 +86,8 @@ if ((!is_dir(_PS_CORE_DIR_.DIRECTORY_SEPARATOR.'vendor') ||
     die('Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
 }
 
+require_once _PS_CORE_DIR_.'/vendor/autoload.php';
 require_once _PS_CORE_DIR_.'/config/defines.inc.php';
-require_once _PS_CORE_DIR_.'/config/autoload.php';
 
 if (file_exists(_PS_CORE_DIR_.'/app/config/parameters.php')) {
     require_once _PS_CORE_DIR_.'/config/bootstrap.php';

--- a/tests-legacy/Endpoints/AbstractEndpointTest.php
+++ b/tests-legacy/Endpoints/AbstractEndpointTest.php
@@ -40,8 +40,8 @@ abstract class AbstractEndpointTest extends TestCase
     {
         define('_PS_ROOT_DIR_', __DIR__ . '/../..');
         define('_PS_ADMIN_DIR_', _PS_ROOT_DIR_ . '/admin-dev');
+        require_once _PS_ROOT_DIR_ . '/vendor/autoload.php';
         require_once _PS_ROOT_DIR_ . '/config/defines.inc.php';
-        require_once _PS_CONFIG_DIR_ . 'autoload.php';
         require_once _PS_CONFIG_DIR_ . 'bootstrap.php';
         $this->contextMocker = new ContextMocker();
         $this->contextMocker->mockContext();

--- a/tests/Integration/Classes/PrestaShopAutoloadTest.php
+++ b/tests/Integration/Classes/PrestaShopAutoloadTest.php
@@ -55,7 +55,7 @@ class PrestaShopAutoloadTest extends TestCase
     {
         $this->assertFileExists($this->file_index);
         $data = include $this->file_index;
-        $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
+        $this->assertSame('controllers/front/OrderController.php', $data['OrderControllerCore']['path']);
     }
 
     public function testLoad(): void
@@ -82,12 +82,12 @@ class PrestaShopAutoloadTest extends TestCase
         PrestaShopAutoload::getInstance()->generateIndex();
         $this->assertFileExists($this->file_index);
         $data = include $this->file_index;
-        $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
-        $this->assertEquals($data['Connection']['override'], false);
+        $this->assertSame('controllers/front/OrderController.php', $data['OrderControllerCore']['path']);
+        $this->assertFalse($data['Connection']['override']);
         Configuration::updateGlobalValue('PS_DISABLE_OVERRIDES', 0);
         PrestaShopAutoload::getInstance()->generateIndex();
         $data = include $this->file_index;
-        $this->assertEquals($data['Connection']['override'], false);
+        $this->assertFalse($data['Connection']['override']);
     }
 
     public function testClassFromCoreDirShouldntBeLoaded(): void

--- a/tests/Unit/Adapter/ToolsTest.php
+++ b/tests/Unit/Adapter/ToolsTest.php
@@ -49,7 +49,11 @@ class ToolsTest extends TestCase
      */
     public function testRefreshCaCertFile(): void
     {
-        @unlink(_PS_CACHE_CA_CERT_FILE_);
+        if (file_exists(dirname(_PS_CACHE_CA_CERT_FILE_))) {
+            @unlink(_PS_CACHE_CA_CERT_FILE_);
+        } else {
+            mkdir(dirname(_PS_CACHE_CA_CERT_FILE_));
+        }
         (new Tools())->refreshCaCertFile();
 
         // get original cacert.pem content and check it against cached version: _PS_CACHE_CA_CERT_FILE_

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -26,8 +26,8 @@
 define('_PS_IN_TEST_', true);
 define('_PS_ROOT_DIR_', __DIR__ . '/../..');
 define('_PS_MODULE_DIR_', _PS_ROOT_DIR_ . '/tests/Resources/modules/');
+require_once _PS_ROOT_DIR_ . '/vendor/autoload.php';
 require_once __DIR__ . '/../../config/defines.inc.php';
-require_once _PS_CONFIG_DIR_ . 'autoload.php';
 
 if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
     define('PHPUNIT_COMPOSER_INSTALL', __DIR__ . '/../../vendor/autoload.php');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Integrate legacy classes autoloader to composer. This PR simplifies the autoloading and allows the developer to use legacy classes out of the box by just including the standard composer `vendor/autoload.php` file. Example below.
| Type?             |  improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| Related PRs       | refactoring from https://github.com/PrestaShop/PrestaShop/pull/28121 must be merged first
| How to test?      | tests must pass
| Possible impacts? | no

Example usage of legacy class that can be now used out of the box by simply including the vendor autoloader file:

```
<?php

require_once __DIR__ . '/vendor/autoload.php';

var_dump(\Tools::passwdGen());
var_dump(_PS_VERSION_);
```

Thanks to this PR, PrestaShop classes can now be used also in an another project by just including PrestaShop (`prestashop/prestashop`) as a composer dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28129)
<!-- Reviewable:end -->
