### PR TITLE
Add cache to AddressFactory::addressExists()

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -2404,7 +2404,7 @@ class CartCore extends ObjectModel
         }
 
         // Get delivery address of the product from the cart
-        if (!$this->addressFactory->addressExists($addressId)) {
+        if (!$this->addressFactory->addressExists($addressId, true)) {
             $addressId = null;
         }
 

--- a/src/Adapter/AddressFactory.php
+++ b/src/Adapter/AddressFactory.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Adapter;
 use Address;
 
 /**
- * Class responsible of creation of Address ObjectModel.
+ * Class responsible for creating Address ObjectModel.
  */
 class AddressFactory
 {
@@ -53,11 +53,12 @@ class AddressFactory
      * Check if an address exists depending on given $id_address.
      *
      * @param int $id_address
+     * @param bool $useCache [default=false] If true, use Cache for optimizing queries
      *
      * @return bool
      */
-    public function addressExists($id_address)
+    public function addressExists($id_address, bool $useCache = false)
     {
-        return Address::addressExists($id_address);
+        return Address::addressExists($id_address, $useCache);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Implement cache option to avoid repeat requests
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26754
| Related PRs       | N/A
| How to test?      | Described here: https://github.com/PrestaShop/PrestaShop/issues/26754#issuecomment-1152941414
| Possible impacts? | Unknown


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
