### PR TITLE
Combination out of stock in single form and bulk action

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1557,7 +1557,7 @@ class CartCore extends ObjectModel
         /* Update quantity if product already exist */
         if (!empty($cartProductQuantity['quantity'])) {
             $productQuantity = Product::getQuantity($id_product, $id_product_attribute, null, $this);
-            $availableOutOfStock = Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($product->id));
+            $availableOutOfStock = Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($product->id, null, $id_product_attribute));
 
             if ($operator == 'up') {
                 $updateQuantity = '+ ' . $quantity;

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -187,7 +187,8 @@ class CombinationCore extends ObjectModel
         if ($product->getType() == Product::PTYPE_VIRTUAL) {
             StockAvailable::setProductOutOfStock((int) $this->id_product, 1, null, (int) $this->id);
         } else {
-            StockAvailable::setProductOutOfStock((int) $this->id_product, StockAvailable::outOfStock((int) $this->id_product), null, $this->id);
+            $productOutOfStock = StockAvailable::outOfStock((int) $this->id_product);
+            StockAvailable::setProductOutOfStock((int) $this->id_product, $productOutOfStock, null, $this->id);
         }
 
         SpecificPriceRule::applyAllRules([(int) $this->id_product]);

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4277,10 +4277,10 @@ class ProductCore extends ObjectModel
      */
     public function checkQty($qty)
     {
-        if ($this->isAvailableWhenOutOfStock(StockAvailable::outOfStock($this->id))) {
+        $id_product_attribute = $this->id_product_attribute ?? null;
+        if ($this->isAvailableWhenOutOfStock(StockAvailable::outOfStock($this->id, null, $id_product_attribute ?? 0))) {
             return true;
         }
-        $id_product_attribute = isset($this->id_product_attribute) ? $this->id_product_attribute : null;
         $availableQuantity = StockAvailable::getQuantityAvailableByProduct($this->id, $id_product_attribute);
 
         return $qty <= $availableQuantity;

--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -187,7 +187,7 @@ class StockAvailableCore extends ObjectModel
         }
 
         // Allow to order the product when out of stock?
-        $out_of_stock = StockAvailable::outOfStock($id_product);
+        $product_out_of_stock = StockAvailable::outOfStock($id_product);
 
         $manager = StockManagerFactory::getManager();
         // loops on $ids_warehouse to synchronize quantities
@@ -255,7 +255,7 @@ class StockAvailableCore extends ObjectModel
                                 'data' => [
                                     'quantity' => $quantity,
                                     'depends_on_stock' => 1,
-                                    'out_of_stock' => $out_of_stock,
+                                    'out_of_stock' => $product_out_of_stock,
                                     'id_product' => (int) $id_product,
                                     'id_product_attribute' => (int) $id_product_attribute,
                                 ],
@@ -593,9 +593,9 @@ class StockAvailableCore extends ObjectModel
                     $stockManager->saveMovement($id_product, $id_product_attribute, $deltaQuantity);
                 }
             } else {
-                $out_of_stock = StockAvailable::outOfStock($id_product, $id_shop);
+                $product_out_of_stock = StockAvailable::outOfStock($id_product, $id_shop);
                 $stock_available = new StockAvailable();
-                $stock_available->out_of_stock = (int) $out_of_stock;
+                $stock_available->out_of_stock = (int) $product_out_of_stock;
                 $stock_available->id_product = (int) $id_product;
                 $stock_available->id_product_attribute = (int) $id_product_attribute;
                 $stock_available->quantity = (int) $quantity;
@@ -742,10 +742,11 @@ class StockAvailableCore extends ObjectModel
      *
      * @param int $id_product
      * @param int|null $id_shop Optional : gets context if null @see Context::getContext()
+     * @param int $id_product_attribute
      *
      * @return int|bool : depends on stock @see $depends_on_stock
      */
-    public static function outOfStock($id_product, $id_shop = null)
+    public static function outOfStock($id_product, $id_shop = null, $id_product_attribute = 0)
     {
         if (!Validate::isUnsignedId($id_product)) {
             return false;
@@ -755,7 +756,7 @@ class StockAvailableCore extends ObjectModel
         $query->select('out_of_stock');
         $query->from('stock_available');
         $query->where('id_product = ' . (int) $id_product);
-        $query->where('id_product_attribute = 0');
+        $query->where('id_product_attribute = ' . (int) $id_product_attribute);
 
         $query = StockAvailable::addSqlShopRestriction($query, $id_shop);
 

--- a/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/AddProductToOrderHandler.php
@@ -561,9 +561,9 @@ final class AddProductToOrderHandler extends AbstractOrderHandler implements Add
      */
     private function checkProductInStock(Product $product, AddProductToOrderCommand $command, int $shopId): void
     {
+        $combinationId = null !== $command->getCombinationId() ? $command->getCombinationId()->getValue() : 0;
         //check if product is available in stock
-        if (!Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($command->getProductId()->getValue()))) {
-            $combinationId = null !== $command->getCombinationId() ? $command->getCombinationId()->getValue() : 0;
+        if (!Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($command->getProductId()->getValue(), null, $combinationId))) {
             $availableQuantity = StockAvailable::getQuantityAvailableByProduct(
                 $command->getProductId()->getValue(),
                 $combinationId,

--- a/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
+++ b/src/Adapter/Order/CommandHandler/UpdateProductInOrderHandler.php
@@ -187,7 +187,7 @@ final class UpdateProductInOrderHandler extends AbstractOrderCommandHandler impl
         }
 
         //check if product is available in stock
-        if (!Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($orderDetail->product_id))) {
+        if (!Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($orderDetail->product_id, null, $orderDetail->product_attribute_id))) {
             $availableQuantity = StockAvailable::getQuantityAvailableByProduct(
                 $orderDetail->product_id,
                 $orderDetail->product_attribute_id,

--- a/src/Adapter/Order/OrderProductQuantityUpdater.php
+++ b/src/Adapter/Order/OrderProductQuantityUpdater.php
@@ -535,7 +535,7 @@ class OrderProductQuantityUpdater
     private function assertValidProductQuantity(OrderDetail $orderDetail, int $newQuantity)
     {
         //check if product is available in stock
-        if (!Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($orderDetail->product_id))) {
+        if (!Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($orderDetail->product_id, null, $orderDetail->product_attribute_id))) {
             $availableQuantity = StockAvailable::getQuantityAvailableByProduct(
                 $orderDetail->product_id,
                 $orderDetail->product_attribute_id,

--- a/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderProductsForViewingHandler.php
@@ -221,10 +221,11 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                 $packItemImagePath = isset($pack_item['image_tag']) ?
                     $this->imageTagSourceParser->parse($pack_item['image_tag']) :
                     null;
+                $combinationId = 0;
                 $packItems[] = new OrderProductForViewing(
                     null,
                     $pack_item['id_product'],
-                    0,
+                    $combinationId,
                     $pack_item['name'],
                     $pack_item['reference'],
                     $pack_item['supplier_reference'],
@@ -244,7 +245,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                     null,
                     '',
                     $packItemType,
-                    (bool) Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($pack_item['id_product']))
+                    (bool) Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($pack_item['id_product'], null, $combinationId))
                 );
             }
 
@@ -273,7 +274,7 @@ final class GetOrderProductsForViewingHandler extends AbstractOrderHandler imple
                     ? $orderInvoice->getInvoiceNumberFormatted((int) $order->getAssociatedLanguage()->getId())
                     : '',
                 $productType,
-                (bool) Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($product['product_id'])),
+                (bool) Product::isAvailableWhenOutOfStock(StockAvailable::outOfStock($product['product_id'], null, $product['product_attribute_id'])),
                 $packItems,
                 $product['customizations']
             );

--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockHandler.php
@@ -96,8 +96,9 @@ final class UpdateCombinationStockHandler implements UpdateCombinationStockHandl
             $command->getMinimalQuantity(),
             $command->getLocation(),
             $command->getLowStockThreshold(),
-            $command->getLowStockAlertEnabled(),
-            $command->getAvailableDate()
+            $command->isLowStockAlertEnabled(),
+            $command->getAvailableDate(),
+            $command->getOutOfStockType()
         );
 
         $this->combinationStockUpdater->update($command->getCombinationId(), $properties);

--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -236,6 +236,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
             (int) $combination->low_stock_threshold,
             (bool) $combination->low_stock_alert,
             $stockAvailable->location,
+            (int) $stockAvailable->out_of_stock,
             DateTimeUtil::buildDateTimeOrNull($combination->available_date)
         );
     }

