### PR TITLE
Remove deprecated in Cart model

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -5070,41 +5070,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Execute hook displayCarrierList (extraCarrier) and merge them into the $array.
-     *
-     * @deprecated since 1.7.6.0.
-     * @see https://github.com/PrestaShop/PrestaShop/issues/10979
-     *
-     * @param array $array
-     */
-    public static function addExtraCarriers(&$array)
-    {
-        @trigger_error(
-            __FUNCTION__ . 'is deprecated since version 1.7.6.0 and will be removed in the next major version.',
-            E_USER_DEPRECATED
-        );
-
-        $first = true;
-        $hook_extracarrier_addr = [];
-        foreach (Context::getContext()->cart->getAddressCollection() as $address) {
-            $hook = Hook::exec('displayCarrierList', ['address' => $address]);
-            $hook_extracarrier_addr[$address->id] = $hook;
-
-            if ($first) {
-                $array = array_merge(
-                    $array,
-                    ['HOOK_EXTRACARRIER' => $hook]
-                );
-                $first = false;
-            }
-            $array = array_merge(
-                $array,
-                ['HOOK_EXTRACARRIER_ADDR' => $hook_extracarrier_addr]
-            );
-        }
-    }
-
-    /**
      * Get all the IDs of the delivery Addresses without Carriers.
      *
      * @param bool $return_collection Returns sa collection

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -410,36 +410,6 @@ class CartCore extends ObjectModel
     }
 
     /**
-     * Calculate average Tax rate in Cart, as a percentage.
-     *
-     * @deprecated since version 1.7.6. Use $cart->getAverageProductsTaxRate() instead.
-     *
-     * @param mixed $cart Cart ID or Cart Object
-     *
-     * @return float Average Tax used in Cart (eg. 20.0 for 20% average rate)
-     */
-    public static function getTaxesAverageUsed($cart)
-    {
-        @trigger_error(
-            'Cart::getTaxesAverageUsed() is deprecated since version 1.7.6. Use $cart->getAverageProductsTaxRate() instead.',
-            E_USER_DEPRECATED
-        );
-
-        if (!is_object($cart)) {
-            $cart = new Cart((int) $cart);
-        }
-        if (!Validate::isLoadedObject($cart)) {
-            die(Tools::displayError());
-        }
-
-        if (!Configuration::get('PS_TAX')) {
-            return 0;
-        }
-
-        return $cart->getAverageProductsTaxRate() * 100;
-    }
-
-    /**
      * Returns the average Tax rate for all products in the cart, as a multiplier.
      *
      * The arguments are optional and only serve as return values in case caller needs the details.

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -791,6 +791,7 @@ class OrderCore extends ObjectModel
     public function getTaxesAverageUsed()
     {
         $cart = new Cart((int) $this->id_cart);
+
         return $cart->getAverageProductsTaxRate() * 100;
     }
 

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -790,7 +790,8 @@ class OrderCore extends ObjectModel
 
     public function getTaxesAverageUsed()
     {
-        return Cart::getTaxesAverageUsed((int) $this->id_cart);
+        $cart = new Cart((int) $this->id_cart);
+        return $cart->getAverageProductsTaxRate() * 100;
     }
 
     /**

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -545,7 +545,7 @@ class CartPresenter implements PresenterInterface
         $cartVouchers = $cart->getCartRules();
         $vouchers = [];
 
-        $cartHasTax = null === $cart->id ? false : $cart::getTaxesAverageUsed($cart);
+        $cartHasTax = null === $cart->id ? false : $cart->getAverageProductsTaxRate() * 100;
         $freeShippingAlreadySet = false;
         foreach ($cartVouchers as $cartVoucher) {
             $vouchers[$cartVoucher['id_cart_rule']]['id_cart_rule'] = $cartVoucher['id_cart_rule'];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated in Cart model
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #26293.
| How to test?      | Automated tests
| Possible impacts? | BC Break.

**:notebook: BC Breaks**
* Removed method : `Cart::getTaxesAverageUsed()`
* Removed method : `Cart::addExtraCarriers()`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->