### PR TITLE
Remove id from entity search input templates

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
@@ -41,7 +41,7 @@
 {% endblock %}
 
 {% block related_product_row %}
-  <li class="related-product entity-item" id="{{ form.vars.name }}">
+  <li class="related-product entity-item">
     <div class="related-product-image">
       {{ form_widget(form.image) }}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
@@ -42,7 +42,7 @@
 
 {% block related_product_row %}
   {% set attr = attr|merge({'class': (attr.class|default('') ~ ' related-product entity-item')|trim}) %}
-  <li {{ block('widget_attributes') }}>
+  <li {{ block('widget_container_attributes') }}>
     <div class="related-product-image">
       {{ form_widget(form.image) }}
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/product.html.twig
@@ -41,12 +41,13 @@
 {% endblock %}
 
 {% block related_product_row %}
-  <li class="related-product entity-item">
+  {% set attr = attr|merge({'class': (attr.class|default('') ~ ' related-product entity-item')|trim}) %}
+  <li {{ block('widget_attributes') }}>
     <div class="related-product-image">
       {{ form_widget(form.image) }}
     </div>
     <div class="related-product-legend">
-      {{ form_widget(form.name, {prefix: '<i class="material-icons delete entity-item-delete">delete</i>'}) }}
+      {{ form_widget(form.name, {prefix: '<i class="material-icons entity-item-delete">delete</i>'}) }}
     </div>
     {{ form_widget(form.id) }}
   </li>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
@@ -26,10 +26,11 @@
 {% extends '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig' %}
 
 {% block searched_customer_row %}
-  <li class="media entity-item">
+  {% set attr = attr|merge({'class': (attr.class|default('') ~ ' media entity-item')|trim}) %}
+  <li {{ block('widget_attributes') }}>
     <div class="media-body media-middle">
       {{ form_widget(form.fullname_and_email) }}
-      <i class="material-icons delete entity-item-delete">clear</i>
+      <i class="material-icons entity-item-delete">clear</i>
     </div>
     {{ form_widget(form.id_customer) }}
   </li>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
@@ -27,7 +27,7 @@
 
 {% block searched_customer_row %}
   {% set attr = attr|merge({'class': (attr.class|default('') ~ ' media entity-item')|trim}) %}
-  <li {{ block('widget_attributes') }}>
+  <li {{ block('widget_container_attributes') }}>
     <div class="media-body media-middle">
       {{ form_widget(form.fullname_and_email) }}
       <i class="material-icons entity-item-delete">clear</i>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
@@ -26,7 +26,7 @@
 {% extends '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig' %}
 
 {% block searched_customer_row %}
-  <li class="media entity-item" id="{{ form.vars.name }}">
+  <li class="media entity-item">
     <div class="media-body media-middle">
       {{ form_widget(form.fullname_and_email) }}
       <i class="material-icons delete entity-item-delete">clear</i>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
@@ -82,7 +82,7 @@
 
 {% block entity_search_table_layout %}
   {%- set attr = list_attr|merge({'class': (list_attr.class|default('') ~ ' entities-list-container')|trim }) -%}
-  <div {{ block('widget_attributes') }}>
+  <div {{ block('widget_container_attributes') }}>
     <div class="row">
       <div class="col-sm">
         <table class="table">
@@ -120,7 +120,7 @@
 
 {% block entity_item_list_row %}
   {% set attr = attr|merge({'class': (attr.class|default('') ~ ' media entity-item')|trim}) %}
-  <li {{ block('widget_attributes') }}>
+  <li {{ block('widget_container_attributes') }}>
     <div class="media-left">
       {{ form_widget(form.image) }}
     </div>
@@ -134,7 +134,7 @@
 
 {%- block entity_item_table_row -%}
   {% set attr = attr|merge({'class': (attr.class|default('') ~ ' entity-item')|trim}) %}
-  <tr {{ block('widget_attributes') }}>
+  <tr {{ block('widget_container_attributes') }}>
   {% for child in form.children %}
     {% set childType = child.vars.block_prefixes.1 %}
     {% if childType == 'hidden'%}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
@@ -119,7 +119,7 @@
 {% endblock %}
 
 {% block entity_item_list_row %}
-  <li class="media entity-item" id="{{ form.vars.name }}">
+  <li class="media entity-item">
     <div class="media-left">
       {{ form_widget(form.image) }}
     </div>
@@ -132,7 +132,7 @@
 {% endblock %}
 
 {%- block entity_item_table_row -%}
-  <tr class="entity-item" id="{{ form.vars.name }}">
+  <tr class="entity-item">
   {% for child in form.children %}
     {% set childType = child.vars.block_prefixes.1 %}
     {% if childType == 'hidden'%}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/entity_search_input.html.twig
@@ -119,20 +119,22 @@
 {% endblock %}
 
 {% block entity_item_list_row %}
-  <li class="media entity-item">
+  {% set attr = attr|merge({'class': (attr.class|default('') ~ ' media entity-item')|trim}) %}
+  <li {{ block('widget_attributes') }}>
     <div class="media-left">
       {{ form_widget(form.image) }}
     </div>
     <div class="media-body media-middle">
       {{ form_widget(form.name) }}
-      <i class="material-icons delete entity-item-delete">clear</i>
+      <i class="material-icons entity-item-delete">clear</i>
     </div>
     {{ form_widget(form.id) }}
   </li>
 {% endblock %}
 
 {%- block entity_item_table_row -%}
-  <tr class="entity-item">
+  {% set attr = attr|merge({'class': (attr.class|default('') ~ ' entity-item')|trim}) %}
+  <tr {{ block('widget_attributes') }}>
   {% for child in form.children %}
     {% set childType = child.vars.block_prefixes.1 %}
     {% if childType == 'hidden'%}
@@ -147,7 +149,7 @@
   {# If item deletion is disabled we don't display the extra column for actions #}
   {% if form.parent.vars.allow_delete %}
     <td>
-      <i class="material-icons delete entity-item-delete">clear</i>
+      <i class="material-icons entity-item-delete">clear</i>
     </td>
   {% endif %}
   </tr>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The templates for the entity search input component included an ID based on `form.vars.name` which is the collection index, this could lead to elements with duplicated ID which is invalid in HTML. Besides the id was never used so it's been decided to remove it.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | CI tests green, check that the elements using this component still work like before (related products, attached files, SEO redirect target, specific price customer)
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

### Preview here is a video showing the places where the component is used

https://watch.screencastify.com/v/jLvUvAUxpeDaUBo8IwNk

Also, I forgot about the specific price customer:

https://watch.screencastify.com/v/me8QIW2Dwm2fbPXSZCCq