### PR TITLE
Cart with wrong id_shop_group when order is made in BO

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -268,9 +268,9 @@ class CartCore extends ObjectModel
         if (!$this->id_shop) {
             $this->id_shop = Context::getContext()->shop->id;
         }
-	if (!$this->id_shop_group) {
-	    $this->id_shop_group = Context::getContext()->shop->id_shop_group;
-	}
+        if (!$this->id_shop_group) {
+            $this->id_shop_group = Context::getContext()->shop->id_shop_group;
+        }
 
         $return = parent::add($autoDate, $nullValues);
         Hook::exec('actionCartSave', ['cart' => $this]);

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -268,6 +268,9 @@ class CartCore extends ObjectModel
         if (!$this->id_shop) {
             $this->id_shop = Context::getContext()->shop->id;
         }
+	if (!$this->id_shop_group) {
+	    $this->id_shop_group = Context::getContext()->shop->id_shop_group;
+	}
 
         $return = parent::add($autoDate, $nullValues);
         Hook::exec('actionCartSave', ['cart' => $this]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Cart class is not saving id_shop_group when an order is made in the BO
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28721 .
| Related PRs       | none.
| How to test?      | Make an order from the BO and check that the id_shop_group field in the cart table created by that order is properly set. More detailed steps explained in bug report.
| Possible impacts? | Cart creation and update.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
