### PR TITLE
Fix bug with all shops context in WebService

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -396,7 +396,9 @@ class ShopCore extends ObjectModel
             Configuration::getMultiShopValues('PS_MEDIA_SERVER_3')
         );
 
-        if ((!$id_shop && defined('_PS_ADMIN_DIR_')) || Tools::isPHPCLI() || in_array($http_host, $all_media)) {
+        $isAllShop = 'all' === $id_shop;
+        $isApiInUse = defined('_PS_API_IN_USE_') && _PS_API_IN_USE_;
+        if ((!$id_shop && defined('_PS_ADMIN_DIR_')) || ($isAllShop && $isApiInUse) || Tools::isPHPCLI() || in_array($http_host, $all_media)) {
             // If in admin, we can access to the shop without right URL
             if ((!$id_shop && Tools::isPHPCLI()) || defined('_PS_ADMIN_DIR_')) {
                 $id_shop = (int) Configuration::get('PS_SHOP_DEFAULT');

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -28,6 +28,10 @@ use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
 
 ob_start();
 
+if (!defined('_PS_API_IN_USE_')) {
+    define('_PS_API_IN_USE_', true);
+}
+
 require_once dirname(__FILE__) . '/../config/config.inc.php';
 
 // Cart is needed for some requests


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In this PR I introduce a new constant `_PS_API_IN_USE_` to allow PrestaShop to detect calls to webservice in multistore and avoid redirecting them.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #12412
| Related PRs       | 
| How to test?      | Follow instructions in issue report
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
