### PR TITLE
Fix inability to delete csv-converted files from import

### DIFF
--- a/src/Core/Import/File/FileRemoval.php
+++ b/src/Core/Import/File/FileRemoval.php
@@ -52,6 +52,14 @@ final class FileRemoval
     public function remove($filename)
     {
         $fs = new Filesystem();
-        $fs->remove($this->importDirectory . $filename);
+        $filesToRemove = [
+            $this->importDirectory . $filename,
+            $this->importDirectory . 'csvfromexcel/' . $filename,
+        ];
+        foreach ($filesToRemove as $fileToRemove) {
+            if (file_exists($fileToRemove)) {
+                $fs->remove($fileToRemove);
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | FileRemoval remove() method to delete imported files from backoffice was not taking into account the /csvfromexcel folder containing CSV converted from Excel by Prestashop itself.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28228
| Related PRs       | N/A
| How to test?      | Follow steps described in #28228 before and after applying the PR
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
