### PR TITLE
Add breadcrumbs for categories with identical names

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -164,8 +164,8 @@ export default class CategoriesManager {
     $(`#${this.defaultCategoryInput.id}`).on('change', (e) => {
       const {currentTarget} = e;
 
-      if (!(currentTarget instanceof HTMLInputElement)) {
-        console.error('currentTarget expected to be HTMLInputElement');
+      if (!(currentTarget instanceof HTMLSelectElement)) {
+        console.error('currentTarget expected to be HTMLSelectElement');
 
         return;
       }

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -131,12 +131,11 @@ export default class CategoriesManager {
   }
 
   private listenDefaultCategorySelect(): void {
-    this.defaultCategoryInput.addEventListener('change', (e) => {
+    $(`#${this.defaultCategoryInput.id}`).on('change', (e) => {
       const currentTarget = e.currentTarget as HTMLInputElement;
       const newDefaultCategoryId = Number(currentTarget.value);
       const categories = this.collectCategories()
         .map((category) => ({...category, isDefault: category.id === newDefaultCategoryId}));
-
       this.tagsRenderer.render(categories, this.getDefaultCategoryId());
     });
   }

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -123,7 +123,7 @@ export default class CategoriesManager {
     categories.forEach((category) => {
       const optionElement = document.createElement('option');
       optionElement.value = String(category.id);
-      optionElement.innerHTML = category.name;
+      optionElement.innerHTML = category.displayName;
       optionElement.selected = category.id === defaultCategoryId;
 
       selectElement.append(optionElement);

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -85,6 +85,8 @@ export default class CategoriesManager {
         categories.push({
           id: Number(idInput.value),
           name: this.extractCategoryName(tag as HTMLElement),
+          breadcrumb: this.extractCategoryBreadcrumb(tag as HTMLElement),
+          preview: this.extractCategoryPreview(tag as HTMLElement),
         });
       }
     });
@@ -92,8 +94,28 @@ export default class CategoriesManager {
     return categories;
   }
 
+  private extractCategoryPreview(tag: HTMLElement): string {
+    const tagPreviewElement = tag.querySelector(ProductCategoryMap.categoryNamePreview) as HTMLElement;
+
+    if (tagPreviewElement) {
+      return tagPreviewElement.innerText;
+    }
+
+    return '';
+  }
+
   private extractCategoryName(tag: HTMLElement): string {
-    const tagNameElement = tag.querySelector(ProductCategoryMap.categoryNamePreview) as HTMLElement;
+    const tagNameInput = tag.querySelector(ProductCategoryMap.categoryNameInput) as HTMLInputElement;
+
+    if (tagNameInput) {
+      return tagNameInput.value;
+    }
+
+    return '';
+  }
+
+  private extractCategoryBreadcrumb(tag: HTMLElement): string {
+    const tagNameElement = tag.querySelector('.category-breadcrumb') as HTMLElement;
 
     if (tagNameElement) {
       return tagNameElement.innerText;

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -85,8 +85,7 @@ export default class CategoriesManager {
         categories.push({
           id: Number(idInput.value),
           name: this.extractCategoryName(tag as HTMLElement),
-          breadcrumb: this.extractCategoryBreadcrumb(tag as HTMLElement),
-          preview: this.extractCategoryPreview(tag as HTMLElement),
+          displayName: this.extractCategoryPreview(tag as HTMLElement),
         });
       }
     });
@@ -109,16 +108,6 @@ export default class CategoriesManager {
 
     if (tagNameInput) {
       return tagNameInput.value;
-    }
-
-    return '';
-  }
-
-  private extractCategoryBreadcrumb(tag: HTMLElement): string {
-    const tagNameElement = tag.querySelector('.category-breadcrumb') as HTMLElement;
-
-    if (tagNameElement) {
-      return tagNameElement.innerText;
     }
 
     return '';

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -47,10 +47,24 @@ export default class CategoriesManager {
   constructor(eventEmitter: EventEmitter) {
     this.eventEmitter = eventEmitter;
     this.categoryTreeSelector = new CategoryTreeSelector(eventEmitter);
-    this.categoriesContainer = document.querySelector(ProductCategoryMap.categoriesContainer) as HTMLElement;
-    this.addCategoriesBtn = this.categoriesContainer.querySelector(ProductCategoryMap.addCategoriesBtn) as HTMLElement;
-    this.defaultCategoryInput = this.categoriesContainer
-      .querySelector(ProductCategoryMap.defaultCategorySelectInput) as HTMLInputElement;
+    const categoriesContainer = document.querySelector<HTMLElement>(ProductCategoryMap.categoriesContainer);
+
+    if (!categoriesContainer) {
+      throw new Error(`Failed to find essential element to run categories manager: ${ProductCategoryMap.categoriesContainer}.`);
+    }
+    this.categoriesContainer = categoriesContainer;
+
+    const addCategoriesBtn = this.categoriesContainer.querySelector<HTMLElement>(ProductCategoryMap.addCategoriesBtn);
+    const defaultCategoryInput = this.categoriesContainer
+      .querySelector<HTMLInputElement>(ProductCategoryMap.defaultCategorySelectInput);
+
+    if (!addCategoriesBtn || !defaultCategoryInput) {
+      throw new Error('Failed to find some essential elements to run categories manager.');
+    }
+
+    this.addCategoriesBtn = addCategoriesBtn;
+    this.defaultCategoryInput = defaultCategoryInput;
+
     this.tagsRenderer = new TagsRenderer(
       eventEmitter,
       `${ProductCategoryMap.categoriesContainer} ${ProductCategoryMap.tagsContainer}`,
@@ -74,19 +88,28 @@ export default class CategoriesManager {
 
   private collectCategories(): Array<Category> {
     // these are at first rendered on page load and later updated dynamically
-    const tagsContainer = this.categoriesContainer.querySelector(ProductCategoryMap.tagsContainer) as HTMLElement;
+    const tagsContainer = this.categoriesContainer.querySelector<HTMLElement>(ProductCategoryMap.tagsContainer);
+
+    if (!tagsContainer) {
+      throw new Error(`Essential element was not found for categories manager: ${ProductCategoryMap.tagsContainer}`);
+    }
+
     const tags = tagsContainer.querySelectorAll(ProductCategoryMap.tagItem);
     const categories: Array<Category> = [];
 
     tags.forEach((tag: Element) => {
       if (tag instanceof HTMLElement) {
-        const idInput = tag.querySelector(ProductCategoryMap.tagCategoryIdInput) as HTMLInputElement;
+        const idInput = tag.querySelector<HTMLInputElement>(ProductCategoryMap.tagCategoryIdInput);
 
-        categories.push({
-          id: Number(idInput.value),
-          name: this.extractCategoryName(tag as HTMLElement),
-          displayName: this.extractCategoryPreview(tag as HTMLElement),
-        });
+        if (idInput instanceof HTMLInputElement) {
+          categories.push({
+            id: Number(idInput.value),
+            name: this.extractCategoryName(tag),
+            displayName: this.extractCategoryPreview(tag),
+          });
+        } else {
+          console.error(`Element ${ProductCategoryMap.tagCategoryIdInput} expected to be HTMLInputElement`);
+        }
       }
     });
 
@@ -94,7 +117,7 @@ export default class CategoriesManager {
   }
 
   private extractCategoryPreview(tag: HTMLElement): string {
-    const tagPreviewElement = tag.querySelector(ProductCategoryMap.categoryNamePreview) as HTMLElement;
+    const tagPreviewElement = tag.querySelector<HTMLElement>(ProductCategoryMap.categoryNamePreview);
 
     if (tagPreviewElement) {
       return tagPreviewElement.innerText;
@@ -104,7 +127,7 @@ export default class CategoriesManager {
   }
 
   private extractCategoryName(tag: HTMLElement): string {
-    const tagNameInput = tag.querySelector(ProductCategoryMap.categoryNameInput) as HTMLInputElement;
+    const tagNameInput = tag.querySelector<HTMLInputElement>(ProductCategoryMap.categoryNameInput);
 
     if (tagNameInput) {
       return tagNameInput.value;
@@ -116,7 +139,14 @@ export default class CategoriesManager {
   private renderDefaultCategorySelection(): void {
     const categories = this.collectCategories();
 
-    const selectElement = this.categoriesContainer.querySelector(ProductCategoryMap.defaultCategorySelectInput) as HTMLElement;
+    const selectElement = this.categoriesContainer.querySelector<HTMLElement>(ProductCategoryMap.defaultCategorySelectInput);
+
+    if (!selectElement) {
+      console.error(`${ProductCategoryMap.defaultCategorySelectInput} element was not found.`);
+
+      return;
+    }
+
     const defaultCategoryId = this.getDefaultCategoryId();
     selectElement.innerHTML = '';
 
@@ -132,7 +162,14 @@ export default class CategoriesManager {
 
   private listenDefaultCategorySelect(): void {
     $(`#${this.defaultCategoryInput.id}`).on('change', (e) => {
-      const currentTarget = e.currentTarget as HTMLInputElement;
+      const {currentTarget} = e;
+
+      if (!(currentTarget instanceof HTMLInputElement)) {
+        console.error('currentTarget expected to be HTMLInputElement');
+
+        return;
+      }
+
       const newDefaultCategoryId = Number(currentTarget.value);
       const categories = this.collectCategories()
         .map((category) => ({...category, isDefault: category.id === newDefaultCategoryId}));

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -341,14 +341,10 @@ export default class CategoryTreeSelector {
       const searchedCategory = this.searchCategoryInTree(categoryId, this.treeCategories);
 
       if (searchedCategory) {
-        const sameNameExists = this.selectedCategories.find(
-          (selectedCategory) => searchedCategory.name === selectedCategory.name);
-
         categories.push({
           id: searchedCategory.id,
           name: searchedCategory.name,
-          preview: sameNameExists ? searchedCategory.breadcrumb : searchedCategory.name,
-          breadcrumb: searchedCategory.breadcrumb,
+          displayName: searchedCategory.displayName,
         });
       }
     });

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -146,7 +146,7 @@ export default class CategoryTreeSelector {
     }
 
     this.treeCategories.forEach((treeCategory) => {
-      const treeCategoryElement = this.generateCategoryTree(treeCategory);
+      const treeCategoryElement = this.generateCategoryTree(treeCategory, null);
       categoryTree.append(treeCategoryElement);
     });
 
@@ -192,15 +192,33 @@ export default class CategoryTreeSelector {
   /**
    * Used to recursively create items of the category tree
    */
-  private generateCategoryTree(treeCategory: TreeCategory): HTMLElement {
+  private generateCategoryTree(treeCategory: TreeCategory, parentNode: HTMLElement|null): HTMLElement {
     const categoryNode = this.generateTreeElement(treeCategory) as HTMLElement;
     const childrenList = categoryNode.querySelector(ProductCategoryMap.childrenList) as HTMLElement;
-
     const hasChildren = treeCategory.children && treeCategory.children.length > 0;
+    const parentInput = parentNode?.querySelector<HTMLInputElement>(ProductCategoryMap.treeCheckboxInput);
+
+    //@todo: check if needed. WIP - commiting progress
+    // // Show child list only if parent is checked
+    // childrenList.classList.toggle(
+    //   'd-none',
+    //   hasChildren && !parentInput?.checked,
+    // );
+
+    const checkboxInput = categoryNode.querySelector<HTMLInputElement>(ProductCategoryMap.treeCheckboxInput);
+
+    if (!checkboxInput) {
+      // checkbox input is mandatory. If there is none, it's something fatally wrong already. Returning empty HTML to respect return type.
+      // eslint-disable-next-line no-throw-literal
+      throw 'Checkbox input not found in category tree. It is mandatory detail for category tree to work.';
+    }
+
+    // force show parent checkbox tree if at least one of childs are checked
+    parentInput?.classList.toggle('d-none', !checkboxInput.checked);
+
     categoryNode.classList.toggle('more', hasChildren);
     if (hasChildren) {
       const inputsContainer = categoryNode.querySelector(ProductCategoryMap.treeElementInputs) as HTMLElement;
-      const checkboxInput = inputsContainer.querySelector(ProductCategoryMap.treeCheckboxInput) as HTMLInputElement;
       checkboxInput.value = String(treeCategory.id);
 
       inputsContainer.addEventListener('click', (event) => {
@@ -218,7 +236,7 @@ export default class CategoryTreeSelector {
 
       // Recursively build the children trees
       treeCategory.children.forEach((childCategory) => {
-        const childTree = this.generateCategoryTree(childCategory);
+        const childTree = this.generateCategoryTree(childCategory, checkboxInput);
 
         childrenList.append(childTree);
       });

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -341,9 +341,14 @@ export default class CategoryTreeSelector {
       const searchedCategory = this.searchCategoryInTree(categoryId, this.treeCategories);
 
       if (searchedCategory) {
+        const sameNameExists = this.selectedCategories.find(
+          (selectedCategory) => searchedCategory.name === selectedCategory.name);
+
         categories.push({
           id: searchedCategory.id,
           name: searchedCategory.name,
+          preview: sameNameExists ? searchedCategory.breadcrumb : searchedCategory.name,
+          breadcrumb: searchedCategory.breadcrumb,
         });
       }
     });

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -71,7 +71,7 @@ export default class CategoryTreeSelector {
 
   public showModal(selectedCategories: Array<Category>, defaultCategoryId: number): void {
     if (!defaultCategoryId) {
-      console.error('Default category id is invalid');
+      console.error('Default category id is invalid.');
 
       return;
     }
@@ -102,8 +102,14 @@ export default class CategoryTreeSelector {
   }
 
   private async initModal(): Promise<void> {
-    this.modalContentContainer = document.querySelector(ProductCategoryMap.modalContentContainer) as HTMLElement;
-    this.categoryTree = this.modalContentContainer.querySelector(ProductCategoryMap.categoryTree) as HTMLElement;
+    const modalContentContainer = document.querySelector<HTMLElement>(ProductCategoryMap.modalContentContainer);
+
+    if (!modalContentContainer) {
+      throw new Error(`Essential element ${ProductCategoryMap.modalContentContainer} was not found.`);
+    }
+
+    this.modalContentContainer = modalContentContainer;
+    this.categoryTree = this.modalContentContainer.querySelector<HTMLElement>(ProductCategoryMap.categoryTree);
     this.tagsRenderer = new TagsRenderer(
       this.eventEmitter,
       `${ProductCategoryMap.modalContentContainer} ${ProductCategoryMap.tagsContainer}`,
@@ -125,9 +131,9 @@ export default class CategoryTreeSelector {
       return;
     }
 
-    const applyBtn = this.modalContentContainer.querySelector(ProductCategoryMap.applyCategoriesBtn) as HTMLElement;
+    const applyBtn = this.modalContentContainer.querySelector<HTMLElement>(ProductCategoryMap.applyCategoriesBtn);
 
-    applyBtn.addEventListener('click', () => {
+    applyBtn?.addEventListener('click', () => {
       this.eventEmitter.emit(ProductEventMap.categories.applyCategoryTreeChanges, {
         categories: this.selectedCategories,
       });
@@ -140,15 +146,15 @@ export default class CategoryTreeSelector {
       return;
     }
 
-    const cancelBtn = this.modalContentContainer.querySelector(ProductCategoryMap.cancelCategoriesBtn) as HTMLElement;
-    cancelBtn.addEventListener('click', () => this.closeModal());
+    const cancelBtn = this.modalContentContainer.querySelector<HTMLElement>(ProductCategoryMap.cancelCategoriesBtn);
+    cancelBtn?.addEventListener('click', () => this.closeModal());
   }
 
   private initTree(): void {
     const {categoryTree} = this;
 
     if (!(categoryTree instanceof HTMLElement)) {
-      console.error('Category tree is not valid HTMLElement');
+      console.error('Category tree is not valid HTMLElement.');
 
       return;
     }
@@ -174,7 +180,13 @@ export default class CategoryTreeSelector {
         }
 
         checkbox.addEventListener('change', (e) => {
-          const currentTarget = e.currentTarget as HTMLInputElement;
+          const {currentTarget} = e;
+
+          if (!(currentTarget instanceof HTMLInputElement)) {
+            console.error('currentTarget expected to be HTMLInputElement.');
+
+            return;
+          }
 
           // do not allow unchecking main category id
           if (Number(currentTarget.value) === this.defaultCategoryId && !currentTarget.checked) {
@@ -189,11 +201,11 @@ export default class CategoryTreeSelector {
     }, this);
     // Tree is initialized we can show it and hide loader
     if (this.modalContentContainer) {
-      const fieldset = this.modalContentContainer.querySelector(ProductCategoryMap.fieldset) as HTMLElement;
-      const loader = this.modalContentContainer.querySelector(ProductCategoryMap.loader) as HTMLElement;
+      const fieldset = this.modalContentContainer.querySelector<HTMLElement>(ProductCategoryMap.fieldset);
+      const loader = this.modalContentContainer.querySelector<HTMLElement>(ProductCategoryMap.loader);
 
-      fieldset.classList.remove('d-none');
-      loader.classList.add('d-none');
+      fieldset?.classList.remove('d-none');
+      loader?.classList.add('d-none');
     }
   }
 
@@ -201,8 +213,8 @@ export default class CategoryTreeSelector {
    * Used to recursively create items of the category tree
    */
   private generateCategoryTree(treeCategory: TreeCategory): HTMLElement {
-    const categoryNode = this.generateTreeElement(treeCategory) as HTMLElement;
-    const childrenList = categoryNode.querySelector(ProductCategoryMap.childrenList) as HTMLElement;
+    const categoryNode = this.generateTreeElement(treeCategory);
+    const childrenList = categoryNode.querySelector<HTMLElement>(ProductCategoryMap.childrenList);
     const hasChildren = treeCategory.children && treeCategory.children.length > 0;
 
     const checkboxInput = categoryNode.querySelector<HTMLInputElement>(ProductCategoryMap.treeCheckboxInput);
@@ -218,20 +230,20 @@ export default class CategoryTreeSelector {
     categoryNode.classList.toggle('more', hasChildren);
 
     if (hasChildren) {
-      const inputsContainer = categoryNode.querySelector(ProductCategoryMap.treeElementInputs) as HTMLElement;
+      const inputsContainer = categoryNode.querySelector<HTMLElement>(ProductCategoryMap.treeElementInputs);
       checkboxInput.value = String(treeCategory.id);
 
-      inputsContainer.addEventListener('click', (event) => {
+      inputsContainer?.addEventListener('click', (event) => {
         // We don't want to mess with the inputs behaviour (no toggle when checkbox or radio is clicked)
         // So we only toggle when the div itself is clicked.
         if (event.target !== event.currentTarget) {
           return;
         }
 
-        const isExpanded = !childrenList.classList.contains('d-none');
+        const isExpanded = !childrenList?.classList.contains('d-none');
         categoryNode.classList.toggle('less', !isExpanded);
         categoryNode.classList.toggle('more', isExpanded);
-        childrenList.classList.toggle('d-none', isExpanded);
+        childrenList?.classList.toggle('d-none', isExpanded);
       });
 
       // Recursively build the children trees
@@ -239,16 +251,17 @@ export default class CategoryTreeSelector {
       treeCategory.children.forEach((childCategory) => {
         const childTree = this.generateCategoryTree(childCategory);
 
-        childrenList.append(childTree);
+        childrenList?.append(childTree);
 
         // check if at least one child is selected in child categories tree. Do not perform the check if at least one is found already
         if (!containsSelectedChild) {
-          containsSelectedChild = this.selectedCategories.some((selectedCategory: Category) => selectedCategory.id === childCategory.id);
+          containsSelectedChild = this.selectedCategories
+            .some((selectedCategory: Category) => selectedCategory.id === childCategory.id);
         }
       });
 
       // Expanding trees which contains at least one selected category or its parent category is selected
-      childrenList.classList.toggle('d-none', !(isSelected || containsSelectedChild));
+      childrenList?.classList.toggle('d-none', !(isSelected || containsSelectedChild));
     }
 
     return categoryNode;
@@ -266,15 +279,28 @@ export default class CategoryTreeSelector {
     const categoryNode = frag.firstChild as HTMLElement;
 
     // Add category name text
-    const checkboxInput = categoryNode.querySelector(ProductCategoryMap.checkboxInput) as HTMLInputElement;
+    const checkboxInput = categoryNode.querySelector<HTMLInputElement>(ProductCategoryMap.checkboxInput);
+
+    if (!checkboxInput) {
+      console.error(`Element ${ProductCategoryMap.checkboxInput} was not found.`);
+
+      return categoryNode;
+    }
+
     checkboxInput.value = String(category.id);
 
     const nameElement = document.createTextNode(category.name);
     const element = category.active
       ? nameElement
-      : document.createElement('i').appendChild(nameElement).parentNode as HTMLElement;
+      : document.createElement('i').appendChild(nameElement).parentNode;
 
-    (checkboxInput.parentNode as HTMLElement).insertBefore(element, checkboxInput);
+    if (!(element instanceof HTMLElement && checkboxInput.parentNode instanceof HTMLElement)) {
+      console.error('Unexpected element type. Expected HTMLElement.');
+
+      return categoryNode;
+    }
+
+    (checkboxInput.parentNode).insertBefore(element, checkboxInput);
 
     return categoryNode;
   }
@@ -284,20 +310,19 @@ export default class CategoryTreeSelector {
    */
   private updateCategory(categoryId: number, check: boolean): void {
     const treeElement = this.categoryTree as HTMLElement;
-    const checkbox = treeElement.querySelector(ProductCategoryMap.inputByValue(categoryId)) as HTMLInputElement;
-    checkbox.checked = check;
-    this.openCategoryParents(checkbox);
-    this.updateSelectedCategories();
+    const checkbox = treeElement.querySelector<HTMLInputElement>(ProductCategoryMap.inputByValue(categoryId));
+
+    if (checkbox) {
+      checkbox.checked = check;
+      this.openCategoryParents(checkbox);
+      this.updateSelectedCategories();
+    } else {
+      console.error(`Checkbox ${ProductCategoryMap.inputByValue(categoryId)} was not found`);
+    }
   }
 
   private openCategoryParents(checkbox: HTMLInputElement): void {
-    // This is the element containing the checkbox
-    let parentItem = checkbox.closest(ProductCategoryMap.treeElement);
-
-    if (parentItem) {
-      // This is the first (potential) parent element
-      parentItem = (parentItem.parentNode as HTMLElement).closest(ProductCategoryMap.treeElement);
-    }
+    let parentItem = this.findParentTreeElement(checkbox);
 
     while (this.categoryTree && parentItem !== null && this.categoryTree.contains(parentItem)) {
       const childrenList = parentItem.querySelector(ProductCategoryMap.childrenList);
@@ -308,8 +333,24 @@ export default class CategoryTreeSelector {
         childrenList.classList.remove('d-none');
       }
 
-      parentItem = (parentItem.parentNode as HTMLElement).closest(ProductCategoryMap.treeElement);
+      parentItem = this.findParentTreeElement(parentItem);
     }
+  }
+
+  private findParentTreeElement(element: HTMLElement): HTMLElement|null {
+    // This is the element containing the checkbox
+    let parentItem = element.closest(ProductCategoryMap.treeElement);
+
+    if (parentItem && parentItem.parentNode instanceof HTMLElement) {
+      // This is the first (potential) parent element
+      parentItem = parentItem.parentNode.closest(ProductCategoryMap.treeElement);
+    }
+
+    if (!(parentItem instanceof HTMLElement)) {
+      return null;
+    }
+
+    return parentItem;
   }
 
   private initTypeaheadData(

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -294,7 +294,13 @@ export default class CategoryTreeSelector {
       ? nameElement
       : document.createElement('i').appendChild(nameElement).parentNode;
 
-    if (!(element instanceof HTMLElement && checkboxInput.parentNode instanceof HTMLElement)) {
+    if (!(element instanceof HTMLElement || element instanceof Text)) {
+      console.error('Unexpected element type. Expected HTMLElement or Text.');
+
+      return categoryNode;
+    }
+
+    if (!(checkboxInput.parentNode instanceof HTMLElement)) {
       console.error('Unexpected element type. Expected HTMLElement.');
 
       return categoryNode;

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
@@ -48,7 +48,6 @@ export default class TagsRenderer {
 
   public render(categories: Array<Category>, defaultCategoryId: number): void {
     this.container.innerHTML = '';
-
     const tagTemplate = this.container.dataset.prototype;
     const {prototypeName} = this.container.dataset;
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
@@ -69,8 +69,8 @@ export default class TagsRenderer {
 
         const tagRemoveBtn = frag.querySelector(ProductCategoryMap.tagRemoveBtn) as HTMLElement;
 
-        if (category.id === defaultCategoryId) {
-          // don't show the tag removal element for main category
+        // don't show the tag removal element for main category or when it is the last category
+        if (category.id === defaultCategoryId || categories.length === 1) {
           tagRemoveBtn.classList.add('d-none');
         } else {
           tagRemoveBtn.classList.remove('d-none');

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
@@ -79,7 +79,7 @@ export default class TagsRenderer {
         const namePreviewElement = frag.querySelector(ProductCategoryMap.categoryNamePreview);
 
         if (namePreviewElement) {
-          namePreviewElement.innerHTML = category.name;
+          namePreviewElement.innerHTML = category.displayName;
 
           const nameInput = frag.querySelector(ProductCategoryMap.categoryNameInput) as HTMLInputElement;
           nameInput.value = category.name;

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
@@ -81,8 +81,17 @@ export default class TagsRenderer {
         if (namePreviewElement) {
           namePreviewElement.innerHTML = category.displayName;
 
-          const nameInput = frag.querySelector(ProductCategoryMap.categoryNameInput) as HTMLInputElement;
+          const nameInput = frag.querySelector<HTMLInputElement>(ProductCategoryMap.categoryNameInput)!;
+          const namePreviewInput = frag.querySelector<HTMLInputElement>(ProductCategoryMap.namePreviewInput)!;
+
+          if (!nameInput || !namePreviewInput) {
+            // eslint-disable-next-line max-len
+            console.error(`Missing ${ProductCategoryMap.categoryNameInput} or ${ProductCategoryMap.namePreviewInput} preview input`);
+            return;
+          }
+
           nameInput.value = category.name;
+          namePreviewInput.value = category.displayName;
         }
 
         this.container.append(frag);

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/types/index.d.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/types/index.d.ts
@@ -4,12 +4,6 @@ type Category = {
   displayName: string,
 }
 
-type TypeaheadCategory = {
-  id: number,
-  name: string,
-  breadcrumb: string,
-}
-
 type TreeCategory = {
   id: number,
   name: string,

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/types/index.d.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/types/index.d.ts
@@ -1,8 +1,7 @@
 type Category = {
   id: number,
   name: string,
-  preview: string,
-  breadcrumb: string
+  displayName: string,
 }
 
 type TypeaheadCategory = {
@@ -14,7 +13,7 @@ type TypeaheadCategory = {
 type TreeCategory = {
   id: number,
   name: string,
+  displayName: string,
   active: boolean,
-  breadcrumb: string,
   children: Array<TreeCategory>,
 }

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/types/index.d.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/types/index.d.ts
@@ -1,6 +1,8 @@
 type Category = {
   id: number,
   name: string,
+  preview: string,
+  breadcrumb: string
 }
 
 type TypeaheadCategory = {
@@ -13,5 +15,6 @@ type TreeCategory = {
   id: number,
   name: string,
   active: boolean,
+  breadcrumb: string,
   children: Array<TreeCategory>,
 }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
@@ -88,7 +88,15 @@ $(() => {
 
   // Product type has strong impact on the page rendering so when it is modified it must be submitted right away
   new ProductTypeSwitcher($productForm);
-  new CategoriesManager(eventEmitter);
+
+  // try-catch block prevents javascript termination when error is thrown.
+  // So only the related component won't work instead of breaking whole product page
+  try {
+    new CategoriesManager(eventEmitter);
+  } catch (e: any) {
+    console.error('Failed to initialize categories manager');
+  }
+
   new ProductFooterManager();
   new ProductModulesManager();
   new RelatedProductsManager(eventEmitter);

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -271,6 +271,8 @@ export default {
     tagCategoryIdInput: '.category-id-input',
     tagItem: '.tag-item',
     categoryNamePreview: '.category-name-preview',
+    // eslint-disable-next-line max-len
+    namePreviewInput: '.category-name-preview-input',
     categoryNameInput: '.category-name-input',
     searchInput: '#ps-select-product-category',
     fieldset: '.tree-fieldset',

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1396,6 +1396,15 @@ class CategoryCore extends ObjectModel
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public static function resetStaticCache()
+    {
+        parent::resetStaticCache();
+        Cache::clean('Category::*');
+    }
+
+    /**
      * Light back office search for categories.
      *
      * @param int $idLang Language ID

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1398,7 +1398,7 @@ class CategoryCore extends ObjectModel
     /**
      * {@inheritdoc}
      */
-    public static function resetStaticCache()
+    public static function resetStaticCache(): void
     {
         parent::resetStaticCache();
         Cache::clean('Category::*');

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -253,6 +253,10 @@ class CategoryCore extends ObjectModel
             $changed = true;
         }
 
+        if (Category::getParentId($this->id) !== (int) $this->id_parent) {
+            $changed = true;
+        }
+
         // If the parent category was changed, we don't want to have 2 categories with the same position
         if (!isset($changed)) {
             $changed = $this->getDuplicatePosition();
@@ -632,6 +636,26 @@ class CategoryCore extends ObjectModel
         }
 
         return $categories;
+    }
+
+    /**
+     * @param int $categoryId
+     *
+     * @return int
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    public static function getParentId(int $categoryId): int
+    {
+        $query = (new DbQuery())
+            ->select('id_parent')
+            ->from('category')
+            ->where('id_category = ' . $categoryId)
+        ;
+
+        $id = Db::getInstance()->getValue($query);
+
+        return (int) $id;
     }
 
     /**

--- a/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
@@ -119,7 +119,7 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
                 );
             }
 
-            $displayName = $this->displayNameBuilder->build(
+            $displayName = $this->displayNameBuilder->buildWithBreadcrumbs(
                 new CategoryId($categoryId),
                 $categoryName,
                 $shopId,

--- a/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
@@ -69,17 +69,24 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
      *
      * @return CategoryForTree[]
      */
-    private function buildCategoriesTree(array $categories, int $langId, array $breadcrumbs = []): array
+    private function buildCategoriesTree(array $categories, int $langId, array $parents = []): array
     {
         $categoriesTree = [];
         foreach ($categories as $category) {
             $categoryId = (int) $category['id_category'];
             $categoryActive = (bool) $category['active'];
             $categoryChildren = [];
+
+            $breadcrumbs = [];
+            foreach ($parents as $parent) {
+                $breadcrumbs[] = $parent['name'];
+            }
             $breadcrumbs[] = $category['name'];
 
             if (!empty($category['children'])) {
-                $categoryChildren = $this->buildCategoriesTree($category['children'], $langId, $breadcrumbs);
+                $parentCategories = $parents;
+                $parentCategories[] = $category;
+                $categoryChildren = $this->buildCategoriesTree($category['children'], $langId, $parentCategories);
             }
 
             $categoriesTree[] = new CategoryForTree(

--- a/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Category\NameBuilder\CategoryDisplayNameBuilder;
 use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree;
 use PrestaShop\PrestaShop\Core\Domain\Category\QueryHandler\GetCategoriesTreeHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\CategoryForTree;
-use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
@@ -120,7 +119,6 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
             }
 
             $displayName = $this->displayNameBuilder->buildWithBreadcrumbs(
-                new CategoryId($categoryId),
                 $categoryName,
                 $shopId,
                 $langId,

--- a/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
+++ b/src/Adapter/Category/QueryHandler/GetCategoriesTreeHandler.php
@@ -65,19 +65,21 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
     /**
      * @param array<string, array<string, mixed>> $categories
      * @param int $langId
+     * @param array<string, mixed> $breadcrumbs
      *
      * @return CategoryForTree[]
      */
-    private function buildCategoriesTree(array $categories, int $langId): array
+    private function buildCategoriesTree(array $categories, int $langId, array $breadcrumbs = []): array
     {
         $categoriesTree = [];
         foreach ($categories as $category) {
             $categoryId = (int) $category['id_category'];
             $categoryActive = (bool) $category['active'];
             $categoryChildren = [];
+            $breadcrumbs[] = $category['name'];
 
             if (!empty($category['children'])) {
-                $categoryChildren = $this->buildCategoriesTree($category['children'], $langId);
+                $categoryChildren = $this->buildCategoriesTree($category['children'], $langId, $breadcrumbs);
             }
 
             $categoriesTree[] = new CategoryForTree(
@@ -86,7 +88,8 @@ final class GetCategoriesTreeHandler implements GetCategoriesTreeHandlerInterfac
                 // @todo: it is always only one language now,
                 //   but this way it doesn't require changing the contract when we want to allow retrieving multiple languages
                 [$langId => $category['name']],
-                $categoryChildren
+                $categoryChildren,
+                [$langId => $breadcrumbs]
             );
         }
 

--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -143,14 +143,36 @@ class CategoryRepository extends AbstractObjectModelRepository
     /**
      * @param CategoryId $categoryId
      * @param LanguageId $languageId
+     *
+     * @return string[]
+     */
+    public function getBreadcrumbParts(CategoryId $categoryId, LanguageId $languageId): array
+    {
+        return $this->fetchBreadcrumbs($categoryId, $languageId);
+    }
+
+    /**
+     * @param CategoryId $categoryId
+     * @param LanguageId $languageId
      * @param string $separator
      *
      * @return string
      */
     public function getBreadcrumb(CategoryId $categoryId, LanguageId $languageId, string $separator = ' > '): string
     {
-        $qb = $this->connection->createQueryBuilder();
-        $qb
+        return implode($separator, $this->fetchBreadcrumbs($categoryId, $languageId));
+    }
+
+    /**
+     * @param CategoryId $categoryId
+     * @param LanguageId $languageId
+     *
+     * @return string[]
+     */
+    private function fetchBreadcrumbs(CategoryId $categoryId, LanguageId $languageId): array
+    {
+        $categoryQb = $this->connection->createQueryBuilder();
+        $categoryQb
             ->select('cl.name, c.nleft, c.nright')
             ->from($this->dbPrefix . 'category', 'c')
             ->innerJoin('c', $this->dbPrefix . 'category_lang', 'cl', 'c.id_category = cl.id_category')
@@ -160,12 +182,12 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->setParameter('languageId', $languageId->getValue())
         ;
 
-        $result = $qb->execute()->fetchAll();
-        if (empty($result)) {
+        $category = $categoryQb->execute()->fetchAssociative();
+
+        if (empty($category)) {
             throw new CategoryNotFoundException($categoryId, 'Cannot find breadcrumb because category does not exist');
         }
 
-        $category = $result[0];
         $categoryName = $category['name'];
 
         $qb = $this->connection->createQueryBuilder();
@@ -184,13 +206,14 @@ class CategoryRepository extends AbstractObjectModelRepository
             ->setParameter('languageId', $languageId->getValue())
         ;
 
-        $result = $qb->execute()->fetchAll();
+        $results = $qb->execute()->fetchAllAssociative();
+
         $parentNames = [];
-        foreach ($result as $category) {
+        foreach ($results as $category) {
             $parentNames[] = $category['name'];
         }
         $parentNames[] = $categoryName;
 
-        return implode($separator, $parentNames);
+        return $parentNames;
     }
 }

--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
 
@@ -138,6 +139,29 @@ class CategoryRepository extends AbstractObjectModelRepository
         } catch (CategoryException $e) {
             throw new CategoryNotFoundException($categoryId, $e->getMessage());
         }
+    }
+
+    public function getDuplicateNames(ShopId $shopId, LanguageId $languageId): array
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->select('cl.name, COUNT(cl.name) AS nameCount')
+            ->from($this->dbPrefix . 'category_lang', 'cl')
+            ->where('id_lang = :langId')
+            ->andWhere('id_shop = :shopId')
+            ->having('nameCount > 1')
+            ->setParameter('langId', $languageId->getValue())
+            ->setParameter('shopId', $shopId->getValue())
+            ->groupBy('cl.name')
+        ;
+
+        $results = $qb->execute()->fetchAllAssociative();
+
+        $names = [];
+        foreach ($results as $result) {
+            $names[] = $result['name'];
+        }
+
+        return $names;
     }
 
     /**

--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -156,11 +156,11 @@ class CategoryRepository extends AbstractObjectModelRepository
     public function getDuplicateNames(ShopId $shopId, LanguageId $languageId): array
     {
         $qb = $this->connection->createQueryBuilder()
-            ->select('cl.name, COUNT(cl.name) AS nameCount')
+            ->select('cl.name')
             ->from($this->dbPrefix . 'category_lang', 'cl')
             ->where('id_lang = :langId')
             ->andWhere('id_shop = :shopId')
-            ->having('nameCount > 1')
+            ->having('COUNT(cl.name) > 1')
             ->setParameter('langId', $languageId->getValue())
             ->setParameter('shopId', $shopId->getValue())
             ->groupBy('cl.name')
@@ -183,29 +183,6 @@ class CategoryRepository extends AbstractObjectModelRepository
      * @return string[]
      */
     public function getBreadcrumbParts(CategoryId $categoryId, LanguageId $languageId): array
-    {
-        return $this->fetchBreadcrumbs($categoryId, $languageId);
-    }
-
-    /**
-     * @param CategoryId $categoryId
-     * @param LanguageId $languageId
-     * @param string $separator
-     *
-     * @return string
-     */
-    public function getBreadcrumb(CategoryId $categoryId, LanguageId $languageId, string $separator = ' > '): string
-    {
-        return implode($separator, $this->fetchBreadcrumbs($categoryId, $languageId));
-    }
-
-    /**
-     * @param CategoryId $categoryId
-     * @param LanguageId $languageId
-     *
-     * @return string[]
-     */
-    private function fetchBreadcrumbs(CategoryId $categoryId, LanguageId $languageId): array
     {
         $categoryQb = $this->connection->createQueryBuilder();
         $categoryQb
@@ -244,12 +221,24 @@ class CategoryRepository extends AbstractObjectModelRepository
 
         $results = $qb->execute()->fetchAllAssociative();
 
-        $parentNames = [];
-        foreach ($results as $category) {
-            $parentNames[] = $category['name'];
+        if ($results) {
+            $parentNames = array_column($results, 'name');
         }
+
         $parentNames[] = $categoryName;
 
         return $parentNames;
+    }
+
+    /**
+     * @param CategoryId $categoryId
+     * @param LanguageId $languageId
+     * @param string $separator
+     *
+     * @return string
+     */
+    public function getBreadcrumb(CategoryId $categoryId, LanguageId $languageId, string $separator = ' > '): string
+    {
+        return implode($separator, $this->getBreadcrumbParts($categoryId, $languageId));
     }
 }

--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -141,6 +141,12 @@ class CategoryRepository extends AbstractObjectModelRepository
         }
     }
 
+    /**
+     * @param ShopId $shopId
+     * @param LanguageId $languageId
+     *
+     * @return string[]
+     */
     public function getDuplicateNames(ShopId $shopId, LanguageId $languageId): array
     {
         $qb = $this->connection->createQueryBuilder()

--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -142,6 +142,12 @@ class CategoryRepository extends AbstractObjectModelRepository
     }
 
     /**
+     * Provides category names which are not unique per shop and language.
+     *
+     * e.g. if certain shop contains following categories in english language:
+     *      Clothes -> Men, Bags -> Men, Clothes -> Woman, Bags -> Women,
+     *      then method should return ["Men", "Women"]
+     *
      * @param ShopId $shopId
      * @param LanguageId $languageId
      *

--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
@@ -142,38 +143,43 @@ class CategoryRepository extends AbstractObjectModelRepository
     }
 
     /**
-     * Provides category names which are not unique per shop and language.
-     *
-     * e.g. if certain shop contains following categories in english language:
-     *      Clothes -> Men, Bags -> Men, Clothes -> Woman, Bags -> Women,
-     *      then method should return ["Men", "Women"]
+     * Provides ids of categories which are not unique per shop and language.
      *
      * @param ShopId $shopId
      * @param LanguageId $languageId
      *
-     * @return string[]
+     * @return CategoryId[]
      */
-    public function getDuplicateNames(ShopId $shopId, LanguageId $languageId): array
+    public function getDuplicateNameIds(ShopId $shopId, LanguageId $languageId): array
     {
-        $qb = $this->connection->createQueryBuilder()
-            ->select('cl.name')
-            ->from($this->dbPrefix . 'category_lang', 'cl')
+        $duplicateNames = $this->getDuplicateNames($shopId, $languageId);
+
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('c.id_category')
+            ->from($this->dbPrefix . 'category', 'c')
+            ->innerJoin(
+                'c',
+                $this->dbPrefix . 'category_lang',
+                'cl',
+                'c.id_category = cl.id_category'
+            )
             ->where('id_lang = :langId')
             ->andWhere('id_shop = :shopId')
-            ->having('COUNT(cl.name) > 1')
+            ->andWhere('c.level_depth >= 1')
+            ->andWhere($qb->expr()->in('cl.name', ':duplicateNames'))
             ->setParameter('langId', $languageId->getValue())
             ->setParameter('shopId', $shopId->getValue())
-            ->groupBy('cl.name')
+            ->setParameter('duplicateNames', $duplicateNames, Connection::PARAM_STR_ARRAY)
         ;
 
         $results = $qb->execute()->fetchAllAssociative();
 
-        $names = [];
+        $categoryIds = [];
         foreach ($results as $result) {
-            $names[] = $result['name'];
+            $categoryIds[] = new CategoryId((int) $result['id_category']);
         }
 
-        return $names;
+        return $categoryIds;
     }
 
     /**
@@ -240,5 +246,81 @@ class CategoryRepository extends AbstractObjectModelRepository
     public function getBreadcrumb(CategoryId $categoryId, LanguageId $languageId, string $separator = ' > '): string
     {
         return implode($separator, $this->getBreadcrumbParts($categoryId, $languageId));
+    }
+
+    /**
+     * @param ProductId $productId
+     * @param ShopId $shopId
+     *
+     * @return CategoryId[]
+     */
+    public function getProductCategoryIds(ProductId $productId, ShopId $shopId): array
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $qb->select('cp.id_category')
+            ->from($this->dbPrefix . 'category_product', 'cp')
+            ->innerJoin(
+                'cp',
+                $this->dbPrefix . 'category_shop',
+                'cs',
+                'cp.id_category = cs.id_category'
+            )
+            ->where('cp.id_product = :productId')
+            ->andWhere('cs.id_shop = :shopId')
+            ->setParameters([
+                'productId' => $productId->getValue(),
+                'shopId' => $shopId->getValue(),
+            ])
+        ;
+
+        $results = $qb->execute()->fetchAllAssociative();
+
+        $categoryIds = [];
+        foreach ($results as $result) {
+            $categoryIds[] = new CategoryId((int) $result['id_category']);
+        }
+
+        return $categoryIds;
+    }
+
+    /**
+     * Provides category names which are not unique per shop and language.
+     *
+     * e.g. if certain shop contains following categories in english language:
+     *      Clothes -> Men, Bags -> Men, Clothes -> Woman, Bags -> Women,
+     *      then method should return ["Men", "Women"]
+     *
+     * @param ShopId $shopId
+     * @param LanguageId $languageId
+     *
+     * @return string[]
+     */
+    protected function getDuplicateNames(ShopId $shopId, LanguageId $languageId): array
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->select('cl.name')
+            ->from($this->dbPrefix . 'category', 'c')
+            ->innerJoin(
+                'c',
+                $this->dbPrefix . 'category_lang', 'cl',
+                'c.id_category = cl.id_category'
+            )
+            ->where('id_lang = :langId')
+            ->andWhere('id_shop = :shopId')
+            ->andWhere('c.level_depth >= 1')
+            ->having('COUNT(cl.name) > 1')
+            ->setParameter('langId', $languageId->getValue())
+            ->setParameter('shopId', $shopId->getValue())
+            ->groupBy('cl.name')
+        ;
+
+        $results = $qb->execute()->fetchAllAssociative();
+
+        $names = [];
+        foreach ($results as $result) {
+            $names[] = $result['name'];
+        }
+
+        return $names;
     }
 }

--- a/src/Adapter/Form/ChoiceProvider/ProductDefaultCategoryChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ProductDefaultCategoryChoiceProvider.php
@@ -132,10 +132,10 @@ class ProductDefaultCategoryChoiceProvider implements ConfigurableFormChoiceProv
     private function getDisplayName(CategoryId $categoryId, string $categoryName): string
     {
         return $this->categoryDisplayNameBuilder->build(
-            $categoryId,
             $categoryName,
             $this->shopId,
-            $this->languageId
+            $this->languageId,
+            $categoryId
         );
     }
 

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -266,19 +266,17 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
 
     /**
      * @param Product $product
+     * @param LanguageId $languageId
      *
      * @return CategoriesInformation
      */
     private function getCategoriesInformation(Product $product, LanguageId $languageId): CategoriesInformation
     {
         $shopId = new ShopId($product->getShopId());
-        $categoryIdValues = $product->getCategories();
-        $defaultCategoryId = (int) $product->id_category_default;
+        $productId = new ProductId((int) $product->id);
 
-        $categoryIds = [];
-        foreach ($categoryIdValues as $categoryIdValue) {
-            $categoryIds[] = new CategoryId((int) $categoryIdValue);
-        }
+        $categoryIds = $this->categoryRepository->getProductCategoryIds($productId, $shopId);
+        $defaultCategoryId = (int) $product->id_category_default;
 
         $categoryNames = $this->categoryRepository->getLocalizedNames($categoryIds);
 

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -144,11 +144,6 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
     private $configuration;
 
     /**
-     * @var int
-     */
-    private $contextLangId;
-
-    /**
      * @var CategoryDisplayNameBuilder
      */
     private $categoryDisplayNameBuilder;
@@ -167,7 +162,6 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
      * @param ProductImagePathFactory $productImageUrlFactory
      * @param SpecificPriceRepository $specificPriceRepository
      * @param Configuration $configuration
-     * @param int $contextLangId
      * @param CategoryDisplayNameBuilder $categoryDisplayNameBuilder
      */
     public function __construct(
@@ -184,7 +178,6 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
         ProductImagePathFactory $productImageUrlFactory,
         SpecificPriceRepository $specificPriceRepository,
         Configuration $configuration,
-        int $contextLangId,
         CategoryDisplayNameBuilder $categoryDisplayNameBuilder
     ) {
         $this->numberExtractor = $numberExtractor;
@@ -200,7 +193,6 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
         $this->productImageUrlFactory = $productImageUrlFactory;
         $this->specificPriceRepository = $specificPriceRepository;
         $this->configuration = $configuration;
-        $this->contextLangId = $contextLangId;
         $this->categoryDisplayNameBuilder = $categoryDisplayNameBuilder;
     }
 
@@ -220,7 +212,7 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
             (bool) $product->active,
             $this->getCustomizationOptions($product),
             $this->getBasicInformation($product),
-            $this->getCategoriesInformation($product),
+            $this->getCategoriesInformation($product, $query->getDisplayLanguageId()),
             $this->getPricesInformation($product, $query->getShopConstraint()),
             $this->getOptions($product),
             $this->getDetails($product),
@@ -277,9 +269,8 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
      *
      * @return CategoriesInformation
      */
-    private function getCategoriesInformation(Product $product): CategoriesInformation
+    private function getCategoriesInformation(Product $product, LanguageId $languageId): CategoriesInformation
     {
-        $languageId = new LanguageId($this->contextLangId);
         $shopId = new ShopId($product->getShopId());
         $categoryIdValues = $product->getCategories();
         $defaultCategoryId = (int) $product->id_category_default;
@@ -293,7 +284,7 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
 
         $categoriesInformation = [];
         foreach ($categoryNames as $categoryId => $localizedNames) {
-            $categoryName = $categoryNames[$categoryId][$this->contextLangId];
+            $categoryName = $categoryNames[$categoryId][$languageId->getValue()];
             $displayName = $this->categoryDisplayNameBuilder->build(
                 new CategoryId($categoryId),
                 $categoryName,

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -286,10 +286,10 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
         foreach ($categoryNames as $categoryId => $localizedNames) {
             $categoryName = $categoryNames[$categoryId][$languageId->getValue()];
             $displayName = $this->categoryDisplayNameBuilder->build(
-                new CategoryId($categoryId),
                 $categoryName,
                 $shopId,
-                $languageId
+                $languageId,
+                new CategoryId($categoryId)
             );
             $categoriesInformation[] = new CategoryInformation(
                 $categoryId,

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -294,8 +294,8 @@ final class GetProductForEditingHandler implements GetProductForEditingHandlerIn
             );
             $categoriesInformation[] = new CategoryInformation(
                 $categoryId,
-                $displayName,
-                $categoryName
+                $categoryName,
+                $displayName
             );
         }
 

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -285,23 +285,39 @@ final class GetProductForEditingHandler implements GetProductForEditingHandlerIn
 
         $categoriesInformation = [];
         foreach ($categoryNames as $categoryId => $localizedNames) {
-            $localizedNames = $categoryNames[$categoryId];
+            $categoryName = $categoryNames[$categoryId][$this->contextLangId];
             $displayName = $this->buildDisplayName(
                 new CategoryId($categoryId),
                 $languageId,
-                $localizedNames[$this->contextLangId],
+                $categoryName,
                 $duplicateNames
             );
             $categoriesInformation[] = new CategoryInformation(
                 $categoryId,
                 $displayName,
-                $localizedNames
+                $categoryName
             );
         }
 
         return new CategoriesInformation($categoriesInformation, $defaultCategoryId);
     }
 
+    /**
+     *  If there are multiple categories with identical names, we want to be able to tell them apart,
+     *  so we use breadcrumb path instead of category name.
+     *  However, whole breadcrumb path would probably be too long, therefore not UX friendly.
+     *  Calculating "optimal" breadcrumb length seems too complex compared to the value it could bring.
+     *  So, we show one parent name and category name, as it is simple and should cover most cases.
+     *
+     * e.g. "Clothes > Women"
+     *
+     * @param CategoryId $categoryId
+     * @param LanguageId $languageId
+     * @param string $categoryName
+     * @param string[] $duplicateNames
+     *
+     * @return string
+     */
     private function buildDisplayName(
         CategoryId $categoryId,
         LanguageId $languageId,

--- a/src/Adapter/Shop/Repository/ShopRepository.php
+++ b/src/Adapter/Shop/Repository/ShopRepository.php
@@ -30,12 +30,32 @@ namespace PrestaShop\PrestaShop\Adapter\Shop\Repository;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
+use Shop;
 
 /**
  * Provides methods to access data storage for shop
  */
 class ShopRepository extends AbstractObjectModelRepository
 {
+    /**
+     * @param ShopId $shopId
+     *
+     * @return Shop
+     *
+     * @throws ShopNotFoundException
+     */
+    public function get(ShopId $shopId): Shop
+    {
+        /** @var Shop $shop */
+        $shop = $this->getObjectModel(
+            $shopId->getValue(),
+            Shop::class,
+            ShopNotFoundException::class
+        );
+
+        return $shop;
+    }
+
     /**
      * @param ShopId $shopId
      *

--- a/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
+++ b/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
@@ -124,6 +124,7 @@ class CategoryDisplayNameBuilder
 
         $cacheKey = $this->buildCacheKey($shopId, $languageId);
 
+//      @todo: consider using Symfony\Component\Cache\Adapter\AdapterInterface instead of legacy Cache
         if (Cache::isStored($this->buildCacheKey($shopId, $languageId))) {
             return Cache::retrieve($cacheKey);
         }

--- a/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
+++ b/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
@@ -34,7 +34,12 @@ use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 /**
- * Builds category display name to avoid confusing categories when they have identical names in multiple levels.
+ * Builds category display name to avoid confusing categories when they have identical names.
+ *
+ * If there are multiple categories with identical names, we want to be able to tell them apart,
+ * so we use breadcrumb path instead of category name.
+ *
+ * e.g. "Clothes > Women"
  */
 class CategoryDisplayNameBuilder
 {
@@ -44,41 +49,52 @@ class CategoryDisplayNameBuilder
     private $categoryRepository;
 
     /**
+     * @var string
+     */
+    private $breadcrumbSeparator;
+
+    /**
      * @param CategoryRepository $categoryRepository
+     * @param string $breadcrumbSeparator
      */
     public function __construct(
-        CategoryRepository $categoryRepository
+        CategoryRepository $categoryRepository,
+        string $breadcrumbSeparator
     ) {
         $this->categoryRepository = $categoryRepository;
+        $this->breadcrumbSeparator = $breadcrumbSeparator;
     }
 
     /**
-     * @see buildDisplayName
-     *
-     * @param CategoryId $categoryId
      * @param string $categoryName
      * @param ShopId $shopId
      * @param LanguageId $languageId
+     * @param CategoryId $categoryId
      * @param bool $useCache
      *
      * @return string
      */
     public function build(
-        CategoryId $categoryId,
         string $categoryName,
         ShopId $shopId,
         LanguageId $languageId,
+        CategoryId $categoryId,
         bool $useCache = true
     ): string {
-        return $this->buildDisplayName($categoryId, $categoryName, $shopId, $languageId, null, $useCache);
+        $duplicateNames = $this->getDuplicateNames($shopId, $languageId, $useCache);
+
+        if (!in_array($categoryName, $duplicateNames, true)) {
+            return $categoryName;
+        }
+
+        $breadcrumbParts = $this->categoryRepository->getBreadcrumbParts($categoryId, $languageId);
+
+        return $this->buildBreadcrumb($breadcrumbParts);
     }
 
     /**
-     * @see buildDisplayName
-     *
      * In some cases we already have breadcrumbs before calling this method, so we allow providing them here for optimization purposes
      *
-     * @param CategoryId $categoryId
      * @param string $categoryName
      * @param ShopId $shopId
      * @param LanguageId $languageId
@@ -88,14 +104,19 @@ class CategoryDisplayNameBuilder
      * @return string
      */
     public function buildWithBreadcrumbs(
-        CategoryId $categoryId,
         string $categoryName,
         ShopId $shopId,
         LanguageId $languageId,
         array $breadcrumbParts,
         bool $useCache = true
     ): string {
-        return $this->buildDisplayName($categoryId, $categoryName, $shopId, $languageId, $breadcrumbParts, $useCache);
+        $duplicateNames = $this->getDuplicateNames($shopId, $languageId, $useCache);
+
+        if (!in_array($categoryName, $duplicateNames, true)) {
+            return $categoryName;
+        }
+
+        return $this->buildBreadcrumb($breadcrumbParts);
     }
 
     /**
@@ -140,44 +161,16 @@ class CategoryDisplayNameBuilder
     }
 
     /**
-     *  If there are multiple categories with identical names, we want to be able to tell them apart,
-     *  so we use breadcrumb path instead of category name.
-     *  However, whole breadcrumb path would probably be too long, therefore not UX friendly.
-     *  Calculating "optimal" breadcrumb length seems too complex compared to the value it could bring.
-     *  So, we show one parent name and category name, as it is simple and should cover most cases.
+     * Whole breadcrumb path would probably be too long, therefore not UX friendly.
+     * Calculating "optimal" breadcrumb length seems too complex compared to the value it could bring.
+     * So, we show one parent name and category name, as it is simple and should cover most cases.
      *
-     * e.g. "Clothes > Women"
-     *
-     * @param CategoryId $categoryId
-     * @param string $categoryName
-     * @param ShopId $shopId
-     * @param LanguageId $languageId
-     * @param array|null $breadcrumbParts
-     * @param bool $useCache
+     * @param string[] $breadcrumbParts
      *
      * @return string
      */
-    private function buildDisplayName(
-        CategoryId $categoryId,
-        string $categoryName,
-        ShopId $shopId,
-        LanguageId $languageId,
-        ?array $breadcrumbParts = null,
-        bool $useCache = true
-    ): string {
-        $duplicateNames = $this->getDuplicateNames($shopId, $languageId, $useCache);
-
-        if (!in_array($categoryName, $duplicateNames, true)) {
-            return $categoryName;
-        }
-
-        if (null === $breadcrumbParts) {
-            $breadcrumbParts = $this->categoryRepository->getBreadcrumbParts(
-                $categoryId,
-                $languageId
-            );
-        }
-
-        return implode(' > ', array_slice($breadcrumbParts, -2, 2));
+    private function buildBreadcrumb(array $breadcrumbParts): string
+    {
+        return implode($this->breadcrumbSeparator, array_slice($breadcrumbParts, -2, 2));
     }
 }

--- a/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
+++ b/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
@@ -34,12 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 /**
- * Builds category display name to avoid confusing categories when they have identical names.
- *
- * If there are multiple categories with identical names, we want to be able to tell them apart,
- * so we use breadcrumb path instead of category name.
- *
- * e.g. "Clothes > Women"
+ * Builds category display name if it needs to differ from original category name.
  */
 class CategoryDisplayNameBuilder
 {
@@ -66,6 +61,11 @@ class CategoryDisplayNameBuilder
     }
 
     /**
+     * If there are multiple categories with identical names, we want to be able to tell them apart,
+     * so we build a display name which may include some (or all) parent category names.
+     *
+     * @see buildBreadcrumb for more details
+     *
      * @param string $categoryName
      * @param ShopId $shopId
      * @param LanguageId $languageId
@@ -79,44 +79,158 @@ class CategoryDisplayNameBuilder
         ShopId $shopId,
         LanguageId $languageId,
         CategoryId $categoryId,
-        bool $useCache = true
+        bool $useCache = false
     ): string {
-        $duplicateNames = $this->getDuplicateNames($shopId, $languageId, $useCache);
+        $duplicateNameIds = $this->getDuplicateNameIds($shopId, $languageId, $useCache);
+        $isDuplicate = false;
 
-        if (!in_array($categoryName, $duplicateNames, true)) {
+        foreach ($duplicateNameIds as $id) {
+            if ($categoryId->getValue() === $id->getValue()) {
+                $isDuplicate = true;
+            }
+        }
+
+        if (!$isDuplicate) {
             return $categoryName;
         }
 
-        $breadcrumbParts = $this->categoryRepository->getBreadcrumbParts($categoryId, $languageId);
-
-        return $this->buildBreadcrumb($breadcrumbParts);
+        return $this->buildBreadcrumb($categoryId, $this->getDuplicateCategoriesBreadcrumbs($duplicateNameIds, $shopId, $languageId, $useCache));
     }
 
     /**
-     * In some cases we already have breadcrumbs before calling this method, so we allow providing them here for optimization purposes
-     *
-     * @param string $categoryName
      * @param ShopId $shopId
      * @param LanguageId $languageId
-     * @param string[] $breadcrumbParts
      * @param bool $useCache
+     *
+     * @return CategoryId[]
+     */
+    private function getDuplicateNameIds(ShopId $shopId, LanguageId $languageId, bool $useCache): array
+    {
+        if (!$useCache) {
+            return $this->categoryRepository->getDuplicateNameIds($shopId, $languageId);
+        }
+
+        $cacheKey = $this->buildCacheKeyForNameIds($shopId, $languageId);
+
+//      @todo: consider using Symfony\Component\Cache\Adapter\AdapterInterface instead of legacy Cache
+        if (Cache::isStored($this->buildCacheKeyForNameIds($shopId, $languageId))) {
+            return Cache::retrieve($cacheKey);
+        }
+
+        $duplicateNameIds = $this->categoryRepository->getDuplicateNameIds($shopId, $languageId);
+        Cache::store($cacheKey, $duplicateNameIds);
+
+        return $duplicateNameIds;
+    }
+
+    /**
+     * @param CategoryId[] $categoryIds
+     * @param ShopId $shopId
+     * @param LanguageId $languageId
+     * @param bool $useCache
+     *
+     * @return array<int, string[]>
+     */
+    private function getDuplicateCategoriesBreadcrumbs(array $categoryIds, ShopId $shopId, LanguageId $languageId, bool $useCache): array
+    {
+        if (!$useCache) {
+            return $this->fetchBreadcrumbs($categoryIds, $languageId);
+        }
+
+        $cacheKey = $this->buildCacheKeyForBreadcrumbs($shopId, $languageId);
+
+//      @todo: consider using Symfony\Component\Cache\Adapter\AdapterInterface instead of legacy Cache
+        if (Cache::isStored($this->buildCacheKeyForBreadcrumbs($shopId, $languageId))) {
+            return Cache::retrieve($cacheKey);
+        }
+
+        $duplicateCategoriesBreadcrumbs = $this->fetchBreadcrumbs($categoryIds, $languageId);
+        Cache::store($cacheKey, $duplicateCategoriesBreadcrumbs);
+
+        return $duplicateCategoriesBreadcrumbs;
+    }
+
+    /**
+     * @param CategoryId[] $categoryIds
+     * @param LanguageId $languageId
+     *
+     * @return array<int, string[]>
+     */
+    private function fetchBreadcrumbs(array $categoryIds, LanguageId $languageId): array
+    {
+        $duplicateCategoriesBreadcrumbs = [];
+        foreach ($categoryIds as $categoryId) {
+            $duplicateCategoriesBreadcrumbs[$categoryId->getValue()] = $this->categoryRepository->getBreadcrumbParts(
+                $categoryId,
+                $languageId
+            );
+        }
+
+        return $duplicateCategoriesBreadcrumbs;
+    }
+
+    /**
+     * Builds a breadcrumb which consists of minimum needed parents to be unique, depending on other categories breadcrumbs.
+     * If breadcrumb is still not unique after showing all of it, then we append category id.
+     *
+     * E.g.:
+     *      For categories: Home > Clothes, Home > Clothes
+     *          breadcrumbs would be: Home > Clothes (#id1), Home > Clothes (#id2)
+     *
+     *      For: Home > Clothes, Home > Clothes > Clothes:
+     *          breadcrumbs would be: Home > Clothes, Clothes > Clothes
+     *
+     * @param CategoryId $categoryId
+     * @param array<int, string[]> $duplicateCategoriesBreadcrumbs
      *
      * @return string
      */
-    public function buildWithBreadcrumbs(
-        string $categoryName,
-        ShopId $shopId,
-        LanguageId $languageId,
-        array $breadcrumbParts,
-        bool $useCache = true
-    ): string {
-        $duplicateNames = $this->getDuplicateNames($shopId, $languageId, $useCache);
+    private function buildBreadcrumb(CategoryId $categoryId, array $duplicateCategoriesBreadcrumbs): string
+    {
+        $breadcrumbParts = $duplicateCategoriesBreadcrumbs[$categoryId->getValue()];
+        unset($duplicateCategoriesBreadcrumbs[$categoryId->getValue()]);
 
-        if (!in_array($categoryName, $duplicateNames, true)) {
-            return $categoryName;
+        $maxSteps = count($breadcrumbParts);
+        $breadcrumb = $breadcrumbParts[0];
+        $duplicatedFound = true;
+
+        if ($maxSteps > 1) {
+            $duplicatedFound = false;
+
+            for ($step = 2; $step <= $maxSteps; ++$step) {
+                $breadcrumb = $this->extractBreadcrumbFromParts($breadcrumbParts, $step);
+                $duplicatedFound = false;
+                foreach ($duplicateCategoriesBreadcrumbs as $otherCategoryBreadcrumbs) {
+                    $otherBreadcrumb = $this->extractBreadcrumbFromParts($otherCategoryBreadcrumbs, $step);
+                    if ($otherBreadcrumb === $breadcrumb) {
+                        $duplicatedFound = true;
+                        break;
+                    }
+                }
+
+                if (!$duplicatedFound) {
+                    break;
+                }
+            }
         }
 
-        return $this->buildBreadcrumb($breadcrumbParts);
+        if ($duplicatedFound) {
+            // if breadcrumbs are still duplicated append category id
+            $breadcrumb = sprintf('%s (#%d)', $breadcrumb, $categoryId->getValue());
+        }
+
+        return $breadcrumb;
+    }
+
+    /**
+     * @param string[] $parts
+     * @param int $step
+     *
+     * @return string
+     */
+    private function extractBreadcrumbFromParts(array $parts, int $step): string
+    {
+        return implode($this->breadcrumbSeparator, array_slice($parts, -$step, $step));
     }
 
     /**
@@ -125,10 +239,10 @@ class CategoryDisplayNameBuilder
      *
      * @return string
      */
-    private function buildCacheKey(ShopId $shopId, LanguageId $langId): string
+    private function buildCacheKeyForNameIds(ShopId $shopId, LanguageId $langId): string
     {
         return sprintf(
-            'Category::duplicateCategoryNames_shop_%s_lang_%s',
+            'Category::duplicateCategoryNameIds_shop_%s_lang_%s',
             $shopId->getValue(),
             $langId->getValue()
         );
@@ -136,41 +250,16 @@ class CategoryDisplayNameBuilder
 
     /**
      * @param ShopId $shopId
-     * @param LanguageId $languageId
-     * @param bool $useCache
-     *
-     * @return string[]
-     */
-    private function getDuplicateNames(ShopId $shopId, LanguageId $languageId, bool $useCache): array
-    {
-        if (!$useCache) {
-            return $this->categoryRepository->getDuplicateNames($shopId, $languageId);
-        }
-
-        $cacheKey = $this->buildCacheKey($shopId, $languageId);
-
-//      @todo: consider using Symfony\Component\Cache\Adapter\AdapterInterface instead of legacy Cache
-        if (Cache::isStored($this->buildCacheKey($shopId, $languageId))) {
-            return Cache::retrieve($cacheKey);
-        }
-
-        $duplicateNames = $this->categoryRepository->getDuplicateNames($shopId, $languageId);
-        Cache::store($cacheKey, $duplicateNames);
-
-        return $duplicateNames;
-    }
-
-    /**
-     * Whole breadcrumb path would probably be too long, therefore not UX friendly.
-     * Calculating "optimal" breadcrumb length seems too complex compared to the value it could bring.
-     * So, we show one parent name and category name, as it is simple and should cover most cases.
-     *
-     * @param string[] $breadcrumbParts
+     * @param LanguageId $langId
      *
      * @return string
      */
-    private function buildBreadcrumb(array $breadcrumbParts): string
+    private function buildCacheKeyForBreadcrumbs(ShopId $shopId, LanguageId $langId): string
     {
-        return implode($this->breadcrumbSeparator, array_slice($breadcrumbParts, -2, 2));
+        return sprintf(
+            'Category::duplicateCategoryBreadcrumbs_shop_%s_lang_%s',
+            $shopId->getValue(),
+            $langId->getValue()
+        );
     }
 }

--- a/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
+++ b/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
@@ -79,7 +79,7 @@ class CategoryDisplayNameBuilder
         ShopId $shopId,
         LanguageId $languageId,
         CategoryId $categoryId,
-        bool $useCache = false
+        bool $useCache = true
     ): string {
         $duplicateNameIds = $this->getDuplicateNameIds($shopId, $languageId, $useCache);
         $isDuplicate = false;
@@ -136,7 +136,6 @@ class CategoryDisplayNameBuilder
         if (!$useCache) {
             return $this->fetchBreadcrumbs($categoryIds, $languageId);
         }
-
         $cacheKey = $this->buildCacheKeyForBreadcrumbs($shopId, $languageId);
 
 //      @todo: consider using Symfony\Component\Cache\Adapter\AdapterInterface instead of legacy Cache

--- a/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
+++ b/src/Core/Category/NameBuilder/CategoryDisplayNameBuilder.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Category\NameBuilder;
+
+use Cache;
+use PrestaShop\PrestaShop\Adapter\Category\Repository\CategoryRepository;
+use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
+
+/**
+ * Builds category display name to avoid confusing categories when they have identical names in multiple levels.
+ */
+class CategoryDisplayNameBuilder
+{
+    /**
+     * @var CategoryRepository
+     */
+    private $categoryRepository;
+
+    /**
+     * @param CategoryRepository $categoryRepository
+     */
+    public function __construct(
+        CategoryRepository $categoryRepository
+    ) {
+        $this->categoryRepository = $categoryRepository;
+    }
+
+    /**
+     *  If there are multiple categories with identical names, we want to be able to tell them apart,
+     *  so we use breadcrumb path instead of category name.
+     *  However, whole breadcrumb path would probably be too long, therefore not UX friendly.
+     *  Calculating "optimal" breadcrumb length seems too complex compared to the value it could bring.
+     *  So, we show one parent name and category name, as it is simple and should cover most cases.
+     *
+     * e.g. "Clothes > Women"
+     *
+     * @param CategoryId $categoryId
+     * @param string $categoryName
+     * @param ShopId $shopId
+     * @param LanguageId $languageId
+     * @param array|null $breadcrumbParts
+     * @param bool $useCache
+     *
+     * @return string
+     */
+    public function build(
+        CategoryId $categoryId,
+        string $categoryName,
+        ShopId $shopId,
+        LanguageId $languageId,
+        ?array $breadcrumbParts = null,
+        bool $useCache = true
+    ): string {
+        $duplicateNames = $this->getDuplicateNames($shopId, $languageId, $useCache);
+
+        if (!in_array($categoryName, $duplicateNames, true)) {
+            return $categoryName;
+        }
+
+        if (null === $breadcrumbParts) {
+            $breadcrumbParts = $this->categoryRepository->getBreadcrumbParts(
+                $categoryId,
+                $languageId
+            );
+        }
+
+        return implode(' > ', array_slice($breadcrumbParts, -2, 2));
+    }
+
+    /**
+     * @param ShopId $shopId
+     * @param LanguageId $langId
+     *
+     * @return string
+     */
+    private function buildCacheKey(ShopId $shopId, LanguageId $langId): string
+    {
+        return sprintf(
+            'Category::duplicateCategoryNames_shop_%s_lang_%s',
+            $shopId->getValue(),
+            $langId->getValue()
+        );
+    }
+
+    /**
+     * @param ShopId $shopId
+     * @param LanguageId $languageId
+     * @param bool $useCache
+     *
+     * @return string[]
+     */
+    private function getDuplicateNames(ShopId $shopId, LanguageId $languageId, bool $useCache): array
+    {
+        if (!$useCache) {
+            return $this->categoryRepository->getDuplicateNames($shopId, $languageId);
+        }
+
+        $cacheKey = $this->buildCacheKey($shopId, $languageId);
+
+        if (Cache::isStored($this->buildCacheKey($shopId, $languageId))) {
+            return Cache::retrieve($cacheKey);
+        }
+
+        $duplicateNames = $this->categoryRepository->getDuplicateNames($shopId, $languageId);
+        Cache::store($cacheKey, $duplicateNames);
+
+        return $duplicateNames;
+    }
+}

--- a/src/Core/Domain/Category/Query/GetCategoriesTree.php
+++ b/src/Core/Domain/Category/Query/GetCategoriesTree.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Category\Query;
 
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 /**
  * Provides Category tree list where each category holds its child categories
@@ -35,24 +36,40 @@ use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 final class GetCategoriesTree
 {
     /**
-     * @var LanguageId|null
+     * @var LanguageId
      */
     private $languageId;
 
     /**
-     * @param int|null $languageId
+     * @var ShopId
+     */
+    private $shopId;
+
+    /**
+     * @param int $languageId
+     * @param int $shopId
      */
     public function __construct(
-        ?int $languageId = null
+        int $languageId,
+        int $shopId
     ) {
-        $this->languageId = $languageId ? new LanguageId($languageId) : null;
+        $this->languageId = new LanguageId($languageId);
+        $this->shopId = new ShopId($shopId);
     }
 
     /**
-     * @return LanguageId|null
+     * @return LanguageId
      */
-    public function getLanguageId(): ?LanguageId
+    public function getLanguageId(): LanguageId
     {
         return $this->languageId;
+    }
+
+    /**
+     * @return ShopId
+     */
+    public function getShopId(): ShopId
+    {
+        return $this->shopId;
     }
 }

--- a/src/Core/Domain/Category/QueryResult/CategoryForTree.php
+++ b/src/Core/Domain/Category/QueryResult/CategoryForTree.php
@@ -50,21 +50,29 @@ class CategoryForTree
     private $children;
 
     /**
+     * @var array<int, string[]>
+     */
+    private $localizedBreadcrumbs;
+
+    /**
      * @param int $categoryId
      * @param bool $active
      * @param array<int, string> $localizedNames
-     * @param array $children
+     * @param CategoryForTree[] $children
+     * @param array<int, string[]> $localizedBreadcrumbs
      */
     public function __construct(
         int $categoryId,
         bool $active,
         array $localizedNames,
-        array $children
+        array $children,
+        array $localizedBreadcrumbs
     ) {
         $this->categoryId = $categoryId;
         $this->active = $active;
         $this->localizedNames = $localizedNames;
         $this->children = $children;
+        $this->localizedBreadcrumbs = $localizedBreadcrumbs;
     }
 
     /**
@@ -97,5 +105,13 @@ class CategoryForTree
     public function getChildren(): array
     {
         return $this->children;
+    }
+
+    /**
+     * @return array<int, string[]>
+     */
+    public function getLocalizedBreadcrumbs(): array
+    {
+        return $this->localizedBreadcrumbs;
     }
 }

--- a/src/Core/Domain/Category/QueryResult/CategoryForTree.php
+++ b/src/Core/Domain/Category/QueryResult/CategoryForTree.php
@@ -40,6 +40,11 @@ class CategoryForTree
     private $active;
 
     /**
+     * @var string
+     */
+    private $displayName;
+
+    /**
      * @var array<int, string>
      */
     private $localizedNames;
@@ -50,29 +55,25 @@ class CategoryForTree
     private $children;
 
     /**
-     * @var array<int, string[]>
-     */
-    private $localizedBreadcrumbs;
-
-    /**
      * @param int $categoryId
      * @param bool $active
+     * @param string $displayName
      * @param array<int, string> $localizedNames
      * @param CategoryForTree[] $children
-     * @param array<int, string[]> $localizedBreadcrumbs
      */
     public function __construct(
         int $categoryId,
         bool $active,
+        string $displayName,
+        //@todo: probably shouldn't even be localized, as query has langId param
         array $localizedNames,
-        array $children,
-        array $localizedBreadcrumbs
+        array $children
     ) {
         $this->categoryId = $categoryId;
         $this->active = $active;
+        $this->displayName = $displayName;
         $this->localizedNames = $localizedNames;
         $this->children = $children;
-        $this->localizedBreadcrumbs = $localizedBreadcrumbs;
     }
 
     /**
@@ -92,6 +93,14 @@ class CategoryForTree
     }
 
     /**
+     * @return string
+     */
+    public function getDisplayName(): string
+    {
+        return $this->displayName;
+    }
+
+    /**
      * @return array<int, string>
      */
     public function getLocalizedNames(): array
@@ -105,13 +114,5 @@ class CategoryForTree
     public function getChildren(): array
     {
         return $this->children;
-    }
-
-    /**
-     * @return array<int, string[]>
-     */
-    public function getLocalizedBreadcrumbs(): array
-    {
-        return $this->localizedBreadcrumbs;
     }
 }

--- a/src/Core/Domain/Category/QueryResult/CategoryForTree.php
+++ b/src/Core/Domain/Category/QueryResult/CategoryForTree.php
@@ -42,12 +42,12 @@ class CategoryForTree
     /**
      * @var string
      */
-    private $displayName;
+    private $name;
 
     /**
-     * @var array<int, string>
+     * @var string
      */
-    private $localizedNames;
+    private $displayName;
 
     /**
      * @var CategoryForTree[]
@@ -57,22 +57,21 @@ class CategoryForTree
     /**
      * @param int $categoryId
      * @param bool $active
+     * @param string $name,
      * @param string $displayName
-     * @param array<int, string> $localizedNames
      * @param CategoryForTree[] $children
      */
     public function __construct(
         int $categoryId,
         bool $active,
+        string $name,
         string $displayName,
-        //@todo: probably shouldn't even be localized, as query has langId param
-        array $localizedNames,
         array $children
     ) {
         $this->categoryId = $categoryId;
         $this->active = $active;
+        $this->name = $name;
         $this->displayName = $displayName;
-        $this->localizedNames = $localizedNames;
         $this->children = $children;
     }
 
@@ -95,17 +94,17 @@ class CategoryForTree
     /**
      * @return string
      */
-    public function getDisplayName(): string
+    public function getName(): string
     {
-        return $this->displayName;
+        return $this->name;
     }
 
     /**
-     * @return array<int, string>
+     * @return string
      */
-    public function getLocalizedNames(): array
+    public function getDisplayName(): string
     {
-        return $this->localizedNames;
+        return $this->displayName;
     }
 
     /**

--- a/src/Core/Domain/Product/Query/GetProductForEditing.php
+++ b/src/Core/Domain/Product/Query/GetProductForEditing.php
@@ -46,7 +46,8 @@ class GetProductForEditing
     private $shopConstraint;
 
     /**
-     * @var LanguageId
+     * @var LanguageId some data from this class is only used for reading and is not expected to be edited, so it
+     *                 is provided only in the language of the user interface, which is defined by this parameter
      */
     private $displayLanguageId;
 

--- a/src/Core/Domain/Product/Query/GetProductForEditing.php
+++ b/src/Core/Domain/Product/Query/GetProductForEditing.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Query;
 
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
@@ -45,17 +46,23 @@ class GetProductForEditing
     private $shopConstraint;
 
     /**
-     * GetProductForEditing constructor.
-     *
+     * @var LanguageId
+     */
+    private $displayLanguageId;
+
+    /**
      * @param int $productId
      * @param ShopConstraint $shopConstraint
+     * @param int $displayLanguageId
      */
     public function __construct(
         int $productId,
-        ShopConstraint $shopConstraint
+        ShopConstraint $shopConstraint,
+        int $displayLanguageId
     ) {
         $this->productId = new ProductId($productId);
         $this->shopConstraint = $shopConstraint;
+        $this->displayLanguageId = new LanguageId($displayLanguageId);
     }
 
     /**
@@ -72,5 +79,13 @@ class GetProductForEditing
     public function getShopConstraint(): ShopConstraint
     {
         return $this->shopConstraint;
+    }
+
+    /**
+     * @return LanguageId
+     */
+    public function getDisplayLanguageId(): LanguageId
+    {
+        return $this->displayLanguageId;
     }
 }

--- a/src/Core/Domain/Product/QueryResult/CategoryInformation.php
+++ b/src/Core/Domain/Product/QueryResult/CategoryInformation.php
@@ -43,25 +43,23 @@ class CategoryInformation
     private $displayName;
 
     /**
-     * @var array<int, string>
-     * @todo: this doesn't need to be localized because we are not updating category info in product page
-     *        (product name, description are localized, because all languages are needed for update)
+     * @var string
      */
-    private $localizedNames;
+    private $name;
 
     /**
      * @param int $id
      * @param string $displayName
-     * @param array<int, string> $localizedNames
+     * @param string $name
      */
     public function __construct(
         int $id,
         string $displayName,
-        array $localizedNames
+        string $name
     ) {
         $this->id = $id;
-        $this->localizedNames = $localizedNames;
         $this->displayName = $displayName;
+        $this->name = $name;
     }
 
     /**
@@ -81,10 +79,10 @@ class CategoryInformation
     }
 
     /**
-     * @return array<int, string>
+     * @return string
      */
-    public function getLocalizedNames(): array
+    public function getName(): string
     {
-        return $this->localizedNames;
+        return $this->name;
     }
 }

--- a/src/Core/Domain/Product/QueryResult/CategoryInformation.php
+++ b/src/Core/Domain/Product/QueryResult/CategoryInformation.php
@@ -40,26 +40,26 @@ class CategoryInformation
     /**
      * @var string
      */
-    private $displayName;
+    private $name;
 
     /**
      * @var string
      */
-    private $name;
+    private $displayName;
 
     /**
      * @param int $id
-     * @param string $displayName
      * @param string $name
+     * @param string $displayName
      */
     public function __construct(
         int $id,
-        string $displayName,
-        string $name
+        string $name,
+        string $displayName
     ) {
         $this->id = $id;
-        $this->displayName = $displayName;
         $this->name = $name;
+        $this->displayName = $displayName;
     }
 
     /**
@@ -73,16 +73,16 @@ class CategoryInformation
     /**
      * @return string
      */
-    public function getDisplayName(): string
+    public function getName(): string
     {
-        return $this->displayName;
+        return $this->name;
     }
 
     /**
      * @return string
      */
-    public function getName(): string
+    public function getDisplayName(): string
     {
-        return $this->name;
+        return $this->displayName;
     }
 }

--- a/src/Core/Domain/Product/QueryResult/CategoryInformation.php
+++ b/src/Core/Domain/Product/QueryResult/CategoryInformation.php
@@ -39,19 +39,29 @@ class CategoryInformation
 
     /**
      * @var array<int, string>
+     * @todo: this doesn't need to be localized because we are not updating category info in product page
+     *        (product name, description are localized, because all languages are needed for update)
      */
     private $localizedNames;
 
     /**
+     * @var string[]
+     */
+    private $breadcrumbs;
+
+    /**
      * @param int $id
      * @param array<int, string> $localizedNames
+     * @param string[] $breadcrumbs
      */
     public function __construct(
         int $id,
-        array $localizedNames
+        array $localizedNames,
+        array $breadcrumbs
     ) {
         $this->id = $id;
         $this->localizedNames = $localizedNames;
+        $this->breadcrumbs = $breadcrumbs;
     }
 
     /**
@@ -68,5 +78,13 @@ class CategoryInformation
     public function getLocalizedNames(): array
     {
         return $this->localizedNames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getBreadcrumbs(): array
+    {
+        return $this->breadcrumbs;
     }
 }

--- a/src/Core/Domain/Product/QueryResult/CategoryInformation.php
+++ b/src/Core/Domain/Product/QueryResult/CategoryInformation.php
@@ -38,6 +38,11 @@ class CategoryInformation
     private $id;
 
     /**
+     * @var string
+     */
+    private $displayName;
+
+    /**
      * @var array<int, string>
      * @todo: this doesn't need to be localized because we are not updating category info in product page
      *        (product name, description are localized, because all languages are needed for update)
@@ -45,23 +50,18 @@ class CategoryInformation
     private $localizedNames;
 
     /**
-     * @var string[]
-     */
-    private $breadcrumbs;
-
-    /**
      * @param int $id
+     * @param string $displayName
      * @param array<int, string> $localizedNames
-     * @param string[] $breadcrumbs
      */
     public function __construct(
         int $id,
-        array $localizedNames,
-        array $breadcrumbs
+        string $displayName,
+        array $localizedNames
     ) {
         $this->id = $id;
         $this->localizedNames = $localizedNames;
-        $this->breadcrumbs = $breadcrumbs;
+        $this->displayName = $displayName;
     }
 
     /**
@@ -73,18 +73,18 @@ class CategoryInformation
     }
 
     /**
+     * @return string
+     */
+    public function getDisplayName(): string
+    {
+        return $this->displayName;
+    }
+
+    /**
      * @return array<int, string>
      */
     public function getLocalizedNames(): array
     {
         return $this->localizedNames;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getBreadcrumbs(): array
-    {
-        return $this->breadcrumbs;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -109,7 +109,9 @@ class ProductFormDataProvider implements FormDataProviderInterface
         $productId = (int) $id;
         $shopConstraint = null !== $this->contextShopId ? ShopConstraint::shop($this->contextShopId) : ShopConstraint::shop($this->defaultShopId);
         /** @var ProductForEditing $productForEditing */
-        $productForEditing = $this->queryBus->handle(new GetProductForEditing($productId, $shopConstraint));
+        $productForEditing = $this->queryBus->handle(
+            new GetProductForEditing($productId, $shopConstraint, $this->contextLangId)
+        );
 
         $productData = [
             'id' => $productId,

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -164,6 +164,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
             $categories[] = [
                 'id' => $categoryId,
                 'name' => $localizedNames[$this->contextLangId],
+                'breadcrumb' => implode(' > ', $categoryInformation->getBreadcrumbs()),
             ];
         }
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -156,21 +156,24 @@ class ProductFormDataProvider implements FormDataProviderInterface
     private function extractCategoriesData(ProductForEditing $productForEditing): array
     {
         $categoriesInformation = $productForEditing->getCategoriesInformation();
+        $categories = $categoriesInformation->getCategoriesInformation();
         $defaultCategoryId = $categoriesInformation->getDefaultCategoryId();
 
-        $categories = [];
-        foreach ($categoriesInformation->getCategoriesInformation() as $categoryInformation) {
-            $categoryId = $categoryInformation->getId();
+        $categoriesData = [];
+        foreach ($categories as $category) {
+            $categoryId = $category->getId();
 
-            $categories[] = [
+            $categoriesData[] = [
                 'id' => $categoryId,
-                'name' => $categoryInformation->getName(),
-                'display_name' => $categoryInformation->getDisplayName(),
+                'name' => $category->getName(),
+                'display_name' => $category->getDisplayName(),
+                // do not allow removing default category or if it is the last one
+                'removable' => $defaultCategoryId !== $category->getId() && 1 !== count($categories),
             ];
         }
 
         return [
-            'product_categories' => $categories,
+            'product_categories' => $categoriesData,
             'default_category_id' => $defaultCategoryId,
         ];
     }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -156,15 +156,31 @@ class ProductFormDataProvider implements FormDataProviderInterface
         $categoriesInformation = $productForEditing->getCategoriesInformation();
         $defaultCategoryId = $categoriesInformation->getDefaultCategoryId();
 
+        $categoryNamesById = [];
+        foreach ($categoriesInformation->getCategoriesInformation() as $categoryInformation) {
+            $name = $categoryInformation->getLocalizedNames()[$this->contextLangId];
+            $categoryNamesById[$categoryInformation->getId()] = $name;
+        }
+
+        $duplicatedNameIds = [];
+        foreach ($categoryNamesById as $id => $name) {
+            if (array_count_values($categoryNamesById)[$name] > 1) {
+                $duplicatedNameIds[] = $id;
+            }
+        }
+
         $categories = [];
         foreach ($categoriesInformation->getCategoriesInformation() as $categoryInformation) {
             $localizedNames = $categoryInformation->getLocalizedNames();
             $categoryId = $categoryInformation->getId();
+            $name = $localizedNames[$this->contextLangId];
+            if (in_array($categoryId, $duplicatedNameIds)) {
+                $name = implode(' > ', array_slice($categoryInformation->getBreadcrumbs(), -2, 2));
+            }
 
             $categories[] = [
                 'id' => $categoryId,
-                'name' => $localizedNames[$this->contextLangId],
-                'breadcrumb' => implode(' > ', $categoryInformation->getBreadcrumbs()),
+                'name' => $name,
             ];
         }
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -174,13 +174,14 @@ class ProductFormDataProvider implements FormDataProviderInterface
             $localizedNames = $categoryInformation->getLocalizedNames();
             $categoryId = $categoryInformation->getId();
             $name = $localizedNames[$this->contextLangId];
-            if (in_array($categoryId, $duplicatedNameIds)) {
-                $name = implode(' > ', array_slice($categoryInformation->getBreadcrumbs(), -2, 2));
-            }
+//            if (in_array($categoryId, $duplicatedNameIds)) {
+//                $name = implode(' > ', array_slice($categoryInformation->getBreadcrumbs(), -2, 2));
+//            }
 
             $categories[] = [
                 'id' => $categoryId,
                 'name' => $name,
+                'breadcrumb' => implode(' > ', array_slice($categoryInformation->getBreadcrumbs(), -2, 2))
             ];
         }
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -156,32 +156,15 @@ class ProductFormDataProvider implements FormDataProviderInterface
         $categoriesInformation = $productForEditing->getCategoriesInformation();
         $defaultCategoryId = $categoriesInformation->getDefaultCategoryId();
 
-        $categoryNamesById = [];
-        foreach ($categoriesInformation->getCategoriesInformation() as $categoryInformation) {
-            $name = $categoryInformation->getLocalizedNames()[$this->contextLangId];
-            $categoryNamesById[$categoryInformation->getId()] = $name;
-        }
-
-        $duplicatedNameIds = [];
-        foreach ($categoryNamesById as $id => $name) {
-            if (array_count_values($categoryNamesById)[$name] > 1) {
-                $duplicatedNameIds[] = $id;
-            }
-        }
-
         $categories = [];
         foreach ($categoriesInformation->getCategoriesInformation() as $categoryInformation) {
             $localizedNames = $categoryInformation->getLocalizedNames();
             $categoryId = $categoryInformation->getId();
-            $name = $localizedNames[$this->contextLangId];
-//            if (in_array($categoryId, $duplicatedNameIds)) {
-//                $name = implode(' > ', array_slice($categoryInformation->getBreadcrumbs(), -2, 2));
-//            }
 
             $categories[] = [
                 'id' => $categoryId,
-                'name' => $name,
-                'breadcrumb' => implode(' > ', array_slice($categoryInformation->getBreadcrumbs(), -2, 2))
+                'name' => $localizedNames[$this->contextLangId] ?? reset($localizedNames),
+                'display_name' => $categoryInformation->getDisplayName(),
             ];
         }
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -158,12 +158,11 @@ class ProductFormDataProvider implements FormDataProviderInterface
 
         $categories = [];
         foreach ($categoriesInformation->getCategoriesInformation() as $categoryInformation) {
-            $localizedNames = $categoryInformation->getLocalizedNames();
             $categoryId = $categoryInformation->getId();
 
             $categories[] = [
                 'id' => $categoryId,
-                'name' => $localizedNames[$this->contextLangId] ?? reset($localizedNames),
+                'name' => $categoryInformation->getName(),
                 'display_name' => $categoryInformation->getDisplayName(),
             ];
         }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -800,12 +800,14 @@ class CategoryController extends FrameworkBundleAdminController
             $children = $this->formatCategoriesTreeForPresentation($categoryForTree->getChildren(), $langId);
 
             $names = $categoryForTree->getLocalizedNames();
+            $breadcrumbs = $categoryForTree->getLocalizedBreadcrumbs();
             $active = $categoryForTree->getActive();
             $formattedCategories[] = [
                 'id' => $categoryForTree->getCategoryId(),
                 'active' => $active,
                 'name' => $names[$langId] ?? reset($names),
                 'children' => $children,
+                'breadcrumb' => implode(' > ', $breadcrumbs[$langId] ?? reset($breadcrumbs)),
             ];
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -807,7 +807,7 @@ class CategoryController extends FrameworkBundleAdminController
                 'active' => $active,
                 'name' => $names[$langId] ?? reset($names),
                 'children' => $children,
-                'breadcrumb' => implode(' > ', $breadcrumbs[$langId] ?? reset($breadcrumbs)),
+                'breadcrumb' => implode(' > ', array_slice($breadcrumbs[$langId], -2, 2)),
             ];
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -778,7 +778,7 @@ class CategoryController extends FrameworkBundleAdminController
     public function getCategoriesTreeAction(Request $request): JsonResponse
     {
         $langId = $request->query->getInt('langId') ?: (int) $this->getContextLangId();
-        $categoriesTree = $this->getQueryBus()->handle(new GetCategoriesTree($langId));
+        $categoriesTree = $this->getQueryBus()->handle(new GetCategoriesTree($langId, $this->getContextShopId()));
 
         return $this->json($this->formatCategoriesTreeForPresentation($categoriesTree, $langId));
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -800,14 +800,13 @@ class CategoryController extends FrameworkBundleAdminController
             $children = $this->formatCategoriesTreeForPresentation($categoryForTree->getChildren(), $langId);
 
             $names = $categoryForTree->getLocalizedNames();
-            $breadcrumbs = $categoryForTree->getLocalizedBreadcrumbs();
             $active = $categoryForTree->getActive();
             $formattedCategories[] = [
                 'id' => $categoryForTree->getCategoryId(),
                 'active' => $active,
                 'name' => $names[$langId] ?? reset($names),
+                'displayName' => $categoryForTree->getDisplayName(),
                 'children' => $children,
-                'breadcrumb' => implode(' > ', array_slice($breadcrumbs[$langId], -2, 2)),
             ];
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -799,12 +799,11 @@ class CategoryController extends FrameworkBundleAdminController
         foreach ($categoriesTree as $categoryForTree) {
             $children = $this->formatCategoriesTreeForPresentation($categoryForTree->getChildren(), $langId);
 
-            $names = $categoryForTree->getLocalizedNames();
             $active = $categoryForTree->getActive();
             $formattedCategories[] = [
                 'id' => $categoryForTree->getCategoryId(),
                 'active' => $active,
-                'name' => $names[$langId] ?? reset($names),
+                'name' => $categoryForTree->getName(),
                 'displayName' => $categoryForTree->getDisplayName(),
                 'children' => $children,
             ];

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
@@ -76,7 +76,6 @@ class CategoriesType extends TranslatorAwareType
             ->add('default_category_id', ChoiceType::class, [
                 'constraints' => [],
                 'choices' => $this->defaultCategoryChoiceProvider->getChoices(['product_id' => $options['product_id']]),
-                //@todo: wording - default or main?
                 'label' => $this->trans('Default category', 'Admin.Catalog.Feature'),
                 'attr' => [
                     'data-toggle' => 'select2',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
@@ -39,6 +39,9 @@ class ProductCategoryType extends TranslatorAwareType
     {
         $builder
             ->add('display_name', TextPreviewType::class, [
+                'attr' => [
+                    'class' => 'category-name-preview-input',
+                ],
                 'preview_class' => 'category-name-preview',
             ])
             ->add('name', HiddenType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
@@ -43,9 +43,24 @@ class ProductCategoryType extends TranslatorAwareType
                 'attr' => [
                     'class' => 'category-name-input',
                 ],
+//@todo:
+//      The whole problem that in js category tree component communicates with tags component by collecting input names
+//      So when I change the name in php side, it all renders fine on page load, but name becomes the breadcrumb, and i cannot compare
+//      previoslySelectedCategory.name with new selectedCategoryName because one will have actual name and another will contain breadcrumb
+//      so its kind of a loophole. I need some additional var "displayName" which would be decided by comparing names.Thought the preview component automatically
+//      But the preview component renders the input value same as preview.
+//
+//      So the idea here was to provide custom value for a preview section (which could be a breadcrumb)
+//      then in js i could compare categories by name which stays in input value and show breadcrumbs as preview
+//      but this doesnt seem to ever work because data provider does not provide options.
+//      i could maybe try custom rendering in twig depending if data provider returns something like "isDuplicateName" in each category
+//      but that also sounds stupid
+//                'custom_preview_value' =>
             ])
-            ->add('breadcrumb', TextPreviewType::class, [
-                'preview_class' => 'category-breadcrumb-preview',
+            ->add('breadcrumb', HiddenType::class, [
+                'attr' => [
+                    'class' => 'category-breadcrumb',
+                ],
             ])
             ->add('id', HiddenType::class)
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
@@ -44,6 +44,9 @@ class ProductCategoryType extends TranslatorAwareType
                     'class' => 'category-name-input',
                 ],
             ])
+            ->add('breadcrumb', TextPreviewType::class, [
+                'preview_class' => 'category-breadcrumb-preview',
+            ])
             ->add('id', HiddenType::class)
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/ProductCategoryType.php
@@ -38,28 +38,12 @@ class ProductCategoryType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('name', TextPreviewType::class, [
+            ->add('display_name', TextPreviewType::class, [
                 'preview_class' => 'category-name-preview',
+            ])
+            ->add('name', HiddenType::class, [
                 'attr' => [
                     'class' => 'category-name-input',
-                ],
-//@todo:
-//      The whole problem that in js category tree component communicates with tags component by collecting input names
-//      So when I change the name in php side, it all renders fine on page load, but name becomes the breadcrumb, and i cannot compare
-//      previoslySelectedCategory.name with new selectedCategoryName because one will have actual name and another will contain breadcrumb
-//      so its kind of a loophole. I need some additional var "displayName" which would be decided by comparing names.Thought the preview component automatically
-//      But the preview component renders the input value same as preview.
-//
-//      So the idea here was to provide custom value for a preview section (which could be a breadcrumb)
-//      then in js i could compare categories by name which stays in input value and show breadcrumbs as preview
-//      but this doesnt seem to ever work because data provider does not provide options.
-//      i could maybe try custom rendering in twig depending if data provider returns something like "isDuplicateName" in each category
-//      but that also sounds stupid
-//                'custom_preview_value' =>
-            ])
-            ->add('breadcrumb', HiddenType::class, [
-                'attr' => [
-                    'class' => 'category-breadcrumb',
                 ],
             ])
             ->add('id', HiddenType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/CategoriesListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/CategoriesListener.php
@@ -66,6 +66,10 @@ class CategoriesListener implements EventSubscriberInterface
         $form = $event->getForm();
         $data = $event->getData();
 
+        if (empty($data)) {
+            return;
+        }
+
         // Update choices list to contain all selected categories, because extra choice might have been added by javascript
         $newChoicesForm = $this->formCloner->cloneForm($form->get('default_category_id'), [
             'choices' => $this->formatNewChoices($data),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/CategoriesListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/CategoriesListener.php
@@ -78,7 +78,7 @@ class CategoriesListener implements EventSubscriberInterface
     {
         $choices = [];
         foreach ($data['product_categories'] as $category) {
-            $choices[$category['name']] = $category['id'];
+            $choices[$category['display_name']] = $category['id'];
         }
 
         return $choices;

--- a/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
@@ -48,7 +48,6 @@ class TextPreviewType extends HiddenType
         parent::buildView($view, $form, $options);
         $view->vars['type'] = 'hidden';
         $view->vars['preview_class'] = $options['preview_class'];
-        $view->vars['preview_value'] = $options['custom_preview_value'] ?? $form->getData();
         if (!empty($options['prefix'])) {
             $view->vars['prefix'] = $options['prefix'];
         }
@@ -70,17 +69,15 @@ class TextPreviewType extends HiddenType
         parent::configureOptions($resolver);
 
         $resolver
+            ->setRequired(['preview_class'])
+            ->setAllowedTypes('preview_class', 'string')
             ->setDefaults([
                 'preview_class' => 'text-preview',
                 'prefix' => null,
                 'suffix' => null,
-                'custom_preview_value' => null,
             ])
-            ->setRequired(['preview_class'])
-            ->setAllowedTypes('preview_class', 'string')
             ->setAllowedTypes('prefix', ['string', 'null'])
             ->setAllowedTypes('suffix', ['string', 'null'])
-            ->setAllowedTypes('custom_preview_value', ['null', 'string'])
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TextPreviewType.php
@@ -48,6 +48,7 @@ class TextPreviewType extends HiddenType
         parent::buildView($view, $form, $options);
         $view->vars['type'] = 'hidden';
         $view->vars['preview_class'] = $options['preview_class'];
+        $view->vars['preview_value'] = $options['custom_preview_value'] ?? $form->getData();
         if (!empty($options['prefix'])) {
             $view->vars['prefix'] = $options['prefix'];
         }
@@ -69,15 +70,17 @@ class TextPreviewType extends HiddenType
         parent::configureOptions($resolver);
 
         $resolver
-            ->setRequired(['preview_class'])
-            ->setAllowedTypes('preview_class', 'string')
             ->setDefaults([
                 'preview_class' => 'text-preview',
                 'prefix' => null,
                 'suffix' => null,
+                'custom_preview_value' => null,
             ])
+            ->setRequired(['preview_class'])
+            ->setAllowedTypes('preview_class', 'string')
             ->setAllowedTypes('prefix', ['string', 'null'])
             ->setAllowedTypes('suffix', ['string', 'null'])
+            ->setAllowedTypes('custom_preview_value', ['null', 'string'])
         ;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
@@ -128,7 +128,8 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Category\QueryHandler\GetCategoriesTreeHandler
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
-      - '@prestashop.adapter.category.repository.category_repository'
+      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
+      - '@prestashop.core.category.name_builder.category_display_name_builder'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree

--- a/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
@@ -128,6 +128,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Category\QueryHandler\GetCategoriesTreeHandler
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
+      - '@prestashop.adapter.category.repository.category_repository'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree

--- a/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
@@ -130,6 +130,7 @@ services:
       - '@prestashop.core.category.name_builder.category_display_name_builder'
       - '@prestashop.adapter.context_state_manager'
       - '@prestashop.adapter.shop.repository.shop_repository'
+      - "@=service('prestashop.adapter.legacy.configuration').get('PS_ROOT_CATEGORY')"
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree

--- a/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
@@ -127,9 +127,9 @@ services:
   prestashop.adapter.category.query_handler.get_categories_tree_handler:
     class: PrestaShop\PrestaShop\Adapter\Category\QueryHandler\GetCategoriesTreeHandler
     arguments:
-      - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
-      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
       - '@prestashop.core.category.name_builder.category_display_name_builder'
+      - '@prestashop.adapter.context_state_manager'
+      - '@prestashop.adapter.shop.repository.shop_repository'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree

--- a/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/form.yml
@@ -85,6 +85,9 @@ services:
     arguments:
       - "@=service('prestashop.adapter.legacy.configuration').getInt('PS_HOME_CATEGORY')"
       - '@prestashop.adapter.category.repository.category_repository'
+      - '@prestashop.core.category.name_builder.category_display_name_builder'
+      - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
 
   prestashop.adapter.form.choice_provider.combination_id_choice_provider:
     class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\CombinationIdChoiceProvider'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -120,6 +120,7 @@ services:
       - '@prestashop.adapter.product.image.product_image_url_factory'
       - '@prestashop.adapter.product.specific_price.repository.specific_price_repository'
       - '@prestashop.adapter.legacy.configuration'
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -120,7 +120,6 @@ services:
       - '@prestashop.adapter.product.image.product_image_url_factory'
       - '@prestashop.adapter.product.specific_price.repository.specific_price_repository'
       - '@prestashop.adapter.legacy.configuration'
-      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
       - '@prestashop.core.category.name_builder.category_display_name_builder'
     tags:
       - name: tactician.handler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -121,6 +121,7 @@ services:
       - '@prestashop.adapter.product.specific_price.repository.specific_price_repository'
       - '@prestashop.adapter.legacy.configuration'
       - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - '@prestashop.core.category.name_builder.category_display_name_builder'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing

--- a/src/PrestaShopBundle/Resources/config/services/core/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/category.yml
@@ -1,0 +1,8 @@
+services:
+  _defaults:
+    public: true
+
+  prestashop.core.category.name_builder.category_display_name_builder:
+    class: 'PrestaShop\PrestaShop\Core\Category\NameBuilder\CategoryDisplayNameBuilder'
+    arguments:
+      - '@prestashop.adapter.category.repository.category_repository'

--- a/src/PrestaShopBundle/Resources/config/services/core/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/category.yml
@@ -6,3 +6,4 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Category\NameBuilder\CategoryDisplayNameBuilder'
     arguments:
       - '@prestashop.adapter.category.repository.category_repository'
+      - ' > '

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
@@ -36,8 +36,8 @@
   {%- set attr = attr|merge({'class': (attr.class|default('') ~ ' pstaggerTag tag-item')|trim }) -%}
 
   <span {{ block('widget_attributes') }}>
+    {{ form_widget(form.display_name) }}
     {{ form_widget(form.name) }}
-    {{ form_widget(form.breadcrumb) }}
     {% set hideCross = (form.vars.data.id is defined) and (form.vars.data.id == form.parent.parent.vars.data.default_category_id) %}
     <a class="pstaggerClosingCross {% if hideCross %}d-none{% endif %}" href="#">x</a>
     {{ form_widget(form.id, {'attr': {'class': 'category-id-input'}}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
@@ -37,6 +37,7 @@
 
   <span {{ block('widget_attributes') }}>
     {{ form_widget(form.name) }}
+    {{ form_widget(form.breadcrumb) }}
     {% set hideCross = (form.vars.data.id is defined) and (form.vars.data.id == form.parent.parent.vars.data.default_category_id) %}
     <a class="pstaggerClosingCross {% if hideCross %}d-none{% endif %}" href="#">x</a>
     {{ form_widget(form.id, {'attr': {'class': 'category-id-input'}}) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
@@ -38,8 +38,8 @@
   <span {{ block('widget_attributes') }}>
     {{ form_widget(form.display_name) }}
     {{ form_widget(form.name) }}
-    {% set hideCross = (form.vars.data.id is defined) and (form.vars.data.id == form.parent.parent.vars.data.default_category_id) %}
-    <a class="pstaggerClosingCross {% if hideCross %}d-none{% endif %}" href="#">x</a>
+    {% set isRemovable = (form.vars.data.removable is defined and form.vars.data.removable) %}
+    <a class="pstaggerClosingCross {% if not isRemovable %}d-none{% endif %}" href="#">x</a>
     {{ form_widget(form.id, {'attr': {'class': 'category-id-input'}}) }}
   </span>
 {% endblock %}

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -296,14 +296,6 @@ abstract class AbstractDomainFeatureContext implements Context
     /**
      * @return int
      */
-    protected function getDefaultShopId(): int
-    {
-        return (int) Configuration::get('PS_SHOP_DEFAULT');
-    }
-
-    /**
-     * @return int
-     */
     protected function getDefaultLangId(): int
     {
         return (int) Configuration::get('PS_LANG_DEFAULT');

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -34,7 +34,6 @@ use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use Configuration;
-use Context as PrestashopContext;
 use Currency;
 use Exception;
 use Language;

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -34,6 +34,7 @@ use Behat\Gherkin\Node\StepNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Testwork\Hook\Scope\BeforeSuiteScope;
 use Configuration;
+use Context as PrestashopContext;
 use Currency;
 use Exception;
 use Language;
@@ -291,6 +292,14 @@ abstract class AbstractDomainFeatureContext implements Context
         }
 
         return $localizedValues;
+    }
+
+    /**
+     * @return int
+     */
+    protected function getDefaultShopId(): int
+    {
+        return (int) Configuration::get('PS_SHOP_DEFAULT');
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -27,7 +27,6 @@
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
 use Behat\Gherkin\Node\TableNode;
-use Cache;
 use Category;
 use Configuration;
 use Language;
@@ -100,7 +99,7 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
     public function assertRootCategoriesTree(TableNode $tableNode, string $langIso): void
     {
         $langId = Language::getIdByIso($langIso);
-        $categoriesTree = $this->getQueryBus()->handle(new GetCategoriesTree($langId));
+        $categoriesTree = $this->getQueryBus()->handle(new GetCategoriesTree($langId, $this->getDefaultShopId()));
 
         Assert::assertNotEmpty($categoriesTree, 'Categories tree is empty');
 
@@ -116,10 +115,9 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
      */
     public function assertCategoriesTree(TableNode $tableNode, string $langIso, string $parentReference): void
     {
-        Cache::clean('Category::getNestedCategories_*');
-        Cache::clean('duplicateCategoryNames_*');
+        Category::resetStaticCache();
         $langId = Language::getIdByIso($langIso);
-        $categoriesTree = $this->getQueryBus()->handle(new GetCategoriesTree($langId));
+        $categoriesTree = $this->getQueryBus()->handle(new GetCategoriesTree($langId, $this->getDefaultShopId()));
 
         Assert::assertNotEmpty($categoriesTree, 'Categories tree is empty');
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
@@ -132,7 +132,8 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
 
         return $this->getQueryBus()->handle(new GetProductForEditing(
             $productId,
-            $shopConstraint
+            $shopConstraint,
+            $this->getDefaultLangId()
         ));
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
@@ -85,7 +85,7 @@ class UpdateCategoriesFeatureContext extends AbstractProductFeatureContext
     {
         Cache::clear();
         $productForEditing = $this->getProductForEditing($productReference);
-        $expectedCategories = $this->localizeByColumns($table);
+        $expectedCategories = $table->getColumnsHash();
         $categoriesInfo = $productForEditing->getCategoriesInformation();
         $actualCategories = $categoriesInfo->getCategoriesInformation();
 
@@ -114,7 +114,7 @@ class UpdateCategoriesFeatureContext extends AbstractProductFeatureContext
             );
             Assert::assertEquals(
                 $expectedCategory['name'],
-                $categoryInformation->getLocalizedNames(),
+                $categoryInformation->getName(),
                 'Category localized names doesn\'t match'
             );
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -22,8 +22,8 @@ Feature: Add basic product from Back Office (BO)
       | locale | value          |
       | en-US  | bottle of beer |
     And product "product1" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
 
   Scenario: I add a product with basic information
     When I add product "product1" with following information:
@@ -44,8 +44,8 @@ Feature: Add basic product from Back Office (BO)
       | locale | value          |
       | en-US  | bottle of beer |
     And product "product1" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
 
   Scenario: I add a product with invalid characters in name
     When I add product "product2" with following information:
@@ -70,7 +70,7 @@ Feature: Add basic product from Back Office (BO)
       | locale | value |
       | en-US  |       |
     And product "product1" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
+      | id reference | name | is default |
       | home         | Home        | true       |
 
   Scenario: Empty friendly-urls should be auto-filled using product name value when adding new product

--- a/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
@@ -125,7 +125,7 @@ Feature: Duplicate product from Back Office (BO).
       | description_short[fr-FR] | Lunettes de lecture transparentes |
     And I assign product product2 to following categories:
       | categories       | [home, women, clothes] |
-      | default category | women              |
+      | default category | women                  |
     And I update product "product2" options with following values:
       | visibility          | catalog      |
       | available_for_order | true         |
@@ -140,8 +140,8 @@ Feature: Duplicate product from Back Office (BO).
       | mpn       | mpn2              |
       | reference | ref2              |
     And I update product "product2" tags with following values:
-      | tags[en-US] | glasses,readingglasses,women      |
-      | tags[fr-FR] | lunettes,lunettespourlire,femmes  |
+      | tags[en-US] | glasses,readingglasses,women     |
+      | tags[fr-FR] | lunettes,lunettespourlire,femmes |
     And I update product "product2" prices with following information:
       | price           | 200.00          |
       | ecotax          | 0               |
@@ -151,13 +151,13 @@ Feature: Duplicate product from Back Office (BO).
       | unit_price      | 500             |
       | unity           | lots            |
     And I update product product2 SEO information with following values:
-      | meta_title[en-US]       | READINGGLASSES meta title   |
-      | meta_description[en-US] | You can read now            |
-      | meta_description[fr-FR] | You can read in french now  |
-      | link_rewrite[en-US]     | reading-glasses             |
-      | link_rewrite[fr-FR]     | lunettes-de-lecture         |
-      | redirect_type           | 301-product                 |
-      | redirect_target         | product1                    |
+      | meta_title[en-US]       | READINGGLASSES meta title  |
+      | meta_description[en-US] | You can read now           |
+      | meta_description[fr-FR] | You can read in french now |
+      | link_rewrite[en-US]     | reading-glasses            |
+      | link_rewrite[fr-FR]     | lunettes-de-lecture        |
+      | redirect_type           | 301-product                |
+      | redirect_target         | product1                   |
     And I update product product2 shipping information with following values:
       | width                                   | 12                   |
       | height                                  | 8                    |
@@ -210,10 +210,10 @@ Feature: Duplicate product from Back Office (BO).
       | en-US  | Simple & nice sunglasses   |
       | fr-FR  | lunettes simples et belles |
     And product copy_of_product1 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | false      |
-      | men          | Men         | Men         | false      |
-      | clothes      | Clothes     | Clothes     | true       |
+      | id reference | name    | is default |
+      | home         | Home    | false      |
+      | men          | Men     | false      |
+      | clothes      | Clothes | true       |
     And product "copy_of_product1" should have following options:
       | product option      | value        |
       | visibility          | catalog      |
@@ -286,22 +286,22 @@ Feature: Duplicate product from Back Office (BO).
     And product "copy_of_product2" should be disabled
     And product "copy_of_product2" type should be standard
     And product "copy_of_product2" localized "name" should be:
-      | locale | value                       |
-      | en-US  | copy of Reading glasses     |
-      | fr-FR  | copie de lunettes           |
+      | locale | value                   |
+      | en-US  | copy of Reading glasses |
+      | fr-FR  | copie de lunettes       |
     And product "copy_of_product2" localized "description" should be:
-      | locale | value                |
-      | en-US  | Reading glasses      |
-      | fr-FR  | lunettes de lecture  |
+      | locale | value               |
+      | en-US  | Reading glasses     |
+      | fr-FR  | lunettes de lecture |
     And product "copy_of_product2" localized "description_short" should be:
       | locale | value                             |
       | en-US  | Clear Reading glasses             |
       | fr-FR  | Lunettes de lecture transparentes |
     And product copy_of_product2 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | false      |
-      | women        | Women       | Women       | true       |
-      | clothes      | Clothes     | Clothes     | false      |
+      | id reference | name    | is default |
+      | home         | Home    | false      |
+      | women        | Women   | true       |
+      | clothes      | Clothes | false      |
     And product "copy_of_product2" should have following options:
       | product option      | value        |
       | visibility          | catalog      |
@@ -336,16 +336,16 @@ Feature: Duplicate product from Back Office (BO).
       | unity            | lots            |
       | unit_price_ratio | 0.4             |
     And product "copy_of_product2" localized "meta_title" should be:
-      | locale | value                 |
+      | locale | value                     |
       | en-US  | READINGGLASSES meta title |
     And product "copy_of_product2" localized "meta_description" should be:
-      | locale | value                          |
-      | en-US  | You can read now               |
-      | fr-FR  | You can read in french now     |
+      | locale | value                      |
+      | en-US  | You can read now           |
+      | fr-FR  | You can read in french now |
     And product "copy_of_product2" localized "link_rewrite" should be:
       | locale | value               |
       | en-US  | reading-glasses     |
-      | fr-FR  |lunettes-de-lecture  |
+      | fr-FR  | lunettes-de-lecture |
     And product copy_of_product2 should have following seo options:
       | redirect_type   | 301-product |
       | redirect_target | product1    |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
@@ -25,20 +25,32 @@ Feature: Show category tree in product page (BO)
     And category "art" in default language named "Art" exists
     And category "art" parent is category "home"
 
-  Scenario: I can see categories tree with product associations
+  Scenario: I can see categories tree
     Given I should see following root categories in "en" language:
-      | id reference | category name | direct child categories   |
-      | home         | Home          | [clothes,accessories,art] |
+      | id reference | category name | display name | direct child categories   |
+      | home         | Home          | Home         | [clothes,accessories,art] |
     And I should see following categories in "home" category in "en" language:
-      | id reference | category name | direct child categories       |
-      | clothes      | Clothes       | [men,women]                   |
-      | accessories  | Accessories   | [stationery,home_accessories] |
-      | art          | Art           |                               |
+      | id reference | category name | display name | direct child categories       |
+      | clothes      | Clothes       | Clothes      | [men,women]                   |
+      | accessories  | Accessories   | Accessories  | [stationery,home_accessories] |
+      | art          | Art           | Art          |                               |
     And I should see following categories in "clothes" category in "en" language:
-      | id reference | category name | direct child categories |
-      | men          | Men           |                         |
-      | women        | Women         |                         |
+      | id reference | category name | display name | direct child categories |
+      | men          | Men           | Men          |                         |
+      | women        | Women         | Women        |                         |
     And I should see following categories in "accessories" category in "en" language:
-      | id reference     | category name    | direct child categories |
-      | stationery       | Stationery       |                         |
-      | home_accessories | Home Accessories |                         |
+      | id reference     | category name    | display name     | direct child categories |
+      | stationery       | Stationery       | Stationery       |                         |
+      | home_accessories | Home Accessories | Home Accessories |                         |
+    When I add new category "artWomen" with following details:
+      | Name            | Women     |
+      | Displayed       | true      |
+      | Parent category | Art       |
+      | Friendly URL    | art-women |
+    Then I should see following categories in "art" category in "en" language:
+      | id reference | category name | display name | direct child categories |
+      | artWomen     | Women         | Art > Women  |                         |
+    And I should see following categories in "clothes" category in "en" language:
+      | id reference | category name | display name    | direct child categories |
+      | men          | Men           | Men             |                         |
+      | women        | Women         | Clothes > Women |                         |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -145,10 +145,10 @@ Feature: Duplicate product from Back Office (BO).
       | en-US  | Simple & nice sunglasses   |
       | fr-FR  | lunettes simples et belles |
     And product copy_of_product1 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | false      |
-      | men          | Men         | Men         | false      |
-      | clothes      | Clothes     | Clothes     | true       |
+      | id reference | name    | is default |
+      | home         | Home    | false      |
+      | men          | Men     | false      |
+      | clothes      | Clothes | true       |
     And product "copy_of_product1" should have following options:
       | product option      | value        |
       | visibility          | catalog      |
@@ -173,10 +173,10 @@ Feature: Duplicate product from Back Office (BO).
       | supplier  | reference                      | currency | price_tax_excluded |
       | supplier1 | my first supplier for product1 | USD      | 10                 |
     And product copy_of_product1 should have following prices information:
-      | price            | 100.00          |
-      | ecotax           | 0               |
-      | tax rules group  | US-AL Rate (4%) |
-      | on_sale          | true            |
+      | price                   | 100.00          |
+      | ecotax                  | 0               |
+      | tax rules group         | US-AL Rate (4%) |
+      | on_sale                 | true            |
       # wholesale_price = 10, because of assigned product supplier 'price tax excluded'.
       | wholesale_price         | 10              |
       | unit_price              | 500             |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_categories.feature
@@ -21,19 +21,19 @@ Feature: Update product categories from Back Office (BO)
       | name[en-US] | eastern european tracksuit |
       | type        | standard                   |
     And product "product1" should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | true      |
+      | id reference | name | is default |
+      | home         | Home | true       |
     Then product product1 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     When I assign product product1 to following categories:
       | categories       | [home, men, clothes] |
       | default category | clothes              |
     Then product product1 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | false      |
-      | men          | Men         | Men         | false      |
-      | clothes      | Clothes     | Clothes     | true       |
+      | id reference | name    | is default |
+      | home         | Home    | false      |
+      | men          | Men     | false      |
+      | clothes      | Clothes | true       |
 
   Scenario: I assign product to disabled categories
     Given I add product "product2" with following information:
@@ -45,74 +45,74 @@ Feature: Update product categories from Back Office (BO)
       | categories       | [home, women, accessories] |
       | default category | women                      |
     Then product product2 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | false      |
-      | women        | Women       | Women       | true       |
-      | accessories  | Accessories | Accessories | false      |
+      | id reference | name        | is default |
+      | home         | Home        | false      |
+      | women        | Women       | true       |
+      | accessories  | Accessories | false      |
 
   Scenario: I assign category which is already assigned to product
     Given product product2 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | false      |
-      | women        | Women       | Women       | true       |
-      | accessories  | Accessories | Accessories | false      |
+      | id reference | name        | is default |
+      | home         | Home        | false      |
+      | women        | Women       | true       |
+      | accessories  | Accessories | false      |
     When I assign product product2 to following categories:
       | categories       | [home, women] |
       | default category | women         |
     Then product product2 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | false      |
-      | women        | Women       | Women       | true       |
+      | id reference | name  | is default |
+      | home         | Home  | false      |
+      | women        | Women | true       |
 
   Scenario: I assign default category which is not in the list of categories
     Given I add product "product3" with following information:
       | name[en-US] | golden bracelet |
       | type        | standard        |
     Then product product3 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     When I assign product product3 to following categories:
       | categories       | [women]     |
       | default category | accessories |
     Then product product3 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | women        | Women       | Women       | false      |
-      | accessories  | Accessories | Accessories | true       |
+      | id reference | name        | is default |
+      | women        | Women       | false      |
+      | accessories  | Accessories | true       |
 
   Scenario: I assign new categories providing one non-existing category
     Given product product3 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | women        | Women       | Women       | false      |
-      | accessories  | Accessories | Accessories | true       |
+      | id reference | name        | is default |
+      | women        | Women       | false      |
+      | accessories  | Accessories | true       |
     When I assign product product3 to following categories:
       | categories       | [women, idontexist1] |
       | default category | accessories          |
     Then I should get error that assigning product to categories failed
     And product product3 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | women        | Women       | Women       | false      |
-      | accessories  | Accessories | Accessories | true       |
+      | id reference | name        | is default |
+      | women        | Women       | false      |
+      | accessories  | Accessories | true       |
 
   Scenario: I assign new categories providing non-existing default category
     Given product product3 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | women        | Women       | Women       | false      |
-      | accessories  | Accessories | Accessories | true       |
+      | id reference | name        | is default |
+      | women        | Women       | false      |
+      | accessories  | Accessories | true       |
     When I assign product product3 to following categories:
       | categories       | [women]     |
       | default category | idontexist2 |
     Then I should get error that assigning product to categories failed
     And product product3 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | women        | Women       | Women       | false      |
-      | accessories  | Accessories | Accessories | true       |
+      | id reference | name        | is default |
+      | women        | Women       | false      |
+      | accessories  | Accessories | true       |
 
   Scenario: I delete all categories from product
     Given product product3 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | women        | Women       | Women       | false      |
-      | accessories  | Accessories | Accessories | true       |
+      | id reference | name        | is default |
+      | women        | Women       | false      |
+      | accessories  | Accessories | true       |
     When I delete all categories from product product3
     Then product product3 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_position.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_position.feature
@@ -7,24 +7,24 @@ Feature: Update product position from BO (Back Office)
 
   Background: I add category and products
     Given I add new category "category_for_positions" with following details:
-      | Name                 | Category for positions |
-      | Displayed            | true                   |
-      | Parent category      | Home Accessories       |
-      | Friendly URL         | category-for-positions |
+      | Name            | Category for positions |
+      | Displayed       | true                   |
+      | Parent category | Home Accessories       |
+      | Friendly URL    | category-for-positions |
     And I add new category "other_category_for_positions" with following details:
-      | Name                 | Other category for positions |
-      | Displayed            | true                         |
-      | Parent category      | Home Accessories             |
-      | Friendly URL         | category-for-positions       |
+      | Name            | Other category for positions |
+      | Displayed       | true                         |
+      | Parent category | Home Accessories             |
+      | Friendly URL    | category-for-positions       |
     And category "home" in default language named "Home" exists
     And I add product "product1" with following information:
       | name[en-US] | Values list poster nr. 1 (paper) |
       | type        | standard                         |
     And I assign product "product1" to following categories:
       | categories       | [home, category_for_positions, other_category_for_positions] |
-      | default category | home                           |
+      | default category | home                                                         |
     And product "product1" should be assigned to following categories:
-      | id reference                 | name[en-US]                  | is default |
+      | id reference                 | name                         | is default |
       | category_for_positions       | Category for positions       | false      |
       | other_category_for_positions | Other category for positions | false      |
       | home                         | Home                         | default    |
@@ -33,9 +33,9 @@ Feature: Update product position from BO (Back Office)
       | type        | standard                         |
     And I assign product "product2" to following categories:
       | categories       | [home, category_for_positions, other_category_for_positions] |
-      | default category | home                           |
+      | default category | home                                                         |
     And product "product2" should be assigned to following categories:
-      | id reference                 | name[en-US]                  | is default |
+      | id reference                 | name                         | is default |
       | category_for_positions       | Category for positions       | false      |
       | other_category_for_positions | Other category for positions | false      |
       | home                         | Home                         | default    |
@@ -50,9 +50,9 @@ Feature: Update product position from BO (Back Office)
 
   Scenario: I update standard product position
     When I update product position in category "category_for_positions" with following values:
-      | row_id | old_position | new_position | product_reference|
-      | 1      | 1            | 2            | product1         |
-      | 2      | 2            | 1            | product2         |
+      | row_id | old_position | new_position | product_reference |
+      | 1      | 1            | 2            | product1          |
+      | 2      | 2            | 1            | product2          |
     Then products in category category_for_positions should have the following positions:
       | position | product_reference |
       | 2        | product1          |
@@ -63,9 +63,9 @@ Feature: Update product position from BO (Back Office)
       | 1        | product1          |
       | 2        | product2          |
     When I update product position in category "other_category_for_positions" with following values:
-      | row_id | old_position | new_position | product_reference|
-      | 1      | 1            | 2            | product1         |
-      | 2      | 2            | 1            | product2         |
+      | row_id | old_position | new_position | product_reference |
+      | 1      | 1            | 2            | product1          |
+      | 2      | 2            | 1            | product2          |
     # Now they are modified
     Then products in category other_category_for_positions should have the following positions:
       | position | product_reference |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
@@ -33,8 +33,8 @@ Feature: Add basic product from Back Office (BO)
       | locale | value          |
       | en-US  | bottle of beer |
     And product "productCombinations" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     When I update product "productCombinations" stock with following information:
       | delta_quantity | 51 |
     And product "productCombinations" should have following stock information:
@@ -58,8 +58,8 @@ Feature: Add basic product from Back Office (BO)
       | locale | value          |
       | en-US  | bottle of beer |
     And product "productCombinations2" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     And product "productCombinations2" should have following stock information:
       | quantity | 0 |
     When I update product "productCombinations2" type to combinations
@@ -77,8 +77,8 @@ Feature: Add basic product from Back Office (BO)
       | locale | value          |
       | en-US  | bottle of beer |
     And product "virtualProduct" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     When I update product "virtualProduct" type to virtual
     Then product "virtualProduct" type should be virtual
 
@@ -125,8 +125,8 @@ Feature: Add basic product from Back Office (BO)
       | locale | value          |
       | en-US  | bottle of beer |
     And product "packProduct" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     When I update product "packProduct" type to pack
     Then product "packProduct" type should be pack
 
@@ -140,8 +140,8 @@ Feature: Add basic product from Back Office (BO)
       | locale | value          |
       | en-US  | bottle of beer |
     And product "standardProduct" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     When I update product "standardProduct" type to standard
     Then product "standardProduct" type should be standard
 
@@ -174,7 +174,7 @@ Feature: Add basic product from Back Office (BO)
       | Size  | [S,M]              |
       | Color | [White,Black,Blue] |
     Then product "productCombinations3" should have following combinations:
-      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default | combination reference |
+      | id reference               | combination name        | reference | attributes           | impact on price | quantity | is default | combination reference |
       | productCombinations3SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |                       |
       | productCombinations3SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |                       |
       | productCombinations3Blue   | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |                       |
@@ -182,29 +182,29 @@ Feature: Add basic product from Back Office (BO)
       | productCombinations3MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |                       |
       | productCombinations3MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |                       |
     When I update combination "productCombinations3SWhite" stock with following details:
-      | delta quantity             | 100         |
+      | delta quantity | 100 |
     Then combination "productCombinations3SWhite" should have following stock details:
-      | combination stock detail   | value       |
-      | quantity                   | 100         |
-      | minimal quantity           | 1           |
-      | low stock threshold        | 0           |
-      | low stock alert is enabled | false       |
-      | location                   |             |
-      | available date             |             |
+      | combination stock detail   | value |
+      | quantity                   | 100   |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
     And combination "productCombinations3SWhite" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
       | Puff       | Daddy     | 100            |
     And combination "productCombinations3SWhite" last stock movement increased by 100
     When I update combination "productCombinations3SBlack" stock with following details:
-      | delta quantity             | 50          |
+      | delta quantity | 50 |
     Then combination "productCombinations3SBlack" should have following stock details:
-      | combination stock detail   | value       |
-      | quantity                   | 50          |
-      | minimal quantity           | 1           |
-      | low stock threshold        | 0           |
-      | low stock alert is enabled | false       |
-      | location                   |             |
-      | available date             |             |
+      | combination stock detail   | value |
+      | quantity                   | 50    |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
     And combination "productCombinations3SBlack" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
       | Puff       | Daddy     | 50             |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
@@ -94,8 +94,8 @@ Feature: Add basic product from Back Office (BO)
       | locale | value          |
       | en-US  | bottle of beer |
     And product "virtualProduct" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     When I update product "virtualProduct" prices with following information:
       | price              | 51.42           |
       | ecotax             | 8.56            |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_status.feature
@@ -48,10 +48,10 @@ Feature: Update product status from BO (Back Office)
       | name[en-US] | T-Shirt with listed values |
       | type        | combinations               |
     When I generate combinations for product product3 using following attributes:
-      | Size  | [S,M]              |
+      | Size  | [S,M]         |
       | Color | [White,Black] |
     Then product "product3" should have following combinations:
-      | id reference        | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
       | product3SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
       | product3SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
       | product3MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
@@ -82,22 +82,22 @@ Feature: Update product status from BO (Back Office)
 
   Scenario: I can not publish a product without a name
     When I add product "product4" with following information:
-      | type        | standard       |
+      | type | standard |
     Then product "product4" should be disabled
     And product "product4" type should be standard
     And product "product4" localized "name" should be:
       | locale | value |
       | en-US  |       |
     And product "product4" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     When I enable product "product4"
     Then I should get an error that product online data are invalid
     And product "product4" should be disabled
     When I update product "product4" basic information with following values:
       | name[en-US] | photo of funny mug |
     Then product "product4" localized "name" should be:
-      | locale     | value              |
-      | en-US      | photo of funny mug |
+      | locale | value              |
+      | en-US  | photo of funny mug |
     When I enable product "product4"
     And product "product4" should be enabled

--- a/tests/Unit/Core/Category/NameBuilder/CategoryDisplayNameBuilderTest.php
+++ b/tests/Unit/Core/Category/NameBuilder/CategoryDisplayNameBuilderTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Category\NameBuilder;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Category\Repository\CategoryRepository;
+use PrestaShop\PrestaShop\Core\Category\NameBuilder\CategoryDisplayNameBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
+use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
+
+class CategoryDisplayNameBuilderTest extends TestCase
+{
+    /**
+     * @dataProvider getDataForTestBuildsDisplayNames
+     *
+     * @param CategoryDisplayNameBuilder $builder
+     * @param string $categoryName
+     * @param int $categoryId
+     * @param string $expectedResult
+     */
+    public function testBuildsDisplayNames(
+        CategoryDisplayNameBuilder $builder,
+        string $categoryName,
+        int $categoryId,
+        string $expectedResult
+    ): void {
+        $actualResult = $builder->build(
+            $categoryName,
+            new ShopId(1),
+            new LanguageId(1),
+            new CategoryId($categoryId),
+            // cannot use cache because legacy Cache is not found by units
+            false
+        );
+
+        $this->assertSame($expectedResult, $actualResult);
+    }
+
+    /**
+     * @return iterable
+     */
+    public function getDataForTestBuildsDisplayNames(): iterable
+    {
+        $categoryRepositoryMock = $this->mockRepository([]);
+        $separator = ' > ';
+        $builder = new CategoryDisplayNameBuilder($categoryRepositoryMock, $separator);
+
+        yield [
+            $builder,
+            'Home',
+            2,
+            'Home',
+        ];
+
+        $categoryRepositoryMock = $this->mockRepository([2 => ['Home'], 3 => ['Home']]);
+        $separator = ' > ';
+        $builder = new CategoryDisplayNameBuilder($categoryRepositoryMock, $separator);
+
+        yield [
+            $builder,
+            'Home',
+            2,
+            'Home (#2)',
+        ];
+
+        $categoryRepositoryMock = $this->mockRepository([
+            2 => ['Home'],
+            4 => ['Home', 'Accessories'],
+            5 => ['Clothes', 'Accessories'],
+        ]);
+        $separator = ' > ';
+        $builder = new CategoryDisplayNameBuilder($categoryRepositoryMock, $separator);
+
+        yield [
+            $builder,
+            'Accessories',
+            4,
+            'Home > Accessories',
+        ];
+
+        $categoryRepositoryMock = $this->mockRepository([
+            2 => ['Home'],
+            4 => ['Home', 'Accessories'],
+            5 => ['Clothes', 'Accessories'],
+            6 => ['Clothes', 'Accessories', 'Accessories'],
+        ]);
+        $separator = ' > ';
+        $builder = new CategoryDisplayNameBuilder($categoryRepositoryMock, $separator);
+
+        yield [
+            $builder,
+            'Accessories',
+            6,
+            'Accessories > Accessories',
+        ];
+
+        $categoryRepositoryMock = $this->mockRepository([
+            2 => ['Home'],
+            4 => ['Home', 'Accessories'],
+            5 => ['Clothes', 'Accessories'],
+            6 => ['Clothes', 'Accessories'],
+            7 => ['Clothes', 'Accessories', 'Accessories'],
+        ]);
+        $separator = ' > ';
+        $builder = new CategoryDisplayNameBuilder($categoryRepositoryMock, $separator);
+
+        yield [
+            $builder,
+            'Accessories',
+            6,
+            'Clothes > Accessories (#6)',
+        ];
+
+        $categoryRepositoryMock = $this->mockRepository([
+            2 => ['Home'],
+            3 => ['Home', 'Clothes'],
+            6 => ['Home', 'Clothes', 'Home'],
+            7 => ['Home', 'Clothes', 'Home', 'Clothes'],
+        ]);
+        $separator = ' > ';
+        $builder = new CategoryDisplayNameBuilder($categoryRepositoryMock, $separator);
+
+        yield [
+            $builder,
+            'Clothes',
+            7,
+            'Clothes > Home > Clothes',
+        ];
+
+        $separator = ' + ';
+        $builder = new CategoryDisplayNameBuilder($categoryRepositoryMock, $separator);
+
+        yield [
+            $builder,
+            'Clothes',
+            7,
+            'Clothes + Home + Clothes',
+        ];
+    }
+
+    /**
+     * @param array<int, string[]> $breadcrumbPartsByDuplicatedIds
+     *
+     * @return CategoryRepository
+     */
+    private function mockRepository(array $breadcrumbPartsByDuplicatedIds): CategoryRepository
+    {
+        $mock = $this->getMockBuilder(CategoryRepository::class)
+            ->onlyMethods([
+                'getDuplicateNameIds',
+                'getBreadcrumbParts',
+            ])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $mock->method('getDuplicateNameIds')
+            ->willReturn(array_map(function (int $id): CategoryId {
+                return new CategoryId($id);
+            }, array_keys($breadcrumbPartsByDuplicatedIds)))
+        ;
+
+        $mock->method('getBreadcrumbParts')
+            ->willReturnCallback(
+                function (CategoryId $categoryId, LanguageId $languageId) use ($breadcrumbPartsByDuplicatedIds): array {
+                    return $breadcrumbPartsByDuplicatedIds[$categoryId->getValue()];
+                }
+            )
+        ;
+
+        return $mock;
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -478,8 +478,8 @@ class ProductFormDataProviderTest extends TestCase
         $expectedOutputData = $this->getDefaultOutputData();
         $productData = [
             'categories' => [
-                ['id' => 42, 'name' => 'test1', 'display_name' => 'test > test1'],
-                ['id' => 51, 'name' => 'test22', 'display_name' => 'test > test22'],
+                ['id' => 42, 'name' => 'test1', 'display_name' => 'test > test1', 'removable' => true],
+                ['id' => 51, 'name' => 'test22', 'display_name' => 'test > test22', 'removable' => false],
             ],
             'default_category' => 51,
         ];
@@ -489,12 +489,14 @@ class ProductFormDataProviderTest extends TestCase
                 'id' => 42,
                 'name' => 'test1',
                 'display_name' => 'test > test1',
+                'removable' => true,
             ],
         ];
         $expectedOutputData['description']['categories']['product_categories'][] = [
             'id' => 51,
             'name' => 'test22',
             'display_name' => 'test > test22',
+            'removable' => false,
         ];
 
         $expectedOutputData['description']['categories']['default_category_id'] = 51;

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -478,8 +478,8 @@ class ProductFormDataProviderTest extends TestCase
         $expectedOutputData = $this->getDefaultOutputData();
         $productData = [
             'categories' => [
-                ['id' => 42, 'localized_names' => [self::CONTEXT_LANG_ID => 'test1', 2 => 'test2']],
-                ['id' => 51, 'localized_names' => [self::CONTEXT_LANG_ID => 'test22', 3 => 'test3']],
+                ['id' => 42, 'name' => 'test1', 'display_name' => 'test > test1'],
+                ['id' => 51, 'name' => 'test22', 'display_name' => 'test > test22'],
             ],
             'default_category' => 51,
         ];
@@ -488,11 +488,13 @@ class ProductFormDataProviderTest extends TestCase
             [
                 'id' => 42,
                 'name' => 'test1',
+                'display_name' => 'test > test1',
             ],
         ];
         $expectedOutputData['description']['categories']['product_categories'][] = [
             'id' => 51,
             'name' => 'test22',
+            'display_name' => 'test > test22',
         ];
 
         $expectedOutputData['description']['categories']['default_category_id'] = 51;
@@ -1359,7 +1361,7 @@ class ProductFormDataProviderTest extends TestCase
         $categoriesInfo = [];
         if (isset($product['categories'])) {
             foreach ($product['categories'] as $category) {
-                $categoriesInfo[] = new CategoryInformation($category['id'], $category['localized_names']);
+                $categoriesInfo[] = new CategoryInformation($category['id'], $category['name'], $category['display_name']);
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When multiple categories with same name exists in shop then categories component in product page shows shortened breadcrumb tags instead of name. Breadcrumb should only contain as many parents until its unique. So for example if there are categories `Home > Accessories` and `Home > Accessories > Accessories` then breadcrumb should be `Accessories > Accessories`, but if there is additional category like `Home > Accessories > Accessories > Accessories`, then breadcrumb should be `Accessories > Accessories > Accessories`. If showing whole breadcrumb still doesn't provide uniqueness, then category id is appended to the end (e.g. `Home > Accessories (#4)`) Same principle applies to default category selection. This is to allow merchant to identify the category (its possible there will be categories with same names from different parents, so that should help). Also additional little issue fixed - when new default category is selected, x" icon to delete previous default category appears (for some reason native javascript "change" event didin't work before for defaultCategoryInput so i just switched to using jquery and it works)  ![Screenshot from 2022-05-18 15-44-50](https://user-images.githubusercontent.com/31609858/169075386-1496726b-bedf-450f-9902-c3ea7ae1cbb6.png)
| Type?             | improvement
| Category?         | BO
| BC breaks?        | see bellow
| Deprecations?     | no
| Fixed ticket?     | #28995
| Related PRs       | 
| How to test?      | :warning: Contains lots of js, so don't forget to recompile the assets for BO. Create multiple categories with identical name in same shop. Open experimental product page, description tab. In tags part categories that has same name should be shown with a optimized breadcrumb instead of name (Please read description for more info)
| Possible impacts? | 

**BC breaks**
* PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\CategoryInformation array $localizedNames replaced with string $name. Added additional constructor argument string $displayName.
* PrestaShopBundle\Controller\Admin\Sell\Catalog\CategoryController::getCategoriesTreeAction() returns additional string "displayName" in categories array.

### Specs
https://github.com/PrestaShop/prestashop-specs/blob/master/content/1.7/back-office/catalog/products/add-edit-v2.md#categories

**Categories**

- **Associated categories**:
The component displays all the associated categories as a list of tags. If categories have the same name, the tags display the parent’s path association until the parents are different. If 2 categories have the same complete tree structure then it displays its category IDs and all its parents categories.

EX:
Product: Comics
Categories 1: US comics > Best-sellers > Thor > Marvel
Categories 2 : Home > Classical > Thor > Marvel
If the product is associated with categories 1 and 2
then the tags will display:
Tag1: Best-sellers > Thor > Marvel
Tag2: Classical > Thor > Marvel

Deleting a tag, removes the tag of the list and deletes the association between the category and the product at the save.

- **Add categories:**
Below the tags’ lists is displayed the “Add categories” button. The button opens a modal with the search component and the category tree.

The user can search by category and the parent’s categories. The search result list displays the breadcrumb of the category.  
The list of categories associated is also displayed below the search component. 

If the product is not associated with any category except the ‘Home’ branch, then ‘Home’’s child categories are displayed, just the first level of the tree is displayed/opened.

If the product is already associated with categories, then the categories branches are opened until the categories associated are displayed.

- **Main category** - Drop-list - It displays the full path of the associated categories. By default, at the creation of the product, the ‘Home’ category is selected as the main category. If categories have the same name, the tags display the parent’s path association until the parents are different. If 2 categories have the same complete tree structure then it displays its category IDs and all its parents categories.


The main category defines the product URL and the breadcrumb of the front office.

Below the drop-list is display the breadcrumb of the product. Updating the main category updates the breadcrumb displayed below the list and the breadcrumb of the front office.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28141)
<!-- Reviewable:end -->
