### PR TITLE
Updated wording about the error when upload a module bigger than post_max_size or upload_max_filesize

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -307,8 +307,12 @@ class ModuleController extends ModuleAbstractController
         try {
             if ($serverParams->hasPostMaxSizeBeenExceeded()) {
                 throw new Exception($this->trans(
-                    'The uploaded file exceeds the post_max_size directive in php.ini',
-                    'Admin.Notifications.Error'
+                    'Your uploaded file might exceed the [1]upload_max_filesize[/1] and the [1]post_max_size[/1] directives in [1]php.ini[/1], please check your server configuration.',
+                    'Admin.Notifications.Error',
+                    [
+                        '[1]' => '<i>',
+                        '[/1]' => '</i>',
+                    ]
                 ));
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update wording about the error when you have _post_max_size_ and _upload_max_filesize_ too low to upload a module bigger than that.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #16428.
| Related PRs       | ~
| How to test?      | Automated test.
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28243)
<!-- Reviewable:end -->
