### PR TITLE
Fix : URL Alternate with unwanted parameters

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -2001,7 +2001,7 @@ class FrontControllerCore extends Controller
 
         foreach ($languages as $lang) {
             $langUrl = $this->context->link->getLanguageLink($lang['id_lang']);
-            $alternativeLangs[$lang['language_code']] = $this->sanitizeUrl($langUrl);
+            $alternativeLangs[$lang['language_code']] = $langUrl;
         }
 
         return $alternativeLangs;


### PR DESCRIPTION
<table width="100%" style="display: table;table-layout: fixed;width: 100%;">
<thead>
<tr>
<th style="width: 18%;">Questions</th>
<th>Answers</th>
</tr>
</thead>
<tbody>
<tr>
<td>Branch?</td>
<td>develop</td>
</tr>
<tr>
<td>Description?</td>
<td>
I have just discovered an embarrassing SEO bug, which multiplies the number of existing URLs for a page.<br><br>This bug concerns the ModuleFrontController (and function hookModuleRoutes) with several languages which are activated on the Prestashop. <br><br>When there is a well-declared rewrite at the module level, such as for the example module, the URL generates well with the URL rewrite. However, when Prestashop generates "alternative" URLs, it executes the "sanitizeUrl" function, which adds parameters that are supposed to be hidden.<br><br>I therefore propose that this sanitize be removed unless there are a few things that escape me.
</td>
</tr>
<tr>
<td>Type?</td>
<td>bug fix</td>
</tr>
<tr>
<td>Category?</td>
<td>FO</td>
</tr>
<tr>
<td>BC breaks?</td>
<td>no</td>
</tr>
<tr>
<td>Deprecations?</td>
<td>no</td>
</tr>
<tr>
<td>Fixed ticket?</td>
<td>Fixes <a class="issue-link js-issue-link" data-error-text="Failed to load title" data-id="1250480241" data-permission-text="Title is private" data-url="https://github.com/PrestaShop/PrestaShop/issues/28609" data-hovercard-type="issue" data-hovercard-url="/PrestaShop/PrestaShop/issues/28609/hovercard" href="https://github.com/PrestaShop/PrestaShop/issues/28609">#28609</a> .</td>
</tr>
<tr>
<td>Related PRs</td>
<td>If theme, autoupgrade or other module change is needed, provide a link to related PRs here.</td>
</tr>
<tr>
<td>How to test?</td>
<td>To illustrate the bug, as precisely as possible, I have just developed a specific module for this issue.<br>A simple module, with a Front Controller.<br><br>It is therefore sufficient:<br>- to set up at least two languages on the Prestashop, for example French and English<br>- To install the module:<br><a href="https://github.com/PrestaShop/PrestaShop/files/8787141/lowissuealternate.zip">lowissuealternate.zip</a><br>- In the configuration of the module, a button allows access to the URL of the module on the Front side, you will see the "alternate" tags<br>- You will be able to see that it has nothing to do with the URL of the page in your web browser<br>- You can also check that it does not come from the module, but from the function that generates the "alternate"
</td>
</tr>
<tr>
<td>Possible impacts?</td>
<td>No</td>
</tr>
</tbody>
</table>

### Here is an example :

```html
<link rel="alternate" hreflang="fr-fr" href="http://www.test.local/fr/blog/category/15_des-conseils.html?slug=des-conseils&module=smartblog">
```
### Expected behavior

We should have :
```html
<link rel="alternate" hreflang="fr-fr" href="http://www.test.local/fr/blog/category/15_des-conseils.html">
```

Checking the code:
https://github.com/PrestaShop/PrestaShop/blob/531c7407104c4d7cfc72c28808ea9fa80794ff7b/classes/controller/FrontController.php#L2004
We can see that the Sanitize is not useful, because the URL is already generated by Prestashop upstream:
https://github.com/PrestaShop/PrestaShop/blob/531c7407104c4d7cfc72c28808ea9fa80794ff7b/classes/controller/FrontController.php#L1995

I therefore propose that this sanitize be removed unless there are a few things that escape me.

