### PR TITLE
Update function checkFieldLength() to support multilanguage input

### DIFF
--- a/classes/form/AbstractForm.php
+++ b/classes/form/AbstractForm.php
@@ -254,7 +254,7 @@ abstract class AbstractFormCore implements FormInterface
      */
     protected function checkFieldLength($field)
     {
-        $error = $field->getMaxLength() != null && strlen($field->getValue()) > (int) $field->getMaxLength();
+        $error = $field->getMaxLength() != null && Tools::strlen($field->getValue()) > (int) $field->getMaxLength();
 
         return !$error;
     }


### PR DESCRIPTION
using Tools::strlen() will check UTF-8 proper string length when field is filled with non-Latin characters

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x
| Description?      | checkFieldLength() function is used for multilanguage fields and need to utilise mb_strlen() if possible. It is already done by Tools::strlen() functionality
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #28675
| Related PRs       | 
| How to test?      | 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
