### PR TITLE
Fix delivery information for the product

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -267,11 +267,13 @@ class ProductLazyArray extends AbstractLazyArray
      */
     public function getDeliveryInformation()
     {
-        if ($this->product['quantity'] > 0) {
+        $productQuantity = $this->product['stock_quantity'] ?? $this->product['quantity'];
+
+        if ($productQuantity >= $this->getQuantityWanted()) {
             $config = $this->configuration->get('PS_LABEL_DELIVERY_TIME_AVAILABLE');
 
             return $config[$this->language->id] ?? null;
-        } elseif ($this->product['allow_oosp']) {
+        } elseif ($this->shouldEnableAddToCartButton($this->product, $this->settings)) {
             $config = $this->configuration->get('PS_LABEL_DELIVERY_TIME_OOSBOA', []);
 
             return $config[$this->language->id] ?? null;
@@ -833,7 +835,7 @@ class ProductLazyArray extends AbstractLazyArray
      */
     private function getQuantityWanted()
     {
-        return (int) Tools::getValue('quantity_wanted', 1);
+        return (int) Tools::getValue('quantity_wanted', $this->product['quantity_wanted'] ?? 1);
     }
 
     /**

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -269,7 +269,7 @@ class ProductLazyArrayTest extends TestCase
             $this->mockConfiguration
         );
 
-        $this->assertEquals($deliveryInformationMessage, $productLazyArray->delivery_information);
+        $this->assertEquals($deliveryInformationMessage, $productLazyArray->getDeliveryInformation());
     }
 
     public function providerDeliveryInformationCases(): iterable


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We didn't get a real wanted quantity to determine delivery information + and there's no point in showing delivery times if you can't buy a product. I added proper tests for three scenarios.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to #9590.
| Related PRs       | https://github.com/PrestaShop/classic-theme/pull/26
| How to test?      | Instruction below
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

 Edit `product-prices.tpl` in your theme and check `{$product.delivery_information|dump}` before and after this change.
