### PR TITLE
Fix features and attributes list for multishop

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3146,9 +3146,10 @@ class AdminControllerCore extends Controller
             $select_shop = ', shop.name as shop_name ';
         }
 
-        if ($this->multishop_context && Shop::isTableAssociated($this->table) && !empty($this->className) && null !== $this->_join) {
+        if ($this->multishop_context && Shop::isTableAssociated($this->table) && !empty($this->className)) {
             if (Shop::getContext() != Shop::CONTEXT_ALL || !$this->context->employee->isSuperAdmin()) {
-                $test_join = !preg_match('#`?' . preg_quote(_DB_PREFIX_ . $this->table . '_shop') . '`? *sa#', $this->_join);
+                // test if multishop is already considered by planned request
+                $test_join = (null === $this->_join) || !preg_match('#`?' . preg_quote(_DB_PREFIX_ . $this->table . '_shop') . '`? *sa#', $this->_join);
                 if (Shop::isFeatureActive() && $test_join) {
                     $this->_where .= ' AND EXISTS (
                         SELECT 1


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?    | Under multishop configuration, Attributes and Features aren't filtered by shop and can't be deleted.
| Type?               | bug fix
| Category?        | BO
| BC breaks?      | no
| Deprecations?  | no
| Fixed ticket?     | Fixes #28770 .
| Related PRs     | Regression came from https://github.com/PrestaShop/PrestaShop/pull/28402/files#r911922212; according @atomiix, he probably tried to fix phpstan problem. 
| How to test?     | Cf. #28770 and enhance step to reproduce.
| Possible impacts? | All legacy object lists under multishop. 

## Steps to reproduce

1. Configure Multistore (**BO**) :
  - Configure > Shop Parameters > General > Enable Multistore : Yes
  - Configure > Advanced Parameters > Multistore > Add a new shop group
  - Configure > Advanced Parameters > Multistore > Add a new shop (in the group you just created)
2. Create a Feature (**BO**) :
  - Sell > Catalog > Attributes & Features > Features > Add new feature > {create a feature and associate it to one shop only} > Save
  - Change the current shop from top right button > PROBLEM : the Feature is always present.
3. Delete a Feature (**BO**) :
  - Delete a Feature > PROBLEM : whatever the shop you consider, feature remains in the list.

Same tests for Attributes.
