### PR TITLE
Use LegacyModule instance instead of ModuleAdaptater

### DIFF
--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -206,10 +206,10 @@ class TranslationRouteFinder
     {
         $module = $this->moduleRepository->getModule($moduleName);
 
-        if (!($module instanceof Module)) {
+        if (!($module->getInstance() instanceof Module)) {
             throw new InvalidModuleException($moduleName);
         }
 
-        return $module->isUsingNewTranslationSystem();
+        return $module->getInstance()->isUsingNewTranslationSystem();
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | The `$module` is a `PrestaShop\PrestaShop\Adapter\Module\Module` instance. Need to use the Legacy instance, there.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28961


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
