### PR TITLE
Error on displaying the order detail shipping price

### DIFF
--- a/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
@@ -229,7 +229,7 @@ class OrderDetailLazyArray extends AbstractLazyArray
                     ($shipping['weight'] > 0) ? sprintf('%.3f', $shipping['weight']) . ' ' .
                         Configuration::get('PS_WEIGHT_UNIT') : '-';
                 $shippingCost =
-                    (!$order->getTaxCalculationMethod()) ? $shipping['shipping_cost_tax_excl']
+                    ($order->getTaxCalculationMethod()) ? $shipping['shipping_cost_tax_excl']
                         : $shipping['shipping_cost_tax_incl'];
                 $orderShipping[$shippingId]['shipping_cost'] =
                     ($shippingCost > 0) ? $this->locale->formatPrice($shippingCost, (Currency::getIsoCodeById((int) $order->id_currency)))


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the order détails, the shipping price is show 1 time in TTC and 1 time in HT on the detail table. The method getTaxCalculationMethod() returns 1 for tax exclude and 0 for tax include. "define('PS_TAX_EXC', 1);define('PS_TAX_INC', 0); With the negation if we have 0 we will see the tax include and and vice versa. So I think it's a issue.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | No
| How to test?      | In front office, open the order details page with shipping wich has tax.
| Possible impacts? | The lazy order details can affect part of displaying order