--- a/src/Adapter/Product/Combination/Update/CombinationStockProperties.php
+++ b/src/Adapter/Product/Combination/Update/CombinationStockProperties.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Update;
 
 use DateTimeInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockModification;
 
 class CombinationStockProperties
@@ -63,12 +64,18 @@ class CombinationStockProperties
     private $availableDate;
 
     /**
+     * @var OutOfStockType|null
+     */
+    private $outOfStockType;
+
+    /**
      * @param StockModification|null $stockModification
      * @param int|null $minimalQuantity
      * @param string|null $location
      * @param int|null $lowStockThreshold
      * @param bool|null $lowStockAlertEnabled
      * @param DateTimeInterface|null $availableDate
+     * @param OutOfStockType|null $outOfStockType
      */
     public function __construct(
         ?StockModification $stockModification = null,
@@ -76,7 +83,8 @@ class CombinationStockProperties
         ?string $location = null,
         ?int $lowStockThreshold = null,
         ?bool $lowStockAlertEnabled = null,
-        ?DateTimeInterface $availableDate = null
+        ?DateTimeInterface $availableDate = null,
+        ?OutOfStockType $outOfStockType
     ) {
         $this->stockModification = $stockModification;
         $this->minimalQuantity = $minimalQuantity;
@@ -85,6 +93,7 @@ class CombinationStockProperties
         $this->lowStockAlertEnabled = $lowStockAlertEnabled;
         $this->availableDate = $availableDate;
         $this->stockModification = $stockModification;
+        $this->outOfStockType = $outOfStockType;
     }
 
     /**
@@ -133,5 +142,13 @@ class CombinationStockProperties
     public function getAvailableDate(): ?DateTimeInterface
     {
         return $this->availableDate;
+    }
+
+    /**
+     * @return OutOfStockType|null
+     */
+    public function getOutOfStockType(): ?OutOfStockType
+    {
+        return $this->outOfStockType;
     }
 }

