### PR TITLE
Add fixed quantity update to bulk combination edition

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/form-field-disabler.ts
+++ b/admin-dev/themes/new-theme/js/components/form/form-field-disabler.ts
@@ -50,6 +50,11 @@ export type InputFormFieldDisablerParams = Partial<FormFieldDisablerParams> & {
   disablingInputSelector: string,
 };
 
+export type SwitchEventData = {
+  targetSelector: string,
+  disable: boolean,
+}
+
 /**
  * Enables or disables element depending on certain input value.
  */
@@ -134,14 +139,22 @@ export default class FormFieldDisabler {
     }
   }
 
-  private toggle(targetSelector: string, disable: boolean, switchEvent: string | null): void {
+  private toggle(
+    targetSelector: string,
+    disable: boolean,
+    switchEvent: string | null,
+  ): void {
     if (switchEvent) {
       const {eventEmitter} = window.prestashop.instance;
 
       if (!eventEmitter) {
         console.error('Trying to use EventEmitter without having initialised the component before.');
       } else {
-        eventEmitter.emit(switchEvent, {targetSelector, disable});
+        const eventData: SwitchEventData = {
+          targetSelector,
+          disable,
+        };
+        eventEmitter.emit(switchEvent, eventData);
       }
     }
 

--- a/admin-dev/themes/new-theme/js/pages/product/combination/QuantityModeSwitcher.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/QuantityModeSwitcher.ts
@@ -1,0 +1,48 @@
+import {SwitchEventData} from '@components/form/form-field-disabler';
+import {EventEmitter} from 'events';
+import ProductMap from '@pages/product/product-map';
+import ProductEventMap from '@pages/product/product-event-map';
+
+const combinationMap = ProductMap.combinations;
+const combinationEvents = ProductEventMap.combinations;
+
+/**
+ * Switches between quantity modes (delta or fixed) to make sure that only one of them is switched on at a time.
+ *
+ * E.g. if user switches on the fixed quantity input, then delta quantity input is switched off.
+ */
+export default class QuantityModeSwitcher {
+  private eventEmitter: EventEmitter;
+
+  constructor() {
+    this.eventEmitter = window.prestashop.component.EventEmitter;
+    this.init();
+  }
+
+  private init(): void {
+    this.eventEmitter.on(combinationEvents.combinationSwitchDeltaQuantity, (eventData: SwitchEventData) => {
+      // switch OFF fixed quantity only when delta quantity is being switched ON
+      if (!eventData.disable) {
+        toggleSwitch(combinationMap.bulkFixedQuantitySwitchName, false);
+      }
+    });
+    this.eventEmitter.on(combinationEvents.combinationSwitchFixedQuantity, (eventData: SwitchEventData) => {
+      // switch OFF delta quantity only when fixed quantity is being switched ON
+      if (!eventData.disable) {
+        toggleSwitch(combinationMap.bulkDeltaQuantitySwitchName, false);
+      }
+    });
+
+    function toggleSwitch(switchName: string, checked: boolean): void {
+      const $switchOn = $(`[name="${switchName}"][value="1"]`);
+      const $switchOff = $(`[name="${switchName}"][value="0"]`);
+
+      if ($switchOn.is(':checked') !== checked) {
+        $switchOn.prop('checked', checked);
+      }
+      if ($switchOff.is(':checked') === checked) {
+        $switchOff.prop('checked', !checked);
+      }
+    }
+  }
+}

--- a/admin-dev/themes/new-theme/js/pages/product/combination/bulk.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/bulk.ts
@@ -24,14 +24,17 @@
  */
 
 import ImageSelector from '@pages/product/combination/form/image-selector';
+import QuantityModeSwitcher from '@pages/product/combination/QuantityModeSwitcher';
 
 // @ts-ignore
 const {$} = window;
 
 $(() => {
   window.prestashop.component.initComponents([
+    'EventEmitter',
     'DeltaQuantityInput',
     'DisablingSwitch',
   ]);
   new ImageSelector();
+  new QuantityModeSwitcher();
 });

--- a/admin-dev/themes/new-theme/js/pages/product/product-event-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-event-map.ts
@@ -55,6 +55,8 @@ export default {
     bulkUpdateFinished: 'combinationsBulkUpdateFinished',
     bulkDeleteFinished: 'combinationsBulkDeleteFinished',
     combinationDeleted: 'combinationDeleted',
+    combinationSwitchDeltaQuantity: 'combinationSwitchDeltaQuantity',
+    combinationSwitchFixedQuantity: 'combinationSwitchFixedQuantity',
   },
   categories: {
     applyCategoryTreeChanges: 'applyCategoryTreeChanges',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -165,6 +165,8 @@ export default {
     bulkSelectAllInPageId: bulkCombinationSelectAllInPageId,
     bulkProgressModalId: progressModalId,
     bulkFormModalId: 'bulk-combination-form-modal',
+    bulkDeltaQuantitySwitchName: 'bulk_combination[stock][disabling_switch_delta_quantity]',
+    bulkFixedQuantitySwitchName: 'bulk_combination[stock][disabling_switch_fixed_quantity]',
   },
   virtualProduct: {
     container: '.virtual-product-file-container',

--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockHandler.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler;
 
-use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockProperties;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository;
@@ -82,7 +81,7 @@ final class UpdateCombinationStockHandler implements UpdateCombinationStockHandl
                 $command->getDeltaQuantity(),
                 $this->movementReasonRepository->getIdForEmployeeEdition($command->getDeltaQuantity() > 0)
             );
-        } else if (null !== $command->getFixedQuantity()) {
+        } elseif (null !== $command->getFixedQuantity()) {
             $currentQuantity = (int) $this->stockAvailableRepository->getForCombination($command->getCombinationId())->quantity;
             $deltaQuantity = $command->getFixedQuantity() - $currentQuantity;
 

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockCommand.php
@@ -29,8 +29,8 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 
 use DateTimeInterface;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CombinationConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
 
 /**
  * Updates combination stock information
@@ -110,9 +110,9 @@ class UpdateCombinationStockCommand
     public function setDeltaQuantity(int $deltaQuantity): UpdateCombinationStockCommand
     {
         if (null !== $this->fixedQuantity) {
-            throw new CombinationConstraintException(
+            throw new ProductStockConstraintException(
                 'Cannot set $deltaQuantity, because $fixedQuantity is already set',
-                CombinationConstraintException::DUPLICATE_QUANTITY_UPDATE
+                ProductStockConstraintException::FIXED_AND_DELTA_QUANTITY_PROVIDED
             );
         }
         $this->deltaQuantity = $deltaQuantity;
@@ -134,9 +134,9 @@ class UpdateCombinationStockCommand
     public function setFixedQuantity(int $fixedQuantity): void
     {
         if ($this->deltaQuantity) {
-            throw new CombinationConstraintException(
+            throw new ProductStockConstraintException(
                 'Cannot set $fixedQuantity, because $deltaQuantity is already set',
-                CombinationConstraintException::DUPLICATE_QUANTITY_UPDATE
+                ProductStockConstraintException::FIXED_AND_DELTA_QUANTITY_PROVIDED
             );
         }
         $this->fixedQuantity = $fixedQuantity;

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockCommand.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 
 use DateTimeInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CombinationConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 
 /**
@@ -45,6 +46,11 @@ class UpdateCombinationStockCommand
      * @var int|null
      */
     private $deltaQuantity;
+
+    /**
+     * @var int|null
+     */
+    private $fixedQuantity;
 
     /**
      * @var int|null
@@ -103,9 +109,37 @@ class UpdateCombinationStockCommand
      */
     public function setDeltaQuantity(int $deltaQuantity): UpdateCombinationStockCommand
     {
+        if (null !== $this->fixedQuantity) {
+            throw new CombinationConstraintException(
+                'Cannot set $deltaQuantity, because $fixedQuantity is already set',
+                CombinationConstraintException::DUPLICATE_QUANTITY_UPDATE
+            );
+        }
         $this->deltaQuantity = $deltaQuantity;
 
         return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getFixedQuantity(): ?int
+    {
+        return $this->fixedQuantity;
+    }
+
+    /**
+     * @param int $fixedQuantity
+     */
+    public function setFixedQuantity(int $fixedQuantity): void
+    {
+        if ($this->deltaQuantity) {
+            throw new CombinationConstraintException(
+                'Cannot set $fixedQuantity, because $deltaQuantity is already set',
+                CombinationConstraintException::DUPLICATE_QUANTITY_UPDATE
+            );
+        }
+        $this->fixedQuantity = $fixedQuantity;
     }
 
     /**

--- a/src/Core/Domain/Product/Combination/Exception/CombinationConstraintException.php
+++ b/src/Core/Domain/Product/Combination/Exception/CombinationConstraintException.php
@@ -37,6 +37,4 @@ class CombinationConstraintException extends CombinationException
      * When combination id is invalid
      */
     public const INVALID_ID = 1;
-
-    public const DUPLICATE_QUANTITY_UPDATE = 2;
 }

--- a/src/Core/Domain/Product/Combination/Exception/CombinationConstraintException.php
+++ b/src/Core/Domain/Product/Combination/Exception/CombinationConstraintException.php
@@ -37,4 +37,6 @@ class CombinationConstraintException extends CombinationException
      * When combination id is invalid
      */
     public const INVALID_ID = 1;
+
+    public const DUPLICATE_QUANTITY_UPDATE = 2;
 }

--- a/src/Core/Domain/Product/Stock/Exception/ProductStockConstraintException.php
+++ b/src/Core/Domain/Product/Stock/Exception/ProductStockConstraintException.php
@@ -62,4 +62,9 @@ class ProductStockConstraintException extends ProductStockException
      * When delta quantity is invalid
      */
     public const INVALID_DELTA_QUANTITY = 60;
+
+    /**
+     * When fixed quantity and delta quantity are both provided
+     */
+    public const FIXED_AND_DELTA_QUANTITY_PROVIDED = 70;
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilder.php
@@ -53,6 +53,9 @@ final class CombinationStockCommandsBuilder implements CombinationCommandsBuilde
         if (isset($quantityData['quantities']['delta_quantity']['delta'])) {
             $command->setDeltaQuantity((int) $quantityData['quantities']['delta_quantity']['delta']);
         }
+        if (isset($quantityData['quantities']['fixed_quantity'])) {
+            $command->setFixedQuantity((int) $quantityData['quantities']['fixed_quantity']);
+        }
         if (isset($quantityData['quantities']['minimal_quantity'])) {
             $command->setMinimalQuantity((int) $quantityData['quantities']['minimal_quantity']);
         }

--- a/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
+++ b/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
@@ -56,6 +56,7 @@ class BulkCombinationFormDataFormatter extends AbstractFormDataFormatter
             '[price][weight]' => '[price_impact][weight]',
             // Stock data are the trickiest
             '[stock][delta_quantity][delta]' => '[stock][quantities][delta_quantity][delta]',
+            '[stock][fixed_quantity]' => '[stock][quantities][fixed_quantity]',
             '[stock][minimal_quantity]' => '[stock][quantities][minimal_quantity]',
             '[stock][stock_location]' => '[stock][options][stock_location]',
             '[stock][low_stock_threshold]' => '[stock][options][low_stock_threshold]',

--- a/src/Core/Form/IdentifiableObject/DataProvider/BulkCombinationFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/BulkCombinationFormDataProvider.php
@@ -42,6 +42,7 @@ class BulkCombinationFormDataProvider implements FormDataProviderInterface
                     'quantity' => 0,
                     'delta' => 0,
                 ],
+                'fixed_quantity' => 0,
                 'minimal_quantity' => 0,
                 'stock_location' => '',
                 'low_stock_threshold' => 0,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -79,6 +79,7 @@ class BulkCombinationStockType extends TranslatorAwareType
                     'required' => false,
                     'label' => $this->trans('Edit quantity', 'Admin.Catalog.Feature'),
                     'disabling_switch' => true,
+                    'disabling_switch_event' => 'combinationSwitchDeltaQuantity',
                     'disabled_value' => function (?array $data) {
                         return empty($data['quantity']) && empty($data['delta']);
                     },
@@ -88,6 +89,7 @@ class BulkCombinationStockType extends TranslatorAwareType
                     'label' => $this->trans('Edit fixed quantity', 'Admin.Catalog.Feature'),
                     'default_empty_data' => 0,
                     'disabling_switch' => true,
+                    'disabling_switch_event' => 'combinationSwitchFixedQuantity',
                     'modify_all_shops' => true,
                 ])
             ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -85,7 +85,10 @@ class BulkCombinationStockType extends TranslatorAwareType
                 ])
                 ->add('fixed_quantity', IntegerType::class, [
                     'required' => false,
+                    'label' => $this->trans('Edit fixed quantity', 'Admin.Catalog.Feature'),
+                    'default_empty_data' => 0,
                     'disabling_switch' => true,
+                    'modify_all_shops' => true,
                 ])
             ;
         }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -32,6 +32,7 @@ use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\DeltaQuantityType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -81,6 +82,10 @@ class BulkCombinationStockType extends TranslatorAwareType
                     'disabled_value' => function (?array $data) {
                         return empty($data['quantity']) && empty($data['delta']);
                     },
