### PR TITLE
Fix `PrestashopLogger`  attr `object_type` validate

### DIFF
--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -92,7 +92,7 @@ class PrestaShopLoggerCore extends ObjectModel
             'id_lang' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'allow_null' => true],
             'in_all_shops' => ['type' => self::TYPE_BOOL, 'validate' => 'isBool'],
             'id_employee' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'],
-            'object_type' => ['type' => self::TYPE_STRING, 'validate' => 'isName'],
+            'object_type' => ['type' => self::TYPE_STRING, 'validate' => 'isValidObjectClassName'],
             'date_add' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
             'date_upd' => ['type' => self::TYPE_DATE, 'validate' => 'isDate'],
         ],

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1289,7 +1289,7 @@ class ValidateCore
     }
 
     /**
-     * Check the given string is a valid object class name
+     * Check the given string is a valid PHP class name
      *
      * @param string $objectClassName object class name
      *

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -37,6 +37,7 @@ use Symfony\Component\Validator\Validation;
 class ValidateCore
 {
     public const ORDER_BY_REGEXP = '/^(?:(`?)[\w!_-]+\1\.)?(?:(`?)[\w!_-]+\2)$/';
+    public const OBJECT_CLASS_NAME_REGEXP = '/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/';
     /**
      * Maximal 32 bits value: (2^32)-1
      *
@@ -1285,5 +1286,17 @@ class ValidateCore
         }
 
         return true;
+    }
+
+    /**
+     * Check the given string is a valid object class name
+     *
+     * @param string $objectClassName object class name
+     *
+     * @return bool
+     */
+    public static function isValidObjectClassName(string $objectClassName): bool
+    {
+        return preg_match(static::OBJECT_CLASS_NAME_REGEXP, $objectClassName);
     }
 }

--- a/src/Adapter/Validate.php
+++ b/src/Adapter/Validate.php
@@ -147,4 +147,16 @@ class Validate
     {
         return ValidateLegacy::isLinkRewrite($value);
     }
+
+    /**
+     * Check the given string is a valid object class name
+     *
+     * @param string $objectClassName object class name
+     *
+     * @return bool
+     */
+    public static function isValidObjectClassName(string $objectClassName): bool
+    {
+        return ValidateLegacy::isValidObjectClassName($objectClassName);
+    }
 }

--- a/tests/Unit/Adapter/ValidateTest.php
+++ b/tests/Unit/Adapter/ValidateTest.php
@@ -124,4 +124,33 @@ class ValidateTest extends TestCase
             [false, '666invalid'],
         ];
     }
+
+    /**
+     * @param bool $expected
+     * @param mixed $value
+     *
+     * @dataProvider isValidObjectClassNameDataProvider
+     */
+    public function testisValidObjectClassName(bool $expected, string $objectClassName): void
+    {
+        $this->assertSame($expected, $this->validate->isValidObjectClassName($objectClassName));
+    }
+
+    public function isValidObjectClassNameDataProvider(): array
+    {
+        return [
+            [true, 'MyClassName'],
+            [true, '_MyClassName'],
+            [true, '_My_Class_Name_'],
+            [true, '_MyClassName_'],
+            [true, '__My__Class__Name__'],
+            [false, ''],
+            [false, null],
+            [false, 666],
+            [false, '666'],
+            [true, '_666'],
+            [true, '_6_6_6_'],
+            [true, '__'],
+        ];
+    }
 }

--- a/tests/Unit/Adapter/ValidateTest.php
+++ b/tests/Unit/Adapter/ValidateTest.php
@@ -127,7 +127,7 @@ class ValidateTest extends TestCase
 
     /**
      * @param bool $expected
-     * @param mixed $value
+     * @param mixed $objectClassName
      *
      * @dataProvider isValidObjectClassNameDataProvider
      */
@@ -145,8 +145,6 @@ class ValidateTest extends TestCase
             [true, '_MyClassName_'],
             [true, '__My__Class__Name__'],
             [false, ''],
-            [false, null],
-            [false, 666],
             [false, '666'],
             [true, '_666'],
             [true, '_6_6_6_'],

--- a/tests/Unit/Adapter/ValidateTest.php
+++ b/tests/Unit/Adapter/ValidateTest.php
@@ -127,7 +127,7 @@ class ValidateTest extends TestCase
 
     /**
      * @param bool $expected
-     * @param mixed $objectClassName
+     * @param string $objectClassName
      *
      * @dataProvider isValidObjectClassNameDataProvider
      */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix `PrestashopLogger`  attr `object_type` validate. Validate object class name according PHP doc https://www.php.net/manual/en/language.oop5.basic.php
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28617
| Related PRs       | N/A.
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/28617.
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
