### PR TITLE
Deprecate URL generation on category with id 0 and remove preview in category creation

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -448,6 +448,10 @@ class LinkCore
             throw new \InvalidArgumentException('Invalid category parameter');
         }
 
+        if ((int) $params['id'] === 0) {
+            Tools::displayAsDeprecated('Generating URL with id 0 is deprecated');
+        }
+
         $rule = 'category_rule';
 
         if (!$alias) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -193,8 +193,7 @@ class CategoryController extends FrameworkBundleAdminController
                 'allowMenuThumbnailsUpload' => true,
                 'categoryForm' => $categoryForm->createView(),
                 'defaultGroups' => $defaultGroups,
-                'categoryUrl' => $this->get('prestashop.adapter.shop.url.category_provider')
-                    ->getUrl(0, '{friendly-url}'),
+                'categoryUrl' => null,
             ]
         );
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Categories/Blocks/form.html.twig
@@ -136,17 +136,20 @@
 
       {{ renderhook('displayBackOfficeCategory') }}
 
-      {% block category_tool_serp %}
-        <div class="form-group row">
-          <label class="form-control-label">{{ 'SEO preview'|trans({}, 'Admin.Global') }}</label>
-          <div class="col-sm">
-            <div id="serp-app" data-category-url="{{ categoryUrl }}"></div>
-            <small class="form-text">
-              {{ 'Here is a preview of how your page will appear in search engine results.'|trans({}, 'Admin.Global') }}
-            </small>
+      {# Do not display category preview while creating a category #}
+      {% if categoryUrl is not null %}
+        {% block category_tool_serp %}
+          <div class="form-group row">
+            <label class="form-control-label">{{ 'SEO preview'|trans({}, 'Admin.Global') }}</label>
+            <div class="col-sm">
+              <div id="serp-app" data-category-url="{{ categoryUrl }}"></div>
+              <small class="form-text">
+                {{ 'Here is a preview of how your page will appear in search engine results.'|trans({}, 'Admin.Global') }}
+              </small>
+            </div>
           </div>
-        </div>
-      {% endblock %}
+        {% endblock %}
+      {% endif %}
 
       <div class="form-group row">
         {{ ps.label_with_help(('Meta title'|trans({}, 'Admin.Global')), ('Invalid characters:'|trans({}, 'Admin.Notifications.Info') ~ ' <>;=#{}')) }}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This fixes 25871 by removing url preview while creating a category. 
| Type?             | bug fix 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Fixes #25871 
| How to test?      | Explained in #25871


