### PR TITLE
Cart rules: Require at least one condition.

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -219,12 +219,12 @@ class AdminCartRulesControllerCore extends AdminController
                 $this->errors[] = $this->trans('The starting time is in the past. To avoid any issue, create a promo code, select a condition or set a starting time in the future.', [], 'Admin.Catalog.Notification');
             }
 
-			$restrictions = [
-				'country' => $this->trans('Country selection', [], 'Admin.Catalog.Feature'),
-				'carrier' => $this->trans('Carrier selection', [], 'Admin.Catalog.Feature'),
-				'group' => $this->trans('Customer group selection', [], 'Admin.Catalog.Feature'),
-				'shop' => $this->trans('Shop selection', [], 'Admin.Catalog.Feature'),
-			];
+            $restrictions = [
+                'country' => $this->trans('Country selection', [], 'Admin.Catalog.Feature'),
+                'carrier' => $this->trans('Carrier selection', [], 'Admin.Catalog.Feature'),
+                'group' => $this->trans('Customer group selection', [], 'Admin.Catalog.Feature'),
+                'shop' => $this->trans('Shop selection', [], 'Admin.Catalog.Feature'),
+            ];
             // If the restriction is checked, but no item is selected, raise an error
             foreach ($restrictions as $type => $restriction_name) {
                 if (Tools::getValue($type . '_restriction') && empty(Tools::getValue($type . '_select'))) {

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -211,7 +211,8 @@ class AdminCartRulesControllerCore extends AdminController
             }
 
             // At least one of these is compulsary: code, customer or any restriction. If none of these are present, the cart rule applies to all carts !
-            if (empty($restrictions_selected) &&
+            if (empty(Tools::getValue('id_cart_rule')) &&
+                empty($restrictions_selected) &&
                 empty(Tools::getValue('id_customer')) && empty(Tools::getValue('code')) && empty(Tools::getValue('minimum_amount')) &&
                 Tools::getValue('date_from') < date('Y-m.d H:i:s')
             ) {

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -237,7 +237,7 @@ class AdminCartRulesControllerCore extends AdminController
                             $restriction_name = $this->trans('Shop selection', [], 'Admin.Catalog.Feature');
                             break;
                     }
-                    $this->errors[] = $this->trans("'%s' is checked, but no item selected", [$restriction_name], 'Admin.Catalog.Notification');
+                    $this->errors[] = $this->trans('The "%s" restriction is checked but no item is selected.', [$restriction_name], 'Admin.Catalog.Notification');
                 }
             }
 

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -211,8 +211,11 @@ class AdminCartRulesControllerCore extends AdminController
             }
 
             // At least one of these is compulsary: code, customer or any restriction. If none of these are present, the cart rule applies to all carts !
-            if (empty($restrictions_selected) && empty(Tools::getValue('id_customer')) && empty(Tools::getValue('code'))) {
-                $this->errors[] = $this->trans('This cart rule would apply to all carts. Please define a code or select any condition.', [], 'Admin.Catalog.Feature');
+            if (empty($restrictions_selected) &&
+                empty(Tools::getValue('id_customer')) && empty(Tools::getValue('code')) && empty(Tools::getValue('minimum_amount')) &&
+                Tools::getValue('date_from') < date('Y-m.d H:i:s')
+            ) {
+                $this->errors[] = $this->trans('This cart rule would apply immediately to all carts. Please define a code, select any condition or define a start time in the future.', [], 'Admin.Catalog.Feature');
             }
 
             // If the restriction is checked, but no item is selected, raise an error

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -219,47 +219,16 @@ class AdminCartRulesControllerCore extends AdminController
                 $this->errors[] = $this->trans('The starting time is in the past. To avoid any issue, create a promo code, select a condition or set a starting time in the future.', [], 'Admin.Catalog.Notification');
             }
 
+			$restrictions = [
+				'country' => $this->trans('Country selection', [], 'Admin.Catalog.Feature'),
+				'carrier' => $this->trans('Carrier selection', [], 'Admin.Catalog.Feature'),
+				'group' => $this->trans('Customer group selection', [], 'Admin.Catalog.Feature'),
+				'shop' => $this->trans('Shop selection', [], 'Admin.Catalog.Feature'),
+			];
             // If the restriction is checked, but no item is selected, raise an error
