### PR TITLE
Change PrestaShop URL in footer of emails

### DIFF
--- a/mails/themes/classic/components/footer.html.twig
+++ b/mails/themes/classic/components/footer.html.twig
@@ -3,6 +3,6 @@
 </tr>
 <tr>
   <td class="footer" style="border-top: 4px solid #333333">
-    <span>{{ '<a href="{shop_url}">{shop_name}</a> powered by <a href="{prestashop_url}">PrestaShop™</a>'|trans({'{prestashop_url}': 'https://www.prestashop.com/?utm_source=marchandprestashop&utm_medium=e-mail&utm_campaign=footer_1-7'}, 'Emails.Body', locale)|raw }}</span>
+    <span>{{ '<a href="{shop_url}">{shop_name}</a> powered by <a href="{prestashop_url}">PrestaShop™</a>'|trans({'{prestashop_url}': 'https://www.prestashop-project.org/'}, 'Emails.Body', locale)|raw }}</span>
   </td>
 </tr>

--- a/mails/themes/modern/components/footer.html.twig
+++ b/mails/themes/modern/components/footer.html.twig
@@ -17,7 +17,7 @@
                               </tr>
                               <tr>
                                 <td align="center" style="font-size:0px;padding:10px 25px;padding-top:0;word-break:break-word;">
-                                  <div style="font-family:Open sans, arial, sans-serif;font-size:12px;line-height:25px;text-align:center;color:#656565;">Powered by <a href="https://www.prestashop.com/?utm_source=marchandprestashop&utm_medium=e-mail&utm_campaign=footer_1-7" style="color:#656565;font-weight:400;">PrestaShop</a></div>
+                                  <div style="font-family:Open sans, arial, sans-serif;font-size:12px;line-height:25px;text-align:center;color:#656565;">Powered by <a href="https://www.prestashop-project.org/" style="color:#656565;font-weight:400;">PrestaShop</a></div>
                                 </td>
                               </tr>
                             </tbody>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | According to Company/OS Project clarification, links in footer of emails should point to https://www.prestashop-project.org/ instead of https://www.prestashop.com/.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22311.
| Related PRs       | -
| How to test?      | -
| Possible impacts? | -
| Sponsor company | @Creabilis


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
