### PR TITLE
Add 1.7.8.6 SQL script

### DIFF
--- a/install-dev/upgrade/sql/1.7.8.6.sql
+++ b/install-dev/upgrade/sql/1.7.8.6.sql
@@ -1,0 +1,4 @@
+SET SESSION sql_mode='';
+SET NAMES 'utf8mb4';
+
+ALTER TABLE `PREFIX_state` MODIFY COLUMN `name` VARCHAR(80) NOT NULL;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Add 1.7.8.6 SQL script. It is used by upgrade module for version below 4.13.0 .
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28299
| Related PRs       | 
| How to test?      | <s>Please upgrade from 1.7.8.5 to 1.7.8.6 using autoupgrade 4.12.0 and verify the `name` SQL column is correctly set to 80. 1.7.8.6 must be this branch.</s><br>1. Install PrestaShop 1.7.8.5<br>2. Checkout this PR<br>3. Run `php install/upgrade/upgrade.php`<br>4. Check that the `name` SQL column is correctly set to 80
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28271)
<!-- Reviewable:end -->