-            foreach (['country', 'carrier', 'group', 'shop'] as $type) {
+            foreach ($restrictions as $type => $restriction_name) {
                 if (Tools::getValue($type . '_restriction') && empty(Tools::getValue($type . '_select'))) {
-                    switch ($type) {
-                        case 'country':
-                            $restriction_name = $this->trans('Country selection', [], 'Admin.Catalog.Feature');
-                            break;
-                        case 'carrier':
-                            $restriction_name = $this->trans('Carrier selection', [], 'Admin.Catalog.Feature');
-                            break;
-                        case 'group':
-                            $restriction_name = $this->trans('Customer group selection', [], 'Admin.Catalog.Feature');
-                            break;
-                        case 'shop':
-                        default:
-                            $restriction_name = $this->trans('Shop selection', [], 'Admin.Catalog.Feature');
-                            break;
-                    }
                     $this->errors[] = $this->trans('The "%s" restriction is checked but no item is selected.', [$restriction_name], 'Admin.Catalog.Notification');
-                }
-            }
-
-            // If the restriction is checked, but no item is selected, raise an error
-            foreach (['country', 'carrier', 'group', 'shop'] as $type) {
-                if (Tools::getValue($type . '_restriction') && empty(Tools::getValue($type . '_select'))) {
-                    switch ($type) {
-                        case 'country':
-                            $restriction_name = $this->trans('Country selection', [], 'Admin.Catalog.Feature');
-                            break;
-                        case 'carrier':
-                            $restriction_name = $this->trans('Carrier selection', [], 'Admin.Catalog.Feature');
-                            break;
-                        case 'group':
-                            $restriction_name = $this->trans('Customer group selection', [], 'Admin.Catalog.Feature');
-                            break;
-                        case 'shop':
-                        default:
-                            $restriction_name = $this->trans('Store selection', [], 'Admin.Catalog.Feature');
-                            break;
-                    }
-                    $this->errors[] = $this->trans('The "%s" restriction is checked, but no item is selected.', [$restriction_name], 'Admin.Catalog.Notification');
                 }
             }
 

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -212,7 +212,7 @@ class AdminCartRulesControllerCore extends AdminController
 
             // At least one of these is compulsory: code, customer or any restriction. If none of these are present, the cart rule applies to all carts !
             if (empty(Tools::getValue('id_cart_rule')) &&
-                empty($restrictions_selected) &&
+                !$restrictions_selected &&
                 empty(Tools::getValue('id_customer')) && empty(Tools::getValue('code')) && empty(Tools::getValue('minimum_amount'))
                 && Tools::getValue('date_from') < date('Y-m-d H:i:s')
             ) {

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -201,9 +201,39 @@ class AdminCartRulesControllerCore extends AdminController
             }
 
             // These are checkboxes (which aren't sent through POST when they are not checked), so they are forced to 0
+            $restrictions_selected = [];
             foreach (['country', 'carrier', 'group', 'cart_rule', 'product', 'shop'] as $type) {
                 if (!Tools::getValue($type . '_restriction')) {
                     $_POST[$type . '_restriction'] = 0;
+                } else {
+                    $restrictions_selected[] = $type;
+                }
+            }
+
+            // At least one of these is compulsary: code, customer or any restriction. If none of these are present, the cart rule applies to all carts !
+            if (empty($restrictions_selected) && empty(Tools::getValue('id_customer')) && empty(Tools::getValue('code'))) {
+                $this->errors[] = $this->trans('This cart rule would apply to all carts. Please define a code or select any condition.', [], 'Admin.Catalog.Feature');
+            }
+
+            // If the restriction is checked, but no item is selected, raise an error
+            foreach (['country', 'carrier', 'group', 'shop'] as $type) {
+                if (Tools::getValue($type . '_restriction') && empty(Tools::getValue($type . '_select'))) {
+                    switch ($type) {
+                        case 'country':
+                            $restriction_name = $this->trans('Country selection', [], 'Admin.Catalog.Feature');
+                            break;
+                        case 'carrier':
+                            $restriction_name = $this->trans('Carrier selection', [], 'Admin.Catalog.Feature');
+                            break;
+                        case 'group':
+                            $restriction_name = $this->trans('Customer group selection', [], 'Admin.Catalog.Feature');
+                            break;
+                        case 'shop':
+                        default:
+                            $restriction_name = $this->trans('Shop selection', [], 'Admin.Catalog.Feature');
+                            break;
+                    }
+                    $this->errors[] = $this->trans("'%s' is checked, but no item selected", [$restriction_name], 'Admin.Catalog.Notification');
                 }
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When creating a cart rule, require at least a code, any condition or a start time in the future. This avoids creating vouchers by error, that apply to all orders.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28154.
| Related PRs       | None
| How to test?      | Create a cart rule with no code, no condition and the default start time in the past. A error should display while saving.
| Possible impacts? | It is no longer possible to create vouchers that apply immediately to all orders. This is not really a restriction, because you can choose a start time just a few minutes ahead.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28160)
<!-- Reviewable:end -->
