### PR TITLE
Prevent using period, comma keys inside quantity input

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/spinner.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/spinner.vue
@@ -41,6 +41,7 @@
       :value="getQuantity()"
       @change="onChange"
       @keyup="onKeyup($event)"
+      @keydown="onKeydown($event)"
       @focus="focusIn"
       @blur="focusOut($event)"
     />
@@ -96,6 +97,11 @@
         this.isEnabled = false;
         this.value = '';
         this.product.qty = null;
+      },
+      onKeydown(event: KeyboardEvent): void {
+        if (event.key === '.' || event.key === ',') {
+          event.preventDefault();
+        }
       },
       onKeyup(event: Event): void {
         const val = (<HTMLInputElement>event.target).value;

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/spinner.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/spinner.vue
@@ -98,6 +98,7 @@
         this.value = '';
         this.product.qty = null;
       },
+      // @see Preventing decimal numbers inside input: https://github.com/PrestaShop/PrestaShop/pull/28510
       onKeydown(event: KeyboardEvent): void {
         if (event.key === '.' || event.key === ',') {
           event.preventDefault();

--- a/admin-dev/themes/new-theme/js/app/widgets/ps-number.vue
+++ b/admin-dev/themes/new-theme/js/app/widgets/ps-number.vue
@@ -35,8 +35,9 @@
       :value="value"
       placeholder="0"
       @keyup="onKeyup($event)"
+      @keydown="onKeydown($event)"
       @focus="focusIn"
-      @blur.native="focusOut($event)"
+      @blur="focusOut($event)"
     >
     <div
       class="ps-number-spinner d-flex"
@@ -79,6 +80,9 @@
     methods: {
       onKeyup($event: JQueryEventObject): void {
         this.$emit('keyup', $event);
+      },
+      onKeydown($event: JQueryEventObject): void {
+        this.$emit('keydown', $event);
       },
       focusIn(): void {
         this.$emit('focus');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | It's probably better to prevent using  these keys instead of forcing browser to validate fields
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9616.
| How to test?      | Details in the issue. You shouldn't be able to use `,` or `.` inside qty field anymore
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
