### PR TITLE
Add module ps_distributionapiclient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
         "prestashop/ps_customersignin": "^2",
         "prestashop/ps_customtext": "^4",
         "prestashop/ps_dataprivacy": "^2.0",
+        "prestashop/ps_distributionapiclient": "^1.0",
         "prestashop/ps_emailalerts": "^2.3",
         "prestashop/ps_emailsubscription": "^2.7",
         "prestashop/ps_facetedsearch": "^3.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7cdbb5f44bee9dae840f726098cd6d2e",
+    "content-hash": "838034d0bbcbdf176a2f4e7e54eca332",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -756,24 +756,23 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "c9622c6820d3ede1e2315a6a377ea1076e421d88"
+                "reference": "331b4d5dbaeab3827976273e9356b3b453c300ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/c9622c6820d3ede1e2315a6a377ea1076e421d88",
-                "reference": "c9622c6820d3ede1e2315a6a377ea1076e421d88",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/331b4d5dbaeab3827976273e9356b3b453c300ce",
+                "reference": "331b4d5dbaeab3827976273e9356b3b453c300ce",
                 "shasum": ""
             },
             "require": {
                 "php": "~7.1 || ^8.0"
             },
             "conflict": {
-                "doctrine/common": ">2.2,<2.4",
-                "psr/cache": ">=3"
+                "doctrine/common": ">2.2,<2.4"
             },
             "require-dev": {
                 "alcaeus/mongo-php-adapter": "^1.1",
@@ -782,8 +781,9 @@
                 "mongodb/mongodb": "^1.1",
                 "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
                 "predis/predis": "~1.0",
-                "psr/cache": "^1.0 || ^2.0",
-                "symfony/cache": "^4.4 || ^5.2"
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.2 || ^6.0@dev",
+                "symfony/var-exporter": "^4.4 || ^5.2 || ^6.0@dev"
             },
             "suggest": {
                 "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
@@ -835,7 +835,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/cache/issues",
-                "source": "https://github.com/doctrine/cache/tree/2.0.3"
+                "source": "https://github.com/doctrine/cache/tree/2.1.1"
             },
             "funding": [
                 {
@@ -851,7 +851,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-25T09:43:04+00:00"
+            "time": "2021-07-17T14:49:29+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -6237,6 +6237,57 @@
                 "source": "https://github.com/PrestaShop/ps_dataprivacy/tree/v2.1.0"
             },
             "time": "2021-12-31T10:42:45+00:00"
+        },
+        {
+            "name": "prestashop/ps_distributionapiclient",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShop/ps_distributionapiclient.git",
+                "reference": "9373148a960b1e061d554385d89e6aa973901d32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShop/ps_distributionapiclient/zipball/9373148a960b1e061d554385d89e6aa973901d32",
+                "reference": "9373148a960b1e061d554385d89e6aa973901d32",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/cache": "^2.1",
+                "php": ">=7.2.5",
+                "prestashop/circuit-breaker": "^4.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "phpunit/phpunit": "^8.5",
+                "prestashop/php-dev-tools": "^4.2"
+            },
+            "type": "prestashop-module",
+            "autoload": {
+                "psr-4": {
+                    "PrestaShop\\Module\\DistributionApiClient\\": "src/"
+                },
+                "classmap": [
+                    "ps_distributionapiclient.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "AFL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "PrestaShop SA",
+                    "email": "contact@prestashop.com"
+                }
+            ],
+            "description": "PrestaShop - Modules from distribution API",
+            "homepage": "https://github.com/PrestaShop/ps_distributionapiclient",
+            "support": {
+                "issues": "https://github.com/PrestaShop/ps_distributionapiclient/issues",
+                "source": "https://github.com/PrestaShop/ps_distributionapiclient/tree/v1.0.0"
+            },
+            "time": "2022-04-20T14:51:39+00:00"
         },
         {
             "name": "prestashop/ps_emailalerts",
@@ -12783,5 +12834,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR includes the module [PrestaShop/ps_distributionapiclient](https://github.com/PrestaShop/ps_distributionapiclient) that allows merchants to download/update PrestaShop's native modules.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27427
| Related PRs       | N/A
| How to test?      | When this module is enable, if you fully delete a native module, you should be able to keep seing it in the module manager and install it back. If you install an old version of a native module, you should also see that you have an upgrade available and you can upgrade it. When this module is not enable, both of the previous actions should not be possible.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
