### PR TITLE
Tax Rules Group : Migrate Add & Edit Forms

### DIFF
--- a/classes/tax/TaxRulesGroup.php
+++ b/classes/tax/TaxRulesGroup.php
@@ -62,6 +62,14 @@ class TaxRulesGroupCore extends ObjectModel
 
     protected static $_taxes = [];
 
+    /**
+     * @param bool $null_values
+     *
+     * @return bool
+     *
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
     public function update($null_values = false)
     {
         if (!$this->deleted && $this->isUsed()) {

--- a/src/Adapter/TaxRulesGroup/AbstractTaxRulesGroupHandler.php
+++ b/src/Adapter/TaxRulesGroup/AbstractTaxRulesGroupHandler.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\TaxRulesGroup;
 
+use PrestaShop\PrestaShop\Adapter\Domain\AbstractObjectModelHandler;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotDeleteTaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupNotFoundException;
@@ -36,7 +37,7 @@ use TaxRulesGroup;
 /**
  * Provides common methods for tax rules group handlers
  */
-abstract class AbstractTaxRulesGroupHandler
+abstract class AbstractTaxRulesGroupHandler extends AbstractObjectModelHandler
 {
     /**
      * Gets legacy TaxRuleGroup object

--- a/src/Adapter/TaxRulesGroup/CommandHandler/AddTaxRulesGroupHandler.php
+++ b/src/Adapter/TaxRulesGroup/CommandHandler/AddTaxRulesGroupHandler.php
@@ -50,7 +50,8 @@ class AddTaxRulesGroupHandler extends AbstractTaxRulesGroupHandler implements Ad
         $taxRulesGroup->active = $command->isEnabled();
 
         try {
-            if (false === $taxRulesGroup->validateFields(false)
+            if (
+                false === $taxRulesGroup->validateFields(false)
                 || false === $taxRulesGroup->validateFieldsLang(false)
             ) {
                 throw new TaxRulesGroupException('Tax Rules Group contains invalid field values');

--- a/src/Adapter/TaxRulesGroup/CommandHandler/AddTaxRulesGroupHandler.php
+++ b/src/Adapter/TaxRulesGroup/CommandHandler/AddTaxRulesGroupHandler.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\TaxRulesGroup\AbstractTaxRulesGroupHandler;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\CommandHandler\AddTaxRulesGroupHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotAddTaxRulesGroupException;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupException;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
+use PrestaShopException;
+use TaxRulesGroup;
+
+/**
+ * Handles tax rules group addition
+ */
+class AddTaxRulesGroupHandler extends AbstractTaxRulesGroupHandler implements AddTaxRulesGroupHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(AddTaxRulesGroupCommand $command): TaxRulesGroupId
+    {
+        $taxRulesGroup = new TaxRulesGroup();
+        $taxRulesGroup->name = $command->getName();
+        $taxRulesGroup->active = $command->isEnabled();
+
+        try {
+            if (false === $taxRulesGroup->validateFields(false)
+                || false === $taxRulesGroup->validateFieldsLang(false)
+            ) {
+                throw new TaxRulesGroupException('Tax Rules Group contains invalid field values');
+            }
+
+            if (!$taxRulesGroup->add()) {
+                throw new CannotAddTaxRulesGroupException('Cannot create tax rules group');
+            }
+            $this->associateWithShops($taxRulesGroup, $command->getShopAssociation());
+        } catch (PrestaShopException $e) {
+            throw new TaxRulesGroupException('An unexpected error occurred when adding cms page', 0, $e);
+        }
+
+        return new TaxRulesGroupId((int) $taxRulesGroup->id);
+    }
+}

--- a/src/Adapter/TaxRulesGroup/CommandHandler/AddTaxRulesGroupHandler.php
+++ b/src/Adapter/TaxRulesGroup/CommandHandler/AddTaxRulesGroupHandler.php
@@ -33,9 +33,7 @@ use PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Repository\TaxRulesGroupReposito
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\CommandHandler\AddTaxRulesGroupHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
-use PrestaShopException;
 use TaxRulesGroup;
 
 /**
@@ -65,20 +63,11 @@ class AddTaxRulesGroupHandler extends AbstractTaxRulesGroupHandler implements Ad
         $taxRulesGroup->name = $command->getName();
         $taxRulesGroup->active = $command->isEnabled();
 
-        try {
-            $shopIds = [];
-            foreach ($command->getShopAssociation() as $shopId) {
-                $shopIds[] = new ShopId($shopId);
-            }
-            $this->taxRulesGroupRepository->add($taxRulesGroup, $shopIds);
-        } catch (PrestaShopException $e) {
-            throw new TaxRulesGroupException(
-                'An unexpected error occurred when adding tax rules group',
-                0,
-                $e
-            );
+        $shopIds = [];
+        foreach ($command->getShopAssociation() as $shopId) {
+            $shopIds[] = new ShopId($shopId);
         }
 
-        return new TaxRulesGroupId((int) $taxRulesGroup->id);
+        return $this->taxRulesGroupRepository->add($taxRulesGroup, $shopIds);
     }
 }

--- a/src/Adapter/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandler.php
+++ b/src/Adapter/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandler.php
@@ -35,7 +35,6 @@ use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCom
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\CommandHandler\EditTaxRulesGroupHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotUpdateTaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupException;
-use PrestaShopException;
 
 /**
  * Handles tax rules group edition
@@ -77,12 +76,6 @@ class EditTaxRulesGroupHandler extends AbstractTaxRulesGroupHandler implements E
             $shopIds[] = new ShopId($shopId);
         }
 
-        try {
-            $this->taxRulesGroupRepository->update($taxRulesGroup, $shopIds);
-        } catch (PrestaShopException $e) {
-            throw new TaxRulesGroupException(
-                sprintf('Cannot update tax rules group with id "%s"', $taxRulesGroup->id)
-            );
-        }
+        $this->taxRulesGroupRepository->update($taxRulesGroup, $shopIds);
     }
 }

--- a/src/Adapter/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandler.php
+++ b/src/Adapter/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandler.php
@@ -64,11 +64,14 @@ class EditTaxRulesGroupHandler extends AbstractTaxRulesGroupHandler implements E
     {
         $taxRulesGroup = $this->getTaxRulesGroup($command->getTaxRulesGroupId());
 
+        $updatableProperties = [];
         if (null !== $command->getName()) {
             $taxRulesGroup->name = $command->getName();
+            $updatableProperties[] = 'name';
         }
         if (null !== $command->isEnabled()) {
             $taxRulesGroup->active = $command->isEnabled();
+            $updatableProperties[] = 'active';
         }
 
         $shopIds = [];
@@ -76,6 +79,11 @@ class EditTaxRulesGroupHandler extends AbstractTaxRulesGroupHandler implements E
             $shopIds[] = new ShopId($shopId);
         }
 
-        $this->taxRulesGroupRepository->update($taxRulesGroup, $shopIds);
+        $this->taxRulesGroupRepository->partialUpdate(
+            $taxRulesGroup,
+            $updatableProperties,
+            $shopIds,
+            CannotUpdateTaxRulesGroupException::FAILED_UPDATE_TAX_RULES_GROUP
+        );
     }
 }

--- a/src/Adapter/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandler.php
+++ b/src/Adapter/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandler.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\TaxRulesGroup\AbstractTaxRulesGroupHandler;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\CommandHandler\EditTaxRulesGroupHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotUpdateTaxRulesGroupException;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupException;
+use PrestaShopException;
+
+/**
+ * Handles tax rules group edition
+ */
+class EditTaxRulesGroupHandler extends AbstractTaxRulesGroupHandler implements EditTaxRulesGroupHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @throws CannotUpdateTaxRulesGroupException
+     * @throws TaxRulesGroupException
+     */
+    public function handle(EditTaxRulesGroupCommand $command): void
+    {
+        $taxRulesGroup = $this->getTaxRulesGroup($command->getTaxRulesGroupId());
+
+        if (null !== $command->getName()) {
+            $taxRulesGroup->name = $command->getName();
+        }
+        if (null !== $command->isEnabled()) {
+            $taxRulesGroup->active = $command->isEnabled();
+        }
+
+        try {
+            if (false === $taxRulesGroup->validateFields(false)
+                || false === $taxRulesGroup->validateFieldsLang(false)) {
+                throw new TaxRulesGroupException('Tax Rules Group contains invalid field values');
+            }
+            if (false === $taxRulesGroup->update()) {
+                throw new CannotUpdateTaxRulesGroupException(
+                    sprintf(
+                        'Failed to update cms page with id %s',
+                        $command->getTaxRulesGroupId()->getValue()
+                    )
+                );
+            }
+            if (null !== $command->getShopAssociation()) {
+                $this->associateWithShops($taxRulesGroup, $command->getShopAssociation());
+            }
+
+            /* @phpstan-ignore-next-line */
+            if (!$taxRulesGroup->update()) {
+                throw new TaxRulesGroupException(sprintf('Cannot update tax with id "%s"', $taxRulesGroup->id));
+            }
+        } catch (PrestaShopException $e) {
+            throw new TaxRulesGroupException(sprintf('Cannot update tax with id "%s"', $taxRulesGroup->id));
+        }
+    }
+}

