### PR TITLE
Call initContent of the parent at the beginning

### DIFF
--- a/controllers/front/OrderDetailController.php
+++ b/controllers/front/OrderDetailController.php
@@ -153,6 +153,7 @@ class OrderDetailControllerCore extends FrontController
      */
     public function initContent()
     {
+        parent::initContent();
         if (Configuration::isCatalogMode()) {
             Tools::redirect('index.php');
         }
@@ -210,7 +211,6 @@ class OrderDetailControllerCore extends FrontController
             unset($order);
         }
 
-        parent::initContent();
         $this->setTemplate('customer/order-detail');
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Call the initContent of FrontController in order to assign general purpose variables as everywhere else.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28813.
| How to test?      | See issue.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
