### PR TITLE
Add default fallback if no customer name

### DIFF
--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/message.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/message.tpl
@@ -46,7 +46,7 @@
 			<h4 class="message-item-heading">
 				<i class="icon-mail-reply text-muted"></i>
 					{if $type == 'customer'}
-						{$message.customer_name|escape:'html':'UTF-8'}
+						{$message.customer_name|default|escape:'html':'UTF-8'}
 					{else}
 						{$message.employee_name|escape:'html':'UTF-8'}
 					{/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since PHP 8.1, a deprecated notice is raised if we try to display non-existing customer name. This PR aims to fix it by adding an empty string as a fallback.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28653
| Related PRs       | 
| How to test?      | Please see #28653
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
