### PR TITLE
Change default assignation of Product::pack_stock_type

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -26,6 +26,7 @@
 
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
@@ -336,7 +337,7 @@ class ProductCore extends ObjectModel
     /**
      * @var int tell the type of stock management to apply on the pack
      */
-    public $pack_stock_type = Pack::STOCK_TYPE_DEFAULT;
+    public $pack_stock_type = PackStockType::STOCK_TYPE_DEFAULT;
 
     /**
      * Type of delivery time.


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x 
| Description?      | changed default assignation of Product::pack_stock_type for exclude loading error of Pack class (inheritance issue).
| Type?             | bug fix 
| Category?         |  CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29077 .
| Related PRs       | NO
| How to test?      | Follow the issue
| Possible impacts? | No impacts.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
