### PR TITLE
Fix non closing modal after module install

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -460,7 +460,7 @@ class AdminModuleController {
 
     self.updateModuleSorting();
 
-    if (self.isModulesPage()) {
+    if (self.isModulesPage() && !self.isReadMoreModalOpened()) {
       $(self.recentlyUsedSelector)
         .find('.module-item')
         .remove();
@@ -1217,6 +1217,10 @@ class AdminModuleController {
 
   isModulesPage() {
     return $(this.upgradeContainer).length === 0 && $(this.notificationContainer).length === 0;
+  }
+
+  isReadMoreModalOpened() {
+    return $('.modal-read-more').is(':visible');
   }
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | After module install, the modules list items are removed one by one. In the case where we have a "Read more modal", removing these items will remove the module button and make the modal not closable. We protect that action when the modal is opened
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #28283


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28281)
<!-- Reviewable:end -->
