### PR TITLE
Fix product images size consistency

### DIFF
--- a/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
+++ b/themes/classic/templates/catalog/_partials/product-cover-thumbnails.tpl
@@ -28,7 +28,7 @@
       {if $product.default_image}
         <img
           class="js-qv-product-cover img-fluid"
-          src="{$product.default_image.bySize.medium_default.url}"
+          src="{$product.default_image.bySize.large_default.url}"
           {if !empty($product.default_image.legend)}
             alt="{$product.default_image.legend}"
             title="{$product.default_image.legend}"
@@ -36,8 +36,8 @@
             alt="{$product.name}"
           {/if}
           loading="lazy"
-          width="{$product.default_image.bySize.medium_default.width}"
-          height="{$product.default_image.bySize.medium_default.height}"
+          width="{$product.default_image.bySize.large_default.width}"
+          height="{$product.default_image.bySize.large_default.height}"
         >
         <div class="layer hidden-sm-down" data-toggle="modal" data-target="#product-modal">
           <i class="material-icons zoom-in">search</i>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Some changes made quickview main image size inconsistent between default template settings and dynamic scripts 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26557.
| Related PRs       | /
| How to test?      |  1. **Prepare** : Go to BO > catalog > product> New product> Drop many images for the same product </br> 2. **Observe problem** : Go to FO > Quick view > change the image > the size of the image changed
| Possible impacts? | Some weird behaviors in product quickview modal