### PR TITLE
FO: Add page number in meta titles for new-products, best-sales, prices-drop

### DIFF
--- a/classes/Meta.php
+++ b/classes/Meta.php
@@ -333,6 +333,7 @@ class MetaCore extends ObjectModel
         $ret['meta_title'] = (isset($metas['title']) && $metas['title']) ? $metas['title'] : Configuration::get('PS_SHOP_NAME');
         $ret['meta_description'] = (isset($metas['description']) && $metas['description']) ? $metas['description'] : '';
         $ret['meta_keywords'] = (isset($metas['keywords']) && $metas['keywords']) ? $metas['keywords'] : '';
+        $ret = Meta::completeMetaTags($ret, $ret['meta_title']);
 
         return $ret;
     }
@@ -376,10 +377,6 @@ class MetaCore extends ObjectModel
      */
     public static function getCategoryMetas($idCategory, $idLang, $pageName, $title = '')
     {
-        if (!empty($title)) {
-            $title = ' - ' . $title;
-        }
-        $pageNumber = (int) Tools::getValue('page');
         $category = new Category($idCategory, $idLang);
 
         $cacheId = 'Meta::getCategoryMetas' . (int) $idCategory . '-' . (int) $idLang;
@@ -390,15 +387,10 @@ class MetaCore extends ObjectModel
                     $row['meta_description'] = strip_tags($row['description']);
                 }
 
-                // Paginate title
-                if (!empty($row['meta_title'])) {
-                    $row['meta_title'] = $title . $row['meta_title'] . (!empty($pageNumber) ? ' (' . $pageNumber . ')' : '');
+                if (is_string($title) && $title !== '') {
+                    $row['meta_title'] = $title;
                 } else {
-                    $row['meta_title'] = $row['name'] . (!empty($pageNumber) ? ' (' . $pageNumber . ')' : '');
-                }
-
-                if (!empty($title)) {
-                    $row['meta_title'] = $title . (!empty($pageNumber) ? ' (' . $pageNumber . ')' : '');
+                    $row['meta_title'] = $row['meta_title'] ?: $row['name'];
                 }
 
                 $result = Meta::completeMetaTags($row, $row['name']);
@@ -426,14 +418,13 @@ class MetaCore extends ObjectModel
      */
     public static function getManufacturerMetas($idManufacturer, $idLang, $pageName)
     {
-        $pageNumber = (int) Tools::getValue('page');
         $manufacturer = new Manufacturer($idManufacturer, $idLang);
         if (Validate::isLoadedObject($manufacturer)) {
             $row = Meta::getPresentedObject($manufacturer);
             if (!empty($row['meta_description'])) {
                 $row['meta_description'] = strip_tags($row['meta_description']);
             }
-            $row['meta_title'] = ($row['meta_title'] ?: $row['name']) . (!empty($pageNumber) ? ' (' . $pageNumber . ')' : '');
+            $row['meta_title'] = $row['meta_title'] ?: $row['name'];
 
             return Meta::completeMetaTags($row, $row['meta_title']);
         }
@@ -528,7 +519,28 @@ class MetaCore extends ObjectModel
             $metaTags['meta_title'] = $defaultValue;
         }
 
+        if (!empty($context->controller) && method_exists($context->controller, 'getTemplateVarPagination')) {
+            $metaTags['meta_title'] = Meta::paginateTitle($metaTags['meta_title']);
+        }
+
         return $metaTags;
+    }
+
+    /**
+     * Add page number to title
+     *
+     * @param string $title
+     *
+     * @return string
+     */
+    public static function paginateTitle(string $title): string
+    {
+        $page_num = (int) Tools::getValue('page');
+        if ($page_num > 1) {
+            $title .= ' (' . $page_num . ')';
+        }
+
+        return $title;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add page number in **meta titles** for listing pages that have pagination, like `new-products`, `best-sales`, `prices-drop`, etc.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27596
| Related PRs       | 
| How to test?      | Go to 2nd page of any controller with pagination and check **meta title**
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/28297)
<!-- Reviewable:end -->
