### PR TITLE
Remove ModuleZipManager service as class is missing

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -38,13 +38,6 @@ services:
     tags:
       - { name: kernel.event_subscriber }
 
-  prestashop.module.zip.manager:
-    class: PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager
-    arguments:
-      - "@filesystem"
-      - "@translator"
-      - "@event_dispatcher"
-
   prestashop.adapter.presenter.module:
     class: PrestaShop\PrestaShop\Adapter\Presenter\Module\ModulePresenter
     arguments: [ "@=service('prestashop.adapter.legacy.context').getContext().currency", "@prestashop.adapter.formatter.price" ]


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The service `prestashop.module.zip.manager` points `PrestaShop\PrestaShop\Adapter\Module\ModuleZipManager` which does not exist anymore
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #28133
| Related PRs       | https://github.com/PrestaShopCorp/ps_mbo/pull/155


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28132)
<!-- Reviewable:end -->
