### PR TITLE
Simplify Employee Form

### DIFF
--- a/src/Core/Domain/Employee/ValueObject/Password.php
+++ b/src/Core/Domain/Employee/ValueObject/Password.php
@@ -35,6 +35,11 @@ use ZxcvbnPhp\Zxcvbn;
 class Password
 {
     /**
+     * @var int Minimum required password length for employee
+     */
+    public const MIN_LENGTH = 8;
+
+    /**
      * @var string
      */
     private $password;
@@ -81,6 +86,8 @@ class Password
 
     /**
      * @param string $password
+     *
+     * @throws EmployeeConstraintException
      */
     private function assertPasswordIsWithinAllowedLength(string $password): void
     {
@@ -100,6 +107,8 @@ class Password
 
     /**
      * @param string $password
+     *
+     * @throws EmployeeConstraintException
      */
     private function assertPasswordScoreIsAllowed(string $password): void
     {

--- a/src/Core/Form/IdentifiableObject/DataProvider/EmployeeFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/EmployeeFormDataProvider.php
@@ -51,18 +51,26 @@ final class EmployeeFormDataProvider implements FormDataProviderInterface
     private $defaultShopAssociation;
 
     /**
+     * @var string
+     */
+    private $defaultAvatarUrl;
+
+    /**
      * @param CommandBusInterface $queryBus
      * @param bool $isMultistoreFeatureActive
      * @param array $defaultShopAssociation
+     * @param string $defaultAvatarUrl
      */
     public function __construct(
         CommandBusInterface $queryBus,
         $isMultistoreFeatureActive,
-        array $defaultShopAssociation
+        array $defaultShopAssociation,
+        string $defaultAvatarUrl
     ) {
         $this->queryBus = $queryBus;
         $this->isMultistoreFeatureActive = $isMultistoreFeatureActive;
         $this->defaultShopAssociation = $defaultShopAssociation;
+        $this->defaultAvatarUrl = $defaultAvatarUrl;
     }
 
     /**
@@ -83,6 +91,7 @@ final class EmployeeFormDataProvider implements FormDataProviderInterface
             'profile' => $editableEmployee->getProfileId(),
             'shop_association' => $editableEmployee->getShopAssociation(),
             'has_enabled_gravatar' => $editableEmployee->hasEnabledGravatar(),
+            'avatar_url' => $editableEmployee->getAvatarUrl(),
         ];
     }
 
@@ -94,6 +103,7 @@ final class EmployeeFormDataProvider implements FormDataProviderInterface
         $data = [
             'active' => true,
             'has_enabled_gravatar' => false,
+            'avatar_url' => $this->defaultAvatarUrl,
         ];
 
         if ($this->isMultistoreFeatureActive) {

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -297,13 +297,14 @@ class EmployeeController extends FrameworkBundleAdminController
         }
 
         $templateVars = [
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'employeeForm' => $employeeForm->createView(),
             'enableSidebar' => true,
         ];
 
         return $this->render(
             '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/create.html.twig',
-            $templateVars + $this->getFormTemplateVariables($request)
+            $templateVars
         );
     }
 
@@ -382,6 +383,7 @@ class EmployeeController extends FrameworkBundleAdminController
         }
 
         $templateVars = [
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'employeeForm' => $employeeForm->createView(),
             'isRestrictedAccess' => $isRestrictedAccess,
             'editableEmployee' => $editableEmployee,
@@ -389,7 +391,7 @@ class EmployeeController extends FrameworkBundleAdminController
 
         return $this->render(
             '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/edit.html.twig',
-            $templateVars + $this->getFormTemplateVariables($request)
+            $templateVars
         );
     }
 
@@ -544,26 +546,6 @@ class EmployeeController extends FrameworkBundleAdminController
                     'Admin.Notifications.Error'
                 ),
             ],
-        ];
-    }
-
-    /**
-     * Get template variables that are same between create and edit forms.
-     *
-     * @param Request $request
-     *
-     * @return array
-     */
-    private function getFormTemplateVariables(Request $request)
-    {
-        $configuration = $this->get('prestashop.adapter.legacy.configuration');
-
-        return [
-            'level' => $this->authorizationLevel($request->attributes->get('_legacy_controller')),
-            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
-            'superAdminProfileId' => $configuration->get('_PS_ADMIN_PROFILE_'),
-            'getTabsUrl' => $this->generateUrl('admin_employees_get_tabs'),
-            'errorMessage' => $this->trans('You need permission to add this.', 'Admin.Notifications.Error'),
         ];
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -27,15 +27,14 @@
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Length;
 
 /**
@@ -69,41 +68,89 @@ class ChangePasswordType extends AbstractType
 
         $builder
             ->add('change_password_button', ButtonType::class, [
-                'label' => false,
+                'label' => $this->trans('Change password...', [], 'Admin.Actions'),
+                'attr' => [
+                    'class' => 'btn-outline-secondary js-change-password',
+                ],
             ])
-            ->add('old_password', PasswordType::class)
+            ->add('old_password', PasswordType::class, [
+                'label' => $this->trans('Current password', [], 'Admin.Advparameters.Feature'),
+                'required' => true,
+            ])
             ->add('new_password', RepeatedType::class, [
                 'type' => PasswordType::class,
-                'options' => [
+                'constraints' => [
+                    $this->getLengthConstraint($maxLength, $minLength),
+                ],
+                'required' => true,
+                'first_options' => [
+                    'label' => $this->trans('New password', [], 'Admin.Advparameters.Feature'),
+                    'help' => $this->trans(
+                        'Password should be at least %num% characters long.',
+                        [
+                            '%num%' => 8,
+                        ],
+                        'Admin.Advparameters.Help'
+                    ),
                     'attr' => [
                         'data-minscore' => $minScore,
                         'data-minlength' => $minLength,
                         'data-maxlength' => $maxLength,
                     ],
                 ],
-                'constraints' => [
-                    new Length(
-                        [
-                            'max' => $maxLength,
-                            'maxMessage' => $this->getMaxLengthValidationMessage($maxLength),
-                            'min' => $minLength,
-                            'minMessage' => $this->getMinLengthValidationMessage($minLength),
-                        ]
-                    ),
+                'second_options' => [
+                    'label' => $this->trans('Confirm password', [], 'Admin.Advparameters.Feature'),
+                    'help' => '',
+                    'attr' => [
+                        'data-invalid-password' => $this->trans(
+                            'The confirmation password doesn\'t match.',
+                            [],
+                            'Admin.Notifications.Error'
+                        ),
+                        'data-minscore' => $minScore,
+                        'data-minlength' => $minLength,
+                        'data-maxlength' => $maxLength,
+                    ],
                 ],
             ])
-            ->add('cancel_button', ButtonType::class)
+            ->add('generated_password', TextType::class, [
+                'label' => false,
+                'disabled' => true,
+            ])
+            ->add('generate_password_button', ButtonType::class, [
+                'label' => $this->trans('Generate password', [], 'messages'),
+                'attr' => [
+                    'class' => 'btn-outline-secondary',
+                ],
+            ])
+            ->add('cancel_button', ButtonType::class, [
+                'label' => $this->trans('Cancel', [], 'Admin.Actions'),
+                'attr' => [
+                    'class' => 'btn-outline-secondary js-change-password-cancel',
+                ],
+            ])
         ;
     }
 
     /**
-     * {@inheritdoc}
+     * @param int $maxLength
+     * @param int|null $minLength
+     *
+     * @return Length
      */
-    public function configureOptions(OptionsResolver $resolver)
+    private function getLengthConstraint(int $maxLength, int $minLength = null): Length
     {
-        $resolver->setDefaults([
-            'required' => false,
-        ]);
+        $options = [
+            'max' => $maxLength,
+            'maxMessage' => $this->getMaxLengthValidationMessage($maxLength),
+        ];
+
+        if (null !== $minLength) {
+            $options['min'] = $minLength;
+            $options['minMessage'] = $this->getMinLengthValidationMessage($minLength);
+        }
+
+        return new Length($options);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
@@ -88,7 +89,7 @@ class ChangePasswordType extends AbstractType
                     'help' => $this->trans(
                         'Password should be at least %num% characters long.',
                         [
-                            '%num%' => 8,
+                            '%num%' => Password::MIN_LENGTH,
                         ],
                         'Admin.Advparameters.Help'
                     ),

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -986,8 +986,9 @@ services:
       - '@=service("prestashop.core.form.choice_provider.accessible_tab").getChoices()'
       - '@=service("prestashop.core.form.choice_provider.profile").getChoices()'
       - '@=service("prestashop.adapter.multistore_feature").isActive()'
-      - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
       - "@=service('prestashop.adapter.legacy.configuration')"
+      - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
+      - '@prestashop.router'
     calls:
       - { method: setTranslator, arguments: [ '@translator' ] }
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -987,7 +987,7 @@ services:
       - '@=service("prestashop.core.form.choice_provider.profile").getChoices()'
       - '@=service("prestashop.adapter.multistore_feature").isActive()'
       - "@=service('prestashop.adapter.legacy.configuration')"
-      - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
+      - !php/const _PS_ADMIN_PROFILE_
       - '@prestashop.router'
     calls:
       - { method: setTranslator, arguments: [ '@translator' ] }

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -85,6 +85,7 @@ services:
       - '@prestashop.core.query_bus'
       - '@=service("prestashop.adapter.multistore_feature").isActive()'
       - '@=service("prestashop.adapter.shop.context").getShops(true, true)'
+      - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
 
   prestashop.core.form.identifiable_object.data_provider.profile_form_data_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ProfileFormDataProvider'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -23,152 +23,30 @@
   * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
   *#}
 
+{% form_theme employeeForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 {% trans_default_domain 'Admin.Advparameters.Feature' %}
 
 {% block employee_form %}
   {{ form_start(employeeForm) }}
-    <div class="card">
-      <h3 class="card-header">
-        {{ 'Employees'|trans }}
-      </h3>
-      <div class="card-body">
-        <div class="form-wrapper">
-          {{ form_errors(employeeForm) }}
-
-          {{ ps.form_group_row(employeeForm.firstname, {}, {
-            'label': 'First name'|trans({}, 'Admin.Global')
-            }) }}
-
-          {{ ps.form_group_row(employeeForm.lastname, {}, {
-            'label': 'Last name'|trans({}, 'Admin.Global')
-            }) }}
-
-          {{ ps.form_group_row(employeeForm.avatarUrl, {}, {
-            'label': 'Avatar'|trans({}, 'Admin.Global')
-            }) }}
-
-          <div class="form-group row">
-            <label class="form-control-label"></label>
-            <div class="col-sm">
-              <img class="img-thumbnail clickable-avatar" src="{{ avatarUrl }}" alt="">
-            </div>
-          </div>
-
-          {{ ps.form_group_row(employeeForm.has_enabled_gravatar, {}, {
-            'label': 'Enable gravatar'|trans({}, 'Admin.Global')
-            }) }}
-
-          {{ ps.form_group_row(employeeForm.email, {}, {
-            'label': 'Email address'|trans({}, 'Admin.Global')
-            }) }}
-
-          {% set passwordHelpMessage = 'Password should be at least %num% characters long.'|trans({ '%num%': ('PS_SECURITY_PASSWORD_POLICY_MINIMUM_LENGTH'|configuration|intCast) }, 'Admin.Advparameters.Help') %}
-
-          {% if isRestrictedAccess %}
-            {% set oldPasswordVars = employeeForm.change_password.old_password.vars|merge(old_password|default({})) %}
-            {% set newPasswordFirstVars = employeeForm.change_password.new_password.children.first.vars|merge(new_password.first_options|default({})) %}
-            {% set newPasswordSecondVars = employeeForm.change_password.new_password.children.second.vars|merge(new_password.second_options|default({})) %}
-
-            <div class="form-group row">
-              <label class="form-control-label">
-                {{ 'Password'|trans({}, 'Admin.Global') }}
-              </label>
-              <div class="col-sm">
-                {# "Change password" button #}
-                {{ form_widget(employeeForm.change_password.change_password_button, {
-                  label: 'Change password...'|trans({}, 'messages'),
-                  attr: {
-                    class: 'btn-outline-secondary js-change-password',
-                  }
-                  }) }}
-
-                <div class="card card-body js-change-password-block d-none">
-                  {# Current password input #}
-                  {{ ps.form_group_row(employeeForm.change_password.old_password, oldPasswordVars, {
-                    label: 'Current password'|trans({}, 'messages'),
-                    required: true,
-                    }) }}
-
-                  {# New password first input #}
-                  <div class="form-group row">
-                    {{ ps.label_with_help('New password'|trans({}, 'messages'), passwordHelpMessage, '', employeeForm.change_password.new_password.children.first.vars.id, true) }}
-                    <div class="col-sm">
-                      {{ ps.form_widget_with_error(employeeForm.change_password.new_password.children.first, employeeForm.change_password.new_password.children.first.vars) }}
-                    </div>
-                  </div>
-
-                  {# New password second input (confirmation) #}
-                  {# Empty help text needed to render the text container for validation feedback messages #}
-                  {{ ps.form_group_row(employeeForm.change_password.new_password.children.second, newPasswordSecondVars, {
-                    label: 'Confirm password'|trans({}, 'messages'),
-                    help: '',
-                    required: true,
-                    }) }}
-
-                  {{ ps.form_group_row(employeeForm.change_password.cancel_button, {
-                    label: 'Cancel'|trans({}, 'Admin.Actions'),
-                    attr: {
-                      class: 'btn-outline-secondary js-change-password-cancel',
-                    }
-                    }) }}
-
-                </div>
-              </div>
-            </div>
-          {% else %}
-            {{ ps.form_group_row(employeeForm.password, {}, {
-              'label': 'Password'|trans({}, 'Admin.Global'),
-              'help': passwordHelpMessage,
-              }) }}
-          {% endif %}
-
-          {{ ps.form_group_row(employeeForm.language, {}, {
-            'label': 'Language'|trans({}, 'Admin.Global')
-            }) }}
-
-          {% if not isRestrictedAccess %}
-            {{ ps.form_group_row(employeeForm.active, {}, {
-              'label': 'Active'|trans({}, 'Admin.Global'),
-              'help': 'Allow or disallow this employee to log in to the Admin panel.'|trans({}, 'Admin.Advparameters.Help')
-              }) }}
-
-            {{ ps.form_group_row(employeeForm.profile, {
-              'attr': {
-                'data-admin-profile': superAdminProfileId,
-                'data-get-tabs-url': getTabsUrl,
-              }
-              }, {
-                'label': 'Permission profile'|trans({}, 'Admin.Advparameters.Feature')
-              }) }}
-
-            {% if employeeForm.shop_association is defined %}
-              {{ ps.form_group_row(employeeForm.shop_association, {}, {
-                'label': 'Shop association'|trans({}, 'Admin.Global'),
-                'help': 'Select the shops the employee is allowed to access.'|trans({}, 'Admin.Advparameters.Help')
-                }) }}
-            {% endif %}
-          {% endif %}
-
-          {{ ps.form_group_row(employeeForm.default_page, {'attr': {'data-minimumResultsForSearch': '7', 'data-toggle': 'select2'}}, {
-            'label': 'Default page'|trans,
-            'help': 'This page will be displayed right after signing in.'|trans({}, 'Admin.Advparameters.Help')
-            }) }}
-
-          {% block employee_form_rest %}
-            {{ form_rest(employeeForm) }}
-          {% endblock %}
-        </div>
-      </div>
-      <div class="card-footer">
-        <a href="{{ path('admin_employees_index') }}" class="btn btn-outline-secondary" id="cancel-link">
-          {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-        </a>
-        <button class="btn btn-primary float-right" id="save-button">
-          {{ 'Save'|trans({}, 'Admin.Actions') }}
-        </button>
+  <div class="card">
+    <h3 class="card-header">
+      {{ 'Employees'|trans }}
+    </h3>
+    <div class="card-body">
+      <div class="form-wrapper">
+        {{ form_widget(employeeForm) }}
       </div>
     </div>
+    <div class="card-footer">
+      <a href="{{ path('admin_employees_index') }}" class="btn btn-outline-secondary" id="cancel-link">
+        {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+      </a>
+      <button class="btn btn-primary float-right" id="save-button">
+        {{ 'Save'|trans({}, 'Admin.Actions') }}
+      </button>
+    </div>
+  </div>
   {{ form_end(employeeForm) }}
 
   {% include '@PrestaShop/Admin/Helpers/password_feedback.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/create.html.twig
@@ -28,17 +28,10 @@
 {% set layoutTitle = 'Add new'|trans({}, 'Admin.Actions') %}
 
 {% block content %}
-
   {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig' with {
-        employeeForm: employeeForm,
-        level: level,
-        errorMessage: errorMessage,
-        isRestrictedAccess: false,
-        superAdminProfileId: superAdminProfileId,
-        getTabsUrl: getTabsUrl,
-        avatarUrl: employeeForm.vars.defaultAvatarUrl
-      } %}
-
+    employeeForm: employeeForm,
+    isRestrictedAccess: false,
+  } %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/edit.html.twig
@@ -41,15 +41,9 @@
   {% endif %}
 
   {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig' with {
-        employeeForm: employeeForm,
-        level: level,
-        errorMessage: errorMessage,
-        isRestrictedAccess: isRestrictedAccess,
-        superAdminProfileId: superAdminProfileId,
-        getTabsUrl: getTabsUrl,
-        avatarUrl: editableEmployee.avatarUrl
-      } %}
-
+    employeeForm: employeeForm,
+    isRestrictedAccess: isRestrictedAccess
+  } %}
 {% endblock %}
 
 {% block javascripts %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/material.html.twig
@@ -25,25 +25,27 @@
 
 {% block material_choice_tree_widget %}
   <div class="material-choice-tree-container js-choice-tree-container{% if required %} required{% endif %}" id="{{ form.vars.id }}">
-  <div class="choice-tree-actions">
-    <span class="form-control-label js-toggle-choice-tree-action"
-          data-expanded-text="{{ 'Expand'|trans({}, 'Admin.Actions') }}"
-          data-expanded-icon="expand_more"
-          data-collapsed-text="{{ 'Collapse'|trans({}, 'Admin.Actions') }}"
-          data-collapsed-icon="expand_less"
-          data-action="expand"
-    >
-      <i class="material-icons">expand_more</i>
-      <span class="js-toggle-text">{{ 'Expand'|trans({}, 'Admin.Actions') }}</span>
-    </span>
+    <div class="choice-tree-actions">
+      <span class="form-control-label js-toggle-choice-tree-action"
+            data-expanded-text="{{ 'Expand'|trans({}, 'Admin.Actions') }}"
+            data-expanded-icon="expand_more"
+            data-collapsed-text="{{ 'Collapse'|trans({}, 'Admin.Actions') }}"
+            data-collapsed-icon="expand_less"
+            data-action="expand"
+      >
+        <i class="material-icons">expand_more</i>
+        <span class="js-toggle-text">{{ 'Expand'|trans({}, 'Admin.Actions') }}</span>
+      </span>
+    </div>
+
+    <ul class="choice-tree">
+      {% for choice in choices_tree %}
+        {{ block('material_choice_tree_item_widget') }}
+      {% endfor %}
+    </ul>
   </div>
 
-  <ul class="choice-tree">
-    {% for choice in choices_tree %}
-      {{ block('material_choice_tree_item_widget') }}
-    {% endfor %}
-  </ul>
-</div>
+  {{- block('form_help') -}}
 {% endblock material_choice_tree_widget %}
 
 {% block material_choice_tree_item_widget %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -87,6 +87,12 @@
   {{ block('form_help') }}
 {% endblock ip_address_text_widget %}
 
+{%- block password_widget -%}
+  {%- set type = type|default('password') -%}
+  {{ block('form_widget_simple') }}
+  {{ block('form_help') }}
+{%- endblock password_widget -%}
+
 {# Rows #}
 
 {% block form_row -%}
@@ -1489,6 +1495,57 @@
         {% endfor %}
       </div>
     {% endfor %}
+  </div>
+{% endblock %}
+
+{% block avatar_url_row %}
+  {{ form_row(form, {'attr': attr}) }}
+
+  <div class="form-group row">
+    <label class="form-control-label"></label>
+    <div class="col-sm">
+      <img class="img-thumbnail clickable-avatar" src="{{ form.parent.vars.value.avatar_url }}" alt="">
+    </div>
+  </div>
+{% endblock %}
+
+{% block change_password_row %}
+  <div class="form-group row">
+    <label class="form-control-label">
+      {{ 'Password'|trans({}, 'Admin.Global') }}
+    </label>
+    <div class="col-sm">
+      {# "Change password" button #}
+      {{ form_row(form.children.change_password_button) }}
+
+      <div class="card card-body js-change-password-block d-none">
+        {# Current password input #}
+        {{ form_row(form.children.old_password) }}
+
+        {# New password first input #}
+        {# New password second input (confirmation) #}
+        {{ form_row(form.children.new_password) }}
+
+        <div class="form-group row">
+          <label class="form-control-label"></label>
+          <div class="col-sm">
+            {{ form_widget(form.children.generated_password) }}
+          </div>
+          <div class="col-sm">
+            {{ form_widget(form.children.generate_password_button) }}
+          </div>
+        </div>
+        {{ form_row(form.children.cancel_button) }}
+
+        {# Password strength feedback messages - used in JS #}
+        <div class="js-password-strength-feedback d-none">
+          <span class="strength-low">{{ 'Invalid'|trans({}, 'Admin.Advparameters.Help') }}</span>
+          <span class="strength-medium">{{ 'Okay'|trans({}, 'Admin.Advparameters.Help') }}</span>
+          <span class="strength-high">{{ 'Good'|trans({}, 'Admin.Advparameters.Help') }}</span>
+          <span class="strength-extreme">{{ 'Fabulous'|trans({}, 'Admin.Advparameters.Help') }}</span>
+        </div>
+      </div>
+    </div>
   </div>
 {% endblock %}
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify Employee Form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Advanced Parameters -> Team -> Employees. Everything must look the same aside for help now appearing under inputs instead as blue box, also some fields now will appear as required because they always were.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/prestashop/prestashop/27892)
<!-- Reviewable:end -->
