### PR TITLE
Fix notifications color contrast on module manager page

### DIFF
--- a/admin-dev/themes/default/scss/partials/_header.scss
+++ b/admin-dev/themes/default/scss/partials/_header.scss
@@ -686,9 +686,10 @@ $search-border-color: #bbcdd2;
     line-height: 0.75rem;
     color: #fff;
     vertical-align: middle;
-    background: #f1b746;
+    background: $brand-danger;
     border: 2px solid #fff;
     border-radius: 0.625rem;
+
     font: {
       size: 0.625rem;
     }

--- a/admin-dev/themes/default/scss/partials/_header.scss
+++ b/admin-dev/themes/default/scss/partials/_header.scss
@@ -686,7 +686,7 @@ $search-border-color: #bbcdd2;
     line-height: 0.75rem;
     color: #fff;
     vertical-align: middle;
-    background: $brand-danger;
+    background: $alert-danger-border;
     border: 2px solid #fff;
     border-radius: 0.625rem;
 

--- a/admin-dev/themes/new-theme/scss/mixins/_notification_counter.scss
+++ b/admin-dev/themes/new-theme/scss/mixins/_notification_counter.scss
@@ -7,7 +7,7 @@
   font-size: 0.625rem;
   line-height: 0.75rem;
   color: $white;
-  background: #f1b746;
+  background: $danger;
   border: 0.125rem solid $white;
   @include border-radius(1rem);
 }

--- a/admin-dev/themes/new-theme/scss/mixins/_notification_counter.scss
+++ b/admin-dev/themes/new-theme/scss/mixins/_notification_counter.scss
@@ -7,7 +7,7 @@
   font-size: 0.625rem;
   line-height: 0.75rem;
   color: $white;
-  background: $danger;
+  background: map-get($alerts-second-colors, "danger");
   border: 0.125rem solid $white;
   @include border-radius(1rem);
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Numbers were unreadable on the module manager page because of a contrast issue
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28053.
| How to test?      | See issue
| Possible impacts? | Nothing except readability of notifications number on module manager


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28226)
<!-- Reviewable:end -->
