### PR TITLE
Fix response for "Add to cart" error

### DIFF
--- a/themes/_core/js/cart.js
+++ b/themes/_core/js/cart.js
@@ -142,16 +142,23 @@ $(document).ready(() => {
 
     $.post(actionURL, query, null, 'json')
       .then((resp) => {
-        prestashop.emit('updateCart', {
-          reason: {
-            idProduct: resp.id_product,
-            idProductAttribute: resp.id_product_attribute,
-            idCustomization: resp.id_customization,
-            linkAction: 'add-to-cart',
-            cart: resp.cart,
-          },
-          resp,
-        });
+        if (!resp.hasError) {
+          prestashop.emit('updateCart', {
+            reason: {
+              idProduct: resp.id_product,
+              idProductAttribute: resp.id_product_attribute,
+              idCustomization: resp.id_customization,
+              linkAction: 'add-to-cart',
+              cart: resp.cart,
+            },
+            resp,
+          });
+        } else {
+          prestashop.emit('handleError', {
+            eventType: 'addProductToCart',
+            resp,
+          });
+        }
       })
       .fail((resp) => {
         prestashop.emit('handleError', {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Fix response on "Add to cart" when wanted quantity is more than product quantity.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/267
| Related PRs       | -
| How to test?      | Doesn't make any changes in current functionality. It will be useful for error handling in FO themes.
| Possible impacts? | No.

We won't get this response on "Add to cart" when wanted quantity is more than product quantity:

![error](https://user-images.githubusercontent.com/85633460/169844350-886889af-8bda-4437-beaa-c142eb3b826f.png)

The response will be:

![Screenshot from 2022-05-23 23-43-28](https://user-images.githubusercontent.com/85633460/169845143-8cf755f7-81ae-49ea-b548-657278942e09.png)

Then you can handle error in FO:

https://user-images.githubusercontent.com/85633460/167399434-ff8bac5f-9bbe-4345-8f85-f5d4b95916a7.mp4


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
