### PR TITLE
Stronger https detection in Tools::getShopProtocol()

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -262,10 +262,9 @@ class ToolsCore
      *
      * @return string
      */
-    public static function getShopProtocol()
+    public static function getShopProtocol(): string
     {
-        $protocol = (Configuration::get('PS_SSL_ENABLED') || (!empty($_SERVER['HTTPS'])
-            && Tools::strtolower($_SERVER['HTTPS']) != 'off')) ? 'https://' : 'http://';
+        $protocol = (Configuration::get('PS_SSL_ENABLED') || Tools::usingSecureMode()) ? 'https://' : 'http://';
 
         return $protocol;
     }

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -262,7 +262,7 @@ class ToolsCore
      *
      * @return string
      */
-    public static function getShopProtocol(): string
+    public static function getShopProtocol()
     {
         $protocol = (Configuration::get('PS_SSL_ENABLED') || Tools::usingSecureMode()) ? 'https://' : 'http://';
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Stronger https detection in Tools::getShopProtocol(): Tools::usingSecureMode() check more server variables like HTTP_X_FORWARDED_PROTO.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28580
| How to test?      | configure and httpd server with only HTTP_X_FORWARDED_PROTO var and see errors un https mode on.
| Possible impacts? | no
| Sponsor company   | Creabilis.com

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
