### PR TITLE
Allow only positive number on password regeneration field

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -31,6 +31,8 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * Class EmployeeOptionsType defines form for employee options.
@@ -67,6 +69,20 @@ class EmployeeOptionsType extends TranslatorAwareType
                 'required' => false,
                 'unit' => $this->trans('minutes', 'Admin.Advparameters.Feature'),
                 'disabled' => !$this->canOptionsBeChanged,
+                'constraints' => [
+                    new GreaterThanOrEqual(
+                        [
+                            'value' => 0,
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                    new Type(
+                        [
+                            'value' => 'numeric',
+                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
+                        ]
+                    ),
+                ],
             ])
             ->add('allow_employee_specific_language', SwitchType::class, [
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -31,8 +31,6 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
-use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * Class EmployeeOptionsType defines form for employee options.
@@ -69,20 +67,6 @@ class EmployeeOptionsType extends TranslatorAwareType
                 'required' => false,
                 'unit' => $this->trans('minutes', 'Admin.Advparameters.Feature'),
                 'disabled' => !$this->canOptionsBeChanged,
-                'constraints' => [
-                    new GreaterThanOrEqual(
-                        [
-                            'value' => 0,
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
-                        ]
-                    ),
-                    new Type(
-                        [
-                            'value' => 'numeric',
-                            'message' => $this->trans('The field is invalid. Please enter a positive integer.', 'Admin.Notifications.Error'),
-                        ]
-                    ),
-                ],
             ])
             ->add('allow_employee_specific_language', SwitchType::class, [
                 'required' => false,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -238,6 +238,7 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee\EmployeeOptionsFormDataProvider'
     arguments:
       - '@prestashop.core.team.employee.configuration.employee_options_configuration'
+      - '@translator'
 
   prestashop.admin.currency.form_data_provider:
     class: 'PrestaShopBundle\Form\Admin\Improve\International\Currencies\CurrencyFormDataProvider'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add constraints to "Password regeneration" field to allow only positive number.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29011.
| Related PRs       | -
| How to test?      | Try to add negative number and see error message.
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
