### PR TITLE
Fix permissions for read-only user

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -54,7 +54,7 @@ class PositionsController extends FrameworkBundleAdminController
      *
      * @Template("@PrestaShop/Admin/Improve/Design/positions.html.twig")
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')~'_') && is_granted('update', request.get('_legacy_controller')~'_') && is_granted('create', request.get('_legacy_controller')~'_') && is_granted('delete', request.get('_legacy_controller')~'_')",
+     *     "is_granted('read', request.get('_legacy_controller')~'_') || is_granted('update', request.get('_legacy_controller')~'_') || is_granted('create', request.get('_legacy_controller')~'_') || is_granted('delete', request.get('_legacy_controller')~'_')",
      *     message="Access denied.")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -99,7 +99,7 @@ class ProductController extends FrameworkBundleAdminController
      *
      * URL example: /product/catalog/40/20/id_product/asc
      *
-     * @AdminSecurity("is_granted('create', 'ADMINPRODUCTS_') || is_granted('update', 'ADMINPRODUCTS_') || is_granted('read', 'ADMINPRODUCTS_')")
+     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
      * @Template("@PrestaShop/Admin/Product/CatalogPage/catalog.html.twig")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -99,6 +99,7 @@ class ProductController extends FrameworkBundleAdminController
      *
      * URL example: /product/catalog/40/20/id_product/asc
      *
+     * @AdminSecurity("is_granted('create', 'ADMINPRODUCTS_') || is_granted('update', 'ADMINPRODUCTS_') || is_granted('read', 'ADMINPRODUCTS_')")
      * @Template("@PrestaShop/Admin/Product/CatalogPage/catalog.html.twig")
      *
      * @param Request $request
@@ -126,12 +127,6 @@ class ProductController extends FrameworkBundleAdminController
     ) {
         if ($this->shouldRedirectToV2()) {
             return $this->redirectToRoute('admin_products_v2_index');
-        }
-
-        foreach ([PageVoter::READ, PageVoter::UPDATE, PageVoter::CREATE] as $permission) {
-            if (!$this->isGranted($permission, self::PRODUCT_OBJECT)) {
-                return $this->redirect('admin_dashboard');
-            }
         }
 
         $language = $this->getContext()->language;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -79,7 +79,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Show categories listing.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
      *     message="You do not have permission to list this."
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -93,7 +93,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Shows products listing.
      *
-     * @AdminSecurity("is_granted('create', 'ADMINPRODUCTS_') || is_granted('update', 'ADMINPRODUCTS_') || is_granted('read', 'ADMINPRODUCTS_')")
+     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param ProductFilters $filters

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -93,7 +93,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Shows products listing.
      *
-     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted('create', 'ADMINPRODUCTS_') || is_granted('update', 'ADMINPRODUCTS_') || is_granted('read', 'ADMINPRODUCTS_')")
      *
      * @param Request $request
      * @param ProductFilters $filters

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
@@ -44,7 +44,7 @@ class DeliveryController extends FrameworkBundleAdminController
      *
      * @Template("@PrestaShop/Admin/Sell/Order/Delivery/slip.html.twig")
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
      *     message="Access denied."
      * )
      *
@@ -60,7 +60,9 @@ class DeliveryController extends FrameworkBundleAdminController
         $form = $formHandler->getForm();
 
         $form->handleRequest($request);
-        if ($form->isSubmitted() && $form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()
+            && $this->isGranted('update', $request->attributes->get('_legacy_controller')
+        )) {
             $errors = $formHandler->save($form->getData());
             if (empty($errors)) {
                 $this->addFlash(

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
@@ -91,7 +91,7 @@ class DeliveryController extends FrameworkBundleAdminController
      * Delivery slips PDF generator.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
      *     message="Access denied."
      * )
      *


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Before Symfony 4.4, voters with many attributes acted as a `OR` condition, and when it was migrated in ff96226eae149d58b34ca6c5228b846595d05914 has been replaced by an `AND` condition. Solution was to migrate back to the `OR` condition
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29001 
| How to test?      | See #29001 .
