### PR TITLE
Remove deprecated addJQuery() method

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -758,9 +758,6 @@ class MediaCore
                                 $version = $matches[1];
                             }
                             if ($version) {
-                                if ($version != _PS_JQUERY_VERSION_) {
-                                    Context::getContext()->controller->addJquery($version, null, $minifier);
-                                }
                                 Media::$inline_script_src[] = $src;
                             }
                         }

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -558,23 +558,6 @@ abstract class ControllerCore
     }
 
     /**
-     * Adds jQuery library file to queued JS file list.
-     *
-     * @param string|null $version jQuery library version
-     * @param string|null $folder jQuery file folder
-     * @param bool $minifier if set tot true, a minified version will be included
-     *
-     * @deprecated 1.7.7 jQuery is always included, this method should no longer be used
-     */
-    public function addJquery($version = null, $folder = null, $minifier = true)
-    {
-        @trigger_error(
-            'Controller->addJquery() is deprecated since version 1.7.7.0, jQuery is always included',
-            E_USER_DEPRECATED
-        );
-    }
-
-    /**
      * Adds jQuery UI component(s) to queued JS file list.
      *
      * @param string|array $component


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated method since 1.7.7
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
