### PR TITLE
Fixed WebP Management in WebService

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -70,7 +70,15 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
     /**
      * @var array The list of supported mime types
      */
-    protected $acceptedImgMimeTypes = ['image/gif', 'image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/x-png'];
+    protected $acceptedImgMimeTypes = [
+        'image/gif',
+        'image/jpg',
+        'image/jpeg',
+        'image/pjpeg',
+        'image/png',
+        'image/webp',
+        'image/x-png',
+    ];
 
     /**
      * @var string The product image declination id
@@ -152,6 +160,10 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                 'gif' => [
                     'function' => 'imagecreatefromgif',
                     'Content-Type' => 'image/gif',
+                ],
+                'webp' => [
+                    'function' => 'imagecreatefromwebp',
+                    'Content-Type' => 'image/webp',
                 ],
             ];
             if (array_key_exists($this->imgExtension, $types)) {
@@ -909,18 +921,18 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
             $dest_height = $source_height;
         }
         switch ($type) {
-            case 1:
+            case IMAGETYPE_GIF:
                 $source_image = imagecreatefromgif($base_path);
-
                 break;
-            case 3:
+            case IMAGETYPE_PNG:
                 $source_image = imagecreatefrompng($base_path);
-
                 break;
-            case 2:
+            case IMAGETYPE_WEBP:
+                $source_image = imagecreatefromwebp($base_path);
+                break;
+            case IMAGETYPE_JPEG:
             default:
                 $source_image = imagecreatefromjpeg($base_path);
-
                 break;
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed WebP Management in WebService
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27706
| How to test?      | Be Ready...

**:notebook: How to test?**
* In Design > Themes, define the "Use WebP for all images." as default
* In Advanced Parameters > Webservice, enable the webservice and create a key (all rights, not the scope of the fix)
* Execute this script (Change `KEY` & `DOMAIN` constants)<br> :information_source: : That create a product and add it two images (`image1.jpg` & `image1.webp`)
```php
<?php

require_once('./PSWebServiceLibrary.php');

const KEY = 'UA177FX1K2PTZVKNXM8SIH2YC9V1UCKJ';
const PROTOCOL = 'https://';
const DOMAIN = 'prestashop.php73.local/';
const URL = PROTOCOL . DOMAIN;
const URLs = PROTOCOL.KEY.'@'.DOMAIN;

$webService = new PrestaShopWebservice(URL, KEY, true);

$internalRef = time();

// Create new product
$productId = createProductResource($webService, $internalRef, 95.50);

// Add image to product
$imgId = createImageResource($webService, "image1.jpg", 'image/jpeg', $productId);

var_dump(URLs.'api/images/products/' . $productId . '/' . $imgId);

// Add image to product
$imgId = createImageResource($webService, "image1.webp", 'image/webp', $productId);

var_dump(URLs.'api/images/products/' . $productId . '/' . $imgId);



function createProductResource(PrestaShopWebservice $webService, int $internalRef, float $price, int $prestashopId = null): int
{
    // According to https://devdocs.prestashop.com/1.7/webservice/tutorials/prestashop-webservice-lib/create-resource/
    //          and https://devdocs.prestashop.com/1.7/webservice/tutorials/prestashop-webservice-lib/update-resource/
    
    $xml = $webService->get(['url' => URL . 'api/products?schema=blank']);
    $xmlFields = $xml->product->children();
    $xmlFields->name = "Test product " . $internalRef;
    $xmlFields->description_short = "This is test product " . $internalRef;
    $xmlFields->description = "This is a long description of test product " . $internalRef;
    $xmlFields->link_rewrite = "test_product";
    $xmlFields->price = $price;
    $xmlFields->reference = $internalRef;
    $xmlFields->type = "simple";
    $xmlFields->state = 1;
    $xmlFields->active = 1; 
    $xmlFields->condition = 'refurbished'; 
    $xmlFields->show_condition = 1; 
    $xmlFields->show_price = 1; 
    $xmlFields->minimal_quantity = 1; 
    $xmlFields->available_for_order = 1; 
    $xmlFields->id_tax_rules_group = 1; 
    $xmlFields->id_shop_default = 1; 
    $xmlFields->id_category_default = 3;
    $xmlFields->position_in_category = 1;
    $xmlFields->unit_price = $price;
    $xmlFields->unit_price_ratio = 1;

    if ($prestashopId == null) {
        $createdXml = $webService->add(['resource' => "products", 'postXml' => $xml->asXML()]);           
        $prestashopId = (int)$createdXml->product->children()->id;
    } else {
        $xmlFields->id = $prestashopId;
        $webService->edit(['resource' => "products", 'putXml' => $xml->asXML(), 'id' => $prestashopId]);
    }

    return $prestashopId;
}

function createImageResource(PrestaShopWebservice $webService, string $imagePath, string $imageMime, int $productId): int
{
    // According to https://devdocs.prestashop.com/1.7/webservice/tutorials/advanced-use/image-management/#using-curl

    $args['image'] = new \CurlFile(__DIR__ . DIRECTORY_SEPARATOR . $imagePath, $imageMime);

    $ch = curl_init();
    curl_setopt($ch, CURLOPT_HEADER, 1);
    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
    curl_setopt($ch, CURLINFO_HEADER_OUT, 1);
    curl_setopt($ch, CURLOPT_URL, URL . 'api/images/products/' . $productId . '/');
    curl_setopt($ch, CURLOPT_POST, 1);
    curl_setopt($ch, CURLOPT_USERPWD, KEY.':');
    curl_setopt($ch, CURLOPT_POSTFIELDS, $args);
    $result = curl_exec($ch);
    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
    curl_close($ch);

    if ($httpCode == 400) {
        $xml = new \SimpleXMLElement(substr($result, strpos($result, "<?xml")));
        throw new \Exception("uploadImage error: " . $xml->errors->error[0]->message->__toString());
    } elseif ($httpCode != 200) {
        throw new \Exception("uploadImage error with http code " . $httpCode);
    }

    $xml = new \SimpleXMLElement(substr($result, strpos($result, "<?xml")));
    $prestashopId = (int)$xml->image->id;

    return $prestashopId;
}
```
* In the dump of this script, two URLs will appear which target the two uploaded files
![image](https://user-images.githubusercontent.com/1533248/172827275-9d44de4b-6de7-4978-a24b-890ac0717fd4.png)
* Before this PR : 
![image](https://user-images.githubusercontent.com/1533248/172827450-d4611052-b70f-486d-8133-be4ba88b1adf.png)
* After this PR : 
![image](https://user-images.githubusercontent.com/1533248/172827333-75190f75-da44-4406-9b44-e932d4963b68.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