--- a/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
@@ -134,9 +134,10 @@ class CombinationStockUpdater
     private function updateStockAvailable(Combination $combination, CombinationStockProperties $properties): void
     {
         $updateLocation = null !== $properties->getLocation();
+        $updateOutOfStock = null !== $properties->getOutOfStockType();
         $stockModification = $properties->getStockModification();
 
-        if (!$stockModification && !$updateLocation) {
+        if (!$stockModification && !$updateLocation && !$updateOutOfStock) {
             return;
         }
 
@@ -148,6 +149,10 @@ class CombinationStockUpdater
 
         if ($updateLocation) {
             $stockAvailable->location = $properties->getLocation();
+        }
+
+        if ($updateOutOfStock) {
+            $stockAvailable->out_of_stock = $properties->getOutOfStockType()->getValue();
         }
 
         $this->stockAvailableRepository->update($stockAvailable);

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -57,8 +57,8 @@ class StockManager implements StockInterface
             $stockAvailable->id_product = (int) $product->id;
             $stockAvailable->id_product_attribute = (int) $id_product_attribute;
 
-            $outOfStock = $this->outOfStock((int) $product->id, $id_shop);
-            $stockAvailable->out_of_stock = (int) $outOfStock;
+            $productOutOfStock = $this->outOfStock((int) $product->id, $id_shop);
+            $stockAvailable->out_of_stock = (int) $productOutOfStock;
 
             if ($id_shop === null) {
                 $shop_group = $shopAdapter->getContextShopGroup();
@@ -210,11 +210,12 @@ class StockManager implements StockInterface
      *
      * @param int $productId
      * @param int $shopId Optional : gets context if null @see Context::getContext()
+     * @param int $combinationId
      *
      * @return bool : depends on stock @see $depends_on_stock
      */
-    public function outOfStock($productId, $shopId = null)
+    public function outOfStock($productId, $shopId = null, $combinationId = 0)
     {
-        return StockAvailable::outOfStock($productId, $shopId);
+        return StockAvailable::outOfStock($productId, $shopId, $combinationId);
     }
 }

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockCommand.php
@@ -31,6 +31,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 use DateTimeInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 
 /**
  * Updates combination stock information
@@ -76,6 +77,11 @@ class UpdateCombinationStockCommand
      * @var DateTimeInterface|null
      */
     private $availableDate;
+
+    /**
+     * @var OutOfStockType|null
+     */
+    private $outOfStockType;
 
     /**
      * @param int $combinationId
@@ -243,10 +249,24 @@ class UpdateCombinationStockCommand
     }
 
     /**
-     * @return bool|null
+     * @return OutOfStockType|null
      */
-    public function getLowStockAlertEnabled(): ?bool
+    public function getOutOfStockType(): ?OutOfStockType
     {
-        return $this->lowStockAlertEnabled;
+        return $this->outOfStockType;
+    }
+
+    /**
+     * @param int $outOfStockType
+     *
+     * @return $this
+     *
+     * @throws ProductStockConstraintException
+     */
+    public function setOutOfStockType(int $outOfStockType): UpdateCombinationStockCommand
+    {
+        $this->outOfStockType = new OutOfStockType($outOfStockType);
+
+        return $this;
     }
 }

--- a/src/Core/Domain/Product/Combination/QueryResult/CombinationStock.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/CombinationStock.php
@@ -63,11 +63,17 @@ class CombinationStock
     private $availableDate;
 
     /**
+     * @var int
+     */
+    private $outOfStockType;
+
+    /**
      * @param int $quantity
      * @param int $minimalQuantity
      * @param int $lowStockThreshold
      * @param bool $lowStockAlertEnabled
      * @param string $location
+     * @param int $outOfStockType
      * @param DateTimeInterface|null $availableDate
      */
     public function __construct(
@@ -76,6 +82,7 @@ class CombinationStock
         int $lowStockThreshold,
         bool $lowStockAlertEnabled,
         string $location,
+        int $outOfStockType,
         ?DateTimeInterface $availableDate
     ) {
         $this->quantity = $quantity;
@@ -83,6 +90,7 @@ class CombinationStock
         $this->location = $location;
         $this->lowStockThreshold = $lowStockThreshold;
         $this->lowStockAlertEnabled = $lowStockAlertEnabled;
+        $this->outOfStockType = $outOfStockType;
         $this->availableDate = $availableDate;
     }
 
@@ -124,6 +132,14 @@ class CombinationStock
     public function isLowStockAlertEnabled(): bool
     {
         return $this->lowStockAlertEnabled;
+    }
+
+    /**
+     * @return int
+     */
+    public function getOutOfStockType(): int
+    {
+        return $this->outOfStockType;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilder.php
@@ -68,6 +68,9 @@ final class CombinationStockCommandsBuilder implements CombinationCommandsBuilde
         if (isset($quantityData['options']['low_stock_alert'])) {
             $command->setLowStockAlert((bool) $quantityData['options']['low_stock_alert']);
         }
+        if (isset($quantityData['out_of_stock_type'])) {
+            $command->setOutOfStockType((int) $quantityData['out_of_stock_type']);
+        }
         if (isset($quantityData['available_date'])) {
             $command->setAvailableDate(new DateTime($quantityData['available_date']));
         }

--- a/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
+++ b/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
@@ -62,6 +62,7 @@ class BulkCombinationFormDataFormatter extends AbstractFormDataFormatter
             '[stock][low_stock_threshold]' => '[stock][options][low_stock_threshold]',
             '[stock][low_stock_alert]' => '[stock][options][low_stock_alert]',
             '[stock][available_date]' => '[stock][available_date]',
+            '[stock][out_of_stock_type]' => '[stock][out_of_stock_type]',
         ];
         $formattedData = $this->formatByPath($formData, $pathAssociations);
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProvider.php
@@ -101,6 +101,7 @@ class CombinationFormDataProvider implements FormDataProviderInterface
                 'low_stock_threshold' => $stockInformation->getLowStockThreshold(),
                 'low_stock_alert' => $stockInformation->isLowStockAlertEnabled(),
             ],
