### PR TITLE
Product list preview in product list V2

### DIFF
--- a/admin-dev/themes/new-theme/js/components/grid/extension/column/common/async-toggle-column-extension.ts
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/column/common/async-toggle-column-extension.ts
@@ -47,6 +47,9 @@ export default class AsyncToggleColumnExtension {
           event.preventDefault();
         }
 
+        const $newStateInput = $button.find('input:checked');
+        const newState = Boolean($newStateInput.val());
+
         $.post({
           url: $button.data('toggle-url'),
         })
@@ -59,14 +62,32 @@ export default class AsyncToggleColumnExtension {
               return;
             }
 
-            window.showErrorMessage(response.message);
+            this.showErrorMessage(response.message, $newStateInput.prop('name'), !newState);
           })
           .catch((error: AjaxError) => {
             const response = error.responseJSON;
-
-            window.showErrorMessage(response.message);
+            this.showErrorMessage(response.message, $newStateInput.prop('name'), !newState);
           });
       });
+  }
+
+  private showErrorMessage(message: string, switchName: string, initialState: boolean): void {
+    // We need to toggle back the switch state
+    this.toggleSwitch(switchName, initialState);
+
+    window.showErrorMessage(message);
+  }
+
+  private toggleSwitch(switchName: string, checked: boolean): void {
+    const $switchOn = $(`[name="${switchName}"][value="1"]`);
+    const $switchOff = $(`[name="${switchName}"][value="0"]`);
+
+    if ($switchOn.is(':checked') !== checked) {
+      $switchOn.prop('checked', checked);
+    }
+    if ($switchOff.is(':checked') === checked) {
+      $switchOff.prop('checked', !checked);
+    }
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/components/navbar-handler.ts
+++ b/admin-dev/themes/new-theme/js/components/navbar-handler.ts
@@ -49,7 +49,13 @@ export default class NavbarHandler {
     this.switchOnPageLoad();
   }
 
-  private switchToTarget(target: string): void {
+  public getHashTarget(): string {
+    const {hash} = document.location;
+
+    return hash.replace(`#${this.tabPrefix}`, '#');
+  }
+
+  public switchToTarget(target: string): void {
     if (!target) {
       return;
     }

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-filter.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-filter.ts
@@ -89,10 +89,16 @@ export default class CategoryTreeFilter {
   }
 
   private resetFilter(): void {
+    // Reset selected category
     this.$categoryTree
       .find(CategoryFilterMap.categoryRadio)
       .prop('checked', false);
     this.$categoryInput.val('');
+
+    // Also reset position filter because it is only useful when a category is selected
+    const $positionInput: JQuery = this.$filterForm.find(CategoryFilterMap.positionInput);
+    $positionInput.val('');
+
     this.$filterForm.submit();
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-filter.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-filter.ts
@@ -35,12 +35,9 @@ export default class CategoryTreeFilter {
 
   private $filterForm: JQuery;
 
-  private $categoryInput: JQuery;
-
   constructor() {
     this.$categoryTree = $(CategoryFilterMap.container);
-    this.$filterForm = $(CategoryFilterMap.filterForm);
-    this.$categoryInput = this.$filterForm.find(CategoryFilterMap.categoryInput);
+    this.$filterForm = this.$categoryTree.parent('form');
 
     this.init();
   }
@@ -51,7 +48,7 @@ export default class CategoryTreeFilter {
       // of the two actions, either expand/collapse or filter the selected category So We check which target has been
       // clicked exactly
       if (event.target instanceof HTMLInputElement) {
-        this.filterCategory(event.target.value);
+        this.$filterForm.submit();
       } else if (event.target.classList.contains(CategoryFilterMap.categoryLabelClass)) {
         this.toggleCategory($(event.currentTarget).parent(CategoryFilterMap.categoryNode));
       }
@@ -63,7 +60,7 @@ export default class CategoryTreeFilter {
     this.$categoryTree.on('click', CategoryFilterMap.collapseAll, () => {
       this.collapseAll();
     });
-    this.$categoryTree.on('click', CategoryFilterMap.resetFilter, () => {
+    $(CategoryFilterMap.resetFilter).on('click', () => {
       this.resetFilter();
     });
 
@@ -83,21 +80,11 @@ export default class CategoryTreeFilter {
     $categoryNode.toggleClass(CategoryFilterMap.collapsedClass, isExpanded);
   }
 
-  private filterCategory(categoryId: string): void {
-    this.$categoryInput.val(categoryId);
-    this.$filterForm.submit();
-  }
-
   private resetFilter(): void {
     // Reset selected category
     this.$categoryTree
       .find(CategoryFilterMap.categoryRadio)
       .prop('checked', false);
-    this.$categoryInput.val('');
-
-    // Also reset position filter because it is only useful when a category is selected
-    const $positionInput: JQuery = this.$filterForm.find(CategoryFilterMap.positionInput);
-    $positionInput.val('');
 
     this.$filterForm.submit();
   }

--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
@@ -67,10 +67,6 @@ $(() => {
   const $productForm = $(ProductMap.productForm);
   const productId = parseInt($productForm.data('productId'), 10);
   const productType = $productForm.data('productType');
-
-  // Responsive navigation tabs
-  initTabs();
-
   const {eventEmitter} = window.prestashop.instance;
 
   // Init product model along with input watching and syncing
@@ -82,7 +78,15 @@ $(() => {
     new CombinationsList(productId, productFormModel);
   }
 
-  new NavbarHandler($(ProductMap.navigationBar));
+  // Responsive navigation tabs
+  initTabs();
+  const navbar = new NavbarHandler($(ProductMap.navigationBar));
+
+  // When combination page is opened on quantity tab we automatically switch to the combination one which replaces it for product with combinations
+  if (productType === ProductConst.PRODUCT_TYPE.COMBINATIONS && navbar.getHashTarget() === ProductMap.stock.navigationTarget) {
+    navbar.switchToTarget(ProductMap.combinations.navigationTarget);
+  }
+
   new ProductSEOManager(eventEmitter);
   new ProductOptionsManager(productType, productFormModel);
   new ProductShippingManager();

--- a/admin-dev/themes/new-theme/js/pages/product/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/index.ts
@@ -25,6 +25,7 @@
 
 import CreateProductModal from '@pages/product/components/create-product-modal';
 import CategoryTreeFilter from '@pages/product/components/categories/category-tree-filter';
+import LinkRowActionExtension from '@components/grid/extension/link-row-action-extension';
 
 const {$} = window;
 
@@ -41,6 +42,7 @@ $(() => {
   grid.addExtension(new window.prestashop.component.GridExtensions.BulkActionCheckboxExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
+  grid.addExtension(new LinkRowActionExtension());
 
   new CreateProductModal();
   grid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(grid));

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -281,6 +281,7 @@ export default {
       categoryRadio: '.category-label input:radio',
       filterForm: '#product_filter_form',
       categoryInput: 'input[name="product[id_category]"]',
+      positionInput: 'input[name="product[position]"]',
       expandedClass: 'less',
       collapsedClass: 'more',
       categoryChildren: '.category-children',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -280,7 +280,6 @@ export default {
       container: '.product_list_category_filter',
       categoryRadio: '.category-label input:radio',
       filterForm: '#product_filter_form',
-      categoryInput: 'input[name="product[id_category]"]',
       positionInput: 'input[name="product[position]"]',
       expandedClass: 'less',
       collapsedClass: 'more',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -77,8 +77,12 @@ export default {
     removeCustomizationBtn: '.remove-customization-btn',
     customizationFieldRow: '.customization-field-row',
   },
+  stock: {
+    navigationTarget: '#product_stock-tab',
+  },
   combinations: {
     navigationTab: '#product_combinations-tab-nav',
+    navigationTarget: '#product_combinations-tab',
     combinationManager: '#product_combinations_combination_manager',
     preloader: '#combinations-preloader',
     emptyState: '#combinations-empty-state',

--- a/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
+++ b/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
@@ -163,6 +163,10 @@ final class ProductGridDataFactoryDecorator implements GridDataFactoryInterface
             } else {
                 $products[$i]['image'] = $this->productImagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT, $this->getLanguageIsoCode());
             }
+            // If no legend is defined use the name as a fallback (used for alt property on image)
+            if (empty($product['legend'])) {
+                $products[$i]['legend'] = $products[$i]['name'];
+            }
 
             $productTaxRulesGroupId = new TaxRulesGroupId((int) ($products[$i]['id_tax_rules_group'] ?? 0));
             $priceTaxExcluded = new DecimalNumber((string) ($products[$i]['price_tax_excluded'] ?? 0));

--- a/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
+++ b/src/Adapter/Product/Grid/Data/Factory/ProductGridDataFactoryDecorator.php
@@ -158,9 +158,10 @@ final class ProductGridDataFactoryDecorator implements GridDataFactoryInterface
                 $products[$i]['name'] = $this->translator->trans('N/A', [], 'Admin.Global');
             }
 
-            $products[$i]['image'] = '';
             if ($product['id_image']) {
                 $products[$i]['image'] = $this->productImagePathFactory->getPathByType(new ImageId((int) $product['id_image']), ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT);
+            } else {
+                $products[$i]['image'] = $this->productImagePathFactory->getNoImagePath(ProductImagePathFactory::IMAGE_TYPE_SMALL_DEFAULT, $this->getLanguageIsoCode());
             }
 
             $productTaxRulesGroupId = new TaxRulesGroupId((int) ($products[$i]['id_tax_rules_group'] ?? 0));
@@ -203,5 +204,15 @@ final class ProductGridDataFactoryDecorator implements GridDataFactoryInterface
         }
 
         return $products;
+    }
+
+    /**
+     * Returns language iso code based on locale, en-US => en
+     *
+     * @return string
+     */
+    private function getLanguageIsoCode(): string
+    {
+        return explode('-', $this->locale->getCode())[0];
     }
 }

--- a/src/Core/Grid/Action/Row/Type/LinkRowAction.php
+++ b/src/Core/Grid/Action/Row/Type/LinkRowAction.php
@@ -60,6 +60,7 @@ final class LinkRowAction extends AbstractRowAction
                 //route_param_name and route_param_field becomes redundant, but it cannot be removed due to BC break
                 'extra_route_params' => [],
                 'clickable_row' => false,
+                'target' => '',
             ])
             ->setAllowedTypes('route', 'string')
             ->setAllowedTypes('route_param_name', 'string')
@@ -68,6 +69,7 @@ final class LinkRowAction extends AbstractRowAction
             ->setAllowedTypes('confirm_message', 'string')
             ->setAllowedTypes('accessibility_checker', [AccessibilityCheckerInterface::class, 'callable', 'null'])
             ->setAllowedTypes('clickable_row', 'boolean')
+            ->setAllowedTypes('target', 'string')
         ;
     }
 

--- a/src/Core/Grid/Column/Type/Common/ImageColumn.php
+++ b/src/Core/Grid/Column/Type/Common/ImageColumn.php
@@ -53,8 +53,11 @@ final class ImageColumn extends AbstractColumn
             ])
             ->setDefaults([
                 'clickable' => true,
+                'alt_field' => '',
             ])
             ->setAllowedTypes('src_field', 'string')
-            ->setAllowedTypes('clickable', 'bool');
+            ->setAllowedTypes('clickable', 'bool')
+            ->setAllowedTypes('alt_field', 'string')
+        ;
     }
 }

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -364,6 +364,17 @@ final class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                     (new Filter('quantity', IntegerMinMaxFilterType::class))
                         ->setTypeOptions([
                             'required' => false,
+                            // Ignore default zero value to use negative values
+                            'min_field_options' => [
+                                'attr' => [
+                                    'min' => false,
+                                ],
+                            ],
+                            'max_field_options' => [
+                                'attr' => [
+                                    'min' => false,
+                                ],
+                            ],
                         ])
                         ->setAssociatedColumn('quantity')
                 )

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -239,6 +239,16 @@ final class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                 'route_param_field' => 'id_product',
             ])
             )
