### PR TITLE
Set Tax included as default value for amounts in cart rule form.

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/actions.tpl
@@ -90,8 +90,8 @@
 			</div>
 			<div class="col-lg-4">
 				<select name="reduction_tax" >
-					<option value="0" {if $currentTab->getFieldValue($currentObject, 'reduction_tax') == 0}selected="selected"{/if}>{l s='Tax excluded' d='Admin.Global'}</option>
-					<option value="1" {if $currentTab->getFieldValue($currentObject, 'reduction_tax') == 1}selected="selected"{/if}>{l s='Tax included' d='Admin.Global'}</option>
+					<option value="0" {if $currentTab->getFieldValue($currentObject, 'reduction_tax') === '0'}selected="selected"{/if}>{l s='Tax excluded' d='Admin.Global'}</option>
+					<option value="1" {if $currentTab->getFieldValue($currentObject, 'reduction_tax') === '1' || $currentTab->getFieldValue($currentObject, 'reduction_tax') === false}selected="selected"{/if}>{l s='Tax included' d='Admin.Global'}</option>
 				</select>
 			</div>
 		</div>

--- a/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
@@ -96,14 +96,14 @@
 			</div>
 			<div class="col-lg-3">
 				<select name="minimum_amount_tax">
-					<option value="0" {if $currentTab->getFieldValue($currentObject, 'minimum_amount_tax') == 0}selected="selected"{/if}>{l s='Tax excluded' d='Admin.Global'}</option>
-					<option value="1" {if $currentTab->getFieldValue($currentObject, 'minimum_amount_tax') == 1}selected="selected"{/if}>{l s='Tax included' d='Admin.Global'}</option>
+					<option value="0" {if $currentTab->getFieldValue($currentObject, 'minimum_amount_tax') === '0'}selected="selected"{/if}>{l s='Tax excluded' d='Admin.Global'}</option>
+					<option value="1" {if $currentTab->getFieldValue($currentObject, 'minimum_amount_tax') === '1' || $currentTab->getFieldValue($currentObject, 'minimum_amount_tax') === false}selected="selected"{/if}>{l s='Tax included' d='Admin.Global'}</option>
 				</select>
 			</div>
 			<div class="col-lg-4">
 				<select name="minimum_amount_shipping">
-					<option value="0" {if $currentTab->getFieldValue($currentObject, 'minimum_amount_shipping') == 0}selected="selected"{/if}>{l s='Shipping excluded' d='Admin.Catalog.Feature'}</option>
-					<option value="1" {if $currentTab->getFieldValue($currentObject, 'minimum_amount_shipping') == 1}selected="selected"{/if}>{l s='Shipping included' d='Admin.Catalog.Feature'}</option>
+					<option value="0" {if $currentTab->getFieldValue($currentObject, 'minimum_amount_shipping') === '0'}selected="selected"{/if}>{l s='Shipping excluded' d='Admin.Catalog.Feature'}</option>
+					<option value="1" {if $currentTab->getFieldValue($currentObject, 'minimum_amount_shipping') === '1'}selected="selected"{/if}>{l s='Shipping included' d='Admin.Catalog.Feature'}</option>
 				</select>
 			</div>
 		</div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A new cart rule should have its amounts specified as `Tax included` by default
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28165.
| Related PRs       | None
| How to test?      | Create a new cart rule and notice that the default values are `Tax included`, both on the `Conditions` and the `Actions` tab.
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28166)
<!-- Reviewable:end -->
