### PR TITLE
Migrate Country list to symfony

### DIFF
--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -135,6 +135,7 @@ module.exports = {
     translations: './js/app/pages/translations',
     webservice: './js/pages/webservice',
     zone: './js/pages/zone',
+    country: './js/pages/country',
   },
   output: {
     path: path.resolve(__dirname, '../public'),

--- a/admin-dev/themes/new-theme/js/pages/country/index.js
+++ b/admin-dev/themes/new-theme/js/pages/country/index.js
@@ -1,0 +1,56 @@
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+import Grid from '@components/grid/grid';
+import FiltersResetExtension from '@components/grid/extension/filters-reset-extension';
+import SortingExtension from '@components/grid/extension/sorting-extension';
+import ExportToSqlManagerExtension from '@components/grid/extension/export-to-sql-manager-extension';
+import ReloadListExtension from '@components/grid/extension/reload-list-extension';
+import BulkActionCheckboxExtension from '@components/grid/extension/bulk-action-checkbox-extension';
+import SubmitBulkExtension from '@components/grid/extension/submit-bulk-action-extension';
+import SubmitRowActionExtension from '@components/grid/extension/action/row/submit-row-action-extension';
+import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
+import FormSubmitButton from '@components/form-submit-button';
+import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
+import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
+
+const {$} = window.$;
+
+$(() => {
+    const countryGrid = new Grid('country');
+
+    countryGrid.addExtension(new FiltersResetExtension());
+    countryGrid.addExtension(new SortingExtension());
+    countryGrid.addExtension(new ExportToSqlManagerExtension());
+    countryGrid.addExtension(new ReloadListExtension());
+    countryGrid.addExtension(new BulkActionCheckboxExtension());
+    countryGrid.addExtension(new SubmitBulkExtension());
+    countryGrid.addExtension(new SubmitRowActionExtension());
+    countryGrid.addExtension(new LinkRowActionExtension());
+    countryGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+    countryGrid.addExtension(new ColumnTogglingExtension());
+
+    new FormSubmitButton();
+});

--- a/admin-dev/themes/new-theme/js/pages/country/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/country/index.ts
@@ -36,21 +36,21 @@ import FormSubmitButton from '@components/form-submit-button';
 import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 import ColumnTogglingExtension from '@components/grid/extension/column-toggling-extension';
 
-const {$} = window.$;
+const {$} = window;
 
 $(() => {
-    const countryGrid = new Grid('country');
+  const countryGrid = new Grid('country');
 
-    countryGrid.addExtension(new FiltersResetExtension());
-    countryGrid.addExtension(new SortingExtension());
-    countryGrid.addExtension(new ExportToSqlManagerExtension());
-    countryGrid.addExtension(new ReloadListExtension());
-    countryGrid.addExtension(new BulkActionCheckboxExtension());
-    countryGrid.addExtension(new SubmitBulkExtension());
-    countryGrid.addExtension(new SubmitRowActionExtension());
-    countryGrid.addExtension(new LinkRowActionExtension());
-    countryGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
-    countryGrid.addExtension(new ColumnTogglingExtension());
+  countryGrid.addExtension(new FiltersResetExtension());
+  countryGrid.addExtension(new SortingExtension());
+  countryGrid.addExtension(new ExportToSqlManagerExtension());
+  countryGrid.addExtension(new ReloadListExtension());
+  countryGrid.addExtension(new BulkActionCheckboxExtension());
+  countryGrid.addExtension(new SubmitBulkExtension());
+  countryGrid.addExtension(new SubmitRowActionExtension());
+  countryGrid.addExtension(new LinkRowActionExtension());
+  countryGrid.addExtension(new FiltersSubmitButtonEnablerExtension());
+  countryGrid.addExtension(new ColumnTogglingExtension());
 
-    new FormSubmitButton();
+  new FormSubmitButton();
 });

--- a/admin-dev/themes/new-theme/js/pages/country/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/country/index.ts
@@ -1,10 +1,11 @@
 /**
- * 2007-2019 PrestaShop and Contributors
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
  * NOTICE OF LICENSE
  *
  * This source file is subject to the Open Software License (OSL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
+ * that is bundled with this package in the file LICENSE.md.
  * It is also available through the world-wide-web at this URL:
  * https://opensource.org/licenses/OSL-3.0
  * If you did not receive a copy of the license and are unable to
@@ -15,12 +16,11 @@
  *
  * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
  * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://www.prestashop.com for more information.
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
  *
- * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- * International Registered Trademark & Property of PrestaShop SA
  */
 
 import Grid from '@components/grid/grid';

--- a/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
@@ -229,13 +229,6 @@ class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
                         'route_param_field' => 'id_country',
                         'clickable_row' => true,
                     ])
-//            )
-//            ->add(
-//                $this->buildDeleteAction(
-//                    'admin_country_delete',
-//                    'countryId',
-//                    'id_country'
-//                )
             );
 
         return $rowActionCollection;
@@ -269,6 +262,7 @@ class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getBulkActions(): BulkActionCollectionInterface
     {
+        //todo: need to implement bulk actions
         return new BulkActionCollection();
     }
 }

