### PR TITLE
Fix DisabledProductGridDefinitionFactory

### DIFF
--- a/src/Core/Grid/Definition/Factory/Monitoring/DisabledProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/DisabledProductGridDefinitionFactory.php
@@ -26,16 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory\Monitoring;
 
-use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\IdentifierColumn;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
-use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
-use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
-use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
-
 /**
  * Builds Grid definition for disabled product grid
  */
@@ -49,97 +39,5 @@ final class DisabledProductGridDefinitionFactory extends AbstractProductGridDefi
     protected function getName()
     {
         return $this->trans('List of disabled products', [], 'Admin.Catalog.Feature');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getColumns()
-    {
-        return (new ColumnCollection())
-            ->add(
-                (new BulkActionColumn('monitoring_products_bulk'))
-                    ->setOptions([
-                        'bulk_field' => 'id_product',
-                    ])
-            )
-            ->add(
-                (new IdentifierColumn('id_product'))
-                    ->setName($this->trans('ID', [], 'Admin.Global'))
-                    ->setOptions([
-                        'identifier_field' => 'id_product',
-                    ])
-            )
-            ->add(
-                (new DataColumn('reference'))
-                    ->setName($this->trans('Reference', [], 'Admin.Global'))
-                    ->setOptions([
-                        'field' => 'reference',
-                    ])
-            )
-            ->add(
-                (new DataColumn('name'))
-                    ->setName($this->trans('Name', [], 'Admin.Global'))
-                    ->setOptions([
-                        'field' => 'name',
-                    ])
-            )
-            ->add(
-                (new ActionColumn('actions'))
-                    ->setName($this->trans('Actions', [], 'Admin.Global'))
-                    ->setOptions([
-                        'actions' => $this->getRowActions(),
-                    ])
-            );
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getFilters()
-    {
-        return (new FilterCollection())
-            ->add(
-                (new Filter('id_product', TextType::class))
-                    ->setAssociatedColumn('id_product')
-                    ->setTypeOptions([
-                        'required' => false,
-                        'attr' => [
-                            'placeholder' => $this->trans('Search ID', [], 'Admin.Actions'),
-                        ],
-                    ])
-            )
-            ->add(
-                (new Filter('reference', TextType::class))
-                    ->setAssociatedColumn('reference')
-                    ->setTypeOptions([
-                        'required' => false,
-                        'attr' => [
-                            'placeholder' => $this->trans('Search reference', [], 'Admin.Actions'),
-                        ],
-                    ])
-            )
-            ->add(
-                (new Filter('name', TextType::class))
-                    ->setAssociatedColumn('name')
-                    ->setTypeOptions([
-                        'required' => false,
-                        'attr' => [
-                            'placeholder' => $this->trans('Search name', [], 'Admin.Actions'),
-                        ],
-                    ])
-            )
-            ->add(
-                (new Filter('actions', SearchAndResetType::class))
-                    ->setAssociatedColumn('actions')
-                    ->setTypeOptions([
-                        'reset_route' => 'admin_common_reset_search_by_filter_id',
-                        'reset_route_params' => [
-                            'filterId' => $this::GRID_ID,
-                        ],
-                        'redirect_route' => 'admin_monitorings_index',
-                    ])
-                    ->setAssociatedColumn('actions')
-            );
     }
 }

--- a/src/Core/Grid/Definition/Factory/Monitoring/DisabledProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/Monitoring/DisabledProductGridDefinitionFactory.php
@@ -40,4 +40,17 @@ final class DisabledProductGridDefinitionFactory extends AbstractProductGridDefi
     {
         return $this->trans('List of disabled products', [], 'Admin.Catalog.Feature');
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns()
+    {
+        return parent::getColumns()->remove('active');
+    }
+
+    protected function getFilters()
+    {
+        return parent::getFilters()->remove('active');
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | **Edited** DisabledProductGridDefinitionFactory was duplicating code which could have been reused from Abstract class (just because it doesn't need "action" column). In this PR i extend DisabledProductGridDefinitionFactory by Monitoring\AbstractProductGridDefinitionFactory and remove "active" column and filter from parent methods instead of duplicating everything.![Screenshot from 2022-05-12 11-42-04](https://user-images.githubusercontent.com/31609858/168030458-69801d51-40ff-4b11-b6d9-f499cd45ad80.png)
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | Affected grid: Catalog->Monitoring -> List Of Disabled Products. Must work exactly the same as before.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28246)
<!-- Reviewable:end -->
