### PR TITLE
Refacto `Product::getDefaultIdProductAttribute` avoid code duplicate

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1044,7 +1044,7 @@ class ProductCore extends ObjectModel
      * @param int $minimum_quantity
      * @param bool $reset
      *
-     * @return int Attributes id
+     * @return int Attribute id
      */
     public static function getDefaultAttribute($id_product, $minimum_quantity = 0, $reset = false)
     {

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1044,7 +1044,7 @@ class ProductCore extends ObjectModel
      * @param int $minimum_quantity
      * @param bool $reset
      *
-     * @return int Attributes list
+     * @return int Attributes id
      */
     public static function getDefaultAttribute($id_product, $minimum_quantity = 0, $reset = false)
     {
@@ -4093,18 +4093,7 @@ class ProductCore extends ObjectModel
      */
     public function getDefaultIdProductAttribute()
     {
-        if (!Combination::isFeatureActive()) {
-            return 0;
-        }
-
-        return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue(
-            '
-            SELECT pa.`id_product_attribute`
-            FROM `' . _DB_PREFIX_ . 'product_attribute` pa
-            ' . Shop::addSqlAssociation('product_attribute', 'pa') . '
-            WHERE pa.`id_product` = ' . (int) $this->id . '
-            AND product_attribute_shop.default_on = 1'
-        );
+        return (int) Product::getDefaultAttribute($this->id);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Refacto `Product::getDefaultIdProductAttribute` avoid code duplicate.
| Type?             | refacto
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Related PRs       | N/A.
| How to test?      | See how to test section.
| Possible impacts? | Product front controller page.

## How to test

- Go to BO
- Add a product with combination
- Select an default combination
- try de code bellow 

```php
$productObject = new Product(YOU_BO_PRODUCT_ID_HERE);
echo $productObject->getDefaultIdProductAttribute();
```

- Make sure that output is the BO selected product default attribute


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
