### PR TITLE
Install theme before modules

### DIFF
--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -155,14 +155,14 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
             }
         }
 
-        if (in_array('modules', $steps)) {
-            if (!$this->processInstallModules()) {
+        if (in_array('theme', $steps)) {
+            if (!$this->processInstallTheme()) {
                 $this->printErrors();
             }
         }
 
-        if (in_array('theme', $steps)) {
-            if (!$this->processInstallTheme()) {
+        if (in_array('modules', $steps)) {
+            if (!$this->processInstallModules()) {
                 $this->printErrors();
             }
         }

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -100,11 +100,11 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
                     ->setProcessFOThemes(['classic'])
                     ->process();
                 $this->processConfigureShop();
-            } elseif (Tools::getValue('installModules') && (!empty($this->session->process_validated['configureShop']) || !$validateFixturesInstallation)) {
-                $this->processInstallModules();
-            } elseif (Tools::getValue('installTheme') && !empty($this->session->process_validated['installModules'])) {
+            } elseif (Tools::getValue('installTheme') && !empty($this->session->process_validated['configureShop'])) {
                 $this->processInstallTheme();
-            } elseif (Tools::getValue('installFixtures') && !empty($this->session->process_validated['installTheme'])) {
+            } elseif (Tools::getValue('installModules') && (!empty($this->session->process_validated['installTheme']) || !$validateFixturesInstallation)) {
+                $this->processInstallModules();
+            } elseif (Tools::getValue('installFixtures') && !empty($this->session->process_validated['installModules'])) {
                 $this->processInstallFixtures();
             } elseif (Tools::getValue('postInstall') && (!$validateFixturesInstallation || $fixturesInstalled)) {
                 $this->processPostInstall();
@@ -310,8 +310,8 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
         $this->process_steps[] = ['key' => 'populateDatabase', 'lang' => $this->translator->trans('Populate database tables', [], 'Install')];
         $this->process_steps[] = ['key' => 'configureShop', 'lang' => $this->translator->trans('Configure shop information', [], 'Install')];
 
-        $this->process_steps[] = ['key' => 'installModules', 'lang' => $this->translator->trans('Install modules', [], 'Install')];
         $this->process_steps[] = ['key' => 'installTheme', 'lang' => $this->translator->trans('Install theme', [], 'Install')];
+        $this->process_steps[] = ['key' => 'installModules', 'lang' => $this->translator->trans('Install modules', [], 'Install')];
 
         if ($this->session->content_install_fixtures) {
             $fixtures_step = ['key' => 'installFixtures', 'lang' => $this->translator->trans('Install demonstration data', [], 'Install')];

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1026,6 +1026,10 @@ class Install extends AbstractInstall
         foreach ($modules as $module_name) {
             $moduleException = null;
 
+            if ($action === 'install' && $moduleManager->isInstalled($module_name)) {
+                continue;
+            }
+
             try {
                 $moduleActionIsExecuted = $moduleManager->{$action}($module_name);
             } catch (PrestaShopException $e) {

--- a/tests/UI/campaigns/sanity/01_installShop/01_installShop.js
+++ b/tests/UI/campaigns/sanity/01_installShop/01_installShop.js
@@ -168,8 +168,8 @@ describe('Install Prestashop', async () => {
       args:
         {
           step: {
-            name: 'Install modules',
-            timeout: 30000,
+            name: 'Install theme',
+            timeout: 60000,
           },
         },
     },
@@ -177,8 +177,8 @@ describe('Install Prestashop', async () => {
       args:
         {
           step: {
-            name: 'Install theme',
-            timeout: 60000,
+            name: 'Install modules',
+            timeout: 30000,
           },
         },
     },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When the theme is installed, it uses the `theme.yml` file to know which modules are required for the theme and to which hooks they must be attached to. Once the install process has this info, it will unhook every modules that are hooked to hooks listed in the `theme.yml` so only theme-related modules are hooked on those hooks. By installing the modules not already installed by the theme **after** the theme, this limitation goes away.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28242
| Related PRs       | 
| How to test?      | Please see #28242
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28258)
<!-- Reviewable:end -->
