### PR TITLE
Fix the load of CSS file to be able to load them with version

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -257,12 +257,12 @@ class MediaCore
         }
 
         $urlData = parse_url($mediaUri);
-        if (!is_array($urlData)) {
+        if (!is_array($urlData) || !array_key_exists('path', $urlData)) {
             return false;
         }
 
         if (!array_key_exists('host', $urlData)) {
-            $mediaUri = '/' . ltrim(str_replace(str_replace(['/', '\\'], DIRECTORY_SEPARATOR, _PS_ROOT_DIR_), __PS_BASE_URI__, $mediaUri), '/\\');
+            $mediaUri = '/' . ltrim(str_replace(str_replace(['/', '\\'], DIRECTORY_SEPARATOR, _PS_ROOT_DIR_), __PS_BASE_URI__, $urlData['path']), '/\\');
             // remove PS_BASE_URI on _PS_ROOT_DIR_ for the following
             $fileUri = _PS_ROOT_DIR_ . Tools::str_replace_once(__PS_BASE_URI__, DIRECTORY_SEPARATOR, $mediaUri);
             if (!file_exists($fileUri) || !@filemtime($fileUri) || @filesize($fileUri) === 0) {
@@ -270,6 +270,9 @@ class MediaCore
             }
 
             $mediaUri = str_replace('//', '/', $mediaUri);
+            if (array_key_exists('query', $urlData)) {
+                $mediaUri .= '?' . $urlData['query'];
+            }
         }
 
         if ($cssMediaType) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Let the possibility to load CSS file with version in query. Example : `$this->context->controller->addCSS('back.css?v=1');` is not working today.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Install this module [prestashopexamplemodule.zip](https://github.com/PrestaShop/PrestaShop/files/8464081/prestashopexamplemodule.zip). On the develop branch, nothing change on the dashboard. On the PR branch, you will see a red background. Also, we see that the file `back.css` is loaded or not (cf screenshots below).




<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

Without the fix, the CSS file is not loaded :
![Capture d’écran 2022-04-11 à 14 38 09](https://user-images.githubusercontent.com/1721887/162741146-58ff88e0-ebf2-4a6b-b733-1e306e70b3a2.png)

With the fix : 
![Capture d’écran 2022-04-11 à 14 36 59](https://user-images.githubusercontent.com/1721887/162741153-277f2a4d-23a6-4bf6-9720-ecb2425e6cb0.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28223)
<!-- Reviewable:end -->
