### PR TITLE
Fix console command not setting Shop::CONTEXT_ALL properly

### DIFF
--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -159,13 +159,12 @@ class Context implements MultistoreContextCheckerInterface, ShopContextInterface
     }
 
     /**
-     * Update Multishop context for only one shop group.
+     * Update Multishop context to global context
      *
-     * @param int $id Shop id to set in the current context
      */
-    public function setAllContext($id)
+    public function setAllContext()
     {
-        Shop::setContext(Shop::CONTEXT_ALL, $id);
+        Shop::setContext(Shop::CONTEXT_ALL);
     }
 
     public function getContextShopGroup()

--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -160,7 +160,6 @@ class Context implements MultistoreContextCheckerInterface, ShopContextInterface
 
     /**
      * Update Multishop context to global context
-     *
      */
     public function setAllContext()
     {

--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -161,8 +161,11 @@ class Context implements MultistoreContextCheckerInterface, ShopContextInterface
     /**
      * Update Multishop context to global context
      */
-    public function setAllContext()
+    public function setAllContext($id = null)
     {
+        if (null !== $id) {
+            trigger_error('id param is deprecated since 8.x', E_USER_DEPRECATED);
+        }
         Shop::setContext(Shop::CONTEXT_ALL);
     }
 

--- a/src/Adapter/Shop/Context.php
+++ b/src/Adapter/Shop/Context.php
@@ -164,7 +164,10 @@ class Context implements MultistoreContextCheckerInterface, ShopContextInterface
     public function setAllContext($id = null)
     {
         if (null !== $id) {
-            trigger_error('id param is deprecated since 8.x', E_USER_DEPRECATED);
+            @trigger_error(
+                'The parameter $id is deprecated since version 8.0.0 and will be removed in the next major version.',
+                E_USER_DEPRECATED
+            );
         }
         Shop::setContext(Shop::CONTEXT_ALL);
     }

--- a/src/PrestaShopBundle/EventListener/MultishopCommandListener.php
+++ b/src/PrestaShopBundle/EventListener/MultishopCommandListener.php
@@ -72,6 +72,10 @@ class MultishopCommandListener
         if ($id_shop_group) {
             $this->context->setShopGroupContext($id_shop_group);
         }
+        if (!$id_shop && !$id_shop_group) {
+            $this->fixUnloadedConfig();
+            $this->context->setAllContext();
+        }
     }
 
     /**

--- a/tests/Integration/PrestaShopBundle/EventListener/MultishopCommandListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/EventListener/MultishopCommandListenerTest.php
@@ -66,6 +66,21 @@ class MultishopCommandListenerTest extends KernelTestCase
         $this->assertFalse($this->multishopContext->isAllContext(), 'isAllContext');
     }
 
+    public function testNoShopID(): void
+    {
+        // Prepare ...
+        $command = new Command('Fake');
+        $input = new StringInput('');
+        $output = new NullOutput();
+        $event = new ConsoleCommandEvent($command, $input, $output);
+
+        // Call ...
+        $this->commandListener->onConsoleCommand($event);
+
+        // Check!
+        $this->assertFalse($this->multishopContext->isShopContext(), 'isShopContext');
+    }
+
     public function testSetShopID(): void
     {
         // Prepare ...


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Console command doesn't set properly CONTEXT_ALL if no id-shop / id-shop-group is used
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #28378
| Related PRs       | NA
| How to test?      | Read the ticket, run the provided test
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
