### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 1 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   nightly-build:
     name: Nightly Build

--- a/.github/workflows/cron_nightly_gcp.yml
+++ b/.github/workflows/cron_nightly_gcp.yml
@@ -7,6 +7,9 @@ on:
     types:
       - requested
 
+permissions:
+  contents: read
+
 jobs:
   nightly:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron_nightly_tests.yml
+++ b/.github/workflows/cron_nightly_tests.yml
@@ -16,6 +16,9 @@ env:
   NIGHTLY_TOKEN: ${{ secrets.NIGHTLY_TOKEN }}  # Nightly token to validate the import
   TESTS_DIR: 'tests/UI'  # Where UI tests are
 
+permissions:
+  contents: read
+
 jobs:
 
   # First job: Run tests in parallel
@@ -169,6 +172,8 @@ jobs:
 
   # Add pushed reports to GCp on nightly
   push-nightly-reports:
+    permissions:
+      contents: none
     name: Push reports to nightly.prestashop.com
     if: ${{ always() }}
     needs:

--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -4,8 +4,14 @@ on:
     - cron: '0 23 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-composer-modules:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     runs-on: ubuntu-latest
     name: Update PHP Modules
     strategy:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,5 +1,8 @@
 name: Js
 on: [ push, pull_request ]
+permissions:
+  contents: read
+
 jobs:
   js-unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 on: [ push, pull_request ]
+permissions:
+  contents: read
+
 jobs:
   stylelint:
     name: SCSS Lint

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,7 +1,13 @@
 name: PHP
 on: [ push, pull_request ]
+permissions:
+  contents: read
+
 jobs:
   php-cs-fixer:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     name: PHP CS Fixer
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +47,9 @@ jobs:
         run: composer normalize --dry-run --no-check-lock
 
   phpstan:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     name: PHP Static Analysis
     runs-on: ubuntu-latest
     strategy:
@@ -82,6 +91,9 @@ jobs:
         run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist
 
   phpunit:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     name: PHPUnit
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ui-tests-code-checks.yml
+++ b/.github/workflows/ui-tests-code-checks.yml
@@ -8,9 +8,15 @@ defaults:
   run:
     working-directory: ./tests/UI/
 
+permissions:
+  contents: read
+
 jobs:
 
   ESLint:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     name: ESLint
     if: contains(github.event.pull_request.labels.*.name, 'TE')
@@ -45,6 +51,9 @@ jobs:
         run: npm run lint
 
   Steps-identifiers:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     name: Checking doubles in steps identifiers
     if: contains(github.event.pull_request.labels.*.name, 'TE')


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | CI runs 
| Possible impacts? | Only CI

# Description

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
