### PR TITLE
Set $registeredHookName as renderWidget when no hook given

### DIFF
--- a/tools/profiling/Hook.php
+++ b/tools/profiling/Hook.php
@@ -63,6 +63,14 @@ class Hook extends HookCore
 
         $result = parent::coreRenderWidget($module, $registeredHookName, $params);
 
+        /*
+         * It's not a hook which has been triggered but
+         * it's a widget
+         */
+        if (empty($registeredHookName)) {
+            $registeredHookName = 'renderWidget';
+        }
+
         Profiler::getInstance()->interceptHook(
             $registeredHookName,
             [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Allow using Profiling when widgets are calls without hook name.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28604
| How to test?      | See issue.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
