### PR TITLE
Add module name parameter to displayModuleConfigureExtraButtons hook

### DIFF
--- a/admin-dev/themes/default/template/controllers/modules/configure.tpl
+++ b/admin-dev/themes/default/template/controllers/modules/configure.tpl
@@ -101,7 +101,7 @@
 					<div>{l s='Manage hooks' d='Admin.Modules.Feature'}</div>
 				</a>
 			</li>
-			{hook h="displayModuleConfigureExtraButtons"}
+			{hook h="displayModuleConfigureExtraButtons" module_name=$module_name}
 		</ul>
 	</div>
 </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The hook displayModuleConfigureExtraButtons needs module name parameter to know which module is being confugured
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28175)
<!-- Reviewable:end -->
