### PR TITLE
Do not allow 0 as number of products per page

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationFormDataProvider.php
@@ -86,9 +86,9 @@ class PaginationFormDataProvider implements FormDataProviderInterface
     {
         $errors = [];
         $productsPerPage = $data['products_per_page'];
-        if (!is_numeric($productsPerPage) || 0 > $productsPerPage) {
+        if (!is_numeric($productsPerPage) || 0 >= $productsPerPage) {
             $errors[] = [
-                'key' => 'The %s field is invalid.',
+                'key' => 'The %s field is invalid. Please enter a positive integer.',
                 'domain' => 'Admin.Notifications.Error',
                 'parameters' => [$this->translator->trans('Products per page', [], 'Admin.Shopparameters.Feature')],
             ];

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/PaginationType.php
@@ -49,6 +49,7 @@ class PaginationType extends TranslatorAwareType
                     'Products per page',
                     'Admin.Shopparameters.Feature'
                 ),
+                'help' => $this->trans('Number of products displayed per page. Default is 12', 'Admin.Shopparameters.Help'),
                 'required' => false,
             ])
             ->add('default_order_by', ChoiceType::class, [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | A wrong check was made to validate the data of the form responsible of the number of product per page. This PR fixes it by checking that the number is strictly positive.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28367
| Related PRs       | 
| How to test?      | Please see #28367
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