+            ->add((new LinkRowAction('preview'))
+            ->setName($this->trans('Preview', [], 'Admin.Actions'))
+            ->setIcon('remove_red_eye')
+            ->setOptions([
+                'route' => 'admin_products_v2_preview',
+                'route_param_name' => 'productId',
+                'route_param_field' => 'id_product',
+                'target' => '_blank',
+            ])
+            )
             ->add((new SubmitRowAction('duplicate'))
             ->setName($this->trans('Duplicate', [], 'Admin.Actions'))
             ->setIcon('content_copy')

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -310,13 +310,6 @@ final class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setAssociatedColumn('reference')
             )
             ->add(
-                (new HiddenFilter('id_category'))
-                    ->setTypeOptions([
-                        'required' => false,
-                    ])
-                    ->setAssociatedColumn('id_category')
-            )
-            ->add(
                 (new Filter('category', TextType::class))
                     ->setTypeOptions([
                         'required' => false,
@@ -349,10 +342,7 @@ final class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
             ->add(
                 (new Filter('actions', SearchAndResetType::class))
                     ->setTypeOptions([
-                        'reset_route' => 'admin_common_reset_search_by_filter_id',
-                        'reset_route_params' => [
-                            'filterId' => self::GRID_ID,
-                        ],
+                        'reset_route' => 'admin_products_reset_grid_search',
                         'redirect_route' => 'admin_products_v2_index',
                     ])
                     ->setAssociatedColumn('actions')

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -122,7 +122,7 @@ final class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setName($this->trans('Image', [], 'Admin.Global'))
                     ->setOptions([
                         'src_field' => 'image',
-                        'alt_field' => 'name',
+                        'alt_field' => 'legend',
                     ])
             )
             ->add(

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -48,7 +48,6 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ToggleColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Filter\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
-use PrestaShop\PrestaShop\Core\Grid\Filter\HiddenFilter;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Form\Admin\Type\IntegerMinMaxFilterType;
 use PrestaShopBundle\Form\Admin\Type\NumberMinMaxFilterType;
@@ -123,6 +122,7 @@ final class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ->setName($this->trans('Image', [], 'Admin.Global'))
                     ->setOptions([
                         'src_field' => 'image',
+                        'alt_field' => 'name',
                     ])
             )
             ->add(

--- a/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/ProductGridDefinitionFactory.php
@@ -136,10 +136,14 @@ final class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                     ])
             )
             ->add(
-                (new DataColumn('reference'))
-                    ->setName($this->trans('Reference', [], 'Admin.Global'))
+                (new LinkColumn('reference'))
+                    ->setName($this->trans('Reference', [], 'Admin.Catalog.Feature'))
                     ->setOptions([
                         'field' => 'reference',
+                        'route' => 'admin_products_v2_edit',
+                        'route_param_name' => 'productId',
+                        'route_param_field' => 'id_product',
+                        'route_fragment' => 'tab-product_specifications-tab',
                     ])
             )
             ->add(
@@ -237,6 +241,7 @@ final class ProductGridDefinitionFactory extends AbstractGridDefinitionFactory
                 'route' => 'admin_products_v2_edit',
                 'route_param_name' => 'productId',
                 'route_param_field' => 'id_product',
+                'clickable_row' => true,
             ])
             )
             ->add((new LinkRowAction('preview'))

--- a/src/Core/Grid/Filter/GridFilterFormFactory.php
+++ b/src/Core/Grid/Filter/GridFilterFormFactory.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Grid\Filter;
 
 use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Exception\ColumnNotFoundException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use Symfony\Component\DependencyInjection\Container;
@@ -71,15 +72,22 @@ final class GridFilterFormFactory implements GridFilterFormFactoryInterface
     {
         $formBuilder = $this->formFactory->createNamedBuilder(
             $definition->getId(),
-            FormType::class
+            FormType::class,
+            null,
+            [
+                'allow_extra_fields' => true,
+            ]
         );
 
         /** @var FilterInterface $filter */
         foreach ($definition->getFilters()->all() as $filter) {
+            $filterOptions = array_merge([
+                'label' => $this->getFilterLabel($definition, $filter),
+            ], $filter->getTypeOptions());
             $formBuilder->add(
                 $filter->getName(),
                 $filter->getType(),
-                $filter->getTypeOptions()
+                $filterOptions
             );
         }
 
@@ -88,5 +96,19 @@ final class GridFilterFormFactory implements GridFilterFormFactoryInterface
         ]);
 
         return $formBuilder->getForm();
