### PR TITLE
Remove deprecated $bo_show_screencast property

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -82,9 +82,6 @@ class EmployeeCore extends ObjectModel
     /** @var bool */
     public $bo_menu = true;
 
-    /* Deprecated */
-    public $bo_show_screencast = false;
-
     /** @var bool Status */
     public $active = true;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Remove deprecated property, set as deprecated in 1.6.0 version (See 06a178b8fe1fb8a4982ca5421bdead268af01745).
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no

📓 BC Breaks

    Removed property : Employee::bo_show_screencast


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28190)
<!-- Reviewable:end -->
