### PR TITLE
BO: Fix overlapping checkoxes on configure buttons

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -26,7 +26,7 @@
 
 {% block content %}
   <div class="row justify-content-center">
-    <div class="col-lg-10">
+    <div class="col-xl-10">
       {# Bulk Action confirm modal #}
       {% include '@PrestaShop/Admin/Module/Includes/modal_confirm_bulk_action.html.twig' %}
       {# Contains toolbar-nav for module page with level authorization #}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I replaced the `col-lg-10` with `col-lg-12 col-xl-10` to fix the overlapping of checkboxes on configure buttons
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28312
| Related PRs       | no
| How to test?      | Try to resize the window and check if you still encounter the issue 
| Possible impacts? | no impact


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
