### PR TITLE
Fix FO address forms reload when switching address's country

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -97,25 +97,19 @@ class CustomerAddressFormCore extends AbstractForm
         // 1) Update the format if a new id_country was set.
         // 2) Detect country from browser language settings and matches BO enabled countries
         // 3) Default country set in BO
-        if (isset($params['id_country']) && $params['id_country'] != $this->formatter->getCountry()->id) {
-            $this->formatter->setCountry(
-                new Country($params['id_country'], $this->language->id)
-            );
+
+        if (isset($params['id_country']) && (int) $params['id_country'] !== (int) $this->formatter->getCountry()->id) {
+            $country = new Country($params['id_country'], $this->language->id);
         } elseif (
             Tools::isCountryFromBrowserAvailable() &&
             Country::getByIso($countryIsoCode = Tools::getCountryIsoCodeFromHeader(), true)
         ) {
-            $this->formatter->setCountry(
-                new Country(
-                    (int) Country::getByIso($countryIsoCode, true),
-                    Language::getIdByIso($countryIsoCode)
-                )
-            );
+            $country = new Country((int) Country::getByIso($countryIsoCode, true), Language::getIdByIso($countryIsoCode));
         } else {
-            $this->formatter->setCountry(
-                new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'), $this->language->id)
-            );
+            $country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'), $this->language->id);
         }
+
+        $this->formatter->setCountry($country);
 
         return parent::fillWith($params);
     }

--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -92,23 +92,29 @@ class CustomerAddressFormCore extends AbstractForm
 
     public function fillWith(array $params = [])
     {
-        // This form is very tricky: fields may change depending on which
-        // country is being submitted!
-        // So we first update the format if a new id_country was set.
-        // If detect country from browser language is selected, default country will be overridden
-        if (Tools::isCountryFromBrowserAvailable()) {
-            $languageAvailable = Tools::getCountryIsoCodeFromHeader();
-            $this->formatter->setCountry(new Country(
-                (int) Country::getByIso($languageAvailable, true),
-                Language::getIdByIso($languageAvailable)
-            ));
-        } elseif (isset($params['id_country'])
-            && $params['id_country'] != $this->formatter->getCountry()->id
+        // This form is tricky: fields may change depending on which country is being selected!
+        // Country preselection priority order :
+        // 1) Update the format if a new id_country was set.
+        // 2) Detect country from browser language settings and matches BO enabled countries
+        // 3) Default country set in BO
+        if (isset($params['id_country']) && $params['id_country'] != $this->formatter->getCountry()->id) {
+            $this->formatter->setCountry(
+                new Country($params['id_country'], $this->language->id)
+            );
+        } elseif (
+            Tools::isCountryFromBrowserAvailable() &&
+            Country::getByIso($countryIsoCode = Tools::getCountryIsoCodeFromHeader(), true)
         ) {
-            $this->formatter->setCountry(new Country(
-                $params['id_country'],
-                $this->language->id
-            ));
+            $this->formatter->setCountry(
+                new Country(
+                    (int) Country::getByIso($countryIsoCode, true),
+                    Language::getIdByIso($countryIsoCode)
+                )
+            );
+        } else {
+            $this->formatter->setCountry(
+                new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'), $this->language->id)
+            );
         }
 
         return parent::fillWith($params);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fixes the address form reload after switching country of the adrdress, updates properly the form fields.
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Resolves #29012, resolves #28781
| Related PRs       | N/A
| How to test?      | 1)Go to BO > International > Localization page & Import the italian pack 2) Go to BO > International > Locations > Countries tab & edit the Italian country 3) Enable "Do you need a tax identification number?" and save 4) Go to BO > Addresses page 5) Select dni as a required field 6) Go to FO > Create an address with the Italian country 7) See NO error 8) Go to FO > Add a product to the cart and proceed to checkout 9) In the Addresses tab, create an address with the Italian country 10) See NO error
| Possible impacts? | Check that #18008 still working


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
