### PR TITLE
Revert a change that caused a problem with bulk actions on the lists

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2402,7 +2402,7 @@ class AdminControllerCore extends Controller
         $this->getList($this->context->language->id);
 
         // If list has 'active' field, we automatically create bulk action
-        if (array_key_exists('active', $this->fields_list) && $this->fields_list['active'] === true) {
+        if (array_key_exists('active', $this->fields_list) && $this->fields_list['active'] == true) {
             if (!is_array($this->bulk_actions)) {
                 $this->bulk_actions = [];
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fixes problem caused by this PR: https://github.com/PrestaShop/PrestaShop/pull/28171
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | n/a
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/28171
| How to test?      | Because of related PR bulk actions were not added properly to the legacy controllers. With this PR, bulk actions should be visible and usable again.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28185)
<!-- Reviewable:end -->
