### PR TITLE
Remove select2 for categories in product v1

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -329,10 +329,6 @@ class ProductInformation extends CommonAbstractType
                 'multiple' => false,
                 'required' => true,
                 'label' => $this->translator->trans('Default category', [], 'Admin.Catalog.Feature'),
-                'attr' => [
-                    'data-toggle' => 'select2',
-                    'data-minimumResultsForSearch' => '7',
-                ],
             ])
             ->add('new_category', SimpleCategory::class, [
                 'ajax' => true,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Since #28066, we use "select2" in select options but in product page v1 we shouldn't be using it for categories as there's a custom behavior.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29072
| Related PRs       | 
| How to test?      | Please see #29072
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
