### PR TITLE
Upgrade module when already installed

### DIFF
--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -99,6 +99,10 @@ class ModuleManager implements ModuleManagerInterface
             $handler->handle($source);
         }
 
+        if ($this->moduleDataProvider->isInstalled($name)) {
+            return $this->upgrade($name);
+        }
+
         $this->hookManager->exec('actionBeforeInstallModule', ['moduleName' => $name]);
 
         $module = $this->moduleRepository->getModule($name);

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -51,9 +51,6 @@ class ModuleRepository implements ModuleRepositoryInterface
         'confirmUninstall',
     ];
 
-    /** @var Finder */
-    private $finder;
-
     /** @var ModuleDataProvider */
     private $moduleDataProvider;
 
@@ -79,7 +76,6 @@ class ModuleRepository implements ModuleRepositoryInterface
         HookManager $hookManager,
         string $modulePath
     ) {
-        $this->finder = new Finder();
         $this->moduleDataProvider = $moduleDataProvider;
         $this->adminModuleDataProvider = $adminModuleDataProvider;
         $this->cacheProvider = $cacheProvider;
@@ -90,7 +86,7 @@ class ModuleRepository implements ModuleRepositoryInterface
     public function getList(): ModuleCollection
     {
         $modules = [];
-        $modulesDirsList = $this->finder->directories()
+        $modulesDirsList = (new Finder())->directories()
             ->in($this->modulePath)
             ->depth('== 0')
             ->exclude(['__MACOSX'])


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When importing a more recent version of a module already installed, an error was shown. This PR fixes it by calling the `upgrade` method instead of the `install` when the module is already installed.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28124
| Related PRs       | 
| How to test?      | Please see #28124
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28173)
<!-- Reviewable:end -->
