### PR TITLE
Catalog rules: don't display the shop column if there is only one shop

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -4127,6 +4127,33 @@ exit;
 
         return false;
     }
+
+    /**
+     * Inserts a new element in array after a given index
+     *
+     * @param array $array Array to modify
+     * @param string $targetKey Key to search for
+     * @param string $newDataKey Key for an added data
+     * @param array $newDataArray New data to insert
+     *
+     * @return array
+     */
+    public static function arrayInsertElementAfterKey(array $array, string $targetKey, string $newDataKey, array $newDataArray): array
+    {
+        if (array_key_exists($targetKey, $array)) {
+            $newArray = [];
+            foreach ($array as $k => $value) {
+                $newArray[$k] = $value;
+                if ($k === $targetKey) {
+                    $newArray[$newDataKey] = $newDataArray;
+                }
+            }
+
+            return $newArray;
+        }
+
+        return $array;
+    }
 }
 
 /**

--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -86,10 +86,6 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                 'filter_key' => 'a!name',
                 'width' => 'auto',
             ],
-            'shop_name' => [
-                'title' => $this->trans('Shop', [], 'Admin.Global'),
-                'filter_key' => 's!name',
-            ],
             'id_currency' => [
                 'title' => $this->trans('Currency', [], 'Admin.Global'),
                 'align' => 'center',
@@ -138,6 +134,18 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
                 'order_key' => 'a!to',
             ],
         ];
+
+        if (Shop::isFeatureActive()) {
+            $this->fields_list = Tools::arrayInsertElementAfterKey(
+                $this->fields_list,
+                'name',
+                'shop_name',
+                [
+                    'title' => $this->trans('Shop', [], 'Admin.Global'),
+                    'filter_key' => 's!name',
+                ]
+            );
+        }
     }
 
     public function initPageHeaderToolbar()

--- a/tests/Unit/Classes/ToolsTest.php
+++ b/tests/Unit/Classes/ToolsTest.php
@@ -735,4 +735,89 @@ class ToolsTest extends TestCase
             ['zh', 'ჟ'],
         ];
     }
+
+    /**
+     * @param array $expectedResult
+     * @param array $originalArray
+     * @param string $insertedArrayKey Key of the inserted array
+     * @param array $insertedArrayData Which data insert to new array?
+     * @param string $key Where to insert the new array?
+     *
+     * @dataProvider providerArrayInsertElementAfterKey
+     */
+    public function testArrayInsertElementAfterKey(array $expectedResult, array $originalArray, string $insertedArrayKey, array $insertedArrayData, string $key): void
+    {
+        $this->assertSame($expectedResult, Tools::arrayInsertElementAfterKey($originalArray, $key, $insertedArrayKey, $insertedArrayData));
+    }
+
+    public function providerArrayInsertElementAfterKey(): iterable
+    {
+        $originalArray = [
+            'field1' => [
+                'value1',
+            ],
+            'field2' => [
+                'value2',
+            ],
+            'field3' => [
+                'value3',
+            ],
+        ];
+
+        yield [
+            [
+                'field1' => [
+                    'value1',
+                ],
+                'field2' => [
+                    'value2',
+                ],
+                'field0' => [
+                    'value0',
+                ],
+                'field3' => [
+                    'value3',
+                ],
+            ],
+            $originalArray,
+            'field0',
+            [
+                'value0',
+            ],
+            'field2',
+        ];
+
+        yield [
+            [
+                'field1' => [
+                    'value1',
+                ],
+                'field2' => [
+                    'value2',
+                ],
+                'field3' => [
+                    'value3',
+                ],
+                'field0' => [
+                    'value0',
+                ],
+            ],
+            $originalArray,
+            'field0',
+            [
+                'value0',
+            ],
+            'field3',
+        ];
+
+        yield [
+            $originalArray, // The field does not exist, we return an original array
+            $originalArray,
+            'field0',
+            [
+                'value0',
+            ],
+            'field4',
+        ];
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The fix is easy, but I decided to introduce a new helper, it might be useful for other developers
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9862.
| Related PRs       | n/a
| How to test?      | See if you still have a Shop name column without multi-store in use
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
