### PR TITLE
Fix missing id_guest in cookie

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -364,10 +364,13 @@ class ContextCore
         if (Configuration::get('PS_CART_FOLLOWING') && (empty($this->cookie->id_cart) || Cart::getNbProducts((int) $this->cookie->id_cart) == 0) && $idCart = (int) Cart::lastNoneOrderedCart($this->customer->id)) {
             $this->cart = new Cart($idCart);
             $this->cart->secure_key = $customer->secure_key;
+            $this->cookie->id_guest = (int) $this->cart->id_guest;
         } else {
+            Guest::setNewGuest($this->cookie);
             if (Validate::isLoadedObject($this->cart)) {
                 $idCarrier = (int) $this->cart->id_carrier;
                 $this->cart->secure_key = $customer->secure_key;
+                $this->cart->id_guest = (int) $this->cookie->id_guest;
                 $this->cart->id_carrier = 0;
                 if (!empty($idCarrier)) {
                     $deliveryOption = [$this->cart->id_address_delivery => $idCarrier . ','];

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1242,6 +1242,7 @@ class FrontControllerCore extends Controller
                     $this->context->cookie->is_guest = $customer->isGuest();
                     $this->context->cookie->passwd = $customer->passwd;
                     $this->context->cookie->email = $customer->email;
+                    $this->context->cookie->id_guest = (int) $cart->id_guest;
 
                     return $id_cart;
                 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When cookie is created, `id_guest` is missing.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28336.
| Related PRs       |
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/28336#issuecomment-1169002509
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