--- a/src/Adapter/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandler.php
+++ b/src/Adapter/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandler.php
@@ -63,7 +63,7 @@ class EditTaxRulesGroupHandler extends AbstractTaxRulesGroupHandler implements E
             if (false === $taxRulesGroup->update()) {
                 throw new CannotUpdateTaxRulesGroupException(
                     sprintf(
-                        'Failed to update cms page with id %s',
+                        'Failed to update tax rules group with id %s',
                         $command->getTaxRulesGroupId()->getValue()
                     )
                 );
@@ -74,10 +74,10 @@ class EditTaxRulesGroupHandler extends AbstractTaxRulesGroupHandler implements E
 
             /* @phpstan-ignore-next-line */
             if (!$taxRulesGroup->update()) {
-                throw new TaxRulesGroupException(sprintf('Cannot update tax with id "%s"', $taxRulesGroup->id));
+                throw new TaxRulesGroupException(sprintf('Cannot update tax rules group with id "%s"', $taxRulesGroup->id));
             }
         } catch (PrestaShopException $e) {
-            throw new TaxRulesGroupException(sprintf('Cannot update tax with id "%s"', $taxRulesGroup->id));
+            throw new TaxRulesGroupException(sprintf('Cannot update tax rules group with id "%s"', $taxRulesGroup->id));
         }
     }
 }

--- a/src/Adapter/TaxRulesGroup/Repository/TaxRulesGroupRepository.php
+++ b/src/Adapter/TaxRulesGroup/Repository/TaxRulesGroupRepository.php
@@ -144,7 +144,10 @@ class TaxRulesGroupRepository extends AbstractMultiShopObjectModelRepository
 
     /**
      * @param TaxRulesGroup $taxRulesGroup
+     * @param ShopId[] $shopIds
      * @param int $errorCode
+     *
+     * @return TaxRulesGroupId
      */
     public function add(TaxRulesGroup $taxRulesGroup, array $shopIds, int $errorCode = 0): TaxRulesGroupId
     {

--- a/src/Adapter/TaxRulesGroup/Repository/TaxRulesGroupRepository.php
+++ b/src/Adapter/TaxRulesGroup/Repository/TaxRulesGroupRepository.php
@@ -32,6 +32,7 @@ use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Validate\TaxRulesGroupValidator;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
+use PrestaShop\PrestaShop\Core\Domain\Store\Exception\CannotUpdateStoreException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotAddTaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotUpdateTaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupNotFoundException;
@@ -152,7 +153,12 @@ class TaxRulesGroupRepository extends AbstractMultiShopObjectModelRepository
     public function add(TaxRulesGroup $taxRulesGroup, array $shopIds, int $errorCode = 0): TaxRulesGroupId
     {
         $this->taxRulesGroupValidator->validate($taxRulesGroup);
-        $id = $this->addObjectModel($taxRulesGroup, CannotAddTaxRulesGroupException::class, $errorCode);
+        $id = $this->addObjectModelToShops(
+            $taxRulesGroup,
+            $shopIds,
+            CannotAddTaxRulesGroupException::class,
+            $errorCode
+        );
 
         return new TaxRulesGroupId($id);
     }
@@ -168,6 +174,27 @@ class TaxRulesGroupRepository extends AbstractMultiShopObjectModelRepository
             $taxRulesGroup,
             $shopIds,
             CannotUpdateTaxRulesGroupException::class
+        );
+    }
+
+    /**
+     * @param TaxRulesGroup $taxRulesGroup
+     * @param array $propertiesToUpdate
+     * @param ShopId[] $shopIds
+     * @param int $errorCode
+     */
+    public function partialUpdate(
+        TaxRulesGroup $taxRulesGroup,
+        array $propertiesToUpdate,
+        array $shopIds,
+        int $errorCode
+    ): void {
+        $this->partiallyUpdateObjectModelForShops(
+            $taxRulesGroup,
+            $propertiesToUpdate,
+            $shopIds,
+            CannotUpdateStoreException::class,
+            $errorCode
         );
     }
 }

--- a/src/Adapter/TaxRulesGroup/Validate/TaxRulesGroupValidator.php
+++ b/src/Adapter/TaxRulesGroup/Validate/TaxRulesGroupValidator.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Validate;
+
+use PrestaShop\PrestaShop\Adapter\AbstractObjectModelValidator;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupConstraintException;
+use TaxRulesGroup;
+
+/**
+ * Validates TaxRulesGroup properties using legacy object model validation
+ */
+class TaxRulesGroupValidator extends AbstractObjectModelValidator
+{
+    /**
+     * @param TaxRulesGroup $taxRulesGroup
+     */
+    public function validate(TaxRulesGroup $taxRulesGroup): void
+    {
+        $this->validateTaxRulesGroupProperty(
+            $taxRulesGroup,
+            'name',
+            TaxRulesGroupConstraintException::INVALID_NAME
+        );
+        $this->validateTaxRulesGroupProperty(
+            $taxRulesGroup,
+            'active',
+            TaxRulesGroupConstraintException::INVALID_ACTIVE
+        );
+        $this->validateTaxRulesGroupProperty(
+            $taxRulesGroup,
+            'deleted',
+            TaxRulesGroupConstraintException::INVALID_DELETED
+        );
+        $this->validateTaxRulesGroupProperty(
+            $taxRulesGroup,
+            'date_add',
+            TaxRulesGroupConstraintException::INVALID_CREATION_DATE
+        );
+        $this->validateTaxRulesGroupProperty(
+            $taxRulesGroup,
+            'date_upd',
+            TaxRulesGroupConstraintException::INVALID_UPDATE_DATE
+        );
+    }
+
+    /**
+     * @param TaxRulesGroup $taxRulesGroup
+     * @param string $propertyName
+     * @param int $errorCode
+     *
+     * @throws TaxRulesGroupConstraintException
+     */
+    private function validateTaxRulesGroupProperty(
+        TaxRulesGroup $taxRulesGroup,
+        string $propertyName,
+        int $errorCode = 0
+    ): void {
+        $this->validateObjectModelProperty(
+            $taxRulesGroup,
+            $propertyName,
+            TaxRulesGroupConstraintException::class,
+            $errorCode
+        );
+    }
+}

--- a/src/Core/Domain/TaxRulesGroup/Command/AddTaxRulesGroupCommand.php
+++ b/src/Core/Domain/TaxRulesGroup/Command/AddTaxRulesGroupCommand.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupConstraintException;
+
+/**
+ * Command responsible for multiple tax rules groups deletion
+ */
+class AddTaxRulesGroupCommand
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var bool
+     */
+    protected $enabled;
+
+    /**
+     * @var int[]
+     */
+    protected $shopAssociation = [];
+
+    /**
+     * @param string $name
+     * @param bool $enabled
+     */
+    public function __construct(string $name, bool $enabled)
+    {
+        $this->name = $name;
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getShopAssociation(): array
+    {
+        return $this->shopAssociation;
+    }
+
+    /**
+     * @param int[] $shopAssociation
+     *
+     * @return self
+     *
+     * @throws TaxRulesGroupConstraintException
+     */
+    public function setShopAssociation(array $shopAssociation): self
+    {
+        if (!$this->assertArrayContainsAllIntegerValues($shopAssociation)) {
+            throw new TaxRulesGroupConstraintException(
+                sprintf(
+                    'Given shop association %s must contain all integer values',
+                    var_export($shopAssociation, true)
+                ),
+                TaxRulesGroupConstraintException::INVALID_SHOP_ASSOCIATION
+            );
+        }
+
+        $this->shopAssociation = $shopAssociation;
+
+        return $this;
+    }
+
+    /**
+     * @param array $values
+     *
+     * @return bool
+     */
+    protected function assertArrayContainsAllIntegerValues(array $values): bool
+    {
+        $filterAllIntegers = function ($value) {
+            return is_int($value);
+        };
+
+        return !empty($values) && count($values) === count(array_filter($values, $filterAllIntegers));
+    }
+}