+            'out_of_stock_type' => $stockInformation->getOutOfStockType(),
             'available_date' => DateTime::isNull($availableDate) ? '' : $availableDate->format(DateTime::DEFAULT_DATE_FORMAT),
         ];
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -28,10 +28,12 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\DeltaQuantityType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -55,6 +57,11 @@ class BulkCombinationStockType extends TranslatorAwareType
     private $stockManagementEnabled;
 
     /**
+     * @var FormChoiceProviderInterface
+     */
+    private $outOfStockTypeChoiceProvider;
+
+    /**
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param RouterInterface $router
@@ -64,11 +71,13 @@ class BulkCombinationStockType extends TranslatorAwareType
         TranslatorInterface $translator,
         array $locales,
         RouterInterface $router,
-        bool $stockManagementEnabled
+        bool $stockManagementEnabled,
+        FormChoiceProviderInterface $outOfStockTypeChoiceProvider
     ) {
         parent::__construct($translator, $locales);
         $this->router = $router;
         $this->stockManagementEnabled = $stockManagementEnabled;
+        $this->outOfStockTypeChoiceProvider = $outOfStockTypeChoiceProvider;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -154,6 +163,14 @@ class BulkCombinationStockType extends TranslatorAwareType
                 'attr' => [
                     'placeholder' => 'YYYY-MM-DD',
                 ],
+                'disabling_switch' => true,
+            ])
+            ->add('out_of_stock_type', ChoiceType::class, [
+                'choices' => $this->outOfStockTypeChoiceProvider->getChoices(),
+                'label' => $this->trans('Behavior when out of stock', 'Admin.Catalog.Feature'),
+                'expanded' => true,
+                'column_breaker' => true,
+                'modify_all_shops' => true,
                 'disabling_switch' => true,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
@@ -28,15 +28,37 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Sell\Product\Stock\QuantityType;
 use PrestaShopBundle\Form\Admin\Sell\Product\Stock\StockOptionsType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class CombinationStockType extends TranslatorAwareType
 {
+    /**
+     * @var FormChoiceProviderInterface
+     */
+    private $outOfStockTypeChoiceProvider;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param FormChoiceProviderInterface $outOfStockTypeChoiceProvider
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        FormChoiceProviderInterface $outOfStockTypeChoiceProvider
+    ) {
+        parent::__construct($translator, $locales);
+        $this->outOfStockTypeChoiceProvider = $outOfStockTypeChoiceProvider;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -51,6 +73,13 @@ class CombinationStockType extends TranslatorAwareType
                 'attr' => [
                     'placeholder' => 'YYYY-MM-DD',
                 ],
+            ])
+            ->add('out_of_stock_type', ChoiceType::class, [
+                'choices' => $this->outOfStockTypeChoiceProvider->getChoices(),
+                'label' => $this->trans('Behavior when out of stock', 'Admin.Catalog.Feature'),
+                'expanded' => true,
+                'column_breaker' => true,
+                'modify_all_shops' => true,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1803,6 +1803,8 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\Combination\CombinationStockType'
     parent: 'form.type.translatable.aware'
     public: true
+    arguments:
+      - '@prestashop.core.form.choice_provider.out_of_stock_type_choice_provider'
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1841,6 +1841,7 @@ services:
     arguments:
       - '@router'
       - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_STOCK_MANAGEMENT')"
+      - '@prestashop.core.form.choice_provider.out_of_stock_type_choice_provider'
     tags:
       - { name: form.type }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCust
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use RuntimeException;
@@ -318,5 +319,22 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
     protected function getDefaultShopId(): int
     {
         return (int) Configuration::get('PS_SHOP_DEFAULT');
+    }
+
+    /**
+     * @param string $outOfStock
+     *
+     * @return int
+     */
+    protected function convertOutOfStockToInt(string $outOfStock): int
+    {
+        $intValues = [
+            'default' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
+            'available' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+            'not_available' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
+            'invalid' => 42, // This random number is hardcoded intentionally to reflect invalid stock type
+        ];
+
+        return $intValues[$outOfStock];
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
@@ -74,6 +74,7 @@ class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureCon
             (int) $dataRows['low stock threshold'],
             PrimitiveUtils::castStringBooleanIntoBoolean($dataRows['low stock alert is enabled']),
             $dataRows['location'],
+            $this->convertOutOfStockToInt($dataRows['out of stock type']),
             '' === $dataRows['available date'] ? null : new DateTime($dataRows['available date'])
         );
     }
@@ -112,6 +113,11 @@ class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureCon
             $expectedStock->getLocation(),
             $actualStock->getLocation(),
             sprintf('Unexpected combination "%s" location', $combinationReference)
+        );
+        Assert::assertSame(
+            $expectedStock->getOutOfStockType(),
+            $actualStock->getOutOfStockType(),
+            sprintf('Unexpected combination "%s" out of stock', $combinationReference)
         );
 
         if (null === $expectedStock->getAvailableDate()) {
@@ -171,6 +177,9 @@ class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureCon
         }
         if (isset($dataRows['available date'])) {
             $command->setAvailableDate(new DateTime($dataRows['available date']));
+        }
+        if (isset($dataRows['out of stock type'])) {
+            $command->setOutOfStockType($this->convertOutOfStockToInt($dataRows['out of stock type']));
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
@@ -41,7 +41,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstr
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Query\GetEmployeesStockMovements;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\QueryResult\EmployeeStockMovement;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\QueryResult\StockMovement;
-use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShopBundle\Api\QueryStockMovementParamsCollection;
@@ -446,23 +445,6 @@ class UpdateStockFeatureContext extends AbstractProductFeatureContext
         }
 
         return $data;
