### PR TITLE
Fix Module Notifications action button behavior

### DIFF
--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -360,7 +360,7 @@ export default class ModuleCard {
     callback = () => true,
   ): boolean {
     const self = this;
-    const jqElementObj = element.closest(this.moduleItemActionsSelector);
+    let jqElementObj = element.closest(this.moduleItemActionsSelector);
     const form = element.closest('form');
     const spinnerObj = $(
       '<button class="btn-primary-reverse onclick unbind spinner "></button>',
@@ -453,7 +453,11 @@ export default class ModuleCard {
           BOEvent.emitEvent('Module Installed', 'CustomEvent', mainElement);
         };
 
-        jqElementObj.replaceWith(result[moduleTechName].action_menu_html);
+        // Since we replace the DOM content
+        // we need to update the jquery object reference to target the new content,
+        // and we need to hide the new content which is not hidden by default
+        jqElementObj = $(result[moduleTechName].action_menu_html).replaceAll(jqElementObj);
+        jqElementObj.hide();
       })
       .fail(() => {
         const moduleItem = jqElementObj.closest('module-item-list');

--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -428,7 +428,10 @@ export default class ModuleCard {
           mainElement.attr('data-installed', '0');
           mainElement.attr('data-active', '0');
 
+          refreshNeeded = true; // if uninstalled, some sub pages may change (updates)
           BOEvent.emitEvent('Module Uninstalled', 'CustomEvent', mainElement);
+        } else if (action === 'update') {
+          refreshNeeded = true; // if module upgraded, sub pages may change (updates)
         } else if (action === 'disable') {
           mainElement = jqElementObj.closest(`.${alteredSelector}`);
           mainElement.addClass(`${alteredSelector}-isNotActive`);
@@ -463,6 +466,7 @@ export default class ModuleCard {
       .always(() => {
         if (refreshNeeded) {
           document.location.reload();
+          refreshNeeded = false;
           return;
         }
         jqElementObj.fadeIn();

--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -428,10 +428,7 @@ export default class ModuleCard {
           mainElement.attr('data-installed', '0');
           mainElement.attr('data-active', '0');
 
-          refreshNeeded = true; // if uninstalled, some sub pages may change (updates)
           BOEvent.emitEvent('Module Uninstalled', 'CustomEvent', mainElement);
-        } else if (action === 'update') {
-          refreshNeeded = true; // if module upgraded, sub pages may change (updates)
         } else if (action === 'disable') {
           mainElement = jqElementObj.closest(`.${alteredSelector}`);
           mainElement.addClass(`${alteredSelector}-isNotActive`);
@@ -470,7 +467,6 @@ export default class ModuleCard {
       .always(() => {
         if (refreshNeeded) {
           document.location.reload();
-          refreshNeeded = false;
           return;
         }
         jqElementObj.fadeIn();

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -109,11 +109,11 @@ class ModulePresenter implements PresenterInterface
      */
     public function presentCollection($modules)
     {
-        $presentedProducts = [];
-        foreach ($modules as $name => $product) {
-            $presentedProducts[$name] = $this->present($product);
+        $presentedModules = [];
+        foreach ($modules as $name => $module) {
+            $presentedModules[$name] = $this->present($module);
         }
 
-        return $presentedProducts;
+        return $presentedModules;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -248,11 +248,15 @@ class ModuleController extends ModuleAbstractController
             }
 
             $collection = ModuleCollection::createFrom([$moduleInstance]);
+            $collectionWithActionUrls = $modulesProvider->setActionUrls($collection);
+
+            $modulePresenter = $this->get('prestashop.adapter.presenter.module');
+            $collectionPresented = $modulePresenter->presentCollection($collectionWithActionUrls);
+
             $response[$module]['action_menu_html'] = $this->container->get('twig')->render(
                 '@PrestaShop/Admin/Module/Includes/action_menu.html.twig',
                 [
-                    'module' => $this->container->get('prestashop.adapter.presenter.module')
-                        ->presentCollection($modulesProvider->setActionUrls($collection))[0],
+                    'module' => $collectionPresented[0],
                     'level' => $this->authorizationLevel(self::CONTROLLER_NAME),
                 ]
             );

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/UpdatesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/UpdatesController.php
@@ -41,11 +41,9 @@ class UpdatesController extends ModuleAbstractController
      */
     public function indexAction()
     {
-        $moduleRepository = $this->getModuleRepository();
+        $moduleList = $this->getModuleRepository()->getUpgradableModules();
+        $pageData = $this->getNotificationPageData($moduleList);
 
-        return $this->render(
-            '@PrestaShop/Admin/Module/updates.html.twig',
-            $this->getNotificationPageData($moduleRepository->getUpgradableModules())
-        );
+        return $this->render('@PrestaShop/Admin/Module/updates.html.twig', $pageData);
     }
 }

--- a/tests/Integration/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Integration/Core/Module/ModuleRepositoryTest.php
@@ -73,7 +73,7 @@ class ModuleRepositoryTest extends TestCase
             // - overrides `dummy_payment` module `fullDescription` attributes
             // - adds `testAttribute` attributes to `dummy_payment` module
             // when 'actionListModules' hook called
-            if($hook_name == 'actionListModules') {
+            if ($hook_name == 'actionListModules') {
                 return [
                     'ps_distributionapiclient' => [
                         [
@@ -81,13 +81,13 @@ class ModuleRepositoryTest extends TestCase
                             'fullDescription' => 'overridden full description',
                             'testAttribute' => 'added value',
                         ],
-                    ]
+                    ],
                 ];
             } else {
                 return [];
             }
         };
-        $hookManager->method("exec")->willReturn(
+        $hookManager->method('exec')->willReturn(
             $this->returnCallback($hookExecMethodMock)
         );
 

--- a/tests/Integration/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Integration/Core/Module/ModuleRepositoryTest.php
@@ -31,6 +31,7 @@ namespace Tests\Integration\Core\Module;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
+use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -55,11 +56,46 @@ class ModuleRepositoryTest extends TestCase
         $translator = $this->createMock(Translator::class);
         $translator->method('trans')->willReturnArgument(0);
 
+        $hookManager = $this->createMock(HookManager::class);
+        $hookExecMethodMock = function () {
+            // cf. HookManager::exec() method signature
+            list(
+                $hook_name,
+                $hook_args,
+                $id_module,
+                $array_return,
+                $check_exceptions,
+                $use_push,
+                $id_shop
+                ) = func_get_args();
+
+            // This mock represents a module that :
+            // - overrides `dummy_payment` module `fullDescription` attributes
+            // - adds `testAttribute` attributes to `dummy_payment` module
+            // when 'actionListModules' hook called
+            if($hook_name == 'actionListModules') {
+                return [
+                    'ps_distributionapiclient' => [
+                        [
+                            'name' => 'dummy_payment',
+                            'fullDescription' => 'overridden full description',
+                            'testAttribute' => 'added value',
+                        ],
+                    ]
+                ];
+            } else {
+                return [];
+            }
+        };
+        $hookManager->method("exec")->willReturn(
+            $this->returnCallback($hookExecMethodMock)
+        );
+
         $this->moduleRepository = new ModuleRepository(
             $moduleDataProvider,
             $this->createMock(AdminModuleDataProvider::class),
             new DoctrineProvider(new ArrayAdapter()),
-            $this->createMock(HookManager::class),
+            $hookManager,
             dirname(__DIR__, 3) . '/Resources/modules/'
         );
     }
@@ -67,5 +103,13 @@ class ModuleRepositoryTest extends TestCase
     public function testGetAtLeastOneModuleFromUniverse(): void
     {
         $this->assertGreaterThan(0, count($this->moduleRepository->getList()));
+    }
+
+    public function testGetModuleWellEnrichedByModules(): void
+    {
+        $dummy_module = $this->moduleRepository->getModule('dummy_payment');
+
+        $this->assertEquals('overridden full description', $dummy_module->get('fullDescription'));
+        $this->assertEquals('added value', $dummy_module->get('testAttribute'));
     }
 }

--- a/tests/Integration/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Integration/Core/Module/ModuleRepositoryTest.php
@@ -71,7 +71,7 @@ class ModuleRepositoryTest extends TestCase
             // - overrides `dummy_payment` module `fullDescription` attributes
             // - adds `testAttribute` attributes to `dummy_payment` module
             // when 'actionListModules' hook called
-            if ($hook_name == 'actionListModules') {
+            if ($hook_name === 'actionListModules') {
                 return [
                     'ps_distributionapiclient' => [
                         [
@@ -102,7 +102,7 @@ class ModuleRepositoryTest extends TestCase
     {
         $moduleList = iterator_to_array($this->moduleRepository->getList());
         $filteredModules = array_filter($moduleList, function ($module, $key) {
-            return $module->get('name') == 'dummy_payment';
+            return $module->get('name') === 'dummy_payment';
         }, ARRAY_FILTER_USE_BOTH);
 
         $this->assertEquals(1, count($filteredModules), 'Returned module list may contain at least "dummy_payment" module.');

--- a/tests/Unit/Core/Module/ModuleRepositoryTest.php
+++ b/tests/Unit/Core/Module/ModuleRepositoryTest.php
@@ -28,16 +28,14 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Core\Module;
 
+use Doctrine\Common\Cache\CacheProvider;
 use Module as LegacyModule;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\HookManager;
 use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
-use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepository;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
 
 class ModuleRepositoryTest extends TestCase
 {
@@ -56,89 +54,52 @@ class ModuleRepositoryTest extends TestCase
         'ps_banner',
     ];
 
+    /** @var ModuleRepository */
+    private $moduleRepository;
+
+    public function setUp(): void
+    {
+        $this->moduleRepository = $this->getMockBuilder(ModuleRepository::class)
+            ->setConstructorArgs([
+                $this->createMock(ModuleDataProvider::class),
+                $this->createMock(AdminModuleDataProvider::class),
+                $this->createMock(CacheProvider::class),
+                $this->createMock(HookManager::class),
+                dirname(__DIR__, 3) . '/Resources/modules',
+            ])
+            ->onlyMethods(['getModule'])
+            ->getMock()
+        ;
+        $this->moduleRepository->method('getModule')->willReturnCallback([$this, 'getModuleMock']);
+    }
+
     public function testGetList(): void
     {
-        $this->assertCount(10, $this->getModuleRepository()->getList());
+        $this->assertCount(10, $this->moduleRepository->getList());
     }
 
     public function testGetInstalledModules(): void
     {
-        $this->assertCount(count(self::INSTALLED_MODULES), $this->getModuleRepository()->getInstalledModules());
+        $this->assertCount(count(self::INSTALLED_MODULES), $this->moduleRepository->getInstalledModules());
     }
 
     public function testGetUpgradableModules(): void
     {
-        $this->assertCount(count(self::UPGRADABLE_MODULES), $this->getModuleRepository()->getUpgradableModules());
+        $this->assertCount(count(self::UPGRADABLE_MODULES), $this->moduleRepository->getUpgradableModules());
     }
 
     public function testGetMustBeConfiguredModules(): void
     {
-        $this->assertCount(count(self::CONFIGURABLE_MODULES), $this->getModuleRepository()->getMustBeConfiguredModules());
+        $this->assertCount(count(self::CONFIGURABLE_MODULES), $this->moduleRepository->getMustBeConfiguredModules());
     }
 
     public function testGetModulePath(): void
     {
-        $moduleRepository = $this->getModuleRepository();
-
         $this->assertEquals(
            dirname(__DIR__, 3) . '/Resources/modules/bankwire',
-           $moduleRepository->getModulePath('bankwire')
+            $this->moduleRepository->getModulePath('bankwire')
         );
-
-        $this->assertNull($moduleRepository->getModulePath('no-existing-module'));
-    }
-
-    private function getModuleRepository(): ModuleRepository
-    {
-        $moduleDataProvider = $this->createMock(ModuleDataProvider::class);
-        $adminModuleDataProvider = $this->createMock(AdminModuleDataProvider::class);
-        $cacheProvider = new DoctrineProvider(new ArrayAdapter());
-        $hookManager = $this->createMock(HookManager::class);
-        $modulePath = dirname(__DIR__, 3) . '/Resources/modules';
-
-        $moduleRepository = new ModuleRepository(
-            $moduleDataProvider,
-            $adminModuleDataProvider,
-            $cacheProvider,
-            $hookManager,
-            $modulePath
-        );
-
-        $reflection = new \ReflectionClass($moduleRepository);
-        $property = $reflection->getProperty('storedSaticCall');
-        $property->setAccessible(true);
-        $property->setValue($moduleRepository,
-            new class($this) {
-                private $testClass;
-
-                public function __construct($testClass)
-                {
-                    $this->testClass = $testClass;
-                }
-
-                public function getContextShopIdListCacheKey()
-                {
-                    return '1';
-                }
-
-                public function moduleCollectionCreateFrom(array $modules): ModuleCollection
-                {
-                    return ModuleCollection::createFrom($modules);
-                }
-
-                public function getModuleInstanceByName(string $moduleName)
-                {
-                    return $this->testClass->getModuleMock($moduleName);
-                }
-
-                public function newModule(array $attributes = [], array $disk = [], array $database = []): Module
-                {
-                    return $this->testClass->getModuleMock($attributes['name']);
-                }
-            }
-        );
-
-        return $moduleRepository;
+        $this->assertNull($this->moduleRepository->getModulePath('no-existing-module'));
     }
 
     public function getModuleMock(string $moduleName): Module


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | In "update notifications" view, action buttons don't update properly after some actions. 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28433.
| Related PRs       |
| How to test?      | Cf. #28433. :point_up: Please notice that to reproduce / test the bug you need to have modules that require to be updated so you may have to downgrade manually a module (in module folder and in db).  
| Possible impacts? | All actions menu in module manager and any code that depends on `ModuleRepository::getModule(...)`


As mentioned in #28433 , after upgrading or uninstalling a module, the module is not removed from update list without a page refresh (F5). I fixed this problem with some js refactoring (`refreshNeeded` part)

Then the main problem was linked to [ModuleController](https://github.com/PrestaShop/PrestaShop/blob/ed982dc0966bd5e9c1e902685bef075191b14c9e/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php#L251) that recreate action menu dynamically. But it uses directly ``ModuleRepository::getModule()`` method that does not apply 'actionListModules' hook for Module description (I suspect it is linked to autoupgrade module).
