### PR TITLE
Fix product import for Product page v2.

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -2100,14 +2100,13 @@ class AdminImportControllerCore extends AdminController
                 Db::getInstance()->getMsgError();
         } else {
             // Product supplier
-            if (!$validateOnly && !empty($product->id) && property_exists($product, 'supplier_reference')) {
+            if (!$validateOnly && !empty($product->id) && property_exists($product, 'supplier_reference') && !empty($product->id_supplier)) {
                 $id_product_supplier = (int) ProductSupplier::getIdByProductAndSupplier((int) $product->id, 0, (int) $product->id_supplier);
                 if ($id_product_supplier) {
                     $product_supplier = new ProductSupplier($id_product_supplier);
                 } else {
                     $product_supplier = new ProductSupplier();
                 }
-
                 $product_supplier->id_product = (int) $product->id;
                 $product_supplier->id_product_attribute = 0;
                 $product_supplier->id_supplier = (int) $product->id_supplier;

--- a/tests/Integration/Behaviour/Features/Context/LegacyProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LegacyProductFeatureContext.php
@@ -988,13 +988,13 @@ class LegacyProductFeatureContext extends AbstractPrestaShopFeatureContext
     }
 
     /**
-     * @Then product :productName as to be editable
+     * @Then product :productName should be editable
      */
-    public function productAsToBeEditable($productName)
+    public function productShouldBeEditable($productName)
     {
         $this->checkProductWithNameExists($productName);
         $productId = (int) $this->getProductWithName($productName)->id;
-        
+
         $formBuilder = CommonFeatureContext::getContainer()->get('prestashop.core.form.identifiable_object.builder.edit_product_form_builder');
 
         $productForm = $formBuilder->getFormFor($productId, [], [

--- a/tests/Integration/Behaviour/Features/Context/LegacyProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LegacyProductFeatureContext.php
@@ -42,6 +42,7 @@ use Product;
 use RuntimeException;
 use SpecificPrice;
 use StockAvailable;
+use Symfony\Component\HttpFoundation\Request;
 use TaxRulesGroup;
 use Tests\Integration\Behaviour\Features\Context\Util\CombinationDetails;
 use Tests\Integration\Behaviour\Features\Context\Util\ProductCombinationFactory;
@@ -984,6 +985,22 @@ class LegacyProductFeatureContext extends AbstractPrestaShopFeatureContext
                 throw new RuntimeException(sprintf('Expects %s, got %s instead', $priceWithReduction, $productPrices['price_with_reduction']));
             }
         }
+    }
+
+    /**
+     * @Then product :productName as to be editable
+     */
+    public function productAsToBeEditable($productName)
+    {
+        $this->checkProductWithNameExists($productName);
+        $productId = (int) $this->getProductWithName($productName)->id;
+        
+        $formBuilder = CommonFeatureContext::getContainer()->get('prestashop.core.form.identifiable_object.builder.edit_product_form_builder');
+
+        $productForm = $formBuilder->getFormFor($productId, [], [
+            'product_id' => $productId,
+            'method' => Request::METHOD_POST,
+        ]);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -64,3 +64,11 @@ Feature: Legacy products have consistent product type through dynamic checking (
     And product "pack_product" type should be pack
     And product "pack_product" persisted type should be pack
     And product "pack_product" dynamic type should be pack
+
+  Scenario: I create a product with undefined type using legacy methods, this product as to be editable
+    Given there is a product in the catalog named "Undefined Product" with a price of 15.0 and 100 items in stock
+    Then there is a product "undefined_product" with name "Undefined Product"
+    And product "undefined_product" type should be standard
+    And product "undefined_product" persisted type should be undefined
+    And product "undefined_product" dynamic type should be standard
+    And product "Undefined Product" as to be editable

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_product_type.feature
@@ -71,4 +71,4 @@ Feature: Legacy products have consistent product type through dynamic checking (
     And product "undefined_product" type should be standard
     And product "undefined_product" persisted type should be undefined
     And product "undefined_product" dynamic type should be standard
-    And product "Undefined Product" as to be editable
+    And product "Undefined Product" should be editable


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Product page v2 display an error after a product import.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28169.
| Related PRs       | Na.
| How to test?      | Cf. #28169 
| Possible impacts? | Product creation.

> :question: for @PrestaShop/prestashop-core-developers , the solution to create a new Product to use `Product::getDynamicProductType()` function according Product state isn't completely satisfying. But with @atomiix we didn't find an easy solution that won't imply deep refactoring. If anyone as a better solution please share :)

In order to fix product import for Product page v2, we 
- Remove default empty supplier creation during import.
    > Import calls legacy controller that creates some weird data with 0 ids (associative tables). Inducing wrong behaviors when trying to get consistent data with product page v2.
- Fix getProductType for `ProductType::TYPE_UNDEFINED`
    > `ProductType::TYPE_UNDEFINED` is kept for legacy shop compatibility (existing databases, import old datas, ...) but a new function as been implemented to manage data consistency : `Product::getDynamicProductType()`. We searched a way to build the ProductType from CQRS Query request while product isn't instantiated yet and it's data are not satisfying new required structure. 