-    }
-
-    /**
-     * @param string $outOfStock
-     *
-     * @return int
-     */
-    private function convertOutOfStockToInt(string $outOfStock): int
-    {
-        $intValues = [
-            'default' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
-            'available' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
-            'not_available' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
-            'invalid' => 42, // This random number is hardcoded intentionally to reflect invalid stock type
-        ];
-
-        return $intValues[$outOfStock];
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -45,13 +45,14 @@ Feature: Update product combination stock information in Back Office (BO)
       | low_stock_alert     | false   |
       | available_date      |         |
     And combination "product1SBlack" should have following stock details:
-      | combination stock detail   | value |
-      | quantity                   | 0     |
-      | minimal quantity           | 1     |
-      | low stock threshold        | 0     |
-      | low stock alert is enabled | false |
-      | location                   |       |
-      | available date             |       |
+      | combination stock detail   | value   |
+      | quantity                   | 0       |
+      | minimal quantity           | 1       |
+      | low stock threshold        | 0       |
+      | low stock alert is enabled | false   |
+      | location                   |         |
+      | available date             |         |
+      | out of stock type          | default |
 
   Scenario: I update combination options:
     When I update combination "product1SBlack" stock with following details:
@@ -61,6 +62,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock threshold        | 10          |
       | low stock alert is enabled | true        |
       | available date             | 2021-10-10  |
+      | out of stock type          | available   |
     Then combination "product1SBlack" should have following stock details:
       | combination stock detail   | value       |
       | quantity                   | 100         |
@@ -69,6 +71,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | true        |
       | location                   | Storage nr1 |
       | available date             | 2021-10-10  |
+      | out of stock type          | available   |
     And combination "product1SBlack" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
       | Puff       | Daddy     | 100            |
@@ -88,6 +91,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | true        |
       | location                   | Storage nr1 |
       | available date             | 2021-10-10  |
+      | out of stock type          | default     |
     And combination "product1SWhite" last stock movement increased by 50
     And product "product1" should have following combinations:
       | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
@@ -113,6 +117,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | true        |
       | location                   | Storage nr2 |
       | available date             | 2021-10-10  |
+      | out of stock type          | available   |
     And combination "product1SBlack" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
       | Puff       | Daddy     | -101           |
@@ -135,6 +140,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | false      |
       | location                   |            |
       | available date             | 2020-01-01 |
+      | out of stock type          | available  |
     And combination "product1SBlack" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
       | Puff       | Daddy     | 1              |
@@ -162,6 +168,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | low stock alert is enabled | false      |
       | location                   |            |
       | available date             | 2020-01-01 |
+      | out of stock type          | available  |
     And combination "product1SBlack" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
       | Puff       | Daddy     | 1              |
@@ -173,24 +180,26 @@ Feature: Update product combination stock information in Back Office (BO)
 
   Scenario: I update combination stock using fixed quantity
     Given combination "product1SBlack" should have following stock details:
-      | combination stock detail   | value |
-      | quantity                   | 0     |
-      | minimal quantity           | 1     |
-      | low stock threshold        | 0     |
-      | low stock alert is enabled | false |
-      | location                   |       |
-      | available date             |       |
+      | combination stock detail   | value   |
+      | quantity                   | 0       |
+      | minimal quantity           | 1       |
+      | low stock threshold        | 0       |
+      | low stock alert is enabled | false   |
+      | location                   |         |
+      | available date             |         |
+      | out of stock type          | default |
     And product "product1" should have no stock movements
     When I update combination "product1SBlack" stock with following details:
       | fixed quantity | 10 |
     Then combination "product1SBlack" should have following stock details:
-      | combination stock detail   | value |
-      | quantity                   | 10    |
-      | minimal quantity           | 1     |
-      | low stock threshold        | 0     |
-      | low stock alert is enabled | false |
-      | location                   |       |
-      | available date             |       |
+      | combination stock detail   | value   |
+      | quantity                   | 10      |
+      | minimal quantity           | 1       |
+      | low stock threshold        | 0       |
+      | low stock alert is enabled | false   |
+      | location                   |         |
+      | available date             |         |
+      | out of stock type          | default |
     And combination "product1SBlack" last stock movement increased by 10
     And combination "product1SBlack" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
@@ -198,13 +207,14 @@ Feature: Update product combination stock information in Back Office (BO)
     When I update combination "product1SBlack" stock with following details:
       | fixed quantity | -3 |
     Then combination "product1SBlack" should have following stock details:
-      | combination stock detail   | value |
-      | quantity                   | -3    |
-      | minimal quantity           | 1     |
-      | low stock threshold        | 0     |
-      | low stock alert is enabled | false |
-      | location                   |       |
-      | available date             |       |
+      | combination stock detail   | value   |
+      | quantity                   | -3      |
+      | minimal quantity           | 1       |
+      | low stock threshold        | 0       |
+      | low stock alert is enabled | false   |
+      | location                   |         |
+      | available date             |         |
+      | out of stock type          | default |
     And combination "product1SBlack" last stock movement decreased by 13
     And combination "product1SBlack" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
@@ -213,24 +223,26 @@ Feature: Update product combination stock information in Back Office (BO)
 
   Scenario: I should not be able to provide both delta and fixed quantities when updating combination stock information
     Given combination "product1SBlack" should have following stock details:
-      | combination stock detail   | value |
-      | quantity                   | 0     |
-      | minimal quantity           | 1     |
-      | low stock threshold        | 0     |
-      | low stock alert is enabled | false |
-      | location                   |       |
-      | available date             |       |
+      | combination stock detail   | value   |
+      | quantity                   | 0       |
+      | minimal quantity           | 1       |
+      | low stock threshold        | 0       |
+      | low stock alert is enabled | false   |
+      | location                   |         |
+      | available date             |         |
+      | out of stock type          | default |
     And product "product1" should have no stock movements
     When I update combination "product1SBlack" stock with following details:
       | fixed quantity | -7 |
       | delta quantity | -5 |
     Then I should get error that it is not allowed to perform update using both - delta and fixed quantity
     And combination "product1SBlack" should have following stock details:
-      | combination stock detail   | value |
-      | quantity                   | 0     |
-      | minimal quantity           | 1     |
-      | low stock threshold        | 0     |
-      | low stock alert is enabled | false |
-      | location                   |       |
-      | available date             |       |
+      | combination stock detail   | value   |
+      | quantity                   | 0       |
+      | minimal quantity           | 1       |
+      | low stock threshold        | 0       |
+      | low stock alert is enabled | false   |
+      | location                   |         |
+      | available date             |         |
+      | out of stock type          | default |
     And product "product1" should have no stock movements

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
@@ -156,6 +156,7 @@ Feature: Add basic product from Back Office (BO)
       | low stock alert is enabled | false       |
       | location                   |             |
       | available date             |             |
+      | out of stock type          | default     |
     And combination "productCombinations3SWhite" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
       | Puff       | Daddy     | 100            |
@@ -170,6 +171,7 @@ Feature: Add basic product from Back Office (BO)
       | low stock alert is enabled | false       |
       | location                   |             |
       | available date             |             |
+      | out of stock type          | default     |
     And combination "productCombinations3SBlack" last employees stock movements should be:
       | first_name | last_name | delta_quantity |
       | Puff       | Daddy     | 50             |

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilderTest.php
@@ -31,6 +31,7 @@ namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product\Combina
 use DateTime;
 use Generator;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationStockCommandsBuilder;
 
 class CombinationStockCommandsBuilderTest extends AbstractCombinationCommandBuilderTest
@@ -147,6 +148,17 @@ class CombinationStockCommandsBuilderTest extends AbstractCombinationCommandBuil
             [
                 'stock' => [
                     'available_date' => '2022-10-10',
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationStockCommand($this->getCombinationId()->getValue());
+        $command->setOutOfStockType(OutOfStockType::OUT_OF_STOCK_AVAILABLE);
+        yield [
+            [
+                'stock' => [
+                    'out_of_stock_type' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
                 ],
             ],
             [$command],

--- a/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Form\IdentifiableObject\DataFormatter;
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataFormatter\BulkCombinationFormDataFormatter;
 
 class BulkCombinationFormDataFormatterTest extends TestCase
@@ -116,6 +117,7 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                     'low_stock_threshold' => 5,
                     'low_stock_alert' => true,
                     'available_date' => '2022-01-15',
+                    'out_of_stock_type' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
                 ],
             ],
             [
@@ -132,6 +134,7 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                         'low_stock_alert' => true,
                     ],
                     'available_date' => '2022-01-15',
+                    'out_of_stock_type' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
                 ],
             ],
         ];

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProviderTest.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\Combinatio
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationPrices;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationStock;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetAssociatedSuppliers;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryResult\AssociatedSuppliers;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\QueryResult\ProductSupplierForEditing;
@@ -119,6 +120,7 @@ class CombinationFormDataProviderTest extends TestCase
             'low_stock_threshold' => 5,
             'low_stock_alert' => true,
             'location' => 'top shelf',
