### PR TITLE
Wrap PDOException in PrestaShopException to cast the string error code to an int

### DIFF
--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -144,7 +144,11 @@ class DbPDOCore extends Db
      */
     protected function _query($sql)
     {
-        return $this->link->query($sql);
+        try {
+            return $this->link->query($sql);
+        } catch (\PDOException $exception) {
+            throw new PrestaShopException($exception->getMessage(), (int) $exception->getCode(), $exception);
+        }
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `\PDOException` is the only `\Exception`'s child that can return a string for the method `getCode()` but there is places where we try to wrap the `\PDOException` in another exception, using `getCode()` of the `\PDOException` to construct the new exception. Starting with PHP 8.0, this is not possible anymore, we should pass an int. This PR solve it by casting the string to an int for `\PDOException`
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27982
| Related PRs       | N/A
| How to test?      | Please see #27982
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28237)
<!-- Reviewable:end -->
