### PR TITLE
Empty state for combinations list

### DIFF
--- a/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
+++ b/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
@@ -151,8 +151,13 @@ export default class DynamicPaginator {
       this.selectorsMap.lastPageItem,
       page < this.pagesCount,
     );
+    this.toggleTargetAvailability(
+      this.selectorsMap.jumpToPageInput,
+      !(this.getCurrentPage() === 1 && this.getPagesCount() === 1),
+    );
 
     this.renderer.render(data);
+    this.$paginationContainer.toggleClass('d-none', this.getTotal() <= this.getMinLimit());
     this.renderer.setLoading(false);
 
     window.prestaShopUiKit.initToolTips();
@@ -265,11 +270,8 @@ export default class DynamicPaginator {
   ): void {
     const target = this.$paginationContainer.find(targetSelector);
 
-    if (enable) {
-      target.removeClass('disabled');
-    } else {
-      target.addClass('disabled');
-    }
+    target.toggleClass('disabled', !enable);
+    target.prop('disabled', !enable);
   }
 
   /**
@@ -295,6 +297,27 @@ export default class DynamicPaginator {
     return <number>(
       this.$paginationContainer.find(this.selectorsMap.limitSelect).val()
     );
+  }
+
+  /**
+   * @returns {Number}
+   *
+   * @private
+   */
+  private getMinLimit(): number {
+    const limitSelections = this.$paginationContainer.find(`${this.selectorsMap.limitSelect} option`).get();
+
+    const limitValues = limitSelections.map((option:HTMLElement) => {
+      if (!(option instanceof HTMLOptionElement)) {
+        console.error('Only <option> elements are expected in <select> for list limit choices');
+
+        return 0;
+      }
+
+      return Number(option.value);
+    });
+
+    return Math.min(...limitValues);
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
+++ b/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
@@ -153,7 +153,7 @@ export default class DynamicPaginator {
     );
     this.toggleTargetAvailability(
       this.selectorsMap.jumpToPageInput,
-      !(this.getCurrentPage() === 1 && this.getPagesCount() === 1),
+      this.getPagesCount() > 1,
     );
 
     this.renderer.render(data);

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -199,9 +199,6 @@ export default class CombinationsListRenderer {
     $combinationsTableBody.empty();
     this.emptyStateCallback(combinations.length === 0);
 
-    // this.getCombinationsTable().removeClass('d-none');
-    // $(CombinationsMap.combinationsPaginatedList).removeClass('d-none');
-
     let rowIndex = 0;
     combinations.forEach((combination: Record<string, any>) => {
       const $row = $(this.getPrototypeRow(rowIndex, combination));
@@ -219,9 +216,7 @@ export default class CombinationsListRenderer {
       rowIndex += 1;
     });
 
-    const rowsCount = rowIndex === 0 ? 0 : rowIndex += 1;
-
-    this.eventEmitter.emit(ProductEventMap.combinations.listRendered, {rowsCount});
+    this.eventEmitter.emit(ProductEventMap.combinations.listRendered);
   }
 
   private getPrototypeRow(rowIndex: number, combination: Record<string, any>): string {

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -60,10 +60,6 @@ export default class CombinationsListRenderer {
 
   private readonly $combinationsListContainer: JQuery;
 
-  private readonly $emptyState: JQuery
-
-  private readonly $emptyFiltersState: JQuery;
-
   private sortingEnabled = true;
 
   constructor(
@@ -78,8 +74,6 @@ export default class CombinationsListRenderer {
     this.emptyStateCallback = emptyStateCallback;
     this.$loadingSpinner = $(ProductMap.combinations.loadingSpinner);
     this.$combinationsListContainer = $(ProductMap.combinations.combinationsFormContainer);
-    this.$emptyState = $(CombinationsMap.emptyState);
-    this.$emptyFiltersState = $(CombinationsMap.emptyFiltersState);
 
     // We can't keep a reference on the table (or its content) since it can be updated via ajax, we always get it just in time
     const $combinationsTable = this.getCombinationsTable();

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
@@ -273,7 +273,6 @@ export default class CombinationsList {
   private emptyStateCallback(isEmpty: boolean): void {
     const hasFilters = Object.keys(this.paginatedCombinationsService.getFilters().attributes).length !== 0;
     const $combinationsTable = $(CombinationsMap.combinationsTable);
-    const $paginationContainer = $(CombinationsMap.paginationContainer);
 
     if (isEmpty) {
       // Toggle empty state. There are 2 different empty states:

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
@@ -282,15 +282,12 @@ export default class CombinationsList {
       this.$emptyState.toggleClass('d-none', hasFilters);
       this.$paginatedList.toggleClass('d-none', !hasFilters);
       this.$emptyFiltersState.toggleClass('d-none', !hasFilters);
-      $combinationsTable.toggleClass('d-none', hasFilters);
-      $paginationContainer.toggleClass('d-none', hasFilters);
     } else {
       // reset everything if combinations list is not empty
       this.$paginatedList.removeClass('d-none');
       this.$emptyState.addClass('d-none');
       this.$emptyFiltersState.addClass('d-none');
       $combinationsTable.removeClass('d-none');
-      $paginationContainer.removeClass('d-none');
     }
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/index.ts
@@ -69,6 +69,8 @@ export default class CombinationsList {
 
   private readonly $emptyState: JQuery;
 
+  private readonly $emptyFiltersState: JQuery;
+
   private readonly combinationsService: CombinationsService;
 
   private readonly paginatedCombinationsService: PaginatedCombinationsService;
@@ -102,6 +104,7 @@ export default class CombinationsList {
     this.$preloader = $(CombinationsMap.preloader);
     this.$paginatedList = $(CombinationsMap.combinationsPaginatedList);
     this.$emptyState = $(CombinationsMap.emptyState);
+    this.$emptyFiltersState = $(CombinationsMap.emptyFiltersState);
 
     this.initialized = false;
     this.combinationsService = new CombinationsService();
@@ -206,6 +209,7 @@ export default class CombinationsList {
       this.eventEmitter,
       this.productFormModel,
       (sortColumn: string, sorOrder: string) => this.sortList(sortColumn, sorOrder),
+      (isEmpty: boolean) => this.emptyStateCallback(isEmpty),
     );
     this.paginator = new DynamicPaginator(
       CombinationsMap.paginationContainer,
@@ -235,8 +239,6 @@ export default class CombinationsList {
   private async refreshCombinationList(firstTime: boolean): Promise<void> {
     // Preloader is only shown on first load
     this.$preloader.toggleClass('d-none', !firstTime);
-    this.$paginatedList.toggleClass('d-none', firstTime);
-    this.$emptyState.addClass('d-none');
 
     // Wait for product attributes to adapt rendering depending on their number
     this.productAttributeGroups = await getProductAttributeGroups(this.productId);
@@ -249,15 +251,6 @@ export default class CombinationsList {
     // the updateAttributeGroups event which is caught by this manager which will in turn refresh the list to first page
     this.eventEmitter.emit(CombinationEvents.clearFilters);
     this.$preloader.addClass('d-none');
-
-    const hasCombinations = this.productAttributeGroups && this.productAttributeGroups.length;
-    this.$paginatedList.toggleClass('d-none', !hasCombinations);
-
-    if (!hasCombinations && this.renderer) {
-      // Empty list
-      this.renderer.render({combinations: []});
-      this.$emptyState.removeClass('d-none');
-    }
   }
 
   private refreshPage(): void {
@@ -274,6 +267,30 @@ export default class CombinationsList {
     this.paginatedCombinationsService.setOrderBy(sortColumn, sortOrder);
     if (this.paginator) {
       this.paginator.paginate(1);
+    }
+  }
+
+  private emptyStateCallback(isEmpty: boolean): void {
+    const hasFilters = Object.keys(this.paginatedCombinationsService.getFilters().attributes).length !== 0;
+    const $combinationsTable = $(CombinationsMap.combinationsTable);
+    const $paginationContainer = $(CombinationsMap.paginationContainer);
+
+    if (isEmpty) {
+      // Toggle empty state. There are 2 different empty states:
+      //   1. when product has no combinations at all
+      //   2. when combinations are not found by certain filters
+      this.$emptyState.toggleClass('d-none', hasFilters);
+      this.$paginatedList.toggleClass('d-none', !hasFilters);
+      this.$emptyFiltersState.toggleClass('d-none', !hasFilters);
+      $combinationsTable.toggleClass('d-none', hasFilters);
+      $paginationContainer.toggleClass('d-none', hasFilters);
+    } else {
+      // reset everything if combinations list is not empty
+      this.$paginatedList.removeClass('d-none');
+      this.$emptyState.addClass('d-none');
+      this.$emptyFiltersState.addClass('d-none');
+      $combinationsTable.removeClass('d-none');
+      $paginationContainer.removeClass('d-none');
     }
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -80,6 +80,7 @@ export default {
     externalCombinationTab: '#external-combination-tab',
     preloader: '#combinations-preloader',
     emptyState: '#combinations-empty-state',
+    emptyFiltersState: '#combinations-empty-filters-state',
     combinationsPaginatedList: '#combinations-paginated-list',
     combinationsFormContainer: '#combinations-list-form-container',
     combinationsFiltersContainer: '#combinations_filters',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/empty_filters_state.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/empty_filters_state.html.twig
@@ -23,10 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<div id="combinations-empty-filters-state" class="d-none">
-  <div class="text-center showcase-list-card">
-    <img alt="{{ 'There are no combinations by these filters'|trans({}, 'Admin.Catalog.Feature') }}" title="{{ 'Loading combinations'|trans({}, 'Admin.Catalog.Feature') }}" class="img-responsive mt-3 img-rtl" src="{{ asset('themes/new-theme/img/empty_state/combinations.svg') }}">
-
-    <p class="mt-4 showcase-list-card__header">{{ 'There are no combinations by these filters'|trans({}, 'Admin.Catalog.Feature') }}</p>
-  </div>
+<div id="combinations-empty-filters-state" class="text-center grid-table-empty">
+  <p class="mb-0 mt-2"><i class="material-icons">warning</i></p>
+  <p class="mb-2">{{ 'No records found'|trans({}, 'Admin.Global') }}</p>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/empty_filters_state.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/empty_filters_state.html.twig
@@ -1,0 +1,32 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+<div id="combinations-empty-filters-state" class="d-none">
+  <div class="text-center showcase-list-card">
+    <img alt="{{ 'There are no combinations by these filters'|trans({}, 'Admin.Catalog.Feature') }}" title="{{ 'Loading combinations'|trans({}, 'Admin.Catalog.Feature') }}" class="img-responsive mt-3 img-rtl" src="{{ asset('themes/new-theme/img/empty_state/combinations.svg') }}">
+
+    <p class="mt-4 showcase-list-card__header">{{ 'There are no combinations by these filters'|trans({}, 'Admin.Catalog.Feature') }}</p>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/paginated_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/paginated_list.html.twig
@@ -31,15 +31,14 @@
     }) }}
 
     <div class="justify-content-center" id="combinations-list">
-      {# Empty state when product has no combinations by specified filters #}
-      {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Combination/empty_filters_state.html.twig') }}
-
       <div class="spinner-product-combinations-container" id="productCombinationsLoading">
         <div class="spinner spinner-primary"></div>
       </div>
 
       <div id="combinations-list-form-container">
         {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Combination/combination_list_form.html.twig', {'combinationsForm': combinationsForm}) }}
+        {# Empty state when product has no combinations by specified filters #}
+        {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Combination/empty_filters_state.html.twig') }}
       </div>
 
       <div id="combinations-list-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/paginated_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/paginated_list.html.twig
@@ -31,6 +31,9 @@
     }) }}
 
     <div class="justify-content-center" id="combinations-list">
+      {# Empty state when product has no combinations by specified filters #}
+      {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Combination/empty_filters_state.html.twig') }}
+
       <div class="spinner-product-combinations-container" id="productCombinationsLoading">
         <div class="spinner spinner-primary"></div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/paginated_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/paginated_list.html.twig
@@ -35,11 +35,16 @@
         <div class="spinner spinner-primary"></div>
       </div>
 
+      {#**
+        * This div contains the whole list with the input fields, it should contain nothing more because the whole
+        * content may be replaced when invalid form values are detected by the update list API in edition mode.
+      *#}
       <div id="combinations-list-form-container">
         {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Combination/combination_list_form.html.twig', {'combinationsForm': combinationsForm}) }}
-        {# Empty state when product has no combinations by specified filters #}
-        {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Combination/empty_filters_state.html.twig') }}
       </div>
+
+      {# Empty state when product has no combinations by specified filters #}
+      {{ include('@PrestaShop/Admin/Sell/Catalog/Product/Combination/empty_filters_state.html.twig') }}
 
       <div id="combinations-list-footer">
         <span>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Introduce second empty state for combinations list. One state was shown when product wouldn't have any combinations at all. Now another one is shown when combinations are not found by filters (see screenshots bellow). Also hide pagination when total records are less or equal to a minimum selection of records per page.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | #28459
| How to test?      | TBD
| Possible impacts? | 

**Screenshots**

1. ![Screenshot from 2022-05-16 15-22-05](https://user-images.githubusercontent.com/31609858/168592106-535d7274-dfee-4e4d-b61e-2981930afaef.png)

2. ![Screenshot from 2022-05-16 16-40-39](https://user-images.githubusercontent.com/31609858/168606030-25ee6974-807e-4953-88df-3bb9dd379d53.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
