### PR TITLE
Change Legacy Hook with new Hook dispatche event: actionAdminProducts…

### DIFF
--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -256,7 +257,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
                 'table' => 'stock_available',
                 'join' => 'LEFT JOIN',
                 'on' => 'sav.`id_product` = p.`id_product` AND sav.`id_product_attribute` = 0' .
-                StockAvailable::addSqlShopRestriction(null, $idShop, 'sav'),
+                    StockAvailable::addSqlShopRestriction(null, $idShop, 'sav'),
             ],
             'sa' => [
                 'table' => 'product_shop',
@@ -338,7 +339,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         $sqlWhere[] = 'state = ' . Product::STATE_SAVED;
 
         // exec legacy hook but with different parameters (retro-compat < 1.7 is broken here)
-        Hook::exec('actionAdminProductsListingFieldsModifier', [
+        $this->hookDispatcher->dispatchWithParameters('actionAdminProductsListingFieldsModifier', [
             '_ps_version' => AppKernel::VERSION,
             'sql_select' => &$sqlSelect,
             'sql_table' => &$sqlTable,
@@ -387,7 +388,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
 
         // post treatment by hooks
         // exec legacy hook but with different parameters (retro-compat < 1.7 is broken here)
-        Hook::exec('actionAdminProductsListingResultsModifier', [
+        $this->hookDispatcher->dispatchWithParameters('actionAdminProductsListingResultsModifier', [
             '_ps_version' => AppKernel::VERSION,
             'products' => &$products,
             'total' => $total,


### PR DESCRIPTION
Upgrade from Legacy Hook::exec to new Hook dispatcher

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.x
| Description?      | Upgrade from Legacy Hook::exec to new Hook dispatcher
| Type?             |  improvement 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | --
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
