### PR TITLE
Fix confusion about how is translated "Reorder"

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -186,7 +186,7 @@
           {% if has_category_filter == true %}
             <td>
               {% if not(activate_drag_and_drop) %}
-                <input type="button" class="btn btn-outline-secondary" name="products_filter_position_asc" value="{{ "Reorder"|trans({}, 'Admin.Actions') }}" onclick="productOrderPrioritiesTable();" />
+                <input type="button" class="btn btn-outline-secondary" name="products_filter_position_asc" value="{{ "Reorganize"|trans({}, 'Admin.Actions') }}" onclick="productOrderPrioritiesTable();" />
                 {% else %}
                 <input type="button" id="bulk_edition_save_keep" class="btn" onclick="bulkProductAction(this, 'edition');" value="{{ "Save & refresh"|trans({}, 'Admin.Actions')|raw }}" />
               {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -186,7 +186,7 @@
           {% if has_category_filter == true %}
             <td>
               {% if not(activate_drag_and_drop) %}
-                <input type="button" class="btn btn-outline-secondary" name="products_filter_position_asc" value="{{ "Reorganize"|trans({}, 'Admin.Actions') }}" onclick="productOrderPrioritiesTable();" />
+                <input type="button" class="btn btn-outline-secondary" name="products_filter_position_asc" value="{{ "Rearrange"|trans({}, 'Admin.Actions') }}" onclick="productOrderPrioritiesTable();" />
                 {% else %}
                 <input type="button" id="bulk_edition_save_keep" class="btn" onclick="bulkProductAction(this, 'edition');" value="{{ "Save & refresh"|trans({}, 'Admin.Actions')|raw }}" />
               {% endif %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update "Reorder" label for products_filter_position_asc  in listing product Backoffice to "Rearrange" for avoid confusion when translated. <br>In french for exemple, the traduction for Reorder is "Commander à nouveau" and it creates confusion in Backoffice to update product position.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | Fixes #28774
| How to test?      | Connect to BO, go to catalog > product , filter by one category, and the "Reorder" button name has changed now it's "Rearrange"
| Possible impacts? | Impact possible on the other language
