### PR TITLE
Remove deprecated method inside Adapter\Shop\Context

### DIFF
--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -91,18 +91,6 @@ class Context implements MultistoreContextCheckerInterface, ShopContextInterface
     }
 
     /**
-     * Get if it's a GroupShop context.
-     *
-     * @return bool
-     *
-     * @deprecated since 1.7.6.0, to be removed in 1.8. Use $this->isGroupShopContext() instead.
-     */
-    public function isShopGroupContext()
-    {
-        return $this->isGroupShopContext();
-    }
-
-    /**
      * Get if it's a Shop context.
      *
      * @return bool
@@ -110,18 +98,6 @@ class Context implements MultistoreContextCheckerInterface, ShopContextInterface
     public function isShopContext()
     {
         return Shop::getContext() === Shop::CONTEXT_SHOP;
-    }
-
-    /**
-     * Get if it's a All context.
-     *
-     * @return bool
-     *
-     * @deprecated since 1.7.6.0, to be removed in 1.8. Use $this->isAllShopContext() instead.
-     */
-    public function isAllContext()
-    {
-        return $this->isAllShopContext();
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/EventListener/MultishopCommandListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/EventListener/MultishopCommandListenerTest.php
@@ -62,8 +62,6 @@ class MultishopCommandListenerTest extends KernelTestCase
     {
         Shop::resetContext();
         $this->assertFalse($this->multishopContext->isShopContext(), 'isShopContext');
-        $this->assertFalse($this->multishopContext->isShopGroupContext(), 'isShopGroupContext');
-        $this->assertFalse($this->multishopContext->isAllContext(), 'isAllContext');
     }
 
     public function testSetShopID(): void


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated method inside Adapter\Shop\Context
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Nothing to test.
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Adapter\Shop\Context::isShopGroupContext()`
* Removed method : `Adapter\Shop\Context::isAllContext()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28199)
<!-- Reviewable:end -->