+                ])
+                ->add('fixed_quantity', IntegerType::class, [
+                    'required' => false,
+                    'disabling_switch' => true,
                 ])
             ;
         }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -33,6 +33,7 @@ services:
     arguments:
       - '@prestashop.adapter.product.combination.update.combination_stock_updater'
       - '@prestashop.adapter.product.stock.repository.movement_reason_repository'
+      - '@prestashop.adapter.product.stock.repository.stock_available_repository'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockCommand

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
@@ -133,6 +133,19 @@ class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureCon
     }
 
     /**
+     * @Then I should get error that it is not allowed to perform update using both - delta and fixed quantity
+     *
+     * @return void
+     */
+    public function assertLastErrorIsDuplicateQuantityUpdate(): void
+    {
+        $this->assertLastErrorIs(
+            ProductStockConstraintException::class,
+            ProductStockConstraintException::FIXED_AND_DELTA_QUANTITY_PROVIDED
+        );
+    }
+
+    /**
      * @param UpdateCombinationStockCommand $command
      * @param array<string, mixed> $dataRows
      */
@@ -140,6 +153,9 @@ class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureCon
     {
         if (isset($dataRows['delta quantity'])) {
             $command->setDeltaQuantity((int) $dataRows['delta quantity']);
+        }
+        if (isset($dataRows['fixed quantity'])) {
+            $command->setFixedQuantity((int) $dataRows['fixed quantity']);
         }
         if (isset($dataRows['minimal quantity'])) {
             $command->setMinimalQuantity((int) $dataRows['minimal quantity']);

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -180,6 +180,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | false |
       | location                   |       |
       | available date             |       |
+    And product "product1" should have no stock movements
     When I update combination "product1SBlack" stock with following details:
       | fixed quantity | 10 |
     Then combination "product1SBlack" should have following stock details:
@@ -190,6 +191,10 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | false |
       | location                   |       |
       | available date             |       |
+    And combination "product1SBlack" last stock movement increased by 10
+    And combination "product1SBlack" last employees stock movements should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | 10             |
     When I update combination "product1SBlack" stock with following details:
       | fixed quantity | -3 |
     Then combination "product1SBlack" should have following stock details:
@@ -200,6 +205,11 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | false |
       | location                   |       |
       | available date             |       |
+    And combination "product1SBlack" last stock movement decreased by 13
+    And combination "product1SBlack" last employees stock movements should be:
+      | first_name | last_name | delta_quantity |
+      | Puff       | Daddy     | -13            |
+      | Puff       | Daddy     | 10             |
 
   Scenario: I should not be able to provide both delta and fixed quantities when updating combination stock information
     Given combination "product1SBlack" should have following stock details:
@@ -210,6 +220,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | false |
       | location                   |       |
       | available date             |       |
+    And product "product1" should have no stock movements
     When I update combination "product1SBlack" stock with following details:
       | fixed quantity | -7 |
       | delta quantity | -5 |
@@ -222,3 +233,4 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | false |
       | location                   |       |
       | available date             |       |
+    And product "product1" should have no stock movements

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -18,9 +18,7 @@ Feature: Update product combination stock information in Back Office (BO)
     And attribute "Black" named "Black" in en language exists
     And attribute "Blue" named "Blue" in en language exists
     And attribute "Red" named "Red" in en language exists
-
-  Scenario: I update combination options:
-    Given I add product "product1" with following information:
+    And I add product "product1" with following information:
       | name[en-US] | universal T-shirt |
       | type        | combinations      |
     And product product1 type should be combinations
@@ -54,6 +52,8 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | false |
       | location                   |       |
       | available date             |       |
+
+  Scenario: I update combination options:
     When I update combination "product1SBlack" stock with following details:
       | delta quantity             | 100         |
       | minimal quantity           | 10          |
@@ -99,7 +99,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     # Product quantity is the sum of all combinations' quantity
     And product "product1" should have following stock information:
-      | quantity            | 150       |
+      | quantity | 150 |
     When I update combination "product1SBlack" stock with following details:
       | delta quantity      | -101        |
       | minimal quantity    | 1           |
@@ -119,7 +119,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | Puff       | Daddy     | 100            |
     And combination "product1SBlack" last stock movement decreased by 101
     And product "product1" should have following stock information:
-      | quantity            | 49       |
+      | quantity | 49 |
     When I update combination "product1SBlack" stock with following details:
       | delta quantity             | 1          |
       | minimal quantity           | 0          |
@@ -150,7 +150,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" should have following stock information:
-      | quantity            | 50       |
+      | quantity | 50 |
     # Following assert makes sure that 0 delta quantity is valid input for command but is skipped and stock does not move
     When I update combination "product1SBlack" stock with following details:
       | delta quantity | 0 |
@@ -169,4 +169,56 @@ Feature: Update product combination stock information in Back Office (BO)
       | Puff       | Daddy     | 100            |
     And combination "product1SBlack" last stock movement increased by 1
     And product "product1" should have following stock information:
-      | quantity            | 50       |
+      | quantity | 50 |
+
+  Scenario: I update combination stock using fixed quantity
+    Given combination "product1SBlack" should have following stock details:
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    When I update combination "product1SBlack" stock with following details:
+      | fixed quantity | 10 |
+    Then combination "product1SBlack" should have following stock details:
+      | combination stock detail   | value |
+      | quantity                   | 10    |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    When I update combination "product1SBlack" stock with following details:
+      | fixed quantity | -3 |
+    Then combination "product1SBlack" should have following stock details:
+      | combination stock detail   | value |
+      | quantity                   | -3    |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+
+  Scenario: I should not be able to provide both delta and fixed quantities when updating combination stock information
+    Given combination "product1SBlack" should have following stock details:
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    When I update combination "product1SBlack" stock with following details:
+      | fixed quantity | -7 |
+      | delta quantity | -5 |
+    Then I should get error that it is not allowed to perform update using both - delta and fixed quantity
+    And combination "product1SBlack" should have following stock details:
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilderTest.php
@@ -90,6 +90,19 @@ class CombinationStockCommandsBuilderTest extends AbstractCombinationCommandBuil
         ];
 
         $command = new UpdateCombinationStockCommand($this->getCombinationId()->getValue());
+        $command->setFixedQuantity(134);
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'fixed_quantity' => 134,
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationStockCommand($this->getCombinationId()->getValue());
         $command->setLocation('Im in miami...');
         yield [
             [

--- a/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
@@ -136,7 +136,7 @@ class BulkCombinationFormDataFormatterTest extends TestCase
             ],
         ];
 
-        yield 'stock dat with fixed quantity' => [
+        yield 'stock data with fixed quantity' => [
             [
                 'stock' => [
                     'fixed_quantity' => 7,

--- a/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
@@ -136,7 +136,32 @@ class BulkCombinationFormDataFormatterTest extends TestCase
             ],
         ];
 
-        yield 'partial stock data wit no options' => [
+        yield 'stock dat with fixed quantity' => [
+            [
+                'stock' => [
+                    'fixed_quantity' => 7,
+                    'stock_location' => 'close',
+                    'low_stock_threshold' => 2,
+                    'low_stock_alert' => false,
+                    'available_date' => '2022-02-15',
+                ],
+            ],
+            [
+                'stock' => [
+                    'quantities' => [
+                        'fixed_quantity' => 7,
+                    ],
+                    'options' => [
+                        'stock_location' => 'close',
+                        'low_stock_threshold' => 2,
+                        'low_stock_alert' => false,
+                    ],
+                    'available_date' => '2022-02-15',
+                ],
+            ],
+        ];
+
+        yield 'partial stock data with no options' => [
             [
                 'stock' => [
                     'delta_quantity' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Now its possible to update quantity in 2 ways when using bulk combination edition form: 1. By delta quantity - provide how many units to add/subtract from current quantity 2. By fixed quantity (was introduced by this pr) - when you provide a fixed quantity for combination (like it used to work in legacy page). Only one of these ways is supported per action.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Refer to description for more details. Check if it works in product experimental page -> combinations -> bulk edition stock tab.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