--- a/src/Core/Domain/TaxRulesGroup/Command/AddTaxRulesGroupCommand.php
+++ b/src/Core/Domain/TaxRulesGroup/Command/AddTaxRulesGroupCommand.php
@@ -93,10 +93,10 @@ class AddTaxRulesGroupCommand
      */
     public function setShopAssociation(array $shopAssociation): self
     {
-        if (!$this->assertArrayContainsAllIntegerValues($shopAssociation)) {
+        if (!$this->assertArrayContainsOnlyIntegerValues($shopAssociation)) {
             throw new TaxRulesGroupConstraintException(
                 sprintf(
-                    'Given shop association %s must contain all integer values',
+                    'Given shop association %s must contain only integer values',
                     var_export($shopAssociation, true)
                 ),
                 TaxRulesGroupConstraintException::INVALID_SHOP_ASSOCIATION
@@ -113,7 +113,7 @@ class AddTaxRulesGroupCommand
      *
      * @return bool
      */
-    protected function assertArrayContainsAllIntegerValues(array $values): bool
+    protected function assertArrayContainsOnlyIntegerValues(array $values): bool
     {
         $filterAllIntegers = function ($value) {
             return is_int($value);

--- a/src/Core/Domain/TaxRulesGroup/Command/EditTaxRulesGroupCommand.php
+++ b/src/Core/Domain/TaxRulesGroup/Command/EditTaxRulesGroupCommand.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
+
+/**
+ * Command responsible for multiple tax rules groups deletion
+ */
+class EditTaxRulesGroupCommand
+{
+    /**
+     * @var TaxRulesGroupId
+     */
+    protected $taxRulesGroupId;
+
+    /**
+     * @var string|null
+     */
+    protected $name;
+
+    /**
+     * @var bool|null
+     */
+    protected $enabled;
+
+    /**
+     * @var int[]|null
+     */
+    protected $shopAssociation;
+
+    /**
+     * @param int $taxRulesGroupId
+     *
+     * @throws TaxRulesGroupConstraintException
+     */
+    public function __construct(int $taxRulesGroupId)
+    {
+        $this->taxRulesGroupId = new TaxRulesGroupId($taxRulesGroupId);
+    }
+
+    /**
+     * @return TaxRulesGroupId
+     */
+    public function getTaxRulesGroupId(): TaxRulesGroupId
+    {
+        return $this->taxRulesGroupId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string|null $name
+     *
+     * @return self
+     */
+    public function setName(?string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isEnabled(): ?bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param bool|null $enabled
+     *
+     * @return self
+     */
+    public function setEnabled(?bool $enabled): self
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * @return int[]|null
+     */
+    public function getShopAssociation(): ?array
+    {
+        return $this->shopAssociation;
+    }
+
+    /**
+     * @param int[] $shopAssociation
+     *
+     * @return self
+     *
+     * @throws TaxRulesGroupConstraintException
+     */
+    public function setShopAssociation(?array $shopAssociation): self
+    {
+        if (!is_null($shopAssociation) && !$this->assertArrayContainsAllIntegerValues($shopAssociation)) {
+            throw new TaxRulesGroupConstraintException(
+                sprintf(
+                    'Given shop association %s must contain all integer values',
+                    var_export($shopAssociation, true)
+                ),
+                TaxRulesGroupConstraintException::INVALID_SHOP_ASSOCIATION
+            );
+        }
+
+        $this->shopAssociation = $shopAssociation;
+
+        return $this;
+    }
+
+    /**
+     * @param array $values
+     *
+     * @return bool
+     */
+    protected function assertArrayContainsAllIntegerValues(array $values): bool
+    {
+        $filterAllIntegers = function ($value) {
+            return is_int($value);
+        };
+
+        return !empty($values) && count($values) === count(array_filter($values, $filterAllIntegers));
+    }
+}

--- a/src/Core/Domain/TaxRulesGroup/Command/EditTaxRulesGroupCommand.php
+++ b/src/Core/Domain/TaxRulesGroup/Command/EditTaxRulesGroupCommand.php
@@ -131,10 +131,10 @@ class EditTaxRulesGroupCommand
      */
     public function setShopAssociation(?array $shopAssociation): self
     {
-        if (!is_null($shopAssociation) && !$this->assertArrayContainsAllIntegerValues($shopAssociation)) {
+        if (!is_null($shopAssociation) && !$this->assertArrayContainsOnlyIntegerValues($shopAssociation)) {
             throw new TaxRulesGroupConstraintException(
                 sprintf(
-                    'Given shop association %s must contain all integer values',
+                    'Given shop association %s must contain only integer values',
                     var_export($shopAssociation, true)
                 ),
                 TaxRulesGroupConstraintException::INVALID_SHOP_ASSOCIATION
@@ -151,7 +151,7 @@ class EditTaxRulesGroupCommand
      *
      * @return bool
      */
-    protected function assertArrayContainsAllIntegerValues(array $values): bool
+    protected function assertArrayContainsOnlyIntegerValues(array $values): bool
     {
         $filterAllIntegers = function ($value) {
             return is_int($value);

--- a/src/Core/Domain/TaxRulesGroup/CommandHandler/AddTaxRulesGroupHandlerInterface.php
+++ b/src/Core/Domain/TaxRulesGroup/CommandHandler/AddTaxRulesGroupHandlerInterface.php
@@ -24,20 +24,20 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception;
+namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
 
 /**
- * Thrown when tax rules group constraint is violated
+ * Defines contract for add tax rules group handler
  */
-class TaxRulesGroupConstraintException extends TaxRulesGroupException
+interface AddTaxRulesGroupHandlerInterface
 {
     /**
-     * Thrown when provided tax rules group id value is not valid
+     * @param AddTaxRulesGroupCommand $command
+     *
+     * @return TaxRulesGroupId
      */
-    public const INVALID_ID = 1;
-
-    /**
-     * @var int - error is raised when a value in array is not integer type
-     */
-    public const INVALID_SHOP_ASSOCIATION = 2;
+    public function handle(AddTaxRulesGroupCommand $command): TaxRulesGroupId;
 }

--- a/src/Core/Domain/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandlerInterface.php
+++ b/src/Core/Domain/TaxRulesGroup/CommandHandler/EditTaxRulesGroupHandlerInterface.php
@@ -24,20 +24,17 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception;
+namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCommand;
 
 /**
- * Thrown when tax rules group constraint is violated
+ * Defines contract for edit tax rules group handler
  */
-class TaxRulesGroupConstraintException extends TaxRulesGroupException
+interface EditTaxRulesGroupHandlerInterface
 {
     /**
-     * Thrown when provided tax rules group id value is not valid
+     * @param EditTaxRulesGroupCommand $command
      */
-    public const INVALID_ID = 1;
-
-    /**
-     * @var int - error is raised when a value in array is not integer type
-     */
-    public const INVALID_SHOP_ASSOCIATION = 2;
+    public function handle(EditTaxRulesGroupCommand $command): void;
 }

--- a/src/Core/Domain/TaxRulesGroup/Exception/CannotAddTaxRulesGroupException.php
+++ b/src/Core/Domain/TaxRulesGroup/Exception/CannotAddTaxRulesGroupException.php
@@ -24,20 +24,13 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception;
 
 /**
- * Thrown when tax rules group constraint is violated
+ * Thrown on failure to add a tax rules group without errors
  */
-class TaxRulesGroupConstraintException extends TaxRulesGroupException
+class CannotAddTaxRulesGroupException extends TaxRulesGroupException
 {
-    /**
-     * Thrown when provided tax rules group id value is not valid
-     */
-    public const INVALID_ID = 1;
-
-    /**
-     * @var int - error is raised when a value in array is not integer type
-     */
-    public const INVALID_SHOP_ASSOCIATION = 2;
 }

--- a/src/Core/Domain/TaxRulesGroup/Exception/CannotUpdateTaxRulesGroupException.php
+++ b/src/Core/Domain/TaxRulesGroup/Exception/CannotUpdateTaxRulesGroupException.php
@@ -35,4 +35,9 @@ class CannotUpdateTaxRulesGroupException extends TaxRulesGroupException
      * Thrown when status toggling fails
      */
     public const FAILED_TOGGLE_STATUS = 1;
+
+    /**
+     * When generic product update fails
+     */
+    public const FAILED_UPDATE_TAX_RULES_GROUP = 10;
 }

--- a/src/Core/Domain/TaxRulesGroup/Exception/TaxRulesGroupConstraintException.php
+++ b/src/Core/Domain/TaxRulesGroup/Exception/TaxRulesGroupConstraintException.php
@@ -40,4 +40,10 @@ class TaxRulesGroupConstraintException extends TaxRulesGroupException
      * @var int - error is raised when a value in array is not integer type
      */
     public const INVALID_SHOP_ASSOCIATION = 2;
+
+    public const INVALID_NAME = 3;
+    public const INVALID_ACTIVE = 4;
+    public const INVALID_DELETED = 5;
+    public const INVALID_CREATION_DATE = 6;
+    public const INVALID_UPDATE_DATE = 7;
 }

--- a/src/Core/Domain/TaxRulesGroup/QueryResult/EditableTaxRulesGroup.php
+++ b/src/Core/Domain/TaxRulesGroup/QueryResult/EditableTaxRulesGroup.php
@@ -36,21 +36,39 @@ class EditableTaxRulesGroup
     /**
      * @var TaxRulesGroupId
      */
-    private $taxRulesGroupId;
+    protected $taxRulesGroupId;
+
+    /**
+     * @var string
+     */
+    protected $name;
 
     /**
      * @var bool
      */
-    private $active;
+    protected $active;
+
+    /**
+     * @var int[]
+     */
+    protected $shopAssociationIds;
 
     /**
      * @param TaxRulesGroupId $taxRulesGroupId
+     * @param string $name
      * @param bool $active
+     * @param array<int> $shopAssociationIds
      */
-    public function __construct(TaxRulesGroupId $taxRulesGroupId, bool $active)
-    {
+    public function __construct(
+        TaxRulesGroupId $taxRulesGroupId,
+        string $name,
+        bool $active,
+        array $shopAssociationIds
+    ) {
         $this->taxRulesGroupId = $taxRulesGroupId;
+        $this->name = $name;
         $this->active = $active;
+        $this->shopAssociationIds = $shopAssociationIds;
     }
 
     /**
@@ -62,10 +80,26 @@ class EditableTaxRulesGroup
     }
 
     /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
      * @return bool
      */
     public function isActive(): bool
     {
         return $this->active;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getShopAssociationIds(): array
+    {
+        return $this->shopAssociationIds;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/TaxRulesGroupFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/TaxRulesGroupFormDataHandler.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
+
+/**
+ * Handles submitted tax form data
+ */
+class TaxRulesGroupFormDataHandler implements FormDataHandlerInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    protected $commandBus;
+
+    public function __construct(CommandBusInterface $commandBus)
+    {
+        $this->commandBus = $commandBus;
+    }
+
+    /**
+     * Create object from form data.
+     *
+     * @param array $data
+     *
+     * @return mixed
+     *
+     * @throws TaxRulesGroupConstraintException
+     */
+    public function create(array $data)
+    {
+        $command = new AddTaxRulesGroupCommand(
+            $data['name'],
+            (bool) $data['is_enabled']
+        );
+        if (isset($data['shop_association'])) {
+            $command->setShopAssociation(is_array($data['shop_association']) ? $data['shop_association'] : []);
+        }
+
+        /** @var TaxRulesGroupId $taxRulesGroupId */
+        $taxRulesGroupId = $this->commandBus->handle($command);
+
+        return $taxRulesGroupId->getValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws TaxRulesGroupConstraintException
+     */
+    public function update($id, array $data)
+    {
+        $command = (new EditTaxRulesGroupCommand($id))
+            ->setName($data['name'])
+            ->setEnabled((bool) $data['is_enabled'])
+            ->setShopAssociation(is_array($data['shop_association']) ? $data['shop_association'] : [])
+        ;
+
+        $this->commandBus->handle($command);
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxRulesGroupController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxRulesGroupController.php
@@ -127,15 +127,6 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
      */
     public function editAction(Request $request, int $taxRulesGroupId): Response
     {
-        try {
-            /** @var EditableTaxRulesGroup $editableTaxRulesGroup */
-            $editableTaxRulesGroup = $this->getQueryBus()->handle(new GetTaxRulesGroupForEditing((int) $taxRulesGroupId));
-        } catch (TaxRulesGroupException $e) {
-            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
-
-            return $this->redirectToRoute('admin_tax_rules_groups_index');
-        }
-
         $taxRulesGroupForm = null;
 
         try {
@@ -149,7 +140,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
                     'taxRulesGroupId' => $taxRulesGroupId,
                 ]);
             }
-        } catch (TaxRulesGroupNotFoundException $e) {
+        } catch (TaxRulesGroupException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             return $this->redirectToRoute('admin_tax_rules_groups_index');
@@ -159,7 +150,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
 
         return $this->render('@PrestaShop/Admin/Improve/International/TaxRulesGroup/edit.html.twig', [
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Edit: %value%', 'Admin.Actions', ['%value%' => $editableTaxRulesGroup->getName()]),
+            'layoutTitle' => $this->trans('Edit: %value%', 'Admin.Actions', ['%value%' => $taxRulesGroupForm->getData()['name']]),
             'taxRulesGroupForm' => $taxRulesGroupForm->createView(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
         ]);

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxRulesGroupController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxRulesGroupController.php
@@ -36,9 +36,12 @@ use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotBulkUpdateTa
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotDeleteTaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotUpdateTaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Query\GetTaxRulesGroupForEditing;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\QueryResult\EditableTaxRulesGroup;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\TaxRulesGroupFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -86,7 +89,27 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
      */
     public function createAction(Request $request): Response
     {
-        return $this->redirect($this->getAdminLink('AdminTaxRulesGroup', []));
+        $taxRulesGroupForm = $this->getFormBuilder()->getForm();
+        $taxRulesGroupForm->handleRequest($request);
+
+        try {
+            $handlerResult = $this->getFormHandler()->handle($taxRulesGroupForm);
+            if ($handlerResult->isSubmitted() && $handlerResult->isValid()) {
+                $this->addFlash('success', $this->trans('Successful creation', 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_tax_rules_groups_edit', [
+                    'taxRulesGroupId' => $handlerResult->getIdentifiableObjectId(),
+                ]);
+            }
+        } catch (Exception $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }
+
+        return $this->render('@PrestaShop/Admin/Improve/International/TaxRulesGroup/create.html.twig', [
+            'enableSidebar' => true,
+            'taxRulesGroupForm' => $taxRulesGroupForm->createView(),
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+        ]);
     }
 
     /**
@@ -104,7 +127,42 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
      */
     public function editAction(Request $request, int $taxRulesGroupId): Response
     {
-        return $this->redirect($this->getAdminLink('AdminTaxRulesGroup', []));
+        try {
+            /** @var EditableTaxRulesGroup $editableTaxRulesGroup */
+            $editableTaxRulesGroup = $this->getQueryBus()->handle(new GetTaxRulesGroupForEditing((int) $taxRulesGroupId));
+        } catch (TaxRulesGroupException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            return $this->redirectToRoute('admin_tax_rules_groups_index');
+        }
+
+        $taxRulesGroupForm = null;
+
+        try {
+            $taxRulesGroupForm = $this->getFormBuilder()->getFormFor((int) $taxRulesGroupId);
+            $taxRulesGroupForm->handleRequest($request);
+            $result = $this->getFormHandler()->handleFor((int) $taxRulesGroupId, $taxRulesGroupForm);
+            if ($result->isSubmitted() && $result->isValid()) {
+                $this->addFlash('success', $this->trans('Update successful', 'Admin.Notifications.Success'));
+
+                return $this->redirectToRoute('admin_tax_rules_groups_edit', [
+                    'taxRulesGroupId' => $taxRulesGroupId,
+                ]);
+            }
+        } catch (TaxRulesGroupNotFoundException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+
+            return $this->redirectToRoute('admin_tax_rules_groups_index');
+        } catch (Exception $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }
+
+        return $this->render('@PrestaShop/Admin/Improve/International/TaxRulesGroup/edit.html.twig', [
+            'enableSidebar' => true,
+            'layoutTitle' => $this->trans('Edit: %value%', 'Admin.Actions', ['%value%' => $editableTaxRulesGroup->getName()]),
+            'taxRulesGroupForm' => $taxRulesGroupForm->createView(),
+            'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+        ]);
     }
 
     /**
@@ -335,5 +393,21 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
                 ),
             ],
         ];
+    }
+
+    /**
+     * @return FormHandlerInterface
+     */
+    protected function getFormHandler(): FormHandlerInterface
+    {
+        return $this->get('prestashop.core.form.identifiable_object.handler.tax_rules_group_form_handler');
+    }
+
+    /**
+     * @return FormBuilderInterface
+     */
+    protected function getFormBuilder(): FormBuilderInterface
+    {
+        return $this->get('prestashop.core.form.identifiable_object.builder.tax_rules_group_form_builder');
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
@@ -72,8 +72,9 @@ class TaxRulesGroupType extends TranslatorAwareType
             ->add('name', TextType::class, [
                 'label' => $this->trans('Name', 'Admin.Global'),
                 'help' => sprintf(
-                    '%s ' . TypedRegexValidator::CATALOG_CHARS,
-                    $this->trans('Invalid characters:', 'Admin.Notifications.Info')
+                    '%s %s',
+                    $this->trans('Invalid characters:', 'Admin.Notifications.Info'),
+                    TypedRegexValidator::CATALOG_CHARS
                 ),
                 'constraints' => [
                     new Length([

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Improve\International\Tax;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\TypedRegexValidator;
+use PrestaShopBundle\Form\Admin\Type\ShopChoiceTreeType;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * Form type for tax add/edit
+ */
+class TaxRulesGroupType extends TranslatorAwareType
+{
+    /**
+     * @var bool
+     */
+    protected $isShopFeatureEnabled;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param bool $isShopFeatureEnabled
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        bool $isShopFeatureEnabled
+    ) {
+        parent::__construct($translator, $locales);
+        $this->isShopFeatureEnabled = $isShopFeatureEnabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => $this->trans('Name', 'Admin.Global'),
+                'help' => sprintf(
+                    '%s ' . TypedRegexValidator::CATALOG_CHARS,
+                    $this->trans('Invalid characters:', 'Admin.Notifications.Info')
+                ),
+                'constraints' => [
+                    new Length([
+                        'max' => 64,
+                        'maxMessage' => $this->trans(
+                            'This field cannot be longer than %limit% characters.',
+                            'Admin.Notifications.Error',
+                            ['%limit%' => 64]
+                        ),
+                    ]),
+                    new TypedRegex([
+                        'type' => TypedRegex::TYPE_CATALOG_NAME,
+                    ]),
+                ],
+            ])
+            ->add('is_enabled', SwitchType::class, [
+                'label' => $this->trans('Enable', 'Admin.Actions'),
+                'required' => false,
+            ])
+        ;
+        if ($this->isShopFeatureEnabled) {
+            $builder->add('shop_association', ShopChoiceTreeType::class, [
+                'label' => $this->trans('Shop association', 'Admin.Global'),
+                'constraints' => [
+                    new NotBlank([
+                        'message' => $this->trans(
+                            'The %s field is required.',
+                            'Admin.Notifications.Error',
+                            [
+                                sprintf('"%s"', $this->trans('Shop association', 'Admin.Global')),
+                            ]
+                        ),
+                    ]),
+                ],
+            ]);
+        }
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/International/Tax/TaxRulesGroupType.php
@@ -35,9 +35,9 @@ use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * Form type for tax add/edit

--- a/src/PrestaShopBundle/Resources/config/services/adapter/tax_rules_group.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/tax_rules_group.yml
@@ -4,12 +4,16 @@ services:
 
   prestashop.adapter.tax_rules_group.command_handler.add_tax_rules_group_handler:
     class: 'PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler\AddTaxRulesGroupHandler'
+    arguments:
+      - '@prestashop.adapter.tax_rules_group.repository.tax_rules_group_repository'
     tags:
       - name: 'tactician.handler'
         command: 'PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand'
 
   prestashop.adapter.tax_rules_group.command_handler.edit_tax_rules_group_handler:
     class: 'PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler\EditTaxRulesGroupHandler'
+    arguments:
+      - '@prestashop.adapter.tax_rules_group.repository.tax_rules_group_repository'
     tags:
       - name: 'tactician.handler'
         command: 'PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCommand'
@@ -48,6 +52,10 @@ services:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
+      - '@prestashop.adapter.tax_rules_group.validate.tax_rules_group_validator'
+
+  prestashop.adapter.tax_rules_group.validate.tax_rules_group_validator:
+    class: PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Validate\TaxRulesGroupValidator
 
   prestashop.adapter.tax_rules_group.repository.tax_rules_group_repository:
     alias: PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Repository\TaxRulesGroupRepository

--- a/src/PrestaShopBundle/Resources/config/services/adapter/tax_rules_group.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/tax_rules_group.yml
@@ -2,18 +2,14 @@ services:
   _defaults:
     public: true
 
-  prestashop.adapter.tax_rules_group.command_handler.add_tax_rules_group_handler:
-    class: 'PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler\AddTaxRulesGroupHandler'
-    arguments:
-      - '@prestashop.adapter.tax_rules_group.repository.tax_rules_group_repository'
+  PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler\AddTaxRulesGroupHandler:
+    autowire: true
     tags:
       - name: 'tactician.handler'
         command: 'PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand'
 
-  prestashop.adapter.tax_rules_group.command_handler.edit_tax_rules_group_handler:
-    class: 'PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler\EditTaxRulesGroupHandler'
-    arguments:
-      - '@prestashop.adapter.tax_rules_group.repository.tax_rules_group_repository'
+  PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler\EditTaxRulesGroupHandler:
+    autowire: true
     tags:
       - name: 'tactician.handler'
         command: 'PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCommand'
@@ -52,10 +48,9 @@ services:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
-      - '@prestashop.adapter.tax_rules_group.validate.tax_rules_group_validator'
+      - '@PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Validate\TaxRulesGroupValidator'
 
-  prestashop.adapter.tax_rules_group.validate.tax_rules_group_validator:
-    class: PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Validate\TaxRulesGroupValidator
+  PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Validate\TaxRulesGroupValidator: ~
 
   prestashop.adapter.tax_rules_group.repository.tax_rules_group_repository:
     alias: PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Repository\TaxRulesGroupRepository

--- a/src/PrestaShopBundle/Resources/config/services/adapter/tax_rules_group.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/tax_rules_group.yml
@@ -2,6 +2,18 @@ services:
   _defaults:
     public: true
 
+  prestashop.adapter.tax_rules_group.command_handler.add_tax_rules_group_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler\AddTaxRulesGroupHandler'
+    tags:
+      - name: 'tactician.handler'
+        command: 'PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand'
+
+  prestashop.adapter.tax_rules_group.command_handler.edit_tax_rules_group_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler\EditTaxRulesGroupHandler'
+    tags:
+      - name: 'tactician.handler'
+        command: 'PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCommand'
+
   prestashop.adapter.tax_rules_group.command_handler.delete_tax_rules_group_handler:
     class: 'PrestaShop\PrestaShop\Adapter\TaxRulesGroup\CommandHandler\DeleteTaxRulesGroupHandler'
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -2184,8 +2184,7 @@ services:
     tags:
       - { name: form.type }
 
-  form.type.improve.international.tax.tax_rules_group_type:
-    class: 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxRulesGroupType'
+  PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxRulesGroupType:
     parent: 'form.type.translatable.aware'
     public: true
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -2183,3 +2183,12 @@ services:
     public: true
     tags:
       - { name: form.type }
+
+  form.type.improve.international.tax.tax_rules_group_type:
+    class: 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxRulesGroupType'
+    parent: 'form.type.translatable.aware'
+    public: true
+    arguments:
+      - '@=service("prestashop.adapter.multistore_feature").isUsed()'
+    tags:
+      - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -291,4 +291,4 @@ services:
     factory: [ '@prestashop.core.form.builder.form_builder_factory', 'create' ]
     arguments:
       - 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxRulesGroupType'
-      - '@prestashop.core.form.identifiable_object.data_provider.tax_rules_group_form_data_provider'
+      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\TaxRulesGroupFormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_builder.yml
@@ -285,3 +285,10 @@ services:
     arguments:
       - 'PrestaShopBundle\Form\Admin\Improve\International\Locations\StateType'
       - '@prestashop.core.form.identifiable_object.data_provider.state_form_data_provider'
+
+  prestashop.core.form.identifiable_object.builder.tax_rules_group_form_builder:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilder'
+    factory: [ '@prestashop.core.form.builder.form_builder_factory', 'create' ]
+    arguments:
+      - 'PrestaShopBundle\Form\Admin\Improve\International\Tax\TaxRulesGroupType'
+      - '@prestashop.core.form.identifiable_object.data_provider.tax_rules_group_form_data_provider'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -255,3 +255,8 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\StateFormDataHandler'
     arguments:
       - '@prestashop.core.command_bus'
+
+  prestashop.core.form.identifiable_object.data_handler.tax_rules_group_form_data_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\TaxRulesGroupFormDataHandler'
+    arguments:
+      - '@prestashop.core.command_bus'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -256,7 +256,6 @@ services:
     arguments:
       - '@prestashop.core.command_bus'
 
-  prestashop.core.form.identifiable_object.data_handler.tax_rules_group_form_data_handler:
-    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\TaxRulesGroupFormDataHandler'
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\TaxRulesGroupFormDataHandler:
     arguments:
       - '@prestashop.core.command_bus'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -221,7 +221,6 @@ services:
       - '@prestashop.core.query_bus'
       - '@=service("prestashop.adapter.legacy.context").getContext().country.id'
 
-  prestashop.core.form.identifiable_object.data_provider.tax_rules_group_form_data_provider:
-    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\TaxRulesGroupFormDataProvider'
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\TaxRulesGroupFormDataProvider:
     arguments:
       - '@prestashop.core.query_bus'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -220,3 +220,8 @@ services:
     arguments:
       - '@prestashop.core.query_bus'
       - '@=service("prestashop.adapter.legacy.context").getContext().country.id'
+
+  prestashop.core.form.identifiable_object.data_provider.tax_rules_group_form_data_provider:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\TaxRulesGroupFormDataProvider'
+    arguments:
+      - '@prestashop.core.query_bus'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
@@ -272,4 +272,4 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler'
     factory: [ '@prestashop.core.form.identifiable_object.handler.form_handler_factory', 'create' ]
     arguments:
-      - '@prestashop.core.form.identifiable_object.data_handler.tax_rules_group_form_data_handler'
+      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\TaxRulesGroupFormDataHandler'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_handler.yml
@@ -267,3 +267,9 @@ services:
     factory: [ '@prestashop.core.form.identifiable_object.handler.form_handler_factory', 'create' ]
     arguments:
       - '@prestashop.core.form.identifiable_object.data_handler.state_form_data_handler'
+
+  prestashop.core.form.identifiable_object.handler.tax_rules_group_form_handler:
+    class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler'
+    factory: [ '@prestashop.core.form.identifiable_object.handler.form_handler_factory', 'create' ]
+    arguments:
+      - '@prestashop.core.form.identifiable_object.data_handler.tax_rules_group_form_data_handler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/Blocks/form.html.twig
@@ -1,5 +1,4 @@
-<?php
-/**
+{#**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -22,22 +21,36 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- */
+ *#}
 
-namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception;
+{% form_theme taxRulesGroupForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
-/**
- * Thrown when tax rules group constraint is violated
- */
-class TaxRulesGroupConstraintException extends TaxRulesGroupException
-{
-    /**
-     * Thrown when provided tax rules group id value is not valid
-     */
-    public const INVALID_ID = 1;
+{{ form_start(taxRulesGroupForm) }}
+<div class="card">
+  <div class="card-header">
+    <i class="material-icons">payments</i>
+    {{ 'Tax Rules'|trans({}, 'Admin.International.Feature') }}
+  </div>
 
-    /**
-     * @var int - error is raised when a value in array is not integer type
-     */
-    public const INVALID_SHOP_ASSOCIATION = 2;
-}
+  <div class="card-body">
+    <div class="form-wrapper">
+      {{ form_errors(taxRulesGroupForm) }}
+      {% block tax_rules_group_form_widget %}
+        {{ form_widget(taxRulesGroupForm) }}
+      {% endblock %}
+    </div>
+  </div>
+
+  <div class="card-footer">
+    <div class="d-inline-flex">
+      <a href="{{ path('admin_taxes_index') }}" class="btn btn-outline-secondary">
+        {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+      </a>
+    </div>
+    <div class="d-inline-flex float-right">
+      <button class="btn btn-primary" id="save-and-stay-button">{{ 'Save and stay'|trans({}, 'Admin.Actions') }}</button>
+    </div>
+  </div>
+
+</div>
+{{ form_end(taxRulesGroupForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/create.html.twig
@@ -28,9 +28,3 @@
 {% block content %}
   {{ include('@PrestaShop/Admin/Improve/International/TaxRulesGroup/Blocks/form.html.twig', {'taxRulesGroupForm': taxRulesGroupForm}) }}
 {% endblock %}
-
-{% block javascripts %}
-  {{ parent() }}
-
-  <script src="{{ asset('themes/new-theme/public/tax_rules_group.bundle.js') }}"></script>
-{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/create.html.twig
@@ -1,5 +1,4 @@
-<?php
-/**
+{#**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -22,22 +21,16 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- */
+ *#}
 
-namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception;
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-/**
- * Thrown when tax rules group constraint is violated
- */
-class TaxRulesGroupConstraintException extends TaxRulesGroupException
-{
-    /**
-     * Thrown when provided tax rules group id value is not valid
-     */
-    public const INVALID_ID = 1;
+{% block content %}
+  {{ include('@PrestaShop/Admin/Improve/International/TaxRulesGroup/Blocks/form.html.twig', {'taxRulesGroupForm': taxRulesGroupForm}) }}
+{% endblock %}
 
-    /**
-     * @var int - error is raised when a value in array is not integer type
-     */
-    public const INVALID_SHOP_ASSOCIATION = 2;
-}
+{% block javascripts %}
+  {{ parent() }}
+
+  <script src="{{ asset('themes/new-theme/public/tax_rules_group.bundle.js') }}"></script>
+{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/edit.html.twig
@@ -28,9 +28,3 @@
 {% block content %}
   {{ include('@PrestaShop/Admin/Improve/International/TaxRulesGroup/Blocks/form.html.twig', {'taxRulesGroupForm': taxRulesGroupForm}) }}
 {% endblock %}
-
-{% block javascripts %}
-  {{ parent() }}
-
-  <script src="{{ asset('themes/new-theme/public/tax_rules_group.bundle.js') }}"></script>
-{% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/International/TaxRulesGroup/edit.html.twig
@@ -1,5 +1,4 @@
-<?php
-/**
+{#**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -22,22 +21,16 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- */
+ *#}
 
-namespace PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception;
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-/**
- * Thrown when tax rules group constraint is violated
- */
-class TaxRulesGroupConstraintException extends TaxRulesGroupException
-{
-    /**
-     * Thrown when provided tax rules group id value is not valid
-     */
-    public const INVALID_ID = 1;
+{% block content %}
+  {{ include('@PrestaShop/Admin/Improve/International/TaxRulesGroup/Blocks/form.html.twig', {'taxRulesGroupForm': taxRulesGroupForm}) }}
+{% endblock %}
 
-    /**
-     * @var int - error is raised when a value in array is not integer type
-     */
-    public const INVALID_SHOP_ASSOCIATION = 2;
-}
+{% block javascripts %}
+  {{ parent() }}
+
+  <script src="{{ asset('themes/new-theme/public/tax_rules_group.bundle.js') }}"></script>
+{% endblock %}

--- a/tests/Integration/Behaviour/Features/Context/Domain/TaxRulesGroupFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/TaxRulesGroupFeatureContext.php
@@ -132,10 +132,8 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
     /**
      * @When /^I (enable|disable)? tax rules group "(.*)"$/
      */
-    public function toggleStatusTaxRulesGroup(string $action, string $taxRulesGroupReference): void
+    public function toggleStatusTaxRulesGroup(bool $expectedStatus, string $taxRulesGroupReference): void
     {
-        $expectedStatus = 'enable' === $action;
-
         $taxRulesGroupId = SharedStorage::getStorage()->get($taxRulesGroupReference);
 
         $this->getCommandBus()->handle(new SetTaxRulesGroupStatusCommand($taxRulesGroupId, $expectedStatus));
@@ -154,10 +152,9 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
     /**
      * @When /^I (enable|disable)? tax rules groups: "([^"]*)"$/
      */
-    public function bulkToggleStatusTaxRulesGroup(string $action, string $taxRulesGroupReference): void
+    public function bulkToggleStatusTaxRulesGroup(bool $expectedStatus, string $taxRulesGroupReference): void
     {
         $taxRulesGroupReferences = PrimitiveUtils::castStringArrayIntoArray($taxRulesGroupReference);
-        $expectedStatus = 'enable' === $action;
 
         $idsByReference = [];
         foreach ($taxRulesGroupReferences as $reference) {
@@ -206,18 +203,16 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
      * @Then /^tax rules group "(.*)" should be (enabled|disabled)?$/
      * @Given /^tax rules group "(.*)" is (enabled|disabled)?$/
      */
-    public function assertTaxRulesGroupStatus(string $taxRulesGroupReference, string $status): void
+    public function assertTaxRulesGroupStatus(string $taxRulesGroupReference, bool $isEnabled): void
     {
         $editableTaxRulesGroup = $this->getEditableTaxRulesGroup($taxRulesGroupReference);
-
-        $isEnabled = $status === 'enabled';
 
         if ($isEnabled !== $editableTaxRulesGroup->isActive()) {
             throw new RuntimeException(sprintf(
                 'Tax Rules Group "%s" is %s, but it was expected to be %s',
                 $taxRulesGroupReference,
                 $editableTaxRulesGroup->isActive() ? 'enabled' : 'disabled',
-                $status
+                $isEnabled ? 'enabled' : 'disabled'
             ));
         }
     }
@@ -225,7 +220,7 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
     /**
      * @Then /^tax rules groups: "(.*)" should be (enabled|disabled)?$/
      */
-    public function assertTaxRulesGroupsStatus(string $taxRulesGroupsReferences, string $status): void
+    public function assertTaxRulesGroupsStatus(string $taxRulesGroupsReferences, bool $status): void
     {
         $taxRulesGroupsReferences = PrimitiveUtils::castStringArrayIntoArray($taxRulesGroupsReferences);
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/TaxRulesGroupFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/TaxRulesGroupFeatureContext.php
@@ -28,9 +28,22 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Behaviour\Features\Context\Domain;
 
+use Behat\Gherkin\Node\TableNode;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\BulkDeleteTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\BulkSetTaxRulesGroupStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\DeleteTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\SetTaxRulesGroupStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Query\GetTaxRulesGroupForEditing;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\QueryResult\EditableTaxRulesGroup;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
 use RuntimeException;
 use TaxRulesGroup;
+use Tests\Integration\Behaviour\Features\Context\SharedStorage;
+use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
 {
@@ -78,5 +91,191 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
     public function assertLastErrorIsTaxRulesGroupNotFound(): void
     {
         $this->assertLastErrorIs(TaxRulesGroupNotFoundException::class);
+    }
+
+    /**
+     * @When I add new tax rules group :taxRulesGroupReference with following properties:
+     */
+    public function createTaxRulesGroup(string $taxRulesGroupReference, TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+
+        $command = new AddTaxRulesGroupCommand(
+            $data['name'],
+            PrimitiveUtils::castStringBooleanIntoBoolean($data['is_enabled'])
+        );
+
+        /** @var TaxRulesGroupId $taxRulesGroupId */
+        $taxRulesGroupId = $this->getCommandBus()->handle($command);
+
+        SharedStorage::getStorage()->set($taxRulesGroupReference, $taxRulesGroupId->getValue());
+    }
+
+    /**
+     * @When I edit tax rules group :taxRulesGroupReference with following properties:
+     */
+    public function editTaxRulesGroup(string $taxRulesGroupReference, TableNode $table): void
+    {
+        $data = $table->getRowsHash();
+
+        $taxRulesGroupId = SharedStorage::getStorage()->get($taxRulesGroupReference);
+        $command = new EditTaxRulesGroupCommand($taxRulesGroupId);
+        if (isset($data['name'])) {
+            $command->setName($data['name']);
+        }
+        if (isset($data['is_enabled'])) {
+            $command->setEnabled(PrimitiveUtils::castStringBooleanIntoBoolean($data['is_enabled']));
+        }
+        $this->getCommandBus()->handle($command);
+    }
+
+    /**
+     * @When /^I (enable|disable)? tax rules group "(.*)"$/
+     */
+    public function toggleStatusTaxRulesGroup(string $action, string $taxRulesGroupReference): void
+    {
+        $expectedStatus = 'enable' === $action;
+
+        $taxRulesGroupId = SharedStorage::getStorage()->get($taxRulesGroupReference);
+
+        $this->getCommandBus()->handle(new SetTaxRulesGroupStatusCommand($taxRulesGroupId, $expectedStatus));
+    }
+
+    /**
+     * @When I delete tax rules group :taxRulesGroupReference
+     */
+    public function deleteTaxRulesGroup(string $taxRulesGroupReference): void
+    {
+        $taxRulesGroupId = SharedStorage::getStorage()->get($taxRulesGroupReference);
+
+        $this->getCommandBus()->handle(new DeleteTaxRulesGroupCommand($taxRulesGroupId));
+    }
+
+    /**
+     * @When /^I (enable|disable)? tax rules groups: "([^"]*)"$/
+     */
+    public function bulkToggleStatusTaxRulesGroup(string $action, string $taxRulesGroupReference): void
+    {
+        $taxRulesGroupReferences = PrimitiveUtils::castStringArrayIntoArray($taxRulesGroupReference);
+        $expectedStatus = 'enable' === $action;
+
+        $idsByReference = [];
+        foreach ($taxRulesGroupReferences as $reference) {
+            $idsByReference[$reference] = SharedStorage::getStorage()->get($reference);
+        }
+
+        $this->getCommandBus()->handle(new BulkSetTaxRulesGroupStatusCommand(
+            $idsByReference,
+            $expectedStatus
+        ));
+    }
+
+    /**
+     * @When /^I bulk delete tax rules groups: "([^"]*)"$/
+     */
+    public function bulkDeleteTaxRulesGroup(string $taxRulesGroupReference): void
+    {
+        $taxRulesGroupReferences = PrimitiveUtils::castStringArrayIntoArray($taxRulesGroupReference);
+
+        $idsByReference = [];
+        foreach ($taxRulesGroupReferences as $reference) {
+            $idsByReference[$reference] = SharedStorage::getStorage()->get($reference);
+        }
+
+        $this->getCommandBus()->handle(new BulkDeleteTaxRulesGroupCommand($idsByReference));
+    }
+
+    /**
+     * @Then tax rules group :taxRulesGroupReference name should be :name
+     */
+    public function assertTaxRulesGroupName(string $taxRulesGroupReference, string $name): void
+    {
+        $editableTaxRulesGroup = $this->getEditableTaxRulesGroup($taxRulesGroupReference);
+
+        if ($editableTaxRulesGroup->getName() !== $name) {
+            throw new RuntimeException(sprintf(
+                'Tax Rules Group "%s" has "%s" name, but "%s" was expected.',
+                $taxRulesGroupReference,
+                $editableTaxRulesGroup->getName(),
+                $name
+            ));
+        }
+    }
+
+    /**
+     * @Then /^tax rules group "(.*)" should be (enabled|disabled)?$/
+     * @Given /^tax rules group "(.*)" is (enabled|disabled)?$/
+     */
+    public function assertTaxRulesGroupStatus(string $taxRulesGroupReference, string $status): void
+    {
+        $editableTaxRulesGroup = $this->getEditableTaxRulesGroup($taxRulesGroupReference);
+
+        $isEnabled = $status === 'enabled';
+
+        if ($isEnabled !== $editableTaxRulesGroup->isActive()) {
+            throw new RuntimeException(sprintf(
+                'Tax Rules Group "%s" is %s, but it was expected to be %s',
+                $taxRulesGroupReference,
+                $editableTaxRulesGroup->isActive() ? 'enabled' : 'disabled',
+                $status
+            ));
+        }
+    }
+
+    /**
+     * @Then /^tax rules groups: "(.*)" should be (enabled|disabled)?$/
+     */
+    public function assertTaxRulesGroupsStatus(string $taxRulesGroupsReferences, string $status): void
+    {
+        $taxRulesGroupsReferences = PrimitiveUtils::castStringArrayIntoArray($taxRulesGroupsReferences);
+
+        foreach ($taxRulesGroupsReferences as $reference) {
+            $this->assertTaxRulesGroupStatus($reference, $status);
+        }
+    }
+
+    /**
+     * @Then /^tax rules groups: "(.*)" should be deleted?$/
+     */
+    public function assertTaxRulesGroupsExist(string $taxRulesGroupsReferences): void
+    {
+        $taxRulesGroupsReferences = PrimitiveUtils::castStringArrayIntoArray($taxRulesGroupsReferences);
+
+        foreach ($taxRulesGroupsReferences as $reference) {
+            $this->assertTaxRulesGroupExist($reference);
+        }
+    }
+
+    /**
+     * @Then tax rules group :taxReference should be deleted
+     */
+    public function assertTaxRulesGroupExist(string $taxRulesGroupReference): void
+    {
+        $taxRulesGroupId = SharedStorage::getStorage()->get($taxRulesGroupReference);
+
+        try {
+            $this->getQueryBus()->handle(new GetTaxRulesGroupForEditing($taxRulesGroupId));
+
+            throw new NoExceptionAlthoughExpectedException(
+                sprintf(
+                    'Tax rules group  %s expected to be deleted, but it was found',
+                    $taxRulesGroupReference
+                )
+            );
+        } catch (TaxRulesGroupNotFoundException $e) {
+            SharedStorage::getStorage()->clear($taxRulesGroupReference);
+        }
+    }
+
+    private function getEditableTaxRulesGroup(string $taxRulesGroupReference): EditableTaxRulesGroup
+    {
+        $taxRulesGroupId = SharedStorage::getStorage()->get($taxRulesGroupReference);
+
+        $query = new GetTaxRulesGroupForEditing($taxRulesGroupId);
+
+        /** @var EditableTaxRulesGroup $editableTaxRulesGroup */
+        $editableTaxRulesGroup = $this->getQueryBus()->handle($query);
+
+        return $editableTaxRulesGroup;
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/TaxRulesGroupFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/TaxRulesGroupFeatureContext.php
@@ -94,7 +94,7 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @When I add new tax rules group :taxRulesGroupReference with following properties:
+     * @When I add a new tax rules group :taxRulesGroupReference with the following properties:
      */
     public function createTaxRulesGroup(string $taxRulesGroupReference, TableNode $table): void
     {
@@ -112,7 +112,7 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @When I edit tax rules group :taxRulesGroupReference with following properties:
+     * @When I edit the tax rules group :taxRulesGroupReference with the following properties:
      */
     public function editTaxRulesGroup(string $taxRulesGroupReference, TableNode $table): void
     {
@@ -200,8 +200,8 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then /^tax rules group "(.*)" should be (enabled|disabled)?$/
-     * @Given /^tax rules group "(.*)" is (enabled|disabled)?$/
+     * @Then /^tax rules group "(.*)" should be (enabled|disabled)$/
+     * @Given /^tax rules group "(.*)" is (enabled|disabled)$/
      */
     public function assertTaxRulesGroupStatus(string $taxRulesGroupReference, bool $isEnabled): void
     {
@@ -218,7 +218,7 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then /^tax rules groups: "(.*)" should be (enabled|disabled)?$/
+     * @Then /^tax rules groups: "(.*)" should be (enabled|disabled)$/
      */
     public function assertTaxRulesGroupsStatus(string $taxRulesGroupsReferences, bool $status): void
     {
@@ -230,7 +230,7 @@ class TaxRulesGroupFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then /^tax rules groups: "(.*)" should be deleted?$/
+     * @Then /^tax rules groups: "(.*)" should be deleted$/
      */
     public function assertTaxRulesGroupsExist(string $taxRulesGroupsReferences): void
     {

--- a/tests/Integration/Behaviour/Features/Scenario/TaxRulesGroup/tax_rule_group_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/TaxRulesGroup/tax_rule_group_management.feature
@@ -5,21 +5,21 @@ Feature: Manage tax
   I must be able to add, edit and delete tax rules group
 
   Scenario: Adding new tax rules group
-    When I add new tax rules group "sales-tax-rules-group" with following properties:
+    When I add a new tax rules group "sales-tax-rules-group" with the following properties:
       | name       | My Sales Tax Rules Group |
       | is_enabled | true                     |
     Then tax rules group "sales-tax-rules-group" name should be "My Sales Tax Rules Group"
     And tax rules group "sales-tax-rules-group" should be enabled
 
   Scenario: Editing tax rules group
-    When I edit tax rules group "sales-tax-rules-group" with following properties:
+    When I edit the tax rules group "sales-tax-rules-group" with the following properties:
       | name       | The Sales Tax Rules Group |
       | is_enabled | false                     |
     Then tax rules group "sales-tax-rules-group" name should be "The Sales Tax Rules Group"
     And tax rules group "sales-tax-rules-group" should be disabled
 
   Scenario: It is possible to modify only the name of a tax rules group, without modifying anything else
-    When I edit tax rules group "sales-tax-rules-group" with following properties:
+    When I edit the tax rules group "sales-tax-rules-group" with the following properties:
       | name | Funny Sales Tax Rules Group |
     Then tax rules group "sales-tax-rules-group" name should be "Funny Sales Tax Rules Group"
     And tax rules group "sales-tax-rules-group" should be disabled
@@ -27,7 +27,7 @@ Feature: Manage tax
   Scenario: Enabling tax rules group status
     Given tax rules group "sales-tax-rules-group" is disabled
     When I enable tax rules group "sales-tax-rules-group"
-    And tax rules group "sales-tax-rules-group" should be enabled
+    Then tax rules group "sales-tax-rules-group" should be enabled
 
   Scenario: Deleting tax rules group right after disabling its status
     When I disable tax rules group "sales-tax-rules-group"
@@ -36,13 +36,13 @@ Feature: Manage tax
     Then tax rules group "sales-tax-rules-group" should be deleted
 
   Scenario: Disabling multiple taxes in bulk action
-    When I add new tax rules group "beard-tax-rules-group" with following properties:
+    When I add a new tax rules group "beard-tax-rules-group" with the following properties:
       | name       | Beard Tax Rules Group |
       | is_enabled | true                  |
-    And I add new tax rules group "state-tax-rules-group" with following properties:
+    And I add a new tax rules group "state-tax-rules-group" with the following properties:
       | name       | State Tax Rules Group |
       | is_enabled | true                  |
-    And I add new tax rules group "pvm-tax-rules-group" with following properties:
+    And I add a new tax rules group "pvm-tax-rules-group" with the following properties:
       | name       | PVM Tax Rules Group |
       | is_enabled | false               |
     When I disable tax rules groups: "beard-tax-rules-group, state-tax-rules-group, pvm-tax-rules-group"

--- a/tests/Integration/Behaviour/Features/Scenario/TaxRulesGroup/tax_rule_group_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/TaxRulesGroup/tax_rule_group_management.feature
@@ -6,21 +6,21 @@ Feature: Manage tax
 
   Scenario: Adding new tax rules group
     When I add new tax rules group "sales-tax-rules-group" with following properties:
-      | name         | My Sales Tax Rules Group |
-      | is_enabled   | true                     |
+      | name       | My Sales Tax Rules Group |
+      | is_enabled | true                     |
     Then tax rules group "sales-tax-rules-group" name should be "My Sales Tax Rules Group"
     And tax rules group "sales-tax-rules-group" should be enabled
 
   Scenario: Editing tax rules group
     When I edit tax rules group "sales-tax-rules-group" with following properties:
-      | name         | The Sales Tax Rules Group |
-      | is_enabled   | false            |
+      | name       | The Sales Tax Rules Group |
+      | is_enabled | false                     |
     Then tax rules group "sales-tax-rules-group" name should be "The Sales Tax Rules Group"
     And tax rules group "sales-tax-rules-group" should be disabled
 
   Scenario: It is possible to modify only the name of a tax rules group, without modifying anything else
     When I edit tax rules group "sales-tax-rules-group" with following properties:
-      | name         | Funny Sales Tax Rules Group |
+      | name | Funny Sales Tax Rules Group |
     Then tax rules group "sales-tax-rules-group" name should be "Funny Sales Tax Rules Group"
     And tax rules group "sales-tax-rules-group" should be disabled
 
@@ -37,14 +37,14 @@ Feature: Manage tax
 
   Scenario: Disabling multiple taxes in bulk action
     When I add new tax rules group "beard-tax-rules-group" with following properties:
-      | name         | Beard Tax Rules Group |
-      | is_enabled   | true                  |
+      | name       | Beard Tax Rules Group |
+      | is_enabled | true                  |
     And I add new tax rules group "state-tax-rules-group" with following properties:
-      | name         | State Tax Rules Group |
-      | is_enabled   | true                  |
+      | name       | State Tax Rules Group |
+      | is_enabled | true                  |
     And I add new tax rules group "pvm-tax-rules-group" with following properties:
-      | name         | PVM Tax Rules Group   |
-      | is_enabled   | false                 |
+      | name       | PVM Tax Rules Group |
+      | is_enabled | false               |
     When I disable tax rules groups: "beard-tax-rules-group, state-tax-rules-group, pvm-tax-rules-group"
     Then tax rules groups: "beard-tax-rules-group, state-tax-rules-group" should be disabled
 

--- a/tests/Integration/Behaviour/Features/Scenario/TaxRulesGroup/tax_rule_group_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/TaxRulesGroup/tax_rule_group_management.feature
@@ -1,0 +1,56 @@
+@restore-all-tables-before-feature
+#./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s tax_rules_group
+Feature: Manage tax
+  As an employee
+  I must be able to add, edit and delete tax rules group
+
+  Scenario: Adding new tax rules group
+    When I add new tax rules group "sales-tax-rules-group" with following properties:
+      | name         | My Sales Tax Rules Group |
+      | is_enabled   | true                     |
+    Then tax rules group "sales-tax-rules-group" name should be "My Sales Tax Rules Group"
+    And tax rules group "sales-tax-rules-group" should be enabled
+
+  Scenario: Editing tax rules group
+    When I edit tax rules group "sales-tax-rules-group" with following properties:
+      | name         | The Sales Tax Rules Group |
+      | is_enabled   | false            |
+    Then tax rules group "sales-tax-rules-group" name should be "The Sales Tax Rules Group"
+    And tax rules group "sales-tax-rules-group" should be disabled
+
+  Scenario: It is possible to modify only the name of a tax rules group, without modifying anything else
+    When I edit tax rules group "sales-tax-rules-group" with following properties:
+      | name         | Funny Sales Tax Rules Group |
+    Then tax rules group "sales-tax-rules-group" name should be "Funny Sales Tax Rules Group"
+    And tax rules group "sales-tax-rules-group" should be disabled
+
+  Scenario: Enabling tax rules group status
+    Given tax rules group "sales-tax-rules-group" is disabled
+    When I enable tax rules group "sales-tax-rules-group"
+    And tax rules group "sales-tax-rules-group" should be enabled
+
+  Scenario: Deleting tax rules group right after disabling its status
+    When I disable tax rules group "sales-tax-rules-group"
+    Then tax rules group "sales-tax-rules-group" should be disabled
+    When I delete tax rules group "sales-tax-rules-group"
+    Then tax rules group "sales-tax-rules-group" should be deleted
+
+  Scenario: Disabling multiple taxes in bulk action
+    When I add new tax rules group "beard-tax-rules-group" with following properties:
+      | name         | Beard Tax Rules Group |
+      | is_enabled   | true                  |
+    And I add new tax rules group "state-tax-rules-group" with following properties:
+      | name         | State Tax Rules Group |
+      | is_enabled   | true                  |
+    And I add new tax rules group "pvm-tax-rules-group" with following properties:
+      | name         | PVM Tax Rules Group   |
+      | is_enabled   | false                 |
+    When I disable tax rules groups: "beard-tax-rules-group, state-tax-rules-group, pvm-tax-rules-group"
+    Then tax rules groups: "beard-tax-rules-group, state-tax-rules-group" should be disabled
+
+  Scenario: Deleting multiple taxes right after their status was enabled
+    When I enable tax rules groups: "beard-tax-rules-group, state-tax-rules-group, pvm-tax-rules-group"
+    Then tax rules groups: "beard-tax-rules-group, state-tax-rules-group, pvm-tax-rules-group" should be enabled
+    When I bulk delete tax rules groups: "beard-tax-rules-group, state-tax-rules-group, pvm-tax-rules-group"
+    Then tax rules groups: "beard-tax-rules-group, state-tax-rules-group, pvm-tax-rules-group" should be deleted
+

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -28,7 +28,8 @@ default:
             contexts:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext
-                title:
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
+        title:
             paths:
                 - "%paths.base%/Features/Scenario/Title"
             contexts:

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -22,7 +22,13 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\StateFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\StateFeatureContext
-        title:
+        tax_rules_group:
+            paths:
+                - "%paths.base%/Features/Scenario/TaxRulesGroup"
+            contexts:
+                - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext
+                title:
             paths:
                 - "%paths.base%/Features/Scenario/Title"
             contexts:

--- a/tests/Unit/Core/Domain/TaxRulesGroup/Command/AddTaxRulesGroupCommandTest.php
+++ b/tests/Unit/Core/Domain/TaxRulesGroup/Command/AddTaxRulesGroupCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\TaxRulesGroup\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupConstraintException;
+
+class AddTaxRulesGroupCommandTest extends TestCase
+{
+    public function testShopAssociation(): void
+    {
+        $command = new AddTaxRulesGroupCommand('a', true);
+
+        $this->assertEquals([], $command->getShopAssociation());
+        $this->assertInstanceOf(AddTaxRulesGroupCommand::class, $command->setShopAssociation([1, 3, 5]));
+        $this->assertEquals([1, 3, 5], $command->getShopAssociation());
+    }
+
+    public function testShopAssociationNotInteger(): void
+    {
+        $command = new AddTaxRulesGroupCommand('a', true);
+
+        $this->expectException(TaxRulesGroupConstraintException::class);
+        $this->expectExceptionCode(TaxRulesGroupConstraintException::INVALID_SHOP_ASSOCIATION);
+        $this->expectExceptionMessage('Given shop association array (
+  0 => 1,
+  1 => \'3\',
+  2 => 5,
+) must contain all integer values');
+
+        /* @phpstan-ignore-next-line */
+        $command->setShopAssociation([1, '3', 5]);
+    }
+}

--- a/tests/Unit/Core/Domain/TaxRulesGroup/Command/AddTaxRulesGroupCommandTest.php
+++ b/tests/Unit/Core/Domain/TaxRulesGroup/Command/AddTaxRulesGroupCommandTest.php
@@ -53,7 +53,7 @@ class AddTaxRulesGroupCommandTest extends TestCase
   0 => 1,
   1 => \'3\',
   2 => 5,
-) must contain all integer values');
+) must contain only integer values');
 
         /* @phpstan-ignore-next-line */
         $command->setShopAssociation([1, '3', 5]);

--- a/tests/Unit/Core/Domain/TaxRulesGroup/Command/EditTaxRulesGroupCommandTest.php
+++ b/tests/Unit/Core/Domain/TaxRulesGroup/Command/EditTaxRulesGroupCommandTest.php
@@ -53,7 +53,7 @@ class EditTaxRulesGroupCommandTest extends TestCase
   0 => 1,
   1 => \'3\',
   2 => 5,
-) must contain all integer values');
+) must contain only integer values');
 
         /* @phpstan-ignore-next-line */
         $command->setShopAssociation([1, '3', 5]);

--- a/tests/Unit/Core/Domain/TaxRulesGroup/Command/EditTaxRulesGroupCommandTest.php
+++ b/tests/Unit/Core/Domain/TaxRulesGroup/Command/EditTaxRulesGroupCommandTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\TaxRulesGroup\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupConstraintException;
+
+class EditTaxRulesGroupCommandTest extends TestCase
+{
+    public function testShopAssociation(): void
+    {
+        $command = new EditTaxRulesGroupCommand(0);
+
+        $this->assertEquals(null, $command->getShopAssociation());
+        $this->assertInstanceOf(EditTaxRulesGroupCommand::class, $command->setShopAssociation([1, 3, 5]));
+        $this->assertEquals([1, 3, 5], $command->getShopAssociation());
+    }
+
+    public function testShopAssociationNotInteger(): void
+    {
+        $command = new EditTaxRulesGroupCommand(0);
+
+        $this->expectException(TaxRulesGroupConstraintException::class);
+        $this->expectExceptionCode(TaxRulesGroupConstraintException::INVALID_SHOP_ASSOCIATION);
+        $this->expectExceptionMessage('Given shop association array (
+  0 => 1,
+  1 => \'3\',
+  2 => 5,
+) must contain all integer values');
+
+        /* @phpstan-ignore-next-line */
+        $command->setShopAssociation([1, '3', 5]);
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/TaxRulesGroupFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/TaxRulesGroupFormDataProviderTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\DataProvider;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Query\GetTaxRulesGroupForEditing;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\QueryResult\EditableTaxRulesGroup;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\TaxRulesGroupFormDataProvider;
+
+class TaxRulesGroupFormDataProviderTest extends TestCase
+{
+    public function testGetDefaultData(): void
+    {
+        $formDataProvider = new TaxRulesGroupFormDataProvider($this->mockQueryBus());
+
+        $this->assertEquals([], $formDataProvider->getDefaultData());
+    }
+
+    public function testGetData(): void
+    {
+        $formDataProvider = new TaxRulesGroupFormDataProvider($this->mockQueryBus());
+
+        $this->assertEquals([
+            'name' => 'My Tax Rules Group',
+            'is_enabled' => true,
+            'shop_association' => [1, 2],
+        ], $formDataProvider->getData(2));
+    }
+
+    private function mockQueryBus(): CommandBusInterface
+    {
+        $queryBus = $this->createMock(CommandBusInterface::class);
+        $queryBus
+            ->method('handle')
+            ->with($this->isInstanceOf(GetTaxRulesGroupForEditing::class))
+            ->willReturn(
+                new EditableTaxRulesGroup(
+                    new TaxRulesGroupId(2),
+                    'My Tax Rules Group',
+                    true,
+                    [1, 2]
+                )
+            )
+        ;
+
+        return $queryBus;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Tax Rules Group : Migrate Add & Edit Forms
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Relative to #10610
| How to test?      | The listing is now available in the URL `/admin-dev/index.php/improve/international/tax_rules_groups/` : Add & Edit are now migrated. FYI, after adding a new tax rule group or editing a new tax rule, the user is redirected to the edit page. 

**:notebook: BC Breaks :**
* For the class `PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\QueryResult`, constructor parameters are now `TaxRulesGroupId $taxRulesGroupId, string $name, bool $active, array $shopAssociationIds` 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
