### PR TITLE
Remove final class from attachment uploader

### DIFF
--- a/src/Adapter/File/Uploader/AttachmentFileUploader.php
+++ b/src/Adapter/File/Uploader/AttachmentFileUploader.php
@@ -40,21 +40,23 @@ use Symfony\Component\HttpFoundation\File\Exception\FileException;
 
 /**
  * Uploads attachment file and if needed deletes old attachment file
- *
- * @internal
  */
-final class AttachmentFileUploader implements AttachmentFileUploaderInterface
+class AttachmentFileUploader implements AttachmentFileUploaderInterface
 {
     /**
      * @var ConfigurationInterface
      */
-    private $configuration;
+    protected $configuration;
 
     /**
      * @var UploadSizeConfigurationInterface
      */
-    private $uploadSizeConfiguration;
+    protected $uploadSizeConfiguration;
 
+    /**
+     * @param ConfigurationInterface $configuration
+     * @param UploadSizeConfigurationInterface $uploadSizeConfiguration
+     */
     public function __construct(
         ConfigurationInterface $configuration,
         UploadSizeConfigurationInterface $uploadSizeConfiguration
@@ -66,6 +68,8 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     /**
      * {@inheritdoc}
      *
+     * @param bool $throwExceptionOnFailure
+     *
      * @throws AttachmentConstraintException
      * @throws AttachmentNotFoundException
      * @throws AttachmentUploadFailedException
@@ -75,7 +79,7 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
         string $uniqueFileName,
         int $fileSize,
         int $id = null,
-        $throwExceptionOnFailure = true
+        bool $throwExceptionOnFailure = true
     ): void {
         $this->checkFileAllowedForUpload($fileSize);
         $this->uploadFile($filePath, $uniqueFileName, $fileSize);
@@ -85,12 +89,13 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     }
 
     /**
+     * @param int $attachmentId
      * @param bool $throwExceptionOnFailure
      *
      * @throws AttachmentNotFoundException
      * @throws CannotUnlinkAttachmentException
      */
-    private function deleteOldFile(int $attachmentId, $throwExceptionOnFailure): void
+    protected function deleteOldFile(int $attachmentId, bool $throwExceptionOnFailure): void
     {
         try {
             $attachment = new Attachment($attachmentId);
@@ -109,10 +114,14 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     }
 
     /**
+     * @param string $filePath
+     * @param string $uniqid
+     * @param int $fileSize
+     *
      * @throws AttachmentConstraintException
      * @throws AttachmentUploadFailedException
      */
-    private function uploadFile(string $filePath, string $uniqid, int $fileSize): void
+    protected function uploadFile(string $filePath, string $uniqid, int $fileSize): void
     {
         if ($fileSize > ($this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') * 1024 * 1024)) {
             throw new AttachmentConstraintException(
@@ -133,9 +142,11 @@ final class AttachmentFileUploader implements AttachmentFileUploaderInterface
     }
 
     /**
+     * @param int $fileSize
+     *
      * @throws AttachmentConstraintException
      */
-    private function checkFileAllowedForUpload(int $fileSize): void
+    protected function checkFileAllowedForUpload(int $fileSize): void
     {
         $maxFileSize = $this->uploadSizeConfiguration->getMaxUploadSizeInBytes();
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | After uploading files you need to do some actions with file, or do some modification. PrestaShop in version 1.7 / 8 doesn not contain any hook for this operation and it is not needed. You can do it using services.yml but only if core class is not final & `@internal`. This change allows you to override this class using module services.yml.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to do symfony override from module using services.yml


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
