### PR TITLE
Add missing translation domains in AdminController

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2401,8 +2401,7 @@ class AdminControllerCore extends Controller
         $this->getList($this->context->language->id);
 
         // If list has 'active' field, we automatically create bulk action
-        if (isset($this->fields_list) && is_array($this->fields_list) && array_key_exists('active', $this->fields_list)
-            && !empty($this->fields_list['active'])) {
+        if (array_key_exists('active', $this->fields_list) && $this->fields_list['active'] === true) {
             if (!is_array($this->bulk_actions)) {
                 $this->bulk_actions = [];
             }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -637,12 +637,12 @@ class AdminControllerCore extends Controller
         /* content, edit, list, add, details, options, view */
         switch ($this->display) {
             case 'add':
-                $breadcrumbs2['action']['name'] = $this->trans('Add');
+                $breadcrumbs2['action']['name'] = $this->trans('Add', [], 'Admin.Actions');
                 $breadcrumbs2['action']['icon'] = 'icon-plus';
 
                 break;
             case 'edit':
-                $breadcrumbs2['action']['name'] = $this->trans('Edit');
+                $breadcrumbs2['action']['name'] = $this->trans('Edit', [], 'Admin.Actions');
                 $breadcrumbs2['action']['icon'] = 'icon-pencil';
 
                 break;
@@ -692,20 +692,20 @@ class AdminControllerCore extends Controller
 
         switch ($this->display) {
             case 'edit':
-                $this->toolbar_title[] = $this->trans('Edit');
-                $this->addMetaTitle($this->trans('Edit'));
+                $this->toolbar_title[] = $this->trans('Edit', [], 'Admin.Actions');
+                $this->addMetaTitle($this->trans('Edit', [], 'Admin.Actions'));
 
                 break;
 
             case 'add':
-                $this->toolbar_title[] = $this->trans('Add new');
-                $this->addMetaTitle($this->trans('Add new'));
+                $this->toolbar_title[] = $this->trans('Add new', [], 'Admin.Actions');
+                $this->addMetaTitle($this->trans('Add new', [], 'Admin.Actions'));
 
                 break;
 
             case 'view':
-                $this->toolbar_title[] = $this->trans('View');
-                $this->addMetaTitle($this->trans('View'));
+                $this->toolbar_title[] = $this->trans('View', [], 'Admin.Actions');
+                $this->addMetaTitle($this->trans('View', [], 'Admin.Actions'));
 
                 break;
         }
@@ -732,7 +732,7 @@ class AdminControllerCore extends Controller
                     if (!is_array($val)) {
                         $filter_value = '';
                         if (isset($t['type']) && $t['type'] == 'bool') {
-                            $filter_value = ((bool) $val) ? $this->trans('yes') : $this->trans('no');
+                            $filter_value = ((bool) $val) ? $this->trans('Yes', [], 'Admin.Global') : $this->trans('No', [], 'Admin.Global');
                         } elseif (isset($t['type']) && $t['type'] == 'date' || isset($t['type']) && $t['type'] == 'datetime') {
                             $date = json_decode($val, true);
                             if (isset($date[0])) {
@@ -1615,7 +1615,7 @@ class AdminControllerCore extends Controller
                 if (!$this->lite_display) {
                     $this->page_header_toolbar_btn['back'] = [
                         'href' => $back,
-                        'desc' => $this->trans('Back to list'),
+                        'desc' => $this->trans('Back to list', [], 'Admin.Actions'),
                     ];
                 }
                 $obj = $this->loadObject(true);
@@ -1640,7 +1640,8 @@ class AdminControllerCore extends Controller
                             )
                                 ? $obj->{$this->identifier_name}[$this->context->employee->id_lang]
                                 : $obj->{$this->identifier_name},
-                        ]
+                        ],
+                        'Admin.Actions'
                     );
                     $this->addMetaTitle($this->toolbar_title[count($this->toolbar_title) - 1]);
                 }
@@ -1674,7 +1675,7 @@ class AdminControllerCore extends Controller
                 // Default save button - action dynamically handled in javascript
                 $this->toolbar_btn['save'] = [
                     'href' => '#',
-                    'desc' => $this->trans('Save'),
+                    'desc' => $this->trans('Save', [], 'Admin.Actions'),
                 ];
                 $back = Tools::safeOutput(Tools::getValue('back', ''));
                 if (empty($back)) {
@@ -1686,7 +1687,7 @@ class AdminControllerCore extends Controller
                 if (!$this->lite_display) {
                     $this->toolbar_btn['cancel'] = [
                         'href' => $back,
-                        'desc' => $this->trans('Cancel'),
+                        'desc' => $this->trans('Cancel', [], 'Admin.Actions'),
                     ];
                 }
 
@@ -1703,7 +1704,7 @@ class AdminControllerCore extends Controller
                 if (!$this->lite_display) {
                     $this->toolbar_btn['back'] = [
                         'href' => $back,
-                        'desc' => $this->trans('Back to list'),
+                        'desc' => $this->trans('Back to list', [], 'Admin.Actions'),
                     ];
                 }
 
@@ -1711,7 +1712,7 @@ class AdminControllerCore extends Controller
             case 'options':
                 $this->toolbar_btn['save'] = [
                     'href' => '#',
-                    'desc' => $this->trans('Save'),
+                    'desc' => $this->trans('Save', [], 'Admin.Actions'),
                 ];
 
                 break;
@@ -1719,12 +1720,12 @@ class AdminControllerCore extends Controller
                 // list
                 $this->toolbar_btn['new'] = [
                     'href' => self::$currentIndex . '&add' . $this->table . '&token=' . $this->token,
-                    'desc' => $this->trans('Add new'),
+                    'desc' => $this->trans('Add new', [], 'Admin.Actions'),
                 ];
                 if ($this->allow_export) {
                     $this->toolbar_btn['export'] = [
                         'href' => self::$currentIndex . '&export' . $this->table . '&token=' . $this->token,
-                        'desc' => $this->trans('Export'),
+                        'desc' => $this->trans('Export', [], 'Admin.Actions'),
                     ];
                 }
         }
@@ -2408,11 +2409,11 @@ class AdminControllerCore extends Controller
 
             $this->bulk_actions = array_merge([
                 'enableSelection' => [
-                    'text' => $this->trans('Enable selection'),
+                    'text' => $this->trans('Enable selection', [], 'Admin.Actions'),
                     'icon' => 'icon-power-off text-success',
                 ],
                 'disableSelection' => [
-                    'text' => $this->trans('Disable selection'),
+                    'text' => $this->trans('Disable selection', [], 'Admin.Actions'),
                     'icon' => 'icon-power-off text-danger',
                 ],
                 'divider' => [
@@ -2425,7 +2426,7 @@ class AdminControllerCore extends Controller
 
         // Empty list is ok
         if (!is_array($this->_list)) {
-            $this->displayWarning($this->trans('Bad SQL query') . '<br />' . htmlspecialchars($this->_list_error));
+            $this->displayWarning($this->trans('Bad SQL query', [], 'Admin.Notifications.Error') . '<br />' . htmlspecialchars($this->_list_error));
 
             return false;
         }
@@ -3085,11 +3086,11 @@ class AdminControllerCore extends Controller
         } elseif (is_array($this->bulk_actions)) {
             $submit_bulk_actions = array_merge([
                 'enableSelection' => [
-                    'text' => $this->trans('Enable selection'),
+                    'text' => $this->trans('Enable selection', [], 'Admin.Actions'),
                     'icon' => 'icon-power-off text-success',
                 ],
                 'disableSelection' => [
-                    'text' => $this->trans('Disable selection'),
+                    'text' => $this->trans('Disable selection', [], 'Admin.Actions'),
                     'icon' => 'icon-power-off text-danger',
                 ],
             ], $this->bulk_actions);
@@ -4414,20 +4415,20 @@ class AdminControllerCore extends Controller
         if (!isset($this->translationsTab['Disable this module'])) {
             $this->translationsTab['Disable this module'] = $this->trans('Disable this module');
             $this->translationsTab['Enable this module for all shops'] = $this->trans('Enable this module for all shops');
-            $this->translationsTab['Disable'] = $this->trans('Disable');
-            $this->translationsTab['Enable'] = $this->trans('Enable');
+            $this->translationsTab['Disable'] = $this->trans('Disable', [], 'Admin.Actions');
+            $this->translationsTab['Enable'] = $this->trans('Enable', [], 'Admin.Actions');
             $this->translationsTab['Disable on mobiles'] = $this->trans('Disable on mobiles');
             $this->translationsTab['Disable on tablets'] = $this->trans('Disable on tablets');
             $this->translationsTab['Disable on computers'] = $this->trans('Disable on computers');
             $this->translationsTab['Display on mobiles'] = $this->trans('Display on mobiles');
             $this->translationsTab['Display on tablets'] = $this->trans('Display on tablets');
             $this->translationsTab['Display on computers'] = $this->trans('Display on computers');
-            $this->translationsTab['Reset'] = $this->trans('Reset');
-            $this->translationsTab['Configure'] = $this->trans('Configure');
-            $this->translationsTab['Delete'] = $this->trans('Delete');
-            $this->translationsTab['Install'] = $this->trans('Install');
-            $this->translationsTab['Uninstall'] = $this->trans('Uninstall');
-            $this->translationsTab['Would you like to delete the content related to this module ?'] = $this->trans('Would you like to delete the content related to this module ?');
+            $this->translationsTab['Reset'] = $this->trans('Reset', [], 'Admin.Actions');
+            $this->translationsTab['Configure'] = $this->trans('Configure', [], 'Admin.Actions');
+            $this->translationsTab['Delete'] = $this->trans('Delete', [], 'Admin.Actions');
+            $this->translationsTab['Install'] = $this->trans('Install', [], 'Admin.Actions');
+            $this->translationsTab['Uninstall'] = $this->trans('Uninstall', [], 'Admin.Actions');
+            $this->translationsTab['Would you like to delete the content related to this module ?'] = $this->trans('Would you like to delete the content related to this module ?', [], 'Admin.Modules.Notification');
             $this->translationsTab['This action will permanently remove the module from the server. Are you sure you want to do this?'] = $this->trans('This action will permanently remove the module from the server. Are you sure you want to do this?');
             $this->translationsTab['Remove from Favorites'] = $this->trans('Remove from Favorites');
             $this->translationsTab['Mark as Favorite'] = $this->trans('Mark as Favorite');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Apply codereview from #28145 to AdminController. I added translation domains for each string that is already in a domain. I did not touch texts that are exclusively in `messages.xlf`.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | None
| Related PRs       | #28145
| How to test?      | There is no change in behavior
| Possible impacts? | None.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28171)
<!-- Reviewable:end -->
