### PR TITLE
Do not allow blank message from customer end on the order detail page

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -49,7 +49,7 @@ class OrderDetailControllerCore extends FrontController
 
             if (!$idOrder || !Validate::isUnsignedId($idOrder)) {
                 $this->errors[] = $this->trans('The order is no longer valid.', [], 'Shop.Notifications.Error');
-            } elseif (empty($msgText)) {
+            } elseif (empty(trim($msgText))) {
                 $this->errors[] = $this->trans('The message cannot be blank.', [], 'Shop.Notifications.Error');
             } elseif (!Validate::isMessage($msgText)) {
                 $this->errors[] = $this->trans('This message is invalid (HTML is not allowed).', [], 'Shop.Notifications.Error');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | 1- Open the order details page from the customer side<br>2- Go to the customer message section<br>3- Select product<br>4- In message box type space only as shown in video<br>5- Now submit<br>6- It submitted successfully with a blank message<br>https://user-images.githubusercontent.com/42021740/171649187-ad2983bc-5a16-4a74-81cb-d6a9a134eda9.mp4
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28638 
| How to test?      |  1- Open the order details page from the customer side<br>2- Go to the customer message section<br>3- Select product<br>4- In message box type space only as shown in video<br>5- Now submit<br>6- It submitted successfully with a blank message<br>https://nimb.ws/sT7qbr| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
