### PR TITLE
Allow clearing modules cache for all shops

### DIFF
--- a/src/Core/Module/EventSubscriber.php
+++ b/src/Core/Module/EventSubscriber.php
@@ -69,7 +69,7 @@ class EventSubscriber implements EventSubscriberInterface
     public function onModuleStateChanged(ModuleManagementEvent $event): void
     {
         $moduleName = $event->getModule()->get('name');
-        $this->moduleRepository->clearCache($moduleName);
+        $this->moduleRepository->clearCache($moduleName, true);
     }
 
     public function onModuleInstalledOrUninstalled(ModuleManagementEvent $event): void

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -213,7 +213,7 @@ class ModuleRepository implements ModuleRepositoryInterface
      *
      * @return string
      */
-    private function getCacheKey(string $moduleName, ?int $shopId = null): string
+    protected function getCacheKey(string $moduleName, ?int $shopId = null): string
     {
         $shop = $shopId ? [$shopId] : Shop::getContextListShopID();
 

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -175,19 +175,37 @@ class ModuleRepository implements ModuleRepositoryInterface
         return $this->adminModuleDataProvider->setActionUrls($collection);
     }
 
-    public function clearCache(?string $moduleName = null): bool
+    public function clearCache(?string $moduleName = null, bool $allShops = false): bool
     {
         $this->installedModules = null;
-        if ($moduleName !== null && $this->cacheProvider->contains($this->getCacheKey($moduleName))) {
-            return $this->cacheProvider->delete($this->getCacheKey($moduleName));
+        if ($moduleName !== null) {
+            if ($allShops) {
+                foreach (Shop::getShops(true, null, true) as $shopId) {
+                    $cacheKey = $this->getCacheKey($moduleName, $shopId);
+                    if ($this->cacheProvider->contains($cacheKey)) {
+                        if (!$this->cacheProvider->delete($cacheKey)) {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            } else {
+                $cacheKey = $this->getCacheKey($moduleName);
+                if ($this->cacheProvider->contains($cacheKey)) {
+                    return $this->cacheProvider->delete($cacheKey);
+                }
+            }
         }
 
         return $this->cacheProvider->deleteAll();
     }
 
-    private function getCacheKey(string $moduleName): string
+    private function getCacheKey(string $moduleName, ?int $shopId = null): string
     {
-        return $moduleName . implode('-', Shop::getContextListShopID());
+        $shop = $shopId ? [$shopId] : Shop::getContextListShopID();
+
+        return $moduleName . implode('-', $shop);
     }
 
     private function getModuleAttributes(string $moduleName, bool $isValid): array

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -175,6 +175,12 @@ class ModuleRepository implements ModuleRepositoryInterface
         return $this->adminModuleDataProvider->setActionUrls($collection);
     }
 
+    /**
+     * @param string|null $moduleName The module to clear the cache for. If the name is null, the cache will be cleared for all modules.
+     * @param bool $allShops Default to false. If the value is true, the cache will be cleared for all the active shops. If not it will be cleared only for the shop in the context.
+     *
+     * @return bool
+     */
     public function clearCache(?string $moduleName = null, bool $allShops = false): bool
     {
         $this->installedModules = null;
@@ -201,6 +207,12 @@ class ModuleRepository implements ModuleRepositoryInterface
         return $this->cacheProvider->deleteAll();
     }
 
+    /**
+     * @param string $moduleName
+     * @param int|null $shopId If this parameter is given, the key returned will be the one for the shop. Otherwise, it will be the cache key for the shop in the context.
+     *
+     * @return string
+     */
     private function getCacheKey(string $moduleName, ?int $shopId = null): string
     {
         $shop = $shopId ? [$shopId] : Shop::getContextListShopID();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add parameter to allow clearing the modules list cache for all shops, in a multishop context
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #28446
| How to test?      | Please use [prestashopexamplemodule.zip](https://github.com/PrestaShop/PrestaShop/files/8806177/prestashopexamplemodule.zip) which implements "enable/disable all shops at once"



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


### BC Breaks

ModuleRepository::clearCache now have a second optional parameter `$allShop`, boolean type, default to false, to allow clearing the cache for all the shops of the BO