### PR TITLE
Add reset button to reset category filter in products list

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
@@ -71,10 +71,11 @@
           </div>
           {% if selected_category is defined and selected_category is not null %}
             <button
-              class="btn btn-outline-secondary"
-              type="button"
+              class="btn btn-link"
+              type="reset"
+              name="categories_filter_reset"
               onclick="productCategoryFilterReset($('div#product_catalog_category_tree_filter'));">
-              {{ 'Reset categories filter'|trans({}, 'Admin.Actions') }}
+              <i class="material-icons">clear</i> {{ 'Clear filter'|trans({}, 'Admin.Actions') }}
             </button>
           {% endif %}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig
@@ -69,6 +69,14 @@
             </div>
               {{ form_widget(categories) }}
           </div>
+          {% if selected_category is defined and selected_category is not null %}
+            <button
+              class="btn btn-outline-secondary"
+              type="button"
+              onclick="productCategoryFilterReset($('div#product_catalog_category_tree_filter'));">
+              {{ 'Reset categories filter'|trans({}, 'Admin.Actions') }}
+            </button>
+          {% endif %}
         </div>
       {% endblock %}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Simply added a reset button to "exit" from the "filtered" status that allow you to rearrange the positions of products. Fix the issue #17942
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #17942
| Related PRs       | ~
| How to test?      | Edit the src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Blocks/filters.html.twig like the commit
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
