### PR TITLE
Consider cart rules in order slip total

### DIFF
--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -481,11 +481,21 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                     $conf[$this->contextLanguageId] ?? '',
                     $document->id
                 );
+
+                $total_cart_rule = 0;
+                $cart_rules = $order->getCartRules();
+
+                if ($document->order_slip_type == 1 && is_array($cart_rules)) {
+                    foreach ($cart_rules as $cart_rule) {
+                        $total_cart_rule += $cart_rule['value'];
+                    }
+                }
+
                 $amount = $this->locale->formatPrice(
-                    $document->total_products_tax_incl + $document->total_shipping_tax_incl,
+                    $document->total_products_tax_incl + $document->total_shipping_tax_incl - $total_cart_rule,
                     $currency->iso_code
                 );
-                $numericAmount = $document->total_products_tax_incl + $document->total_shipping_tax_incl;
+                $numericAmount = $document->total_products_tax_incl + $document->total_shipping_tax_incl - $total_cart_rule;
             }
 
             $documentsForViewing[] = new OrderDocumentForViewing(

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -491,11 +491,8 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                     }
                 }
 
-                $amount = $this->locale->formatPrice(
-                    $document->total_products_tax_incl + $document->total_shipping_tax_incl - $total_cart_rule,
-                    $currency->iso_code
-                );
                 $numericAmount = $document->total_products_tax_incl + $document->total_shipping_tax_incl - $total_cart_rule;
+                $amount = $this->locale->formatPrice($numericAmount, $currency->iso_code);
             }
 
             $documentsForViewing[] = new OrderDocumentForViewing(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Cart rules are not used to display order slip amount in order page.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~~Fixes #18319 (?)~~
| Related PRs       | N/A
| How to test?      | Create an order with a discount voucher, refund partially the order and check if the order view has same total as the generated pdf (this one is already correct).
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
