### PR TITLE
Fix anchor links in product list

### DIFF
--- a/themes/classic/_dev/js/listing.js
+++ b/themes/classic/_dev/js/listing.js
@@ -30,8 +30,6 @@ import "velocity-animate";
 import ProductMinitature from './components/product-miniature';
 
 $(document).ready(() => {
-  const history = window.location.href;
-
   prestashop.on('clickQuickView', (elm) => {
     const data = {
       action: 'quickview',
@@ -198,12 +196,11 @@ $(document).ready(() => {
     );
   });
 
-  if ($(prestashop.themeSelectors.listing.list).length) {
-    window.addEventListener('popstate', (e) => {
-      const {state} = e;
-      window.location.href = state && state.current_url ? state.current_url : history;
-    });
-  }
+  window.addEventListener('popstate', (e) => {
+    if (e.state && e.state.current_url) {
+      window.location.href = e.state.current_url;
+    }
+  });
 
   $('body').on(
     'change',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Prevent popstate listener from refreshing the page on events related to anchor links A previous fix was realized in this PR https://github.com/PrestaShop/PrestaShop/pull/17014 to handle history correctly but the event seems to be catching too many things (including anchor clicks which trigger a `popstate` event) another PR tried to fix this https://github.com/PrestaShop/PrestaShop/pull/26380 but it only works on pages that don't have a listing not in the listing themselves This fix aims at ignoring the events triggered by anchor clicks in which the `state` property is null
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28932
| Related PRs       | ~
| How to test?      | Test if the original issue #28932 is fixed (mobile back to top button) but we should also make sure that those two issues are still ok https://github.com/PrestaShop/PrestaShop/issues/14821 and https://github.com/PrestaShop/PrestaShop/issues/26326
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
