### PR TITLE
Apply employee permissions to cart_rule list

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -144,7 +144,6 @@ class AdminCartRulesControllerCore extends AdminController
         }
 
         $helper->is_cms = $this->is_cms;
-        $helper->sql = $this->_listsql;
         $list = $helper->generateList($this->_list, $this->fields_list);
 
         return $list;

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -150,6 +150,7 @@ class AdminCartRulesControllerCore extends AdminController
 
         return $list;
     }
+
     public function ajaxProcessLoadCartRules()
     {
         if (!$this->access('view')) {

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -99,8 +99,7 @@ class AdminCartRulesControllerCore extends AdminController
         }
 
         // If list has 'active' field, we automatically create bulk action
-        if (isset($this->fields_list) && is_array($this->fields_list) && array_key_exists('active', $this->fields_list)
-            && !empty($this->fields_list['active'])) {
+        if (array_key_exists('active', $this->fields_list) && $this->fields_list['active'] === true) {
             if (!is_array($this->bulk_actions)) {
                 $this->bulk_actions = [];
             }

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -106,11 +106,11 @@ class AdminCartRulesControllerCore extends AdminController
 
             $this->bulk_actions = array_merge([
                 'enableSelection' => [
-                    'text' => $this->trans('Enable selection'),
+                    'text' => $this->trans('Enable selection', [], 'Admin.Actions'),
                     'icon' => 'icon-power-off text-success',
                 ],
                 'disableSelection' => [
-                    'text' => $this->trans('Disable selection'),
+                    'text' => $this->trans('Disable selection', [], 'Admin.Actions'),
                     'icon' => 'icon-power-off text-danger',
                 ],
                 'divider' => [
@@ -123,7 +123,7 @@ class AdminCartRulesControllerCore extends AdminController
 
         // Empty list is ok
         if (!is_array($this->_list)) {
-            $this->displayWarning($this->trans('Bad SQL query') . '<br />' . htmlspecialchars($this->_list_error));
+            $this->displayWarning($this->trans('Bad SQL query', [], 'Admin.Notifications.Error') . '<br />' . htmlspecialchars($this->_list_error));
 
             return false;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Applies the employee permissions to the list of cart rules. The employee is able to see only cart rules that are associated with a shop where he has permissions. If a rule is associated with a shop that the employee has no access to, he is not able to edit or delete the cart rule.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28139
| Related PRs       | No
| How to test?      | Follow the instructions in #28139
| Possible impacts? | This PR only affects display in BO, so there should not be other impacts.

Note: I decided to hide the `edit` action, if the employee has not sufficient permissions. We could argue that the employee should be able to consult the settings of the cart_rule, but not be able to edit it. I have chosen the simpler way.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28145)
<!-- Reviewable:end -->
