### PR TITLE
Disable toggle switch 'show out of stock label' based on stock management

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/product-preferences/stock-management-option-handler.ts
@@ -41,6 +41,7 @@ class StockManagementOptionHandler {
 
     this.handleAllowOrderingOutOfStockOption(isStockManagementEnabled);
     this.handleDisplayAvailableQuantitiesOption(isStockManagementEnabled);
+    this.handleDisplayOutOfStockLabelOption(isStockManagementEnabled);
   }
 
   /**
@@ -78,6 +79,26 @@ class StockManagementOptionHandler {
     } else {
       displayQuantitiesRadio.val(['0']);
       displayQuantitiesRadio.attr('disabled', 'disabled');
+    }
+  }
+
+  /**
+   * If stock managament is disabled
+   * then 'Display out-of-stock label on product listing pages' option must be No and disabled
+   * otherwise it should be enabled
+   *
+   * @param {int} isStockManagementEnabled
+   */
+  handleDisplayOutOfStockLabelOption(
+    isStockManagementEnabled: number,
+  ): void {
+    const displayOutOfStockLabelRadio = $('input[name="stock[oos_show_label_listing_pages]"]');
+
+    if (isStockManagementEnabled) {
+      displayOutOfStockLabelRadio.removeAttr('disabled');
+    } else {
+      displayOutOfStockLabelRadio.val(['0']);
+      displayOutOfStockLabelRadio.attr('disabled', 'disabled');
     }
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  Develop
| Description?      | I think that if stock management is disabled, the "show out of stock label" option should not be able to be modified in the same way as the "allow sale of products that are out of stock" option does. check this issue: https://github.com/PrestaShop/PrestaShop/issues/28098
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #28098

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28189)
<!-- Reviewable:end -->
