### PR TITLE
Fix exception during profil edition if invalid field given with avatar

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/EmployeeFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/EmployeeFormDataHandler.php
@@ -143,12 +143,6 @@ final class EmployeeFormDataHandler implements FormDataHandlerInterface
      */
     public function update($id, array $data)
     {
-        /** @var UploadedFile $uploadedAvatar */
-        $uploadedAvatar = $data['avatarUrl'];
-        if ($uploadedAvatar instanceof UploadedFile) {
-            $this->imageUploader->upload($id, $uploadedAvatar);
-        }
-
         $command = (new EditEmployeeCommand($id))
             ->setFirstName($data['firstname'])
             ->setLastName($data['lastname'])
@@ -181,6 +175,29 @@ final class EmployeeFormDataHandler implements FormDataHandlerInterface
         }
 
         $this->bus->handle($command);
+
+        /**
+         * IMPORTANT : Apply all validations before file upload
+         *
+         * During avatar upload, EmployeeController::editAction takes image path
+         * from `$_FILES["employee"]["tmp_name"]["avatarUrl"]`
+         * But AbstractImageUploader::createTemporaryImage($image) executes
+         * `move_uploaded_file($image->getPathname(), $temporaryImageName))`
+         * that removes the image but keep $_FILES["employee"]["tmp_name"]["avatarUrl"] value.
+         *
+         * During data validation (`setXXX($value)` apply validation),
+         * any error would break the workflow and call `render(...)`
+         * (cf. EmployeeController::editAction).
+         * But `DispatcherCore::getInstance(...)` runs
+         * `$request = SymfonyRequest::createFromGlobals()` that take `$_FILES` global variable.
+         * Then during Request object creation,
+         * `$_FILES["employee"]["tmp_name"]["avatarUrl"]` is detected as invalid.
+         */
+        /** @var UploadedFile $uploadedAvatar */
+        $uploadedAvatar = $data['avatarUrl'];
+        if ($uploadedAvatar instanceof UploadedFile) {
+            $this->imageUploader->upload($id, $uploadedAvatar);
+        }
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | A weird 500 error occurred during profile edition if an avatar and an invalid field was given.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28253.
| Related PRs       | /
| How to test?      | cf. #28253 
| Possible impacts? | Really low risk.

I am not satisfied by this bug fix but I added a full comment to explain the problem. I think solving `$_FILES` consistency with `AbstractImageUploader` and `FormBuilder` behavior would induce too much work for this simple bug.
Maybe I don't know some easy trick so feel free to suggest any better solution :blush:. 

After some exchange with maintainers, I created this issue : #28664 . Let's think about it and prioritize it.