+    }
+
+    private function getFilterLabel(GridDefinitionInterface $definition, FilterInterface $filter): string
+    {
+        $filterLabel = $filter->getName();
+        try {
+            if ($filter->getAssociatedColumn()) {
+                $column = $definition->getColumnById($filter->getAssociatedColumn());
+                $filterLabel = $column->getName();
+            }
+        } catch (ColumnNotFoundException $e) {
+        }
+
+        return $filterLabel;
     }
 }

--- a/src/Core/Grid/Query/ProductQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductQueryBuilder.php
@@ -124,8 +124,15 @@ final class ProductQueryBuilder extends AbstractDoctrineQueryBuilder
 
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
-            ->applySorting($searchCriteria, $qb)
         ;
+
+        // Any sorting that is not based on position can be applied
+        if ($searchCriteria->getOrderBy() !== 'position') {
+            $this->searchCriteriaApplicator->applySorting($searchCriteria, $qb);
+        } elseif (array_key_exists('id_category', $searchCriteria->getFilters())) {
+            // Sort by position only works when we filter by category, so we need to be cautious and apply it only when the filter is present
+            $this->searchCriteriaApplicator->applySorting($searchCriteria, $qb);
+        }
 
         return $qb;
     }

--- a/src/Core/Grid/Query/ProductQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductQueryBuilder.php
@@ -108,6 +108,7 @@ final class ProductQueryBuilder extends AbstractDoctrineQueryBuilder
             ->addSelect('pl.`name`, pl.`link_rewrite`')
             ->addSelect('cl.`name` AS `category`')
             ->addSelect('img_shop.`id_image`')
