### PR TITLE
Combination tab out of stock

### DIFF
--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/StockCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/StockCommandsBuilder.php
@@ -97,6 +97,7 @@ final class StockCommandsBuilder implements MultiShopProductCommandsBuilderInter
     {
         $config = new CommandBuilderConfig($this->modifyAllNamePrefix);
         $config
+            ->addMultiShopField('[combinations][availability][out_of_stock_type]', 'setOutOfStockType', DataField::TYPE_INT)
             ->addMultiShopField('[combinations][availability][available_now_label]', 'setLocalizedAvailableNowLabels', DataField::TYPE_ARRAY)
             ->addMultiShopField('[combinations][availability][available_later_label]', 'setLocalizedAvailableLaterLabels', DataField::TYPE_ARRAY)
         ;

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -127,6 +127,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
         if ($productForEditing->getType() === ProductType::TYPE_COMBINATIONS) {
             $productData['combinations'] = [
                 'availability' => [
+                    'out_of_stock_type' => $productData['stock']['availability']['out_of_stock_type'],
                     'available_now_label' => $productData['stock']['availability']['available_now_label'] ?? [],
                     'available_later_label' => $productData['stock']['availability']['available_later_label'] ?? [],
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
@@ -54,6 +54,7 @@ class CombinationAvailabilityType extends TranslatorAwareType
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param FormChoiceProviderInterface $outOfStockTypeChoiceProvider
+     * @param RouterInterface $router
      */
     public function __construct(
         TranslatorInterface $translator,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
@@ -28,17 +28,58 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class CombinationAvailabilityType extends TranslatorAwareType
 {
+    /**
+     * @var FormChoiceProviderInterface
+     */
+    private $outOfStockTypeChoiceProvider;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param FormChoiceProviderInterface $outOfStockTypeChoiceProvider
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        FormChoiceProviderInterface $outOfStockTypeChoiceProvider,
+        RouterInterface $router
+    ) {
+        parent::__construct($translator, $locales);
+        $this->outOfStockTypeChoiceProvider = $outOfStockTypeChoiceProvider;
+        $this->router = $router;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            ->add('out_of_stock_type', ChoiceType::class, [
+                'choices' => $this->outOfStockTypeChoiceProvider->getChoices(),
+                'label' => false,
+                'expanded' => true,
+                'column_breaker' => true,
+                'modify_all_shops' => true,
+                'external_link' => [
+                    'text' => $this->trans('[1]Edit default behavior[/1]', 'Admin.Catalog.Feature'),
+                    'href' => $this->router->generate('admin_product_preferences') . '#configuration_fieldset_stock',
+                ],
+            ])
             ->add('available_now_label', TranslatableType::class, [
                 'type' => TextType::class,
                 'label' => $this->trans('Label when in stock', 'Admin.Catalog.Feature'),
@@ -62,7 +103,7 @@ class CombinationAvailabilityType extends TranslatorAwareType
         $resolver
             ->setDefaults([
                 'label' => $this->trans('When out of stock', 'Admin.Catalog.Feature'),
-                'label_tag_name' => 'h2',
+                'label_tag_name' => 'h3',
                 'required' => false,
                 'columns_number' => 3,
             ])

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -55,6 +55,7 @@ class AvailabilityType extends TranslatorAwareType
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param FormChoiceProviderInterface $outOfStockTypeChoiceProvider
+     * @param RouterInterface $router
      */
     public function __construct(
         TranslatorInterface $translator,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -36,6 +36,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class AvailabilityType extends TranslatorAwareType
@@ -46,6 +47,11 @@ class AvailabilityType extends TranslatorAwareType
     private $outOfStockTypeChoiceProvider;
 
     /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param FormChoiceProviderInterface $outOfStockTypeChoiceProvider
@@ -53,10 +59,12 @@ class AvailabilityType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        FormChoiceProviderInterface $outOfStockTypeChoiceProvider
+        FormChoiceProviderInterface $outOfStockTypeChoiceProvider,
+        RouterInterface $router
     ) {
         parent::__construct($translator, $locales);
         $this->outOfStockTypeChoiceProvider = $outOfStockTypeChoiceProvider;
+        $this->router = $router;
     }
 
     /**
@@ -67,10 +75,14 @@ class AvailabilityType extends TranslatorAwareType
         $builder
             ->add('out_of_stock_type', ChoiceType::class, [
                 'choices' => $this->outOfStockTypeChoiceProvider->getChoices(),
-                'label' => $this->trans('Behavior when out of stock', 'Admin.Catalog.Feature'),
+                'label' => false,
                 'expanded' => true,
                 'column_breaker' => true,
                 'modify_all_shops' => true,
+                'external_link' => [
+                    'text' => $this->trans('[1]Edit default behavior[/1]', 'Admin.Catalog.Feature'),
+                    'href' => $this->router->generate('admin_product_preferences') . '#configuration_fieldset_stock',
+                ],
             ])
             ->add('available_now_label', TranslatableType::class, [
                 'type' => TextType::class,
@@ -105,7 +117,7 @@ class AvailabilityType extends TranslatorAwareType
     {
         parent::configureOptions($resolver);
         $resolver->setDefaults([
-            'label' => $this->trans('Availability preferences', 'Admin.Catalog.Feature'),
+            'label' => $this->trans('When out of stock', 'Admin.Catalog.Feature'),
             'label_tag_name' => 'h3',
             'required' => false,
             'columns_number' => 3,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1496,6 +1496,7 @@ services:
     public: true
     arguments:
       - '@prestashop.core.form.choice_provider.out_of_stock_type_choice_provider'
+      - '@router'
     tags:
       - { name: form.type }
 
@@ -1773,6 +1774,9 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\Combination\CombinationAvailabilityType'
     parent: 'form.type.translatable.aware'
     public: true
+    arguments:
+      - '@prestashop.core.form.choice_provider.out_of_stock_type_choice_provider'
+      - '@router'
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/pagination.html.twig
@@ -37,7 +37,8 @@
       'total': grid.data.records_total,
       'prefix': grid.form_prefix,
       'caller_route': app.request.attributes.get('_route'),
-      'caller_parameters': route_params
+      'caller_parameters': route_params,
+      'view': grid.view_options.pagination_view|default('full')
     })) }}
   {% endif %}
 {% endblock %}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/StockCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/StockCommandsBuilderTest.php
@@ -153,6 +153,35 @@ class StockCommandsBuilderTest extends AbstractProductCommandBuilderTest
             [$command],
         ];
 
+        // Handle out_of_stock_type for product with combinations
+        $command->setOutOfStockType(OutOfStockType::OUT_OF_STOCK_DEFAULT);
+        yield [
+            [
+                'header' => [
+                    'type' => ProductType::TYPE_COMBINATIONS,
+                ],
+                'combinations' => [
+                    'availability' => [
+                        'out_of_stock_type' => '2',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setAvailableDate(new DateTimeImmutable('2022-10-10'));
+        yield [
+            [
+                'stock' => [
+                    'availability' => [
+                        'available_date' => '2022-10-10',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
         $command = $this->getSingleShopCommand();
         $localizedNotes = [
             '1' => 'hello',

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -409,7 +409,7 @@ class ProductFormDataProviderTest extends TestCase
             'low_stock_threshold' => 5,
             'low_stock_alert' => true,
             'pack_stock_type' => PackStockType::STOCK_TYPE_PACK_ONLY,
-            'out_of_stock' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+            'out_of_stock_type' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
             'available_now' => $localizedValues,
             'available_later' => $localizedValues,
             'available_date' => new DateTime('1969/07/20'),
@@ -941,15 +941,18 @@ class ProductFormDataProviderTest extends TestCase
         $expectedOutputData = $this->getDefaultOutputData();
         $productData = [
             'type' => ProductType::TYPE_COMBINATIONS,
+            'out_of_stock_type' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
             'available_now' => $localizedValues,
             'available_later' => $localizedValues,
         ];
 
         $expectedOutputData['header']['type'] = ProductType::TYPE_COMBINATIONS;
+        $expectedOutputData['combinations']['availability']['out_of_stock_type'] = OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE;
         $expectedOutputData['combinations']['availability']['available_now_label'] = $localizedValues;
         $expectedOutputData['combinations']['availability']['available_later_label'] = $localizedValues;
         $expectedOutputData['stock']['availability']['available_now_label'] = $localizedValues;
         $expectedOutputData['stock']['availability']['available_later_label'] = $localizedValues;
+        $expectedOutputData['stock']['availability']['out_of_stock_type'] = OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE;
 
         $datasets[] = [
             $productData,
@@ -1150,7 +1153,7 @@ class ProductFormDataProviderTest extends TestCase
     {
         return new ProductStockInformation(
             $product['pack_stock_type'] ?? PackStockType::STOCK_TYPE_DEFAULT,
-            $product['out_of_stock'] ?? OutOfStockType::OUT_OF_STOCK_DEFAULT,
+            $product['out_of_stock_type'] ?? OutOfStockType::OUT_OF_STOCK_DEFAULT,
             $product['quantity'] ?? self::DEFAULT_QUANTITY,
             $product['minimal_quantity'] ?? 0,
             $product['low_stock_threshold'] ?? 0,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle out of stock configuration in combinations tab
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | CI tests green, part of a bigger feature (combinations) will be tested by QA later
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
