### PR TITLE
Replace unit type with a form type extension

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
@@ -30,7 +30,7 @@ use Cookie;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -54,13 +54,15 @@ class GeneralType extends TranslatorAwareType
                 'label' => $this->trans('Check the cookie\'s IP address', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Check the IP address of the cookie in order to prevent your cookie from being stolen.', 'Admin.Advparameters.Help'),
             ])
-            ->add(self::FIELD_FRONT_COOKIE_LIFETIME, TextType::class, [
+            ->add(self::FIELD_FRONT_COOKIE_LIFETIME, IntegerType::class, [
                 'label' => $this->trans('Lifetime of front office cookies', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Set the amount of hours during which the front office cookies are valid. After that amount of time, the customer will have to log in again.', 'Admin.Advparameters.Help'),
+                'unit' => $this->trans('hours', 'Admin.Shopparameters.Feature'),
             ])
-            ->add(self::FIELD_BACK_COOKIE_LIFETIME, TextType::class, [
+            ->add(self::FIELD_BACK_COOKIE_LIFETIME, IntegerType::class, [
                 'label' => $this->trans('Lifetime of back office cookies', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('When you access your back office and decide to stay logged in, your cookies lifetime defines your browser session. Set here the number of hours during which you want them valid before logging in again.', 'Admin.Advparameters.Help'),
+                'unit' => $this->trans('hours', 'Admin.Shopparameters.Feature'),
             ])
             ->add(self::FIELD_COOKIE_SAMESITE, ChoiceType::class, [
                 'label' => $this->trans('Cookie SameSite', 'Admin.Advparameters.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
@@ -48,7 +48,7 @@ class UploadQuotaType extends TranslatorAwareType
         $builder
             ->add(
                 self::FIELD_MAX_SIZE_ATTACHED_FILES,
-                TextWithUnitType::class,
+                IntegerType::class,
                 [
                     'label' => $this->trans(
                         'Maximum size for attached files',
@@ -80,7 +80,7 @@ class UploadQuotaType extends TranslatorAwareType
             )
             ->add(
                 self::FIELD_MAX_SIZE_DOWNLOADABLE_FILE,
-                TextWithUnitType::class,
+                IntegerType::class,
                 [
                     'label' => $this->trans(
                         'Maximum size for a downloadable product',
@@ -112,7 +112,7 @@ class UploadQuotaType extends TranslatorAwareType
             )
             ->add(
                 self::FIELD_MAX_SIZE_PRODUCT_IMAGE,
-                TextWithUnitType::class,
+                IntegerType::class,
                 [
                     'label' => $this->trans(
                         'Maximum size for a product\'s image',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -27,8 +27,8 @@
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
@@ -63,7 +63,7 @@ class EmployeeOptionsType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('password_change_time', TextWithUnitType::class, [
+            ->add('password_change_time', IntegerType::class, [
                 'required' => false,
                 'unit' => $this->trans('minutes', 'Admin.Advparameters.Feature'),
                 'disabled' => !$this->canOptionsBeChanged,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/CustomerPreferences/GeneralType.php
@@ -27,8 +27,8 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\CustomerPreferences;
 
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
@@ -63,7 +63,7 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Help'
                 ),
             ])
-            ->add('password_reset_delay', TextWithUnitType::class, [
+            ->add('password_reset_delay', IntegerType::class, [
                 'label' => $this->trans(
                     'Password reset delay',
                     'Admin.Shopparameters.Feature'

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreference
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPricePriorityType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -104,7 +103,7 @@ class GeneralType extends TranslatorAwareType
                 ),
                 'required' => false,
             ])
-            ->add('short_description_limit', TextWithUnitType::class, [
+            ->add('short_description_limit', IntegerType::class, [
                 'label' => $this->trans(
                     'Max size of product summary',
                     'Admin.Shopparameters.Feature'

--- a/src/PrestaShopBundle/Form/Admin/Extension/UnitTypeExtension.php
+++ b/src/PrestaShopBundle/Form/Admin/Extension/UnitTypeExtension.php
@@ -24,33 +24,31 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShopBundle\Form\Admin\Type;
+declare(strict_types=1);
 
-use Symfony\Component\Form\AbstractType;
+namespace PrestaShopBundle\Form\Admin\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TextWithUnitType extends AbstractType
+/**
+ * Adds a unit suffix to form type.
+ */
+class UnitTypeExtension extends AbstractTypeExtension
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
-    {
-        return NumberType::class;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults([
-            'widget' => 'single_text',
-            'unit' => 'unit',
-        ]);
+        $resolver
+            ->setDefined('unit')
+            ->setAllowedTypes('unit', 'string')
+        ;
     }
 
     /**
@@ -58,18 +56,16 @@ class TextWithUnitType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        parent::buildView($view, $form, $options);
-
-        $view->vars = array_merge($view->vars, [
-            'unit' => $options['unit'],
-        ]);
+        if (isset($options['unit'])) {
+            $view->vars['unit'] = $options['unit'];
+        }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public static function getExtendedTypes(): iterable
     {
-        return 'text_with_unit';
+        return [IntegerType::class, NumberType::class];
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -30,9 +30,9 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
 use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
 use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -98,7 +98,7 @@ class HandlingType extends TranslatorAwareType
                 ),
                 'multistore_configuration_key' => 'PS_SHIPPING_FREE_PRICE',
             ])
-            ->add('free_shipping_weight', TextWithUnitType::class, [
+            ->add('free_shipping_weight', NumberType::class, [
                 'unit' => $weightUnit,
                 'required' => false,
                 'empty_data' => '0',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/AddProductRowType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/AddProductRowType.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Order;
 
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -96,14 +95,14 @@ class AddProductRowType extends TranslatorAwareType
                     'class' => 'custom-select',
                 ],
             ])
-            ->add('price_tax_excluded', TextWithUnitType::class, [
+            ->add('price_tax_excluded', NumberType::class, [
                 'label' => false,
                 'unit' => sprintf('%s %s',
                     $options['symbol'],
                         $this->trans('tax excl.', 'Admin.Global')
                 ),
             ])
-            ->add('price_tax_included', TextWithUnitType::class, [
+            ->add('price_tax_included', NumberType::class, [
                 'label' => false,
                 'unit' => sprintf('%s %s',
                     $options['symbol'],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/EditProductRowType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/EditProductRowType.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Order;
 
 use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -81,7 +80,7 @@ class EditProductRowType extends TranslatorAwareType
             ]) : [];
 
         $builder
-            ->add('price_tax_excluded', TextWithUnitType::class, [
+            ->add('price_tax_excluded', NumberType::class, [
                 'label' => false,
                 'unit' => sprintf('%s %s',
                     $options['symbol'],
@@ -91,7 +90,7 @@ class EditProductRowType extends TranslatorAwareType
                     'class' => 'editProductPriceTaxExcl',
                 ],
             ])
-            ->add('price_tax_included', TextWithUnitType::class, [
+            ->add('price_tax_included', NumberType::class, [
                 'label' => false,
                 'unit' => sprintf('%s %s',
                     $options['symbol'],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationPriceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationPriceType.php
@@ -29,9 +29,9 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 
 use Currency;
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -125,7 +125,7 @@ class BulkCombinationPriceType extends TranslatorAwareType
                 'disabling_switch' => true,
                 'disabled_value' => 0,
             ])
-            ->add('weight', TextWithUnitType::class, [
+            ->add('weight', NumberType::class, [
                 'required' => false,
                 'label' => $this->trans('Impact on weight', 'Admin.Catalog.Feature'),
                 'unit' => $this->weightUnit,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationPriceImpactType.php
@@ -29,9 +29,9 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 
 use Currency;
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -117,7 +117,7 @@ class CombinationPriceImpactType extends TranslatorAwareType
                     new Type(['type' => 'float']),
                 ],
             ])
-            ->add('weight', TextWithUnitType::class, [
+            ->add('weight', NumberType::class, [
                 'required' => false,
                 'label' => $this->trans('Impact on weight', 'Admin.Catalog.Feature'),
                 'unit' => $this->weightUnit,

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Shipping/DimensionsType.php
@@ -29,8 +29,8 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Shipping;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\PositiveOrZero;
-use PrestaShopBundle\Form\Admin\Type\TextWithUnitType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -72,7 +72,7 @@ class DimensionsType extends TranslatorAwareType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('width', TextWithUnitType::class, [
+            ->add('width', NumberType::class, [
                 'required' => false,
                 'label' => $this->trans('Width', 'Admin.Catalog.Feature'),
                 'unit' => $this->dimensionUnit,
@@ -89,7 +89,7 @@ class DimensionsType extends TranslatorAwareType
                 ],
                 'default_empty_data' => 0,
             ])
-            ->add('height', TextWithUnitType::class, [
+            ->add('height', NumberType::class, [
                 'required' => false,
                 'label' => $this->trans('Height', 'Admin.Catalog.Feature'),
                 'unit' => $this->dimensionUnit,
@@ -106,7 +106,7 @@ class DimensionsType extends TranslatorAwareType
                 ],
                 'default_empty_data' => 0,
             ])
-            ->add('depth', TextWithUnitType::class, [
+            ->add('depth', NumberType::class, [
                 'required' => false,
                 'label' => $this->trans('Depth', 'Admin.Catalog.Feature'),
                 'unit' => $this->dimensionUnit,
@@ -123,7 +123,7 @@ class DimensionsType extends TranslatorAwareType
                 ],
                 'default_empty_data' => 0,
             ])
-            ->add('weight', TextWithUnitType::class, [
+            ->add('weight', NumberType::class, [
                 'required' => false,
                 'label' => $this->trans('Weight', 'Admin.Catalog.Feature'),
                 'unit' => $this->weightUnit,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -69,6 +69,11 @@ services:
     tags:
       - { name: form.type_extension, extended_type: PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType }
 
+  form.extension.unit:
+    class: 'PrestaShopBundle\Form\Admin\Extension\UnitTypeExtension'
+    tags:
+      - { name: form.type_extension }
+
   form.extension.multistore_dropdown:
     class: 'PrestaShopBundle\Form\Admin\Extension\MultistoreExtension'
     tags:

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
@@ -99,17 +99,6 @@
     form-group row
 {%- endblock form_row_class %}
 
-{% block text_with_unit_widget %}
-<div class="input-group">
-    {{- block('form_widget_simple') -}}
-    {% if form.vars.unit is defined %}
-        <div class="input-group-append">
-            <span class="input-group-text">{{ form.vars.unit }}</span>
-        </div>
-    {% endif %}
-</div>
-{% endblock text_with_unit_widget %}
-
 {% block ip_address_text_widget %}
 <div class="input-group">
     {{- block('form_widget_simple') -}}
@@ -151,3 +140,29 @@
     {% endif %}
   </div>
 {% endblock text_with_length_counter_widget %}
+
+{%- block number_widget -%}
+  {%- set type = type|default('text') -%}
+  <div class="input-group">
+    {{- block('form_widget_simple') -}}
+    {{- block('form_unit') -}}
+  </div>
+  {{ block('form_help') }}
+{%- endblock number_widget -%}
+
+{%- block integer_widget -%}
+  {%- set type = type|default('number') -%}
+  <div class="input-group">
+    {{- block('form_widget_simple') -}}
+    {{- block('form_unit') -}}
+  </div>
+  {{ block('form_help') }}
+{%- endblock integer_widget -%}
+
+{% block form_unit %}
+  {% if form.vars.unit is defined %}
+    <div class="input-group-append">
+      <span class="input-group-text">{{ form.vars.unit }}</span>
+    </div>
+  {% endif %}
+{% endblock form_unit %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -75,18 +75,6 @@
   {% include '@PrestaShop/Admin/TwigTemplateForm/form_max_length.html.twig' with {'attr': attr} %}
 {%- endblock form_widget_simple -%}
 
-{% block text_with_unit_widget %}
-  <div class="input-group">
-    {{- block('form_widget_simple') -}}
-    {% if form.vars.unit is defined %}
-      <div class="input-group-append">
-        <span class="input-group-text">{{ form.vars.unit }}</span>
-      </div>
-    {% endif %}
-  </div>
-  {{ block('form_help') }}
-{% endblock text_with_unit_widget %}
-
 {% block ip_address_text_widget %}
   <div class="input-group">
     {{- block('form_widget_simple') -}}
@@ -1135,15 +1123,29 @@
 
 {%- block number_widget -%}
   {%- set type = type|default('text') -%}
-  {{ block('form_widget_simple') }}
-  {{- block('form_help') -}}
+  <div class="input-group">
+    {{- block('form_widget_simple') -}}
+    {{- block('form_unit') -}}
+  </div>
+  {{ block('form_help') }}
 {%- endblock number_widget -%}
 
 {%- block integer_widget -%}
   {%- set type = type|default('number') -%}
-  {{ block('form_widget_simple') }}
-  {{- block('form_help') -}}
+  <div class="input-group">
+    {{- block('form_widget_simple') -}}
+    {{- block('form_unit') -}}
+  </div>
+  {{ block('form_help') }}
 {%- endblock integer_widget -%}
+
+{% block form_unit %}
+  {% if form.vars.unit is defined %}
+    <div class="input-group-append">
+      <span class="input-group-text">{{ form.vars.unit }}</span>
+    </div>
+  {% endif %}
+{% endblock form_unit %}
 
 {% block form_help %}
   {% if help is not null %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Create unit form type extension to avoid creating unit types for all concerned form types.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #27787.
| Related PRs       | Closes #27788.
| How to test?      | Test modified fields to see if same display remains. Some examples:<br>- Advanced Parameters > Administration > Upload Quota<br>- Advanced Parameters > Employees > Options > 'Password change time' field<br><br>Or add 'unit' to any integer or number field.

| Possible impacts? | N/A

### Breaking changes

- `TextWithUnitType` has been deleted because it has been replaced by `UnitTypeExtension`.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
