### PR TITLE
Set $available_in_your_account as false by default, true on invoice

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -42,7 +42,7 @@ abstract class HTMLTemplateCore
     /**
      * @var bool
      */
-    public $available_in_your_account = true;
+    public $available_in_your_account = false;
 
     /**
      * @var Smarty

--- a/classes/pdf/HTMLTemplateInvoice.php
+++ b/classes/pdf/HTMLTemplateInvoice.php
@@ -42,7 +42,7 @@ class HTMLTemplateInvoiceCore extends HTMLTemplate
     /**
      * @var bool
      */
-    public $available_in_your_account = false;
+    public $available_in_your_account = true;
 
     /**
      * @param OrderInvoice $order_invoice


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Display the 'An electronic version of this invoice is available in your account. To access it, log in to our website using your e-mail address and password (which you created when placing your first order).' only on invoice PDF.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29123.
| How to test?      | See issue.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
