### PR TITLE
fixes #28520 Backup - Ignore Statistics don't work as expected

### DIFF
--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -42,7 +42,7 @@ class PrestaShopBackupCore
     public $customBackupDir = null;
 
     /** @var bool|string */
-    public $psBackupAll = true;
+    public $psIgnoreStats = false;
     /** @var bool|string */
     public $psBackupDropTable = true;
 
@@ -57,9 +57,9 @@ class PrestaShopBackupCore
             $this->id = $this->getRealBackupPath($filename);
         }
 
-        $psBackupAll = Configuration::get('PS_BACKUP_ALL');
+        $psIgnoreStats = Configuration::get('PS_IGNORE_STATS');
         $psBackupDropTable = Configuration::get('PS_BACKUP_DROP_TABLE');
-        $this->psBackupAll = $psBackupAll !== false ? $psBackupAll : true;
+        $this->psIgnoreStats = $psIgnoreStats !== false ? $psIgnoreStats : true;
         $this->psBackupDropTable = $psBackupDropTable !== false ? $psBackupDropTable : true;
     }
 
@@ -224,7 +224,7 @@ class PrestaShopBackupCore
      */
     public function add()
     {
-        if (!$this->psBackupAll) {
+        if ($this->psIgnoreStats) {
             $ignoreInsertTable = [_DB_PREFIX_ . 'connections', _DB_PREFIX_ . 'connections_page', _DB_PREFIX_
                 . 'connections_source', _DB_PREFIX_ . 'guest', _DB_PREFIX_ . 'statssearch',
             ];

--- a/src/Core/Backup/Configuration/BackupOptionsConfiguration.php
+++ b/src/Core/Backup/Configuration/BackupOptionsConfiguration.php
@@ -53,7 +53,7 @@ final class BackupOptionsConfiguration implements DataConfigurationInterface
     public function getConfiguration()
     {
         return [
-            'backup_all' => (bool) $this->configuration->get('PS_BACKUP_ALL'),
+            'ignore_stats' => (bool) $this->configuration->get('PS_IGNORE_STATS'),
             'backup_drop_tables' => (bool) $this->configuration->get('PS_BACKUP_DROP_TABLE'),
         ];
     }
@@ -64,7 +64,7 @@ final class BackupOptionsConfiguration implements DataConfigurationInterface
     public function updateConfiguration(array $config)
     {
         if ($this->validateConfiguration($config)) {
-            $this->configuration->set('PS_BACKUP_ALL', $config['backup_all']);
+            $this->configuration->set('PS_IGNORE_STATS', $config['ignore_stats']);
             $this->configuration->set('PS_BACKUP_DROP_TABLE', $config['backup_drop_tables']);
         }
 
@@ -77,7 +77,7 @@ final class BackupOptionsConfiguration implements DataConfigurationInterface
     public function validateConfiguration(array $config)
     {
         return isset(
-            $config['backup_all'],
+            $config['ignore_stats'],
             $config['backup_drop_tables']
         );
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Backup/BackupOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Backup/BackupOptionsType.php
@@ -81,7 +81,7 @@ class BackupOptionsType extends TranslatorAwareType
         );
 
         $builder
-            ->add('backup_all', SwitchType::class, [
+            ->add('ignore_stats', SwitchType::class, [
                 'label' => $this->trans('Ignore statistics tables', 'Admin.Advparameters.Feature'),
                 'help' => $backupAllHelp,
             ])


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | fixes Backup - Ignore Statistics don't work as expected
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     |  no
| Fixed ticket?     | Fixes #28520
| Related PRs       | N/A
| How to test?      | Perform a DB backup before / after applying PR. See statistics table INSERT data being written or ignored properly in dump file. Check also #28520 comments for more details.
| Possible impacts? | 



