### PR TITLE
Add regex constraint to the webservice key

### DIFF
--- a/src/Core/ConstraintValidator/Constraints/TypedRegex.php
+++ b/src/Core/ConstraintValidator/Constraints/TypedRegex.php
@@ -56,6 +56,7 @@ class TypedRegex extends Constraint
     public const TYPE_REFERENCE = 'reference';
     public const TYPE_URL = 'url';
     public const TYPE_MODULE_NAME = 'module_name';
+    public const TYPE_WEBSERVICE_KEY = 'webservice_key';
 
     /**
      * @var string

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -127,6 +127,8 @@ class TypedRegexValidator extends ConstraintValidator
                 return '/^[a-zA-Z0-9_-]+$/';
             case TypedRegex::TYPE_URL:
                 return '/^[~:#,$%&_=\(\)\.\? \+\-@\/a-zA-Z0-9\pL\pS-]+$/u';
+            case TypedRegex::TYPE_WEBSERVICE_KEY:
+                return '/^[a-zA-Z0-9@\#\?\-\_]+$/i';
             default:
                 $definedTypes = implode(', ', array_values((new ReflectionClass(TypedRegex::class))->getConstants()));
                 throw new InvalidArgumentException(sprintf('Type "%s" is not defined. Defined types are: %s', $type, $definedTypes));

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -115,8 +115,11 @@ class WebserviceKeyType extends TranslatorAwareType
                     new Regex([
                         'pattern' => '/^[a-zA-Z0-9@\#\?\-\_]+$/i',
                         'message' => $this->trans(
-                            'The key can contains only numbers, letters, and these special chars: @ ? # - _',
-                            'Admin.Advparameters.Notification'
+                            'Only letters, numbers, and the following special characters are allowed: %allowed_characters%',
+                            'Admin.Advparameters.Notification',
+                            [
+                                '%allowed_characters%' => '@ ? # - _',
+                            ]
                         ),
                     ]),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -39,7 +39,6 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Regex;
 
 /**
  * Is used to create form for adding/editing Webservice Key

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Webservice;
 
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\ValueObject\Key;
 use PrestaShopBundle\Form\Admin\Type\GeneratableTextType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialMultipleChoiceTableType;
@@ -112,8 +113,8 @@ class WebserviceKeyType extends TranslatorAwareType
                             'Admin.Advparameters.Notification'
                         ),
                     ]),
-                    new Regex([
-                        'pattern' => '/^[a-zA-Z0-9@\#\?\-\_]+$/i',
+                    new TypedRegex([
+                        'type' => TypedRegex::TYPE_WEBSERVICE_KEY,
                         'message' => $this->trans(
                             'Only letters, numbers, and the following special characters are allowed: %allowed_characters%',
                             'Admin.Advparameters.Notification',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -38,6 +38,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
 
 /**
  * Is used to create form for adding/editing Webservice Key
@@ -108,6 +109,13 @@ class WebserviceKeyType extends TranslatorAwareType
                         'max' => Key::LENGTH,
                         'exactMessage' => $this->trans(
                             'Key length must be 32 character long.',
+                            'Admin.Advparameters.Notification'
+                        ),
+                    ]),
+                    new Regex([
+                        'pattern' => '/^[a-zA-Z0-9@\#\?\-\_]+$/i',
+                        'message' => $this->trans(
+                            'The key can contains only numbers, letters, and these special chars: @ ? # - _',
                             'Admin.Advparameters.Notification'
                         ),
                     ]),

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Webservice/WebserviceKeyType.php
@@ -115,7 +115,7 @@ class WebserviceKeyType extends TranslatorAwareType
                     new TypedRegex([
                         'type' => TypedRegex::TYPE_WEBSERVICE_KEY,
                         'message' => $this->trans(
-                            'Only letters, numbers, and the following special characters are allowed: %allowed_characters%',
+                            'Only non-accented letters, numbers, and the following special characters are allowed: %allowed_characters%',
                             'Admin.Advparameters.Notification',
                             [
                                 '%allowed_characters%' => '@ ? # - _',

--- a/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
@@ -321,7 +321,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 
     public function testItSucceedsForWebserviceKeyTypeWhenValidCharactersGiven(): void
     {
-        $this->validator->validate('22XRNQR7X4RLAGCBSSNQIVPXQ271ZIKE', new TypedRegex(['type' => 'webservice_key']));
+        $this->validator->validate('22XRNQR7X4RLAGCBSSNQIVPXQ271ZIKE', new TypedRegex(['type' => TypedRegex::TYPE_WEBSERVICE_KEY]));
 
         $this->assertNoViolation();
     }
@@ -333,7 +333,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
      */
     public function testItFailsForWebserviceKeyTypeWhenInvalidCharactersGiven(string $invalidChar): void
     {
-        $this->assertViolationIsRaised(new TypedRegex(['type' => 'webservice_key']), $invalidChar);
+        $this->assertViolationIsRaised(new TypedRegex(['type' => TypedRegex::TYPE_WEBSERVICE_KEY]), $invalidChar);
     }
 
     /**

--- a/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
@@ -319,6 +319,23 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
         $this->assertViolationIsRaised(new TypedRegex(['type' => 'module_name']), $invalidChar);
     }
 
+    public function testItSucceedsForWebserviceKeyTypeWhenValidCharactersGiven(): void
+    {
+        $this->validator->validate('22XRNQR7X4RLAGCBSSNQIVPXQ271ZIKE', new TypedRegex(['type' => 'webservice_key']));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getInvalidCharactersForWebserviceKey
+     *
+     * @param string $invalidChar
+     */
+    public function testItFailsForWebserviceKeyTypeWhenInvalidCharactersGiven(string $invalidChar): void
+    {
+        $this->assertViolationIsRaised(new TypedRegex(['type' => 'webservice_key']), $invalidChar);
+    }
+
     /**
      * @return string[][]
      */
@@ -594,6 +611,42 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
         yield ['<'];
         yield ['>'];
         yield ['|'];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function getInvalidCharactersForWebServiceKey(): Generator
+    {
+        yield ['~'];
+        yield ['ˇ'];
+        yield ['"'];
+        yield ['€'];
+        yield ['$'];
+        yield ['£'];
+        yield ['%'];
+        yield ['&'];
+        yield ['§'];
+        yield ['/'];
+        yield ['('];
+        yield [')'];
+        yield ['='];
+        yield ['`'];
+        yield ['\\'];
+        yield ['\''];
+        yield ['}'];
+        yield [']'];
+        yield ['['];
+        yield ['{'];
+        yield ['*'];
+        yield ['.'];
+        yield [','];
+        yield [':'];
+        yield [';'];
+        yield ['<'];
+        yield ['>'];
+        yield ['|'];
+        yield [' '];
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a regex constraint to the webservice key `Type` that allow only numbers, letters, and these special chars: @ ? # - _
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22565 
| Related PRs       | ~
| How to test?      | Automated test + Manual test.
| Possible impacts? | ~.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

My proposal is to allow only numbers, letters (uppercase or lowercase) and some special chars (@ ? # - _) to improve security in case. No angle brackets allowed 😊

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28266)
<!-- Reviewable:end -->
