### PR TITLE
New product price display and product summary

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/form-object-mapper.ts
+++ b/admin-dev/themes/new-theme/js/components/form/form-object-mapper.ts
@@ -26,6 +26,9 @@
 import BigNumber from 'bignumber.js';
 import EventEmitter from '@components/event-emitter';
 import {transform as numberCommaTransform} from '@js/app/utils/number-comma-transformer';
+import {isUndefined} from '@PSTypes/typeguard';
+
+import NameValuePair = JQuery.NameValuePair;
 
 const {$} = window;
 
@@ -253,7 +256,9 @@ export default class FormObjectMapper {
    * @param modelKey
    */
   getBigNumber(modelKey: string): BigNumber {
-    return new BigNumber(numberCommaTransform(this.getValue(modelKey)));
+    const numberValue = this.getValue(modelKey);
+
+    return new BigNumber(isUndefined(numberValue) ? NaN : numberCommaTransform(numberValue));
   }
 
   /**
@@ -451,15 +456,21 @@ export default class FormObjectMapper {
    * This method is called when this component initializes or when triggered by an external event.
    */
   private updateFullObject():void {
-    const serializedForm = this.$form.serializeJSON({
-      checkboxUncheckedValue: '0',
+    // Temporarily enable all inputs or they will not be serialized
+    const $disabledInputs: JQuery<HTMLElement> = this.$form.find(':input:disabled').removeAttr('disabled');
+    const serializedFormArray = this.$form.serializeArray();
+    // Restore initial disabled state
+    $disabledInputs.prop('disabled', true);
+
+    const serializedFormMap: Record<string, any> = {};
+    serializedFormArray.forEach((value: NameValuePair) => {
+      serializedFormMap[value.name] = value.value;
     });
 
     this.model = {};
     Object.keys(this.modelMapping).forEach((modelKey) => {
       const formMapping = this.modelMapping[modelKey];
-      const formKeys = $.serializeJSON.splitInputNameIntoKeysArray(formMapping);
-      const formValue = $.serializeJSON.deepGet(serializedForm, formKeys);
+      const formValue = serializedFormMap[formMapping];
 
       this.updateObjectByKey(modelKey, formValue);
     });

--- a/admin-dev/themes/new-theme/js/components/form/form-object-mapper.ts
+++ b/admin-dev/themes/new-theme/js/components/form/form-object-mapper.ts
@@ -236,16 +236,20 @@ export default class FormObjectMapper {
    * additionally any callback assigned
    * to this specific value is also called, the parameter is the same event.
    *
-   * @param {string} modelKey
+   * @param {string | string[]} modelKeys
    * @param {function} callback
    */
-  watch(modelKey: string, callback: (event: FormUpdateEvent) => void): void {
-    if (
-      !Object.prototype.hasOwnProperty.call(this.watchedProperties, modelKey)
-    ) {
-      this.watchedProperties[modelKey] = [];
-    }
-    this.watchedProperties[modelKey].push(callback);
+  watch(modelKeys: string | string[], callback: (event: FormUpdateEvent) => void): void {
+    const watchedKeys: string[] = Array.isArray(modelKeys) ? modelKeys : [modelKeys];
+
+    watchedKeys.forEach((modelKey: string) => {
+      if (
+        !Object.prototype.hasOwnProperty.call(this.watchedProperties, modelKey)
+      ) {
+        this.watchedProperties[modelKey] = [];
+      }
+      this.watchedProperties[modelKey].push(callback);
+    });
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
@@ -45,6 +45,7 @@ import CreateProductModal from '@pages/product/components/create-product-modal';
 import SpecificPricesManager from '@pages/product/edit/specific-prices-manager';
 import initDropzone from '@pages/product/components/dropzone';
 import initTabs from '@pages/product/components/nav-tabs';
+import PriceSummary from '@pages/product/edit/price-summary';
 
 const {$} = window;
 
@@ -70,7 +71,7 @@ $(() => {
   const {eventEmitter} = window.prestashop.instance;
 
   // Init product model along with input watching and syncing
-  const productFormModel = new ProductFormModel($productForm, eventEmitter);
+  const productFormModel: ProductFormModel = new ProductFormModel($productForm, eventEmitter);
 
   if (productType === ProductConst.PRODUCT_TYPE.COMBINATIONS) {
     // Combinations manager must be initialized BEFORE nav handler, or it won't trigger the pagination if the tab is
@@ -88,6 +89,7 @@ $(() => {
   new ProductModulesManager();
   new RelatedProductsManager(eventEmitter);
   new CreateProductModal();
+  new PriceSummary(productFormModel);
 
   const $productFormSubmitButton = $(ProductMap.productFormSubmitButton);
   new ProductPartialUpdater(

--- a/admin-dev/themes/new-theme/js/pages/product/edit/price-summary.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/price-summary.ts
@@ -1,0 +1,155 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+import ProductFormModel from '@pages/product/edit/product-form-model';
+import ProductMap from '@pages/product/product-map';
+import BigNumber from '@node_modules/bignumber.js';
+import {isUndefined} from '@PSTypes/typeguard';
+
+/**
+ * This component watches for product form changes in inputs related to price and display them in a summary block.
+ */
+export default class PriceSummary {
+  private readonly productFormModel: ProductFormModel;
+
+  private summaryContainer: HTMLElement | null;
+
+  private priceTaxExcluded?: HTMLElement;
+
+  private priceTaxIncluded?: HTMLElement;
+
+  private unitPrice?: HTMLElement;
+
+  private margin?: HTMLElement;
+
+  private marginRate?: HTMLElement;
+
+  private wholesalePrice?: HTMLElement;
+
+  private priceTaxExcludedLabel: string;
+
+  private priceTaxIncludedLabel: string;
+
+  private unitPriceLabel: string;
+
+  private marginLabel: string;
+
+  private marginRateLabel: string;
+
+  private wholesalePriceLabel: string;
+
+  constructor(productFormModel: ProductFormModel) {
+    this.productFormModel = productFormModel;
+
+    this.summaryContainer = document.querySelector<HTMLElement>(ProductMap.priceSummary.container);
+
+    this.priceTaxExcluded = this.getSummaryField(ProductMap.priceSummary.priceTaxExcluded);
+    this.priceTaxIncluded = this.getSummaryField(ProductMap.priceSummary.priceTaxIncluded);
+    this.unitPrice = this.getSummaryField(ProductMap.priceSummary.unitPrice);
+    this.margin = this.getSummaryField(ProductMap.priceSummary.margin);
+    this.marginRate = this.getSummaryField(ProductMap.priceSummary.marginRate);
+    this.wholesalePrice = this.getSummaryField(ProductMap.priceSummary.wholesalePrice);
+
+    this.priceTaxExcludedLabel = this.getSummaryLabel('priceTaxExcluded', '%price% tax excl.');
+    this.priceTaxIncludedLabel = this.getSummaryLabel('priceTaxIncluded', '%price% tax incl.');
+    this.unitPriceLabel = this.getSummaryLabel('unitPrice', '%price% %unity%');
+    this.marginLabel = this.getSummaryLabel('margin', '%price% margin');
+    this.marginRateLabel = this.getSummaryLabel('marginRate', '%margin_rate% margin rate');
+    this.wholesalePriceLabel = this.getSummaryLabel('wholesalePrice', '%price% cost price');
+
+    this.init();
+  }
+
+  private init(): void {
+    const watchedFields: string[] = [
+      'price.priceTaxExcluded',
+      'price.priceTaxIncluded',
+      'price.wholesalePrice',
+      'price.unitPriceTaxExcluded',
+      'price.unitPriceTaxIncluded',
+      'price.unity',
+    ];
+
+    this.productFormModel.watch(watchedFields, () => this.updateSummary());
+    this.updateSummary();
+  }
+
+  private updateSummary(): void {
+    this.updateField(this.priceTaxExcluded, this.getLabelWithPrice(this.priceTaxExcludedLabel, 'price.priceTaxExcluded'));
+    this.updateField(this.priceTaxIncluded, this.getLabelWithPrice(this.priceTaxIncludedLabel, 'price.priceTaxIncluded'));
+    this.updateField(this.wholesalePrice, this.getLabelWithPrice(this.wholesalePriceLabel, 'price.wholesalePrice'));
+
+    const wholesalePrice = this.productFormModel.getBigNumber('price.wholesalePrice');
+    const price:BigNumber = this.productFormModel.getBigNumber('price.priceTaxExcluded');
+    const margin:BigNumber = price.minus(wholesalePrice);
+    this.updateField(this.margin, this.marginLabel.replace('%price%', this.productFormModel.displayPrice(margin)));
+
+    const marginRate:BigNumber = margin.dividedBy(price).times(new BigNumber('100'));
+    this.updateField(this.marginRate, this.marginRateLabel.replace('%margin_rate%', marginRate.toFixed(2)));
+
+    // Unit price is composed of two fields and it is shown only when values are not empty
+    const unitPrice = this.productFormModel.getBigNumber('price.wholesalePrice');
+    const {unity} = this.productFormModel.getProduct().price;
+
+    if (unity !== '' && !unitPrice.isZero()) {
+      const unitPriceLabel = this.getLabelWithPrice(this.unitPriceLabel, 'price.unitPriceTaxExcluded');
+      this.updateField(this.unitPrice, unitPriceLabel.replace('%unity%', unity));
+      this.unitPrice?.classList.remove('d-none');
+    } else {
+      this.unitPrice?.classList.add('d-none');
+    }
+  }
+
+  private updateField(summaryField: HTMLElement | undefined, content: string): void {
+    if (isUndefined(summaryField)) {
+      return;
+    }
+
+    // eslint-disable-next-line no-param-reassign
+    summaryField.innerHTML = content;
+  }
+
+  private getLabelWithPrice(label: string, priceModelKey: string): string {
+    const price: BigNumber = this.productFormModel.getBigNumber(priceModelKey);
+
+    return label.replace('%price%', this.productFormModel.displayPrice(price));
+  }
+
+  private getSummaryField(selector: string): HTMLElement | undefined {
+    if (!this.summaryContainer) {
+      return undefined;
+    }
+
+    return this.summaryContainer.querySelector<HTMLElement>(selector) ?? undefined;
+  }
+
+  private getSummaryLabel(labelName: string, defaultLabel: string): string {
+    if (!this.summaryContainer) {
+      return defaultLabel;
+    }
+
+    return this.summaryContainer.dataset[labelName] ?? defaultLabel;
+  }
+};

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-form-mapping.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-form-mapping.ts
@@ -31,7 +31,7 @@ export default {
     'product[pricing][retail_price][modify_all_shops_price_tax_included]',
   ],
   'product.price.priceTaxIncluded': 'product[pricing][retail_price][price_tax_included]',
-  'product.price.taxRulesGroupId': 'product[pricing][tax_rules_group_id]',
+  'product.price.taxRulesGroupId': 'product[pricing][retail_price][tax_rules_group_id]',
   'product.price.wholesalePrice': 'product[pricing][wholesale_price]',
   'product.price.unitPriceTaxExcluded': 'product[pricing][unit_price][price_tax_excluded]',
   'product.price.unitPriceTaxIncluded': 'product[pricing][unit_price][price_tax_included]',

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-form-mapping.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-form-mapping.ts
@@ -35,6 +35,7 @@ export default {
   'product.price.wholesalePrice': 'product[pricing][wholesale_price]',
   'product.price.unitPriceTaxExcluded': 'product[pricing][unit_price][price_tax_excluded]',
   'product.price.unitPriceTaxIncluded': 'product[pricing][unit_price][price_tax_included]',
+  'product.price.unity': 'product[pricing][unit_price][unity]',
   'product.price.overrideAllUnitPriceTaxExcluded': [
     'product[pricing][unit_price][modify_all_shops_price_tax_excluded]',
     'product[pricing][unit_price][modify_all_shops_price_tax_included]',

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-form-model.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-form-model.ts
@@ -80,13 +80,16 @@ export default class ProductFormModel {
   }
 
   /**
-   * @param {string} productModelKey
+   * @param {string | string[]} productModelKeys
    * @param {function} callback
    *
    * @private
    */
-  watch(productModelKey: string, callback: (event: FormUpdateEvent) => void): void {
-    this.mapper.watch(`product.${productModelKey}`, callback);
+  watch(productModelKeys: string | string[], callback: (event: FormUpdateEvent) => void): void {
+    const watchedKeys: string[] = Array.isArray(productModelKeys) ? productModelKeys : [productModelKeys];
+    const modelKeys: string[] = watchedKeys.map((productModelKey: string) => `product.${productModelKey}`);
+
+    this.mapper.watch(modelKeys, callback);
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -272,6 +272,15 @@ export default {
   relatedProducts: {
     searchInput: '#product_description_related_products',
   },
+  priceSummary: {
+    container: '.price-summary-widget',
+    priceTaxExcluded: '.price-tax-excluded-value',
+    priceTaxIncluded: '.price-tax-included-value',
+    unitPrice: '.unit-price-value',
+    margin: '.margin-value',
+    marginRate: '.margin-rate-value',
+    wholesalePrice: '.wholesale-price-value',
+  },
   specificPrice: {
     container: '#specific-prices-container',
     modalTemplate: '#specific-price-modal-template',

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1319,6 +1319,54 @@ $product-page-padding-bottom: 80px !default;
       width: auto;
     }
   }
+
+  .retail-price-widget {
+    display: flex;
+    flex-direction: row;
+
+    .form-group {
+      margin-bottom: 0;
+    }
+
+    .retail-price-tax-rules-group-id {
+      margin-left: 3rem;
+
+      .select2-container {
+        position: relative;
+
+        .select2-selection {
+          height: auto;
+          padding: 0.5rem 2.2rem 0.5rem 1rem;
+
+          .select2-selection__rendered {
+            line-height: 1.5;
+          }
+        }
+
+        &::before {
+          position: absolute;
+          left: -2rem;
+          font-size: 1.5rem;
+          content: "+";
+        }
+      }
+    }
+
+    .retail-price-tax-included {
+      margin-left: 3rem;
+
+      .input-group {
+        position: relative;
+
+        &::before {
+          position: absolute;
+          left: -2rem;
+          font-size: 1.5rem;
+          content: "=";
+        }
+      }
+    }
+  }
 }
 
 // Some of the following styles target product page v2 components, but since the are new and only used in the new

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1367,6 +1367,29 @@ $product-page-padding-bottom: 80px !default;
       }
     }
   }
+
+  .price-summary-widget {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+
+    .price-summary-block {
+      padding: 1rem 2rem;
+      @include border-radius(0.5rem);
+      font-size: 1rem;
+      font-weight: 700;
+      color: #363a41;
+      background-color: #eaebec;
+
+      .price-summary-value {
+        margin-bottom: 0.8rem;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+    }
+  }
 }
 
 // Some of the following styles target product page v2 components, but since the are new and only used in the new

--- a/src/Adapter/Session/Repository/CustomerSessionRepository.php
+++ b/src/Adapter/Session/Repository/CustomerSessionRepository.php
@@ -141,7 +141,7 @@ class CustomerSessionRepository extends AbstractObjectModelRepository
 
             $qb = $this->connection->createQueryBuilder();
             $qb->delete($this->dbPrefix . 'customer_session')
-                ->where('date_upd < :dateUpdated')
+                ->where('date_upd <= :dateUpdated')
                 ->setParameter('dateUpdated', $date->format('Y-m-d H:i:s'));
 
             $qb->execute();

--- a/src/Adapter/Session/Repository/EmployeeSessionRepository.php
+++ b/src/Adapter/Session/Repository/EmployeeSessionRepository.php
@@ -141,8 +141,8 @@ class EmployeeSessionRepository extends AbstractObjectModelRepository
 
             $qb = $this->connection->createQueryBuilder();
             $qb->delete($this->dbPrefix . 'employee_session')
-                ->where('date_upd < :dateUpdated')
-                ->setParameter('dateUpdated', $date->format('Y-m-d'));
+                ->where('date_upd <= :dateUpdated')
+                ->setParameter('dateUpdated', $date->format('Y-m-d H:i:s'));
 
             $qb->execute();
         } catch (CoreException $e) {

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/PricesCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/PricesCommandsBuilder.php
@@ -67,7 +67,7 @@ class PricesCommandsBuilder implements MultiShopProductCommandsBuilderInterface
         $config
             ->addMultiShopField('[retail_price][price_tax_excluded]', 'setPrice', DataField::TYPE_STRING)
             ->addMultiShopField('[retail_price][ecotax]', 'setEcotax', DataField::TYPE_STRING)
-            ->addMultiShopField('[tax_rules_group_id]', 'setTaxRulesGroupId', DataField::TYPE_INT)
+            ->addMultiShopField('[retail_price][tax_rules_group_id]', 'setTaxRulesGroupId', DataField::TYPE_INT)
             ->addMultiShopField('[on_sale]', 'setOnSale', DataField::TYPE_BOOL)
             ->addMultiShopField('[wholesale_price]', 'setWholesalePrice', DataField::TYPE_STRING)
             ->addMultiShopField('[unit_price][price_tax_excluded]', 'setUnitPrice', DataField::TYPE_STRING)

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -377,9 +377,9 @@ class ProductFormDataProvider implements FormDataProviderInterface
             'retail_price' => [
                 'price_tax_excluded' => (float) (string) $productForEditing->getPricesInformation()->getPrice(),
                 'price_tax_included' => (float) (string) $productForEditing->getPricesInformation()->getPriceTaxIncluded(),
+                'tax_rules_group_id' => $productForEditing->getPricesInformation()->getTaxRulesGroupId(),
                 'ecotax' => (float) (string) $productForEditing->getPricesInformation()->getEcotax(),
             ],
-            'tax_rules_group_id' => $productForEditing->getPricesInformation()->getTaxRulesGroupId(),
             'on_sale' => $productForEditing->getPricesInformation()->isOnSale(),
             'wholesale_price' => (float) (string) $productForEditing->getPricesInformation()->getWholesalePrice(),
             'unit_price' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PriceSummaryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PriceSummaryType.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
+
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PriceSummaryType extends TranslatorAwareType
+{
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'label' => $this->trans('Summary', 'Admin.Global'),
+            'label_tag_name' => 'h3',
+            'attr' => [
+                'class' => 'price-summary-widget form-group',
+                'data-price-tax-excluded' => $this->trans('%price% tax excl.', 'Admin.Catalog.Feature'),
+                'data-price-tax-included' => $this->trans('%price% tax incl.', 'Admin.Catalog.Feature'),
+                'data-unit-price' => $this->trans('%price% %unity%', 'Admin.Catalog.Feature'),
+                'data-margin' => $this->trans('%price% margin', 'Admin.Catalog.Feature'),
+                'data-margin-rate' => $this->trans('%margin_rate%% margin rate', 'Admin.Catalog.Feature'),
+                'data-wholesale-price' => $this->trans('%price% cost price', 'Admin.Catalog.Feature'),
+            ],
+        ]);
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -31,11 +31,9 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product\Pricing;
 use Currency;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\PositiveOrZero;
@@ -47,54 +45,17 @@ use Symfony\Component\Validator\Constraints\Type;
 class PricingType extends TranslatorAwareType
 {
     /**
-     * @var array
-     */
-    private $taxRuleGroupChoices;
-
-    /**
-     * @var array
-     */
-    private $taxRuleGroupChoicesAttributes;
-
-    /**
      * @var Currency
      */
     private $defaultCurrency;
 
-    /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
-     * @var bool
-     */
-    private $taxEnabled;
-
-    /**
-     * @param TranslatorInterface $translator
-     * @param array $locales
-     * @param array $taxRuleGroupChoices
-     * @param array $taxRuleGroupChoicesAttributes
-     * @param Currency $defaultCurrency
-     * @param RouterInterface $router
-     * @param bool $taxEnabled
-     */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        array $taxRuleGroupChoices,
-        array $taxRuleGroupChoicesAttributes,
-        Currency $defaultCurrency,
-        RouterInterface $router,
-        bool $taxEnabled
+        Currency $defaultCurrency
     ) {
         parent::__construct($translator, $locales);
-        $this->taxRuleGroupChoices = $taxRuleGroupChoices;
-        $this->taxRuleGroupChoicesAttributes = $taxRuleGroupChoicesAttributes;
         $this->defaultCurrency = $defaultCurrency;
-        $this->router = $router;
-        $this->taxEnabled = $taxEnabled;
     }
 
     /**
@@ -105,35 +66,6 @@ class PricingType extends TranslatorAwareType
     {
         $builder
             ->add('retail_price', RetailPriceType::class)
-            ->add('tax_rules_group_id', ChoiceType::class, [
-                'choices' => $this->taxRuleGroupChoices,
-                'required' => false,
-                // placeholder false is important to avoid empty option in select input despite required being false
-                'placeholder' => false,
-                'choice_attr' => $this->taxRuleGroupChoicesAttributes,
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                    'data-tax-enabled' => $this->taxEnabled,
-                ],
-                'label' => $this->trans('Tax rule', 'Admin.Catalog.Feature'),
-                'help' => !$this->taxEnabled ? $this->trans('Tax feature is disabled, it will not affect price tax included.', 'Admin.Catalog.Feature') : '',
-                'external_link' => [
-                    'text' => $this->trans('[1]Manage tax rules[/1]', 'Admin.Catalog.Feature'),
-                    'href' => $this->router->generate('admin_taxes_index'),
-                    'align' => 'right',
-                ],
-                'modify_all_shops' => true,
-            ])
-            ->add('unit_price', UnitPriceType::class)
-            ->add('on_sale', CheckboxType::class, [
-                'required' => false,
-                'label' => $this->trans(
-                    'Display the "On sale!" flag on the product page, and on product listings.',
-                    'Admin.Catalog.Feature'
-                ),
-                'modify_all_shops' => true,
-            ])
             ->add('wholesale_price', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
@@ -147,6 +79,15 @@ class PricingType extends TranslatorAwareType
                     new Type(['type' => 'float']),
                     new PositiveOrZero(),
                 ],
+            ])
+            ->add('unit_price', UnitPriceType::class)
+            ->add('on_sale', CheckboxType::class, [
+                'required' => false,
+                'label' => $this->trans(
+                    'Display the "On sale!" flag on the product page, and on product listings.',
+                    'Admin.Catalog.Feature'
+                ),
+                'modify_all_shops' => true,
             ])
             ->add('specific_prices', SpecificPricesType::class, [
                 'label' => $this->trans('Specific prices', 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -81,6 +81,7 @@ class PricingType extends TranslatorAwareType
                 ],
             ])
             ->add('unit_price', UnitPriceType::class)
+            ->add('summary', PriceSummaryType::class)
             ->add('on_sale', CheckboxType::class, [
                 'required' => false,
                 'label' => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/PricingType.php
@@ -68,9 +68,9 @@ class PricingType extends TranslatorAwareType
             ->add('retail_price', RetailPriceType::class)
             ->add('wholesale_price', MoneyType::class, [
                 'required' => false,
-                'label' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
+                'label' => $this->trans('Cost price', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
-                'label_help_box' => $this->trans('The cost price is the price you paid for the product. Do not include the tax. It should be lower than the retail price: the difference between the two will be your margin.', 'Admin.Catalog.Help'),
+                'label_subtitle' => $this->trans('Cost price (tax excl.)', 'Admin.Catalog.Feature'),
                 'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
                 'currency' => $this->defaultCurrency->iso_code,
                 'modify_all_shops' => true,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/RetailPriceType.php
@@ -114,6 +114,9 @@ class RetailPriceType extends TranslatorAwareType
                     'data-display-price-precision' => self::PRESTASHOP_DECIMALS,
                     'data-price-specification' => json_encode($this->contextLocale->getPriceSpecification($this->defaultCurrency->iso_code)->toArray()),
                 ],
+                'row_attr' => [
+                    'class' => 'retail-price-tax-excluded',
+                ],
                 'currency' => $this->defaultCurrency->iso_code,
                 'constraints' => [
                     new NotBlank(),
@@ -134,6 +137,9 @@ class RetailPriceType extends TranslatorAwareType
                     'data-minimumResultsForSearch' => '7',
                     'data-tax-enabled' => $this->taxEnabled,
                 ],
+                'row_attr' => [
+                    'class' => 'retail-price-tax-rules-group-id',
+                ],
                 'label' => $this->trans('Tax rule', 'Admin.Catalog.Feature'),
                 'help' => !$this->taxEnabled ? $this->trans('Tax feature is disabled, it will not affect price tax included.', 'Admin.Catalog.Feature') : '',
                 'external_link' => [
@@ -146,7 +152,12 @@ class RetailPriceType extends TranslatorAwareType
             ->add('price_tax_included', MoneyType::class, [
                 'required' => false,
                 'label' => $this->trans('Retail price (tax incl.)', 'Admin.Catalog.Feature'),
-                'attr' => ['data-display-price-precision' => self::PRESTASHOP_DECIMALS],
+                'attr' => [
+                    'data-display-price-precision' => self::PRESTASHOP_DECIMALS,
+                ],
+                'row_attr' => [
+                    'class' => 'retail-price-tax-included',
+                ],
                 'currency' => $this->defaultCurrency->iso_code,
                 'constraints' => [
                     new NotBlank(),
@@ -181,9 +192,10 @@ class RetailPriceType extends TranslatorAwareType
         $resolver->setDefaults([
             'label' => $this->trans('Retail price', 'Admin.Catalog.Feature'),
             'label_tag_name' => 'h3',
-            'label_help_box' => $this->trans('This is the net sales price for your customers. The retail price (tax incl.) will automatically be calculated using the selected tax rate.', 'Admin.Catalog.Help'),
             'required' => false,
-            'columns_number' => 4,
+            'attr' => [
+                'class' => 'retail-price-widget',
+            ],
         ]);
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1514,11 +1514,7 @@ services:
     parent: 'form.type.translatable.aware'
     public: true
     arguments:
-      - '@=service("prestashop.core.form.choice_provider.tax_rule_group_choice_provider").getChoices()'
-      - '@=service("prestashop.core.form.choice_provider.tax_rule_group_choice_provider").getChoicesAttributes()'
       - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrency()'
-      - '@router'
-      - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_TAX')"
     tags:
       - { name: form.type }
 
@@ -1529,6 +1525,10 @@ services:
     arguments:
       - '@prestashop.core.localization.locale.context_locale'
       - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrency()'
+      - '@=service("prestashop.core.form.choice_provider.tax_rule_group_choice_provider").getChoices()'
+      - '@=service("prestashop.core.form.choice_provider.tax_rule_group_choice_provider").getChoicesAttributes()'
+      - '@router'
+      - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_TAX')"
       - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_USE_ECOTAX')"
     tags:
       - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1542,6 +1542,13 @@ services:
     tags:
       - { name: form.type }
 
+  form.type.sell.product.pricing.price_summary_type:
+    class: 'PrestaShopBundle\Form\Admin\Sell\Product\Pricing\PriceSummaryType'
+    parent: 'form.type.translatable.aware'
+    public: true
+    tags:
+      - { name: form.type }
+
   form.type.sell.product.pricing.specific_prices_type:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPricesType'
     parent: 'form.type.translatable.aware'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/header-details.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/header-details.html.twig
@@ -48,8 +48,8 @@
         {% if taxEnabled %}
           {# First find the selected tax rate #}
           {% set taxRate = 0 %}
-          {% for group_label, choice in productForm.pricing.tax_rules_group_id.vars.choices %}
-            {% if choice.data == productData.pricing.tax_rules_group_id %}
+          {% for group_label, choice in productForm.pricing.retail_price.tax_rules_group_id.vars.choices %}
+            {% if choice.data == productData.pricing.retail_price.tax_rules_group_id %}
               {% set taxRate = choice.attr['data-tax-rate'] %}
             {% endif %}
           {% endfor %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
@@ -69,3 +69,18 @@
     {{ form_widget(form) }}
   </div>
 {% endblock %}
+
+{% block price_summary_widget %}
+  <div {{ block('widget_attributes') }}>
+    <div class="price-summary-block">
+      <div class="price-summary-value price-tax-excluded-value"></div>
+      <div class="price-summary-value price-tax-included-value"></div>
+      <div class="price-summary-value unit-price-value"></div>
+    </div>
+    <div class="price-summary-block">
+      <div class="price-summary-value margin-value"></div>
+      <div class="price-summary-value margin-rate-value"></div>
+      <div class="price-summary-value wholesale-price-value"></div>
+    </div>
+  </div>
+{% endblock %}

--- a/tests/Integration/Behaviour/Features/Scenario/Security/security_configuration.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Security/security_configuration.feature
@@ -1,5 +1,5 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s security
-@reset-database-before-feature
+@restore-all-tables-before-feature
 Feature: Security configuration form
   PrestaShop allows BO users to manage Security configuration
   As a BO user
@@ -30,10 +30,12 @@ Feature: Security configuration form
 
   Scenario: Clear outdated employee sessions
     Given a session for the employee is created 1 hour ago
-    And a session for the employee is created 20 hours ago
-    And a session for the employee is created 2 hours ago
+    And a session for the employee is created 2 hour ago
+    # these ones will be cleared
+    And a session for the employee is created 5 hours ago
+    And a session for the employee is created 10 hours ago
     # Means one hour
-    And shop configuration for "PS_COOKIE_LIFETIME_BO" is set to 1
-    Then there is 3 employee sessions left
+    And shop configuration for "PS_COOKIE_LIFETIME_BO" is set to 3
+    Then there is 4 employee sessions left
     When I clear outdated employee sessions
     Then there is 2 employee session left

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/PricesCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/PricesCommandsBuilderTest.php
@@ -114,7 +114,9 @@ class PricesCommandsBuilderTest extends AbstractProductCommandBuilderTest
             [
                 'pricing' => [
                     'not_handled' => 0,
-                    'tax_rules_group_id' => '42',
+                    'retail_price' => [
+                        'tax_rules_group_id' => '42',
+                    ],
                 ],
             ],
             [$command],
@@ -245,8 +247,8 @@ class PricesCommandsBuilderTest extends AbstractProductCommandBuilderTest
                     'retail_price' => [
                         'price_tax_excluded' => 45.56,
                         'ecotax' => '45.56',
+                        'tax_rules_group_id' => '42',
                     ],
-                    'tax_rules_group_id' => '42',
                     'on_sale' => true,
                     'wholesale_price' => '45.56',
                     'unit_price' => [
@@ -275,8 +277,8 @@ class PricesCommandsBuilderTest extends AbstractProductCommandBuilderTest
                         'price_tax_excluded' => 45.56,
                         self::MODIFY_ALL_SHOPS_PREFIX . 'price_tax_excluded' => false,
                         'ecotax' => '45.56',
+                        'tax_rules_group_id' => '42',
                     ],
-                    'tax_rules_group_id' => '42',
                     'on_sale' => true,
                     'wholesale_price' => '45.56',
                     'unit_price' => [
@@ -308,8 +310,8 @@ class PricesCommandsBuilderTest extends AbstractProductCommandBuilderTest
                         'price_tax_excluded' => 45.56,
                         self::MODIFY_ALL_SHOPS_PREFIX . 'price_tax_excluded' => true,
                         'ecotax' => '45.56',
+                        'tax_rules_group_id' => '42',
                     ],
-                    'tax_rules_group_id' => '42',
                     'on_sale' => true,
                     'wholesale_price' => '45.56',
                     'unit_price' => [

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -348,8 +348,8 @@ class ProductFormDataProviderTest extends TestCase
         ];
         $expectedOutputData['pricing']['retail_price']['price_tax_excluded'] = 42.00;
         $expectedOutputData['pricing']['retail_price']['price_tax_included'] = 50.40;
+        $expectedOutputData['pricing']['retail_price']['tax_rules_group_id'] = 49;
         $expectedOutputData['pricing']['retail_price']['ecotax'] = 69.51;
-        $expectedOutputData['pricing']['tax_rules_group_id'] = 49;
         $expectedOutputData['pricing']['on_sale'] = true;
         $expectedOutputData['pricing']['wholesale_price'] = 66.56;
         $expectedOutputData['pricing']['unit_price']['price_tax_excluded'] = 6.656;
@@ -1381,9 +1381,9 @@ class ProductFormDataProviderTest extends TestCase
                 'retail_price' => [
                     'price_tax_excluded' => 19.86,
                     'price_tax_included' => 23.832,
+                    'tax_rules_group_id' => 1,
                     'ecotax' => 19.86,
                 ],
-                'tax_rules_group_id' => 1,
                 'on_sale' => false,
                 'wholesale_price' => 19.86,
                 'unit_price' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Integrate the new display of form price in the form of an addition between `priceTaxExcluded + taxRate = priceTaxIncluded` The product form now includes a product summary which updates automatically when inputs are modifed
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | This is only a partial feature, the ecotax is still missing so no QA for this one Only green CI The functional tests will be performed on the next PR that integrates ecotax
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

![Capture d’écran 2022-05-10 à 04 26 23](https://user-images.githubusercontent.com/13801017/167530152-9a1e8a26-ff84-48ce-8cf7-07a6b37e08e6.png)

