### PR TITLE
Allow product gift voucher with attribute and the same product as restriction 

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1019,7 +1019,7 @@ class CartRuleCore extends ObjectModel
                             foreach ($cart_products as $cart_product) {
                                 if (in_array($cart_product['id_product'], $product_rule['values'])) {
                                     $count_matching_products += $cart_product['quantity'];
-                                    if ($alreadyInCart && $this->gift_product == $cart_product['id_product']) {
+                                    if ($alreadyInCart && $this->gift_product == $cart_product['id_product'] && ($cart_product['id_product_attribute'] == $this->gift_product_attribute || !(int) $this->gift_product_attribute)) {
                                         --$count_matching_products;
                                     }
                                     $matching_products_list[] = $cart_product['id_product'] . '-0';


### PR DESCRIPTION
Extended if condition for --$count_matching_products to fix issue when the gift product has an attribute.

Otherwise the voucher is not added if the restriction product in the cart and the gift product are the same but have different attributes.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Cart rule can not be added in FO if the same product is used for "Restrictions" and "Free gift".
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | Add a cart rule with the same product for "Restrictions" and "Free gift". The product must have attributes. In the frontoffice the voucher could not be added. It only works if the selected gift attribute and the cart product attribute are the same.
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
