### PR TITLE
WIP - Add filter to hide unused order states from admin

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1520,6 +1520,7 @@ CREATE TABLE `PREFIX_order_state` (
   `pdf_invoice` tinyint(1) UNSIGNED NOT NULL default '0',
   `pdf_delivery` tinyint(1) UNSIGNED NOT NULL default '0',
   `deleted` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
+  `hidden_employee` tinyint(1) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (`id_order_state`),
   KEY `module_name` (`module_name`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;

--- a/src/Adapter/OrderState/CommandHandler/AddOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/AddOrderStateHandler.php
@@ -94,5 +94,6 @@ final class AddOrderStateHandler extends AbstractOrderStateHandler implements Ad
         if ($command->isSendEmailEnabled()) {
             $orderState->template = $command->getLocalizedTemplates();
         }
+        $orderState->hidden_employee = $command->isHiddenEmployee();
     }
 }

--- a/src/Adapter/OrderState/CommandHandler/EditOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/EditOrderStateHandler.php
@@ -152,5 +152,9 @@ final class EditOrderStateHandler extends AbstractOrderStateHandler implements E
         if (null !== $command->isDelivery()) {
             $orderState->delivery = $command->isDelivery();
         }
+
+        if (null !== $command->isHiddenEmployee()) {
+            $orderState->hidden_employee = $command->isHiddenEmployee();
+        }
     }
 }

--- a/src/Adapter/OrderState/OrderStateDataProvider.php
+++ b/src/Adapter/OrderState/OrderStateDataProvider.php
@@ -40,6 +40,6 @@ final class OrderStateDataProvider implements OrderStateDataProviderInterface
      */
     public function getOrderStates($languageId)
     {
-        return OrderState::getOrderStates($languageId, false);
+        return OrderState::getOrderStates($languageId, true, true);
     }
 }

--- a/src/Adapter/OrderState/QueryHandler/GetOrderStateForEditingHandler.php
+++ b/src/Adapter/OrderState/QueryHandler/GetOrderStateForEditingHandler.php
@@ -73,7 +73,8 @@ final class GetOrderStateForEditingHandler implements GetOrderStateForEditingHan
             (bool) $orderState->paid,
             (bool) $orderState->delivery,
             $orderState->template,
-            (bool) $orderState->deleted
+            (bool) $orderState->deleted,
+            (bool) $orderState->hidden_employee
         );
     }
 }

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -463,6 +463,7 @@ class OrderLazyArray extends AbstractLazyArray
             'ostate_name' => '',
             'history_date' => '',
             'contrast' => '',
+            'hidden_employee' => '',
         ];
     }
 

--- a/src/Core/Domain/OrderState/Command/AddOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/AddOrderStateCommand.php
@@ -83,6 +83,10 @@ class AddOrderStateCommand
      * @var array
      */
     private $localizedTemplates;
+    /**
+     * @var bool
+     */
+    private $hidden_employee;
 
     /**
      * @var string|null
@@ -120,7 +124,8 @@ class AddOrderStateCommand
         bool $shipped,
         bool $paid,
         bool $delivery,
-        array $localizedTemplates
+        array $localizedTemplates,
+        bool $hidden_employee
     ) {
         $this->setLocalizedNames($localizedNames);
         $this->color = $color;
@@ -134,6 +139,7 @@ class AddOrderStateCommand
         $this->paid = $paid;
         $this->delivery = $delivery;
         $this->localizedTemplates = $localizedTemplates;
+        $this->hidden_employee = $hidden_employee;
     }
 
     /**
@@ -192,6 +198,14 @@ class AddOrderStateCommand
     public function isHidden()
     {
         return $this->hidden;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHiddenEmployee()
+    {
+        return $this->hidden_employee;
     }
 
     /**

--- a/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
@@ -237,6 +237,24 @@ class EditOrderStateCommand
     /**
      * @return bool|null
      */
