### PR TITLE
Fix form_help block shown twice in text fields

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/form_div_layout.html.twig
@@ -30,8 +30,6 @@
   {% else %}
     {{- block('form_widget_simple') -}}
   {% endif %}
-
-  {{- block('form_help') -}}
 {%- endblock form_widget -%}
 
 {%- block form_widget_simple -%}


### PR DESCRIPTION
closes #19547
superseeds #28150

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes form_help block shown twice in form text blocks.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19547
| Related PRs       | #28150
| How to test?      | Create a custom form in the admin with text fields (and others in case you wanna check I really didn't break anything) and a `help` attribute. 
| Possible impacts? | Affect other field types, although I checked and I attach an image showing the before and after, where you'll see others aren't affected.

### Before:
![imatge](https://user-images.githubusercontent.com/153305/169829090-de54895b-e751-4346-ad16-dde5a9270be8.png)

### After:
![imatge](https://user-images.githubusercontent.com/153305/169828919-2a8f0e79-dc98-44af-8eef-ccd03b4b9c73.png)

Note only the very first two fields are text fields, the other ones are numbers, emails, checkboxes...