### PR TITLE
Fix missing translations on meta pages

### DIFF
--- a/classes/lang/KeysReference/MetaLang.php
+++ b/classes/lang/KeysReference/MetaLang.php
@@ -26,7 +26,7 @@
 trans('404 error', 'Shop.Navigation');
 trans('Best sales', 'Shop.Navigation');
 trans('Contact us', 'Shop.Navigation');
-trans('Manufacturers', 'Shop.Navigation');
+trans('Brands', 'Shop.Navigation');
 trans('New products', 'Shop.Navigation');
 trans('Forgot your password', 'Shop.Navigation');
 trans('Prices drop', 'Shop.Navigation');
@@ -56,13 +56,13 @@ trans('Use our form to contact us', 'Shop.Navigation');
 
 trans('Shop powered by PrestaShop', 'Shop.Navigation');
 
-trans('Brand list', 'Shop.Navigation');
+trans('Brands list', 'Shop.Navigation');
 
 trans('Our new products', 'Shop.Navigation');
 
 trans('Enter the e-mail address you use to sign in to receive an e-mail with a new password', 'Shop.Navigation');
 
-trans('On-sale products', 'Shop.Navigation');
+trans('Our special products', 'Shop.Navigation');
 
 trans('Lost ? Find what your are looking for', 'Shop.Navigation');
 
@@ -70,7 +70,7 @@ trans('Suppliers list', 'Shop.Navigation');
 trans('page-not-found', 'Shop.Navigation');
 trans('best-sales', 'Shop.Navigation');
 trans('contact-us', 'Shop.Navigation');
-trans('manufacturers', 'Shop.Navigation');
+trans('brands', 'Shop.Navigation');
 trans('new-products', 'Shop.Navigation');
 trans('password-recovery', 'Shop.Navigation');
 trans('prices-drop', 'Shop.Navigation');

--- a/classes/lang/KeysReference/MetaLang.php
+++ b/classes/lang/KeysReference/MetaLang.php
@@ -75,7 +75,7 @@ trans('new-products', 'Shop.Navigation');
 trans('password-recovery', 'Shop.Navigation');
 trans('prices-drop', 'Shop.Navigation');
 trans('sitemap', 'Shop.Navigation');
-trans('supplier', 'Shop.Navigation');
+trans('suppliers', 'Shop.Navigation');
 trans('address', 'Shop.Navigation');
 trans('addresses', 'Shop.Navigation');
 trans('login', 'Shop.Navigation');

--- a/install-dev/langs/en/data/meta.xml
+++ b/install-dev/langs/en/data/meta.xml
@@ -58,7 +58,7 @@
     <title>Suppliers</title>
     <description>Suppliers list</description>
     <keywords/>
-    <url_rewrite>supplier</url_rewrite>
+    <url_rewrite>suppliers</url_rewrite>
   </meta>
   <meta id="address" id_shop="1">
     <title>Address</title>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR fixes missing translations on `manufacturers` and `prices-drop` pages.<br><br>Translation strings must match those used here: https://github.com/PrestaShop/PrestaShop/blob/develop/install-dev/langs/en/data/meta.xml.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28944.
| Related PRs       | -
| How to test?      | See issue description.
| Possible impacts? | -
| Sponsor company | @Creabilis


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
