### PR TITLE
Use `is_int` instead of `is_numeric` for ID Value Objects

### DIFF
--- a/src/Adapter/Feature/CommandHandler/AddFeatureHandler.php
+++ b/src/Adapter/Feature/CommandHandler/AddFeatureHandler.php
@@ -62,6 +62,6 @@ final class AddFeatureHandler extends AbstractObjectModelHandler implements AddF
 
         $this->associateWithShops($feature, $command->getShopAssociation());
 
-        return new FeatureId($feature->id);
+        return new FeatureId((int) $feature->id);
     }
 }

--- a/src/Adapter/SqlManager/CommandHandler/AddSqlRequestHandler.php
+++ b/src/Adapter/SqlManager/CommandHandler/AddSqlRequestHandler.php
@@ -62,7 +62,7 @@ final class AddSqlRequestHandler extends AbstractSqlRequestHandler implements Ad
                 throw new CannotAddSqlRequestException(sprintf('Invalid entity id after creation: %s', $entity->id));
             }
 
-            return new SqlRequestId($entity->id);
+            return new SqlRequestId((int) $entity->id);
         } catch (PrestaShopException $e) {
             throw new SqlRequestException('Failed to create SqlRequest', 0, $e);
         }

--- a/src/Core/Domain/Feature/ValueObject/FeatureId.php
+++ b/src/Core/Domain/Feature/ValueObject/FeatureId.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Feature\ValueObject;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Exception\InvalidFeatureIdException;
 
 /**
- * Defines Feature ID with it's constraints.
+ * Defines Feature ID with its constraints.
  */
 class FeatureId
 {
@@ -61,9 +61,9 @@ class FeatureId
      *
      * @throws InvalidFeatureIdException
      */
-    private function assertIntegerIsGreaterThanZero($featureId)
+    private function assertIntegerIsGreaterThanZero($featureId): void
     {
-        if (!is_numeric($featureId) || 0 > $featureId) {
+        if (!is_int($featureId) || 0 > $featureId) {
             throw new InvalidFeatureIdException(sprintf('Invalid feature id %s supplied. Feature id must be positive integer.', var_export($featureId, true)));
         }
     }

--- a/src/Core/Domain/SqlManagement/ValueObject/SqlRequestId.php
+++ b/src/Core/Domain/SqlManagement/ValueObject/SqlRequestId.php
@@ -45,7 +45,7 @@ class SqlRequestId
      */
     public function __construct($requestSqlId)
     {
-        if (!is_numeric($requestSqlId) || $requestSqlId <= 0) {
+        if (!is_int($requestSqlId) || $requestSqlId <= 0) {
             throw new SqlRequestException(sprintf('Invalid SqlRequest id: %s', var_export($requestSqlId, true)));
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
@@ -219,7 +219,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      *
      * @return Response
      */
-    public function editAction($sqlRequestId, Request $request)
+    public function editAction(int $sqlRequestId, Request $request)
     {
         $sqlRequestForm = $this->getSqlRequestFormBuilder()->getFormFor($sqlRequestId);
         $sqlRequestForm->handleRequest($request);
@@ -266,7 +266,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      */
-    public function deleteAction($sqlRequestId)
+    public function deleteAction(int $sqlRequestId)
     {
         try {
             $deleteSqlRequestCommand = new DeleteSqlRequestCommand(
@@ -300,7 +300,7 @@ class SqlManagerController extends FrameworkBundleAdminController
     public function deleteBulkAction(Request $request)
     {
         try {
-            $requestSqlIds = $request->request->get('sql_request_bulk');
+            $requestSqlIds = $this->getBulkSqlRequestFromRequest($request);
             $bulkDeleteSqlRequestCommand = new BulkDeleteSqlRequestCommand($requestSqlIds);
 
             $this->getCommandBus()->handle($bulkDeleteSqlRequestCommand);
@@ -330,7 +330,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      *
      * @return Response
      */
-    public function viewAction(Request $request, $sqlRequestId)
+    public function viewAction(Request $request, int $sqlRequestId)
     {
         try {
             $query = new GetSqlRequestExecutionResult($sqlRequestId);
@@ -364,7 +364,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse|BinaryFileResponse
      */
-    public function exportAction($sqlRequestId)
+    public function exportAction(int $sqlRequestId)
     {
         $requestSqlExporter = $this->get('prestashop.core.sql_manager.exporter.sql_request_exporter');
 
@@ -600,5 +600,23 @@ class SqlManagerController extends FrameworkBundleAdminController
         $databaseTablesList = $this->getQueryBus()->handle(new GetDatabaseTablesList());
 
         return $databaseTablesList->getTables();
+    }
+
+    /**
+     * Get SQL Request IDs from request for bulk actions.
+     *
+     * @param Request $request
+     *
+     * @return int[]
+     */
+    protected function getBulkSqlRequestFromRequest(Request $request): array
+    {
+        $sqlRequestIds = $request->request->get('sql_request_bulk');
+
+        if (!is_array($sqlRequestIds)) {
+            return [];
+        }
+
+        return array_map('intval', $sqlRequestIds);
     }
 }

--- a/tests/Unit/Core/Domain/FeatureValue/ValueObject/FeatureIdTest.php
+++ b/tests/Unit/Core/Domain/FeatureValue/ValueObject/FeatureIdTest.php
@@ -26,43 +26,42 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Core\Domain\Employee\ValueObject;
+namespace Tests\Unit\Core\Domain\FeatureValue\ValueObject;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidEmployeeIdException;
-use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\EmployeeId;
+use PrestaShop\PrestaShop\Core\Domain\Feature\Exception\InvalidFeatureIdException;
+use PrestaShop\PrestaShop\Core\Domain\Feature\ValueObject\FeatureId;
 
-class EmployeeIdTest extends TestCase
+class FeatureIdTest extends TestCase
 {
     /**
-     * @dataProvider getValidValues
+     * @dataProvider getValidInput
      */
-    public function testItCreatesEmployeeWithValidValues($employeId): void
+    public function testValidInput($featureValueId): void
     {
-        $employeeId = new EmployeeId($employeId);
-
-        $this->assertEquals($employeId, $employeeId->getValue());
+        $vo = new FeatureId($featureValueId);
+        $this->assertEquals($featureValueId, $vo->getValue());
     }
 
-    public function getValidValues(): iterable
+    public function getValidInput(): iterable
     {
         yield [0];
-        yield [1];
+        yield [42];
     }
 
     /**
-     * @dataProvider getInvalidValues
+     * @dataProvider getInvalidInput
      */
-    public function testItExceptionThrownWithInvalidValues($employeId): void
+    public function testInvalidInput($featureValueId): void
     {
-        $this->expectException(InvalidEmployeeIdException::class);
-        new EmployeeId($employeId);
+        $this->expectException(InvalidFeatureIdException::class);
+        new FeatureId($featureValueId);
     }
 
-    public function getInvalidValues(): iterable
+    public function getInvalidInput(): iterable
     {
-        yield ['-1'];
-        yield ['1.1'];
+        yield [-1];
+        yield [1.1];
         yield ['a'];
         yield ['+'];
     }

--- a/tests/Unit/Core/Domain/SqlManagement/ValueObject/SqlRequestIdTest.php
+++ b/tests/Unit/Core/Domain/SqlManagement/ValueObject/SqlRequestIdTest.php
@@ -26,44 +26,37 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Core\Domain\Employee\ValueObject;
+namespace Tests\Unit\Core\Domain\SqlManagement\ValueObject;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidEmployeeIdException;
-use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\EmployeeId;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestException;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\ValueObject\SqlRequestId;
 
-class EmployeeIdTest extends TestCase
+class SqlRequestIdTest extends TestCase
 {
-    /**
-     * @dataProvider getValidValues
-     */
-    public function testItCreatesEmployeeWithValidValues($employeId): void
+    public function testValidValues(): void
     {
-        $employeeId = new EmployeeId($employeId);
-
-        $this->assertEquals($employeId, $employeeId->getValue());
-    }
-
-    public function getValidValues(): iterable
-    {
-        yield [0];
-        yield [1];
+        $vo = new SqlRequestId(1);
+        $this->assertEquals(1, $vo->getValue());
     }
 
     /**
      * @dataProvider getInvalidValues
      */
-    public function testItExceptionThrownWithInvalidValues($employeId): void
+    public function testInvalidValues($sqlRequestId): void
     {
-        $this->expectException(InvalidEmployeeIdException::class);
-        new EmployeeId($employeId);
+        $this->expectException(SqlRequestException::class);
+        new SqlRequestId($sqlRequestId);
     }
 
     public function getInvalidValues(): iterable
     {
-        yield ['-1'];
-        yield ['1.1'];
-        yield ['a'];
-        yield ['+'];
+        return [
+            [0],
+            ['-1'],
+            ['1.1'],
+            ['a'],
+            ['+'],
+        ];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use is_int instead of is_numeric for ID Value Objects
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes #15145
| How to test?      | Automated full suite.

**:notebook: BC Breaks :**
* Strict types some methods in `\PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\SqlManagerController`
  * `public function editAction(int $sqlRequestId, Request $request)`
  * `public function deleteAction(int $sqlRequestId)`
  * `public function viewAction(Request $request, int $sqlRequestId)`
  * `public function exportAction(int $sqlRequestId)`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
