### PR TITLE
Extra message to display for an empty modules category

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3610,5 +3610,10 @@
       <title>BO themes list extra content</title>
       <description>This hook displays content after the themes list in the back office</description>
     </hook>
+    <hook id="displayEmptyModuleCategoryExtraMessage">
+      <name>displayEmptyModuleCategoryExtraMessage</name>
+      <title>Extra message to display for an empty modules category</title>
+      <description>This hook allows to add an extra message to display in the Module manager page when a category doesn't have any module</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig
@@ -27,6 +27,7 @@
   <div class="modules-list module-list-empty" data-name="{{ category.refMenu }}">
     <p>
       {{ 'You do not have module in « %categoryName% ».' | trans({'%categoryName%': category.name}, 'Admin.Modules.Feature') }}<br/>
+      {{ renderhook('displayEmptyModuleCategoryExtraMessage', {'category_name': category.name}) }}
     </p>
   </div>
 {% endblock %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds the hook to display extra message in module manager
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28317 
| How to test?      | Register the hook in a module and return a text/link/anything. or you can use [prestashopexamplemodule.zip](https://github.com/PrestaShop/PrestaShop/files/8553562/prestashopexamplemodule.zip)



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
