### PR TITLE
Autofill empty link_rewrite in product update handlers

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
@@ -112,5 +112,6 @@ export default class ProductSEOManager {
     }
 
     linkRewriteInput.value = window.str2url(nameValue);
+    linkRewriteInput.dispatchEvent(new Event('change', {bubbles: true}));
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
@@ -27,7 +27,6 @@ import {EventEmitter} from 'events';
 import RedirectOptionManager from '@pages/product/edit/redirect-option-manager';
 import ProductMap from '@pages/product/product-map';
 import TaggableField from '@components/taggable-field';
-import textToLinkRewriteCopier from '@components/text-to-link-rewrite-copier';
 import TranslatableInput from '@components/translatable-input';
 
 const {$} = window;

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-seo-manager.ts
@@ -93,16 +93,6 @@ export default class ProductSEOManager {
 
     const resetLinkRewriteBtn = document.querySelector<HTMLButtonElement>(ProductMap.seo.resetLinkRewriteBtn)!;
     resetLinkRewriteBtn.addEventListener('click', () => this.resetLinkRewrite());
-
-    textToLinkRewriteCopier({
-      sourceElementSelector: 'input[name^="product[header][name]"]',
-      /* eslint-disable-next-line max-len */
-      destinationElementSelector: `${this.translatableInput.localeInputSelector}:not(.d-none) input[name^="product[seo][link_rewrite]"]`,
-      options: {
-        eventName: 'click',
-        triggeringElementSelector: '.reset-link-rewrite',
-      },
-    });
   }
 
   private resetLinkRewrite(): void {

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -33,6 +33,8 @@ const progressModalId = 'bulk-combination-progress-modal';
 
 export default {
   productForm: 'form[name=product]',
+  productLocalizedNameInput: 'input[name^="product[header][name]"]',
+  productLocalizedLinkRewriteInput: 'input[name^="product[seo][link_rewrite]"]',
   productTypePreview: '.product-type-preview',
   productType: {
     headerSelector: '#product_header_type',
@@ -211,6 +213,7 @@ export default {
       labelSelector: 'label',
       helpSelector: 'small.form-text',
     },
+    resetLinkRewriteBtn: '.reset-link-rewrite',
   },
   jsTabs: '.js-tabs',
   jsArrow: '.js-arrow',

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -170,7 +170,7 @@ class ProductCore extends ObjectModel
     /** @var string MPN */
     public $mpn;
 
-    /** @var string|array Friendly URL or array of friendly URL by id_lang */
+    /** @var string[] friendly url values indexed by language id */
     public $link_rewrite;
 
     /** @var string|array Meta description or array of meta description by id_lang */

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -170,7 +170,7 @@ class ProductCore extends ObjectModel
     /** @var string MPN */
     public $mpn;
 
-    /** @var string[] friendly url values indexed by language id */
+    /** @var string|string[] Friendly URL or array of friendly URL by id_lang */
     public $link_rewrite;
 
     /** @var string|array Meta description or array of meta description by id_lang */

--- a/src/Adapter/Product/CommandHandler/AddProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/AddProductHandler.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\AddProductHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
@@ -42,14 +43,20 @@ final class AddProductHandler implements AddProductHandlerInterface
      * @var ProductMultiShopRepository
      */
     private $productRepository;
+    /**
+     * @var Tools
+     */
+    private $tools;
 
     /**
      * @param ProductMultiShopRepository $productRepository
      */
     public function __construct(
-        ProductMultiShopRepository $productRepository
+        ProductMultiShopRepository $productRepository,
+        Tools $tools
     ) {
         $this->productRepository = $productRepository;
+        $this->tools = $tools;
     }
 
     /**
@@ -57,8 +64,20 @@ final class AddProductHandler implements AddProductHandlerInterface
      */
     public function handle(AddProductCommand $command): ProductId
     {
+        $localizedNames = $command->getLocalizedNames();
+        $localizedLinkRewrites = [];
+
+        foreach ($localizedNames as $langId => $name) {
+            if (empty($name)) {
+                continue;
+            }
+
+            $localizedLinkRewrites[$langId] = $this->tools->linkRewrite($name);
+        }
+
         $product = $this->productRepository->create(
             $command->getLocalizedNames(),
+            $localizedLinkRewrites,
             $command->getProductType()->getValue(),
             $command->getShopId()
         );

--- a/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
@@ -119,7 +119,7 @@ class UpdateProductBasicInformationHandler implements UpdateProductBasicInformat
         }
 
         foreach ($product->link_rewrite as $langId => $linkRewrite) {
-            if (!empty($linkRewrite)) {
+            if (!empty($linkRewrite) || empty($product->name[$langId])) {
                 continue;
             }
 

--- a/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductBasicInformationHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
@@ -50,14 +51,23 @@ class UpdateProductBasicInformationHandler implements UpdateProductBasicInformat
     private $defaultLanguageId;
 
     /**
+     * @var Tools
+     */
+    private $tools;
+
+    /**
      * @param ProductMultiShopRepository $productRepository
+     * @param int $defaultLanguageId
+     * @param Tools $tools
      */
     public function __construct(
         ProductMultiShopRepository $productRepository,
-        int $defaultLanguageId
+        int $defaultLanguageId,
+        Tools $tools
     ) {
         $this->productRepository = $productRepository;
         $this->defaultLanguageId = $defaultLanguageId;
+        $this->tools = $tools;
     }
 
     /**
@@ -106,6 +116,15 @@ class UpdateProductBasicInformationHandler implements UpdateProductBasicInformat
             }
             $product->name = $localizedNames;
             $updatableProperties['name'] = array_keys($localizedNames);
+        }
+
+        foreach ($product->link_rewrite as $langId => $linkRewrite) {
+            if (!empty($linkRewrite)) {
+                continue;
+            }
+
+            $product->link_rewrite[$langId] = $this->tools->linkRewrite($product->name[$langId]);
+            $updatableProperties['link_rewrite'][] = $langId;
         }
 
         $localizedDescriptions = $command->getLocalizedDescriptions();

--- a/src/Adapter/Product/CommandHandler/UpdateProductSeoHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductSeoHandler.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Update\ProductSeoPropertiesFiller;
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductSeoCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductSeoHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
@@ -51,15 +52,23 @@ class UpdateProductSeoHandler implements UpdateProductSeoHandlerInterface
     private $productSeoPropertiesFiller;
 
     /**
+     * @var Tools
+     */
+    private $tools;
+
+    /**
      * @param ProductMultiShopRepository $productRepository
      * @param ProductSeoPropertiesFiller $productSeoPropertiesFiller
+     * @param Tools $tools
      */
     public function __construct(
         ProductMultiShopRepository $productRepository,
-        ProductSeoPropertiesFiller $productSeoPropertiesFiller
+        ProductSeoPropertiesFiller $productSeoPropertiesFiller,
+        Tools $tools
     ) {
         $this->productRepository = $productRepository;
         $this->productSeoPropertiesFiller = $productSeoPropertiesFiller;
+        $this->tools = $tools;
     }
 
     /**
@@ -111,9 +120,21 @@ class UpdateProductSeoHandler implements UpdateProductSeoHandlerInterface
         }
 
         $localizedLinkRewrites = $command->getLocalizedLinkRewrites();
+
         if (null !== $localizedLinkRewrites) {
             $product->link_rewrite = $localizedLinkRewrites;
             $updatableProperties['link_rewrite'] = array_keys($localizedLinkRewrites);
+        }
+
+        foreach ($product->link_rewrite as $langId => $linkRewrite) {
+            if (!empty($linkRewrite)) {
+                continue;
+            }
+
+            $product->link_rewrite[$langId] = $this->tools->linkRewrite($product->name[$langId]);
+            if (!isset($updatableProperties['link_rewrite']) || !in_array($langId, $updatableProperties['link_rewrite'])) {
+                $updatableProperties['link_rewrite'][] = $langId;
+            }
         }
 
         return $updatableProperties;

--- a/src/Adapter/Product/CommandHandler/UpdateProductSeoHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductSeoHandler.php
@@ -121,16 +121,20 @@ class UpdateProductSeoHandler implements UpdateProductSeoHandlerInterface
 
         $localizedLinkRewrites = $command->getLocalizedLinkRewrites();
 
-        foreach ($product->link_rewrite as $langId => $linkRewrite) {
-            if (!empty($localizedLinkRewrites[$langId])) {
-                $product->link_rewrite[$langId] = $localizedLinkRewrites[$langId];
-            } elseif (empty($linkRewrite) && !empty($product->name[$langId])) {
-                $product->link_rewrite[$langId] = $this->tools->linkRewrite($product->name[$langId]);
-            } else {
-                continue;
-            }
+        if (null !== $localizedLinkRewrites) {
+            foreach ($localizedLinkRewrites as $langId => $linkRewrite) {
+                if (!empty($linkRewrite)) {
+                    $product->link_rewrite[$langId] = $linkRewrite;
+                } elseif (!empty($product->name[$langId])) {
+                    // When link rewrite is provided empty, then use product name.
+                    // There is similar behavior in UpdateProductBasicInformationHandler
+                    $product->link_rewrite[$langId] = $this->tools->linkRewrite($product->name[$langId]);
+                } else {
+                    continue;
+                }
 
-            $updatableProperties['link_rewrite'][] = $langId;
+                $updatableProperties['link_rewrite'][] = $langId;
+            }
         }
 
         return $updatableProperties;

--- a/src/Adapter/Product/CommandHandler/UpdateProductSeoHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductSeoHandler.php
@@ -121,19 +121,10 @@ class UpdateProductSeoHandler implements UpdateProductSeoHandlerInterface
 
         $localizedLinkRewrites = $command->getLocalizedLinkRewrites();
 
-        if (null !== $localizedLinkRewrites) {
-            $product->link_rewrite = $localizedLinkRewrites;
-            $updatableProperties['link_rewrite'] = array_keys($localizedLinkRewrites);
-        }
-
         foreach ($product->link_rewrite as $langId => $linkRewrite) {
-            if (!empty($linkRewrite)) {
-                continue;
-            }
-
             if (!empty($localizedLinkRewrites[$langId])) {
                 $product->link_rewrite[$langId] = $localizedLinkRewrites[$langId];
-            } elseif (!empty($product->name[$langId])) {
+            } elseif (empty($linkRewrite) && !empty($product->name[$langId])) {
                 $product->link_rewrite[$langId] = $this->tools->linkRewrite($product->name[$langId]);
             } else {
                 continue;

--- a/src/Adapter/Product/CommandHandler/UpdateProductSeoHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductSeoHandler.php
@@ -131,10 +131,15 @@ class UpdateProductSeoHandler implements UpdateProductSeoHandlerInterface
                 continue;
             }
 
-            $product->link_rewrite[$langId] = $this->tools->linkRewrite($product->name[$langId]);
-            if (!isset($updatableProperties['link_rewrite']) || !in_array($langId, $updatableProperties['link_rewrite'])) {
-                $updatableProperties['link_rewrite'][] = $langId;
+            if (!empty($localizedLinkRewrites[$langId])) {
+                $product->link_rewrite[$langId] = $localizedLinkRewrites[$langId];
+            } elseif (!empty($product->name[$langId])) {
+                $product->link_rewrite[$langId] = $this->tools->linkRewrite($product->name[$langId]);
+            } else {
+                continue;
             }
+
+            $updatableProperties['link_rewrite'][] = $langId;
         }
 
         return $updatableProperties;

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -178,7 +178,6 @@ final class GetProductForEditingHandler implements GetProductForEditingHandlerIn
         $this->virtualProductFileRepository = $virtualProductFileRepository;
         $this->taxComputer = $taxComputer;
         $this->countryId = $countryId;
-        $this->productRepository = $productRepository;
         $this->attachmentRepository = $attachmentRepository;
         $this->targetProvider = $targetProvider;
         $this->productImageRepository = $productImageRepository;

--- a/src/Adapter/Product/Repository/ProductMultiShopRepository.php
+++ b/src/Adapter/Product/Repository/ProductMultiShopRepository.php
@@ -33,7 +33,6 @@ use ObjectModel;
 use PrestaShop\PrestaShop\Adapter\Manufacturer\Repository\ManufacturerRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Validate\ProductValidator;
 use PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Repository\TaxRulesGroupRepository;
-use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierReferenceId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
@@ -104,7 +103,6 @@ class ProductMultiShopRepository extends AbstractMultiShopObjectModelRepository
      * @param int $defaultCategoryId
      * @param TaxRulesGroupRepository $taxRulesGroupRepository
      * @param ManufacturerRepository $manufacturerRepository
-     * @param Tools $tools
      */
     public function __construct(
         Connection $connection,

--- a/src/Adapter/Product/Repository/ProductMultiShopRepository.php
+++ b/src/Adapter/Product/Repository/ProductMultiShopRepository.php
@@ -33,6 +33,7 @@ use ObjectModel;
 use PrestaShop\PrestaShop\Adapter\Manufacturer\Repository\ManufacturerRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Validate\ProductValidator;
 use PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Repository\TaxRulesGroupRepository;
+use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierReferenceId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
@@ -103,6 +104,7 @@ class ProductMultiShopRepository extends AbstractMultiShopObjectModelRepository
      * @param int $defaultCategoryId
      * @param TaxRulesGroupRepository $taxRulesGroupRepository
      * @param ManufacturerRepository $manufacturerRepository
+     * @param Tools $tools
      */
     public function __construct(
         Connection $connection,
@@ -184,22 +186,29 @@ class ProductMultiShopRepository extends AbstractMultiShopObjectModelRepository
 
     /**
      * @param array<int, string> $localizedNames
+     * @param array<int, string> $localizedLinkRewrites
      * @param string $productType
+     * @param ShopId $shopId
      *
      * @return Product
      *
-     * @throws CannotAddProductException
+     * @throws CoreException
      */
-    public function create(array $localizedNames, string $productType, ShopId $shopId): Product
-    {
+    public function create(
+        array $localizedNames,
+        array $localizedLinkRewrites,
+        string $productType,
+        ShopId $shopId
+    ): Product {
         $product = new Product(null, false, null, $shopId->getValue());
         $product->active = false;
         $product->id_category_default = $this->defaultCategoryId;
-        $product->name = $localizedNames;
         $product->is_virtual = ProductType::TYPE_VIRTUAL === $productType;
         $product->cache_is_pack = ProductType::TYPE_PACK === $productType;
         $product->product_type = $productType;
         $product->id_shop_default = $shopId->getValue();
+        $product->name = $localizedNames;
+        $product->link_rewrite = $localizedLinkRewrites;
 
         $this->productValidator->validateCreation($product);
         $this->addObjectModelToShop($product, $shopId->getValue(), CannotAddProductException::class);

--- a/src/Core/ConstraintValidator/Constraints/TypedRegex.php
+++ b/src/Core/ConstraintValidator/Constraints/TypedRegex.php
@@ -57,6 +57,7 @@ class TypedRegex extends Constraint
     public const TYPE_URL = 'url';
     public const TYPE_MODULE_NAME = 'module_name';
     public const TYPE_WEBSERVICE_KEY = 'webservice_key';
+    public const TYPE_LINK_REWRITE = 'link_rewrite';
 
     /**
      * @var string

--- a/src/Core/ConstraintValidator/TypedRegexValidator.php
+++ b/src/Core/ConstraintValidator/TypedRegexValidator.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\ConstraintValidator;
 
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Address\Configuration\AddressConstraint;
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\AlphaIsoCode;
@@ -49,6 +50,20 @@ class TypedRegexValidator extends ConstraintValidator
     public const GENERIC_NAME_CHARS = '<>={}';
     public const MESSAGE_CHARS = '<>{}';
     public const NAME_CHARS = '0-9!<>,;?=+()@#"�{}_$%:';
+
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(
+        ConfigurationInterface $configuration
+    ) {
+        $this->configuration = $configuration;
+    }
 
     /**
      * {@inheritdoc}
@@ -129,6 +144,12 @@ class TypedRegexValidator extends ConstraintValidator
                 return '/^[~:#,$%&_=\(\)\.\? \+\-@\/a-zA-Z0-9\pL\pS-]+$/u';
             case TypedRegex::TYPE_WEBSERVICE_KEY:
                 return '/^[a-zA-Z0-9@\#\?\-\_]+$/i';
+            case TypedRegex::TYPE_LINK_REWRITE:
+                if ($this->configuration->get('PS_ALLOW_ACCENTED_CHARS_URL')) {
+                    return '/^[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]+$/u';
+                }
+
+                return '/^[_a-zA-Z0-9\-]+$/';
             default:
                 $definedTypes = implode(', ', array_values((new ReflectionClass(TypedRegex::class))->getConstants()));
                 throw new InvalidArgumentException(sprintf('Type "%s" is not defined. Defined types are: %s', $type, $definedTypes));

--- a/src/Core/Domain/Product/ProductSettings.php
+++ b/src/Core/Domain/Product/ProductSettings.php
@@ -51,4 +51,5 @@ class ProductSettings
 
     public const MAX_DESCRIPTION_SHORT_LENGTH = 800;
     public const MAX_DESCRIPTION_LENGTH = 21844;
+    public const MAX_LINK_REWRITE_LENGTH = 128;
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShopBundle\Form\Admin\Type\ImagePreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -63,7 +64,6 @@ class HeaderType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $nameConstraints = $options['active'] ? [new DefaultLanguage()] : [];
         $builder
             ->add('cover_thumbnail', ImagePreviewType::class, [
                 'label' => false,
@@ -71,8 +71,9 @@ class HeaderType extends TranslatorAwareType
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Product name', 'Admin.Catalog.Feature'),
                 'type' => TextType::class,
-                'constraints' => $nameConstraints,
+                'constraints' => $options['active'] ? [new DefaultLanguage()] : [],
                 'options' => [
+                    'constraints' => [new TypedRegex(TypedRegex::TYPE_CATALOG_NAME)],
                     'attr' => [
                         'class' => 'serp-default-title',
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShopBundle\Form\Admin\Type\ImagePreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -37,6 +38,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\Length;
 
 class HeaderType extends TranslatorAwareType
 {
@@ -73,7 +75,10 @@ class HeaderType extends TranslatorAwareType
                 'type' => TextType::class,
                 'constraints' => $options['active'] ? [new DefaultLanguage()] : [],
                 'options' => [
-                    'constraints' => [new TypedRegex(TypedRegex::TYPE_CATALOG_NAME)],
+                    'constraints' => [
+                        new TypedRegex(TypedRegex::TYPE_CATALOG_NAME),
+                        new Length(['max' => ProductSettings::MAX_NAME_LENGTH]),
+                    ],
                     'attr' => [
                         'class' => 'serp-default-title',
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -153,9 +153,6 @@ class SEOType extends TranslatorAwareType
                 'modify_all_shops' => true,
             ])
             ->add('link_rewrite', TranslatableType::class, [
-                'constraints' => [
-                    new TypedRegex(TypedRegex::TYPE_LINK_REWRITE),
-                ],
                 'label' => $this->trans('Friendly URL', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans('This is the human-readable URL, as generated from the product\'s name. You can change it if you want.', 'Admin.Catalog.Help'),
                 'required' => false,
@@ -166,6 +163,9 @@ class SEOType extends TranslatorAwareType
                 ),
                 'alert_message' => $this->getFriendlyAlterMessages(),
                 'options' => [
+                    'constraints' => [
+                        new TypedRegex(TypedRegex::TYPE_LINK_REWRITE),
+                    ],
                     'attr' => [
                         'class' => 'serp-watched-url',
                     ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -153,6 +153,9 @@ class SEOType extends TranslatorAwareType
                 'modify_all_shops' => true,
             ])
             ->add('link_rewrite', TranslatableType::class, [
+                'constraints' => [
+                    new TypedRegex(TypedRegex::TYPE_LINK_REWRITE),
+                ],
                 'label' => $this->trans('Friendly URL', 'Admin.Catalog.Feature'),
                 'label_help_box' => $this->trans('This is the human-readable URL, as generated from the product\'s name. You can change it if you want.', 'Admin.Catalog.Help'),
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/SEOType.php
@@ -165,6 +165,7 @@ class SEOType extends TranslatorAwareType
                 'options' => [
                     'constraints' => [
                         new TypedRegex(TypedRegex::TYPE_LINK_REWRITE),
+                        new Length(['max' => ProductSettings::MAX_LINK_REWRITE_LENGTH]),
                     ],
                     'attr' => [
                         'class' => 'serp-watched-url',

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -126,6 +126,7 @@ services:
     arguments:
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@=service("prestashop.adapter.legacy.configuration").get("PS_LANG_DEFAULT")'
+      - '@prestashop.adapter.tools'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand
@@ -257,6 +258,7 @@ services:
     arguments:
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@prestashop.adapter.product.update.product_seo_properties_filler'
+      - '@prestashop.adapter.tools'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductSeoCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -117,6 +117,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductHandler
     arguments:
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
+      - '@prestashop.adapter.tools'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Command\AddProductCommand

--- a/src/PrestaShopBundle/Resources/config/services/core/constraint_validator.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/constraint_validator.yml
@@ -23,6 +23,8 @@ services:
 
   prestashop.core.constraint_validator.typed_regex_validator:
     class: 'PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator'
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
     tags:
       - { name: validator.constraint_validator }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product_seo.html.twig
@@ -28,5 +28,5 @@
 
 {% block _product_seo_link_rewrite_widget %}
   {{ form_widget(form) }}
-  <button type="button" class="reset-link-rewrite btn btn-outline-secondary">Reset URL</button>
+  <button type="button" class="reset-link-rewrite btn btn-outline-secondary">{{ 'Reset URL'|trans({}, 'Admin.Catalog.Feature') }}</button>
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product_seo.html.twig
@@ -22,8 +22,11 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-{% form_theme productForm.seo '@PrestaShop/Admin/Sell/Catalog/Product/FormTheme/product_seo.html.twig' %}
 
-<div role="tabpanel" class="form-contenttab tab-pane container-fluid" id="seo-tab">
-  {{ form_row(productForm.seo) }}
-</div>
+{# This form theme is the root one for all the product form so we define here which base theme is used for all the children #}
+{% use '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig' %}
+
+{% block _product_seo_link_rewrite_widget %}
+  {{ form_widget(form) }}
+  <button type="button" class="reset-link-rewrite btn btn-outline-secondary">Reset URL</button>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -936,9 +936,11 @@
         {% if default_locale.id_lang != translateField.vars.name %}
           {% set classes = classes ~ ' d-none' %}
         {% endif %}
-        <div class="{{ classes }}" style="flex-grow: 1;">
-          {{ form_widget(translateField) }}
-        </div>
+        {% block translatable_fields_with_dropdown_t %}
+          <div data-lang-id="{{ translateField.vars.name }}" class="{{ classes }}" style="flex-grow: 1;">
+            {{ form_widget(translateField) }}
+          </div>
+        {%  endblock %}
       {% endfor %}
       {% if not hide_locales %}
         <div class="dropdown">

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -936,11 +936,9 @@
         {% if default_locale.id_lang != translateField.vars.name %}
           {% set classes = classes ~ ' d-none' %}
         {% endif %}
-        {% block translatable_fields_with_dropdown_t %}
-          <div data-lang-id="{{ translateField.vars.name }}" class="{{ classes }}" style="flex-grow: 1;">
-            {{ form_widget(translateField) }}
-          </div>
-        {%  endblock %}
+        <div data-lang-id="{{ translateField.vars.name }}" class="{{ classes }}" style="flex-grow: 1;">
+          {{ form_widget(translateField) }}
+        </div>
       {% endfor %}
       {% if not hide_locales %}
         <div class="dropdown">

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateBasicInformationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateBasicInformationFeatureContext.php
@@ -32,6 +32,7 @@ use Behat\Gherkin\Node\TableNode;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Product;
 
 class UpdateBasicInformationFeatureContext extends AbstractProductFeatureContext
 {
@@ -46,6 +47,27 @@ class UpdateBasicInformationFeatureContext extends AbstractProductFeatureContext
         $shopId = $this->getSharedStorage()->get(trim($shopReference));
         $shopConstraint = ShopConstraint::shop($shopId);
         $this->updateProductBasicInfo($productReference, $table, $shopConstraint);
+    }
+
+    /**
+     * This method is created just for specific cases when product name needs to be updated
+     * using legacy object model, but not cqrs commands, to avoid some side effects while testing.
+     * For example when testing how cqrs command auto-fills link_rewrite in certain cases.
+     *
+     * @When /^I update product "([^"]*)" name \(not using commands\) with following localized values:$/
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     *
+     * @return void
+     */
+    public function updateProductName(string $productReference, TableNode $table): void
+    {
+        $productId = $this->getSharedStorage()->get($productReference);
+        $product = new Product($productId, true);
+        $product->name = $this->localizeByRows($table)['name'];
+
+        $product->update();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/add_product.feature
@@ -63,7 +63,7 @@ Feature: Add basic product from Back Office (BO)
 
   Scenario: I can add a product without providing a name
     When I add product "product1" with following information:
-      | type        | standard       |
+      | type | standard |
     Then product "product1" should be disabled
     And product "product1" type should be standard
     And product "product1" localized "name" should be:
@@ -72,3 +72,14 @@ Feature: Add basic product from Back Office (BO)
     And product "product1" should be assigned to following categories:
       | id reference | name[en-US] | is default |
       | home         | Home        | true       |
+
+  Scenario: Empty friendly-urls should be auto-filled using product name value when adding new product
+    And I add product "product4" with following information:
+      | type        | standard     |
+      | name[en-US] | en product 4 |
+    Then product "product4" localized "name" should be:
+      | locale | value        |
+      | en-US  | en product 4 |
+    And product "product4" localized "link_rewrite" should be:
+      | locale | value        |
+      | en-US  | en-product-4 |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
@@ -11,16 +11,16 @@ Feature: Update product basic information from Back Office (BO)
       | type        | standard  |
     And product "product1" type should be standard
     And product "product1" localized "name" should be:
-      | locale     | value     |
-      | en-US      | funny mug |
+      | locale | value     |
+      | en-US  | funny mug |
     When I update product "product1" basic information with following values:
       | name[en-US]              | photo of funny mug |
       | description[en-US]       | nice mug           |
       | description_short[en-US] | Just a nice mug    |
     Then product "product1" type should be standard
     And product "product1" localized "name" should be:
-      | locale     | value              |
-      | en-US      | photo of funny mug |
+      | locale | value              |
+      | en-US  | photo of funny mug |
     And product "product1" localized "description" should be:
       | locale | value    |
       | en-US  | nice mug |
@@ -95,7 +95,7 @@ Feature: Update product basic information from Back Office (BO)
   Scenario: When product has empty names in some languages the default language is used to prefill them all
     Given language "fr" with locale "fr-FR" exists
     And I add product "empty_product" with following information:
-      | type        | standard  |
+      | type | standard |
     Then product "empty_product" localized "name" should be:
       | locale | value |
       | en-US  |       |
@@ -106,3 +106,38 @@ Feature: Update product basic information from Back Office (BO)
       | locale | value        |
       | en-US  | english name |
       | fr-FR  | english name |
+
+  Scenario: When product name is updated, empty friendly-urls are auto-filled
+    Given language "fr" with locale "fr-FR" exists
+    And I add product "empty_product2" with following information:
+      | type | standard |
+    Then product "empty_product2" localized "name" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    And product "empty_product2" localized "link_rewrite" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    When I update product "empty_product2" basic information with following values:
+      | name[en-US] | english name |
+      | name[fr-FR] | french name  |
+    Then product "empty_product2" localized "name" should be:
+      | locale | value        |
+      | en-US  | english name |
+      | fr-FR  | french name  |
+    And product "empty_product2" localized "link_rewrite" should be:
+      | locale | value        |
+      | en-US  | english-name |
+      | fr-FR  | french-name  |
+    When I update product "empty_product2" basic information with following values:
+      | name[en-US] | english name v2 |
+      | name[fr-FR] | french name v2  |
+    Then product "empty_product2" localized "name" should be:
+      | locale | value           |
+      | en-US  | english name v2 |
+      | fr-FR  | french name v2  |
+    And product "empty_product2" localized "link_rewrite" should be:
+      | locale | value        |
+      | en-US  | english-name |
+      | fr-FR  | french-name  |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
@@ -26,23 +26,24 @@ Feature: Update product SEO options from Back Office (BO)
       | locale | value |
       | en-US  |       |
     And product "product1" localized "link_rewrite" is:
-      | locale | value |
-      | en-US  |       |
+      | locale | value      |
+      | en-US  | just-boots |
     And I add product "product2" with following information:
       | name[en-US] | magical boots |
       | type        | virtual       |
     And product product2 should have following seo options:
       | redirect_type | 404 |
     And product product2 should not have a redirect target
-    And product "product1" localized "meta_title" is:
+    And product "product2" localized "meta_title" is:
       | locale | value |
       | en-US  |       |
-    And product "product1" localized "meta_description" is:
+    And product "product2" localized "meta_description" is:
       | locale | value |
       | en-US  |       |
-    And product "product1" localized "link_rewrite" is:
-      | locale | value |
-      | en-US  |       |
+    And product "product2" localized "link_rewrite" is:
+      | locale | value         |
+      | en-US  | magical-boots |
+      | fr-FR  |               |
     And I add product "product3" with following information:
       | name[en-US] | amazing boots |
       | type        | standard      |
@@ -253,9 +254,9 @@ Feature: Update product SEO options from Back Office (BO)
       | en-US  |       |
       | fr-FR  |       |
     And product "product2" localized "link_rewrite" should be:
-      | locale | value |
-      | en-US  |       |
-      | fr-FR  |       |
+      | locale | value         |
+      | en-US  | magical-boots |
+      | fr-FR  |               |
     When I update product product2 SEO information with following values:
       | meta_title[en-US]       | metatitl prod2            |
       | meta_description[en-US] | product2 meta description |
@@ -283,9 +284,9 @@ Feature: Update product SEO options from Back Office (BO)
       | en-US  |       |
       | fr-FR  |       |
     And product "product2" localized "link_rewrite" should be:
-      | locale | value |
-      | en-US  |       |
-      | fr-FR  |       |
+      | locale | value         |
+      | en-US  | magical-boots |
+      | fr-FR  |               |
     When I update product product2 SEO information with following values:
       | meta_title[fr-FR]       | la meta title1 |
       | meta_description[fr-FR] | la meta desc1  |
@@ -299,9 +300,9 @@ Feature: Update product SEO options from Back Office (BO)
       | en-US  |               |
       | fr-FR  | la meta desc1 |
     And product "product2" localized "link_rewrite" should be:
-      | locale | value    |
-      | en-US  |          |
-      | fr-FR  | la-boots |
+      | locale | value         |
+      | en-US  | magical-boots |
+      | fr-FR  | la-boots      |
 
   Scenario: Update product SEO multi-lang fields with invalid values
     Given I update product product1 SEO information with following values:
@@ -317,9 +318,9 @@ Feature: Update product SEO options from Back Office (BO)
       | en-US  |               |
       | fr-FR  | la meta desc1 |
     And product "product1" localized "link_rewrite" should be:
-      | locale | value    |
-      | en-US  |          |
-      | fr-FR  | la-boots |
+      | locale | value      |
+      | en-US  | just-boots |
+      | fr-FR  | la-boots   |
     When I update product product1 SEO information with following values:
       | meta_title[en-US] | #{ |
     Then I should get error that product meta_title is invalid
@@ -344,9 +345,9 @@ Feature: Update product SEO options from Back Office (BO)
       | en-US  |               |
       | fr-FR  | la meta desc1 |
     And product "product1" localized "link_rewrite" should be:
-      | locale | value    |
-      | en-US  |          |
-      | fr-FR  | la-boots |
+      | locale | value      |
+      | en-US  | just-boots |
+      | fr-FR  | la-boots   |
 
   Scenario: I update product SEO with image
     When I update product product2 SEO information with following values:
@@ -386,42 +387,26 @@ Feature: Update product SEO options from Back Office (BO)
 
   Scenario: Empty friendly-urls should be auto-filled using product name value
     And I add product "product4" with following information:
-      | type        | standard     |
-      | name[en-US] | en product 4 |
-      | name[fr-FR] | fr product 4 |
+      | type        | standard |
+      | name[en-US] |          |
+      | name[fr-FR] |          |
     Then product "product4" localized "name" should be:
-      | locale | value        |
-      | en-US  | en product 4 |
-      | fr-FR  | fr product 4 |
-    And product "product4" localized "link_rewrite" should be:
       | locale | value |
       | en-US  |       |
       | fr-FR  |       |
+    When I update product "product4" basic information with following values:
+      | name[en-US] | en product 04 |
+      | name[fr-FR] | fr product 04 |
+    Then product "product4" localized "name" should be:
+      | locale | value         |
+      | en-US  | en product 04 |
+      | fr-FR  | fr product 04 |
     When I update product product4 SEO information with following values:
       | link_rewrite[en-US] |  |
       | link_rewrite[fr-FR] |  |
+    # UpdateProductBasicInformationCommand also modifies link_rewrite, so it was already changed during name update
+    # therefore this test is not the most accurate
     And product "product4" localized "link_rewrite" should be:
-      | locale | value        |
-      | en-US  | en-product-4 |
-      | fr-FR  | fr-product-4 |
-    When I add product "product5" with following information:
-      | type | standard |
-    Then product "product5" localized "name" should be:
-      | locale | value |
-      | en-US  |       |
-      | fr-FR  |       |
-    When I update product product5 SEO information with following values:
-      | link_rewrite[en-US] | en-no-name |
-      | link_rewrite[fr-FR] | fr-no-name |
-    And product "product5" localized "link_rewrite" should be:
-      | locale | value      |
-      | en-US  | en-no-name |
-      | fr-FR  | fr-no-name |
-    When I update product product5 SEO information with following values:
-      | link_rewrite[en-US] |  |
-      | link_rewrite[fr-FR] |  |
-    # Name is still empty, so link rewrite is too
-    And product "product5" localized "link_rewrite" should be:
-      | locale | value |
-      | en-US  |       |
-      | fr-FR  |       |
+      | locale | value         |
+      | en-US  | en-product-04 |
+      | fr-FR  | fr-product-04 |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
@@ -390,22 +390,28 @@ Feature: Update product SEO options from Back Office (BO)
       | type        | standard |
       | name[en-US] |          |
       | name[fr-FR] |          |
-    Then product "product4" localized "name" should be:
+    Then product "product4" localized "link_rewrite" should be:
       | locale | value |
       | en-US  |       |
       | fr-FR  |       |
-    When I update product "product4" basic information with following values:
+    # This custom step allows to update only name without affecting link_rewrite,
+    # so that later we can assert that the UpdateProductSEOCommand updates the link_rewrite.
+    # (UpdateProductBasicInformationCommand also has a side effect which updates the link_rewrite,
+    # so we cannot use that command here if we want the test to be accurate)
+    When I update product "product4" name (not using commands) with following localized values:
       | name[en-US] | en product 04 |
       | name[fr-FR] | fr product 04 |
     Then product "product4" localized "name" should be:
       | locale | value         |
       | en-US  | en product 04 |
       | fr-FR  | fr product 04 |
+    And product "product4" localized "link_rewrite" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
     When I update product product4 SEO information with following values:
       | link_rewrite[en-US] |  |
       | link_rewrite[fr-FR] |  |
-    # UpdateProductBasicInformationCommand also modifies link_rewrite, so it was already changed during name update
-    # therefore this test is not the most accurate
     And product "product4" localized "link_rewrite" should be:
       | locale | value         |
       | en-US  | en-product-04 |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
@@ -74,9 +74,9 @@ Feature: Update product SEO options from Back Office (BO)
       | fr-FR  |                  |
     # Default no picture image
     And product product2 should have following seo options:
-      | redirect_type   | 301-product                                          |
-      | redirect_target | product1                                             |
-      | redirect_name   | just boots                                           |
+      | redirect_type   | 301-product                                            |
+      | redirect_target | product1                                               |
+      | redirect_name   | just boots                                             |
       | redirect_image  | http://myshop.com/img/p/{no_picture}-small_default.jpg |
 
   Scenario: Update product redirect type without providing redirect target
@@ -383,3 +383,45 @@ Feature: Update product SEO options from Back Office (BO)
       | redirect_target | clothes                               |
       | redirect_name   | Home > Clothes                        |
       | redirect_image  | http://myshop.com/img/c/{clothes}.jpg |
+
+  Scenario: Empty friendly-urls should be auto-filled using product name value
+    And I add product "product4" with following information:
+      | type        | standard     |
+      | name[en-US] | en product 4 |
+      | name[fr-FR] | fr product 4 |
+    Then product "product4" localized "name" should be:
+      | locale | value        |
+      | en-US  | en product 4 |
+      | fr-FR  | fr product 4 |
+    And product "product4" localized "link_rewrite" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    When I update product product4 SEO information with following values:
+      | link_rewrite[en-US] |  |
+      | link_rewrite[fr-FR] |  |
+    And product "product4" localized "link_rewrite" should be:
+      | locale | value        |
+      | en-US  | en-product-4 |
+      | fr-FR  | fr-product-4 |
+    When I add product "product5" with following information:
+      | type | standard |
+    Then product "product5" localized "name" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |
+    When I update product product5 SEO information with following values:
+      | link_rewrite[en-US] | en-no-name |
+      | link_rewrite[fr-FR] | fr-no-name |
+    And product "product5" localized "link_rewrite" should be:
+      | locale | value      |
+      | en-US  | en-no-name |
+      | fr-FR  | fr-no-name |
+    When I update product product5 SEO information with following values:
+      | link_rewrite[en-US] |  |
+      | link_rewrite[fr-FR] |  |
+    # Name is still empty, so link rewrite is too
+    And product "product5" localized "link_rewrite" should be:
+      | locale | value |
+      | en-US  |       |
+      | fr-FR  |       |

--- a/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
@@ -27,12 +27,22 @@
 namespace Tests\Unit\Core\ConstraintValidator;
 
 use Generator;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class TypedRegexValidatorTest extends ConstraintValidatorTestCase
 {
+    protected const ALLOW_ACCENTED_CHARS_CONFIG_NAME = 'PS_ALLOW_ACCENTED_CHARS_URL';
+
+    /**
+     * Modify this configuration data before creating new validator when needed to inject different configuration values into validator
+     */
+    protected $configurationData = [
+        self::ALLOW_ACCENTED_CHARS_CONFIG_NAME => '0',
+    ];
+
     public function testItSucceedsForNameTypeWhenValidCharactersGiven(): void
     {
         $value = 'goodname';
@@ -334,6 +344,46 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
     public function testItFailsForWebserviceKeyTypeWhenInvalidCharactersGiven(string $invalidChar): void
     {
         $this->assertViolationIsRaised(new TypedRegex(['type' => TypedRegex::TYPE_WEBSERVICE_KEY]), $invalidChar);
+    }
+
+    /**
+     * @dataProvider getDataForLinkRewriteTest
+     *
+     * @param string $value
+     *
+     * @return void
+     */
+    public function testLinkRewriteType(string $value, string $allowAccentedChars, bool $expectSuccess): void
+    {
+        $this->configurationData[self::ALLOW_ACCENTED_CHARS_CONFIG_NAME] = $allowAccentedChars;
+        $this->reinitializeValidator([
+            self::ALLOW_ACCENTED_CHARS_CONFIG_NAME => $allowAccentedChars,
+        ]);
+
+        $constraint = new TypedRegex(TypedRegex::TYPE_LINK_REWRITE);
+        $this->validator->validate($value, $constraint);
+
+        if ($expectSuccess) {
+            $this->assertNoViolation();
+        } else {
+            $this->buildViolation($constraint->message)
+                ->setParameter('%s', '"' . $value . '"')
+                ->assertRaised();
+        }
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getDataForLinkRewriteTest(): array
+    {
+        return [
+            ['okay', '0', true],
+            ['Notebook-13', '0', true],
+            ['Notebook_3', '0', true],
+            ['notebook-ė', '0', false],
+            ['notebook-ė', '1', true],
+        ];
     }
 
     /**
@@ -654,7 +704,15 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
      */
     protected function createValidator(): TypedRegexValidator
     {
-        return new TypedRegexValidator();
+        $configurationMock = $this->createMock(ConfigurationInterface::class);
+        $configurationMock->method('get')
+            ->willReturnMap(
+            [
+                ['PS_ALLOW_ACCENTED_CHARS_URL', $this->configurationData['PS_ALLOW_ACCENTED_CHARS_URL']],
+            ]
+        );
+
+        return new TypedRegexValidator($configurationMock);
     }
 
     /**
@@ -668,5 +726,15 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation($constraint->message)
             ->setParameter('%s', '"' . $invalidChar . '"')
             ->assertRaised();
+    }
+
+    /**
+     * Reinitialize validator when custom configuration data needs to be injected
+     */
+    private function reinitializeValidator(array $configurationData): void
+    {
+        $this->configurationData = $configurationData;
+        $this->validator = $this->createValidator();
+        $this->validator->initialize($this->context);
     }
 }

--- a/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
+++ b/tests/Unit/Core/ConstraintValidator/TypedRegexValidatorTest.php
@@ -383,6 +383,7 @@ class TypedRegexValidatorTest extends ConstraintValidatorTestCase
             ['Notebook_3', '0', true],
             ['notebook-ė', '0', false],
             ['notebook-ė', '1', true],
+            ['notebook with spaces', '1', false],
         ];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When updating product name and the link_rewrite (friendly url) is empty, then link-rewrite is automatically filled using product name. When updating link_rewrite manually, if empty value is provided then its also automatically filled using product-name (so when product has a name it should be impossible to have empty link_rewrite)
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes (see bellow)
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/14984
| Related PRs       | 
| How to test?      | see description for logic. Check it works in experimental product page (related form fields: product name & Friendly URL (in SEO tab)
| Possible impacts? | 

**BC BREAKS** (only affecting experimental product page)
1. Added argument `PrestaShop\PrestaShop\Adapter\Tools` in PrestaShop\PrestaShop\Adapter\Product\CommandHandler\AddProductHandler constructor.
2. Added argument `PrestaShop\PrestaShop\Adapter\Tools` in PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductSeoHandler
3. Added argument `PrestaShop\PrestaShop\Adapter\Tools` in PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductBasicInformationHandler
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
