### PR TITLE
Combination bulk action. Handle new bulk choices: select all | select all in page

### DIFF
--- a/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
+++ b/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
@@ -88,6 +88,10 @@ export default class DynamicPaginator {
 
   private pagesCount: number;
 
+  private total: number;
+
+  private totalInPage: number;
+
   /**
    * @param {String} containerSelector
    * @param {Object} paginationService
@@ -108,6 +112,8 @@ export default class DynamicPaginator {
     this.selectorsMap = {};
     this.setSelectorsMap(selectorsMap);
     this.pagesCount = 0;
+    this.total = 0;
+    this.totalInPage = 0;
     this.init();
     this.currentPage = startingPage;
     if (startingPage > 0) {
@@ -132,6 +138,8 @@ export default class DynamicPaginator {
     this.countPages(<number>data.total);
     this.refreshButtonsData(page);
     this.refreshInfoLabel(page, <number>data.total);
+    this.total = data.total;
+    this.setTotalInPage(page, limit, data.total);
 
     this.toggleTargetAvailability(this.selectorsMap.firstPageItem, page > 1);
     this.toggleTargetAvailability(this.selectorsMap.previousPageItem, page > 1);
@@ -156,6 +164,14 @@ export default class DynamicPaginator {
 
   getPagesCount(): number {
     return this.pagesCount;
+  }
+
+  getTotal(): number {
+    return this.total;
+  }
+
+  getTotalInPage(): number {
+    return this.totalInPage;
   }
 
   /**
@@ -226,12 +242,10 @@ export default class DynamicPaginator {
       this.selectorsMap.paginationInfoLabel,
     );
     const limit = this.getLimit();
-    const from = page === 1 ? 1 : Math.round((page - 1) * limit);
-    const to = page === this.pagesCount ? total : Math.round(page * limit);
     const modifiedInfoText = infoLabel
       .data('pagination-info')
-      .replace(/%from%/g, from)
-      .replace(/%to%/g, to)
+      .replace(/%from%/g, this.calculateFrom(page, limit))
+      .replace(/%to%/g, this.calculateTo(page, limit, total))
       .replace(/%total%/g, total)
       .replace(/%current_page%/g, page)
       .replace(/%page_count%/g, this.pagesCount);
@@ -324,5 +338,19 @@ export default class DynamicPaginator {
       //override with custom selectors if any provided
       ...selectorsMap,
     };
+  }
+
+  private calculateFrom(page: number, limit: number): number {
+    // increment by 1 because offset, starts from 0, but lowest "from" can be 1
+    return page === 1 ? 1 : Math.round((page - 1) * limit + 1);
+  }
+
+  private calculateTo(page: number, limit:number, total: number) {
+    return page === this.pagesCount ? total : Math.round(page * limit);
+  }
+
+  private setTotalInPage(page: number, limit: number, total: number): void {
+    // increment by 1 to include the first "from" result to total count
+    this.totalInPage = this.calculateTo(page, limit, total) - this.calculateFrom(page, limit) + 1;
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -46,8 +46,25 @@ export default class BulkChoicesSelector {
     this.init();
   }
 
+  //@todo: may become private
   public getSelectedCheckboxes(): NodeListOf<HTMLInputElement> {
     return this.tabContainer.querySelectorAll<HTMLInputElement>(`${CombinationMap.tableRow.isSelectedCombination}:checked`);
+  }
+
+  //@todo: could as well return count?
+  public getSelectedIds(): number[] {
+    const allSelected = this.tabContainer.querySelector<HTMLInputElement>(`${CombinationMap.bulkSelectAll}:checked`);
+
+    if (allSelected) {
+      // call api to get selected ids by filters
+      return [1, 2, 3];
+    }
+    const combinationIds: number[] = [];
+    this.getSelectedCheckboxes().forEach((checkbox: HTMLInputElement) => {
+      combinationIds.push(Number(checkbox.value));
+    });
+
+    return combinationIds;
   }
 
   private init() {
@@ -66,7 +83,7 @@ export default class BulkChoicesSelector {
         return;
       }
 
-      const isBulkSelectAll = checkbox.matches(CombinationMap.bulkSelectAll);
+      const isBulkSelectAll = checkbox.matches(`${CombinationMap.bulkSelectAllInPage},${CombinationMap.bulkSelectAll}`);
 
       // don't proceed if its not one of the expected checkboxes
       if (!isBulkSelectAll && !checkbox.matches(CombinationMap.tableRow.isSelectedCombination)) {
@@ -82,7 +99,7 @@ export default class BulkChoicesSelector {
   }
 
   private updateBulkButtonsState(): void {
-    const selectAllCheckbox = document.querySelector(CombinationMap.bulkSelectAll);
+    const selectAllCheckbox = document.querySelector(CombinationMap.bulkSelectAllInPage);
     const dropdownBtn = this.tabContainer.querySelector<HTMLInputElement>(CombinationMap.bulkActionsDropdownBtn);
     const selectedCombinationsCount = this.getSelectedCheckboxes().length;
     const enable = isChecked(selectAllCheckbox) || selectedCombinationsCount !== 0;

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -69,7 +69,7 @@ export default class BulkChoicesSelector {
     const allSelected = this.tabContainer.querySelector<HTMLInputElement>(`${CombinationMap.bulkSelectAll}:checked`);
 
     if (allSelected) {
-      const response: JQuery.jqXHR = await this.paginatedCombinationsService.getCombinationIds(false);
+      const response: JQuery.jqXHR = await this.paginatedCombinationsService.getCombinationIds();
 
       return response;
     }
@@ -227,12 +227,13 @@ export default class BulkChoicesSelector {
 
   private async refreshSelectableCombinationsCount(): Promise<void> {
     //@todo: endpoint could return count to make it more performant (especially when selecting across all pages)
-    await this.paginatedCombinationsService.getCombinationIds(false).then((combinationIds) => {
+    await this.paginatedCombinationsService.getCombinationIds().then((combinationIds) => {
       this.allCombinationsCount = combinationIds.length;
     });
 
-    await this.paginatedCombinationsService.getCombinationIds(true).then((combinationIds) => {
-      this.paginatedCombinationsCount = combinationIds.length;
-    });
+    const selectableCheckboxes = this.tabContainer
+      .querySelectorAll<HTMLInputElement>(`${CombinationMap.tableRow.isSelectedCombination}`);
+
+    this.paginatedCombinationsCount = selectableCheckboxes.length;
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -195,7 +195,7 @@ export default class BulkChoicesSelector {
   }
 
   private checkAllCombinations(checked: boolean): void {
-    const allDisplayCheckbox = this.tabContainer.querySelector<HTMLInputElement>(CombinationMap.bulkSelectAllDisplay);
+    const allDisplayCheckbox = this.tabContainer.querySelector<HTMLInputElement>(CombinationMap.bulkAllPreviewInput);
 
     if (allDisplayCheckbox instanceof HTMLInputElement) {
       allDisplayCheckbox.checked = checked;

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -87,6 +87,12 @@ export default class BulkChoicesSelector {
    * Delegated event listener on tabContainer, because every checkbox is re-rendered with dynamic pagination
    */
   private listenCheckboxesChange(): void {
+    this.eventEmitter.on(CombinationEvents.listRendered, () => {
+      const bulkSelectedAll = this.tabContainer
+        .querySelector<HTMLInputElement>(`${CombinationMap.bulkSelectAllCheckboxes}:checked`);
+      this.checkAll(!!bulkSelectedAll);
+    });
+
     this.tabContainer.addEventListener('change', (e) => {
       const checkbox = e.target;
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -135,27 +135,27 @@ export default class BulkChoicesSelector {
     });
   }
 
-  private updateBulkButtonsState(): void {
+  private async updateBulkButtonsState(): Promise<void> {
     const dropdownBtn = this.tabContainer.querySelector<HTMLInputElement>(CombinationMap.bulkActionsDropdownBtn);
-    this.getSelectedIds().then((combinationIds) => {
-      const selectedCombinationsCount = combinationIds.length;
-      const bulkActionButtons = this.tabContainer.querySelectorAll<HTMLButtonElement>(CombinationMap.bulkActionBtn);
+    const selectedCombinationIds = await this.getSelectedIds();
 
-      bulkActionButtons.forEach((button: HTMLButtonElement) => {
-        const label = button.dataset.btnLabel;
+    const selectedCombinationsCount = selectedCombinationIds.length;
+    const bulkActionButtons = this.tabContainer.querySelectorAll<HTMLButtonElement>(CombinationMap.bulkActionBtn);
 
-        if (!label) {
-          console.error('Attribute "data-btn-label" is not defined for combinations bulk action button');
-          return;
-        }
+    bulkActionButtons.forEach((button: HTMLButtonElement) => {
+      const label = button.dataset.btnLabel;
 
-        // eslint-disable-next-line no-param-reassign
-        button.innerHTML = label.replace(/%combinations_number%/, String(selectedCombinationsCount));
-        button?.toggleAttribute('disabled', !selectedCombinationsCount);
-      });
+      if (!label) {
+        console.error('Attribute "data-btn-label" is not defined for combinations bulk action button');
+        return;
+      }
 
-      dropdownBtn?.toggleAttribute('disabled', !selectedCombinationsCount);
+      // eslint-disable-next-line no-param-reassign
+      button.innerHTML = label.replace(/%combinations_number%/, String(selectedCombinationsCount));
+      button?.toggleAttribute('disabled', !selectedCombinationsCount);
     });
+
+    dropdownBtn?.toggleAttribute('disabled', !selectedCombinationsCount);
   }
 
   private checkAll(checked: boolean): void {

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -27,6 +27,7 @@ import ProductMap from '@pages/product/product-map';
 import ProductEvents from '@pages/product/product-event-map';
 import {EventEmitter} from 'events';
 import PaginatedCombinationsService from '@pages/product/services/paginated-combinations-service';
+import DynamicPaginator from '@components/pagination/dynamic-paginator';
 
 const CombinationMap = ProductMap.combinations;
 const CombinationEvents = ProductEvents.combinations;
@@ -46,16 +47,21 @@ export default class BulkChoicesSelector {
 
   private paginatedCombinationsCount: number;
 
+  paginator: DynamicPaginator;
+
   constructor(
     eventEmitter: EventEmitter,
     tabContainer: HTMLDivElement,
     paginatedCombinationsService: PaginatedCombinationsService,
+    paginator: DynamicPaginator,
   ) {
     this.eventEmitter = eventEmitter;
     this.tabContainer = tabContainer;
     this.paginatedCombinationsService = paginatedCombinationsService;
     this.allCombinationsCount = 0;
     this.paginatedCombinationsCount = 0;
+    this.paginator = paginator;
+
     this.init();
   }
 
@@ -223,14 +229,7 @@ export default class BulkChoicesSelector {
   }
 
   private async refreshSelectableCombinationsCount(): Promise<void> {
-    //@todo: endpoint could return count to make it more performant (especially when selecting across all pages)
-    await this.paginatedCombinationsService.getCombinationIds().then((combinationIds) => {
-      this.allCombinationsCount = combinationIds.length;
-    });
-
-    const selectableCheckboxes = this.tabContainer
-      .querySelectorAll<HTMLInputElement>(`${CombinationMap.tableRow.isSelectedCombination}`);
-
-    this.paginatedCombinationsCount = selectableCheckboxes.length;
+    this.allCombinationsCount = this.paginator.getTotal();
+    this.paginatedCombinationsCount = this.paginator.getTotalInPage();
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -177,17 +177,23 @@ export default class BulkChoicesSelector {
         return;
       }
 
-      const labelElement = input.parentNode?.querySelector<HTMLLabelElement>(`label[for=${input.id}]`);
+      const labelElement = this.tabContainer.querySelector<HTMLLabelElement>(`label[for=${input.id}]`);
 
       if (!labelElement) {
-        console.error(`All ${CombinationMap.commonBulkAllSelector} expected to have dedicated <label> elements`);
+        console.error(`Each ${CombinationMap.commonBulkAllSelector} is expected to have dedicated a <label> element`);
+        return;
+      }
+      const span = labelElement.querySelector<HTMLSpanElement>('span');
+
+      if (!span) {
+        console.error(`Each label for ${CombinationMap.commonBulkAllSelector} is expected to have a <span> element`);
         return;
       }
 
       const {label} = labelElement.dataset;
 
       if (!label) {
-        console.error(`All ${CombinationMap.commonBulkAllSelector} expected to have "data-label" attribute`);
+        console.error(`Each label for ${CombinationMap.commonBulkAllSelector} is expected to have "data-label" attribute`);
         return;
       }
 
@@ -203,14 +209,14 @@ export default class BulkChoicesSelector {
         const selectedCombinationsCount = combinationIds.length;
 
         if (selectedCombinationsCount) {
-          labelElement.classList.toggle('d-none', false);
+          span.classList.toggle('d-none', false);
           combinationsCount = selectedCombinationsCount;
         } else {
-          labelElement.classList.toggle('d-none', true);
+          span.classList.toggle('d-none', true);
         }
       }
 
-      labelElement.innerHTML = label.replace(/%combinations_number%/, String(combinationsCount));
+      span.innerHTML = label.replace(/%combinations_number%/, String(combinationsCount));
     }
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -83,7 +83,7 @@ export default class BulkChoicesSelector {
         return;
       }
 
-      const isBulkSelectAll = checkbox.matches(`${CombinationMap.bulkSelectAllInPage},${CombinationMap.bulkSelectAll}`);
+      const isBulkSelectAll = checkbox.matches(`${CombinationMap.bulkSelectAllCheckboxes}`);
 
       // don't proceed if its not one of the expected checkboxes
       if (!isBulkSelectAll && !checkbox.matches(CombinationMap.tableRow.isSelectedCombination)) {
@@ -91,6 +91,17 @@ export default class BulkChoicesSelector {
       }
 
       if (isBulkSelectAll) {
+        const bulkSelectAllCheckboxes = this.tabContainer.querySelectorAll(CombinationMap.bulkSelectAllCheckboxes);
+        //@todo: this loop allows only checking one checkbox at a time, but it seems to complicated
+        //       need to check refactoring options, html could probably handle this by its own
+        bulkSelectAllCheckboxes.forEach((input) => {
+          if (checkbox.id !== input.id) {
+            if (input instanceof HTMLInputElement) {
+              // eslint-disable-next-line no-param-reassign
+              input.checked = false;
+            }
+          }
+        });
         this.checkAll(checkbox.checked);
       }
 
@@ -123,6 +134,12 @@ export default class BulkChoicesSelector {
   }
 
   private checkAll(checked: boolean): void {
+    const allDisplayCheckbox = this.tabContainer.querySelector<HTMLInputElement>(CombinationMap.bulkSelectAllDisplay);
+
+    if (allDisplayCheckbox instanceof HTMLInputElement) {
+      allDisplayCheckbox.checked = checked;
+    }
+
     const allCheckboxes = this.tabContainer.querySelectorAll<HTMLInputElement>(CombinationMap.tableRow.isSelectedCombination);
 
     allCheckboxes.forEach((checkbox: HTMLInputElement) => {

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -169,18 +169,18 @@ export default class BulkChoicesSelector {
     const selectedCombinationsCount = combinationIds.length;
 
     inputs.forEach((input: HTMLInputElement) => {
-      const labelElement = this.tabContainer.querySelector<HTMLLabelElement>(`label[for=${input.id}]`);
+      const label = this.tabContainer.querySelector<HTMLLabelElement>(`label[for=${input.id}]`);
       const span = this.tabContainer.querySelector<HTMLSpanElement>(`label[for=${input.id}] span`);
 
-      if (!labelElement || !span) {
+      if (!label || !span) {
         // eslint-disable-next-line max-len
         console.error(`Each ${CombinationMap.commonBulkAllSelector} is expected to have a dedicated <label> containing a <span>`);
         return;
       }
 
-      const {label} = labelElement.dataset;
+      let labelText = label.dataset.label;
 
-      if (!label) {
+      if (!labelText) {
         console.error(`Each label for ${CombinationMap.commonBulkAllSelector} is expected to have "data-label" attribute`);
         return;
       }
@@ -194,11 +194,12 @@ export default class BulkChoicesSelector {
       } else if (selectedCombinationsCount) {
         span.classList.toggle('d-none', false);
         combinationsCount = selectedCombinationsCount;
+        labelText = labelText.replace(/%total_combinations%/, String(this.paginator.getTotal()));
       } else {
         span.classList.toggle('d-none', true);
       }
 
-      span.innerHTML = label.replace(/%combinations_number%/, String(combinationsCount));
+      span.innerHTML = labelText.replace(/%combinations_number%/, String(combinationsCount));
     });
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-choices-selector.ts
@@ -59,12 +59,6 @@ export default class BulkChoicesSelector {
     this.init();
   }
 
-  //@todo: may become private or unused
-  public getSelectedCheckboxes(): NodeListOf<HTMLInputElement> {
-    return this.tabContainer.querySelectorAll<HTMLInputElement>(`${CombinationMap.tableRow.isSelectedCombination}:checked`);
-  }
-
-  //@todo: could as well return count?
   public async getSelectedIds(): Promise<number[]> {
     const allSelected = this.tabContainer.querySelector<HTMLInputElement>(`${CombinationMap.bulkSelectAll}:checked`);
 
@@ -75,7 +69,10 @@ export default class BulkChoicesSelector {
     }
 
     const combinationIds: number[] = [];
-    this.getSelectedCheckboxes().forEach((checkbox: HTMLInputElement) => {
+    const selectedCheckboxes = this.tabContainer
+      .querySelectorAll<HTMLInputElement>(`${CombinationMap.tableRow.isSelectedCombination}:checked`);
+
+    selectedCheckboxes.forEach((checkbox: HTMLInputElement) => {
       combinationIds.push(Number(checkbox.value));
     });
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-delete-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-delete-handler.ts
@@ -86,7 +86,7 @@ export default class BulkDeleteHandler {
             },
             async () => {
               await this.bulkDelete(selectedCombinationIds);
-              //@todo: hardcoded success. Pass translated message to modal data attribute?
+              //@todo: hardcoded success for now, but it should still be removed when new modal is implemented in #26004.
               $.growl({message: 'Success'});
               this.eventEmitter.emit(CombinationEvents.refreshCombinationList);
             },

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-delete-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-delete-handler.ts
@@ -59,7 +59,7 @@ export default class BulkDeleteHandler {
     this.init();
   }
 
-  private init(): void {
+  private async init(): Promise<void> {
     const bulkDeleteBtn = document.querySelector<HTMLButtonElement>(CombinationMap.bulkDeleteBtn);
 
     if (!(bulkDeleteBtn instanceof HTMLButtonElement)) {
@@ -69,33 +69,34 @@ export default class BulkDeleteHandler {
     }
 
     bulkDeleteBtn.addEventListener('click', () => {
-      try {
-        const selectedCombinationIds = this.bulkChoicesSelector.getSelectedIds();
-        const selectedCombinationsCount = selectedCombinationIds.length;
-        const confirmLabel = bulkDeleteBtn.dataset.modalConfirmLabel
-          ?.replace(/%combinations_number%/, String(selectedCombinationsCount));
+      this.bulkChoicesSelector.getSelectedIds().then((selectedCombinationIds) => {
+        try {
+          const selectedCombinationsCount = selectedCombinationIds.length;
+          const confirmLabel = bulkDeleteBtn.dataset.modalConfirmLabel
+            ?.replace(/%combinations_number%/, String(selectedCombinationsCount));
 
-        const modal = new ConfirmModal(
-          {
-            id: 'modal-confirm-delete-combinations',
-            confirmTitle: bulkDeleteBtn.innerHTML,
-            confirmMessage: bulkDeleteBtn.dataset.modalMessage,
-            confirmButtonLabel: confirmLabel,
-            closeButtonLabel: bulkDeleteBtn.dataset.modalCancelLabel,
-            closable: true,
-          },
-          async () => {
-            await this.bulkDelete(selectedCombinationIds);
-            //@todo: hardcoded success. Pass translated message to modal data attribute?
-            $.growl({message: 'Success'});
-            this.eventEmitter.emit(CombinationEvents.refreshCombinationList);
-          },
-        );
-        modal.show();
-      } catch (error) {
-        const errorMessage = error.response?.JSON ?? error;
-        $.growl.error({message: errorMessage});
-      }
+          const modal = new ConfirmModal(
+            {
+              id: 'modal-confirm-delete-combinations',
+              confirmTitle: bulkDeleteBtn.innerHTML,
+              confirmMessage: bulkDeleteBtn.dataset.modalMessage,
+              confirmButtonLabel: confirmLabel,
+              closeButtonLabel: bulkDeleteBtn.dataset.modalCancelLabel,
+              closable: true,
+            },
+            async () => {
+              await this.bulkDelete(selectedCombinationIds);
+              //@todo: hardcoded success. Pass translated message to modal data attribute?
+              $.growl({message: 'Success'});
+              this.eventEmitter.emit(CombinationEvents.refreshCombinationList);
+            },
+          );
+          modal.show();
+        } catch (error) {
+          const errorMessage = error.response?.JSON ?? error;
+          $.growl.error({message: errorMessage});
+        }
+      });
     });
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-delete-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-delete-handler.ts
@@ -68,35 +68,35 @@ export default class BulkDeleteHandler {
       return;
     }
 
-    bulkDeleteBtn.addEventListener('click', () => {
-      this.bulkChoicesSelector.getSelectedIds().then((selectedCombinationIds) => {
-        try {
-          const selectedCombinationsCount = selectedCombinationIds.length;
-          const confirmLabel = bulkDeleteBtn.dataset.modalConfirmLabel
-            ?.replace(/%combinations_number%/, String(selectedCombinationsCount));
+    bulkDeleteBtn.addEventListener('click', async () => {
+      const selectedCombinationIds = await this.bulkChoicesSelector.getSelectedIds();
 
-          const modal = new ConfirmModal(
-            {
-              id: 'modal-confirm-delete-combinations',
-              confirmTitle: bulkDeleteBtn.innerHTML,
-              confirmMessage: bulkDeleteBtn.dataset.modalMessage,
-              confirmButtonLabel: confirmLabel,
-              closeButtonLabel: bulkDeleteBtn.dataset.modalCancelLabel,
-              closable: true,
-            },
-            async () => {
-              await this.bulkDelete(selectedCombinationIds);
-              //@todo: hardcoded success for now, but it should still be removed when new modal is implemented in #26004.
-              $.growl({message: 'Success'});
-              this.eventEmitter.emit(CombinationEvents.refreshCombinationList);
-            },
-          );
-          modal.show();
-        } catch (error) {
-          const errorMessage = error.response?.JSON ?? error;
-          $.growl.error({message: errorMessage});
-        }
-      });
+      try {
+        const selectedCombinationsCount = selectedCombinationIds.length;
+        const confirmLabel = bulkDeleteBtn.dataset.modalConfirmLabel
+          ?.replace(/%combinations_number%/, String(selectedCombinationsCount));
+
+        const modal = new ConfirmModal(
+          {
+            id: 'modal-confirm-delete-combinations',
+            confirmTitle: bulkDeleteBtn.innerHTML,
+            confirmMessage: bulkDeleteBtn.dataset.modalMessage,
+            confirmButtonLabel: confirmLabel,
+            closeButtonLabel: bulkDeleteBtn.dataset.modalCancelLabel,
+            closable: true,
+          },
+          async () => {
+            await this.bulkDelete(selectedCombinationIds);
+            //@todo: hardcoded success for now, but it should still be removed when new modal is implemented in #26004.
+            $.growl({message: 'Success'});
+            this.eventEmitter.emit(CombinationEvents.bulkDeleteFinished);
+          },
+        );
+        modal.show();
+      } catch (error) {
+        const errorMessage = error.response?.JSON ?? error;
+        $.growl.error({message: errorMessage});
+      }
     });
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-edition-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/bulk-edition-handler.ts
@@ -86,9 +86,14 @@ export default class BulkEditionHandler {
     ));
   }
 
-  private showFormModal(formUrl: string, modalTitle: string, confirmButtonLabel: string, closeButtonLabel: string): void {
-    const selectedCombinationsCount = this.bulkChoicesSelector.getSelectedCheckboxes().length;
-
+  private async showFormModal(
+    formUrl: string,
+    modalTitle: string,
+    confirmButtonLabel: string,
+    closeButtonLabel: string,
+  ): Promise<void> {
+    const selectedCombinationIds = await this.bulkChoicesSelector.getSelectedIds();
+    const selectedCombinationsCount = selectedCombinationIds.length;
     let initialSerializedData: string;
     const iframeModal = new IframeModal({
       id: CombinationMap.bulkFormModalId,
@@ -146,21 +151,20 @@ export default class BulkEditionHandler {
 
   private async submitForm(form: HTMLFormElement): Promise<void> {
     const progressModal = this.showProgressModal();
-
-    const checkboxes = this.bulkChoicesSelector.getSelectedCheckboxes();
+    const selectedIds = await this.bulkChoicesSelector.getSelectedIds();
     const progressModalElement = document.getElementById(CombinationMap.bulkProgressModalId);
 
     let progress = 1;
 
-    for (let i = 0; i < checkboxes.length; i += 1) {
-      const checkbox = checkboxes[i];
+    for (let i = 0; i < selectedIds.length; i += 1) {
+      const combinationId = selectedIds[i];
 
       // @todo when the ProgressModal will be integrated this will update it after each request
       try {
         // eslint-disable-next-line no-await-in-loop
         const response: Response = await this.combinationsService.bulkUpdate(
           this.productId,
-          Number(checkbox.value),
+          combinationId,
           new FormData(form),
         );
         // eslint-disable-next-line no-await-in-loop

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-editor.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-editor.ts
@@ -58,7 +58,7 @@ export default class CombinationsListEditor {
   private readonly editionDisabledElements: string[] = [
     CombinationsMap.bulkActionsDropdownBtn,
     CombinationsMap.tableRow.isSelectedCombination,
-    CombinationsMap.bulkSelectAll,
+    CombinationsMap.bulkSelectAllInPage,
     CombinationsMap.filtersSelectorButtons,
     CombinationsMap.generateCombinationsButton,
     CombinationsMap.list.rowActionButtons,

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -187,7 +187,7 @@ export default class CombinationsListRenderer {
     const $combinationsTableBody = $(CombinationsMap.combinationsTableBody);
 
     $combinationsTableBody.empty();
-    $combinationsTable.find(CombinationsMap.bulkSelectAll).prop('checked', false);
+    $combinationsTable.find(CombinationsMap.bulkSelectAllInPage).prop('checked', false);
 
     let rowIndex = 0;
     combinations.forEach((combination: Record<string, any>) => {

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -183,11 +183,9 @@ export default class CombinationsListRenderer {
    * @private
    */
   private renderCombinations(combinations: Array<Record<string, any>>): void {
-    const $combinationsTable = this.getCombinationsTable();
     const $combinationsTableBody = $(CombinationsMap.combinationsTableBody);
 
     $combinationsTableBody.empty();
-    $combinationsTable.find(CombinationsMap.bulkSelectAllInPage).prop('checked', false);
 
     let rowIndex = 0;
     combinations.forEach((combination: Record<string, any>) => {

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
@@ -162,6 +162,8 @@ export default class CombinationsList {
       );
     });
 
+    this.eventEmitter.on(CombinationEvents.combinationDeleted, () => this.refreshPage());
+    this.eventEmitter.on(CombinationEvents.bulkDeleteFinished, () => this.refreshPage());
     this.eventEmitter.on(CombinationEvents.bulkUpdateFinished, () => this.refreshPage());
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
@@ -108,14 +108,6 @@ export default class CombinationsList {
     this.paginatedCombinationsService = new PaginatedCombinationsService(productId);
     this.productAttributeGroups = [];
 
-    const bulkChoicesSelector = new BulkChoicesSelector(
-      this.eventEmitter,
-      this.externalCombinationTab,
-      this.paginatedCombinationsService,
-    );
-
-    new BulkEditionHandler(productId, this.eventEmitter, bulkChoicesSelector, this.combinationsService);
-    new BulkDeleteHandler(productId, this.eventEmitter, bulkChoicesSelector, this.combinationsService);
     new RowDeleteHandler(this.eventEmitter, this.combinationsService);
 
     this.init();
@@ -224,6 +216,15 @@ export default class CombinationsList {
       this.renderer,
       this.combinationsService,
     );
+    const bulkChoicesSelector = new BulkChoicesSelector(
+      this.eventEmitter,
+      this.externalCombinationTab,
+      this.paginatedCombinationsService,
+      this.paginator,
+    );
+
+    new BulkEditionHandler(this.productId, this.eventEmitter, bulkChoicesSelector, this.combinationsService);
+    new BulkDeleteHandler(this.productId, this.eventEmitter, bulkChoicesSelector, this.combinationsService);
 
     this.refreshCombinationList(true);
   }

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
@@ -189,6 +189,7 @@ export default class CombinationsList {
     );
     this.combinationModalApp = initCombinationModal(
       CombinationsMap.editModal,
+      this.paginatedCombinationsService,
       this.productId,
       this.eventEmitter,
     );

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
@@ -108,7 +108,11 @@ export default class CombinationsList {
     this.paginatedCombinationsService = new PaginatedCombinationsService(productId);
     this.productAttributeGroups = [];
 
-    const bulkChoicesSelector = new BulkChoicesSelector(this.eventEmitter, this.externalCombinationTab);
+    const bulkChoicesSelector = new BulkChoicesSelector(
+      this.eventEmitter,
+      this.externalCombinationTab,
+      this.paginatedCombinationsService,
+    );
 
     new BulkEditionHandler(productId, this.eventEmitter, bulkChoicesSelector, this.combinationsService);
     new BulkDeleteHandler(productId, this.eventEmitter, bulkChoicesSelector, this.combinationsService);

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/row-delete-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/row-delete-handler.ts
@@ -76,7 +76,7 @@ export default class RowDeleteHandler {
           this.findCombinationId(button),
         );
         $.growl({message: response.message});
-        this.eventEmitter.emit(CombinationEvents.refreshCombinationList);
+        this.eventEmitter.emit(CombinationEvents.combinationDeleted);
       });
       modal.show();
     } catch (error) {

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/CombinationModal.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/CombinationModal.vue
@@ -138,12 +138,12 @@
 </template>
 
 <script lang="ts">
-  import CombinationsService from '@pages/product/services/combinations-service';
   import ProductMap from '@pages/product/product-map';
   import ProductEventMap from '@pages/product/product-event-map';
   import Modal from '@vue/components/Modal.vue';
   import Router from '@components/router';
   import Vue from 'vue';
+  import PaginatedCombinationsService from '@pages/product/services/paginated-combinations-service';
   import History from './History.vue';
 
   export interface Combination {
@@ -151,7 +151,6 @@
   }
 
   interface CombinationModalStates {
-    combinationsService: null | CombinationsService,
     combinationIds: Array<number>,
     selectedCombinationId: number | null,
     selectedCombinationName: string | null,
@@ -179,7 +178,6 @@
     components: {Modal, History},
     data(): CombinationModalStates {
       return {
-        combinationsService: null,
         combinationIds: [],
         selectedCombinationId: null,
         selectedCombinationName: null,
@@ -198,6 +196,10 @@
       };
     },
     props: {
+      paginatedCombinationsService: {
+        type: PaginatedCombinationsService,
+        required: true,
+      },
       productId: {
         type: Number,
         required: true,
@@ -213,7 +215,6 @@
     },
     mounted() {
       this.combinationList = $(ProductMap.combinations.combinationsFormContainer);
-      this.combinationsService = new CombinationsService();
       this.initCombinationIds();
       this.watchEditButtons();
       this.eventEmitter.on(CombinationEvents.refreshCombinationList, () => this.initCombinationIds(),
@@ -235,7 +236,7 @@
         );
       },
       async initCombinationIds() {
-        this.combinationIds = await this.combinationsService?.getCombinationIds(this.productId);
+        this.combinationIds = await this.paginatedCombinationsService.getCombinationIds();
       },
       frameLoading(): void {
         this.applyIframeStyling();

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/CombinationModal.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/CombinationModal.vue
@@ -200,10 +200,6 @@
         type: PaginatedCombinationsService,
         required: true,
       },
-      productId: {
-        type: Number,
-        required: true,
-      },
       eventEmitter: {
         type: Object,
         required: true,

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/CombinationModal.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/CombinationModal.vue
@@ -213,8 +213,8 @@
       this.combinationList = $(ProductMap.combinations.combinationsFormContainer);
       this.initCombinationIds();
       this.watchEditButtons();
-      this.eventEmitter.on(CombinationEvents.refreshCombinationList, () => this.initCombinationIds(),
-      );
+      this.eventEmitter.on(CombinationEvents.refreshCombinationList, () => this.initCombinationIds());
+      this.eventEmitter.on(CombinationEvents.listRendered, () => this.initCombinationIds());
     },
     methods: {
       watchEditButtons(): void {

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/index.ts
@@ -28,11 +28,13 @@ import VueI18n from 'vue-i18n';
 import EventEmitter from '@components/event-emitter';
 import ReplaceFormatter from '@vue/plugins/vue-i18n/replace-formatter';
 import CombinationModal from '@pages/product/components/combination-modal/CombinationModal.vue';
+import PaginatedCombinationsService from '@pages/product/services/paginated-combinations-service';
 
 Vue.use(VueI18n);
 
 /**
  * @param {string} combinationModalSelector
+ * @param {PaginatedCombinationsService} paginatedCombinationsService
  * @param {int} productId
  * @param {Object} eventEmitter
  *
@@ -40,6 +42,7 @@ Vue.use(VueI18n);
  */
 export default function initCombinationModal(
   combinationModalSelector: string,
+  paginatedCombinationsService: PaginatedCombinationsService,
   productId: number,
   eventEmitter: typeof EventEmitter,
 ): Vue {
@@ -56,10 +59,12 @@ export default function initCombinationModal(
   return new Vue({
     el: combinationModalSelector,
     template:
-      '<combination-modal :productId=productId :emptyImageUrl="emptyImage" :eventEmitter=eventEmitter />',
+    // eslint-disable-next-line max-len
+      '<combination-modal :productId=productId :emptyImageUrl="emptyImage" :eventEmitter=eventEmitter :paginated-combinations-service="paginatedCombinationsService"/>',
     components: {CombinationModal},
     i18n,
     data: {
+      paginatedCombinationsService,
       productId,
       eventEmitter,
       emptyImage,

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/index.ts
@@ -60,12 +60,11 @@ export default function initCombinationModal(
     el: combinationModalSelector,
     template:
     // eslint-disable-next-line max-len
-      '<combination-modal :productId=productId :emptyImageUrl="emptyImage" :eventEmitter=eventEmitter :paginated-combinations-service="paginatedCombinationsService"/>',
+      '<combination-modal :emptyImageUrl="emptyImage" :eventEmitter=eventEmitter :paginated-combinations-service="paginatedCombinationsService"/>',
     components: {CombinationModal},
     i18n,
     data: {
       paginatedCombinationsService,
-      productId,
       eventEmitter,
       emptyImage,
     },

--- a/admin-dev/themes/new-theme/js/pages/product/components/filters/Filters.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/filters/Filters.vue
@@ -115,6 +115,12 @@
         this.selectedFilters[parentId] = this.selectedFilters[parentId].filter(
           (e: Record<string, any>) => filter.id !== e.id,
         );
+
+        if (this.selectedFilters[parentId].length === 0) {
+          // remove parent array if it became empty after filters removal
+          this.selectedFilters.splice(parentId, 1);
+        }
+
         this.updateFilters();
       },
       clearAll(): void {

--- a/admin-dev/themes/new-theme/js/pages/product/product-event-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-event-map.ts
@@ -53,6 +53,8 @@ export default {
     listRendered: 'combinationsListRendered',
     buildCombinationRow: 'buildCombinationRow',
     bulkUpdateFinished: 'combinationsBulkUpdateFinished',
+    bulkDeleteFinished: 'combinationsBulkDeleteFinished',
+    combinationDeleted: 'combinationDeleted',
   },
   categories: {
     applyCategoryTreeChanges: 'applyCategoryTreeChanges',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -157,8 +157,7 @@ export default {
     bulkDeleteBtn: '#combination-bulk-delete-btn',
     bulkActionBtn: '.bulk-action-btn',
     bulkActionsDropdownBtn: '#combination-bulk-actions-btn',
-    //@todo: rename? its the checkbox that displays status of bulk selection (if one of options is checked: all or all in page)
-    bulkSelectAllDisplay: '#bulk-select-all-display',
+    bulkAllPreviewInput: '#bulk-all-preview',
     bulkSelectAll: '#bulk-select-all',
     commonBulkAllSelector: `.${commonBulkSelectAllClass}`,
     bulkSelectAllInPage: `#${bulkCombinationSelectAllInPageId}`,

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -159,7 +159,7 @@ export default {
     //@todo: rename? its the checkbox that displays status of bulk selection (if one of options is checked: all or all in page)
     bulkSelectAllDisplay: '#bulk-select-all-display',
     bulkSelectAll: '#bulk-select-all',
-    bulkSelectAllCheckboxes: '.bulk-select-all',
+    commonBulkAllSelector: '.bulk-select-all',
     bulkSelectAllInPage: `#${bulkCombinationSelectAllInPageId}`,
     bulkSelectAllInPageId: bulkCombinationSelectAllInPageId,
     bulkProgressModalId: progressModalId,

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -27,6 +27,7 @@ const combinationListFormId = '#combination_list';
 const attachmentsBlockId = '#product_specifications_attachments';
 // It does not include "#" so it can be selected by getElementById
 const isSelectedCombinationClass = 'combination-is-selected';
+const commonBulkSelectAllClass = 'bulk-select-all';
 const bulkCombinationSelectAllInPageId = 'bulk-select-all-in-page';
 const progressModalId = 'bulk-combination-progress-modal';
 
@@ -133,7 +134,7 @@ export default {
       modifiedFieldClass: 'combination-value-changed',
       invalidClass: 'is-invalid',
       editionModeClass: 'edition-mode',
-      fieldInputs: `.combination-list-row :input:not(#${bulkCombinationSelectAllInPageId}):not(.${isSelectedCombinationClass})`,
+      fieldInputs: `.combination-list-row :input:not(.${commonBulkSelectAllClass}):not(.${isSelectedCombinationClass})`,
       errorAlerts: '.combination-list-row .alert-danger',
       rowActionButtons: '.combination-row-actions button',
       footer: {
@@ -159,7 +160,7 @@ export default {
     //@todo: rename? its the checkbox that displays status of bulk selection (if one of options is checked: all or all in page)
     bulkSelectAllDisplay: '#bulk-select-all-display',
     bulkSelectAll: '#bulk-select-all',
-    commonBulkAllSelector: '.bulk-select-all',
+    commonBulkAllSelector: `.${commonBulkSelectAllClass}`,
     bulkSelectAllInPage: `#${bulkCombinationSelectAllInPageId}`,
     bulkSelectAllInPageId: bulkCombinationSelectAllInPageId,
     bulkProgressModalId: progressModalId,

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -27,7 +27,7 @@ const combinationListFormId = '#combination_list';
 const attachmentsBlockId = '#product_specifications_attachments';
 // It does not include "#" so it can be selected by getElementById
 const isSelectedCombinationClass = 'combination-is-selected';
-const bulkCombinationSelectAllId = 'bulk-select-all-in-page';
+const bulkCombinationSelectAllInPageId = 'bulk-select-all-in-page';
 const progressModalId = 'bulk-combination-progress-modal';
 
 export default {
@@ -133,7 +133,7 @@ export default {
       modifiedFieldClass: 'combination-value-changed',
       invalidClass: 'is-invalid',
       editionModeClass: 'edition-mode',
-      fieldInputs: `.combination-list-row :input:not(#${bulkCombinationSelectAllId}):not(.${isSelectedCombinationClass})`,
+      fieldInputs: `.combination-list-row :input:not(#${bulkCombinationSelectAllInPageId}):not(.${isSelectedCombinationClass})`,
       errorAlerts: '.combination-list-row .alert-danger',
       rowActionButtons: '.combination-row-actions button',
       footer: {
@@ -156,8 +156,9 @@ export default {
     bulkDeleteBtn: '#combination-bulk-delete-btn',
     bulkActionBtn: '.bulk-action-btn',
     bulkActionsDropdownBtn: '#combination-bulk-actions-btn',
-    bulkSelectAll: `#${bulkCombinationSelectAllId}`,
-    bulkSelectAllId: bulkCombinationSelectAllId,
+    bulkSelectAll: '#bulk-select-all',
+    bulkSelectAllInPage: `#${bulkCombinationSelectAllInPageId}`,
+    bulkSelectAllInPageId: bulkCombinationSelectAllInPageId,
     bulkProgressModalId: progressModalId,
     bulkFormModalId: 'bulk-combination-form-modal',
   },

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -156,7 +156,10 @@ export default {
     bulkDeleteBtn: '#combination-bulk-delete-btn',
     bulkActionBtn: '.bulk-action-btn',
     bulkActionsDropdownBtn: '#combination-bulk-actions-btn',
+    //@todo: rename? its the checkbox that displays status of bulk selection (if one of options is checked: all or all in page)
+    bulkSelectAllDisplay: '#bulk-select-all-display',
     bulkSelectAll: '#bulk-select-all',
+    bulkSelectAllCheckboxes: '.bulk-select-all',
     bulkSelectAllInPage: `#${bulkCombinationSelectAllInPageId}`,
     bulkSelectAllInPageId: bulkCombinationSelectAllInPageId,
     bulkProgressModalId: progressModalId,

--- a/admin-dev/themes/new-theme/js/pages/product/services/combinations-service.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/services/combinations-service.ts
@@ -105,12 +105,4 @@ export default class CombinationsService {
       },
     });
   }
-
-  getCombinationIds(productId: number): JQuery.jqXHR<any> {
-    return $.get(
-      this.router.generate('admin_products_combinations_ids', {
-        productId,
-      }),
-    );
-  }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
@@ -28,6 +28,9 @@ import PaginationServiceType from '@PSTypes/services';
 
 const {$} = window;
 
+/**
+ * @todo: rename to FilterableCombinationsService?
+ */
 export default class PaginatedCombinationsService implements PaginationServiceType {
   productId: number;
 
@@ -66,6 +69,19 @@ export default class PaginatedCombinationsService implements PaginationServiceTy
     }
 
     return $.get(this.router.generate('admin_products_combinations', requestParams));
+  }
+
+  //@todo: duplicate from combination-service, except that passes filters
+  getCombinationIds(): JQuery.jqXHR<any> {
+    const requestParams: Record<string, any> = {};
+    requestParams[`product_combinations_${this.productId}`] = {
+      filters: this.filters,
+    };
+
+    return $.get(
+      this.router.generate('admin_products_combinations_ids', {productId: this.productId}),
+      requestParams,
+    );
   }
 
   setOrderBy(orderBy: string, orderWay: string): void {

--- a/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
@@ -51,7 +51,7 @@ export default class PaginatedCombinationsService implements PaginationServiceTy
   }
 
   fetch(offset: number, limit: number): JQuery.jqXHR<any> {
-    const filterId = `product_combinations_${this.productId}`;
+    const filterId = this.getFilterId();
     const requestParams: Record<string, any> = {};
     // Required for route generation
     requestParams.productId = this.productId;
@@ -73,14 +73,12 @@ export default class PaginatedCombinationsService implements PaginationServiceTy
 
   //@todo: duplicate from combination-service, except that passes filters
   getCombinationIds(): JQuery.jqXHR<any> {
-    const requestParams: Record<string, any> = {};
-    requestParams[`product_combinations_${this.productId}`] = {
-      filters: this.filters,
-    };
-
     return $.get(
-      this.router.generate('admin_products_combinations_ids', {productId: this.productId}),
-      requestParams,
+      this.router.generate('admin_products_combinations_ids', {productId: this.productId}), {
+        [this.getFilterId()]: {
+          filters: this.filters,
+        },
+      },
     );
   }
 
@@ -95,5 +93,9 @@ export default class PaginatedCombinationsService implements PaginationServiceTy
 
   setFilters(filters: Record<string, any>): void {
     this.filters = filters;
+  }
+
+  private getFilterId(): string {
+    return `product_combinations_${this.productId}`;
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
@@ -28,9 +28,6 @@ import PaginationServiceType from '@PSTypes/services';
 
 const {$} = window;
 
-/**
- * @todo: rename to FilterableCombinationsService?
- */
 export default class PaginatedCombinationsService implements PaginationServiceType {
   productId: number;
 
@@ -80,21 +77,17 @@ export default class PaginatedCombinationsService implements PaginationServiceTy
   }
 
   //@todo: duplicate from combination-service, except that passes filters
-  getCombinationIds(paginated: boolean): JQuery.jqXHR<any> {
-    const filterId = this.getFilterId();
-    const requestParams: Record<string, any> = {};
-
-    requestParams[filterId] = {};
-    requestParams[filterId].filters = this.filters;
-
-    if (!paginated) {
-      requestParams[filterId].offset = null;
-      requestParams[filterId].limit = null;
-    }
-
+  getCombinationIds(): JQuery.jqXHR<any> {
     return $.get(
       this.router.generate('admin_products_combinations_ids', {productId: this.productId}),
-      requestParams,
+      {
+        [this.getFilterId()]: {
+          filters: this.filters,
+          // It is important that we reset offset and limit, because we want to get all results without pagination
+          offset: null,
+          limit: null,
+        },
+      },
     );
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
@@ -38,6 +38,10 @@ export default class PaginatedCombinationsService implements PaginationServiceTy
 
   filters: Record<string, any>;
 
+  offset: number;
+
+  limit: number;
+
   orderBy: string | null;
 
   orderWay: string | null;
@@ -46,11 +50,15 @@ export default class PaginatedCombinationsService implements PaginationServiceTy
     this.productId = productId;
     this.router = new Router();
     this.filters = {};
+    this.offset = 0;
+    this.limit = 0;
     this.orderBy = null;
     this.orderWay = null;
   }
 
   fetch(offset: number, limit: number): JQuery.jqXHR<any> {
+    this.offset = offset;
+    this.limit = limit;
     const filterId = this.getFilterId();
     const requestParams: Record<string, any> = {};
     // Required for route generation
@@ -72,13 +80,21 @@ export default class PaginatedCombinationsService implements PaginationServiceTy
   }
 
   //@todo: duplicate from combination-service, except that passes filters
-  getCombinationIds(): JQuery.jqXHR<any> {
+  getCombinationIds(paginated: boolean): JQuery.jqXHR<any> {
+    const filterId = this.getFilterId();
+    const requestParams: Record<string, any> = {};
+
+    requestParams[filterId] = {};
+    requestParams[filterId].filters = this.filters;
+
+    if (!paginated) {
+      requestParams[filterId].offset = null;
+      requestParams[filterId].limit = null;
+    }
+
     return $.get(
-      this.router.generate('admin_products_combinations_ids', {productId: this.productId}), {
-        [this.getFilterId()]: {
-          filters: this.filters,
-        },
-      },
+      this.router.generate('admin_products_combinations_ids', {productId: this.productId}),
+      requestParams,
     );
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/services/paginated-combinations-service.ts
@@ -76,7 +76,6 @@ export default class PaginatedCombinationsService implements PaginationServiceTy
     return $.get(this.router.generate('admin_products_combinations', requestParams));
   }
 
-  //@todo: duplicate from combination-service, except that passes filters
   getCombinationIds(): JQuery.jqXHR<any> {
     return $.get(
       this.router.generate('admin_products_combinations_ids', {productId: this.productId}),

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1585,7 +1585,7 @@ $product-page-padding-bottom: 80px !default;
 
       .dropdown-toggle {
         background-color: inherit;
-        border:none;
+        border: none;
       }
     }
   }

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1575,6 +1575,19 @@ $product-page-padding-bottom: 80px !default;
         margin-left: auto;
       }
     }
+
+    #bulk-all-selection-dropdown {
+      cursor: pointer;
+
+      label {
+        cursor: pointer;
+      }
+
+      .dropdown-toggle {
+        background-color: inherit;
+        border:none;
+      }
+    }
   }
 
   #combinations-list-footer {

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1505,6 +1505,10 @@ $product-page-padding-bottom: 80px !default;
         display: inline-block;
       }
 
+      .dropdown-menu .md-checkbox {
+        display: block;
+      }
+
       .ps-sortable-column {
         display: inline-block;
       }

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1507,6 +1507,7 @@ $product-page-padding-bottom: 80px !default;
 
       .dropdown-menu .md-checkbox {
         display: block;
+        padding-left: 38px;
       }
 
       .ps-sortable-column {

--- a/src/Adapter/Form/ChoiceProvider/CombinationIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/CombinationIdChoiceProvider.php
@@ -83,7 +83,7 @@ class CombinationIdChoiceProvider implements ConfigurableFormChoiceProviderInter
     public function getChoices(array $options): array
     {
         $options = $this->resolveOptions($options);
-        $combinationIds = $this->combinationRepository->getCombinationIdsByProductId(new ProductId($options['product_id']));
+        $combinationIds = $this->combinationRepository->getCombinationIds(new ProductId($options['product_id']));
         $attributesInfo = $this->attributeRepository->getAttributesInfoByCombinationIds($combinationIds, $this->languageId);
 
         $choices = [];

--- a/src/Adapter/Product/Combination/Repository/CombinationRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationRepository.php
@@ -184,7 +184,7 @@ class CombinationRepository extends AbstractObjectModelRepository
      */
     public function deleteByProductId(ProductId $productId): void
     {
-        $combinationIds = $this->getCombinationIdsByProductId($productId);
+        $combinationIds = $this->getCombinationIds($productId);
 
         $this->bulkDelete($combinationIds);
     }
@@ -215,10 +215,11 @@ class CombinationRepository extends AbstractObjectModelRepository
 
     /**
      * @param ProductId $productId
+     * @param ProductCombinationFilters|null $filters
      *
      * @return CombinationId[]
      */
-    public function getCombinationIdsByProductId(ProductId $productId, ?ProductCombinationFilters $filters = null): array
+    public function getCombinationIds(ProductId $productId, ?ProductCombinationFilters $filters = null): array
     {
         if ($filters) {
             $qb = $this->combinationQueryBuilder->getSearchQueryBuilder($filters)
@@ -235,7 +236,7 @@ class CombinationRepository extends AbstractObjectModelRepository
             ;
         }
 
-        $combinationIds = $qb->execute()->fetchAll();
+        $combinationIds = $qb->execute()->fetchAllAssociative();
 
         return array_map(
             function (array $combination) { return new CombinationId((int) $combination['id_product_attribute']); },

--- a/src/Adapter/Product/Update/ProductSupplierUpdater.php
+++ b/src/Adapter/Product/Update/ProductSupplierUpdater.php
@@ -131,7 +131,7 @@ class ProductSupplierUpdater
         // We should always create an association not related to a combination
         $combinationIds = [new NoCombinationId()];
         if ($productType->getValue() === ProductType::TYPE_COMBINATIONS) {
-            $combinationIds = array_merge($combinationIds, $this->combinationRepository->getCombinationIdsByProductId($productId));
+            $combinationIds = array_merge($combinationIds, $this->combinationRepository->getCombinationIds($productId));
         }
 
         // Now we search for each associated supplier if some associations are missing

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -247,21 +247,19 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @todo: is it worth implementing new separate action to get ids with filters?
-     *
      * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
      *
      * @param int $productId
-     * @param ProductCombinationFilters|null $filters
+     * @param ProductCombinationFilters $filters
      *
      * @return JsonResponse
      */
-    public function getListIdsAction(int $productId, ?ProductCombinationFilters $filters = null): JsonResponse
+    public function getCombinationIdsAction(int $productId, ProductCombinationFilters $filters): JsonResponse
     {
         /** @var CombinationRepository $repository */
         $repository = $this->get('prestashop.adapter.product.combination.repository.combination_repository');
 
-        $combinationIds = $repository->getCombinationIdsByProductId(new ProductId($productId), $filters);
+        $combinationIds = $repository->getCombinationIds(new ProductId($productId), $filters);
         $data = [];
         foreach ($combinationIds as $combinationId) {
             $data[] = $combinationId->getValue();

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -291,7 +291,8 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @todo: this might not be needed anymore
+     * @todo: this has left unused after some changes, but it may be needed for bulk deletion by chunks
+     *        (remove this code if its still unused after issue #28491 is closed)
      *
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -290,6 +290,8 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
+     * @todo: this might not be needed anymore
+     *
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param int $productId

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -247,18 +247,21 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
+     * @todo: is it worth implementing new separate action to get ids with filters?
+     *
      * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
      *
      * @param int $productId
+     * @param ProductCombinationFilters|null $filters
      *
      * @return JsonResponse
      */
-    public function getListIdsAction(int $productId): JsonResponse
+    public function getListIdsAction(int $productId, ?ProductCombinationFilters $filters = null): JsonResponse
     {
         /** @var CombinationRepository $repository */
         $repository = $this->get('prestashop.adapter.product.combination.repository.combination_repository');
 
-        $combinationIds = $repository->getCombinationIdsByProductId(new ProductId($productId));
+        $combinationIds = $repository->getCombinationIdsByProductId(new ProductId($productId), $filters);
         $data = [];
         foreach ($combinationIds as $combinationId) {
             $data[] = $combinationId->getValue();

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationItemType.php
@@ -56,6 +56,8 @@ class CombinationItemType extends TranslatorAwareType
                 'label' => false,
                 'attr' => [
                     'class' => 'combination-is-selected',
+                    // Force placeholder in value so that the JS replaces it at the same time as the combination_id field
+                    'value' => '__combination_id__',
                 ],
             ])
             ->add('image_url', ImagePreviewType::class, [

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/combination.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/combination.yml
@@ -14,7 +14,7 @@ admin_products_combinations_ids:
   options:
     expose: true
   defaults:
-    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\CombinationController::getListIdsAction
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\CombinationController::getCombinationIdsAction
     _legacy_controller: AdminProducts
 
 admin_products_combinations_update_combination_from_listing:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -86,6 +86,7 @@ services:
       - '%database_prefix%'
       - '@prestashop.adapter.attribute.repository.attribute_repository'
       - '@prestashop.adapter.product.combination.validate.combination_validator'
+      - '@prestashop.core.grid.query_builder.product_combination'
 
   prestashop.adapter.product.combination.update.combination_stock_updater:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -55,15 +55,19 @@
     <tr class="column-headers">
       <th scope="col" id="id-header">
         <div class="dropdown">
-{#          #}
-          <div class="md-checkbox md-checkbox-inline dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <button type="button"
+                  class="md-checkbox dropdown-toggle"
+                  data-toggle="dropdown"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+          >
             <label>
               <input type="checkbox" id="bulk-select-all-display">
               <i class="md-checkbox-control"></i>
             </label>
-          </div>
+          </button>
 
-          <div aria-labelledby="form_invoice_prefix" class="dropdown-menu">
+          <div class="dropdown-menu">
             <div class="md-checkbox">
               <label class="dropdown-item">
                 <div class="md-checkbox-container">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -54,45 +54,36 @@
     <thead class="thead-default">
     <tr class="column-headers">
       <th scope="col" id="id-header">
-        <div class="dropdown">
+        <div class="dropdown" id="bulk-all-selection-dropdown">
           <button type="button"
                   class="md-checkbox dropdown-toggle"
                   data-toggle="dropdown"
                   aria-haspopup="true"
                   aria-expanded="false"
           >
-            <label>
-              <input type="checkbox" id="bulk-all-preview" class="bulk-select-all">
-              <i class="md-checkbox-control"></i>
-            </label>
+            <label for="bulk-all-preview" data-label="(%combinations_number%)"></label>
+            <input type="checkbox" id="bulk-all-preview" class="bulk-select-all">
+            <i class="md-checkbox-control"></i>
           </button>
 
           <div class="dropdown-menu">
-            <div class="md-checkbox">
-              <label class="dropdown-item">
-                <div class="md-checkbox-container">
-                  <label
-                    for="bulk-select-all-in-page"
-                    data-label="{{'Select results on this page (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
-                  >
-                  </label>
-                  <input type="checkbox" id="bulk-select-all-in-page" class="bulk-select-all">
-                  <i class="md-checkbox-control"></i>
-                </div>
+            <div class="md-checkbox dropdown-item">
+              <label
+                for="bulk-select-all-in-page"
+                data-label="{{'Select results on this page (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
+              >
               </label>
+              <input type="checkbox" id="bulk-select-all-in-page" class="bulk-select-all">
+              <i class="md-checkbox-control"></i>
             </div>
-            <div class="md-checkbox">
-              <label class="dropdown-item">
-                <div class="md-checkbox-container">
-                  <label
-                    for="bulk-select-all"
-                    data-label="{{'Select all results (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
-                  >
-                  </label>
-                  <input type="checkbox" id="bulk-select-all" class="bulk-select-all">
-                  <i class="md-checkbox-control"></i>
-                </div>
+            <div class="md-checkbox dropdown-item">
+              <label
+                for="bulk-select-all"
+                data-label="{{'Select all results (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
+              >
               </label>
+              <input type="checkbox" id="bulk-select-all" class="bulk-select-all">
+              <i class="md-checkbox-control"></i>
             </div>
           </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -62,7 +62,7 @@
                   aria-expanded="false"
           >
             <label>
-              <input type="checkbox" id="bulk-select-all-display" class="bulk-select-all">
+              <input type="checkbox" id="bulk-all-preview" class="bulk-select-all">
               <i class="md-checkbox-control"></i>
             </label>
           </button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -67,20 +67,20 @@
             <div class="md-checkbox">
               <label class="dropdown-item">
                 <div class="md-checkbox-container">
-                  <input type="checkbox" id="bulk-select-all-in-page">
+                  <input type="checkbox" id="bulk-select-all-in-page" class="bulk-select-all">
                   <i class="md-checkbox-control"></i>
-{#                  @todo: hardcoded#}
-                  Select results on this page
+{#                  @todo: hardcoded + need dynamic combinations count#}
+                  Select results on this page (0)
                 </div>
               </label>
             </div>
             <div class="md-checkbox">
               <label class="dropdown-item">
                 <div class="md-checkbox-container">
-                  <input type="checkbox" id="bulk-select-all">
+                  <input type="checkbox" id="bulk-select-all" class="bulk-select-all">
                   <i class="md-checkbox-control"></i>
                   {#                  @todo: hardcoded#}
-                  Select all results
+                  Select all results (0)
                 </div>
               </label>
             </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -75,7 +75,6 @@
                     for="bulk-select-all-in-page"
                     data-label="{{'Select results on this page (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
                   >
-                    Select results on this page (0)
                   </label>
                   <input type="checkbox" id="bulk-select-all-in-page" class="bulk-select-all">
                   <i class="md-checkbox-control"></i>
@@ -89,7 +88,6 @@
                     for="bulk-select-all"
                     data-label="{{'Select all results (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
                   >
-                    Select all results (0)
                   </label>
                   <input type="checkbox" id="bulk-select-all" class="bulk-select-all">
                   <i class="md-checkbox-control"></i>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -55,13 +55,14 @@
     <tr class="column-headers">
       <th scope="col" id="id-header">
         <div class="dropdown" id="bulk-all-selection-dropdown">
-          <button type="button"
-                  class="md-checkbox dropdown-toggle"
-                  data-toggle="dropdown"
-                  aria-haspopup="true"
-                  aria-expanded="false"
+          <button
+            type="button"
+            class="md-checkbox dropdown-toggle"
+            data-toggle="dropdown"
+            aria-haspopup="true"
+            aria-expanded="false"
           >
-            <label for="bulk-all-preview" data-label="(%combinations_number%)"><span></span></label>
+            <label for="bulk-all-preview" data-label="(%combinations_number% / %total_combinations%)"><span></span></label>
             <input type="checkbox" id="bulk-all-preview" class="bulk-select-all">
             <i class="md-checkbox-control"></i>
           </button>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -61,30 +61,31 @@
                   aria-haspopup="true"
                   aria-expanded="false"
           >
-            <label for="bulk-all-preview" data-label="(%combinations_number%)"></label>
+            <label for="bulk-all-preview" data-label="(%combinations_number%)"><span></span></label>
             <input type="checkbox" id="bulk-all-preview" class="bulk-select-all">
             <i class="md-checkbox-control"></i>
           </button>
 
           <div class="dropdown-menu">
-            <div class="md-checkbox dropdown-item">
-              <label
-                for="bulk-select-all-in-page"
-                data-label="{{'Select results on this page (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
-              >
-              </label>
+            <label
+              class="md-checkbox dropdown-item"
+              for="bulk-select-all-in-page"
+              data-label="{{'Select results on this page (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
+            >
+              <span></span>
               <input type="checkbox" id="bulk-select-all-in-page" class="bulk-select-all">
               <i class="md-checkbox-control"></i>
-            </div>
-            <div class="md-checkbox dropdown-item">
-              <label
-                for="bulk-select-all"
-                data-label="{{'Select all results (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
-              >
-              </label>
+            </label>
+
+            <label
+              class="md-checkbox dropdown-item"
+              for="bulk-select-all"
+              data-label="{{'Select all results (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
+            >
+              <span></span>
               <input type="checkbox" id="bulk-select-all" class="bulk-select-all">
               <i class="md-checkbox-control"></i>
-            </div>
+            </label>
           </div>
         </div>
       </th>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -1,4 +1,4 @@
-{# **
+{#**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,7 +21,7 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- * #}
+ *#}
 {% extends '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {%- block combination_item_row -%}
@@ -71,20 +71,28 @@
             <div class="md-checkbox">
               <label class="dropdown-item">
                 <div class="md-checkbox-container">
+                  <label
+                    for="bulk-select-all-in-page"
+                    data-label="{{'Select results on this page (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
+                  >
+                    Select results on this page (0)
+                  </label>
                   <input type="checkbox" id="bulk-select-all-in-page" class="bulk-select-all">
                   <i class="md-checkbox-control"></i>
-{#                  @todo: hardcoded + need dynamic combinations count#}
-                  Select results on this page (0)
                 </div>
               </label>
             </div>
             <div class="md-checkbox">
               <label class="dropdown-item">
                 <div class="md-checkbox-container">
+                  <label
+                    for="bulk-select-all"
+                    data-label="{{'Select all results (%combinations_number%)'|trans({}, 'Admin.Actions')}}"
+                  >
+                    Select all results (0)
+                  </label>
                   <input type="checkbox" id="bulk-select-all" class="bulk-select-all">
                   <i class="md-checkbox-control"></i>
-                  {#                  @todo: hardcoded#}
-                  Select all results (0)
                 </div>
               </label>
             </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -1,4 +1,4 @@
-{#**
+{# **
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,7 +21,7 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ * #}
 {% extends '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {%- block combination_item_row -%}
@@ -52,29 +52,55 @@
       {{ form_widget(form._token) }}
     {% endif %}
     <thead class="thead-default">
-      <tr class="column-headers">
-        <th scope="col" id="id-header">
-          <div class="md-checkbox md-checkbox-inline">
+    <tr class="column-headers">
+      <th scope="col" id="id-header">
+        <div class="dropdown">
+{#          #}
+          <div class="md-checkbox md-checkbox-inline dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <label>
-              <input type="checkbox" id="bulk-select-all-in-page">
+              <input type="checkbox" id="bulk-select-all-display">
               <i class="md-checkbox-control"></i>
             </label>
           </div>
-        </th>
 
-        {% for child in prototype.children %}
-          {# Exception: is_selected header has already been rendered manually #}
-          {% if child.vars.name != 'is_selected' %}
-            <th scope="col">
-              {% if child.vars.attr['data-order-by'] is defined %}
-                {{ ps.sortable_column_header(child.vars.label, child.vars.attr['data-order-by']) }}
-              {% else %}
-                {{ child.vars.label }}
-              {% endif %}
-            </th>
-          {% endif %}
-        {% endfor %}
-      </tr>
+          <div aria-labelledby="form_invoice_prefix" class="dropdown-menu">
+            <div class="md-checkbox">
+              <label class="dropdown-item">
+                <div class="md-checkbox-container">
+                  <input type="checkbox" id="bulk-select-all-in-page">
+                  <i class="md-checkbox-control"></i>
+{#                  @todo: hardcoded#}
+                  Select results on this page
+                </div>
+              </label>
+            </div>
+            <div class="md-checkbox">
+              <label class="dropdown-item">
+                <div class="md-checkbox-container">
+                  <input type="checkbox" id="bulk-select-all">
+                  <i class="md-checkbox-control"></i>
+                  {#                  @todo: hardcoded#}
+                  Select all results
+                </div>
+              </label>
+            </div>
+          </div>
+        </div>
+      </th>
+
+      {% for child in prototype.children %}
+        {# Exception: is_selected header has already been rendered manually #}
+        {% if child.vars.name != 'is_selected' %}
+          <th scope="col">
+            {% if child.vars.attr['data-order-by'] is defined %}
+              {{ ps.sortable_column_header(child.vars.label, child.vars.attr['data-order-by']) }}
+            {% else %}
+              {{ child.vars.label }}
+            {% endif %}
+          </th>
+        {% endif %}
+      {% endfor %}
+    </tr>
     </thead>
     <tbody>
     {{- block('form_rows') -}}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination_listing.html.twig
@@ -62,7 +62,7 @@
                   aria-expanded="false"
           >
             <label>
-              <input type="checkbox" id="bulk-select-all-display">
+              <input type="checkbox" id="bulk-select-all-display" class="bulk-select-all">
               <i class="md-checkbox-control"></i>
             </label>
           </button>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add bulk selection options to new product combination list to be able to select all combinations that are shown in current page, or to select all combinations per all the pages. Use javascript loop to call deleteCombinationAction one by one with progress modal. Later its planned to add deletion by chuncks when selected combinations number is large.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.

**screenshots**
![Screenshot from 2022-05-12 21-17-39](https://user-images.githubusercontent.com/31609858/168142245-623812e8-549c-4a36-ac73-bce1a2ca6b89.png)
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
