### PR TITLE
feat: change AUTH_COOKIE_LIFETIME from const into public variable

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -412,7 +412,7 @@ class AdminControllerCore extends Controller
     const AUTH_COOKIE_LIFETIME = 3600;
     
     /** @var int Auth cookie lifetime */
-    public $AUTH_COOKIE_LIFETIME = self::AUTH_COOKIE_LIFETIME;
+    public $authCookieLifetime = self::AUTH_COOKIE_LIFETIME;
 
     /** @var array */
     public $_conf;

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -409,7 +409,10 @@ class AdminControllerCore extends Controller
     protected $tabSlug;
 
     /** @var int Auth cookie lifetime */
-    public $AUTH_COOKIE_LIFETIME = 3600;
+    const AUTH_COOKIE_LIFETIME = 3600;
+    
+    /** @var int Auth cookie lifetime */
+    public $AUTH_COOKIE_LIFETIME = self::AUTH_COOKIE_LIFETIME;
 
     /** @var array */
     public $_conf;

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2751,7 +2751,7 @@ class AdminControllerCore extends Controller
             $this->context->employee->logout();
         }
         if (isset(Context::getContext()->cookie->last_activity)) {
-            if (((int) $this->context->cookie->last_activity) + $this->AUTH_COOKIE_LIFETIME < time()) {
+            if (((int) $this->context->cookie->last_activity) + $this->authCookieLifetime < time()) {
                 $this->context->employee->logout();
             } else {
                 $this->context->cookie->last_activity = time();

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -409,7 +409,7 @@ class AdminControllerCore extends Controller
     protected $tabSlug;
 
     /** 
-     * @deprecated use $this->authCookieLifetime
+     * @deprecated since version 8.0.1. Use $this->authCookieLifetime instead
      * @var int Auth cookie lifetime
      */
     const AUTH_COOKIE_LIFETIME = 3600;

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -409,7 +409,7 @@ class AdminControllerCore extends Controller
     protected $tabSlug;
 
     /** @var int Auth cookie lifetime */
-    const AUTH_COOKIE_LIFETIME = 3600;
+    public $AUTH_COOKIE_LIFETIME = 3600;
 
     /** @var array */
     public $_conf;
@@ -2748,7 +2748,7 @@ class AdminControllerCore extends Controller
             $this->context->employee->logout();
         }
         if (isset(Context::getContext()->cookie->last_activity)) {
-            if (((int) $this->context->cookie->last_activity) + self::AUTH_COOKIE_LIFETIME < time()) {
+            if (((int) $this->context->cookie->last_activity) + $this->AUTH_COOKIE_LIFETIME < time()) {
                 $this->context->employee->logout();
             } else {
                 $this->context->cookie->last_activity = time();

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -407,7 +407,7 @@ class AdminControllerCore extends Controller
 
     /** @var string */
     protected $tabSlug;
-
+// @deprecated
     /** @var int Auth cookie lifetime */
     const AUTH_COOKIE_LIFETIME = 3600;
     

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -407,8 +407,11 @@ class AdminControllerCore extends Controller
 
     /** @var string */
     protected $tabSlug;
-// @deprecated
-    /** @var int Auth cookie lifetime */
+
+    /** 
+     * @deprecated use $this->authCookieLifetime
+     * @var int Auth cookie lifetime
+     */
     const AUTH_COOKIE_LIFETIME = 3600;
     
     /** @var int Auth cookie lifetime */


### PR DESCRIPTION
I think it is better to change this constant variable into a public variable, in such change we as developers are able to create a module which can override or modify the value of that variable.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This just changes a constant variable into a public variable which lets developers to override the cookie timeout easily
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | Fetch the commit. Then create a dummy module which overrides this variable and test this. I am going to write a dummy module soon.
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
