### PR TITLE
Update AbstractForm.php for Multilanguage fields

### DIFF
--- a/classes/form/AbstractForm.php
+++ b/classes/form/AbstractForm.php
@@ -236,7 +236,7 @@ abstract class AbstractFormCore implements FormInterface
      */
     protected function checkFieldLength($field)
     {
-        $error = $field->getMaxLength() != null && strlen($field->getValue()) > (int) $field->getMaxLength();
+        $error = $field->getMaxLength() != null && Tools::strlen($field->getValue()) > (int) $field->getMaxLength();
 
         return !$error;
     }


### PR DESCRIPTION
use Tools::strlen instead of strlen for proper UTF-8 sting measurement

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This function is used in 1.7.8.x to validate address fields which leads to shorten valid lenght than DB can store.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #28675
| Related PRs       |
| How to test?      | 
| Possible impacts? | this function should not be used for fields that meant to be ASCII-only.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
