### PR TITLE
Disable box shadow on focused buttons

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_button.scss
+++ b/admin-dev/themes/new-theme/scss/components/_button.scss
@@ -19,3 +19,13 @@
 a.btn.auto-pointer-events {
   pointer-events: auto;
 }
+
+.btn-primary:not(:disabled):not(.disabled).active:focus,
+.btn-primary:not(:disabled):not(.disabled):active:focus,
+.show>.btn-primary.dropdown-toggle:focus,
+.btn-primary.focus:active,
+.btn-primary:focus:active,
+.btn-primary.focus,
+.btn-primary:focus {
+  box-shadow: none;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | The solution in this PR for now is to override the bootstrap box shadows, but it's not ideal because it implies a lot of selectors, it only works for `btn-primary` buttons for now And most of all seems like this shadow can be handled via the bootstrap variables at compilation which seem to be defined in the prestakit here https://github.com/PrestaShop/prestashop-ui-kit/blob/develop/scss/_variables.scss#L379-L383 but without effects
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28874
| Related PRs       | ~
| How to test?      | ~
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
