### PR TITLE
Fix select2 style in order view

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -85,6 +85,20 @@
   }
 
   // Todo: Looks like we don't have any custom select without JS to add in a form
+  // Please notice that you have two different select2 component inside order view
+  .select2-container,
+  .select2-selection {
+    min-width: 36ch;
+    height: 100%;
+  }
+
+  .select-status-colored,
+  .select2-selection {
+    display: flex;
+    align-items: center;
+    padding: 0.375rem 2.2rem 0.375rem 0.4375rem;
+  }
+
   .select-status {
     position: relative;
     max-width: 280px;
@@ -94,11 +108,6 @@
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.1);
     @include transition(0.2s ease-out);
 
-    .select2-container,
-    .select2-selection {
-      height: 100%;
-    }
-
     .select2-selection__rendered,
     .select2-selection__arrow b::after {
       color: $white;
@@ -106,9 +115,6 @@
 
     .select-status-colored,
     .select2-selection {
-      display: flex;
-      align-items: center;
-      padding: 0.375rem 2.2rem 0.375rem 0.4375rem;
       color: $white;
       background: none;
       border: none;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fix second select2 component arrow of order view and add min-width attribute for select2 components (evaluated to `Awaiting Cash On Delivery validation` size.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28405 and #28494.
| Related PRs       | #28066
| How to test?      | cf. #28494 
| Possible impacts? | Please test all select2 components of order view.