### PR TITLE
Adjust footer on V2 product page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
@@ -94,10 +94,21 @@ $(() => {
   new PriceSummary(productFormModel);
 
   const $productFormSubmitButton = $(ProductMap.productFormSubmitButton);
+  const $productFormPreviewButton = $(ProductMap.footer.previewUrlButton);
+  const $productFormDuplicateButton = $(ProductMap.footer.duplicateProductButton);
+  const $productFormNewProductButton = $(ProductMap.footer.newProductButton);
+  const $productFormGoToCatalogButton = $(ProductMap.footer.goToCatalogButton);
+  const $productFormCancelButton = $(ProductMap.footer.cancelButton);
+
   new ProductPartialUpdater(
     eventEmitter,
     $productForm,
     $productFormSubmitButton,
+    $productFormPreviewButton,
+    $productFormDuplicateButton,
+    $productFormNewProductButton,
+    $productFormGoToCatalogButton,
+    $productFormCancelButton,
   ).watch();
 
   // From here we init component specific to edition

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-footer-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-footer-manager.ts
@@ -35,7 +35,7 @@ export default class ProductFooterManager {
   }
 
   private deleteProduct(): void {
-    const modal = new (ConfirmModal as any)(
+    const modal = new ConfirmModal(
       {
         id: 'modal-confirm-delete-product',
         confirmTitle: this.$deleteProductButton.data('modal-title'),
@@ -48,7 +48,13 @@ export default class ProductFooterManager {
       () => {
         const removeUrl = this.$deleteProductButton.data('removeUrl');
         $(ProductMap.productFormSubmitButton).prop('disabled', true);
-        window.location = removeUrl;
+
+        const form = document.createElement('form');
+        form.setAttribute('method', 'POST');
+        form.setAttribute('action', removeUrl);
+        form.setAttribute('style', 'display: none;');
+        document.body.appendChild(form);
+        form.submit();
       },
     );
     modal.show();

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-footer-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-footer-manager.ts
@@ -27,36 +27,37 @@ import ConfirmModal from '@components/modal';
 import ProductMap from '@pages/product/product-map';
 
 export default class ProductFooterManager {
-  $deleteProductButton: JQuery;
-
   constructor() {
-    this.$deleteProductButton = $(ProductMap.footer.deleteProductButton);
-    this.$deleteProductButton.click(() => this.deleteProduct());
+    this.initFooterButton(ProductMap.footer.deleteProductButton, ProductMap.footer.deleteProductModalId);
+    this.initFooterButton(ProductMap.footer.duplicateProductButton, ProductMap.footer.duplicateProductModalId);
   }
 
-  private deleteProduct(): void {
-    const modal = new ConfirmModal(
-      {
-        id: 'modal-confirm-delete-product',
-        confirmTitle: this.$deleteProductButton.data('modal-title'),
-        confirmMessage: this.$deleteProductButton.data('modal-message'),
-        confirmButtonLabel: this.$deleteProductButton.data('modal-apply'),
-        closeButtonLabel: this.$deleteProductButton.data('modal-cancel'),
-        confirmButtonClass: 'btn-danger',
-        closable: true,
-      },
-      () => {
-        const removeUrl = this.$deleteProductButton.data('removeUrl');
-        $(ProductMap.productFormSubmitButton).prop('disabled', true);
+  private initFooterButton(buttonId: string, modalId: string): void {
+    const $footerButton = $(buttonId);
+    $footerButton.on('click', () => {
+      const modal = new ConfirmModal(
+        {
+          id: modalId,
+          confirmTitle: $footerButton.data('modal-title'),
+          confirmMessage: $footerButton.data('modal-message'),
+          confirmButtonLabel: $footerButton.data('modal-apply'),
+          closeButtonLabel: $footerButton.data('modal-cancel'),
+          confirmButtonClass: $footerButton.data('confirm-button-class'),
+          closable: true,
+        },
+        () => {
+          const buttonUrl = $footerButton.data('buttonUrl');
+          $(ProductMap.productFormSubmitButton).prop('disabled', true);
 
-        const form = document.createElement('form');
-        form.setAttribute('method', 'POST');
-        form.setAttribute('action', removeUrl);
-        form.setAttribute('style', 'display: none;');
-        document.body.appendChild(form);
-        form.submit();
-      },
-    );
-    modal.show();
+          const form = document.createElement('form');
+          form.setAttribute('method', 'POST');
+          form.setAttribute('action', buttonUrl);
+          form.setAttribute('style', 'display: none;');
+          document.body.appendChild(form);
+          form.submit();
+        },
+      );
+      modal.show();
+    });
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-footer-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-footer-manager.ts
@@ -39,7 +39,7 @@ export default class ProductFooterManager {
         {
           id: modalId,
           confirmTitle: $footerButton.data('modal-title'),
-          confirmMessage: $footerButton.data('modal-message'),
+          confirmMessage: $footerButton.data('modal-message') ?? '',
           confirmButtonLabel: $footerButton.data('modal-apply'),
           closeButtonLabel: $footerButton.data('modal-cancel'),
           confirmButtonClass: $footerButton.data('confirm-button-class'),

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
@@ -46,17 +46,45 @@ export default class ProductPartialUpdater {
 
   $productFormSubmitButton: JQuery;
 
+  $productFormPreviewButton: JQuery;
+
+  $productFormDuplicateButton: JQuery;
+
+  $productFormNewProductButton: JQuery;
+
+  $productFormGoToCatalogButton: JQuery;
+
+  $productFormCancelButton: JQuery;
+
   initialData: Record<string, any>;
 
   /**
    * @param eventEmitter {EventEmitter}
    * @param $productForm {JQuery}
    * @param $productFormSubmitButton {JQuery}
+   * @param $productFormPreviewButton {JQuery}
+   * @param $productFormDuplicateButton {JQuery}
+   * @param $productFormNewProductButton {JQuery}
+   * @param $productFormGoToCatalogButton
    */
-  constructor(eventEmitter: EventEmitter, $productForm: JQuery, $productFormSubmitButton: JQuery) {
+  constructor(
+    eventEmitter: EventEmitter,
+    $productForm: JQuery,
+    $productFormSubmitButton: JQuery,
+    $productFormPreviewButton: JQuery,
+    $productFormDuplicateButton: JQuery,
+    $productFormNewProductButton: JQuery,
+    $productFormGoToCatalogButton: JQuery,
+    $productFormCancelButton: JQuery,
+  ) {
     this.eventEmitter = eventEmitter;
     this.$productForm = $productForm;
     this.$productFormSubmitButton = $productFormSubmitButton;
+    this.$productFormPreviewButton = $productFormPreviewButton;
+    this.$productFormDuplicateButton = $productFormDuplicateButton;
+    this.$productFormNewProductButton = $productFormNewProductButton;
+    this.$productFormGoToCatalogButton = $productFormGoToCatalogButton;
+    this.$productFormCancelButton = $productFormCancelButton;
     this.initialData = {};
   }
 
@@ -71,8 +99,8 @@ export default class ProductPartialUpdater {
     this.initialData = this.getFormDataAsObject();
     this.$productForm.submit(() => this.updatePartialForm());
     // 'dp.change' event allows tracking datepicker input changes
-    this.$productForm.on('keyup change dp.change', ':input', () => this.updateSubmitButtonState());
-    this.eventEmitter.on(ProductEventMap.updateSubmitButtonState, () => this.updateSubmitButtonState());
+    this.$productForm.on('keyup change dp.change', ':input', () => this.updateFooterButtonStates());
+    this.eventEmitter.on(ProductEventMap.updateSubmitButtonState, () => this.updateFooterButtonStates());
 
     this.watchCustomizations();
     this.watchCategories();
@@ -85,8 +113,8 @@ export default class ProductPartialUpdater {
    * @private
    */
   private watchCustomizations(): void {
-    this.eventEmitter.on(ProductEventMap.customizations.rowAdded, () => this.updateSubmitButtonState());
-    this.eventEmitter.on(ProductEventMap.customizations.rowRemoved, () => this.updateSubmitButtonState());
+    this.eventEmitter.on(ProductEventMap.customizations.rowAdded, () => this.updateFooterButtonStates());
+    this.eventEmitter.on(ProductEventMap.customizations.rowRemoved, () => this.updateFooterButtonStates());
   }
 
   /**
@@ -95,7 +123,7 @@ export default class ProductPartialUpdater {
    * @private
    */
   private watchCategories(): void {
-    this.eventEmitter.on(ProductEventMap.categories.categoriesUpdated, () => this.updateSubmitButtonState());
+    this.eventEmitter.on(ProductEventMap.categories.categoriesUpdated, () => this.updateFooterButtonStates());
   }
 
   /**
@@ -105,7 +133,7 @@ export default class ProductPartialUpdater {
    */
   private initFormattedTextarea(): void {
     this.eventEmitter.on('tinymceEditorSetup', (event) => {
-      event.editor.on('change', () => this.updateSubmitButtonState());
+      event.editor.on('change', () => this.updateFooterButtonStates());
     });
   }
 
@@ -186,9 +214,24 @@ export default class ProductPartialUpdater {
    *
    * @private
    */
-  private updateSubmitButtonState(): void {
+  private updateFooterButtonStates(): void {
     const updatedData = this.getUpdatedFormData();
-    this.$productFormSubmitButton.prop('disabled', updatedData === null);
+
+    if (updatedData === null) {
+      this.$productFormSubmitButton.prop('disabled', true);
+      this.$productFormCancelButton.addClass('disabled');
+      this.$productFormGoToCatalogButton.removeClass('disabled');
+      this.$productFormPreviewButton.removeClass('disabled');
+      this.$productFormDuplicateButton.removeClass('disabled');
+      this.$productFormNewProductButton.removeClass('disabled');
+    } else {
+      this.$productFormSubmitButton.prop('disabled', false);
+      this.$productFormCancelButton.removeClass('disabled');
+      this.$productFormGoToCatalogButton.addClass('disabled');
+      this.$productFormPreviewButton.addClass('disabled');
+      this.$productFormDuplicateButton.addClass('disabled');
+      this.$productFormNewProductButton.addClass('disabled');
+    }
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -224,7 +224,11 @@ export default {
   rightArrow: '.right-arrow',
   footer: {
     previewUrlButton: '.preview-url-button',
+    duplicateProductButton: '.duplicate-product-button',
     deleteProductButton: '.delete-product-button',
+    newProductButton: '.new-product-button',
+    goToCatalogButton: '.go-to-catalog-button',
+    cancelButton: '.cancel-button',
   },
   categories: {
     categoriesContainer: '#product_description_categories',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -50,7 +50,7 @@ export default {
     },
   },
   create: {
-    newProductButton: 'a.new-product',
+    newProductButton: '.new-product-button',
     createModalSelector: '#product_type',
   },
   invalidField: '.is-invalid',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -224,8 +224,10 @@ export default {
   rightArrow: '.right-arrow',
   footer: {
     previewUrlButton: '.preview-url-button',
-    duplicateProductButton: '.duplicate-product-button',
     deleteProductButton: '.delete-product-button',
+    deleteProductModalId: 'delete-product-footer-modal',
+    duplicateProductButton: '.duplicate-product-button',
+    duplicateProductModalId: 'duplicate-product-footer-modal',
     newProductButton: '.new-product-button',
     goToCatalogButton: '.go-to-catalog-button',
     cancelButton: '.cancel-button',

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -112,8 +112,8 @@ $product-page-padding-bottom: 80px !default;
   .product-header-v2 {
     display: flex;
     flex-direction: row;
-    gap: 1.5625rem;
-    padding: 0.625rem;
+    gap: 1rem;
+    padding: 0;
     margin: 1rem 0;
     background: $white;
     @include border-radius(0.375rem);
@@ -123,7 +123,7 @@ $product-page-padding-bottom: 80px !default;
       flex-grow: 1;
     }
 
-    $product-cover-size: 110px;
+    $product-cover-size: 130px;
 
     .product-header-cover {
       flex-grow: 0;
@@ -132,12 +132,17 @@ $product-page-padding-bottom: 80px !default;
 
       .form-group {
         margin-bottom: 0;
+
+        img {
+          @include border-left-radius(0.375rem);
+        }
       }
     }
 
     .product-header-form {
       flex-grow: 2;
       min-width: 35%;
+      padding: 0.625rem 0;
 
       > .form-group {
         margin-bottom: 0;
@@ -175,14 +180,16 @@ $product-page-padding-bottom: 80px !default;
     }
 
     .product-header-details {
-      padding: 1.125rem 1.125rem 0 0;
+      padding-top: 1.125rem;
 
       .product-header-summary {
+        position: relative;
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: flex-end;
         gap: 1rem;
+        padding-right: 1.125rem;
 
         .product-field-preview {
           display: flex;
@@ -212,6 +219,19 @@ $product-page-padding-bottom: 80px !default;
             }
           }
         }
+
+        &::after {
+          position: absolute;
+          right: 0;
+          bottom: -0.875rem;
+          left: 0;
+          content: " ";
+          border-style: solid;
+          border-width: 1px;
+          border-top: 0;
+          // stylelint-disable-next-line
+          border-image: linear-gradient(to left, #c6d5da, #fff) 1;
+        }
       }
 
       .product-header-references {
@@ -219,6 +239,7 @@ $product-page-padding-bottom: 80px !default;
         flex-direction: row;
         flex-wrap: wrap;
         justify-content: flex-end;
+        padding-right: 1.125rem;
         margin: 1.75rem 0 0;
         font-size: 0.875rem;
         font-weight: 400;

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -143,6 +143,27 @@ $product-page-padding-bottom: 80px !default;
         margin-bottom: 0;
       }
 
+      #product_header {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 0.5rem 1rem;
+
+        .header-name {
+          flex-basis: 100%;
+        }
+
+        .ps-switch {
+          /* This is a temporary fix, ps-switch component behaves poorly in a flex container this should be handled correctly in prestakit */
+          min-width: 7rem;
+          margin-top: 0;
+        }
+
+        .form-group {
+          margin-bottom: 0;
+        }
+      }
+
       .product-type-preview {
         color: $medium-gray;
         cursor: pointer;

--- a/src/Adapter/Shop/Url/ProductPreview.php
+++ b/src/Adapter/Shop/Url/ProductPreview.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Shop\Url;
+
+use Link;
+use PrestaShop\PrestaShop\Core\Shop\Url\UrlProviderInterface;
+use Tools;
+
+class ProductPreview implements UrlProviderInterface
+{
+    /**
+     * @var Link
+     */
+    protected $link;
+
+    /**
+     * @var int
+     */
+    protected $employeeId;
+
+    /**
+     * @var bool
+     */
+    private $urlRewritingIsEnabled;
+
+    public function __construct(
+        Link $link,
+        bool $urlRewritingIsEnabled,
+        int $employeeId
+    ) {
+        $this->link = $link;
+        $this->employeeId = $employeeId;
+        $this->urlRewritingIsEnabled = $urlRewritingIsEnabled;
+    }
+
+    /**
+     * Create a link to a product.
+     *
+     * @param int|null $productId
+     * @param bool $active
+     *
+     * @return string
+     */
+    public function getUrl(?int $productId = null, ?bool $active = true): string
+    {
+        $preview_url = $this->link->getProductLink(
+            $productId,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            $this->urlRewritingIsEnabled
+        );
+
+        if (!$active) {
+            $token = Tools::getAdminTokenLite('AdminProducts');
+            $preview_url = sprintf(
+                '%s%sadtoken=%s&id_employee=%d&preview=1',
+                $preview_url,
+                ((strpos($preview_url, '?') === false) ? '?' : '&'),
+                $token,
+                $this->employeeId
+            );
+        }
+
+        return $preview_url;
+    }
+}

--- a/src/Adapter/Shop/Url/ProductPreviewProvider.php
+++ b/src/Adapter/Shop/Url/ProductPreviewProvider.php
@@ -32,7 +32,7 @@ use Link;
 use PrestaShop\PrestaShop\Core\Shop\Url\UrlProviderInterface;
 use Tools;
 
-class ProductPreview implements UrlProviderInterface
+class ProductPreviewProvider implements UrlProviderInterface
 {
     /**
      * @var Link

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductStatusCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductStatusCommandsBuilder.php
@@ -38,10 +38,10 @@ class ProductStatusCommandsBuilder implements ProductCommandsBuilderInterface
      */
     public function buildCommands(ProductId $productId, array $formData): array
     {
-        if (!isset($formData['footer']['active'])) {
+        if (!isset($formData['header']['active'])) {
             return [];
         }
 
-        return [new UpdateProductStatusCommand($productId->getValue(), (bool) $formData['footer']['active'])];
+        return [new UpdateProductStatusCommand($productId->getValue(), (bool) $formData['header']['active'])];
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -119,9 +119,6 @@ class ProductFormDataProvider implements FormDataProviderInterface
             'seo' => $this->extractSEOData($productForEditing),
             'shipping' => $this->extractShippingData($productForEditing),
             'options' => $this->extractOptionsData($productForEditing),
-            'footer' => [
-                'active' => $productForEditing->isActive(),
-            ],
         ];
 
         if ($productForEditing->getType() === ProductType::TYPE_COMBINATIONS) {
@@ -244,6 +241,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
             'initial_type' => $productForEditing->getType(),
             'name' => $productForEditing->getBasicInformation()->getLocalizedNames(),
             'cover_thumbnail' => $productForEditing->getCoverThumbnailUrl(),
+            'active' => $productForEditing->isActive(),
         ];
     }
 

--- a/src/Core/Form/IdentifiableObject/OptionProvider/ProductFormOptionsProvider.php
+++ b/src/Core/Form/IdentifiableObject/OptionProvider/ProductFormOptionsProvider.php
@@ -28,6 +28,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\OptionProvider;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+
 /**
  * Provide dynamic complex options to the product type (like preview data that depend
  * on product current data, or specific options for inputs that are deep in the form
@@ -41,6 +43,7 @@ class ProductFormOptionsProvider implements FormOptionsProviderInterface
     public function getOptions(int $id, array $data): array
     {
         return [
+            'product_type' => $data['header']['type'] ?? ProductType::TYPE_STANDARD,
             'virtual_product_file_id' => $data['stock']['virtual_product_file']['virtual_product_file_id'] ?? null,
             'active' => $data['footer']['active'] ?? false,
         ];

--- a/src/Core/Form/IdentifiableObject/OptionProvider/ProductFormOptionsProvider.php
+++ b/src/Core/Form/IdentifiableObject/OptionProvider/ProductFormOptionsProvider.php
@@ -45,7 +45,7 @@ class ProductFormOptionsProvider implements FormOptionsProviderInterface
         return [
             'product_type' => $data['header']['type'] ?? ProductType::TYPE_STANDARD,
             'virtual_product_file_id' => $data['stock']['virtual_product_file']['virtual_product_file_id'] ?? null,
-            'active' => $data['footer']['active'] ?? false,
+            'active' => $data['header']['active'] ?? false,
         ];
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -504,8 +504,8 @@ class ProductController extends FrameworkBundleAdminController
             'href' => $this->generateUrl('admin_products_v2_create'),
             'desc' => $this->trans('New product', 'Admin.Actions'),
             'icon' => 'add_circle_outline',
-            'class' => 'btn-primary new-product',
-            'floating_class' => 'new-product',
+            'class' => 'btn-primary new-product-button',
+            'floating_class' => 'new-product-button',
         ];
 
         return $toolbarButtons;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Category/CategoriesType.php
@@ -100,11 +100,15 @@ class CategoriesType extends TranslatorAwareType
     public function configureOptions(OptionsResolver $resolver)
     {
         parent::configureOptions($resolver);
-        $resolver->setDefaults([
-            'label' => false,
-            'required' => false,
-            'product_id' => null,
-        ]);
-        $resolver->setAllowedTypes('product_id', ['int', 'null']);
+        $resolver
+            ->setDefaults([
+                'label' => false,
+                'required' => false,
+            ])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
+        ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
@@ -67,7 +67,9 @@ class BulkCombinationType extends TranslatorAwareType
                     'class' => 'bulk-combination-form',
                 ],
             ])
-            ->setRequired(['product_id'])
+            ->setRequired([
+                'product_id',
+            ])
             ->setAllowedTypes('product_id', 'int')
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationFormType.php
@@ -99,8 +99,10 @@ class CombinationFormType extends TranslatorAwareType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
-            ->setRequired(['product_id'])
-            ->setAllowedTypes('product_id', ['int'])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
             ->setDefaults([
                 'required' => false,
                 'label' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationImagesChoiceType.php
@@ -61,7 +61,9 @@ class CombinationImagesChoiceType extends TranslatorAwareType
     {
         parent::configureOptions($resolver);
         $resolver
-            ->setRequired('product_id')
+            ->setRequired([
+                'product_id',
+            ])
             ->setAllowedTypes('product_id', 'int')
             ->setDefaults([
                 'label' => $this->trans('Images', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
@@ -56,9 +56,11 @@ class CombinationManagerType extends TranslatorAwareType
             ->setDefaults([
                 'label' => $this->trans('Manage product combinations', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h2',
-                'product_id' => null,
             ])
-            ->setAllowedTypes('product_id', ['null', 'int'])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationsType.php
@@ -50,9 +50,11 @@ class CombinationsType extends TranslatorAwareType
             ->setDefaults([
                 'label' => false,
                 'required' => false,
-                'product_id' => null,
             ])
-            ->setAllowedTypes('product_id', ['null', 'int'])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/DescriptionType.php
@@ -167,11 +167,13 @@ class DescriptionType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver
             ->setDefaults([
-                'product_id' => null,
                 'required' => false,
                 'label' => false,
             ])
-            ->setAllowedTypes('product_id', ['null', 'int'])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EditProductFormType.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShopBundle\Form\Admin\Sell\Product\Combination\CombinationsType;
 use PrestaShopBundle\Form\Admin\Sell\Product\Description\DescriptionType;
 use PrestaShopBundle\Form\Admin\Sell\Product\Options\OptionsType;
@@ -74,7 +73,7 @@ class EditProductFormType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $productId = $options['product_id'] ?? null;
+        $productId = $options['product_id'];
         $builder
             ->add('header', HeaderType::class, [
                 'active' => $options['active'],
@@ -114,12 +113,9 @@ class EditProductFormType extends TranslatorAwareType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        // Important to get data from form and not options as it's the most up to date
-        $formData = $form->getData();
-        $productType = $formData['header']['type'] ?? ProductType::TYPE_STANDARD;
         $formVars = [
-            'product_type' => $productType,
-            'product_id' => $options['product_id'] ?? null,
+            'product_type' => $options['product_type'],
+            'product_id' => $options['product_id'],
         ];
 
         $view->vars = array_replace($view->vars, $formVars);
@@ -135,14 +131,16 @@ class EditProductFormType extends TranslatorAwareType
         // We must allow extra fields because when we switch product type some former fields may be present in request
         $resolver
             ->setDefaults([
-                'product_id' => null,
-                'product_type' => null,
                 'virtual_product_file_id' => null,
                 'active' => false,
                 'allow_extra_fields' => true,
             ])
-            ->setAllowedTypes('product_id', ['null', 'int'])
-            ->setAllowedTypes('product_type', ['null', 'string'])
+            ->setRequired([
+                'product_id',
+                'product_type',
+            ])
+            ->setAllowedTypes('product_id', 'int')
+            ->setAllowedTypes('product_type', 'string')
             ->setAllowedTypes('virtual_product_file_id', ['null', 'int'])
             ->setAllowedTypes('active', ['bool'])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -34,7 +34,6 @@ use PrestaShopBundle\Form\Admin\Type\IconButtonType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -112,7 +111,15 @@ class FooterType extends TranslatorAwareType
                 'icon' => 'content_copy',
                 'attr' => [
                     'class' => 'btn-outline-secondary duplicate-product-button',
-                    'href' => $duplicateUrl,
+                    'data-modal-title' => $this->trans('Duplicate this product.', 'Admin.Catalog.Help'),
+                    'data-modal-message' => $this->trans('Are you sure you want to duplicate this item?', 'Admin.Notifications.Warning'),
+                    'data-modal-apply' => $this->trans('Duplicate', 'Admin.Actions'),
+                    'data-modal-cancel' => $this->trans('Cancel', 'Admin.Actions'),
+                    'data-confirm-button-class' => 'btn-primary',
+                    'data-button-url' => $duplicateUrl,
+                    'data-toggle' => 'pstooltip',
+                    'data-placement' => 'left',
+                    'title' => $this->trans('Duplicate this product.', 'Admin.Catalog.Help'),
                 ],
             ])
             ->add('delete', IconButtonType::class, [
@@ -124,7 +131,8 @@ class FooterType extends TranslatorAwareType
                     'data-modal-message' => $this->trans('Are you sure you want to delete this item?', 'Admin.Notifications.Warning'),
                     'data-modal-apply' => $this->trans('Delete', 'Admin.Actions'),
                     'data-modal-cancel' => $this->trans('Cancel', 'Admin.Actions'),
-                    'data-remove-url' => $deleteUrl,
+                    'data-confirm-button-class' => 'btn-danger',
+                    'data-button-url' => $deleteUrl,
                     'data-toggle' => 'pstooltip',
                     'data-placement' => 'left',
                     'title' => $this->trans('Permanently delete this product.', 'Admin.Catalog.Help'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -108,7 +108,6 @@ class FooterType extends TranslatorAwareType
             ->add('duplicate_product', IconButtonType::class, [
                 'label' => $this->trans('Duplicate', 'Admin.Actions'),
                 'type' => 'link',
-                'icon' => 'content_copy',
                 'attr' => [
                     'class' => 'btn-outline-secondary duplicate-product-button',
                     'data-modal-title' => $this->trans('Duplicate this product.', 'Admin.Catalog.Help'),
@@ -123,7 +122,6 @@ class FooterType extends TranslatorAwareType
                 ],
             ])
             ->add('delete', IconButtonType::class, [
-                'icon' => 'delete',
                 'label' => $this->trans('Delete', 'Admin.Actions'),
                 'attr' => [
                     'class' => 'tooltip-link delete-product-button btn-outline-secondary',
@@ -141,7 +139,6 @@ class FooterType extends TranslatorAwareType
             ->add('new_product', IconButtonType::class, [
                 'label' => $this->trans('New product', 'Admin.Catalog.Feature'),
                 'type' => 'link',
-                'icon' => 'add_circle_outline',
                 'attr' => [
                     'class' => 'btn-outline-secondary new-product-button',
                     'href' => $this->router->generate('admin_products_v2_create'),
@@ -149,7 +146,6 @@ class FooterType extends TranslatorAwareType
             ])
             ->add('cancel', IconButtonType::class, [
                 'label' => $this->trans('Cancel', 'Admin.Actions'),
-                'icon' => 'undo',
                 'type' => 'link',
                 'attr' => [
                     'href' => $editUrl,
@@ -160,7 +156,6 @@ class FooterType extends TranslatorAwareType
             // These two inputs are displayed separately
             ->add('preview', IconButtonType::class, [
                 'label' => $this->trans('Preview', 'Admin.Actions'),
-                'icon' => 'remove_red_eye',
                 'type' => 'link',
                 'attr' => [
                     'target' => '_blank',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -84,7 +84,7 @@ class FooterType extends TranslatorAwareType
         $request = Request::createFromGlobals();
         $page = $request->query->get('page');
 
-        $productId = !empty($options['product_id']) ? (int) $options['product_id'] : null;
+        $productId = $options['product_id'];
         $deleteUrl = $productId ? $this->router->generate('admin_product_unit_action', [
             'action' => 'delete',
             'id' => $productId,
@@ -183,7 +183,6 @@ class FooterType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver
             ->setDefaults([
-                'product_id' => null,
                 'active' => false,
                 'required' => false,
                 'label' => false,
@@ -194,7 +193,10 @@ class FooterType extends TranslatorAwareType
                     'class' => 'product-footer-left',
                 ],
             ])
-            ->setAllowedTypes('product_id', ['null', 'int'])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
             ->setAllowedTypes('active', ['bool'])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -166,6 +166,7 @@ class FooterType extends TranslatorAwareType
                 'label' => $options['active'] ? $this->trans('Save and publish', 'Admin.Actions') : $this->trans('Save', 'Admin.Actions'),
                 'attr' => [
                     'data-toggle' => 'pstooltip',
+                    'accesskey' => 's',
                     'disabled' => true,
                     'title' => $this->trans('Save the product and stay on the current page: ALT+SHIFT+S', 'Admin.Catalog.Help'),
                     'class' => 'btn-primary product-form-save-button',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -81,20 +81,20 @@ class FooterType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $request = Request::createFromGlobals();
-        $page = $request->query->get('page');
-
         $productId = $options['product_id'];
-        $deleteUrl = $productId ? $this->router->generate('admin_product_unit_action', [
-            'action' => 'delete',
-            'id' => $productId,
-        ]) : null;
-        $seoUrl = $productId ? $this->productUrlProvider->getUrl($productId, '{friendly-url}') : null;
+
+        $deleteUrl = $this->router->generate('admin_products_v2_delete', [
+            'productId' => $productId,
+        ]);
+        $duplicateUrl = $this->router->generate('admin_products_v2_duplicate', [
+            'productId' => $productId,
+        ]);
+        $editUrl = $this->router->generate('admin_products_v2_edit', [
+            'productId' => $productId,
+        ]);
         $productPreviewUrl = $this->productPreviewUrlProvider->getUrl($productId, $options['active']);
-        $duplicateUrl = $productId ? $this->router->generate('admin_product_unit_action', [
-            'action' => 'duplicate',
-            'id' => $productId,
-        ]) : null;
+        // We use a placeholder {friendly-url} as the rewrite part so that it can be replaced dynamically by js
+        $seoUrl = $this->productUrlProvider->getUrl($productId, '{friendly-url}');
 
         $builder
             ->add('catalog', IconButtonType::class, [
@@ -111,7 +111,7 @@ class FooterType extends TranslatorAwareType
                 'type' => 'link',
                 'icon' => 'content_copy',
                 'attr' => [
-                    'class' => 'btn-outline-secondary  duplicate-product-button' . (empty($productId) ? ' disabled' : ''),
+                    'class' => 'btn-outline-secondary duplicate-product-button',
                     'href' => $duplicateUrl,
                 ],
             ])
@@ -128,7 +128,6 @@ class FooterType extends TranslatorAwareType
                     'data-toggle' => 'pstooltip',
                     'data-placement' => 'left',
                     'title' => $this->trans('Permanently delete this product.', 'Admin.Catalog.Help'),
-                    'disabled' => empty($productId),
                 ],
             ])
             ->add('new_product', IconButtonType::class, [
@@ -136,7 +135,7 @@ class FooterType extends TranslatorAwareType
                 'type' => 'link',
                 'icon' => 'add_circle_outline',
                 'attr' => [
-                    'class' => 'btn-outline-secondary new-product-button' . (empty($productId) ? ' disabled' : ''),
+                    'class' => 'btn-outline-secondary new-product-button',
                     'href' => $this->router->generate('admin_products_v2_create'),
                 ],
             ])
@@ -145,8 +144,8 @@ class FooterType extends TranslatorAwareType
                 'icon' => 'undo',
                 'type' => 'link',
                 'attr' => [
-                    'href' => $page,
-                    'class' => 'btn-secondary cancel-button' . (empty($productId) ? ' disabled' : ''),
+                    'href' => $editUrl,
+                    'class' => 'btn-secondary cancel-button',
                     'disabled' => true,
                 ],
             ])
@@ -158,7 +157,7 @@ class FooterType extends TranslatorAwareType
                 'attr' => [
                     'target' => '_blank',
                     'href' => $productPreviewUrl,
-                    'class' => 'btn-outline-secondary preview-url-button' . (empty($productId) ? ' disabled' : ''),
+                    'class' => 'btn-outline-secondary preview-url-button',
                     'data-seo-url' => $seoUrl,
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -31,10 +31,10 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product;
 use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductPreviewProvider;
 use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductProvider;
 use PrestaShopBundle\Form\Admin\Type\IconButtonType;
-use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -81,6 +81,9 @@ class FooterType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $request = Request::createFromGlobals();
+        $page = $request->query->get('page');
+
         $productId = !empty($options['product_id']) ? (int) $options['product_id'] : null;
         $deleteUrl = $productId ? $this->router->generate('admin_product_unit_action', [
             'action' => 'delete',
@@ -99,7 +102,7 @@ class FooterType extends TranslatorAwareType
                 'type' => 'link',
                 'icon' => 'arrow_back_ios',
                 'attr' => [
-                    'class' => 'btn-outline-secondary border-white',
+                    'class' => 'btn-outline-secondary border-white go-to-catalog-button',
                     'href' => $this->router->generate('admin_products_v2_index', ['offset' => 'last', 'limit' => 'last']),
                 ],
             ])
@@ -108,9 +111,8 @@ class FooterType extends TranslatorAwareType
                 'type' => 'link',
                 'icon' => 'content_copy',
                 'attr' => [
-                    'class' => 'btn-outline-secondary',
+                    'class' => 'btn-outline-secondary  duplicate-product-button' . (empty($productId) ? ' disabled' : ''),
                     'href' => $duplicateUrl,
-                    'disabled' => empty($productId),
                 ],
             ])
             ->add('delete', IconButtonType::class, [
@@ -134,9 +136,18 @@ class FooterType extends TranslatorAwareType
                 'type' => 'link',
                 'icon' => 'add_circle_outline',
                 'attr' => [
-                    'class' => 'btn-outline-secondary new-product',
+                    'class' => 'btn-outline-secondary new-product-button' . (empty($productId) ? ' disabled' : ''),
                     'href' => $this->router->generate('admin_products_v2_create'),
-                    'disabled' => empty($productId),
+                ],
+            ])
+            ->add('cancel', IconButtonType::class, [
+                'label' => $this->trans('Cancel', 'Admin.Actions'),
+                'icon' => 'undo',
+                'type' => 'link',
+                'attr' => [
+                    'href' => $page,
+                    'class' => 'btn-secondary cancel-button' . (empty($productId) ? ' disabled' : ''),
+                    'disabled' => true,
                 ],
             ])
             // These two inputs are displayed separately
@@ -147,16 +158,8 @@ class FooterType extends TranslatorAwareType
                 'attr' => [
                     'target' => '_blank',
                     'href' => $productPreviewUrl,
-                    'class' => 'btn-outline-secondary preview-url-button',
+                    'class' => 'btn-outline-secondary preview-url-button' . (empty($productId) ? ' disabled' : ''),
                     'data-seo-url' => $seoUrl,
-                    'disabled' => empty($productId),
-                ],
-            ])
-            ->add('active', SwitchType::class, [
-                'label' => false,
-                'choices' => [
-                    $this->trans('Offline', 'Admin.Global') => false,
-                    $this->trans('Online', 'Admin.Global') => true,
                 ],
             ])
             ->add('save', SubmitType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -110,30 +110,22 @@ class FooterType extends TranslatorAwareType
                 'type' => 'link',
                 'attr' => [
                     'class' => 'btn-outline-secondary duplicate-product-button',
-                    'data-modal-title' => $this->trans('Duplicate this product.', 'Admin.Catalog.Help'),
-                    'data-modal-message' => $this->trans('Are you sure you want to duplicate this item?', 'Admin.Notifications.Warning'),
+                    'data-modal-title' => $this->trans('Duplicate product?', 'Admin.Catalog.Notification'),
                     'data-modal-apply' => $this->trans('Duplicate', 'Admin.Actions'),
                     'data-modal-cancel' => $this->trans('Cancel', 'Admin.Actions'),
                     'data-confirm-button-class' => 'btn-primary',
                     'data-button-url' => $duplicateUrl,
-                    'data-toggle' => 'pstooltip',
-                    'data-placement' => 'left',
-                    'title' => $this->trans('Duplicate this product.', 'Admin.Catalog.Help'),
                 ],
             ])
             ->add('delete', IconButtonType::class, [
                 'label' => $this->trans('Delete', 'Admin.Actions'),
                 'attr' => [
                     'class' => 'tooltip-link delete-product-button btn-outline-secondary',
-                    'data-modal-title' => $this->trans('Permanently delete this product.', 'Admin.Catalog.Help'),
-                    'data-modal-message' => $this->trans('Are you sure you want to delete this item?', 'Admin.Notifications.Warning'),
+                    'data-modal-title' => $this->trans('Permanently delete this product?', 'Admin.Catalog.Notification'),
                     'data-modal-apply' => $this->trans('Delete', 'Admin.Actions'),
                     'data-modal-cancel' => $this->trans('Cancel', 'Admin.Actions'),
                     'data-confirm-button-class' => 'btn-danger',
                     'data-button-url' => $deleteUrl,
-                    'data-toggle' => 'pstooltip',
-                    'data-placement' => 'left',
-                    'title' => $this->trans('Permanently delete this product.', 'Admin.Catalog.Help'),
                 ],
             ])
             ->add('new_product', IconButtonType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -91,13 +91,6 @@ class HeaderType extends TranslatorAwareType
                 ],
                 'modify_all_shops' => true,
             ])
-            ->add('active', SwitchType::class, [
-                'label' => false,
-                'choices' => [
-                    $this->trans('Offline', 'Admin.Global') => false,
-                    $this->trans('Online', 'Admin.Global') => true,
-                ],
-            ])
             ->add('type', ProductTypeType::class, [
                 'attr' => [
                     'data-switch-modal-title' => $this->trans('Change the product type', 'Admin.Catalog.Notification'),
@@ -113,6 +106,13 @@ class HeaderType extends TranslatorAwareType
                     'data-stock-enabled' => $this->stockManagementEnabled,
                     'data-ecotax-enabled' => $this->isEcotaxEnabled,
                     'class' => 'header-product-type-selector',
+                ],
+            ])
+            ->add('active', SwitchType::class, [
+                'label' => false,
+                'choices' => [
+                    $this->trans('Offline', 'Admin.Global') => false,
+                    $this->trans('Online', 'Admin.Global') => true,
                 ],
             ])
             ->add('initial_type', HiddenType::class)

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShopBundle\Form\Admin\Type\ImagePreviewType;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -89,6 +90,13 @@ class HeaderType extends TranslatorAwareType
                     'class' => 'header-name',
                 ],
                 'modify_all_shops' => true,
+            ])
+            ->add('active', SwitchType::class, [
+                'label' => false,
+                'choices' => [
+                    $this->trans('Offline', 'Admin.Global') => false,
+                    $this->trans('Online', 'Admin.Global') => true,
+                ],
             ])
             ->add('type', ProductTypeType::class, [
                 'attr' => [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ImageDropzoneType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Image/ImageDropzoneType.php
@@ -90,7 +90,6 @@ class ImageDropzoneType extends TranslatorAwareType
                 'window.cover' => $this->trans('Cover', 'Admin.Catalog.Feature'),
                 'window.caption' => $this->trans('Caption', 'Admin.Catalog.Feature'),
             ],
-            'product_id' => null,
             'update_form_type' => null,
             'attr' => [
                 'class' => 'product-image-dropzone',
@@ -99,9 +98,14 @@ class ImageDropzoneType extends TranslatorAwareType
             'label' => false,
         ]);
 
-        $resolver->setAllowedTypes('product_id', ['int', 'null']);
-        $resolver->setAllowedTypes('update_form_type', ['string', 'null']);
-        $resolver->setAllowedTypes('translations', ['array']);
+        $resolver
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
+            ->setAllowedTypes('update_form_type', ['string', 'null'])
+            ->setAllowedTypes('translations', ['array'])
+        ;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
@@ -107,7 +107,7 @@ class RedirectOptionType extends TranslatorAwareType
                     'languageCode' => $this->employeeIsoCode,
                     'query' => '__QUERY__',
                 ]),
-                'filtered' => json_encode(!empty($options['product_id']) ? [$options['product_id']] : []),
+                'filtered' => json_encode([$options['product_id']]),
             ],
             'category' => [
                 'label' => $this->trans('Target category', 'Admin.Catalog.Feature'),
@@ -175,7 +175,6 @@ class RedirectOptionType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver
             ->setDefaults([
-                'product_id' => null,
                 'required' => false,
                 'label' => $this->trans('Redirection page', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
@@ -186,7 +185,10 @@ class RedirectOptionType extends TranslatorAwareType
                 ],
                 'alert_message' => $this->getRedirectionAlertMessages(),
             ])
-            ->setAllowedTypes('product_id', ['null', 'int'])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
         ;
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -249,13 +249,15 @@ class SEOType extends TranslatorAwareType
         parent::configureOptions($resolver);
         $resolver
             ->setDefaults([
-                'product_id' => null,
                 'label' => $this->trans('Search engine optimization', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
                 'label_subtitle' => $this->trans('Improve your ranking and how your product page will appear in search engines results.', 'Admin.Catalog.Feature'),
                 'required' => false,
             ])
-            ->setAllowedTypes('product_id', ['null', 'int'])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/QuantityType.php
@@ -74,8 +74,7 @@ class QuantityType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($this->stockManagementEnabled) {
-            $urlParameters = !empty($options['product_id']) ? ['productId' => (int) $options['product_id']] : [];
-            $stockMovementsUrl = $this->router->generate('admin_stock_movements_overview', $urlParameters);
+            $stockMovementsUrl = $this->router->generate('admin_stock_movements_overview', ['productId' => $options['product_id']]);
 
             $builder
                 ->add('delta_quantity', DeltaQuantityType::class, [
@@ -126,9 +125,11 @@ class QuantityType extends TranslatorAwareType
                 'label' => $this->trans('Quantities', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
                 'required' => false,
-                'product_id' => null,
             ])
-            ->setAllowedTypes('product_id', ['null', 'int'])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
         ;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/StockType.php
@@ -89,12 +89,14 @@ class StockType extends TranslatorAwareType
             ->setDefaults([
                 'label' => false,
                 'required' => false,
-                'product_id' => null,
                 'virtual_product_file_id' => null,
                 // Suppliers can be removed so there might be extra data during type switching
                 'allow_extra_fields' => true,
             ])
-            ->setAllowedTypes('product_id', ['null', 'int'])
+            ->setRequired([
+                'product_id',
+            ])
+            ->setAllowedTypes('product_id', 'int')
             ->setAllowedTypes('virtual_product_file_id', ['int', 'null'])
         ;
     }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
@@ -29,7 +29,14 @@ services:
   prestashop.adapter.shop.url.product_provider:
     class: 'PrestaShop\PrestaShop\Adapter\Shop\Url\ProductProvider'
     arguments:
+      - '@=service("prestashop.adapter.legacy.context").getContext().link'
+
+  prestashop.adapter.shop.url.product_preview_provider:
+    class: 'PrestaShop\PrestaShop\Adapter\Shop\Url\ProductPreviewProvider'
+    arguments:
       - "@=service('prestashop.adapter.legacy.context').getContext().link"
+      - '@=service("prestashop.adapter.legacy.configuration").getBoolean("PS_REWRITING_SETTINGS")'
+      - '@=service("prestashop.adapter.legacy.context").getContext().employee.id'
 
   prestashop.adapter.shop.query_handler.get_logos_paths_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Shop\QueryHandler\GetLogosPathsHandler'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1726,6 +1726,7 @@ services:
     public: true
     arguments:
       - '@prestashop.adapter.shop.url.product_provider'
+      - '@prestashop.adapter.shop.url.product_preview_provider'
       - '@router'
     tags:
       - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1317,7 +1317,6 @@ services:
     public: true
     arguments:
       - '@form.type.sell.product.event_listener.product_type_listener'
-      - '@prestashop.adapter.product.repository.product_repository'
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1317,6 +1317,7 @@ services:
     public: true
     arguments:
       - '@form.type.sell.product.event_listener.product_type_listener'
+      - '@prestashop.adapter.product.repository.product_repository'
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
@@ -29,6 +29,7 @@
       {# Only a few selected elements are in the right column #}
       <div class="form-group product-footer-right">
         <div id="product-footer-right" class="footer-buttons-container">
+          {{ form_row(productForm.footer.preview) }}
           {{ form_row(productForm.footer.active) }}
           {{ form_row(productForm.footer.save) }}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
@@ -37,7 +37,6 @@
 
       {# The rest is displayed in the left column, it is displayed after because it renders all that's left #}
       {{ form_row(productForm.footer) }}
-      {{ form_row(productForm.footer.cancel) }}
     </div>
   {% endblock %}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
@@ -30,13 +30,14 @@
       <div class="form-group product-footer-right">
         <div id="product-footer-right" class="footer-buttons-container">
           {{ form_row(productForm.footer.preview) }}
-          {{ form_row(productForm.footer.active) }}
           {{ form_row(productForm.footer.save) }}
+
         </div>
       </div>
 
       {# The rest is displayed in the left column, it is displayed after because it renders all that's left #}
       {{ form_row(productForm.footer) }}
+      {{ form_row(productForm.footer.cancel) }}
     </div>
   {% endblock %}
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
@@ -31,7 +31,6 @@
         <div id="product-footer-right" class="footer-buttons-container">
           {{ form_row(productForm.footer.preview) }}
           {{ form_row(productForm.footer.save) }}
-
         </div>
       </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/header.html.twig
@@ -29,7 +29,7 @@
   <div class="product-header-form">
     {% block product_header_form %}
       {% form_theme productForm.header '@PrestaShop/Admin/Sell/Catalog/Product/FormTheme/header.html.twig' %}
-          {{ form_row(productForm.header) }}
+      {{ form_row(productForm.header) }}
     {% endblock %}
   </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/header.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/header.html.twig
@@ -29,7 +29,7 @@
   <div class="product-header-form">
     {% block product_header_form %}
       {% form_theme productForm.header '@PrestaShop/Admin/Sell/Catalog/Product/FormTheme/header.html.twig' %}
-      {{ form_row(productForm.header) }}
+          {{ form_row(productForm.header) }}
     {% endblock %}
   </div>
 

--- a/tests/Integration/Adapter/Shop/Url/ProductPreviewProviderTest.php
+++ b/tests/Integration/Adapter/Shop/Url/ProductPreviewProviderTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Shop\Url;
+
+use Link;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductPreviewProvider;
+
+class ProductPreviewProviderTest extends TestCase
+{
+    public function testGetUrl(): void
+    {
+        $employeeId = 1;
+        $productId = 18;
+        $expectedUrlActive = 'http://superurl';
+        $linkMock = $this->createMock(Link::class);
+        $linkMock->method('getProductLink')
+            ->with($productId)
+            ->willReturn($expectedUrlActive)
+        ;
+        $provider = new ProductPreviewProvider($linkMock, true, $employeeId);
+        $generatedUrlActive = $provider->getUrl($productId, true);
+        $this->assertEquals($expectedUrlActive, $generatedUrlActive);
+
+        $expectedUrlInactive = 'http://superurl';
+        $linkMock = $this->createMock(Link::class);
+        $linkMock->method('getProductLink')
+            ->with($productId)
+            ->willReturn($expectedUrlInactive)
+        ;
+        $provider = new ProductPreviewProvider($linkMock, true, $employeeId);
+        $generatedUrlInactive = $provider->getUrl($productId, false);
+        $urlParts = parse_url($generatedUrlInactive);
+        parse_str($urlParts['query'], $queryParts);
+        $this->assertEquals('http', $urlParts['scheme']);
+        $this->assertEquals('superurl', $urlParts['host']);
+        $this->assertArrayHasKey('adtoken', $queryParts);
+        $this->assertArrayHasKey('id_employee', $queryParts);
+        $this->assertArrayHasKey('preview', $queryParts);
+        $this->assertEquals('1', $queryParts['id_employee']);
+        $this->assertEquals('1', $queryParts['preview']);
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductStatusCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductStatusCommandsBuilderTest.php
@@ -58,7 +58,7 @@ class ProductStatusCommandsBuilderTest extends AbstractProductCommandBuilderTest
         $command = new UpdateProductStatusCommand($this->getProductId()->getValue(), true);
         yield [
             [
-                'footer' => [
+                'header' => [
                     'active' => true,
                 ],
             ],
@@ -68,7 +68,7 @@ class ProductStatusCommandsBuilderTest extends AbstractProductCommandBuilderTest
         $command = new UpdateProductStatusCommand($this->getProductId()->getValue(), false);
         yield [
             [
-                'footer' => [
+                'header' => [
                     'active' => false,
                 ],
             ],

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -645,7 +645,7 @@ class ProductFormDataProviderTest extends TestCase
                 ),
             ],
         ];
-        $expectedOutputData['footer']['active'] = false;
+        $expectedOutputData['header']['active'] = false;
         $expectedOutputData['options']['visibility']['visibility'] = ProductVisibility::VISIBLE_IN_CATALOG;
         $expectedOutputData['options']['visibility']['available_for_order'] = false;
         $expectedOutputData['options']['visibility']['online_only'] = true;
@@ -1393,6 +1393,7 @@ class ProductFormDataProviderTest extends TestCase
                 'initial_type' => ProductType::TYPE_STANDARD,
                 'name' => [],
                 'cover_thumbnail' => self::COVER_URL,
+                'active' => true,
             ],
             'description' => [
                 'description' => [],
@@ -1500,9 +1501,6 @@ class ProductFormDataProviderTest extends TestCase
                     'supplier_ids' => [],
                 ],
                 'product_suppliers' => [],
-            ],
-            'footer' => [
-                'active' => true,
             ],
         ];
     }

--- a/tests/Unit/Core/Form/IdentifiableObject/OptionsProvider/ProductFormOptionsProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/OptionsProvider/ProductFormOptionsProviderTest.php
@@ -70,7 +70,7 @@ class ProductFormOptionsProviderTest extends TestCase
         $this->assertFalse($options['active']);
 
         $options = $provider->getOptions(self::PRODUCT_ID, [
-            'footer' => [
+            'header' => [
                 'active' => true,
             ],
         ]);

--- a/tests/Unit/Core/Form/IdentifiableObject/OptionsProvider/ProductFormOptionsProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/OptionsProvider/ProductFormOptionsProviderTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Form\IdentifiableObject\OptionsProvider;
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\OptionProvider\ProductFormOptionsProvider;
 
 class ProductFormOptionsProviderTest extends TestCase
@@ -75,5 +76,21 @@ class ProductFormOptionsProviderTest extends TestCase
         ]);
         $this->assertArrayHasKey('active', $options);
         $this->assertTrue($options['active']);
+    }
+
+    public function testProductTypeOption(): void
+    {
+        $provider = new ProductFormOptionsProvider();
+        $options = $provider->getOptions(self::PRODUCT_ID, []);
+        $this->assertArrayHasKey('product_type', $options);
+        $this->assertEquals(ProductType::TYPE_STANDARD, $options['product_type']);
+
+        $options = $provider->getOptions(self::PRODUCT_ID, [
+            'header' => [
+                'type' => ProductType::TYPE_COMBINATIONS,
+            ],
+        ]);
+        $this->assertArrayHasKey('product_type', $options);
+        $this->assertEquals(ProductType::TYPE_COMBINATIONS, $options['product_type']);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adjust footer on product page V2
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28411
| Related PRs       | 
| How to test?      | Compare feature an look'n'feel of the footer according specifications (Edit by @jolelievre : this PR mainly handles the preview button, moves it on the right and removes legacy switch buttons, so no need for exploratory tests Only the footer buttons should be tested, thanks ^^) (Edit 2: after discussion the online switch is now in the header)
| Possible impacts? | 

BC Breaks : 

in the constructor of FooterType
- add an injected parameter as ProductPreviewProvider

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
