### PR TITLE
Add recommended length counters to SEO fields in CMS Pages Add/Edit and SEO Add/Edit URLs

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/cms-page/form/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/cms-page/form/index.ts
@@ -26,6 +26,7 @@
 import ChoiceTree from '@components/form/choice-tree';
 import textToLinkRewriteCopier from '@components/text-to-link-rewrite-copier';
 import Serp from '@app/utils/serp/index';
+import TextWithRecommendedLengthCounter from '@components/form/text-with-recommended-length-counter';
 
 const {$} = window;
 
@@ -72,4 +73,6 @@ $(() => {
   });
 
   new ChoiceTree('#cms_page_shop_association').enableAutoCheckChildren();
+
+  new TextWithRecommendedLengthCounter();
 });

--- a/admin-dev/themes/new-theme/js/pages/meta/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/meta/index.ts
@@ -39,6 +39,7 @@ import TaggableField from '@components/taggable-field';
 import TranslatableInput from '@components/translatable-input';
 import FiltersSubmitButtonEnablerExtension from '@components/grid/extension/filters-submit-button-enabler-extension';
 import MetaPageNameOptionHandler from '@pages/meta/meta-page-name-option-handler';
+import TextWithRecommendedLengthCounter from '@components/form/text-with-recommended-length-counter';
 
 const {$} = window;
 
@@ -73,4 +74,6 @@ $(() => {
       'MultistoreConfigField',
     ],
   );
+
+  new TextWithRecommendedLengthCounter();
 });

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/TrafficSeo/Meta/MetaType.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\TrafficSeo\Meta;
 
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\IsUrlRewrite;
+use PrestaShopBundle\Form\Admin\Type\TextWithRecommendedLengthType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
@@ -35,6 +36,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Regex;
 
@@ -45,6 +47,11 @@ use Symfony\Component\Validator\Constraints\Regex;
 class MetaType extends AbstractType
 {
     use TranslatorAwareTrait;
+
+    public const TITLE_MAX_CHARS = 128;
+    public const META_DESCRIPTION_MAX_CHARS = 255;
+    public const RECOMMENDED_TITLE_LENGTH = 70;
+    public const RECOMMENDED_DESCRIPTION_LENGTH = 160;
 
     /**
      * @var array
@@ -102,7 +109,12 @@ class MetaType extends AbstractType
             ])
             ->add('page_title', TranslatableType::class, [
                 'required' => false,
+                'type' => TextWithRecommendedLengthType::class,
                 'options' => [
+                    'recommended_length' => self::RECOMMENDED_TITLE_LENGTH,
+                    'attr' => [
+                        'maxlength' => self::TITLE_MAX_CHARS,
+                    ],
                     'constraints' => [
                         new Regex([
                             'pattern' => '/^[^<>={}]*$/u',
@@ -112,19 +124,40 @@ class MetaType extends AbstractType
                                 'Admin.Notifications.Error'
                             ),
                         ]),
+                        new Length([
+                            'max' => self::TITLE_MAX_CHARS,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters',
+                                ['%limit%' => self::TITLE_MAX_CHARS],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
                     ],
                     'required' => false,
                 ],
             ])
             ->add('meta_description', TranslatableType::class, [
                 'required' => false,
+                'type' => TextWithRecommendedLengthType::class,
                 'options' => [
+                    'recommended_length' => self::RECOMMENDED_DESCRIPTION_LENGTH,
+                    'attr' => [
+                        'maxlength' => self::META_DESCRIPTION_MAX_CHARS,
+                    ],
                     'constraints' => [
                         new Regex([
                             'pattern' => '/^[^<>={}]*$/u',
                             'message' => $this->trans(
                                 '%s is invalid.',
                                 [],
+                                'Admin.Notifications.Error'
+                            ),
+                        ]),
+                        new Length([
+                            'max' => self::META_DESCRIPTION_MAX_CHARS,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters',
+                                ['%limit%' => self::META_DESCRIPTION_MAX_CHARS],
                                 'Admin.Notifications.Error'
                             ),
                         ]),

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/Pages/CmsPageType.php
@@ -35,6 +35,7 @@ use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TextWithRecommendedLengthType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -53,6 +54,8 @@ class CmsPageType extends TranslatorAwareType
     public const META_DESCRIPTION_MAX_CHARS = 512;
     public const META_KEYWORD_MAX_CHARS = 512;
     public const FRIENDLY_URL_MAX_CHARS = 128;
+    public const RECOMMENDED_TITLE_LENGTH = 70;
+    public const RECOMMENDED_DESCRIPTION_LENGTH = 160;
 
     /**
      * @var array
@@ -146,12 +149,17 @@ class CmsPageType extends TranslatorAwareType
             ])
             ->add('meta_title', TranslatableType::class, [
                 'label' => $this->trans('Meta title', 'Admin.Global'),
+                'type' => TextWithRecommendedLengthType::class,
                 'help' => sprintf('%s %s',
                     $this->trans('Used to override the title tag value. If left blank, the default title value is used.', 'Admin.Design.Help'),
                     $invalidCharsText
                 ),
                 'required' => false,
                 'options' => [
+                    'recommended_length' => self::RECOMMENDED_TITLE_LENGTH,
+                    'attr' => [
+                        'maxlength' => self::TITLE_MAX_CHARS,
+                    ],
                     'constraints' => [
                         new TypedRegex([
                             'type' => 'generic_name',
@@ -169,9 +177,14 @@ class CmsPageType extends TranslatorAwareType
             ])
             ->add('meta_description', TranslatableType::class, [
                 'label' => $this->trans('Meta description', 'Admin.Global'),
+                'type' => TextWithRecommendedLengthType::class,
                 'help' => $invalidCharsText,
                 'required' => false,
                 'options' => [
+                    'recommended_length' => self::RECOMMENDED_DESCRIPTION_LENGTH,
+                    'attr' => [
+                        'maxlength' => self::META_DESCRIPTION_MAX_CHARS,
+                    ],
                     'constraints' => [
                         new TypedRegex([
                             'type' => 'generic_name',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add recommended length counters to SEO fields in CMS Pages Add/Edit and SEO Add/Edit URLs
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #14266
| How to test?      | Go to Trafic & SEO page and to the "Add/Edit an URL" form, the fields "page title" and "meta description" have a working SEO chars counter (70c for title & 160 for description). <br />Go to CMS Page and to the "Add/Edit" form, the fields "meta title" and "meta description" have a working SEO chars counter (70c for title & 160 for description).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
