### PR TITLE
Update min & max php version of the installer

### DIFF
--- a/tools/build/Library/InstallUnpacker/index_template.php
+++ b/tools/build/Library/InstallUnpacker/index_template.php
@@ -25,10 +25,10 @@
  */
 set_time_limit(0);
 
-define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 70103);
-define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '7.1.3');
-define('_PS_INSTALL_MAXIMUM_PHP_VERSION_ID_', 70499);
-define('_PS_INSTALL_MAXIMUM_PHP_VERSION_', '7.4');
+define('_PS_INSTALL_MINIMUM_PHP_VERSION_ID_', 70205);
+define('_PS_INSTALL_MINIMUM_PHP_VERSION_', '7.2.5');
+define('_PS_INSTALL_MAXIMUM_PHP_VERSION_ID_', 81099);
+define('_PS_INSTALL_MAXIMUM_PHP_VERSION_', '8.1');
 define('_PS_VERSION_', '%ps-version-placeholder%');
 
 define('ZIP_NAME', 'prestashop.zip');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The PrestaShop ZIP installer min and max php version was outdated compared to the actual range of compatibility of php. This PR fixes it.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | Create a release with `php tools/build/CreateRelease.php` and try a clean install from the zip with a php version:<ul><li>below 7.2.5: It should not work.</li><li>between 7.2.5 and 8.1 (included): it should work</li></ul>
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
