### PR TITLE
Add a lock file during the install (and it's removed only if the install is well finished)

### DIFF
--- a/.github/workflows/phpstan/autoload.php
+++ b/.github/workflows/phpstan/autoload.php
@@ -136,6 +136,7 @@ $constantsToDefine = [
     '_THEME_SUP_DIR_' => 'string',
     '_THEME_PROFILE_DIR_' => 'string',
     '_THEMES_DIR_' => 'string',
+    'PS_INSTALLATION_LOCK_FILE' => 'string',
 ];
 
 foreach ($constantsToDefine as $key => $value) {

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -102,7 +102,12 @@ class AdminLoginControllerCore extends AdminController
             $this->context->smarty->assign('wrong_install_name', true);
         }
 
-        if (basename(_PS_ADMIN_DIR_) == 'admin' && file_exists(_PS_ADMIN_DIR_ . '/../admin/')) {
+        if (
+            // The install is well finished
+            !file_exists(_PS_ROOT_DIR_ . '/var/.install.prestashop')
+            && basename(_PS_ADMIN_DIR_) == 'admin'
+            && file_exists(_PS_ADMIN_DIR_ . '/../admin/')
+        ) {
             $rand = sprintf(
                 'admin%03d%s/',
                 mt_rand(0, 999),

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -116,6 +116,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
             $steps = ['database', 'modules', 'theme', 'fixtures', 'postInstall'];
         }
         if (!file_exists(PS_INSTALLATION_LOCK_FILE)) {
+            // Set the install lock file
             file_put_contents(PS_INSTALLATION_LOCK_FILE, '1');
         }
 

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -115,6 +115,9 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         if (in_array('all', $steps)) {
             $steps = ['database', 'modules', 'theme', 'fixtures', 'postInstall'];
         }
+        if (!file_exists(PS_INSTALLATION_LOCK_FILE)) {
+            file_put_contents(PS_INSTALLATION_LOCK_FILE, '1');
+        }
 
         if (in_array('database', $steps)) {
             if (!$this->processGenerateSettingsFile()) {

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -80,8 +80,6 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
 
         if (!$this->session->process_validated) {
             $this->session->process_validated = [];
-
-            file_put_contents(PS_INSTALLATION_LOCK_FILE, '1');
         }
 
         try {
@@ -140,6 +138,9 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
      */
     public function processGenerateSettingsFile()
     {
+        // Set the install lock file
+        file_put_contents(PS_INSTALLATION_LOCK_FILE, '1');
+
         $success = $this->model_install->generateSettingsFile(
             $this->session->database_server,
             $this->session->database_login,

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -80,6 +80,8 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
 
         if (!$this->session->process_validated) {
             $this->session->process_validated = [];
+
+            file_put_contents(PS_INSTALLATION_LOCK_FILE, '1');
         }
 
         try {

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -142,6 +142,7 @@ require_once _PS_CORE_DIR_.'/config/defines_uri.inc.php';
 
 // Generate common constants
 define('PS_INSTALLATION_IN_PROGRESS', true);
+define('PS_INSTALLATION_LOCK_FILE',  _PS_CORE_DIR_ . '/var/.install.prestashop');
 define('_PS_INSTALL_PATH_', dirname(__FILE__).'/');
 define('_PS_INSTALL_DATA_PATH_', _PS_INSTALL_PATH_.'data/');
 define('_PS_INSTALL_CONTROLLERS_PATH_', _PS_INSTALL_PATH_.'controllers/');

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1018,6 +1018,7 @@ class Install extends AbstractInstall
             return false;
         }
 
+        // Remove the install lock file
         return Tools::deleteFile(PS_INSTALLATION_LOCK_FILE);
     }
 

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1006,7 +1006,7 @@ class Install extends AbstractInstall
             return $module->get('name');
         }, iterator_to_array($moduleCollection));
 
-        return $this->executeAction(
+        if (!$this->executeAction(
             $modules,
             'postInstall',
             $this->translator->trans(
@@ -1014,7 +1014,11 @@ class Install extends AbstractInstall
                 ['%module%' => '%module%'],
                 'Install'
             )
-        );
+        )) {
+            return false;
+        }
+
+        return Tools::deleteFile(PS_INSTALLATION_LOCK_FILE);
     }
 
     protected function executeAction(array $modules, string $action, string $errorMessage): bool


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a lock file during the install
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28499
| How to test?      | * Install (normally) and the lock file `var/.install.prestashop` is removed<br />* Install (with making an error) and the lock file `var/.install.prestashop` remains present

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