--- a/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
@@ -47,7 +47,7 @@ use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
 use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
-final class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
+class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
 {
     use BulkDeleteActionTrait;
     use DeleteActionTrait;
@@ -67,7 +67,7 @@ final class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
      */
     protected function getName(): string
     {
-        return $this->trans('Country', [], 'Admin.International.Feature');
+        return $this->trans('Country', [], 'Admin.Global');
     }
 
     /**
@@ -98,14 +98,14 @@ final class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
             )
             ->add(
                 (new DataColumn('iso_code'))
-                    ->setName($this->trans('ISO Code', [], 'Admin.Global'))
+                    ->setName($this->trans('ISO Code', [], 'Admin.International.Feature'))
                     ->setOptions([
                         'field' => 'iso_code',
                     ])
             )
             ->add(
                 (new DataColumn('call_prefix'))
-                    ->setName($this->trans('Call prefix', [], 'Admin.Global'))
+                    ->setName($this->trans('Call prefix', [], 'Admin.International.Feature'))
                     ->setOptions([
                         'field' => 'call_prefix',
                     ])

--- a/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\BulkActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
+use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
+use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollectionInterface;
+use PrestaShopBundle\Form\Admin\Type\SearchAndResetType;
+use PrestaShopBundle\Form\Admin\Type\YesAndNoChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+final class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    use BulkDeleteActionTrait;
+    use DeleteActionTrait;
+
+    public const GRID_ID = 'country';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId(): string
+    {
+        return self::GRID_ID;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName(): string
+    {
+        return $this->trans('Country', [], 'Admin.International.Feature');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns(): ColumnCollectionInterface
+    {
+        return (new ColumnCollection())
+            ->add(
+                (new BulkActionColumn('bulk'))
+                    ->setOptions([
+                        'bulk_field' => 'id_country',
+                    ])
+            )
+            ->add(
+                (new DataColumn('id_country'))
+                    ->setName($this->trans('ID', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'id_country',
+                    ])
+            )
+            ->add(
+                (new DataColumn('name'))
+                    ->setName($this->trans('Country', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'name',
+                    ])
+            )
+            ->add(
+                (new DataColumn('iso_code'))
+                    ->setName($this->trans('ISO Code', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'iso_code',
+                    ])
+            )
+            ->add(
+                (new DataColumn('call_prefix'))
+                    ->setName($this->trans('Call prefix', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'call_prefix',
+                    ])
+            )
+            ->add(
+                (new DataColumn('zone_name'))
+                    ->setName($this->trans('Zone', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'zone_name',
+                    ])
+            )
+            //todo: change it to ToggleColumn when toggle status route is created
+            ->add(
+                (new DataColumn('active'))
+                    ->setName($this->trans('Enabled', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'active',
+                    ])
+            )
+            ->add(
+                (new ActionColumn('actions'))
+                    ->setName($this->trans('Actions', [], 'Admin.Global'))
+                    ->setOptions([
+                        'actions' => $this->getRowActions(),
+                    ])
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFilters(): FilterCollectionInterface
+    {
+        return (new FilterCollection())
+            ->add(
+                (new Filter('id_country', TextType::class))
+                    ->setAssociatedColumn('id_country')
+                    ->setTypeOptions([
+                        'required' => false,
+                        'attr' => [
+                            'placeholder' => $this->trans('Search ID', [], 'Admin.Actions'),
+                        ],
+                    ])
+            )
+            ->add(
+                (new Filter('name', TextType::class))
+                    ->setAssociatedColumn('name')
+                    ->setTypeOptions([
+                        'required' => false,
+                        'attr' => [
+                            'placeholder' => $this->trans('Search country', [], 'Admin.Actions'),
+                        ],
+                    ])
+            )
+            ->add(
+                (new Filter('iso_code', TextType::class))
+                    ->setAssociatedColumn('iso_code')
+                    ->setTypeOptions([
+                        'required' => false,
+                        'attr' => [
+                            'placeholder' => $this->trans('Search ISO code', [], 'Admin.Actions'),
+                        ],
+                    ])
+            )
+            ->add(
+                (new Filter('call_prefix', TextType::class))
+                    ->setAssociatedColumn('call_prefix')
+                    ->setTypeOptions([
+                        'required' => false,
+                        'attr' => [
+                            'placeholder' => $this->trans('Search call prefix', [], 'Admin.Actions'),
+                        ],
+                    ])
+            )
+            ->add(
+                (new Filter('zone_name', TextType::class))
+                    ->setAssociatedColumn('zone_name')
+                    ->setTypeOptions([
+                        'required' => false,
+                        'attr' => [
+                            'placeholder' => $this->trans('Search zones', [], 'Admin.Actions'),
+                        ],
+                    ])
+            )
+            ->add(
+                (new Filter('active', YesAndNoChoiceType::class))
+                    ->setAssociatedColumn('active')
+                    ->setTypeOptions([
+                        'required' => false,
+                        'choice_translation_domain' => false,
+                    ])
+            )
+            ->add(
+                (new Filter('actions', SearchAndResetType::class))
+                    ->setAssociatedColumn('actions')
+                    ->setTypeOptions([
+                        'reset_route' => 'admin_common_reset_search_by_filter_id',
+                        'reset_route_params' => [
+                            'filterId' => self::GRID_ID,
+                        ],
+                        'redirect_route' => 'admin_countries_index',
+                    ])
+            );
+    }
+
+    /**
+     * @return RowActionCollection
+     */
+    private function getRowActions(): RowActionCollection
+    {
+        $rowActionCollection = new RowActionCollection();
+
+        return $rowActionCollection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getGridActions(): GridActionCollectionInterface
+    {
+        return (new GridActionCollection())
+            ->add(
+                (new SimpleGridAction('common_refresh_list'))
+                    ->setName($this->trans('Refresh list', [], 'Admin.Advparameters.Feature'))
+                    ->setIcon('refresh')
+            )
+            ->add(
+                (new SimpleGridAction('common_show_query'))
+                    ->setName($this->trans('Show SQL query', [], 'Admin.Actions'))
+                    ->setIcon('code')
+            )
+            ->add(
+                (new SimpleGridAction('common_export_sql_manager'))
+                    ->setName($this->trans('Export to SQL manager', [], 'Admin.Actions'))
+                    ->setIcon('storage')
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getBulkActions(): BulkActionCollectionInterface
+    {
+        return new BulkActionCollection();
+    }
+}

--- a/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CountryGridDefinitionFactory.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollectionInterface;
@@ -217,6 +218,25 @@ class CountryGridDefinitionFactory extends AbstractGridDefinitionFactory
     private function getRowActions(): RowActionCollection
     {
         $rowActionCollection = new RowActionCollection();
+        $rowActionCollection
+            ->add(
+                (new LinkRowAction('edit'))
+                    ->setName($this->trans('Edit', [], 'Admin.Actions'))
+                    ->setIcon('edit')
+                    ->setOptions([
+                        'route' => 'admin_country_edit',
+                        'route_param_name' => 'countryId',
+                        'route_param_field' => 'id_country',
+                        'clickable_row' => true,
+                    ])
+//            )
+//            ->add(
+//                $this->buildDeleteAction(
+//                    'admin_country_delete',
+//                    'countryId',
+//                    'id_country'
+//                )
+            );
 
         return $rowActionCollection;
     }

--- a/src/Core/Grid/Query/CountryQueryBuilder.php
+++ b/src/Core/Grid/Query/CountryQueryBuilder.php
@@ -98,6 +98,12 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
             ->from($this->dbPrefix . 'country', 'c')
             ->innerJoin(
                 'c',
+                $this->dbPrefix . 'country_shop',
+                'cs',
+                'c.id_country = cs.id_country'
+            )
+            ->innerJoin(
+                'c',
                 $this->dbPrefix . 'country_lang',
                 'cl',
                 'cl.id_country = cs.id_country'
@@ -142,7 +148,7 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
             }
 
             if ($filterName === 'zone_name') {
-                $builder->andWhere('zn.' . $filterName . ' LIKE :' . $filterName);
+                $builder->andWhere('z.name' . ' LIKE :' . $filterName);
                 $builder->setParameter($filterName, '%' . $filterValue . '%');
                 continue;
             }

--- a/src/Core/Grid/Query/CountryQueryBuilder.php
+++ b/src/Core/Grid/Query/CountryQueryBuilder.php
@@ -35,7 +35,7 @@ use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 /**
  * Builds search and count query builders for zone grid.
  */
-final class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
+class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
 {
     /**
      * @var DoctrineSearchCriteriaApplicatorInterface
@@ -51,7 +51,7 @@ final class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param array $contextShopIds
+     * @param int[] $contextShopIds
      */
     public function __construct(
         Connection $connection,
@@ -70,7 +70,7 @@ final class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         $qb = $this->getQueryBuilder($searchCriteria)
-            ->select('c.*, cl.name, z.name as zone_name')
+            ->select('c.id_country, c.iso_code, c.call_prefix, c.active, cl.name, z.name as zone_name')
             ->groupBy('c.id_country');
 
         $this->searchCriteriaApplicator

--- a/src/Core/Grid/Query/CountryQueryBuilder.php
+++ b/src/Core/Grid/Query/CountryQueryBuilder.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Builds search and count query builders for zone grid.
+ */
+final class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
+{
+    /**
+     * @var DoctrineSearchCriteriaApplicatorInterface
+     */
+    private $searchCriteriaApplicator;
+
+    /**
+     * @var int[]
+     */
+    private $contextShopIds;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
+     * @param array $contextShopIds
+     */
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
+        array $contextShopIds
+    ) {
+        parent::__construct($connection, $dbPrefix);
+        $this->searchCriteriaApplicator = $searchCriteriaApplicator;
+        $this->contextShopIds = $contextShopIds;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->getQueryBuilder($searchCriteria)
+            ->select('c.*, cl.name, z.name as zone_name')
+            ->groupBy('c.id_country');
+
+        $this->searchCriteriaApplicator
+            ->applyPagination($searchCriteria, $qb)
+            ->applySorting($searchCriteria, $qb);
+
+        return $qb;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        return $this->getQueryBuilder($searchCriteria)->select('COUNT(DISTINCT c.id_country)');
+    }
+
+    /**
+     * @param SearchCriteriaInterface $searchCriteria
+     *
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->from($this->dbPrefix . 'country', 'c')
+            ->innerJoin(
+                'c',
+                $this->dbPrefix . 'country_shop',
+                'cs',
+                'c.id_country = cs.id_country'
+            )
+            ->innerJoin(
+                'c',
+                $this->dbPrefix . 'country_lang',
+                'cl',
+                'cl.id_country = cs.id_country'
+            )
+            ->innerJoin(
+                'c',
+                $this->dbPrefix . 'zone',
+                'z',
+                'z.id_zone = c.id_zone'
+            )
+            ->where('cs.id_shop IN (:contextShopIds)')
+            ->setParameter('contextShopIds', $this->contextShopIds, Connection::PARAM_INT_ARRAY);
+
+        $this->applyFilters($qb, $searchCriteria);
+
+        return $qb;
+    }
+
+    /**
+     * @param QueryBuilder $builder
+     * @param SearchCriteriaInterface $criteria
+     */
+    private function applyFilters(QueryBuilder $builder, SearchCriteriaInterface $criteria): void
+    {
+        $allowedFilters = ['id_country', 'name', 'iso_code', 'call_prefix', 'zone_name', 'active'];
+
+        foreach ($criteria->getFilters() as $filterName => $filterValue) {
+            if (!in_array($filterName, $allowedFilters)) {
+                continue;
+            }
+
+            if (in_array($filterName, ['id_country', 'active'])) {
+                $builder->andWhere('c.' . $filterName . ' = :' . $filterName);
+                $builder->setParameter($filterName, $filterValue);
+                continue;
+            }
+
+            if ($filterName === 'name') {
+                $builder->andWhere('cl.' . $filterName . ' LIKE :' . $filterName);
+                $builder->setParameter($filterName, '%' . $filterValue . '%');
+                continue;
+            }
+
+            if ($filterName === 'zone_name') {
+                $builder->andWhere('zn.' . $filterName . ' LIKE :' . $filterName);
+                $builder->setParameter($filterName, '%' . $filterValue . '%');
+                continue;
+            }
+
+            if (in_array($filterName, ['iso_code', 'call_prefix'])) {
+                $builder->andWhere('c.' . $filterName . ' LIKE :' . $filterName);
+                $builder->setParameter($filterName, '%' . $filterValue . '%');
+            }
+        }
+    }
+}

--- a/src/Core/Grid/Query/CountryQueryBuilder.php
+++ b/src/Core/Grid/Query/CountryQueryBuilder.php
@@ -37,10 +37,14 @@ use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
  */
 class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
 {
-    /** @var DoctrineSearchCriteriaApplicatorInterface */
+    /**
+     * @var DoctrineSearchCriteriaApplicatorInterface
+     */
     protected $searchCriteriaApplicator;
 
-    /** @var int[] */
+    /**
+     * @var int[]
+     */
     protected $contextShopIds;
 
     /**

--- a/src/Core/Grid/Query/CountryQueryBuilder.php
+++ b/src/Core/Grid/Query/CountryQueryBuilder.php
@@ -37,10 +37,10 @@ use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
  */
 class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
 {
-    /** @var DoctrineSearchCriteriaApplicatorInterface  */
+    /** @var DoctrineSearchCriteriaApplicatorInterface */
     protected $searchCriteriaApplicator;
 
-    /** @var int[]  */
+    /** @var int[] */
     protected $contextShopIds;
 
     /**

--- a/src/Core/Grid/Query/CountryQueryBuilder.php
+++ b/src/Core/Grid/Query/CountryQueryBuilder.php
@@ -37,15 +37,11 @@ use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
  */
 class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
 {
-    /**
-     * @var DoctrineSearchCriteriaApplicatorInterface
-     */
-    private $searchCriteriaApplicator;
+    /** @var DoctrineSearchCriteriaApplicatorInterface  */
+    protected $searchCriteriaApplicator;
 
-    /**
-     * @var int[]
-     */
-    private $contextShopIds;
+    /** @var int[]  */
+    protected $contextShopIds;
 
     /**
      * @param Connection $connection
@@ -93,7 +89,7 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
      *
      * @return QueryBuilder
      */
-    private function getQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    protected function getQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         $qb = $this->connection->createQueryBuilder()
             ->from($this->dbPrefix . 'country', 'c')
@@ -127,7 +123,7 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
      * @param QueryBuilder $builder
      * @param SearchCriteriaInterface $criteria
      */
-    private function applyFilters(QueryBuilder $builder, SearchCriteriaInterface $criteria): void
+    protected function applyFilters(QueryBuilder $builder, SearchCriteriaInterface $criteria): void
     {
         $allowedFilters = ['id_country', 'name', 'iso_code', 'call_prefix', 'zone_name', 'active'];
 

--- a/src/Core/Grid/Query/CountryQueryBuilder.php
+++ b/src/Core/Grid/Query/CountryQueryBuilder.php
@@ -70,8 +70,7 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
     public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         $qb = $this->getQueryBuilder($searchCriteria)
-            ->select('c.id_country, c.iso_code, c.call_prefix, c.active, cl.name, z.name as zone_name')
-            ->groupBy('c.id_country');
+            ->select('c.id_country, c.iso_code, c.call_prefix, c.active, cl.name, z.name as zone_name');
 
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
@@ -99,17 +98,11 @@ class CountryQueryBuilder extends AbstractDoctrineQueryBuilder
             ->from($this->dbPrefix . 'country', 'c')
             ->innerJoin(
                 'c',
-                $this->dbPrefix . 'country_shop',
-                'cs',
-                'c.id_country = cs.id_country'
-            )
-            ->innerJoin(
-                'c',
                 $this->dbPrefix . 'country_lang',
                 'cl',
                 'cl.id_country = cs.id_country'
             )
-            ->innerJoin(
+            ->leftJoin(
                 'c',
                 $this->dbPrefix . 'zone',
                 'z',

--- a/src/Core/Search/Filters/CountryFilters.php
+++ b/src/Core/Search/Filters/CountryFilters.php
@@ -24,6 +24,8 @@
  * International Registered Trademark & Property of PrestaShop SA
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Search\Filters;
 
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory;
@@ -32,7 +34,7 @@ use PrestaShop\PrestaShop\Core\Search\Filters;
 /**
  * Default Countries list filters
  */
-final class CountryFilters extends Filters
+class CountryFilters extends Filters
 {
     /**
      * @var string

--- a/src/Core/Search/Filters/CountryFilters.php
+++ b/src/Core/Search/Filters/CountryFilters.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * 2007-2019 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2019 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+/**
+ * Default Countries list filters
+ */
+final class CountryFilters extends Filters
+{
+    /**
+     * @var string
+     */
+    protected $filterId = CountryGridDefinitionFactory::GRID_ID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults(): array
+    {
+        return [
+            'limit' => 50,
+            'offset' => 0,
+            'orderBy' => 'id_country',
+            'sortOrder' => 'asc',
+            'filters' => [],
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -68,9 +68,9 @@ class CountryController extends FrameworkBundleAdminController
 
         Tools::redirectAdmin(
             \Context::getContext()->link->getAdminLink('AdminCountries', true, [], [
-                    'updatecountry' => '',
-                    'id_country' => $countryId
-                ]
+                'updatecountry' => '',
+                'id_country' => $countryId,
+            ]
             )
         );
     }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -33,6 +33,7 @@ use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tools;
 
 /**
  * CountryController is responsible for handling "Improve > International > Locations > Countries"
@@ -59,5 +60,18 @@ class CountryController extends FrameworkBundleAdminController
             'countryGrid' => $this->presentGrid($countryGrid),
             'enableSidebar' => true,
         ]);
+    }
+
+    public function editAction(int $countryId, Request $request): Response
+    {
+        //todo: complete edit action migration to symfony
+
+        Tools::redirectAdmin(
+            \Context::getContext()->link->getAdminLink('AdminCountries', true, [], [
+                    'updatecountry' => '',
+                    'id_country' => $countryId
+                ]
+            )
+        );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -24,13 +24,13 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
-use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\CountryFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -59,26 +59,5 @@ class CountryController extends FrameworkBundleAdminController
             'countryGrid' => $this->presentGrid($countryGrid),
             'enableSidebar' => true,
         ]);
-    }
-
-    /**
-     * Provides filters functionality.
-     *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
-     *
-     * @param Request $request
-     *
-     * @return RedirectResponse
-     */
-    public function searchAction(Request $request): RedirectResponse
-    {
-        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
-
-        return $responseBuilder->buildSearchResponse(
-            $this->get('prestashop.core.grid.definition.factory.country'),
-            $request,
-            CountryGridDefinitionFactory::GRID_ID,
-            'admin_countries_index'
-        );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -34,7 +34,6 @@ use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Tools;
 
 /**
  * CountryController is responsible for handling "Improve > International > Locations > Countries"

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
+use Context;
 use PrestaShop\PrestaShop\Core\Search\Filters\CountryFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -62,12 +63,21 @@ class CountryController extends FrameworkBundleAdminController
         ]);
     }
 
+    /**
+     * Display country edit form
+     *
+     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     *
+     * @param int $countryId
+     * @param Request $request
+     *
+     * @return Response
+     */
     public function editAction(int $countryId, Request $request): Response
     {
         //todo: complete edit action migration to symfony
-
-        Tools::redirectAdmin(
-            \Context::getContext()->link->getAdminLink(
+        return $this->redirect(
+            Context::getContext()->link->getAdminLink(
                 'AdminCountries',
                 true,
                 [],

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Controller\Admin\Improve\International;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters\CountryFilters;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * CountryController is responsible for handling "Improve > International > Locations > Countries"
+ */
+class CountryController extends FrameworkBundleAdminController
+{
+    /**
+     * Show countries listing page
+     *
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     *
+     * @param Request $request
+     * @param CountryFilters $filters
+     *
+     * @return Response
+     */
+    public function indexAction(Request $request, CountryFilters $filters): Response
+    {
+        $countryGridFactory = $this->get('prestashop.core.grid.factory.country');
+        $countryGrid = $countryGridFactory->getGrid($filters);
+
+        return $this->render('@PrestaShop/Admin/Improve/International/Country/index.html.twig', [
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'countryGrid' => $this->presentGrid($countryGrid),
+            'enableSidebar' => true,
+        ]);
+    }
+
+    /**
+     * Provides filters functionality.
+     *
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     *
+     * @param Request $request
+     *
+     * @return RedirectResponse
+     */
+    public function searchAction(Request $request): RedirectResponse
+    {
+        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
+
+        return $responseBuilder->buildSearchResponse(
+            $this->get('prestashop.core.grid.definition.factory.country'),
+            $request,
+            CountryGridDefinitionFactory::GRID_ID,
+            'admin_countries_index'
+        );
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -67,10 +67,14 @@ class CountryController extends FrameworkBundleAdminController
         //todo: complete edit action migration to symfony
 
         Tools::redirectAdmin(
-            \Context::getContext()->link->getAdminLink('AdminCountries', true, [], [
-                'updatecountry' => '',
-                'id_country' => $countryId,
-            ]
+            \Context::getContext()->link->getAdminLink(
+                'AdminCountries',
+                true,
+                [],
+                [
+                    'updatecountry' => '',
+                    'id_country' => $countryId,
+                ]
             )
         );
     }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/_international.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/_international.yml
@@ -33,3 +33,7 @@ _tax_rules_groups:
 _zone:
   resource: "zone.yml"
   prefix: /zones/
+
+_country:
+  resource: "country.yml"
+  prefix: /countries/

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
@@ -1,4 +1,4 @@
-#todo uncomment all legacy links when page is finished.
+# todo uncomment all legacy links when page is finished.
 admin_countries_index:
   path: /
   methods: GET
@@ -29,7 +29,7 @@ admin_country_edit:
   requirements:
     countryId: \d+
 #
-#admin_zones_delete:
+# admin_zones_delete:
 #  path: /{zoneId}/delete
 #  methods: [ POST, DELETE ]
 #  defaults:

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
@@ -1,0 +1,16 @@
+#todo uncomment all legacy links when page is finished.
+admin_countries_index:
+  path: /
+  methods: GET
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::indexAction'
+    _legacy_controller: AdminCountries
+#    _legacy_link: AdminCountries
+
+admin_countries_search:
+  path: /
+  methods: POST
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::searchAction'
+    _legacy_controller: AdminCountries
+#    _legacy_link: AdminCountries:submitFiltercountry

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
@@ -23,12 +23,12 @@ admin_country_edit:
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::editAction'
     _legacy_controller: AdminCountry
-#    _legacy_link: AdminCountry:updateCountry
+    # _legacy_link: AdminCountry:updateCountry
     _legacy_parameters:
       id_country: countryId
   requirements:
     countryId: \d+
-#
+
 # admin_zones_delete:
 #  path: /{zoneId}/delete
 #  methods: [ POST, DELETE ]

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
@@ -11,6 +11,8 @@ admin_countries_search:
   path: /
   methods: POST
   defaults:
-    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::searchAction'
+    _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
+    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.country
+    redirectRoute: admin_countries_index
     _legacy_controller: AdminCountries
 #    _legacy_link: AdminCountries:submitFiltercountry

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/international/country.yml
@@ -16,3 +16,27 @@ admin_countries_search:
     redirectRoute: admin_countries_index
     _legacy_controller: AdminCountries
 #    _legacy_link: AdminCountries:submitFiltercountry
+
+admin_country_edit:
+  path: /{countryId}/edit
+  methods: [ GET, POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\CountryController::editAction'
+    _legacy_controller: AdminCountry
+#    _legacy_link: AdminCountry:updateCountry
+    _legacy_parameters:
+      id_country: countryId
+  requirements:
+    countryId: \d+
+#
+#admin_zones_delete:
+#  path: /{zoneId}/delete
+#  methods: [ POST, DELETE ]
+#  defaults:
+#    _controller: 'PrestaShopBundle\Controller\Admin\Improve\International\ZoneController::deleteAction'
+#    _legacy_controller: AdminZones
+#    _legacy_link: AdminZones:deletezone
+#    _legacy_parameters:
+#      id_zone: zoneId
+#  requirements:
+#    zoneId: \d+

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -374,6 +374,14 @@ services:
       - '@prestashop.core.query.doctrine_search_criteria_applicator'
       - '@=service("prestashop.adapter.shop.context").getContextListShopId()'
 
+  prestashop.core.grid.query_builder.country:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Query\CountryQueryBuilder'
+    parent: 'prestashop.core.grid.abstract_query_builder'
+    public: true
+    arguments:
+      - '@prestashop.core.query.doctrine_search_criteria_applicator'
+      - '@=service("prestashop.adapter.shop.context").getContextListShopId()'
+
   prestashop.core.grid.query_builder.product_combination:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\ProductCombinationQueryBuilder'
     parent: 'prestashop.core.grid.abstract_query_builder'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -453,6 +453,14 @@ services:
       - '@prestashop.core.grid.query.doctrine_query_parser'
       - 'zone'
 
+  prestashop.core.grid.data.factory.country:
+    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+    arguments:
+      - '@prestashop.core.grid.query_builder.country'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.core.grid.query.doctrine_query_parser'
+      - 'country'
+
   prestashop.core.grid.data.factory.zone_decorator:
     class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\ZoneGridDataFactory'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -285,6 +285,11 @@ services:
     parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
     public: true
 
+  prestashop.core.grid.definition.factory.country:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CountryGridDefinitionFactory'
+    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+    public: true
+
   prestashop.core.grid.definition.factory.search_engines:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\SearchEngineGridDefinitionFactory'
     parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -360,6 +360,14 @@ services:
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
 
+  prestashop.core.grid.factory.country:
+    class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+    arguments:
+      - '@prestashop.core.grid.definition.factory.country'
+      - '@prestashop.core.grid.data.factory.country'
+      - '@prestashop.core.grid.filter.form_factory'
+      - '@prestashop.core.hook.dispatcher'
+
   prestashop.core.grid.factory.search_engines:
     class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
     arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/Country/index.html.twig
@@ -1,0 +1,38 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  {% include '@PrestaShop/Admin/Common/Grid/grid_panel.html.twig' with {'grid': countryGrid} %}
+{% endblock %}
+
+{% block javascripts %}
+  {{ parent() }}
+
+  <script src="{{ asset('themes/new-theme/public/country.bundle.js') }}"></script>
+  <script src="{{ asset('themes/default/js/bundle/pagination.js') }}"></script>
+{% endblock %}
+

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
@@ -48,7 +48,7 @@ class CountryControllerTest extends FormGridControllerTestCase
      *
      * @param int $initialEntityCount
      */
-    public function testCreate(int $initialEntityCount)
+    public function testCreate(int $initialEntityCount): void
     {
         $this->markTestSkipped('Not implemented');
         // TODO: Implement when create action is created
@@ -59,7 +59,7 @@ class CountryControllerTest extends FormGridControllerTestCase
      *
      * @param int $countryId
      */
-    public function testEdit(int $countryId)
+    public function testEdit(int $countryId): void
     {
         $this->markTestSkipped('Not implemented');
         // TODO: Implement when edit action is created
@@ -70,7 +70,7 @@ class CountryControllerTest extends FormGridControllerTestCase
      *
      * @param int $countryId
      */
-    public function testFilters(int $countryId)
+    public function testFilters(int $countryId): void
     {
         $this->markTestSkipped('Not implemented');
         // TODO: Implement when testEdit is finished

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\PrestaShopBundle\Controller\Admin\Improve\International;
+
+use Symfony\Component\DomCrawler\Crawler;
+use Tests\Integration\Core\Form\IdentifiableObject\Handler\FormHandlerChecker;
+use Tests\Integration\PrestaShopBundle\Controller\FormGridControllerTestCase;
+use Tests\Integration\PrestaShopBundle\Controller\TestEntityDTO;
+
+class CountryControllerTest extends FormGridControllerTestCase
+{
+    public function testIndex(): int
+    {
+        $countries = $this->getEntitiesFromGrid();
+        $this->assertNotEmpty($countries);
+
+        return $countries->count();
+    }
+
+    /**
+     * @depends testIndex
+     *
+     * @param int $initialEntityCount
+     */
+    public function testCreate(int $initialEntityCount)
+    {
+        $this->markTestSkipped('Not implemented');
+        // TODO: Implement when create action is created
+    }
+
+    /**
+     * @depends testCreate
+     *
+     * @param int $countryId
+     */
+    public function testEdit(int $countryId)
+    {
+        $this->markTestSkipped('Not implemented');
+        // TODO: Implement when edit action is created
+    }
+
+    /**
+     * @depends testEdit
+     *
+     * @param int $countryId
+     */
+    public function testFilters(int $countryId)
+    {
+        $this->markTestSkipped('Not implemented');
+        // TODO: Implement when testEdit is finished
+    }
+
+    protected function generateCreateUrl(): string
+    {
+        // TODO: Implement generateCreateUrl() method.
+    }
+
+    protected function getCreateSubmitButtonSelector(): string
+    {
+        // TODO: Implement getCreateSubmitButtonSelector() method.
+    }
+
+    protected function getFormHandlerChecker(): FormHandlerChecker
+    {
+        // TODO: Implement getFormHandlerChecker() method.
+    }
+
+    protected function generateEditUrl(array $routeParams): string
+    {
+        // TODO: Implement generateEditUrl() method.
+    }
+
+    protected function getEditSubmitButtonSelector(): string
+    {
+        // TODO: Implement getEditSubmitButtonSelector() method.
+    }
+
+    protected function getFilterSearchButtonSelector(): string
+    {
+        return 'country[actions][search]';
+    }
+
+    protected function generateGridUrl(array $routeParams = []): string
+    {
+        if (empty($routeParams)) {
+            $routeParams = [
+                'country[offset]' => 0,
+                'country[limit]' => 100,
+            ];
+        }
+
+        return $this->router->generate('admin_countries_index', $routeParams);
+    }
+
+    protected function getGridSelector(): string
+    {
+        return '#country_grid_table';
+    }
+
+    protected function parseEntityFromRow(Crawler $tr, int $i): TestEntityDTO
+    {
+        return new TestEntityDTO(
+            (int) trim($tr->filter('.column-id_country')->text()),
+            [
+                'country' => trim($tr->filter('.column-name')->text()),
+                'isoCode' => trim($tr->filter('.column-iso_code')->text()),
+                'callPrefix' => trim($tr->filter('.column-call_prefix')->text()),
+                'zone' => trim($tr->filter('.column-zone_name')->text()),
+                'enabled' => trim($tr->filter('.column-active')->text()),
+            ]
+        );
+    }
+}

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
@@ -79,26 +79,34 @@ class CountryControllerTest extends FormGridControllerTestCase
     protected function generateCreateUrl(): string
     {
         // TODO: Implement generateCreateUrl() method.
+        return 'Not implemented yet';
     }
 
     protected function getCreateSubmitButtonSelector(): string
     {
         // TODO: Implement getCreateSubmitButtonSelector() method.
+        return 'Not implemented yet';
     }
 
     protected function getFormHandlerChecker(): FormHandlerChecker
     {
         // TODO: Implement getFormHandlerChecker() method.
+        /** @var FormHandlerChecker $checker */
+        $checker = $this->client->getContainer()->get('prestashop.core.form.identifiable_object.country_form_handler');
+
+        return $checker;
     }
 
     protected function generateEditUrl(array $routeParams): string
     {
         // TODO: Implement generateEditUrl() method.
+        return 'Not implemented yet';
     }
 
     protected function getEditSubmitButtonSelector(): string
     {
         // TODO: Implement getEditSubmitButtonSelector() method.
+        return 'Not implemented yet';
     }
 
     protected function getFilterSearchButtonSelector(): string

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
@@ -65,28 +65,26 @@ class CountryControllerTest extends FormGridControllerTestCase
         // TODO: Implement when edit action is created
     }
 
-    /**
-     * @param int $countryId
-     */
-    public function testFilters(int $countryId): int
+    public function testFilters(): int
     {
+        //todo: when edit form is finished we can use it for filter test. Example AddressControllerTest.php
+        $countryId = 1;
         $gridFilters = [
-            ['country[id_address]' => $countryId],
-            ['address[firstname]' => 'editfirstname'],
-            ['address[lastname]' => 'editlastname'],
-            ['address[address1]' => 'editaddress1'],
-            ['address[postcode]' => '11111'],
-            ['address[city]' => 'editcity'],
-            ['address[id_country]' => $this->countryId],
+            ['country[id_country]' => $countryId],
+            ['country[name]' => 'Germany'],
+            ['country[iso_code]' => 'DE'],
+            ['country[call_prefix]' => 49],
+            ['country[zone_name]' => 'Europe'],
+            ['country[active]' => 0],
         ];
 
         foreach ($gridFilters as $testFilter) {
-            $addresses = $this->getFilteredEntitiesFromGrid($testFilter);
-            $this->assertGreaterThanOrEqual(1, count($addresses), sprintf(
+            $countries = $this->getFilteredEntitiesFromGrid($testFilter);
+            $this->assertGreaterThanOrEqual(1, count($countries), sprintf(
                 'Expected at least one address with filters %s',
                 var_export($testFilter, true)
             ));
-            $this->assertCollectionContainsEntity($addresses, $countryId);
+            $this->assertCollectionContainsEntity($countries, $countryId);
         }
 
         return $countryId;

--- a/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Admin/Improve/International/CountryControllerTest.php
@@ -66,14 +66,30 @@ class CountryControllerTest extends FormGridControllerTestCase
     }
 
     /**
-     * @depends testEdit
-     *
      * @param int $countryId
      */
-    public function testFilters(int $countryId): void
+    public function testFilters(int $countryId): int
     {
-        $this->markTestSkipped('Not implemented');
-        // TODO: Implement when testEdit is finished
+        $gridFilters = [
+            ['country[id_address]' => $countryId],
+            ['address[firstname]' => 'editfirstname'],
+            ['address[lastname]' => 'editlastname'],
+            ['address[address1]' => 'editaddress1'],
+            ['address[postcode]' => '11111'],
+            ['address[city]' => 'editcity'],
+            ['address[id_country]' => $this->countryId],
+        ];
+
+        foreach ($gridFilters as $testFilter) {
+            $addresses = $this->getFilteredEntitiesFromGrid($testFilter);
+            $this->assertGreaterThanOrEqual(1, count($addresses), sprintf(
+                'Expected at least one address with filters %s',
+                var_export($testFilter, true)
+            ));
+            $this->assertCollectionContainsEntity($addresses, $countryId);
+        }
+
+        return $countryId;
     }
 
     protected function generateCreateUrl(): string


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Migration of /international/locations/countries list. This PR only contains grid and search. No actions implemented yet.
| Type?             | refacto
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#10604](https://github.com/PrestaShop/PrestaShop/issues/10604)
| How to test?      | You can access controller by using route in url: improve/international/countries. It should look just like legacy but without actions, only filter is implemented.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
