### PR TITLE
Discount is not visible on customer group form

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -355,7 +355,7 @@ class AdminGroupsControllerCore extends AdminController
                     'label' => $this->trans('Discount', [], 'Admin.Global'),
                     'name' => 'reduction',
                     'suffix' => '%',
-                    'col' => 1,
+                    'col' => 3,
                     'hint' => $this->trans('Automatically apply this value as a discount on all products for members of this customer group.', [], 'Admin.Shopparameters.Help'),
                 ],
                 [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Discount is not visible on customer group when editing customer group from Customer Settings ->Groups
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28285 .
| How to test?      | 1- Go to Customer Settings ->Groups<br>2- Edit group from<br>3- No entered discount is visible

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28286)
<!-- Reviewable:end -->
