### PR TITLE
Fix GeneratableTextType and ReductionType show help two times 

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -826,11 +826,7 @@
   {{ form_widget(form['max_field'], { attr: {class: 'max-field'}}) }}
 {% endblock %}
 
-{% block form_help %}
-  {% if help %}
-    <small class="form-text">{{ help }}</small>
-  {% endif %}
-{% endblock form_help %}
+{% block form_help %}{% endblock form_help %}
 
 {% block form_hint %}
   {% if hint %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | GeneratableTextType and ReductionType show help two times 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19547
| How to test?      | 1. Load a fresh PrestaShop.<br>2. isntall this module[checkboform.zip](https://github.com/PrestaShop/PrestaShop/files/8427375/checkboform.zip)<br>Befor the fix: please see the issue<br>After the fix <br>![2022-04-06_15-57](https://user-images.githubusercontent.com/52157233/161991769-79ac8f24-04dd-437e-a8e3-49de64640982.png)
| Possible impacts? | All form field containing an help message


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28150)
<!-- Reviewable:end -->
