### PR TITLE
Show errors when installing a module fails

### DIFF
--- a/install-dev/theme/js/process.js
+++ b/install-dev/theme/js/process.js
@@ -161,11 +161,25 @@ function install_error(step, errors) {
   if (errors) {
     var list_errors = errors;
 
-    if ($.type(list_errors) == 'string') {
-      list_errors = [];
-      list_errors[0] = errors;
-    } else if ($.type(list_errors) == 'array') {
-      list_errors = [list_errors[0]];
+    switch (typeof list_errors) {
+      case 'string':
+        list_errors = [errors];
+        break;
+
+      case 'array':
+        list_errors = [list_errors[0]];
+        break;
+
+      case 'object':
+        let err = []
+        $.each(list_errors, function(prop, val){
+          if (typeof val === 'array') {
+            val = val.map(function(v){ return "<li>" + v + "</li>"});
+          }
+          err.push(prop + ' <ul>' + val + '</ul>');
+        });
+        list_errors = err;
+        break;
     }
 
     var display = '<ol>';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When a module install fails during the shop install process, no error details are shown. With this change, error messages coming from the server are displayed. Thanks to this change, you can now find out which module triggered the error.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Related PRs       | n/a
| How to test?      | Add a module that won't install for some reason in the modules directory. Install PrestaShop. Without the PR, no error message is shown. With the PR, the backend's error message is shown (and you can tell which module failed).
| Possible impacts? | None that I can see

Screenshot:
<img width="687" alt="Screenshot 2022-07-04 at 13 43 09" src="https://user-images.githubusercontent.com/1009343/177148631-154506b6-26bc-49b0-ba0d-6b9d0593017f.png">


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
