### PR TITLE
Fix : methods with "process" prefix are not called

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1012,7 +1012,7 @@ class AdminControllerCore extends Controller
                     Hook::exec('actionAdmin' . ucfirst($this->action) . 'Before', ['controller' => $this]);
                     Hook::exec('action' . get_class($this) . ucfirst($this->action) . 'Before', ['controller' => $this]);
                     // Call process
-                    $return = $this->{'process' . Tools::toCamelCase($this->action)}();
+                    $return = $this->{'process' . ucfirst(Tools::toCamelCase($this->action))}();
 
                     // Hook After Action
                     Hook::exec('actionAdmin' . ucfirst($this->action) . 'After', ['controller' => $this, 'return' => $return]);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop and 1.7.8.x
| Description?      | When you create a method that must be called with the "action" URL parameters on an AdminController, you can simply create the method with the name "processMyMethod". <br/>Except that there is an error, we check if the method exists with a "UcFirst" (line 1010), but we call the method without the "UcFirst".<br/> So the method can never be called. Unless we trick by creating two methods, with UcFirst and one without UcFirst
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue number here}.
| Related PRs       | --
| How to test?      | I created a module to show you the bug : [lowissueadmin.zip(https://github.com/PrestaShop/PrestaShop/files/9139167/lowissueadmin.zip). The module contains an AdminController with a method. Simply access the AdminController, and then click on the "Link to action "my-action"" button to execute the "processMyAction" method. A message should appear if the method is executed: "Hello World My Action" 
| Possible impacts? | --


