### PR TITLE
Pass $query with reference into actionProductSearchProviderRunQueryBefore hook

### DIFF
--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -325,7 +325,7 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
         $query->setEncodedFacets($encodedFacets);
 
         Hook::exec('actionProductSearchProviderRunQueryBefore', [
-            'query' => $query,
+            'query' => &$query,
         ]);
 
         // We're ready to run the actual query!


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The actionProductSearchProviderRunQueryBefore hook is call before the query run. It could be usefull to be able to update the query itself (sort orders, for examples) if needed.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Implement a module with this hook and check to modify the vars on the hook return.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
