### PR TITLE
clear cache on address controller

### DIFF
--- a/controllers/front/AddressController.php
+++ b/controllers/front/AddressController.php
@@ -58,6 +58,7 @@ class AddressControllerCore extends FrontController
      */
     public function postProcess()
     {
+    	Tools::clearAllCache();
         $this->context->smarty->assign('editing', false);
         $id_address = (int) Tools::getValue('id_address');
         // Initialize address if an id exists
@@ -78,7 +79,6 @@ class AddressControllerCore extends FrontController
                 } else {
                     $this->success[] = $this->trans('Address successfully added!', [], 'Shop.Notifications.Success');
                 }
-
                 $this->should_redirect = true;
             }
         }
@@ -107,6 +107,7 @@ class AddressControllerCore extends FrontController
                 new Address($id_address, $this->context->language->id),
                 Tools::getValue('token')
             );
+
             if ($ok) {
                 $this->success[] = $this->trans('Address successfully deleted!', [], 'Shop.Notifications.Success');
                 $this->should_redirect = true;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fixes wording problem switching from singular to plural on addresses by clearing cache on addresses updating.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28983 
| Related PRs       | n/a
| How to test?      | Like on the issue testing protocol
| Possible impacts? | Clears the cache on addresses manipulations, so it can slow a bit the reloading of the page at that time

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
