### PR TITLE
Deprecate AdminPdf calls and use Sf routes

### DIFF
--- a/controllers/admin/AdminPdfController.php
+++ b/controllers/admin/AdminPdfController.php
@@ -158,8 +158,24 @@ class AdminPdfControllerCore extends AdminController
         $this->generatePDF($supply_order, PDF::TEMPLATE_SUPPLY_ORDER_FORM);
     }
 
+    /**
+     * @deprecated Since 8.1.0, use the route `admin_orders_generate_delivery_slip_pdf` instead.
+     *
+     * @param int $id_order
+     *
+     * @return void
+     */
     public function generateDeliverySlipPDFByIdOrder($id_order)
     {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.1.0. Use the route %s instead.',
+                __METHOD__,
+                'admin_orders_generate_delivery_slip_pdf'
+            ),
+            E_USER_DEPRECATED
+        );
+
         $order = new Order((int) $id_order);
         if (!Validate::isLoadedObject($order)) {
             throw new PrestaShopException('Can\'t load Order object');
@@ -179,8 +195,24 @@ class AdminPdfControllerCore extends AdminController
         $this->generatePDF($order_invoice, PDF::TEMPLATE_DELIVERY_SLIP);
     }
 
+    /**
+     * @deprecated Since 8.1.0, use the route `admin_orders_generate_invoice_pdf` instead.
+     *
+     * @param int $id_order
+     *
+     * @return void
+     */
     public function generateInvoicePDFByIdOrder($id_order)
     {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.1.0. Use the route %s instead.',
+                __METHOD__,
+                'admin_orders_generate_invoice_pdf'
+            ),
+            E_USER_DEPRECATED
+        );
+
         $order = new Order((int) $id_order);
         if (!Validate::isLoadedObject($order)) {
             die($this->trans('The order cannot be found within your database.', [], 'Admin.Orderscustomers.Notification'));

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -180,7 +180,16 @@ class AdminSearchControllerCore extends AdminController
             /* Invoices */
             if ($searchType == 4) {
                 if ($invoice = OrderInvoice::getInvoiceByNumber($this->query)) {
-                    Tools::redirectAdmin($this->context->link->getAdminLink('AdminPdf') . '&submitAction=generateInvoicePDF&id_order=' . (int) ($invoice->id_order));
+                    Tools::redirectAdmin(
+                        $this->context->link->getAdminLink(
+                            'AdminPdf',
+                            true,
+                            [
+                                'route' => 'admin_orders_generate_invoice_pdf',
+                                'orderId' => (int) ($invoice->id_order),
+                            ]
+                        )
+                    );
                 }
                 $this->errors[] = $this->trans('No invoice was found with this ID:', [], 'Admin.Orderscustomers.Notification') . ' ' . Tools::htmlentitiesUTF8($this->query);
             }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/documents.html.twig
@@ -62,13 +62,13 @@
         <td class="documents-table-column-download-link">
           {% if document.type == 'invoice' %}
             <a target="_blank" rel="noopener noreferrer nofollow"
-               href="{{ getAdminLink('AdminPdf', true, {'submitAction': 'generateInvoicePDF', 'id_order_invoice': document.id}) }}"
+               href="{{ path('admin_orders_generate_invoice_pdf', {'orderId': orderForViewing.id}) }}"
             >
               {{ document.referenceNumber }}
             </a>
           {% elseif document.type == 'delivery_slip' %}
             <a target="_blank" rel="noopener noreferrer nofollow"
-               href="{{ getAdminLink('AdminPdf', true, {'submitAction': 'generateDeliverySlipPDF', 'id_order_invoice': document.id}) }}"
+               href="{{ path('admin_orders_generate_delivery_slip_pdf', {'orderId': orderForViewing.id}) }}"
             >
               {{ document.referenceNumber }}
             </a>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Deprecate AdminPdf calls and use Sf routes
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | N/A
| How to test?      | The generation of delivery slip PDF and invoice PDF in BackOffice is always OK (Documents Tab / Search by the reference of the invoice in Admin Search).

**:notebook: Deprecations :**
* The method `generateDeliverySlipPDFByIdOrder` in `AdminPdfController` is now deprecated in favor of the Symfony route `admin_orders_generate_delivery_slip_pdf`
* The method `generateInvoicePDFByIdOrder` in `AdminPdfController` is now deprecated in favor of the Symfony route `admin_orders_generate_invoice_pdf`


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
