### PR TITLE
Fix carriers with same names don't show in Shipping > Preferences

### DIFF
--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -735,7 +735,7 @@ class AdminCartRulesControllerCore extends AdminController
                             $value = $carrier['id_carrier'] . ' - ' . Configuration::get('PS_SHOP_NAME');
                         } else {
                             $value = $carrier['id_carrier'] . ' - ' . $carrier['name'];
-                            if (isset($carrier['delay'])) {
+                            if (!empty($carrier['delay'])) {
                                 $value .= ' (' . $carrier['delay'] . ')';
                             }
                         }

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -735,7 +735,7 @@ class AdminCartRulesControllerCore extends AdminController
                             $value = $carrier['id_carrier'] . ' - ' . Configuration::get('PS_SHOP_NAME');
                         } else {
                             $value = $carrier['id_carrier'] . ' - ' . $carrier['name'];
-                            if ($carrier['name']) {
+                            if (isset($carrier['delay'])) {
                                 $value .= ' (' . $carrier['delay'] . ')';
                             }
                         }

--- a/src/Adapter/Carrier/CarrierDataProvider.php
+++ b/src/Adapter/Carrier/CarrierDataProvider.php
@@ -83,7 +83,12 @@ class CarrierDataProvider
         $carriersChoices = [];
 
         foreach ($carriers as $carrier) {
-            $carriersChoices[$carrier['name']] = (int) $carrier['id_carrier'];
+            $choiceId = (int) $carrier['id_carrier'] . ' - ' . $carrier['name'];
+            if (isset($carrier['delay'])) {
+                $choiceId .= ' (' . $carrier['delay'] . ')';
+            }
+
+            $carriersChoices[$choiceId] = $carrier['id_carrier'];
         }
 
         return $carriersChoices;

--- a/src/Adapter/Carrier/CarrierDataProvider.php
+++ b/src/Adapter/Carrier/CarrierDataProvider.php
@@ -84,7 +84,7 @@ class CarrierDataProvider
 
         foreach ($carriers as $carrier) {
             $choiceId = (int) $carrier['id_carrier'] . ' - ' . $carrier['name'];
-            if (isset($carrier['delay'])) {
+            if (!empty($carrier['delay'])) {
                 $choiceId .= ' (' . $carrier['delay'] . ')';
             }
 

--- a/src/Adapter/Carrier/CarrierDataProvider.php
+++ b/src/Adapter/Carrier/CarrierDataProvider.php
@@ -88,7 +88,7 @@ class CarrierDataProvider
                 $choiceId .= ' (' . $carrier['delay'] . ')';
             }
 
-            $carriersChoices[$choiceId] = $carrier['id_carrier'];
+            $carriersChoices[$choiceId] = (int) $carrier['id_carrier'];
         }
 
         return $carriersChoices;

--- a/src/Core/Form/ChoiceProvider/CarrierByReferenceChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CarrierByReferenceChoiceProvider.php
@@ -73,7 +73,7 @@ final class CarrierByReferenceChoiceProvider implements FormChoiceProviderInterf
 
         foreach ($carriers as $carrier) {
             $choiceId = $carrier['id_carrier'] . ' - ' . $carrier['name'];
-            if ($carrier['name']) {
+            if (isset($carrier['delay'])) {
                 $choiceId .= ' (' . $carrier['delay'] . ')';
             }
 

--- a/src/Core/Form/ChoiceProvider/CarrierByReferenceChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CarrierByReferenceChoiceProvider.php
@@ -73,7 +73,7 @@ final class CarrierByReferenceChoiceProvider implements FormChoiceProviderInterf
 
         foreach ($carriers as $carrier) {
             $choiceId = $carrier['id_carrier'] . ' - ' . $carrier['name'];
-            if (isset($carrier['delay'])) {
+            if (!empty($carrier['delay'])) {
                 $choiceId .= ' (' . $carrier['delay'] . ')';
             }
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -95,7 +95,7 @@ class ProductShipping extends CommonAbstractType
         $this->carriersChoices = [];
         foreach ($carriers as $carrier) {
             $choiceId = $carrier['id_carrier'] . ' - ' . $carrier['name'];
-            if ($carrier['name']) {
+            if (isset($carrier['delay'])) {
                 $choiceId .= ' (' . $carrier['delay'] . ')';
             }
 

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -95,7 +95,7 @@ class ProductShipping extends CommonAbstractType
         $this->carriersChoices = [];
         foreach ($carriers as $carrier) {
             $choiceId = $carrier['id_carrier'] . ' - ' . $carrier['name'];
-            if (isset($carrier['delay'])) {
+            if (!empty($carrier['delay'])) {
                 $choiceId .= ' (' . $carrier['delay'] . ')';
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix carriers with same names don't show in Shipping > Preferences
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #20023
| How to test?      | Create more than one carrier with the same name and in the carrier selection at Shipping > Preferences > Carrier options > Default carrier will display only one. Please test with special caracters and/or long delay text in carriers.
| Possible impacts? | none

Rework of closed PR https://github.com/PrestaShop/PrestaShop/pull/19971

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