+            ->addSelect('img_lang.legend')
             ->addSelect('p.`id_tax_rules_group`')
         ;
 
@@ -183,6 +184,12 @@ final class ProductQueryBuilder extends AbstractDoctrineQueryBuilder
                 $this->dbPrefix . 'image_shop',
                 'img_shop',
                 'img_shop.`id_product` = ps.`id_product` AND img_shop.`cover` = 1 AND img_shop.`id_shop` = :id_shop'
+            )
+            ->leftJoin(
+                'img_shop',
+                $this->dbPrefix . 'image_lang',
+                'img_lang',
+                'img_shop.`id_image` = img_lang.`id_image` AND img_lang.`id_lang` = :id_lang'
             )
             ->andWhere('p.`state`=1')
         ;

--- a/src/Core/Grid/Query/ProductQueryBuilder.php
+++ b/src/Core/Grid/Query/ProductQueryBuilder.php
@@ -276,7 +276,8 @@ final class ProductQueryBuilder extends AbstractDoctrineQueryBuilder
                 $qb->setParameter('category', '%' . $filter . '%');
             }
 
-            if ('position' === $filterName) {
+            // Filter by position is only relevant when a category has been selected
+            if (array_key_exists('id_category', $filterValues) && 'position' === $filterName) {
                 $qb->andWhere('pc.`position` = :position');
                 $qb->setParameter('position', $filter);
             }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -43,6 +43,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotDeleteProductExcep
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductPositionException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\InvalidProductTypeException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\DuplicateFeatureValueAssociationException;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\InvalidAssociatedFeatureException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductIsEnabled;
@@ -51,7 +52,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForAssociation;
 use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Exception\SpecificPriceConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
-use PrestaShop\PrestaShop\Core\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -55,13 +55,17 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Entity\AdminFilter;
 use PrestaShopBundle\Entity\ProductDownload;
 use PrestaShopBundle\Form\Admin\Sell\Product\Category\CategoryFilterType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use PrestaShopBundle\Security\Voter\PageVoter;
+use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -115,7 +119,9 @@ class ProductController extends FrameworkBundleAdminController
         if (isset($filters->getFilters()['id_category'])) {
             $filteredCategoryId = (int) $filters->getFilters()['id_category'];
         }
-        $categoriesForm = $this->createForm(CategoryFilterType::class, $filteredCategoryId);
+        $categoriesForm = $this->createForm(CategoryFilterType::class, $filteredCategoryId, [
+            'action' => $this->generateUrl('admin_products_grid_category_filter'),
+        ]);
 
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Product/index.html.twig', [
             'categoryFilterForm' => $categoriesForm->createView(),
@@ -124,6 +130,102 @@ class ProductController extends FrameworkBundleAdminController
             'layoutHeaderToolbarBtn' => $this->getProductToolbarButtons(),
             'help_link' => $this->generateSidebarLink('AdminProducts'),
         ]);
