### PR TITLE
Request prestashop/blockreassurance 5.1.0 for 1.7.8.6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4158,20 +4158,23 @@
         },
         {
             "name": "prestashop/blockreassurance",
-            "version": "v5.1.1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/blockreassurance.git",
-                "reference": "7ec28ecf52fcc0ca9787a81edb00f9e7e85d4400"
+                "reference": "c33ba8e4eee14bb45675816155814ae7106d0981"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/blockreassurance/zipball/7ec28ecf52fcc0ca9787a81edb00f9e7e85d4400",
-                "reference": "7ec28ecf52fcc0ca9787a81edb00f9e7e85d4400",
+                "url": "https://api.github.com/repos/PrestaShop/blockreassurance/zipball/c33ba8e4eee14bb45675816155814ae7106d0981",
+                "reference": "c33ba8e4eee14bb45675816155814ae7106d0981",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "doctrine/cache": "^1.6",
+                "guzzlehttp/cache-subscriber": "^0.2.0",
+                "php": ">=5.6.0",
+                "symfony/css-selector": "^3.4 || ^4.4 || ^5.0"
             },
             "require-dev": {
                 "prestashop/php-dev-tools": "^3.4"
@@ -4200,9 +4203,9 @@
             "description": "PrestaShop module blockreassurance",
             "homepage": "https://github.com/PrestaShop/blockreassurance",
             "support": {
-                "source": "https://github.com/PrestaShop/blockreassurance/tree/v5.1.1"
+                "source": "https://github.com/PrestaShop/blockreassurance/tree/v5.1.0"
             },
-            "time": "2022-04-08T15:28:20+00:00"
+            "time": "2022-02-14T15:11:34+00:00"
         },
         {
             "name": "prestashop/blockwishlist",


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Major issue https://github.com/PrestaShop/PrestaShop/issues/28264 was reported on module 5.1.1 . However after exploring the bug for 1 week, me and @AureRita we found there is a deeper issue way more important (see our back-and-forths on https://github.com/PrestaShop/blockreassurance/pull/393). I believe a new major version will be needed for blockreassurance but this will require multiple days to develop, review and tests.<br/>In order not to postpone 1.7.8.6 release any later, I simply revert partially my PR https://github.com/PrestaShop/PrestaShop/pull/28259 and downgrade blockreassurance module to 5.1.0 . When blockreassurance is fixed, we will be able to once more package it into 1.7.8.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | No need I think. Similar to https://github.com/PrestaShop/PrestaShop/pull/28259
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
