### PR TITLE
Fix back-office translations when multishop and multiple languages

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -221,7 +221,13 @@ if (defined('_PS_ADMIN_DIR_')) {
 if (isset($cookie->id_lang) && $cookie->id_lang) {
     $language = new Language($cookie->id_lang);
 }
-if (!isset($language) || !Validate::isLoadedObject($language) || !$language->isAssociatedToShop()) {
+
+$isNotValidLanguage = !isset($language) || !Validate::isLoadedObject($language);
+// `true` if language is defined from multishop or backoffice session
+$isLanguageDefinedFromCustomSession = (isset($language) && $language->isAssociatedToShop()) || isset($employee);
+
+$useDefaultLanguage = $isNotValidLanguage || !$isLanguageDefinedFromCustomSession;
+if ($useDefaultLanguage) {
     $language = new Language(Configuration::get('PS_LANG_DEFAULT'));
 }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Multishop translations interfered with BO ones
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27617
| Related PRs       | Na.
| How to test?      | <ul><li>1.- Make a fresh installation of prestashop with two languages, for example English and Spanish.</li><li> 2.- configure the user's language in Spanish. All BO menus appear in Spanish. </li><li> 3.- activate the multistore </li><li> 4.- Set up a second store. </li><li> 5.- configure English only for store 1 </li><li> 6.- configure Spanish only for store 2 </li><li> 7.- You should have all translations Ok (menus, pages, etc. for BO and every shops). </li></ul>
| Possible impacts? | This change could impact translations for multishop (FO and BO)

Thanks @AureRita  for finding [another issue](https://github.com/PrestaShop/PrestaShop/pull/28392#issuecomment-1119581385)

When you setup multishop, default Prestashop language is applied to every shop even if it is not available to those shops.
As no "default language" attribute is defined for shops in multishop, I solved this inconsistency by taking the first language available I find for the shop. This way,
- If you have only one language available, it will be used.
- If you have several languages allowed,
    - If default Prestashop language is one of them, it will be used.
    - If default Prestashop language is not allowed for this shop, the first time you visit, it may be "random" language but once you select your language, it will be taken from your session.

@PrestaShop/product-team , are you Ok with this behavior ?