### PR TITLE
Throw exception when ImageType doesn't return anything on FO

### DIFF
--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -34,6 +34,7 @@ use ImageType;
 use Language;
 use Link;
 use PrestaShopDatabaseException;
+use PrestaShopException;
 use Product;
 use Store;
 
@@ -274,24 +275,29 @@ class ImageRetriever
      * @return array
      *
      * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException if the image type is not found
      */
     public function getNoPictureImage(Language $language)
     {
         $urls = [];
         $type = 'products';
-        $image_types = ImageType::getImagesTypes($type, true);
+        $imageTypes = ImageType::getImagesTypes($type, true);
 
-        foreach ($image_types as $image_type) {
+        if (empty($imageTypes)) {
+            throw new PrestaShopException(sprintf('There is no image type defined for "%s".', $type));
+        }
+
+        foreach ($imageTypes as $imageType) {
             $url = $this->link->getImageLink(
                 '',
                 $language->iso_code . '-default',
-                $image_type['name']
+                $imageType['name']
             );
 
-            $urls[$image_type['name']] = [
+            $urls[$imageType['name']] = [
                 'url' => $url,
-                'width' => (int) $image_type['width'],
-                'height' => (int) $image_type['height'],
+                'width' => (int) $imageType['width'],
+                'height' => (int) $imageType['height'],
             ];
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When there is no "product" image type defined, the home page on FO displays a cryptical error. I added an exception so that when in dev mode you can get a more detailed error message and be able to understand the root cause.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29145
| Related PRs       | N/A
| How to test?      | Remove the "product" image type, load FO, see error message
| Possible impacts? | None

This is what you get now:
<img width="1150" alt="Screenshot 2022-07-22 at 18 08 03" src="https://user-images.githubusercontent.com/1009343/180480312-eeea0ece-1604-41ad-af46-1fe05e035f47.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
