### PR TITLE
Fixed incorrect stock at Partial refund of an order even if "Re-stock products checkbox" is not checked

### DIFF
--- a/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
+++ b/src/Adapter/Order/CommandHandler/IssuePartialRefundHandler.php
@@ -140,7 +140,12 @@ final class IssuePartialRefundHandler extends AbstractOrderCommandHandler implem
 
         // @todo This part should probably be in a share abstract class as it will probably be common with other handlers
         // Update order details and reinject quantities
-        $shouldReinjectProducts = !$order->hasBeenDelivered() || $command->restockRefundedProducts();
+        $shouldReinjectProducts = !$order->hasBeenDelivered();
+
+        if (!$command->restockRefundedProducts()) {
+            $shouldReinjectProducts = false;
+        }
+
         foreach ($orderRefundSummary->getProductRefunds() as $orderDetailId => $productRefund) {
             $orderDetail = $orderRefundSummary->getOrderDetailById($orderDetailId);
             if ($shouldReinjectProducts) {


### PR DESCRIPTION
Fixed incorrect stock at Partial refund of an order even if "Re-stock products checkbox" is not checked
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When doing a partial refund, even if "Re-stock products checkbox" is not checked, the product is restock
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | No
| Deprecations?     | No
| Fixed ticket?     | Fixes #16869 
| Related PRs       | 
| How to test?      |  1. Go to make an order. 2. Go to the BO and the order, check the stock of the product in the order. 3. Do a partial refund and restock of products, check the stock
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
