### PR TITLE
Fix BO Units on inputs

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductShipping.php
@@ -67,6 +67,14 @@ class ProductShipping extends CommonAbstractType
      * @var array
      */
     private $warehouses;
+    /**
+     * @var string
+     */
+    private $dimensionUnit;
+    /**
+     * @var string
+     */
+    private $weightUnit;
 
     /**
      * Constructor.
@@ -75,8 +83,10 @@ class ProductShipping extends CommonAbstractType
      * @param LegacyContext $legacyContext
      * @param WarehouseDataProvider $warehouseDataProvider
      * @param CarrierDataProvider $carrierDataProvider
+     * @param string $dimensionUnit
+     * @param string $weightUnit
      */
-    public function __construct($translator, $legacyContext, $warehouseDataProvider, $carrierDataProvider)
+    public function __construct($translator, $legacyContext, $warehouseDataProvider, $carrierDataProvider, string $dimensionUnit, string $weightUnit)
     {
         $this->translator = $translator;
         $this->legacyContext = $legacyContext;
@@ -101,6 +111,8 @@ class ProductShipping extends CommonAbstractType
 
             $this->carriersChoices[$choiceId] = $carrier['id_reference'];
         }
+        $this->dimensionUnit = $dimensionUnit;
+        $this->weightUnit = $weightUnit;
     }
 
     /**
@@ -114,6 +126,7 @@ class ProductShipping extends CommonAbstractType
             'width',
             FormType\NumberType::class,
             [
+                'unit' => $this->dimensionUnit,
                 'required' => false,
                 'label' => $this->translator->trans('Width', [], 'Admin.Catalog.Feature'),
                 'constraints' => [
@@ -126,6 +139,7 @@ class ProductShipping extends CommonAbstractType
                 'height',
                 FormType\NumberType::class,
                 [
+                    'unit' => $this->dimensionUnit,
                     'required' => false,
                     'label' => $this->translator->trans('Height', [], 'Admin.Catalog.Feature'),
                     'constraints' => [
@@ -138,6 +152,7 @@ class ProductShipping extends CommonAbstractType
                 'depth',
                 FormType\NumberType::class,
                 [
+                    'unit' => $this->dimensionUnit,
                     'required' => false,
                     'label' => $this->translator->trans('Depth', [], 'Admin.Catalog.Feature'),
                     'constraints' => [
@@ -150,6 +165,7 @@ class ProductShipping extends CommonAbstractType
                 'weight',
                 FormType\NumberType::class,
                 [
+                    'unit' => $this->weightUnit,
                     'scale' => static::PRESTASHOP_WEIGHT_DECIMALS,
                     'required' => false,
                     'label' => $this->translator->trans('Weight', [], 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSpecificPrice.php
@@ -264,6 +264,7 @@ class ProductSpecificPrice extends CommonAbstractType
                     'constraints' => [
                         new Assert\Type(['type' => 'numeric']),
                     ],
+                    'unit' => $this->translator->trans('Unit(s)', [], 'Admin.Catalog.Feature'),
                 ]
             )
             ->add(

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -168,6 +168,8 @@ services:
       - "@prestashop.adapter.legacy.context"
       - "@prestashop.adapter.data_provider.warehouse"
       - "@prestashop.adapter.data_provider.carrier"
+      - "@=service('prestashop.adapter.legacy.configuration').get('PS_DIMENSION_UNIT')"
+      - "@=service('prestashop.adapter.legacy.configuration').get('PS_WEIGHT_UNIT')"
     parent: 'form.type.common_type'
     public: true
     tags:

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_shipping.html.twig
@@ -22,7 +22,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-{% set dimension_unit, weight_unit = configuration('PS_DIMENSION_UNIT'), configuration('PS_WEIGHT_UNIT') %}
 
 <div class="col-md-12 pb-1">
   <h2>{{ 'Package dimension'|trans({}, 'Admin.Catalog.Feature') }}</h2>
@@ -35,9 +34,6 @@
     {{ form_errors(form.width) }}
     <div class="input-group">
       {{ form_widget(form.width) }}
-      <div class="input-group-append">
-        <span class="input-group-text">{{ dimension_unit }}</span>
-      </div>
     </div>
   </div>
 </div>
@@ -47,9 +43,6 @@
     {{ form_errors(form.height) }}
     <div class="input-group">
       {{ form_widget(form.height) }}
-      <div class="input-group-append">
-        <span class="input-group-text">{{ dimension_unit }}</span>
-      </div>
     </div>
   </div>
 </div>
@@ -59,9 +52,6 @@
     {{ form_errors(form.depth) }}
     <div class="input-group">
       {{ form_widget(form.depth) }}
-      <div class="input-group-append">
-        <span class="input-group-text">{{ dimension_unit }}</span>
-      </div>
     </div>
   </div>
 </div>
@@ -71,9 +61,6 @@
     {{ form_errors(form.weight) }}
     <div class="input-group">
       {{ form_widget(form.weight) }}
-      <div class="input-group-append">
-        <span class="input-group-text">{{ weight_unit }}</span>
-      </div>
     </div>
   </div>
 </div>
@@ -82,7 +69,7 @@
   <div class="form-group">
     <h2>
       {{ form.additional_delivery_times.vars.label }}
-      <span class="help-box" 
+      <span class="help-box"
             data-toggle="popover"
             data-content="{{ "Display delivery time for a product is advised for merchants selling in Europe to comply with the local laws."|trans({}, 'Admin.Catalog.Help') }}" >
       </span>
@@ -125,7 +112,7 @@
   <div class="form-group">
     <h2>
       {{ form.additional_shipping_cost.vars.label }}
-      <span class="help-box" 
+      <span class="help-box"
             data-toggle="popover"
             data-content="{{ "If a carrier has a tax, it will be added to the shipping fees. Does not apply to free shipping."|trans({}, 'Admin.Catalog.Help') }}" >
       </span>

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_specific_price.html.twig
@@ -115,12 +115,7 @@
       <fieldset class="form-group">
         <label>{{ form.sp_from_quantity.vars.label }}</label>
         {{ form_errors(form.sp_from_quantity) }}
-        <div class="input-group">
-          {{ form_widget(form.sp_from_quantity) }}
-          <div class="input-group-append">
-            <span class="input-group-text">{{ 'Unit(s)'|trans({}, 'Admin.Catalog.Feature') }}</span>
-          </div>
-        </div>
+        {{ form_widget(form.sp_from_quantity) }}
       </fieldset>
     </div>
   </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?    | Since commit 1ac33da1254044268a2c0f8a8e9d4907947bba4a, form types have a new 'unit' option that customize input block. This PR fixes some UI issues by adding that property. 
| Branch?           | 8.0.x 
| Type?             | bug fix 
| Category?         |  BO
| BC breaks?        | yes 
| Deprecations?     |  no
| Fixed ticket?     | Fixes #28892.
| How to test?      | See issue


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


Breaking changes: 

- Added two string parameters on `PrestaShopBundle\Form\Admin\Product\ProductShipping` 
 