+    }
+
+    /**
+     * Process Grid search, but we need to add the category filter which is handled independently.
+     *
+     * @param Request $request
+     *
+     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
+     *
+     * @return RedirectResponse
+     */
+    public function searchGridAction(Request $request)
+    {
+        /** @var GridDefinitionFactoryInterface $definitionFactory */
+        $definitionFactory = $this->get('prestashop.core.grid.definition.factory.product');
+
+        $filterId = ProductGridDefinitionFactory::GRID_ID;
+
+        $adminFilter = $this->getGridAdminFilter();
+        if (isset($adminFilter)) {
+            $currentFilters = json_decode($adminFilter->getFilter(), true);
+            if (!empty($currentFilters['filters']['id_category'])) {
+                $request->query->add([
+                    'product[filters][id_category]' => $currentFilters['filters']['id_category'],
+                ]);
+            }
+        }
+
+        /** @var ResponseBuilder $responseBuilder */
+        $responseBuilder = $this->get('prestashop.bundle.grid.response_builder');
+
+        return $responseBuilder->buildSearchResponse(
+            $definitionFactory,
+            $request,
+            $filterId,
+            'admin_products_v2_index',
+            ['product[filters][id_category]']
+        );
+    }
+
+    /**
+     * Reset filters for the grid only (category is kept, it can be cleared via another dedicated action)
+     *
+     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
+     *
+     * @return JsonResponse
+     */
+    public function resetGridSearchAction(): JsonResponse
+    {
+        $adminFilter = $this->getGridAdminFilter();
+        if (isset($adminFilter)) {
+            $adminFiltersRepository = $this->get('prestashop.core.admin.admin_filter.repository');
+            $currentFilters = json_decode($adminFilter->getFilter(), true);
+
+            // This reset action only reset the filters from the Grid, we keep the filter by category if it was present (we still reset to page 1 though)
+            if (!empty($currentFilters['filters']['id_category'])) {
+                $adminFilter->setFilter(json_encode([
+                    'filters' => [
+                        'id_category' => $currentFilters['filters']['id_category'],
+                    ],
+                    'offset' => 0,
+                ]));
+                $adminFiltersRepository->updateFilter($adminFilter);
+            } else {
+                $adminFiltersRepository->unsetFilters($adminFilter);
+            }
+        }
+
+        return new JsonResponse();
+    }
+
+    /**
+     * Apply the category filter and redirect to list on first page.
+     *
+     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
+     *
+     * @return RedirectResponse
+     */
+    public function gridCategoryFilterAction(Request $request): RedirectResponse
+    {
+        $filteredCategoryId = $request->request->get('category_filter');
+        $adminFilter = $this->getGridAdminFilter();
+        if (isset($adminFilter)) {
+            $adminFiltersRepository = $this->get('prestashop.core.admin.admin_filter.repository');
+            $currentFilters = json_decode($adminFilter->getFilter(), true);
+            if (empty($filteredCategoryId)) {
+                unset($currentFilters['filters']['id_category']);
+            } else {
+                $currentFilters['filters']['id_category'] = $filteredCategoryId;
+            }
+            $currentFilters['offset'] = 0;
+            $adminFilter->setFilter(json_encode($currentFilters));
+            $adminFiltersRepository->updateFilter($adminFilter);
+        }
+
+        return $this->redirectToRoute('admin_products_v2_index');
     }
 
     /**
@@ -846,6 +948,19 @@ class ProductController extends FrameworkBundleAdminController
                 ]
             ),
         ]);
+    }
+
+    private function getGridAdminFilter(): ?AdminFilter
+    {
+        if (null === $this->getUser() || null === $this->getContext()->shop || empty($this->getContext()->shop->id)) {
+            return null;
+        }
+
+        $adminFiltersRepository = $this->get('prestashop.core.admin.admin_filter.repository');
+        $employeeId = $this->getUser()->getId();
+        $shopId = $this->getContext()->shop->id;
+
+        return $adminFiltersRepository->findByEmployeeAndFilterId($employeeId, $shopId, ProductGridDefinitionFactory::GRID_ID);
     }
 
     /**

--- a/src/PrestaShopBundle/Entity/Repository/AdminFilterRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/AdminFilterRepository.php
@@ -117,6 +117,17 @@ class AdminFilterRepository extends EntityRepository
     }
 
     /**
+     * Updates and persists modification to a filter (that was previously modified).
+     *
+     * @param AdminFilter $adminFilter
+     */
+    public function updateFilter(AdminFilter $adminFilter): void
+    {
+        $this->getEntityManager()->persist($adminFilter);
+        $this->getEntityManager()->flush();
+    }
+
+    /**
      * Persist (create or update) filters into database using employee and uuid
      *
      * @param int $employeeId

--- a/src/PrestaShopBundle/Form/Admin/Type/IntegerMinMaxFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/IntegerMinMaxFilterType.php
@@ -31,6 +31,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Defines the integer type two inputs of min and max value - designed to fit grid in grid filter.
@@ -47,6 +49,22 @@ final class IntegerMinMaxFilterType extends AbstractType
         $resolver->setDefaults([
             'min_field_options' => [],
             'max_field_options' => [],
+            'constraints' => [
+                new Callback([
+                    'callback' => function (?array $impactData, ExecutionContextInterface $context) {
+                        if (!isset($impactData['min_field']) || !isset($impactData['max_field'])) {
+                            return;
+                        }
+
+                        if ((int) $impactData['min_field'] > (int) $impactData['max_field']) {
+                            $context
+                                ->buildViolation($this->trans('Maximum value must be higher than minimum value.', [], 'Admin.Notifications.Warning'))
+                                ->addViolation()
+                            ;
+                        }
+                    },
+                ]),
+            ],
         ]);
 
         $resolver->setAllowedTypes('min_field_options', 'array');

--- a/src/PrestaShopBundle/Form/Admin/Type/NumberMinMaxFilterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/NumberMinMaxFilterType.php
@@ -31,6 +31,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Defines the number type two inputs of min and max value - designed to fit grid in grid filter.
@@ -47,6 +49,22 @@ final class NumberMinMaxFilterType extends AbstractType
         $resolver->setDefaults([
             'min_field_options' => [],
             'max_field_options' => [],
+            'constraints' => [
+                new Callback([
+                    'callback' => function (?array $impactData, ExecutionContextInterface $context) {
+                        if (!isset($impactData['min_field']) || !isset($impactData['max_field'])) {
+                            return;
+                        }
+
+                        if ($impactData['min_field'] > $impactData['max_field']) {
+                            $context
+                                ->buildViolation($this->trans('Maximum value must be higher than minimum value.', [], 'Admin.Notifications.Warning'))
+                                ->addViolation()
+                            ;
+                        }
+                    },
+                ]),
+            ],
         ]);
 
         $resolver->setAllowedTypes('min_field_options', 'array');

--- a/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/SearchAndResetType.php
@@ -105,6 +105,7 @@ class SearchAndResetType extends AbstractType
                 'reset_route_params' => [],
                 'redirect_route' => null,
                 'redirect_route_params' => [],
+                'allow_extra_fields' => true,
             ])
             ->setAllowedTypes('reset_route', ['string', 'null'])
             ->setAllowedTypes('reset_route_params', 'array')

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/product.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/product.yml
@@ -37,9 +37,21 @@ admin_products_search:
   path: /
   methods: [ POST ]
   defaults:
-    _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
-    gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.product
-    redirectRoute: admin_products_v2_index
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::searchGridAction
+    _legacy_controller: AdminProducts
+
+admin_products_reset_grid_search:
+  path: /reset_grid_search
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::resetGridSearchAction
+    _legacy_controller: AdminProducts
+
+admin_products_grid_category_filter:
+  path: /grid_category_filter
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::gridCategoryFilterAction
     _legacy_controller: AdminProducts
 
 admin_products_v2_create:

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/product.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/product_v2/product.yml
@@ -21,6 +21,18 @@ admin_products_v2_light_list:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::lightListAction
     _legacy_controller: AdminProducts
 
+admin_products_v2_preview:
+  path: /{productId}/preview
+  methods: [ GET ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\Product\ProductController::previewAction
+    _legacy_controller: AdminProducts
+    _legacy_link: AdminProducts:preview
+    _legacy_parameters:
+      id_product: productId
+  requirements:
+    productId: \d+
+
 admin_products_search:
   path: /
   methods: [ POST ]

--- a/src/PrestaShopBundle/Resources/config/services/bundle/grid.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/grid.yml
@@ -10,6 +10,7 @@ services:
       - '@prestashop.core.admin.admin_filter.repository'
       - '@=service("prestashop.adapter.legacy.context").getContext().employee.id'
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
+      - '@session'
 
   prestashop.bundle.grid.controller_response_builder:
     class: PrestaShopBundle\Service\Grid\ControllerResponseBuilder

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/link.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Actions/Row/link.html.twig
@@ -45,6 +45,7 @@
     data-original-title="{{ action.name }}"
   {% endif %}
   data-clickable-row="{{ action.options.clickable_row|default(false) }}"
+  {% if action.options.target is not empty %}target="{{ action.options.target }}"{% endif %}
 >
   {% if action.icon is not empty %}
     <i class="material-icons">{{ action.icon }}</i>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/EmptyState/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Blocks/EmptyState/product.html.twig
@@ -23,15 +23,18 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% extends '@PrestaShop/Admin/Common/Grid/grid.html.twig' %}
+<div class="text-center showcase-list-card">
+  <img class="img-responsive mt-3 img-rtl" src="{{ asset('themes/new-theme/img/empty_state/catalog.png') }}">
 
-{% form_theme categoryFilterForm '@PrestaShop/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig' %}
+  <p class="mt-4 showcase-list-card__header">{{ 'Manage your products'|trans({}, 'Admin.Catalog.Feature') }}</p>
 
-{% block grid_bulk_actions_block %}
-  {% if not grid.attributes.is_empty_state %}
-  {{ form_start(categoryFilterForm, {attr: {class: 'd-inline-block'}}) }}
-    {{ form_row(categoryFilterForm) }}
-  {{ form_end(categoryFilterForm) }}
-  {% endif %}
-  {{ parent() }}
-{% endblock %}
+  <div class="mt-4">
+    <a href="{{ path('admin_products_v2_create') }}" class="btn btn-primary ml-1 new-product-button">
+      {{ 'Create new product'|trans({}, 'Admin.Catalog.Feature') }}
+    </a>
+    {{ 'or'|trans({}, 'Admin.Global') }}
+    <a href="{{ path('admin_import') }}" target="_blank" class="btn btn-outline-secondary mr-1">
+      {{ 'Import a list of products.'|trans({}, 'Admin.Catalog.Feature') }}
+    </a>
+  </div>
+</div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/image.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/image.html.twig
@@ -23,4 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-<img src="{{ record[column.options.src_field] }}">
+<img
+  src="{{ record[column.options.src_field] }}"
+  {% if record[column.options.alt_field] is defined %}alt="{{ record[column.options.alt_field] }}"{% endif %}
+/>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig
@@ -127,6 +127,11 @@
       {{ form_widget(form) }}
     </div>
   </div>
+  {% if form.vars.data is not empty %}
+  <button class="btn btn-link category_tree_filter_reset" type="button">
+    <i class="material-icons">clear</i> Clear filter
+  </button>
+  {% endif %}
 {% endblock %}
 
 {% block category_filter_widget -%}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Grid/grid.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Grid/grid.html.twig
@@ -28,6 +28,8 @@
 {% form_theme categoryFilterForm '@PrestaShop/Admin/Sell/Catalog/Product/FormTheme/categories.html.twig' %}
 
 {% block grid_bulk_actions_block %}
-  {{ form_row(categoryFilterForm) }}
+  {{ form_start(categoryFilterForm, {attr: {class: 'd-inline-block'}}) }}
+    {{ form_row(categoryFilterForm) }}
+  {{ form_end(categoryFilterForm) }}
   {{ parent() }}
 {% endblock %}

--- a/tests/Unit/PrestaShopBundle/Service/Grid/ResponseBuilderTest.php
+++ b/tests/Unit/PrestaShopBundle/Service/Grid/ResponseBuilderTest.php
@@ -34,14 +34,22 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Filter\GridFilterFormFactoryInterface;
 use PrestaShopBundle\Entity\Repository\AdminFilterRepository;
 use PrestaShopBundle\Service\Grid\ResponseBuilder;
+use Symfony\Component\Form\FormConfigInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormErrorIterator;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Router;
 
 class ResponseBuilderTest extends TestCase
 {
+    private const ERROR_MESSAGE = 'An error occurred.';
+    private const ERROR_LABEL = 'Field label';
+
     /**
      * @dataProvider dataProviderBuildSearchResponse
      *
@@ -50,43 +58,7 @@ class ResponseBuilderTest extends TestCase
      */
     public function testBuildSearchResponse(array $data, array $redirectParams): void
     {
-        $mockForm = $this->createMock(FormInterface::class);
-        $mockForm->method('isSubmitted')->willReturn(true);
-        $mockForm->method('getData')->willReturn($data);
-
-        $mockFilterFormFactory = $this->createMock(GridFilterFormFactoryInterface::class);
-        $mockFilterFormFactory->method('create')->willReturn($mockForm);
-
-        $mockDefinitionFactory = $this->createMock(GridDefinitionFactoryInterface::class);
-        $mockDefinitionFactory->method('getDefinition')->willReturn(
-            $this->createMock(GridDefinitionInterface::class)
-        );
-
-        $mockRouter = $this->createMock(Router::class);
-        $mockRouter->method('generate')->willReturnCallback(function (string $name, array $parameters = []) {
-            return $name . '?' . http_build_query($parameters);
-        });
-
-        $mockRequest = $this->createMock(Request::class);
-        $mockRequest->setMethod('POST');
-        $mockRequest->request = $this->createMock(ParameterBag::class);
-
-        $responseBuilder = new ResponseBuilder(
-            $mockFilterFormFactory,
-            $mockRouter,
-            $this->createMock(AdminFilterRepository::class),
-            1,
-            1
-        );
-
-        $response = $responseBuilder->buildSearchResponse(
-            $mockDefinitionFactory,
-            $mockRequest,
-            'filterId',
-            'index',
-            []
-        );
-
+        $response = $this->buildResponse($data, true);
         self::assertInstanceOf(RedirectResponse::class, $response);
 
         $parts = parse_url($response->getTargetUrl());
@@ -94,6 +66,28 @@ class ResponseBuilderTest extends TestCase
         self::assertEquals('index', $parts['path']);
         // Query
         parse_str($parts['query'] ?? '', $query);
+        self::assertEquals($redirectParams, $query);
+    }
+
+    /**
+     * @dataProvider dataProviderBuildSearchResponse
+     *
+     * @param array $data
+     * @param array $redirectParams
+     */
+    public function testInvalidBuildSearchResponse(array $data, array $redirectParams): void
+    {
+        // The error message are tested via the mocks
+        $response = $this->buildResponse($data, false);
+        self::assertInstanceOf(RedirectResponse::class, $response);
+
+        $parts = parse_url($response->getTargetUrl());
+        // Path
+        self::assertEquals('index', $parts['path']);
+        // Query
+        parse_str($parts['query'] ?? '', $query);
+        // The filters are ignored and not passed in redirect params when the form is invalid
+        unset($redirectParams['filterId']);
         self::assertEquals($redirectParams, $query);
     }
 
