### PR TITLE
[BO] : Unable to increase width of select (multiple) option in field form

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -342,7 +342,7 @@
 										{$input.desc = null}
 									{else}
 										<select name="{$input.name|escape:'html':'utf-8'}"
-												class="{if isset($input.class)}{$input.class|escape:'html':'utf-8'}{/if} fixed-width-xl"
+												class="{if isset($input.class)}{$input.class|escape:'html':'utf-8'}{/if}"
 												id="{if isset($input.id)}{$input.id|escape:'html':'utf-8'}{else}{$input.name|escape:'html':'utf-8'}{/if}"
 												{if isset($input.multiple) && $input.multiple} multiple="multiple"{/if}
 												{if isset($input.size)} size="{$input.size|escape:'html':'utf-8'}"{/if}


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Unable to increase the width of select input field from class when the form is created using fields form.<br> The class must not be hardcoded. It must be provided during form creation like full-width-lg, full-width-md,fixed-width-lg, etc.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      |  Need to create a select field with multiselection and then try to increase the width of that field based on the requirement.
