### PR TITLE
Fix grid offset management

### DIFF
--- a/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
+++ b/src/Core/Grid/Data/Factory/DoctrineGridDataFactory.php
@@ -32,9 +32,11 @@ use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Query\DoctrineQueryBuilderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Query\QueryParserInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteria;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters;
+use PrestaShop\PrestaShop\Core\Search\Pagination;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
@@ -95,26 +97,29 @@ final class DoctrineGridDataFactory implements GridDataFactoryInterface
         ]);
 
         $recordsTotal = (int) $countQueryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
+        $searchOffset = (int) $searchCriteria->getOffset();
 
-        // If offset is out of range, we apply biggest valid offset.
-        if ($recordsTotal > 0 && $searchCriteria->getOffset() >= $recordsTotal) {
-            $inRangeOffset = floor($recordsTotal / $searchCriteria->getLimit()) * $searchCriteria->getLimit();
+        // If offset is out of range, we compute and apply a valid offset.
+        if (Pagination::isOffsetOutOfRange($recordsTotal, $searchOffset)) {
+            // @TODO : those cases should be simplified with some refactoring cf. https://github.com/PrestaShop/PrestaShop/issues/29131
+
+            $searchLimit = $searchCriteria->getLimit();
+            $inRangeOffset = Pagination::computeValidOffset($recordsTotal, $searchOffset, $searchLimit);
+
             // @TODO : add INFO log to prevent that we overwrite offset from `$searchCriteria->getOffset()` to `$inRangeOffset`
 
             if ($searchCriteria instanceof Filters) {
                 $newSearchCriteria = clone $searchCriteria;
                 $newSearchCriteria->add(['offset' => $inRangeOffset]);
             } else {
-                // @TODO : add INFO/WARN log to prevent that we replaced `get_class($searchCriteria)` by `Filters` search criteria
+                // @TODO : add INFO/WARN log to prevent that we replaced `get_class($searchCriteria)` by `SearchCriteria`
 
-                $newSearchCriteria = new Filters(
-                    [
-                        'limit' => $searchCriteria->getLimit(),
-                        'offset' => $inRangeOffset,
-                        'orderBy' => $searchCriteria->getOrderBy(),
-                        'sortOrder' => $searchCriteria->getOrderWay(),
-                        'filters' => $searchCriteria->getFilters(),
-                    ]
+                $newSearchCriteria = new SearchCriteria(
+                    $searchCriteria->getFilters(),
+                    $searchCriteria->getOrderBy(),
+                    $searchCriteria->getOrderWay(),
+                    $inRangeOffset,
+                    $searchLimit
                 );
             }
 

--- a/src/Core/Localization/CLDR/CurrencyInterface.php
+++ b/src/Core/Localization/CLDR/CurrencyInterface.php
@@ -1,9 +1,27 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: thomasleviandier
- * Date: 2018-12-20
- * Time: 16:44
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
 namespace PrestaShop\PrestaShop\Core\Localization\CLDR;

--- a/src/Core/Search/Pagination.php
+++ b/src/Core/Search/Pagination.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search;
+
+/**
+ * Class Pagination
+ * defines pagination methods according
+ * PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface
+ * search parameters definitions
+ * (offset starts at 0, null Limit imply that no limit used, etc.)
+ */
+class Pagination
+{
+    public static function isOffsetOutOfRange(int $total, int $offset = null): bool
+    {
+        return $total > 0 && $offset >= $total;
+    }
+
+    /**
+     * @param int $total
+     * @param int $offset
+     *
+     * @return int offset if given offset is valid, it will be returned (0 if null given)
+     */
+    public static function computeValidOffset(int $total, int $offset = null, int $limit = null): int
+    {
+        if (static::isOffsetOutOfRange($total, $offset)) {
+            if (empty($limit) || $limit > $total) {
+                return 0;
+            } else {
+                return $total - $limit;
+            }
+        }
+
+        return (int) $offset;
+    }
+}

--- a/src/Core/Search/SearchParametersInterface.php
+++ b/src/Core/Search/SearchParametersInterface.php
@@ -1,9 +1,27 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: dev
- * Date: 04/07/18
- * Time: 12:24.
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
 namespace PrestaShop\PrestaShop\Core\Search;

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFac
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\FilterableGridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowInterface;
+use PrestaShop\PrestaShop\Core\Search\Pagination;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\Grid\ControllerResponseBuilder;
 use PrestaShopBundle\Service\Grid\ResponseBuilder;
@@ -111,6 +112,13 @@ class CommonController extends FrameworkBundleAdminController
      */
     public function paginationAction(Request $request, $limit = 10, $offset = 0, $total = 0, $view = 'full', $prefix = '')
     {
+        // DoctrineGridDataFactory::getData(...)
+        // offset is dynamically changed by getData method if invalid offset given,
+        // so we need to apply the same change here.
+        if (Pagination::isOffsetOutOfRange($total, $offset)) {
+            $offset = Pagination::computeValidOffset($total, $offset, $limit);
+        }
+
         $offsetParam = empty($prefix) ? 'offset' : sprintf('%s[offset]', $prefix);
         $limitParam = empty($prefix) ? 'limit' : sprintf('%s[limit]', $prefix);
 

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Customer/Address/AddressControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Customer/Address/AddressControllerTest.php
@@ -178,6 +178,34 @@ class AddressControllerTest extends FormGridControllerTestCase
      * @depends testFilters
      *
      * @param int $addressId
+     *
+     * @return int
+     */
+    public function testOffsetOutOfRange(int $addressId): int
+    {
+        // We validate that the request return an address with valid offset
+        $addresses = $this->getEntitiesFromGrid(
+            ['address[offset]' => 0]
+        );
+        $this->assertGreaterThanOrEqual(1, count($addresses), 'Expected at least one address with valid offset');
+        // Preceding filter parameters should be applied here.
+        $this->assertCollectionContainsEntity($addresses, $addressId);
+
+        // We should get an address even with offset out of range
+        $addresses = $this->getEntitiesFromGrid(
+            ['address[offset]' => 10]
+        );
+        $this->assertGreaterThanOrEqual(1, count($addresses), 'Should return last element even if offset out of range.');
+        // Preceding filter parameters should be applied here.
+        $this->assertCollectionContainsEntity($addresses, $addressId);
+
+        return $addressId;
+    }
+
+    /**
+     * @depends testOffsetOutOfRange
+     *
+     * @param int $addressId
      */
     public function testDelete(int $addressId): void
     {

--- a/tests/Unit/Core/Search/PaginationTest.php
+++ b/tests/Unit/Core/Search/PaginationTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Search;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Search\Pagination;
+
+class PaginationTest extends TestCase
+{
+    public function testIsOffsetOutOfRange(): void
+    {
+        $this->assertTrue(Pagination::isOffsetOutOfRange(10, 20));
+        $this->assertFalse(Pagination::isOffsetOutOfRange(20, 10));
+        $this->assertTrue(Pagination::isOffsetOutOfRange(10, 10));
+        $this->assertFalse(Pagination::isOffsetOutOfRange(10));
+    }
+
+    public function testComputeValidOffset(): void
+    {
+        $this->assertEquals(0, Pagination::computeValidOffset(10, 20, 10));
+        $this->assertEquals(10, Pagination::computeValidOffset(20, 10, 10));
+        $this->assertEquals(0, Pagination::computeValidOffset(10, 20, 30));
+        $this->assertEquals(10, Pagination::computeValidOffset(20, 10, 30));
+        $this->assertEquals(0, Pagination::computeValidOffset(10, 20));
+        $this->assertEquals(10, Pagination::computeValidOffset(20, 10));
+        $this->assertEquals(0, Pagination::computeValidOffset(10));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Grid behavior if offset out of range given wasn't consistent. We decided to force offset to a valid value.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26218.
| Related PRs       | Na.
| How to test?      | Cf. #26218; As we change abstract grid behavior, you may test almost all grids. Simple way to do so is to change `offset` element value in request query.
| Possible impacts? | All grid views may be impacted.


> :warning: Please notice that in some really specific case, it is possible that some external contributions encounter strange behavior if given offset is out of range (due to `Filter` class usage replacing original `SearchCriteria` class.