### PR TITLE
Remove deprecated method inside OrderPayment class

### DIFF
--- a/classes/order/OrderPayment.php
+++ b/classes/order/OrderPayment.php
@@ -75,23 +75,6 @@ class OrderPaymentCore extends ObjectModel
     /**
      * Get the detailed payment of an order.
      *
-     * @deprecated 1.5.3.0
-     *
-     * @param int $id_order
-     *
-     * @return array
-     */
-    public static function getByOrderId($id_order)
-    {
-        Tools::displayAsDeprecated();
-        $order = new Order($id_order);
-
-        return OrderPayment::getByOrderReference($order->reference);
-    }
-
-    /**
-     * Get the detailed payment of an order.
-     *
      * @param string $order_reference
      *
      * @return array


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in OrderPayment model
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `OrderPayment::getByOrderId()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28194)
<!-- Reviewable:end -->
