### PR TITLE
Add product property `manufacturer_name`

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5466,7 +5466,7 @@ class ProductCore extends ObjectModel
         $row['category'] = Category::getLinkRewrite((int) $row['id_category_default'], (int) $id_lang);
         $row['category_name'] = Db::getInstance()->getValue('SELECT name FROM ' . _DB_PREFIX_ . 'category_lang WHERE id_shop = ' . (int) $context->shop->id . ' AND id_lang = ' . (int) $id_lang . ' AND id_category = ' . (int) $row['id_category_default']);
         $row['link'] = $context->link->getProductLink((int) $row['id_product'], $row['link_rewrite'], $row['category'], $row['ean13']);
-        $row['manufacturer_name'] = Manufacturer::getNameById((int) $this->id_manufacturer);
+        $row['manufacturer_name'] = Manufacturer::getNameById((int) $row['id_manufacturer']);
 
         $row['attribute_price'] = 0;
         if ($id_product_attribute) {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5466,6 +5466,7 @@ class ProductCore extends ObjectModel
         $row['category'] = Category::getLinkRewrite((int) $row['id_category_default'], (int) $id_lang);
         $row['category_name'] = Db::getInstance()->getValue('SELECT name FROM ' . _DB_PREFIX_ . 'category_lang WHERE id_shop = ' . (int) $context->shop->id . ' AND id_lang = ' . (int) $id_lang . ' AND id_category = ' . (int) $row['id_category_default']);
         $row['link'] = $context->link->getProductLink((int) $row['id_product'], $row['link_rewrite'], $row['category'], $row['ean13']);
+        $row['manufacturer_name'] = Manufacturer::getNameById((int) $this->id_manufacturer);
 
         $row['attribute_price'] = 0;
         if ($id_product_attribute) {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5466,7 +5466,7 @@ class ProductCore extends ObjectModel
         $row['category'] = Category::getLinkRewrite((int) $row['id_category_default'], (int) $id_lang);
         $row['category_name'] = Db::getInstance()->getValue('SELECT name FROM ' . _DB_PREFIX_ . 'category_lang WHERE id_shop = ' . (int) $context->shop->id . ' AND id_lang = ' . (int) $id_lang . ' AND id_category = ' . (int) $row['id_category_default']);
         $row['link'] = $context->link->getProductLink((int) $row['id_product'], $row['link_rewrite'], $row['category'], $row['ean13']);
-        $row['manufacturer_name'] = Manufacturer::getNameById((int) $row['id_manufacturer']);
+        $row['manufacturer_name'] = (int) $row['id_manufacturer'] > 0 ? Manufacturer::getNameById((int) $row['id_manufacturer']) : null;
 
         $row['attribute_price'] = 0;
         if ($id_product_attribute) {

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -1059,6 +1059,7 @@ class ProductLazyArray extends AbstractLazyArray
             'low_stock_alert',
             'low_stock_threshold',
             'main_variants',
+            'manufacturer_name',
             'meta_description',
             'meta_keywords',
             'meta_title',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Add product propertie `manufacturer_name`, to access product manufacturer name in presented product object .
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Resolves #28289, resolves #20880
| Related PRs       | N/A
| How to test?      | See how to test section bellow :
| Possible impacts? | N/A.

# How to test

- Go to BO product and assign a product to manufacturer
- Edit theme product miniature and dump `$product.manufacturer_name`
- Check that product manufacturer name is displayed wherever the miniature is called (product controller, listing controller, wishlist, related products)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28290)
<!-- Reviewable:end -->
