### PR TITLE
Fix docker files to use UID and the right PHP and Nodejs version 

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,20 +1,26 @@
-FROM prestashop/prestashop-git:latest
+FROM prestashop/prestashop-git:7.4
 
 # To run files with the same group as your primary user
-RUN groupmod -g 1000 www-data \
-  && usermod -u 1000 -g 1000 www-data
+ARG GROUP_ID
+ARG USER_ID
 
-COPY /wait-for-it.sh /tmp/
-COPY /docker_run_git.sh /tmp/
+RUN groupmod -g $GROUP_ID www-data \
+  && usermod -u $USER_ID -g $GROUP_ID www-data
+
+COPY .docker/wait-for-it.sh /tmp/
+COPY .docker/docker_run_git.sh /tmp/
 
 RUN mkdir -p /var/www/.npm
 RUN chown -R www-data:www-data /var/www/.npm
+RUN mkdir -p /var/www/.composer
+RUN chown -R www-data:www-data /var/www/.composer
 
-# These two directories are docker mounted volumes
-RUN chown -R www-data:www-data /var/www/html/vendor
-RUN chown -R www-data:www-data /var/www/html/var
-
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt install -y nodejs
+
+# Install mailutils to make sendmail work
+RUN apt install -y \
+    apt-utils \
+    mailutils
 
 CMD ["/tmp/docker_run_git.sh"]

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -30,6 +30,11 @@ fi
 # From now, stop at error
 set -e
 
+if [ $PS_DEV_MODE -ne 1 ]; then
+  echo "\n* Disabling DEV mode ...";
+  sed -ie "s/define('_PS_MODE_DEV_', true);/define('_PS_MODE_DEV_',\ false);/g" /var/www/html/config/defines.inc.php
+fi
+
 if [ ! -f ./config/settings.inc.php ]; then
     if [ $PS_INSTALL_AUTO = 1 ]; then
 
@@ -57,8 +62,8 @@ if [ ! -f ./config/settings.inc.php ]; then
         echo "\n* Launching the installer script..."
         runuser -g www-data -u www-data -- php /var/www/html/$PS_FOLDER_INSTALL/index_cli.php \
         --domain="$PS_DOMAIN" --db_server=$DB_SERVER:$DB_PORT --db_name="$DB_NAME" --db_user=$DB_USER \
-        --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="John" --lastname="Doe" \
-        --password=$ADMIN_PASSWD --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
+        --db_password=$DB_PASSWD --prefix="$DB_PREFIX" --firstname="Marc" --lastname="Beier" \
+        --password="$ADMIN_PASSWD" --email="$ADMIN_MAIL" --language=$PS_LANGUAGE --country=$PS_COUNTRY \
         --all_languages=$PS_ALL_LANGUAGES --newsletter=0 --send_email=0 --ssl=$PS_ENABLE_SSL
 
         if [ $? -ne 0 ]; then
@@ -66,7 +71,7 @@ if [ ! -f ./config/settings.inc.php ]; then
         fi
     fi
 else
-    echo "\n* Pretashop Core already installed...";
+    echo "\n* PrestaShop Core already installed...";
 fi
 
 if [ $PS_DEMO_MODE -ne 0 ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,20 +17,28 @@ services:
       MYSQL_DATABASE: prestashop
     restart: always
   prestashop-git:
-    build: .docker
+    build:
+      dockerfile: .docker/Dockerfile
+      context: .
+      args:
+        - USER_ID=${USER_ID:-1000}
+        - GROUP_ID=${GROUP_ID:-1000}
     environment:
       DISABLE_MAKE: ${DISABLE_MAKE:-0}
       PS_INSTALL_AUTO: ${PS_INSTALL_AUTO:-1}
       DB_PASSWD: ${DB_PASSWD:-prestashop}
       DB_NAME: ${DB_NAME:-prestashop}
       DB_SERVER: ${DB_SERVER:-mysql}
+      DB_PREFIX: ${DB_PREFIX:-ps_}
       PS_DOMAIN: ${PS_DOMAIN:-localhost:8001}
       PS_FOLDER_INSTALL: ${PS_FOLDER_INSTALL:-install-dev}
       PS_FOLDER_ADMIN: ${PS_FOLDER_ADMIN:-admin-dev}
+      PS_COUNTRY: ${PS_COUNTRY:-fr}
+      PS_LANGUAGE: ${PS_LANGUAGE:-fr}
+      PS_DEV_MODE: ${PS_DEV_MODE:-0}
+      ADMIN_PASSWD: ${ADMIN_PASSWD:-Correct Horse Battery Staple}
     command: ["/tmp/wait-for-it.sh", "--timeout=60", "--strict", "mysql:3306", "--", "/tmp/docker_run_git.sh"]
     ports:
       - "8001:80"
     volumes:
-      - ./:/var/www/html/:delegated
-      - vendor:/var/www/html/vendor
-      - var:/var/www/html/var
+      - ./:/var/www/html:delegated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       PS_COUNTRY: ${PS_COUNTRY:-fr}
       PS_LANGUAGE: ${PS_LANGUAGE:-fr}
       PS_DEV_MODE: ${PS_DEV_MODE:-0}
-      ADMIN_PASSWD: ${ADMIN_PASSWD:-Correct Horse Battery Staple}
+      ADMIN_PASSWD: ${ADMIN_PASSWD:-prestashop_demo}
     command: ["/tmp/wait-for-it.sh", "--timeout=60", "--strict", "mysql:3306", "--", "/tmp/docker_run_git.sh"]
     ports:
       - "8001:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       PS_FOLDER_ADMIN: ${PS_FOLDER_ADMIN:-admin-dev}
       PS_COUNTRY: ${PS_COUNTRY:-fr}
       PS_LANGUAGE: ${PS_LANGUAGE:-fr}
-      PS_DEV_MODE: ${PS_DEV_MODE:-0}
+      PS_DEV_MODE: ${PS_DEV_MODE:-1}
       ADMIN_PASSWD: ${ADMIN_PASSWD:-prestashop_demo}
     command: ["/tmp/wait-for-it.sh", "--timeout=60", "--strict", "mysql:3306", "--", "/tmp/docker_run_git.sh"]
     ports:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fix docker files to use UID and the right PHP and Nodejs version (
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | fix #29037 
| Related PRs       | 
| How to test?      | Run `USER_ID=$UID GROUP_ID=$GID docker-compose up --build --force-recreate` and you should have your shop running on `http://localhost:8001/`
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
