### PR TITLE
HelperList: remove notice if specificConfirmDelete is set to false #27718

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -597,7 +597,7 @@ class HelperListCore extends Helper
             $this->identifier => $id,
             'href' => $href,
             'action' => self::$cache_lang['Delete'],
-            'confirm' => '',
+            'confirm' => Tools::safeOutput(self::$cache_lang['DeleteItem'] . $name),
         ];
 
         if ($this->specificConfirmDelete !== false) {

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -600,8 +600,8 @@ class HelperListCore extends Helper
             'confirm' => Tools::safeOutput(self::$cache_lang['DeleteItem'] . $name),
         ];
 
-        if (!empty($this->specificConfirmDelete)) {
-            $data['confirm'] = '\r' . $this->specificConfirmDelete;
+        if ($this->specificConfirmDelete !== false) {
+            $data['confirm'] = null !== $this->specificConfirmDelete ? '\r' . $this->specificConfirmDelete : Tools::safeOutput(self::$cache_lang['DeleteItem'] . $name);
         }
 
         $tpl->assign(array_merge($this->tpl_delete_link_vars, $data));

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -597,6 +597,7 @@ class HelperListCore extends Helper
             $this->identifier => $id,
             'href' => $href,
             'action' => self::$cache_lang['Delete'],
+            'confirm' => '',
         ];
 
         if ($this->specificConfirmDelete !== false) {

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -600,8 +600,8 @@ class HelperListCore extends Helper
             'confirm' => Tools::safeOutput(self::$cache_lang['DeleteItem'] . $name),
         ];
 
-        if ($this->specificConfirmDelete !== false) {
-            $data['confirm'] = null !== $this->specificConfirmDelete ? '\r' . $this->specificConfirmDelete : Tools::safeOutput(self::$cache_lang['DeleteItem'] . $name);
+        if (!empty($this->specificConfirmDelete)) {
+            $data['confirm'] = '\r' . $this->specificConfirmDelete;
         }
 
         $tpl->assign(array_merge($this->tpl_delete_link_vars, $data));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | HelperList: notice if specificConfirmDelete is set to false
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/27717
| How to test?      |  See issue 27717 and below scenario
| Possible impacts? | none
| Sponsor company   | Creabilis.com

### 2nd scenario to test (provided by @kpodemski - https://github.com/PrestaShop/PrestaShop/pull/27718#pullrequestreview-887699805)

Steps to reproduce:

1. Open AdminCartController
2. set specificConfirmDelete to false.
3. Verify carts can be deleted


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27718)
<!-- Reviewable:end -->
