### PR TITLE
Add hook to allow additional search panels

### DIFF
--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -151,16 +151,24 @@ $(function() {
 
 {/if}
 <div class="row">
-    <div class="col-lg-6">
+    <div class="col-lg-{if $alternativeSearchPanels|@count == 0}6{else}4{/if}">
         <div class="panel">
             <h3>{l s='Search doc.prestashop.com' d='Admin.Navigation.Search'}</h3>
             <a href="https://doc.prestashop.com/dosearchsite.action?spaceSearch=true&amp;queryString={$query}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content=download" class="btn btn-default _blank">{l s='Go to the documentation' d='Admin.Navigation.Search'}</a>
         </div>
     </div>
-    <div class="col-lg-6">
+    <div class="col-lg-{if $alternativeSearchPanels|@count == 0}6{else}4{/if}">
         <div class="panel">
             <h3>{l s='Search prestashop.com forum' d='Admin.Navigation.Search'}</h3>
             <a href="https://www.google.fr/search?q=site%3Aprestashop.com%2Fforums%2F+{$query}" class="btn btn-default _blank">{l s='Go to the Forum' d='Admin.Navigation.Search'}</a>
         </div>
     </div>
+    {foreach $alternativeSearchPanels key=key item=alternativeSearchPanel}
+        <div class="col-lg-4">
+            <div class="panel">
+                <h3>{$alternativeSearchPanel->getTitle()}</h3>
+                <a href="{$alternativeSearchPanel->getLink()}" class="btn btn-default _blank">{$alternativeSearchPanel->getButtonLabel()}</a>
+            </div>
+        </div>
+    {/foreach}
 </div>

--- a/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/search/helpers/view/view.tpl
@@ -151,23 +151,11 @@ $(function() {
 
 {/if}
 <div class="row">
-    <div class="col-lg-{if $alternativeSearchPanels|@count == 0}6{else}4{/if}">
-        <div class="panel">
-            <h3>{l s='Search doc.prestashop.com' d='Admin.Navigation.Search'}</h3>
-            <a href="https://doc.prestashop.com/dosearchsite.action?spaceSearch=true&amp;queryString={$query}&amp;utm_source=back-office&amp;utm_medium=search&amp;utm_campaign=back-office-{$lang_iso|upper}&amp;utm_content=download" class="btn btn-default _blank">{l s='Go to the documentation' d='Admin.Navigation.Search'}</a>
-        </div>
-    </div>
-    <div class="col-lg-{if $alternativeSearchPanels|@count == 0}6{else}4{/if}">
-        <div class="panel">
-            <h3>{l s='Search prestashop.com forum' d='Admin.Navigation.Search'}</h3>
-            <a href="https://www.google.fr/search?q=site%3Aprestashop.com%2Fforums%2F+{$query}" class="btn btn-default _blank">{l s='Go to the Forum' d='Admin.Navigation.Search'}</a>
-        </div>
-    </div>
-    {foreach $alternativeSearchPanels key=key item=alternativeSearchPanel}
-        <div class="col-lg-4">
+    {foreach $searchPanels key=key item=searchPanel}
+        <div class="col-lg-{if $searchPanels|@count <= 2}6{else}4{/if}">
             <div class="panel">
-                <h3>{$alternativeSearchPanel->getTitle()}</h3>
-                <a href="{$alternativeSearchPanel->getLink()}" class="btn btn-default _blank">{$alternativeSearchPanel->getButtonLabel()}</a>
+                <h3>{$searchPanel.title}</h3>
+                <a href="{$searchPanel.link}" class="btn btn-default _blank">{$searchPanel.button_label}</a>
             </div>
         </div>
     {/foreach}

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -23,6 +23,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+use PrestaShop\PrestaShop\Core\Search\AlternativeSearchPanel;
+
 class AdminSearchControllerCore extends AdminController
 {
     const TOKEN_CHECK_START_POS = 34;
@@ -469,6 +472,24 @@ class AdminSearchControllerCore extends AdminController
             if ($this->isCountableAndNotEmpty($this->_list, 'modules')) {
                 $this->tpl_view_vars['modules'] = $this->_list['modules'];
             }
+
+            $alternativeSearchPanels = [];
+            $alternativeSearchPanelsFromModules = Hook::exec(
+                'actionGetAlternativeSearchPanels',
+                [],
+                null,
+                true
+            );
+
+            foreach ($alternativeSearchPanelsFromModules as $alternativeSearchPanelsFromModule) {
+                foreach ($alternativeSearchPanelsFromModule as $alternativeSearchPanel) {
+                    if ($alternativeSearchPanel instanceof AlternativeSearchPanel) {
+                        $alternativeSearchPanels[] = $alternativeSearchPanel;
+                    }
+                }
+            }
+
+            $this->tpl_view_vars['alternativeSearchPanels'] = $alternativeSearchPanels;
 
             return parent::renderView();
         }

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -486,24 +486,11 @@ class AdminSearchControllerCore extends AdminController
         // Build native search panels
         $searchPanels = [];
         $searchPanels[] = new SearchPanel(
-            $this->trans('Search doc.prestashop.com', [], 'Admin.Navigation.Search'),
+            $this->trans('Search docs.prestashop-project.org', [], 'Admin.Navigation.Search'),
             $this->trans('Go to the documentation', [], 'Admin.Navigation.Search'),
-            'https://doc.prestashop.com/dosearchsite.action',
+            'https://docs.prestashop-project.org/welcome/',
             [
-                'spaceSearch' => 'true',
-                'queryString' => $searchedExpression,
-                'utm_source' => 'back-office',
-                'utm_medium' => 'search',
-                'utm_campaign' => 'back-office-{$lang_iso|upper}',
-                'utm_content' => 'download',
-            ]
-        );
-        $searchPanels[] = new SearchPanel(
-            $this->trans('Search prestashop.com forum', [], 'Admin.Navigation.Search'),
-            $this->trans('Go to the Forum', [], 'Admin.Navigation.Search'),
-            'https://www.google.fr/search',
-            [
-                'q' => sprintf('site:prestashop.com/forums/ %s', $searchedExpression),
+                'q' => $searchedExpression,
             ]
         );
 
@@ -511,6 +498,7 @@ class AdminSearchControllerCore extends AdminController
         $alternativeSearchPanelsFromModules = Hook::exec(
             'actionGetAlternativeSearchPanels',
             [
+                'previous_search_panels' => $searchPanels,
                 'bo_query' => $searchedExpression,
             ],
             null,
@@ -531,7 +519,7 @@ class AdminSearchControllerCore extends AdminController
             $this->tpl_view_vars['searchPanels'][] = [
                 'title' => $searchPanel->getTitle(),
                 'button_label' => $searchPanel->getButtonLabel(),
-                'link' => $searchPanel->buildLink(),
+                'link' => $searchPanel->getLink(),
             ];
         }
     }

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -368,7 +368,8 @@ class AdminSearchControllerCore extends AdminController
 
     public function renderView()
     {
-        $this->tpl_view_vars['query'] = Tools::safeOutput($this->query);
+        $searchedExpression = Tools::safeOutput($this->query);
+        $this->tpl_view_vars['query'] = $searchedExpression;
         $this->tpl_view_vars['show_toolbar'] = true;
 
         if (count($this->errors)) {
@@ -476,7 +477,9 @@ class AdminSearchControllerCore extends AdminController
             $alternativeSearchPanels = [];
             $alternativeSearchPanelsFromModules = Hook::exec(
                 'actionGetAlternativeSearchPanels',
-                [],
+                [
+                    'bo_query' => $searchedExpression,
+                ],
                 null,
                 true
             );

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -3620,5 +3620,10 @@
       <title>Extra message to display for an empty modules category</title>
       <description>This hook allows to add an extra message to display in the Module manager page when a category doesn't have any module</description>
     </hook>
+    <hook id="actionGetAlternativeSearchPanels">
+      <name>actionGetAlternativeSearchPanels</name>
+      <title>Additional search panel</title>
+      <description>This hook allows to add an additional search panel for external providers in PrestaShop back office</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/src/Core/Search/AlternativeSearchPanel.php
+++ b/src/Core/Search/AlternativeSearchPanel.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Search;
+
+class AlternativeSearchPanel
+{
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var string
+     */
+    private $buttonLabel;
+
+    /**
+     * @var string
+     */
+    private $link;
+
+    /**
+     * @var array
+     */
+    private $queryParams;
+
+    public function __construct(
+        string $title,
+        string $buttonLabel,
+        string $link,
+        array $queryParams
+    ) {
+        $this->title = $title;
+        $this->buttonLabel = $buttonLabel;
+        $this->link = $link;
+        $this->queryParams = $queryParams;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getButtonLabel(): string
+    {
+        return $this->buttonLabel;
+    }
+
+    public function getLink(): string
+    {
+        return $this->link;
+    }
+
+    public function getQueryParams(): array
+    {
+        return $this->queryParams;
+    }
+}

--- a/src/Core/Search/SearchPanel.php
+++ b/src/Core/Search/SearchPanel.php
@@ -72,7 +72,7 @@ class SearchPanel implements SearchPanelInterface
         return $this->buttonLabel;
     }
 
-    public function buildLink(): string
+    public function getLink(): string
     {
         return sprintf('%s?%s', $this->link, http_build_query($this->queryParams));
     }

--- a/src/Core/Search/SearchPanel.php
+++ b/src/Core/Search/SearchPanel.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search;
+
+class SearchPanel implements SearchPanelInterface
+{
+    /**
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * @var string
+     */
+    protected $buttonLabel;
+
+    /**
+     * @var string
+     */
+    protected $link;
+
+    /**
+     * @var array
+     */
+    protected $queryParams;
+
+    public function __construct(
+        string $title,
+        string $buttonLabel,
+        string $link,
+        array $queryParams
+    ) {
+        $this->title = $title;
+        $this->buttonLabel = $buttonLabel;
+        $this->link = $link;
+        $this->queryParams = $queryParams;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getButtonLabel(): string
+    {
+        return $this->buttonLabel;
+    }
+
+    public function buildLink(): string
+    {
+        return sprintf('%s?%s', $this->link, http_build_query($this->queryParams));
+    }
+}

--- a/src/Core/Search/SearchPanelInterface.php
+++ b/src/Core/Search/SearchPanelInterface.php
@@ -32,5 +32,5 @@ interface SearchPanelInterface
 
     public function getButtonLabel(): string;
 
-    public function buildLink(): string;
+    public function getLink(): string;
 }

--- a/src/Core/Search/SearchPanelInterface.php
+++ b/src/Core/Search/SearchPanelInterface.php
@@ -26,57 +26,11 @@
 
 namespace PrestaShop\PrestaShop\Core\Search;
 
-class AlternativeSearchPanel
+interface SearchPanelInterface
 {
-    /**
-     * @var string
-     */
-    private $title;
+    public function getTitle(): string;
 
-    /**
-     * @var string
-     */
-    private $buttonLabel;
+    public function getButtonLabel(): string;
 
-    /**
-     * @var string
-     */
-    private $link;
-
-    /**
-     * @var array
-     */
-    private $queryParams;
-
-    public function __construct(
-        string $title,
-        string $buttonLabel,
-        string $link,
-        array $queryParams
-    ) {
-        $this->title = $title;
-        $this->buttonLabel = $buttonLabel;
-        $this->link = $link;
-        $this->queryParams = $queryParams;
-    }
-
-    public function getTitle(): string
-    {
-        return $this->title;
-    }
-
-    public function getButtonLabel(): string
-    {
-        return $this->buttonLabel;
-    }
-
-    public function getLink(): string
-    {
-        return $this->link;
-    }
-
-    public function getQueryParams(): array
-    {
-        return $this->queryParams;
-    }
+    public function buildLink(): string;
 }

--- a/tests/Integration/Controllers/AdminSearchControllerCoreTest.php
+++ b/tests/Integration/Controllers/AdminSearchControllerCoreTest.php
@@ -67,7 +67,13 @@ class AdminSearchControllerCoreTest extends TestCase
                     'query' => '',
                     'show_toolbar' => true,
                     'nb_results' => 0,
-                    'alternativeSearchPanels' => [],
+                    'searchPanels' => [
+                        [
+                            'title' => 'Search docs.prestashop-project.org',
+                            'button_label' => 'Go to the documentation',
+                            'link' => 'https://docs.prestashop-project.org/welcome/?q=',
+                        ],
+                    ],
                 ],
             ],
             [
@@ -83,7 +89,13 @@ class AdminSearchControllerCoreTest extends TestCase
                             ],
                         ],
                     ],
-                    'alternativeSearchPanels' => [],
+                    'searchPanels' => [
+                        [
+                            'title' => 'Search docs.prestashop-project.org',
+                            'button_label' => 'Go to the documentation',
+                            'link' => 'https://docs.prestashop-project.org/welcome/?q=orders',
+                        ],
+                    ],
                 ],
             ],
         ];

--- a/tests/Integration/Controllers/AdminSearchControllerCoreTest.php
+++ b/tests/Integration/Controllers/AdminSearchControllerCoreTest.php
@@ -67,6 +67,7 @@ class AdminSearchControllerCoreTest extends TestCase
                     'query' => '',
                     'show_toolbar' => true,
                     'nb_results' => 0,
+                    'alternativeSearchPanels' => [],
                 ],
             ],
             [
@@ -82,6 +83,7 @@ class AdminSearchControllerCoreTest extends TestCase
                             ],
                         ],
                     ],
+                    'alternativeSearchPanels' => [],
                 ],
             ],
         ];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow modules to add an additional search panel for external providers in PrestaShop back office
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28635
| How to test?      | You can use [prestashopexamplemodule.zip](https://github.com/PrestaShop/PrestaShop/files/8831410/prestashopexamplemodule.zip). Once installed, make a search in the header of the BO and you will see the extra search panel with a title, a button and a link



![Capture d’écran de 2022-05-16 11-45-30](https://user-images.githubusercontent.com/7426640/168585675-3c4cb92d-b3a1-4718-b45d-9ac2329933f8.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
