### PR TITLE
Validate by github action if phpunit tests don't change repos state

### DIFF
--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -68,3 +68,6 @@ jobs:
         run: composer run-script integration-behaviour-tests --timeout=0
         env:
           SYMFONY_DEPRECATIONS_HELPER: disabled
+
+      - name: Test git versionned files unchanged
+        run: git diff --exit-code

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,3 +68,6 @@ jobs:
         run: composer run-script integration-tests --timeout=0
         env:
           SYMFONY_DEPRECATIONS_HELPER: disabled
+
+      - name: Test git versionned files unchanged
+        run: git diff --exit-code

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -122,3 +122,6 @@ jobs:
         run: ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml
         env:
           SYMFONY_DEPRECATIONS_HELPER: disabled
+
+      - name: Test git versionned files unchanged
+        run: git diff --exit-code


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When i run `php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/Module` some of test resources are deleted.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Na.
| Related PRs       | 
| How to test?      | CI should pass; run `php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml tests/Unit/Core/Module` command, then `git status` nothing should have changed.
| Possible impacts? | CI and tests could be broken.