### PR TITLE
Remove deprecated method inside ThemeProvider

### DIFF
--- a/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/ThemeProvider.php
@@ -67,23 +67,6 @@ class ThemeProvider extends AbstractProvider
     public $defaultTranslationDir;
 
     /**
-     * Get domain.
-     *
-     * @deprecated since 1.7.6, to be removed in the next major
-     *
-     * @return mixed
-     */
-    public function getDomain()
-    {
-        @trigger_error(
-            'getDomain function is deprecated and will be removed in the next major',
-            E_USER_DEPRECATED
-        );
-
-        return $this->domain;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getTranslationDomains()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated method inside ThemeProvider
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `PrestaShopBundle\Translation\Provider\ThemeProvider::getDomain()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28196)
<!-- Reviewable:end -->
