### PR TITLE
Remove deprecated variable _PS_PRICE_COMPUTE_PRECISION_

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -1153,7 +1153,7 @@ abstract class PaymentModuleCore extends Module
                 );
             }
             $remainingValue = $cartRuleReductionAmountConverted - $values[$cartRule->reduction_tax ? 'tax_incl' : 'tax_excl'];
-            $remainingValue = Tools::ps_round($remainingValue, _PS_PRICE_COMPUTE_PRECISION_);
+            $remainingValue = Tools::ps_round($remainingValue, Context::getContext()->getComputingPrecision());
             if (count($order_list) == 1 && $remainingValue > 0 && $cartRule->partial_use == 1 && $cartRuleReductionAmountConverted > 0) {
                 // Create a new voucher from the original
                 $voucher = new CartRule((int) $cartRule->id); // We need to instantiate the CartRule without lang parameter to allow saving it


### PR DESCRIPTION
Deprecated `_PS_PRICE_COMPUTE_PRECISION_` instead of `Context::getContext()->getComputingPrecision()` was used. This cause an error when value from the 2 variables didn't match.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When the value from `_PS_PRICE_COMPUTE_PRECISION_` and `Context::getContext()->getComputingPrecision()` was different, the order was created as Payment Error
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Follow the same steps as PR https://github.com/PrestaShop/PrestaShop/pull/26824 . PR https://github.com/PrestaShop/PrestaShop/pull/26824 solved the issue for 1.7.8.x and this PR solves the issue for develop.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
