### PR TITLE
Remove deprecated methods inside Cart class

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -3559,16 +3559,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * @deprecated 1.5.0, use Cart->getPackageShippingCost()
-     */
-    public function getOrderShippingCost($id_carrier = null, $use_tax = true, Country $default_country = null, $product_list = null)
-    {
-        Tools::displayAsDeprecated('Use Cart->getPackageShippingCost()');
-
-        return $this->getPackageShippingCost((int) $id_carrier, $use_tax, $default_country, $product_list);
-    }
-
-    /**
      * Return package shipping cost.
      *
      * @param int $id_carrier Carrier ID (default : current carrier)
@@ -3978,23 +3968,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * @deprecated 1.5.0
-     *
-     * @param CartRule $obj
-     *
-     * @return bool|string
-     */
-    public function checkDiscountValidity($obj, $discounts, $order_total, $products, $check_cart_discount = false)
-    {
-        Tools::displayAsDeprecated();
-        $context = Context::getContext()->cloneContext();
-        /* @phpstan-ignore-next-line */
-        $context->cart = $this;
-
-        return $obj->checkValidity($context);
-    }
-
-    /**
      * Return useful information about the cart for display purpose.
      * Products are splitted between paid ones and gift
      * Gift price and shipping (if shipping is free) are removed from Discounts
@@ -4353,21 +4326,6 @@ class CartCore extends ObjectModel
             0,
             $returnCustomizationId
         );
-    }
-
-    /**
-     * @deprecated 1.5.5.0
-     *
-     * @param int $id_product Product ID
-     * @param int $index Customization field identifier as id_customization_field in table customization_field
-     *
-     * @return bool
-     */
-    public function deletePictureToProduct($id_product, $index)
-    {
-        Tools::displayAsDeprecated('Use deleteCustomizationToProduct() instead');
-
-        return $this->deleteCustomizationToProduct($id_product, (int) $index);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Cart model
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Cart::checkDiscountValidity()`
* Removed method : `Cart::deletePictureToProduct()`
* Removed method : `Cart::getOrderShippingCost()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28191)
<!-- Reviewable:end -->
