### PR TITLE
Change internationalization API urls to i18n.prestashop-project.org

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -41,8 +41,8 @@ use Symfony\Component\Intl\Intl;
 class LanguageCore extends ObjectModel implements LanguageInterface
 {
     const ALL_LANGUAGES_FILE = '/app/Resources/all_languages.json';
-    const SF_LANGUAGE_PACK_URL = 'https://i18n.prestashop.com/translations/%version%/%locale%/%locale%.zip';
-    const EMAILS_LANGUAGE_PACK_URL = 'https://i18n.prestashop.com/mails/%version%/%locale%/%locale%.zip';
+    const SF_LANGUAGE_PACK_URL = 'https://i18n.prestashop-project.org/translations/%version%/%locale%/%locale%.zip';
+    const EMAILS_LANGUAGE_PACK_URL = 'https://i18n.prestashop-project.org/mails/%version%/%locale%/%locale%.zip';
     public const PACK_TYPE_EMAILS = 'emails';
     public const PACK_TYPE_SYMFONY = 'sf';
 

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -34,7 +34,7 @@ class AdminTranslationsControllerCore extends AdminController
     const TEXTAREA_SIZED = 70;
 
     /** @var string : Link which list all pack of language */
-    protected $link_lang_pack = 'http://i18n.prestashop.com/translations/%ps_version%/available_languages.json';
+    protected $link_lang_pack = 'http://i18n.prestashop-project.org/translations/%ps_version%/available_languages.json';
 
     /** @var int : number of sentence which can be translated */
     protected $total_expression = 0;

--- a/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
+++ b/src/Core/Language/Pack/Loader/RemoteLanguagePackLoader.php
@@ -36,7 +36,7 @@ final class RemoteLanguagePackLoader implements LanguagePackLoaderInterface
     /**
      * The link from which available languages are retrieved.
      */
-    public const PACK_LINK = 'http://i18n.prestashop.com/translations/%ps_version%/available_languages.json';
+    public const PACK_LINK = 'http://i18n.prestashop-project.org/translations/%ps_version%/available_languages.json';
 
     /**
      * @var Version


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Changed i18n API URLs to prestashop-project.org
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25888
| Related PRs       | N/A
| How to test?      | See below
| Possible impacts? | N/A

## Notes
There's another PR (#28057) that does this but includes refactoring. To ensure the change is done by FF, I suggest merging this PR, then rebasing the other one.

## How to test
* You can choose another language during the installation. Make sure you don't have it locally.
* You can download a language pack.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28244)
<!-- Reviewable:end -->
