### PR TITLE
Fix cart rule shop association

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
@@ -297,7 +297,7 @@
 		{if ($all_shops|@count) > 1}
 			<p class="checkbox">
 				<label>
-					<input type="checkbox" id="shop_restriction" name="shop_restriction" value="1" {if $shops.unselected|@count}checked="checked"{/if} />
+					<input type="checkbox" id="shop_restriction" name="shop_restriction" value="1" {if $shops.selected|@count || $shops.selected|@count + $shops.unselected|@count < $all_shops|@count}checked="checked"{/if} />
 					{l s='Shop selection' d='Admin.Catalog.Feature'}
 				</label>
 			</p>

--- a/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
@@ -294,7 +294,7 @@
 				</a>
 			</div>
 
-		{if ($shops.unselected|@count) + ($shops.selected|@count) > 1}
+		{if ($all_shops|@count) > 1}
 			<p class="checkbox">
 				<label>
 					<input type="checkbox" id="shop_restriction" name="shop_restriction" value="1" {if $shops.unselected|@count}checked="checked"{/if} />

--- a/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
@@ -297,7 +297,7 @@
 		{if ($all_shops|@count) > 1}
 			<p class="checkbox">
 				<label>
-					<input type="checkbox" id="shop_restriction" name="shop_restriction" value="1" {if $shops.selected|@count || $shops.selected|@count + $shops.unselected|@count < $all_shops|@count}checked="checked"{/if} />
+					<input type="checkbox" id="shop_restriction" name="shop_restriction" value="1" {if $shops.selected|@count || ($shops.selected|@count + $shops.unselected|@count < $all_shops|@count)}checked="checked"{/if} />
 					{l s='Shop selection' d='Admin.Catalog.Feature'}
 				</label>
 			</p>

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -255,12 +255,9 @@ $('#cart_rule_form').submit(() => {
   if ($('#customerFilter').val() == '') $('#id_customer').val('0');
 
   for (i in restrictions) {
-    if ($(`#${restrictions[i]}_select_1 option`).length == 0) $(`#${restrictions[i]}_restriction`).prop('checked', false);
-    else {
-      $(`#${restrictions[i]}_select_2 option`).each(function (i) {
-        $(this).prop('selected', true);
-      });
-    }
+    $(`#${restrictions[i]}_select_2 option`).each(function (i) {
+      $(this).prop('selected', true);
+    });
   }
 
   $('.product_rule_toselect option').each(function (i) {

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -225,7 +225,7 @@ class AdminCartRulesControllerCore extends AdminController
                             $restriction_name = $this->trans('Shop selection', [], 'Admin.Catalog.Feature');
                             break;
                     }
-                    $this->errors[] = $this->trans("'%s' is checked, but no item selected", [$restriction_name], 'Admin.Catalog.Notification');
+                    $this->errors[] = $this->trans('The "%s" restriction is checked, but no item is selected.', [$restriction_name], 'Admin.Catalog.Notification');
                 }
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The shop association of a cart rule is filled automatically, if an employee is restricted to certain shops and does not select himself shop associated to the cart rule. Never uncheck `shop association` if a shop is already selected. If we check a simple restriction, but do not select an item, an error is raised.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28148.
| Related PRs       | Related to, but independent from #28145
| How to test?      | All three cases explained in #28148 are no longer possible to reproduce
| Possible impacts? | Permissions are locked down. An employee restricted to a set of shops can no longer create cart rules valid in other shops


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28153)
<!-- Reviewable:end -->
