### PR TITLE
Fix WebserviceOutputBuilder - handle api categories blank schema

### DIFF
--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -664,10 +664,8 @@ class WebserviceOutputBuilderCore
                             continue;
                         }
                         $value = $object_assoc;
-                        if (empty($fields_assoc)) {
-                            if (!empty($value['id'])) {
-                                $fields_assoc = [['id' => $value['id']]];
-                            }
+                        if (empty($fields_assoc) && !empty($value['id'])) {
+                            $fields_assoc = [['id' => $value['id']]];
                         }
                         $output_details .= $this->renderFlatAssociation($object, $depth, $assoc_name, $association['resource'], $fields_assoc, $value, $parent_details);
                     } else {

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -660,12 +660,12 @@ class WebserviceOutputBuilderCore
                 $output_details = '';
                 foreach ($objects_assoc as $object_assoc) {
                     if ($depth == 0 || $class_name === null) {
-                        $value = null;
-                        if (!empty($object_assoc)) {
-                            $value = $object_assoc;
+                        if (empty($object_assoc)) {
+                            continue;
                         }
+                        $value = $object_assoc;
                         if (empty($fields_assoc)) {
-                            if (!empty($value)) {
+                            if (!empty($value['id'])) {
                                 $fields_assoc = [['id' => $value['id']]];
                             }
                         }

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -665,7 +665,9 @@ class WebserviceOutputBuilderCore
                             $value = $object_assoc;
                         }
                         if (empty($fields_assoc)) {
-                            $fields_assoc = [['id' => $value['id']]];
+                            if (!empty($value)) {
+                                $fields_assoc = [['id' => $value['id']]];
+                            }
                         }
                         $output_details .= $this->renderFlatAssociation($object, $depth, $assoc_name, $association['resource'], $fields_assoc, $value, $parent_details);
                     } else {


### PR DESCRIPTION
Validation of category association id

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Resolve 'Trying to access array offset on value of type null' in calling api categories blank schema
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28543
| How to test?      | Follow above ticket steps. Call a blank schema of Categories in a shop with Categories tree level depth > 1
| Possible impacts? | Categories API


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
