### PR TITLE
Fix showing price of customized products in Order Confirmation page

### DIFF
--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -178,7 +178,11 @@ class OrderLazyArray extends AbstractLazyArray
             $orderProduct['id_product_attribute'] = $orderProduct['product_attribute_id'];
 
             $productPrice = $includeTaxes ? 'product_price_wt' : 'product_price';
-            $totalPrice = $includeTaxes ? 'total_wt' : 'total_price';
+            if (is_array($orderProduct['customizedDatas']) && count($orderProduct['customizedDatas'])) {
+                $totalPrice = $includeTaxes ? 'total_customization_wt' : 'total_customization';
+            } else {
+                $totalPrice = $includeTaxes ? 'total_wt' : 'total_price';
+            }
 
             $orderProduct['price'] = $this->priceFormatter->format(
                 $orderProduct[$productPrice],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix showing zero price of customized product in Order Confirmation page. The bug is there for a long time. At lease since OrderLazyArray has been introduced. 
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #10912
| Related PRs       | 
| How to test?      | Add customized product to a cart (Customized mug in fresh installation) and finish the order. On Order Confirmation page there will be zero price next to customized product.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
