### PR TITLE
Handle fallback when currency has empty display names

### DIFF
--- a/src/Core/Form/ChoiceProvider/CurrencyNameByIsoCodeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/CurrencyNameByIsoCodeChoiceProvider.php
@@ -61,7 +61,11 @@ final class CurrencyNameByIsoCodeChoiceProvider implements FormChoiceProviderInt
             }
             $currencyNames = $cldrCurrency->getDisplayNames();
             $isoCode = $cldrCurrency->getIsoCode();
-            $displayName = sprintf('%s (%s)', $currencyNames['default'], $isoCode);
+            if (!empty($currencyNames['default'])) {
+                $displayName = sprintf('%s (%s)', $currencyNames['default'], $isoCode);
+            } else {
+                $displayName = $isoCode;
+            }
 
             $result[$displayName] = $isoCode;
         }

--- a/src/Core/Localization/CLDR/Currency.php
+++ b/src/Core/Localization/CLDR/Currency.php
@@ -140,6 +140,10 @@ final class Currency implements CurrencyInterface
      */
     public function getDisplayName($countContext = CurrencyInterface::DISPLAY_NAME_COUNT_DEFAULT)
     {
+        if (empty($this->displayNames)) {
+            return $this->isoCode;
+        }
+
         if (!in_array($countContext, [CurrencyInterface::DISPLAY_NAME_COUNT_DEFAULT, CurrencyInterface::DISPLAY_NAME_COUNT_ONE, CurrencyInterface::DISPLAY_NAME_COUNT_OTHER])) {
             throw new LocalizationException(sprintf('Unknown display name: "%s"', print_r($countContext, true)));
         }

--- a/src/Core/Localization/CLDR/Currency.php
+++ b/src/Core/Localization/CLDR/Currency.php
@@ -140,15 +140,11 @@ final class Currency implements CurrencyInterface
      */
     public function getDisplayName($countContext = CurrencyInterface::DISPLAY_NAME_COUNT_DEFAULT)
     {
-        if (empty($this->displayNames)) {
-            return $this->isoCode;
-        }
-
         if (!in_array($countContext, [CurrencyInterface::DISPLAY_NAME_COUNT_DEFAULT, CurrencyInterface::DISPLAY_NAME_COUNT_ONE, CurrencyInterface::DISPLAY_NAME_COUNT_OTHER])) {
             throw new LocalizationException(sprintf('Unknown display name: "%s"', print_r($countContext, true)));
         }
 
-        return $this->displayNames[$countContext];
+        return $this->displayNames[$countContext] ?? $this->isoCode;
     }
 
     /**

--- a/tests/Unit/Core/Localization/CLDR/CurrencyTest.php
+++ b/tests/Unit/Core/Localization/CLDR/CurrencyTest.php
@@ -145,4 +145,30 @@ class CurrencyTest extends TestCase
 
         $this->cldrCurrency->getSymbol('foobar');
     }
+
+    /**
+     * @dataProvider getEmptyDisplayNames
+     */
+    public function testFallbackWhenEmptyDisplayNames($displayNamesData): void
+    {
+        $currencyData = new CurrencyData();
+        $currencyData->setIsoCode('PCE');
+        $currencyData->setNumericIsoCode(333);
+        $currencyData->setDecimalDigits(2);
+        $currencyData->setDisplayNames($displayNamesData);
+        $currencyData->setSymbols([CurrencyInterface::SYMBOL_TYPE_DEFAULT => 'PS☮', CurrencyInterface::SYMBOL_TYPE_NARROW => '☮']);
+
+        $cldrCurrency = new Currency($currencyData);
+        $this->assertEquals('PCE', $cldrCurrency->getDisplayName());
+        $this->assertEquals('PCE', $cldrCurrency->getDisplayName(CurrencyInterface::DISPLAY_NAME_COUNT_DEFAULT));
+        $this->assertEquals('PCE', $cldrCurrency->getDisplayName(CurrencyInterface::DISPLAY_NAME_COUNT_ONE));
+        $this->assertEquals('PCE', $cldrCurrency->getDisplayName(CurrencyInterface::DISPLAY_NAME_COUNT_OTHER));
+    }
+
+    public function getEmptyDisplayNames(): iterable
+    {
+        yield 'empty array' => [[]];
+        yield 'null values' => [null];
+        yield 'array without proper context' => [['useless_context' => 'toto']];
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Avoid bug when display names of a currency are empty which happens which custom languages, in this case we use the iso code as a fallback
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27921
| Related PRs       | This fix was originally fixed in this PR https://github.com/PrestaShop/PrestaShop/pull/28081 which has been closed
| How to test?      | Follow ticket instruction.
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
