### PR TITLE
Remove useless controller permission suffix

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php
@@ -122,7 +122,7 @@ class BackupController extends FrameworkBundleAdminController
     /**
      * Return a backup content as a download.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      * @DemoRestricted(redirectRoute="admin_backup")
      *
      * @param string $downloadFileName

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -224,7 +224,7 @@ class ProfileController extends FrameworkBundleAdminController
      * Delete a profile.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller')~'_')",
+     *     "is_granted('delete', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      * @DemoRestricted(redirectRoute="admin_profiles_index")
@@ -252,7 +252,7 @@ class ProfileController extends FrameworkBundleAdminController
      * Bulk delete profiles.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller')~'_')",
+     *     "is_granted('delete', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      * @DemoRestricted(redirectRoute="admin_profiles_index")

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -270,19 +270,19 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function authorizationLevel($controller)
     {
-        if ($this->isGranted(PageVoter::DELETE, $controller . '_')) {
+        if ($this->isGranted(PageVoter::DELETE, $controller)) {
             return PageVoter::LEVEL_DELETE;
         }
 
-        if ($this->isGranted(PageVoter::CREATE, $controller . '_')) {
+        if ($this->isGranted(PageVoter::CREATE, $controller)) {
             return PageVoter::LEVEL_CREATE;
         }
 
-        if ($this->isGranted(PageVoter::UPDATE, $controller . '_')) {
+        if ($this->isGranted(PageVoter::UPDATE, $controller)) {
             return PageVoter::LEVEL_UPDATE;
         }
 
-        if ($this->isGranted(PageVoter::READ, $controller . '_')) {
+        if ($this->isGranted(PageVoter::READ, $controller)) {
             return PageVoter::LEVEL_READ;
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -54,7 +54,7 @@ class PositionsController extends FrameworkBundleAdminController
      *
      * @Template("@PrestaShop/Admin/Improve/Design/positions.html.twig")
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')~'_') || is_granted('update', request.get('_legacy_controller')~'_') || is_granted('create', request.get('_legacy_controller')~'_') || is_granted('delete', request.get('_legacy_controller')~'_')",
+     *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
      *     message="Access denied.")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
@@ -125,7 +125,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Modify translations action.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')~'_')")
+     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -150,7 +150,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Add language pack for new languages and updates for the existing ones action.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')~'_')"))
+     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))"))
      *
      * @param Request $request
      *
@@ -189,7 +189,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Extract catalogues using locale.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')~'_')")
+     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -286,7 +286,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Copy language action.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')~'_')")
+     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
      *
      * @param Request $request
      *


### PR DESCRIPTION
| Questions         | Answers |
| ----------------- | ------------------------------------------------------- |
| Branch?           | 8.0.x  |
| Description?      | This check is already done in PageVoter so we don't need to check in the annotation.  |
| Type?             | improvement  |
| Category?         | BO |
| BC breaks?        | no |
| Deprecations?     | no |
| How to test     |  Check pages used by Positions, Backup and profile controller with different roles. Check whatever the role you have, you can send a test mail. This validates the FrameworkBundleAdminController.php modifications |