### PR TITLE
Use toolbar buttons array index as class when missing

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4815,10 +4815,10 @@ class AdminControllerCore extends Controller
         $controllerButtons = $this->page_header_toolbar_btn;
         if (!empty($controllerButtons)) {
             // Build ActionsBarButton based on array setting from the controller and add it to collection
-            foreach ($controllerButtons as $controllerButton) {
+            foreach ($controllerButtons as $controllerButtonIndex => $controllerButton) {
                 $toolbarButtonsCollection->add(
                     new ActionsBarButton(
-                        $controllerButton['class'] ?? '',
+                        $controllerButton['class'] ?? $controllerButtonIndex,
                         $controllerButton,
                         $controllerButton['desc'] ?? ''
                     )


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Sometimes the class attribute is not set when defining the toolbar buttons. In that cases, we use the buttons arra index as class name
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28448
| How to test?      | Without the PR, go to BO > Catalog > Discount, inspect the "Add cart rule" button => the ID will be `page-header-desc-cart_rule-`<br>Adn with the PR, you will have `page-header-desc-cart_rule-new_cart_rule`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
