### PR TITLE
Remove deprecated method inside SearchProvider

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/translation.yml
@@ -146,7 +146,6 @@ services:
       - "@prestashop.translation.database_loader"
       - "@prestashop.translation.external_module_provider"
       - "%translations_dir%"
-      - "%modules_dir%"
     tags:
       - { name: "ps.translation_provider" }
 

--- a/src/PrestaShopBundle/Translation/Provider/SearchProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/SearchProvider.php
@@ -59,23 +59,6 @@ class SearchProvider extends AbstractProvider implements UseDefaultCatalogueInte
     }
 
     /**
-     * Get domain.
-     *
-     * @deprecated since 1.7.6, to be removed in the next major
-     *
-     * @return mixed
-     */
-    public function getDomain()
-    {
-        @trigger_error(
-            __METHOD__ . ' function is deprecated and will be removed in the next major',
-            E_USER_DEPRECATED
-        );
-
-        return $this->domain;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getTranslationDomains()
@@ -134,21 +117,6 @@ class SearchProvider extends AbstractProvider implements UseDefaultCatalogueInte
         }
 
         return $xliffCatalogue;
-    }
-
-    /**
-     * @deprecated since 1.7.6, to be removed in the next major
-     *
-     * @return string
-     */
-    public function getModuleDirectory()
-    {
-        @trigger_error(
-            __METHOD__ . ' function is deprecated and will be removed in the next major',
-            E_USER_DEPRECATED
-        );
-
-        return $this->modulesDirectory;
     }
 
     /**

--- a/src/PrestaShopBundle/Translation/Provider/SearchProvider.php
+++ b/src/PrestaShopBundle/Translation/Provider/SearchProvider.php
@@ -37,11 +37,6 @@ use Symfony\Component\Translation\MessageCatalogueInterface;
 class SearchProvider extends AbstractProvider implements UseDefaultCatalogueInterface, UseModuleInterface
 {
     /**
-     * @var string the "modules" directory path
-     */
-    private $modulesDirectory;
-
-    /**
      * @var ExternalModuleLegacySystemProvider
      */
     private $externalModuleLegacySystemProvider;
@@ -49,10 +44,8 @@ class SearchProvider extends AbstractProvider implements UseDefaultCatalogueInte
     public function __construct(
         LoaderInterface $databaseLoader,
         ExternalModuleLegacySystemProvider $externalModuleLegacySystemProvider,
-        $resourceDirectory,
-        $modulesDirectory
+        $resourceDirectory
     ) {
-        $this->modulesDirectory = $modulesDirectory;
         $this->externalModuleLegacySystemProvider = $externalModuleLegacySystemProvider;
 
         parent::__construct($databaseLoader, $resourceDirectory);

--- a/tests/Integration/PrestaShopBundle/Translation/Provider/SearchProviderTest.php
+++ b/tests/Integration/PrestaShopBundle/Translation/Provider/SearchProviderTest.php
@@ -56,8 +56,7 @@ class SearchProviderTest extends TestCase
         $this->provider = new SearchProvider(
             $loader,
             $externalSystemProvider,
-            $resourcesDir,
-            ''
+            $resourcesDir
         );
 
         $this->provider->setDomain('AdminActions');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated method inside SearchProvider
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `PrestaShopBundle\Translation\Provider\SearchProvider::getDomain()`
* Removed method : `PrestaShopBundle\Translation\Provider\SearchProvider::getModuleDirectory()`
* Removed `$modulesDirectory` parameter from `SearchProvider::__construct`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28197)
<!-- Reviewable:end -->