+    public function isHiddenEmployee()
+    {
+        return $this->hidden_employee;
+    }
+
+    /**
+     * @return self
+     */
+    public function setHiddenEmployee(?bool $hidden_employee)
+    {
+        $this->hidden_employee = $hidden_employee;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
     public function isSendEmailEnabled()
     {
         return $this->sendEmail;

--- a/src/Core/Domain/OrderState/QueryResult/EditableOrderState.php
+++ b/src/Core/Domain/OrderState/QueryResult/EditableOrderState.php
@@ -95,6 +95,7 @@ class EditableOrderState
      * @var bool
      */
     private $isDeleted;
+    private $hidden_employee;
 
     public function __construct(
         OrderStateId $orderStateId,
@@ -111,7 +112,8 @@ class EditableOrderState
         bool $paid,
         bool $delivery,
         array $localizedTemplates,
-        bool $isDeleted
+        bool $isDeleted,
+        bool $hidden_employee
     ) {
         $this->orderStateId = $orderStateId;
         $this->localizedNames = $name;
@@ -128,6 +130,7 @@ class EditableOrderState
         $this->delivery = $delivery;
         $this->localizedTemplates = $localizedTemplates;
         $this->isDeleted = $isDeleted;
+        $this->hidden_employee = $hidden_employee;
     }
 
     /**
@@ -184,6 +187,14 @@ class EditableOrderState
     public function isHidden()
     {
         return $this->hidden;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHiddenEmployee()
+    {
+        return $this->hidden_employee;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/DataHandler/OrderStateFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/OrderStateFormDataHandler.php
@@ -89,7 +89,8 @@ final class OrderStateFormDataHandler implements FormDataHandlerInterface
             $data['shipped'],
             $data['paid'],
             $data['delivery'],
-            $data['template']
+            $data['template'],
+            $data['hidden_employee']
         );
 
         if (isset($data['icon'])) {
@@ -127,6 +128,7 @@ final class OrderStateFormDataHandler implements FormDataHandlerInterface
             ->setPaid($data['paid'])
             ->setDelivery($data['delivery'])
             ->setTemplate($data['template'])
+            ->setHiddenEmployee($data['hidden_employee'])
         ;
 
         /** @var UploadedFile|null $fileObject */

--- a/src/Core/Form/IdentifiableObject/DataProvider/OrderStateFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/OrderStateFormDataProvider.php
@@ -68,6 +68,7 @@ final class OrderStateFormDataProvider implements FormDataProviderInterface
             'paid' => $editableOrderState->isPaid(),
             'delivery' => $editableOrderState->isDelivery(),
             'template' => $editableOrderState->getLocalizedTemplates(),
+            'hidden_employee' => $editableOrderState->isHiddenEmployee(),
         ];
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
@@ -181,6 +181,13 @@ class OrderStateType extends TranslatorAwareType
                     'material_design' => true,
                 ],
             ])
+            ->add('hidden_employee', CheckboxType::class, [
+                'required' => false,
+                'label' => $this->trans('Hide on from employees on orders page.', 'Admin.Shopparameters.Feature'),
+                'attr' => [
+                    'material_design' => true,
+                ],
+            ])
             ->add('send_email', CheckboxType::class, [
                 'required' => false,
                 'label' => $this->trans('Send an email to the customer when their order status has changed.', 'Admin.Shopparameters.Feature'),


### PR DESCRIPTION
Work in progress - the actual hiding feature not implemented yet. Will be finished when https://github.com/PrestaShop/PrestaShop/pull/27590 is merged, because there seems to be both legacy and symfony code???

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allows to hide some order states from order screen selectbox. This makes the list much shorter and easier to orientate.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | maybe
| Deprecations?     | no
| Fixed ticket?     | Fixes #14752
| Related PRs       | -
| How to test?      | Hide some states you don't want to use, go to order edit screen and check that they don't appear in the list. This should not affect anything other.
| Possible impacts? | No.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28184)
<!-- Reviewable:end -->
