### PR TITLE
Order invoices configuration form: add multistore compatibility and some refactoring

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/invoices/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/invoices/index.ts
@@ -31,4 +31,10 @@ const {$} = window;
 $(() => {
   initDatePickers();
   new TranslatableInput();
+
+  window.prestashop.component.initComponents(
+    [
+      'MultistoreConfigField',
+    ],
+  );
 });

--- a/src/Adapter/Invoice/InvoiceOptionsConfiguration.php
+++ b/src/Adapter/Invoice/InvoiceOptionsConfiguration.php
@@ -30,7 +30,7 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
-use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\InvoiceModelByNameChoiceProvider;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -39,7 +39,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class InvoiceOptionsConfiguration extends AbstractMultistoreConfiguration
 {
     /**
-     * @var InvoiceModelByNameChoiceProvider
+     * @var FormChoiceProviderInterface
      */
     private $invoiceModelByNameChoiceProvider;
 
@@ -49,12 +49,16 @@ final class InvoiceOptionsConfiguration extends AbstractMultistoreConfiguration
      * @param Configuration $configuration
      * @param Context $shopContext
      * @param FeatureInterface $multistoreFeature
-     * @param InvoiceModelByNameChoiceProvider $choiceProvider
+     * @param FormChoiceProviderInterface $invoiceModelByNameChoiceProvider
      */
-    public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature, InvoiceModelByNameChoiceProvider $choiceProvider)
-    {
+    public function __construct(
+        Configuration $configuration,
+        Context $shopContext,
+        FeatureInterface $multistoreFeature,
+        FormChoiceProviderInterface $invoiceModelByNameChoiceProvider
+        ) {
         parent::__construct($configuration, $shopContext, $multistoreFeature);
-        $this->invoiceModelByNameChoiceProvider = $choiceProvider;
+        $this->invoiceModelByNameChoiceProvider = $invoiceModelByNameChoiceProvider;
     }
 
     /**
@@ -134,7 +138,11 @@ final class InvoiceOptionsConfiguration extends AbstractMultistoreConfiguration
             ->setAllowedTypes('add_current_year', ['bool'])
             ->setAllowedTypes('reset_number_annually', ['bool'])
             ->setAllowedTypes('year_position', ['integer'])
+            ->setAllowedValues('year_position', [0, 1])
             ->setAllowedTypes('invoice_number', ['integer'])
+            ->setAllowedValues('invoice_number', function (int $value) {
+                return $value >= 0;
+            })
             ->setAllowedTypes('legal_free_text', ['array'])
             ->setAllowedTypes('footer_text', ['array'])
             ->setAllowedTypes('invoice_model', ['string'])

--- a/src/Adapter/Invoice/InvoiceOptionsConfiguration.php
+++ b/src/Adapter/Invoice/InvoiceOptionsConfiguration.php
@@ -27,24 +27,34 @@
 namespace PrestaShop\PrestaShop\Adapter\Invoice;
 
 use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Configuration\AbstractMultistoreConfiguration;
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+use PrestaShop\PrestaShop\Core\Form\ChoiceProvider\InvoiceModelByNameChoiceProvider;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class InvoiceOptionsConfiguration is responsible for saving & loading invoice configuration.
  */
-final class InvoiceOptionsConfiguration implements DataConfigurationInterface
+final class InvoiceOptionsConfiguration extends AbstractMultistoreConfiguration
 {
     /**
-     * @var Configuration
+     * @var InvoiceModelByNameChoiceProvider
      */
-    private $configuration;
+    private $invoiceModelByNameChoiceProvider;
 
     /**
+     * AbstractMultistoreConfiguration constructor.
+     *
      * @param Configuration $configuration
+     * @param Context $shopContext
+     * @param FeatureInterface $multistoreFeature
+     * @param InvoiceModelByNameChoiceProvider $choiceProvider
      */
-    public function __construct(Configuration $configuration)
+    public function __construct(Configuration $configuration, Context $shopContext, FeatureInterface $multistoreFeature, InvoiceModelByNameChoiceProvider $choiceProvider)
     {
-        $this->configuration = $configuration;
+        parent::__construct($configuration, $shopContext, $multistoreFeature);
+        $this->invoiceModelByNameChoiceProvider = $choiceProvider;
     }
 
     /**
@@ -52,19 +62,21 @@ final class InvoiceOptionsConfiguration implements DataConfigurationInterface
      */
     public function getConfiguration()
     {
+        $shopConstraint = $this->getShopConstraint();
+
         return [
-            'enable_invoices' => $this->configuration->getBoolean('PS_INVOICE'),
-            'enable_tax_breakdown' => $this->configuration->getBoolean('PS_INVOICE_TAXES_BREAKDOWN'),
-            'enable_product_images' => $this->configuration->getBoolean('PS_PDF_IMG_INVOICE'),
-            'invoice_prefix' => $this->configuration->get('PS_INVOICE_PREFIX'),
-            'add_current_year' => $this->configuration->getBoolean('PS_INVOICE_USE_YEAR'),
-            'reset_number_annually' => $this->configuration->getBoolean('PS_INVOICE_RESET'),
-            'year_position' => $this->configuration->getInt('PS_INVOICE_YEAR_POS'),
-            'invoice_number' => $this->configuration->getInt('PS_INVOICE_START_NUMBER'),
-            'legal_free_text' => $this->configuration->get('PS_INVOICE_LEGAL_FREE_TEXT'),
-            'footer_text' => $this->configuration->get('PS_INVOICE_FREE_TEXT'),
-            'invoice_model' => $this->configuration->get('PS_INVOICE_MODEL'),
-            'use_disk_cache' => $this->configuration->getBoolean('PS_PDF_USE_CACHE'),
+            'enable_invoices' => (bool) $this->configuration->get('PS_INVOICE', true, $shopConstraint),
+            'enable_tax_breakdown' => (bool) $this->configuration->get('PS_INVOICE_TAXES_BREAKDOWN', false, $shopConstraint),
+            'enable_product_images' => (bool) $this->configuration->get('PS_PDF_IMG_INVOICE', false, $shopConstraint),
+            'invoice_prefix' => $this->configuration->get('PS_INVOICE_PREFIX', ['#IN', '#FA'], $shopConstraint),
+            'add_current_year' => (bool) $this->configuration->get('PS_INVOICE_USE_YEAR', false, $shopConstraint),
+            'reset_number_annually' => (bool) $this->configuration->get('PS_INVOICE_RESET', false, $shopConstraint),
+            'year_position' => (int) $this->configuration->get('PS_INVOICE_YEAR_POS', 0, $shopConstraint),
+            'invoice_number' => (int) $this->configuration->get('PS_INVOICE_START_NUMBER', 0, $shopConstraint),
+            'legal_free_text' => $this->configuration->get('PS_INVOICE_LEGAL_FREE_TEXT', null, $shopConstraint),
+            'footer_text' => $this->configuration->get('PS_INVOICE_FREE_TEXT', null, $shopConstraint),
+            'invoice_model' => $this->configuration->get('PS_INVOICE_MODEL', 'invoice', $shopConstraint),
+            'use_disk_cache' => (bool) $this->configuration->get('PS_PDF_USE_CACHE', false, $shopConstraint),
         ];
     }
 
@@ -74,41 +86,61 @@ final class InvoiceOptionsConfiguration implements DataConfigurationInterface
     public function updateConfiguration(array $configuration)
     {
         if ($this->validateConfiguration($configuration)) {
-            $this->configuration->set('PS_INVOICE', $configuration['enable_invoices']);
-            $this->configuration->set('PS_INVOICE_TAXES_BREAKDOWN', $configuration['enable_tax_breakdown']);
-            $this->configuration->set('PS_PDF_IMG_INVOICE', $configuration['enable_product_images']);
-            $this->configuration->set('PS_INVOICE_PREFIX', $configuration['invoice_prefix']);
-            $this->configuration->set('PS_INVOICE_USE_YEAR', $configuration['add_current_year']);
-            $this->configuration->set('PS_INVOICE_RESET', $configuration['reset_number_annually']);
-            $this->configuration->set('PS_INVOICE_YEAR_POS', $configuration['year_position']);
-            $this->configuration->set('PS_INVOICE_START_NUMBER', $configuration['invoice_number']);
-            $this->configuration->set('PS_INVOICE_LEGAL_FREE_TEXT', $configuration['legal_free_text']);
-            $this->configuration->set('PS_INVOICE_FREE_TEXT', $configuration['footer_text']);
-            $this->configuration->set('PS_INVOICE_MODEL', $configuration['invoice_model']);
-            $this->configuration->set('PS_PDF_USE_CACHE', $configuration['use_disk_cache']);
+            $shopConstraint = $this->getShopConstraint();
+
+            $this->updateConfigurationValue('PS_INVOICE', 'enable_invoices', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_INVOICE_TAXES_BREAKDOWN', 'enable_tax_breakdown', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_PDF_IMG_INVOICE', 'enable_product_images', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_INVOICE_PREFIX', 'invoice_prefix', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_INVOICE_USE_YEAR', 'add_current_year', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_INVOICE_RESET', 'reset_number_annually', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_INVOICE_YEAR_POS', 'year_position', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_INVOICE_START_NUMBER', 'invoice_number', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_INVOICE_LEGAL_FREE_TEXT', 'legal_free_text', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_INVOICE_FREE_TEXT', 'footer_text', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_INVOICE_MODEL', 'invoice_model', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_PDF_USE_CACHE', 'use_disk_cache', $configuration, $shopConstraint);
         }
 
         return [];
     }
 
     /**
-     * {@inheritdoc}
+     * @return OptionsResolver
      */
-    public function validateConfiguration(array $configuration)
+    protected function buildResolver(): OptionsResolver
     {
-        return isset(
-            $configuration['enable_invoices'],
-            $configuration['enable_tax_breakdown'],
-            $configuration['enable_product_images'],
-            $configuration['invoice_prefix'],
-            $configuration['add_current_year'],
-            $configuration['reset_number_annually'],
-            $configuration['year_position'],
-            $configuration['invoice_number'],
-            $configuration['legal_free_text'],
-            $configuration['footer_text'],
-            $configuration['invoice_model'],
-            $configuration['use_disk_cache']
-        );
+        $resolver = (new OptionsResolver())
+            ->setDefined(
+                [
+                    'enable_invoices',
+                    'enable_tax_breakdown',
+                    'enable_product_images',
+                    'invoice_prefix',
+                    'add_current_year',
+                    'reset_number_annually',
+                    'year_position',
+                    'invoice_number',
+                    'legal_free_text',
+                    'footer_text',
+                    'invoice_model',
+                    'use_disk_cache',
+                ]
+            )
+            ->setAllowedTypes('enable_invoices', ['bool'])
+            ->setAllowedTypes('enable_tax_breakdown', ['bool'])
+            ->setAllowedTypes('enable_product_images', ['bool'])
+            ->setAllowedTypes('invoice_prefix', ['array'])
+            ->setAllowedTypes('add_current_year', ['bool'])
+            ->setAllowedTypes('reset_number_annually', ['bool'])
+            ->setAllowedTypes('year_position', ['integer'])
+            ->setAllowedTypes('invoice_number', ['integer'])
+            ->setAllowedTypes('legal_free_text', ['array'])
+            ->setAllowedTypes('footer_text', ['array'])
+            ->setAllowedTypes('invoice_model', ['string'])
+            ->setAllowedValues('invoice_model', array_keys($this->invoiceModelByNameChoiceProvider->getChoices()))
+            ->setAllowedTypes('use_disk_cache', ['bool']);
+
+        return $resolver;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
@@ -131,7 +131,7 @@ class InvoicesController extends FrameworkBundleAdminController
     private function processForm(FormHandlerInterface $formHandler, Request $request)
     {
         $form = $formHandler->getForm();
-        $form->submit($request->request->get($form->getName()));
+        $form->handleRequest($request);
 
         if ($form->isSubmitted()) {
             if ($errors = $formHandler->save($form->getData())) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
@@ -40,6 +40,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\PositiveOrZero;
 
 /**
  * Class InvoiceOptionsType generates "Invoice options" form
@@ -79,9 +80,6 @@ class InvoiceOptionsType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $featureTranslationKey = 'Admin.Orderscustomers.Feature';
-        $helpTranslationKey = 'Admin.Orderscustomers.Help';
-
         $builder
             ->add(
                 'enable_invoices',
@@ -89,10 +87,10 @@ class InvoiceOptionsType extends TranslatorAwareType
                 [
                     'required' => true,
                     'multistore_configuration_key' => 'PS_INVOICE',
-                    'label' => $this->trans('Enable invoices', $featureTranslationKey),
+                    'label' => $this->trans('Enable invoices', 'Admin.Orderscustomers.Feature'),
                     'help' => $this->trans(
                         'If enabled, your customers will receive an invoice for the purchase.',
-                        $helpTranslationKey
+                        'Admin.Orderscustomers.Help'
                     ),
                 ]
             )
@@ -101,10 +99,10 @@ class InvoiceOptionsType extends TranslatorAwareType
                 SwitchType::class,
                 [
                     'multistore_configuration_key' => 'PS_INVOICE_TAXES_BREAKDOWN',
-                    'label' => $this->trans('Enable tax breakdown', $featureTranslationKey),
+                    'label' => $this->trans('Enable tax breakdown', 'Admin.Orderscustomers.Feature'),
                     'help' => $this->trans(
                         'If required, show the total amount per rate of the corresponding tax.',
-                        $helpTranslationKey
+                        'Admin.Orderscustomers.Help'
                     ),
                 ]
             )
@@ -113,10 +111,10 @@ class InvoiceOptionsType extends TranslatorAwareType
                 SwitchType::class,
                 [
                     'multistore_configuration_key' => 'PS_PDF_IMG_INVOICE',
-                    'label' => $this->trans('Enable product image', $featureTranslationKey),
+                    'label' => $this->trans('Enable product image', 'Admin.Orderscustomers.Feature'),
                     'help' => $this->trans(
                         'Adds an image in front of the product name on the invoice',
-                        $helpTranslationKey
+                        'Admin.Orderscustomers.Help'
                     ),
                 ]
             )
@@ -126,10 +124,10 @@ class InvoiceOptionsType extends TranslatorAwareType
                 [
                     'type' => TextType::class,
                     'multistore_configuration_key' => 'PS_INVOICE_PREFIX',
-                    'label' => $this->trans('Invoice prefix', $featureTranslationKey),
+                    'label' => $this->trans('Invoice prefix', 'Admin.Orderscustomers.Feature'),
                     'help' => $this->trans(
                         'Freely definable prefix for invoice number (e.g. #IN00001).',
-                        $helpTranslationKey
+                        'Admin.Orderscustomers.Help'
                     ),
                 ]
             )
@@ -140,7 +138,7 @@ class InvoiceOptionsType extends TranslatorAwareType
                     'multistore_configuration_key' => 'PS_INVOICE_USE_YEAR',
                     'label' => $this->trans(
                         'Add current year to invoice number',
-                        $featureTranslationKey
+                        'Admin.Orderscustomers.Feature'
                     ),
                 ]
             )
@@ -151,7 +149,7 @@ class InvoiceOptionsType extends TranslatorAwareType
                     'multistore_configuration_key' => 'PS_INVOICE_RESET',
                     'label' => $this->trans(
                         'Reset sequential invoice number at the beginning of the year',
-                        $featureTranslationKey
+                        'Admin.Orderscustomers.Feature'
                     ),
                 ]
             )
@@ -160,12 +158,12 @@ class InvoiceOptionsType extends TranslatorAwareType
                 ChoiceType::class,
                 [
                     'choices' => [
-                        $this->trans('After the sequential number', $featureTranslationKey) => 0,
-                        $this->trans('Before the sequential number', $featureTranslationKey) => 1,
+                        $this->trans('After the sequential number', 'Admin.Orderscustomers.Feature') => 0,
+                        $this->trans('Before the sequential number', 'Admin.Orderscustomers.Feature') => 1,
                     ],
                     'expanded' => true,
                     'multistore_configuration_key' => 'PS_INVOICE_YEAR_POS',
-                    'label' => $this->trans('Position of the year date', $featureTranslationKey),
+                    'label' => $this->trans('Position of the year date', 'Admin.Orderscustomers.Feature'),
                 ]
             )
             ->add(
@@ -173,11 +171,12 @@ class InvoiceOptionsType extends TranslatorAwareType
                 IntegerType::class,
                 [
                     'required' => false,
+                    'constraints' => [new PositiveOrZero()],
                     'multistore_configuration_key' => 'PS_INVOICE_START_NUMBER',
-                    'label' => $this->trans('Invoice number', $featureTranslationKey),
+                    'label' => $this->trans('Invoice number', 'Admin.Orderscustomers.Feature'),
                     'help' => $this->trans(
                         'The next invoice will begin with this number, and then increase with each additional invoice. Set to 0 if you want to keep the current number (which is #%number%).',
-                        $helpTranslationKey,
+                        'Admin.Orderscustomers.Help',
                         [
                             '%number%' => $this->nextInvoiceNumber,
                         ]
@@ -190,10 +189,10 @@ class InvoiceOptionsType extends TranslatorAwareType
                 [
                     'type' => TextareaType::class,
                     'multistore_configuration_key' => 'PS_INVOICE_LEGAL_FREE_TEXT',
-                    'label' => $this->trans('Legal free text', $featureTranslationKey),
+                    'label' => $this->trans('Legal free text', 'Admin.Orderscustomers.Feature'),
                     'help' => $this->trans(
                         'Use this field to show additional information on the invoice, below the payment methods summary (like specific legal information).',
-                        $helpTranslationKey
+                        'Admin.Orderscustomers.Help'
                     ),
                 ]
             )
@@ -203,10 +202,10 @@ class InvoiceOptionsType extends TranslatorAwareType
                 [
                     'type' => TextType::class,
                     'multistore_configuration_key' => 'PS_INVOICE_FREE_TEXT',
-                    'label' => $this->trans('Footer text', $featureTranslationKey),
+                    'label' => $this->trans('Footer text', 'Admin.Orderscustomers.Feature'),
                     'help' => $this->trans(
                         'This text will appear at the bottom of the invoice, below your company details.',
-                        $helpTranslationKey
+                        'Admin.Orderscustomers.Help'
                     ),
                 ]
             )
@@ -217,8 +216,8 @@ class InvoiceOptionsType extends TranslatorAwareType
                     'choices' => $this->invoiceModelChoiceProvider->getChoices(),
                     'translation_domain' => false,
                     'multistore_configuration_key' => 'PS_INVOICE_MODEL',
-                    'label' => $this->trans('Invoice model', $featureTranslationKey),
-                    'help' => $this->trans('Choose an invoice model.', $helpTranslationKey),
+                    'label' => $this->trans('Invoice model', 'Admin.Orderscustomers.Feature'),
+                    'help' => $this->trans('Choose an invoice model.', 'Admin.Orderscustomers.Help'),
                 ]
             )
             ->add(
@@ -228,11 +227,11 @@ class InvoiceOptionsType extends TranslatorAwareType
                     'multistore_configuration_key' => 'PS_PDF_USE_CACHE',
                     'label' => $this->trans(
                         'Use the disk as cache for PDF invoices',
-                        $featureTranslationKey
+                        'Admin.Orderscustomers.Feature'
                     ),
                     'help' => $this->trans(
                         'Saves memory but slows down the PDF generation.',
-                        $helpTranslationKey
+                        'Admin.Orderscustomers.Help'
                     ),
                 ]
             );

--- a/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Order/Invoices/InvoiceOptionsType.php
@@ -27,11 +27,12 @@
 namespace PrestaShopBundle\Form\Admin\Sell\Order\Invoices;
 
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -78,36 +79,163 @@ class InvoiceOptionsType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $featureTranslationKey = 'Admin.Orderscustomers.Feature';
+        $helpTranslationKey = 'Admin.Orderscustomers.Help';
+
         $builder
-            ->add('enable_invoices', SwitchType::class)
-            ->add('enable_tax_breakdown', SwitchType::class)
-            ->add('enable_product_images', SwitchType::class)
-            ->add('invoice_prefix', TranslatableType::class, [
-                'type' => TextType::class,
-            ])
-            ->add('add_current_year', SwitchType::class)
-            ->add('reset_number_annually', SwitchType::class)
-            ->add('year_position', ChoiceType::class, [
-                'choices' => [
-                    $this->trans('After the sequential number', 'Admin.Orderscustomers.Feature') => 0,
-                    $this->trans('Before the sequential number', 'Admin.Orderscustomers.Feature') => 1,
-                ],
-                'expanded' => true,
-            ])
-            ->add('invoice_number', NumberType::class, [
-                'required' => false,
-            ])
-            ->add('legal_free_text', TranslatableType::class, [
-                'type' => TextareaType::class,
-            ])
-            ->add('footer_text', TranslatableType::class, [
-                'type' => TextType::class,
-            ])
-            ->add('invoice_model', ChoiceType::class, [
-                'choices' => $this->invoiceModelChoiceProvider->getChoices(),
-                'translation_domain' => false,
-            ])
-            ->add('use_disk_cache', SwitchType::class);
+            ->add(
+                'enable_invoices',
+                SwitchType::class,
+                [
+                    'required' => true,
+                    'multistore_configuration_key' => 'PS_INVOICE',
+                    'label' => $this->trans('Enable invoices', $featureTranslationKey),
+                    'help' => $this->trans(
+                        'If enabled, your customers will receive an invoice for the purchase.',
+                        $helpTranslationKey
+                    ),
+                ]
+            )
+            ->add(
+                'enable_tax_breakdown',
+                SwitchType::class,
+                [
+                    'multistore_configuration_key' => 'PS_INVOICE_TAXES_BREAKDOWN',
+                    'label' => $this->trans('Enable tax breakdown', $featureTranslationKey),
+                    'help' => $this->trans(
+                        'If required, show the total amount per rate of the corresponding tax.',
+                        $helpTranslationKey
+                    ),
+                ]
+            )
+            ->add(
+                'enable_product_images',
+                SwitchType::class,
+                [
+                    'multistore_configuration_key' => 'PS_PDF_IMG_INVOICE',
+                    'label' => $this->trans('Enable product image', $featureTranslationKey),
+                    'help' => $this->trans(
+                        'Adds an image in front of the product name on the invoice',
+                        $helpTranslationKey
+                    ),
+                ]
+            )
+            ->add(
+                'invoice_prefix',
+                TranslatableType::class,
+                [
+                    'type' => TextType::class,
+                    'multistore_configuration_key' => 'PS_INVOICE_PREFIX',
+                    'label' => $this->trans('Invoice prefix', $featureTranslationKey),
+                    'help' => $this->trans(
+                        'Freely definable prefix for invoice number (e.g. #IN00001).',
+                        $helpTranslationKey
+                    ),
+                ]
+            )
+            ->add(
+                'add_current_year',
+                SwitchType::class,
+                [
+                    'multistore_configuration_key' => 'PS_INVOICE_USE_YEAR',
+                    'label' => $this->trans(
+                        'Add current year to invoice number',
+                        $featureTranslationKey
+                    ),
+                ]
+            )
+            ->add(
+                'reset_number_annually',
+                SwitchType::class,
+                [
+                    'multistore_configuration_key' => 'PS_INVOICE_RESET',
+                    'label' => $this->trans(
+                        'Reset sequential invoice number at the beginning of the year',
+                        $featureTranslationKey
+                    ),
+                ]
+            )
+            ->add(
+                'year_position',
+                ChoiceType::class,
+                [
+                    'choices' => [
+                        $this->trans('After the sequential number', $featureTranslationKey) => 0,
+                        $this->trans('Before the sequential number', $featureTranslationKey) => 1,
+                    ],
+                    'expanded' => true,
+                    'multistore_configuration_key' => 'PS_INVOICE_YEAR_POS',
+                    'label' => $this->trans('Position of the year date', $featureTranslationKey),
+                ]
+            )
+            ->add(
+                'invoice_number',
+                IntegerType::class,
+                [
+                    'required' => false,
+                    'multistore_configuration_key' => 'PS_INVOICE_START_NUMBER',
+                    'label' => $this->trans('Invoice number', $featureTranslationKey),
+                    'help' => $this->trans(
+                        'The next invoice will begin with this number, and then increase with each additional invoice. Set to 0 if you want to keep the current number (which is #%number%).',
+                        $helpTranslationKey,
+                        [
+                            '%number%' => $this->nextInvoiceNumber,
+                        ]
+                    ),
+                ]
+            )
+            ->add(
+                'legal_free_text',
+                TranslatableType::class,
+                [
+                    'type' => TextareaType::class,
+                    'multistore_configuration_key' => 'PS_INVOICE_LEGAL_FREE_TEXT',
+                    'label' => $this->trans('Legal free text', $featureTranslationKey),
+                    'help' => $this->trans(
+                        'Use this field to show additional information on the invoice, below the payment methods summary (like specific legal information).',
+                        $helpTranslationKey
+                    ),
+                ]
+            )
+            ->add(
+                'footer_text',
+                TranslatableType::class,
+                [
+                    'type' => TextType::class,
+                    'multistore_configuration_key' => 'PS_INVOICE_FREE_TEXT',
+                    'label' => $this->trans('Footer text', $featureTranslationKey),
+                    'help' => $this->trans(
+                        'This text will appear at the bottom of the invoice, below your company details.',
+                        $helpTranslationKey
+                    ),
+                ]
+            )
+            ->add(
+                'invoice_model',
+                ChoiceType::class,
+                [
+                    'choices' => $this->invoiceModelChoiceProvider->getChoices(),
+                    'translation_domain' => false,
+                    'multistore_configuration_key' => 'PS_INVOICE_MODEL',
+                    'label' => $this->trans('Invoice model', $featureTranslationKey),
+                    'help' => $this->trans('Choose an invoice model.', $helpTranslationKey),
+                ]
+            )
+            ->add(
+                'use_disk_cache',
+                SwitchType::class,
+                [
+                    'multistore_configuration_key' => 'PS_PDF_USE_CACHE',
+                    'label' => $this->trans(
+                        'Use the disk as cache for PDF invoices',
+                        $featureTranslationKey
+                    ),
+                    'help' => $this->trans(
+                        'Saves memory but slows down the PDF generation.',
+                        $helpTranslationKey
+                    ),
+                ]
+            );
     }
 
     /**
@@ -126,5 +254,15 @@ class InvoiceOptionsType extends TranslatorAwareType
         $resolver->setDefaults([
             'translation_domain' => 'Admin.Orderscustomers.Feature',
         ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see MultistoreConfigurationTypeExtension
+     */
+    public function getParent(): string
+    {
+        return MultistoreConfigurationType::class;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/invoices.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/orders/invoices.yml
@@ -10,7 +10,7 @@ admin_order_invoices:
 # Process Invoice Options form
 admin_order_invoices_process:
   path: /
-  methods: [ POST ]
+  methods: [ PATCH, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Order\InvoicesController::processAction'
     _legacy_controller: AdminInvoices

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -129,6 +129,9 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Invoice\InvoiceOptionsConfiguration'
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+      - '@prestashop.adapter.shop.context'
+      - '@prestashop.adapter.multistore_feature'
+      - '@prestashop.core.form.choice_provider.invoice_model_by_name'
 
   prestashop.adapter.data_provider.language:
     class: 'PrestaShop\PrestaShop\Adapter\Language\LanguageDataProvider'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Invoices/Blocks/invoice_options.html.twig
@@ -26,113 +26,28 @@
 {% trans_default_domain "Admin.Orderscustomers.Feature" %}
 {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
 
-{% block invoice_options %}
-  {{ form_start(invoiceOptionsForm, {method: 'POST', action: path('admin_order_invoices_process'), attr: {id: 'form-invoices-options'}}) }}
-  <div class="card">
-    <h3 class="card-header">
-      <i class="material-icons">settings</i>
-      {{ 'Invoice options'|trans }}
-    </h3>
-    <div class="card-body">
-      <div class="form-wrapper">
-        <div class="form-group row">
-          {{ ps.label_with_help('Enable invoices'|trans, 'If enabled, your customers will receive an invoice for the purchase.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.enable_invoices) }}
-            {{ form_widget(invoiceOptionsForm.enable_invoices) }}
-          </div>
+{% form_theme invoiceOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+
+{% block content %}
+  {{ form_start(invoiceOptionsForm, {action: path('admin_order_invoices_process'), attr: {id: 'form-invoices-options'}}) }}
+    {% block invoice_options %}
+    <div class="card">
+      <h3 class="card-header">
+        <i class="material-icons">settings</i>
+        {{ 'Invoice options'|trans }}
+      </h3>
+      <div class="card-body">
+        <div class="form-wrapper">
+          {{ form_widget(invoiceOptionsForm) }}
+          {{ form_rest(invoiceOptionsForm) }}
         </div>
-        <div class="form-group row">
-          {{ ps.label_with_help('Enable tax breakdown'|trans, 'If required, show the total amount per rate of the corresponding tax.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.enable_tax_breakdown) }}
-            {{ form_widget(invoiceOptionsForm.enable_tax_breakdown) }}
-          </div>
+      </div>
+      <div class="card-footer">
+        <div class="d-flex justify-content-end">
+          <button class="btn btn-primary" id="save-invoices-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
         </div>
-        <div class="form-group row">
-          {{ ps.label_with_help('Enable product image'|trans, 'Adds an image in front of the product name on the invoice'|trans({}, 'Admin.Orderscustomers.Help')) }}
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.enable_product_images) }}
-            {{ form_widget(invoiceOptionsForm.enable_product_images) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help('Invoice prefix'|trans, 'Freely definable prefix for invoice number (e.g. #IN00001).'|trans({}, 'Admin.Orderscustomers.Help')) }}
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.invoice_prefix) }}
-            {{ form_widget(invoiceOptionsForm.invoice_prefix) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Add current year to invoice number'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.add_current_year) }}
-            {{ form_widget(invoiceOptionsForm.add_current_year) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Reset sequential invoice number at the beginning of the year'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.reset_number_annually) }}
-            {{ form_widget(invoiceOptionsForm.reset_number_annually) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          <label class="form-control-label">
-            {{ 'Position of the year date'|trans }}
-          </label>
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.year_position) }}
-            {{ form_widget(invoiceOptionsForm.year_position) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help('Invoice number'|trans, 'The next invoice will begin with this number, and then increase with each additional invoice. Set to 0 if you want to keep the current number (which is #%number%).'|trans({'%number%': invoiceOptionsForm.vars.next_invoice_number}, 'Admin.Orderscustomers.Help')) }}
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.invoice_number) }}
-            {{ form_widget(invoiceOptionsForm.invoice_number) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help('Legal free text'|trans, 'Use this field to show additional information on the invoice, below the payment methods summary (like specific legal information).'|trans({}, 'Admin.Orderscustomers.Help')) }}
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.legal_free_text) }}
-            {{ form_widget(invoiceOptionsForm.legal_free_text) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help('Footer text'|trans, 'This text will appear at the bottom of the invoice, below your company details.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.footer_text) }}
-            {{ form_widget(invoiceOptionsForm.footer_text) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help('Invoice model'|trans, 'Choose an invoice model.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.invoice_model) }}
-            {{ form_widget(invoiceOptionsForm.invoice_model) }}
-          </div>
-        </div>
-        <div class="form-group row">
-          {{ ps.label_with_help('Use the disk as cache for PDF invoices'|trans, 'Saves memory but slows down the PDF generation.'|trans({}, 'Admin.Orderscustomers.Help')) }}
-          <div class="col-sm">
-            {{ form_errors(invoiceOptionsForm.use_disk_cache) }}
-            {{ form_widget(invoiceOptionsForm.use_disk_cache) }}
-          </div>
-        </div>
-        {{ form_rest(invoiceOptionsForm) }}
       </div>
     </div>
-    <div class="card-footer">
-      <div class="d-flex justify-content-end">
-        <button class="btn btn-primary" id="save-invoices-options-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
-      </div>
-    </div>
-  </div>
+    {% endblock %}
   {{ form_end(invoiceOptionsForm) }}
 {% endblock %}

--- a/tests/Unit/Adapter/Invoice/InvoicesConfigurationTest.php
+++ b/tests/Unit/Adapter/Invoice/InvoicesConfigurationTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Invoice;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PrestaShop\PrestaShop\Adapter\Invoice\InvoiceOptionsConfiguration;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Tests\TestCase\AbstractConfigurationTestCase;
+
+class InvoiceOptionsConfigurationTest extends AbstractConfigurationTestCase
+{
+    private const SHOP_ID = 42;
+
+    private const VALID_CONFIGURATION = [
+        'enable_invoices' => false,
+        'enable_tax_breakdown' => true,
+        'enable_product_images' => true,
+        'invoice_prefix' => ['#EN', '#FR'],
+        'add_current_year' => true,
+        'reset_number_annually' => true,
+        'year_position' => 0,
+        'invoice_number' => 42,
+        'legal_free_text' => [
+            'Legal free text - Test - EN',
+            'Legal free text - Test - FR',
+        ],
+        'footer_text' => [
+            'Footer text - Test - EN',
+            'Footer text - Test - FR',
+        ],
+        'invoice_model' => 'invoice',
+        'use_disk_cache' => true,
+    ];
+
+    /**
+     * @var FormChoiceProviderInterface|MockObject
+     */
+    private $invoiceModelChoiceProvider;
+
+    protected function setUp(): void
+    {
+        $this->mockConfiguration = $this->createConfigurationMock();
+        $this->mockShopConfiguration = $this->createShopContextMock();
+        $this->mockMultistoreFeature = $this->createMultistoreFeatureMock();
+
+        $this->invoiceModelChoiceProvider = $this->getMockBuilder(FormChoiceProviderInterface::class)
+            ->setMethods(['getChoices'])
+            ->getMock()
+        ;
+
+        $this->invoiceModelChoiceProvider
+            ->method('getChoices')
+            ->willReturn([
+                'invoice' => 'invoice',
+                'invoice-test' => 'invoice-test',
+            ])
+        ;
+    }
+
+    /**
+     * @dataProvider provideInvalidConfiguration
+     *
+     * @param string $exception
+     * @param array $values
+     */
+    public function testUpdateConfigurationWithInvalidConfiguration(string $exception, array $values): void
+    {
+        $invoiceOptionsConfiguration = new InvoiceOptionsConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature, $this->invoiceModelChoiceProvider);
+
+        $this->expectException($exception);
+        $invoiceOptionsConfiguration->updateConfiguration($values);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideInvalidConfiguration(): array
+    {
+        return [
+            [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_invoices' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_tax_breakdown' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_product_images' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['invoice_prefix' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['add_current_year' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['reset_number_annually' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['year_position' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['year_position' => 999])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['invoice_number' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['invoice_number' => 0.42])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['invoice_number' => -42])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['legal_free_text' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['footer_text' => 'invalid_value_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['invoice_model' => null])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['invoice_model' => 'invalid_value'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['use_disk_cache' => 'invalid_value_type'])],
+        ];
+    }
+
+    /**
+     * @dataProvider provideValidConfiguration
+     *
+     * @param array $values
+     */
+    public function testSuccessfulUpdate(array $values): void
+    {
+        $invoiceOptionsConfiguration = new InvoiceOptionsConfiguration($this->mockConfiguration, $this->mockShopConfiguration, $this->mockMultistoreFeature, $this->invoiceModelChoiceProvider);
+
+        $res = $invoiceOptionsConfiguration->updateConfiguration($values);
+        $this->assertSame([], $res);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideValidConfiguration(): array
+    {
+        return [
+            [self::VALID_CONFIGURATION],
+            [array_merge(self::VALID_CONFIGURATION, ['year_position' => 1])],
+            [array_merge(self::VALID_CONFIGURATION, ['invoice_number' => 0])],
+            [array_merge(self::VALID_CONFIGURATION, ['invoice_model' => 'invoice-test'])],
+        ];
+    }
+
+    /**
+     * @return array[]
+     */
+    public function provideShopConstraints(): array
+    {
+        return [
+            [ShopConstraint::shop(self::SHOP_ID)],
+            [ShopConstraint::shopGroup(self::SHOP_ID)],
+            [ShopConstraint::allShops()],
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?              | develop
| Description?       | Order Invoice refactoring : multistore checkboxes, form simplification (use abstract architecture), fix `invoice_number` type, review previous #10474 bugfix, add unit tests.
| Type?                 | refacto
| Category?          | BO
| BC breaks?        | no
| Deprecations?    | no
| Fixed ticket?       | Fixes #19381.
| Related PRs       | #10474
| How to test?       | See [official documentation for Multistore Checkboxes](https://devdocs.prestashop.com/8/development/multistore/configuration-forms/); Configure to use Multistore and then go to `Orders > Invoices > Invoice options` 
| Possible impacts? | Order invoices configuration

> :point_up: I applied few type and constraints update and I am not convinced by error management for Configuration. I started some product definitions with @eshraw (especially about invoice number) but I think that some product definitions may help.