+            'out_of_stock_type' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
             'available_date' => new DateTime('1969/07/20'),
         ];
         $expectedOutputData['stock']['quantities']['delta_quantity']['quantity'] = 42;
@@ -126,6 +128,7 @@ class CombinationFormDataProviderTest extends TestCase
         $expectedOutputData['stock']['options']['low_stock_threshold'] = 5;
         $expectedOutputData['stock']['options']['low_stock_alert'] = true;
         $expectedOutputData['stock']['options']['stock_location'] = 'top shelf';
+        $expectedOutputData['stock']['out_of_stock_type'] = OutOfStockType::OUT_OF_STOCK_AVAILABLE;
         $expectedOutputData['stock']['available_date'] = '1969-07-20';
 
         $datasets[] = [
@@ -412,6 +415,7 @@ class CombinationFormDataProviderTest extends TestCase
             $combination['low_stock_threshold'] ?? 0,
             $combination['low_stock_alert'] ?? false,
             $combination['location'] ?? 'location',
+            $combination['out_of_stock_type'] ?? OutOfStockType::OUT_OF_STOCK_DEFAULT,
             $combination['available_date'] ?? null
         );
     }
@@ -497,6 +501,7 @@ class CombinationFormDataProviderTest extends TestCase
                     'low_stock_threshold' => 0,
                     'low_stock_alert' => false,
                 ],
+                'out_of_stock_type' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
                 'available_date' => '',
             ],
             'price_impact' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR integrates the edition of the out of stock property for combinations, they are now editable combination by combination, and via bulk action for a faster edition
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | CI tests green
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
