### PR TITLE
Extra message on module description

### DIFF
--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -45,6 +45,7 @@ class ModuleRepository implements ModuleRepositoryInterface
         'tab',
         'displayName',
         'description',
+        'additional_description',
         'author',
         'limited_countries',
         'need_instance',

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -88,6 +88,11 @@
               ...
             {% endif %}
           {% endblock %}
+          {% block addon_additional_description %}
+            {% if module.attributes.additional_description is defined %}
+              {{ module.attributes.additional_description|raw }}
+            {% endif %}
+          {% endblock %}
         </div>
         <div class="col-lg-3 text-md-right">
           {% block module_actions %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds the hook to display extra message after module description in module manager
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28329 
| How to test?      | Register the hook actionListModules in a module and add a text/link/anything to the additional_descripton property of the modules. or you can use [prestashopexamplemodule.zip](https://github.com/PrestaShop/PrestaShop/files/8805312/prestashopexamplemodule.zip)<br>If you use the example module, you'll have in front of each module a text with "this is my additional desc"