@@ -173,5 +167,66 @@ class ResponseBuilderTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    private function buildResponse(array $data, bool $isValid): RedirectResponse
+    {
+        $mockForm = $this->createMock(FormInterface::class);
+        $mockForm->method('isSubmitted')->willReturn(true);
+        $mockForm->method('isValid')->willReturn($isValid);
+        $mockForm->method('getData')->willReturn($data);
+
+        if (!$isValid) {
+            $mockFieldConfig = $this->createMock(FormConfigInterface::class);
+            $mockFieldConfig->method('getOption')->with('label')->willReturn(self::ERROR_LABEL);
+            $mockFormField = $this->createMock(FormInterface::class);
+            $mockFormField->method('getConfig')->willReturn($mockFieldConfig);
+
+            $formError = new FormError(self::ERROR_MESSAGE);
+            $formError->setOrigin($mockFormField);
+
+            $mockForm->method('getErrors')->willReturn(new FormErrorIterator($mockForm, [$formError]));
+        }
+
+        $mockFilterFormFactory = $this->createMock(GridFilterFormFactoryInterface::class);
+        $mockFilterFormFactory->method('create')->willReturn($mockForm);
+
+        $mockDefinitionFactory = $this->createMock(GridDefinitionFactoryInterface::class);
+        $mockDefinitionFactory->method('getDefinition')->willReturn(
+            $this->createMock(GridDefinitionInterface::class)
+        );
+
+        $mockRouter = $this->createMock(Router::class);
+        $mockRouter->method('generate')->willReturnCallback(function (string $name, array $parameters = []) {
+            return $name . '?' . http_build_query($parameters);
+        });
+
+        $mockRequest = $this->createMock(Request::class);
+        $mockRequest->setMethod('POST');
+        $mockRequest->request = $this->createMock(ParameterBag::class);
+
+        $session = $this->createMock(Session::class);
+        if (!$isValid) {
+            $mockFlashBag = $this->createMock(FlashBagInterface::class);
+            $mockFlashBag->method('add')->with('error', sprintf('%s: %s', self::ERROR_LABEL, self::ERROR_MESSAGE));
+            $session->method('getFlashBag')->willReturn($mockFlashBag);
+        }
+
+        $responseBuilder = new ResponseBuilder(
+            $mockFilterFormFactory,
+            $mockRouter,
+            $this->createMock(AdminFilterRepository::class),
+            1,
+            1,
+            $session
+        );
+
+        return $responseBuilder->buildSearchResponse(
+            $mockDefinitionFactory,
+            $mockRequest,
+            'filterId',
+            'index',
+            []
+        );
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | This PR adds the preview action in the product list v2, we had to introduce an intermediate Symfony action because the service that generates the URL isn't usable directly in the grid (which only works based on Symfony routes)
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30212
| Related PRs       | ~
| How to test?      | This PR is the last one for the product list V2 which has not been fully tested yet, so it should be used as an opportunity to test it as a whole
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
