### PR TITLE
Fixes related product missing ref

### DIFF
--- a/src/Adapter/Product/ProductDataProvider.php
+++ b/src/Adapter/Product/ProductDataProvider.php
@@ -75,8 +75,17 @@ class ProductDataProvider
 
         if (!is_array($product->link_rewrite)) {
             $linkRewrite = $product->link_rewrite;
+        } elseif ($id_lang !== null && !empty($product->link_rewrite[$id_lang])) {
+            // Use the current langage rewrite if defined.
+            $linkRewrite = $product->link_rewrite[$id_lang];
         } else {
-            $linkRewrite = $product->link_rewrite[$id_lang ? $id_lang : key($product->link_rewrite)];
+            // Take the first rewrite defined.
+            foreach ($product->link_rewrite as $productLinkRewrite) {
+                if (!empty($productLinkRewrite)) {
+                    $linkRewrite = $productLinkRewrite;
+                    break;
+                }
+            }
         }
 
         $cover = Product::getCover($product->id);

--- a/src/Adapter/Product/ProductDataProvider.php
+++ b/src/Adapter/Product/ProductDataProvider.php
@@ -73,6 +73,7 @@ class ProductDataProvider
 
         $product = new Product($id_product, $full, $id_lang, $id_shop, $context);
 
+        $linkRewrite = '';
         if (!is_array($product->link_rewrite)) {
             $linkRewrite = $product->link_rewrite;
         } elseif ($id_lang !== null && !empty($product->link_rewrite[$id_lang])) {

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use Context;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -90,11 +91,24 @@ class TypeaheadProductCollectionType extends CommonAbstractType
                         break;
 
                     default:
+                        $lang = Context::getContext()->language->id;
                         $product = $this->productAdapter->getProduct($id);
+
+                        $productName = '';
+                        if (!empty($product->name[$lang])) {
+                            $productName .= $product->name[$lang] . ' ';
+                        }
+
+                        if (!empty($product->reference)) {
+                            $productName .= '(ref:' . $product->reference . ')';
+                        } else {
+                            $productName .= '(id:' . $product->id . ')';
+                        }
+
                         $collection[] = [
                             'id' => $id,
-                            'name' => reset($product->name) . ' (ref:' . $product->reference . ')',
-                            'image' => $product->image,
+                            'name' => $productName,
+                            'image' => !empty($product->image) ? $product->image : null,
                         ];
 
                         break;

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -97,6 +97,8 @@ class TypeaheadProductCollectionType extends CommonAbstractType
                         $productName = '';
                         if (!empty($product->name[$lang])) {
                             $productName .= $product->name[$lang] . ' ';
+                        } elseif (!empty(reset($product->name))) {
+                            $productName .= reset($product->name);
                         }
 
                         if (!empty($product->reference)) {

--- a/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TypeaheadProductCollectionType.php
@@ -91,26 +91,35 @@ class TypeaheadProductCollectionType extends CommonAbstractType
                         break;
 
                     default:
-                        $lang = Context::getContext()->language->id;
+                        $id_lang = Context::getContext()->language->id;
                         $product = $this->productAdapter->getProduct($id);
 
                         $productName = '';
-                        if (!empty($product->name[$lang])) {
-                            $productName .= $product->name[$lang] . ' ';
-                        } elseif (!empty(reset($product->name))) {
-                            $productName .= reset($product->name);
+                        if (!is_array($product->name)) {
+                            $productName = $product->name;
+                        } elseif (!empty($product->name[$id_lang])) {
+                            // Use the current langage product name if defined.
+                            $productName = $product->name[$id_lang];
+                        } else {
+                            // Use the first product name defined.
+                            foreach ($product->name as $pname) {
+                                if (!empty($pname)) {
+                                    $productName = $pname;
+                                    break;
+                                }
+                            }
                         }
 
                         if (!empty($product->reference)) {
-                            $productName .= '(ref:' . $product->reference . ')';
+                            $productName .= ' (ref:' . $product->reference . ')';
                         } else {
-                            $productName .= '(id:' . $product->id . ')';
+                            $productName .= ' (id:' . $product->id . ')';
                         }
 
                         $collection[] = [
                             'id' => $id,
                             'name' => $productName,
-                            'image' => !empty($product->image) ? $product->image : null,
+                            'image' => $product->image,
                         ];
 
                         break;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Related products miss the ref when empty, show ID instead
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28269
| Related PRs       | None
| How to test?      | Use a product without a reference in the related product field, in a product edit form. See https://github.com/PrestaShop/PrestaShop/issues/28269 for details.
| Possible impacts? | None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28270)
<!-- Reviewable:end -->
