### PR TITLE
Fix stock policy propagation on product combination

### DIFF
--- a/src/Adapter/Product/Combination/Update/CombinationStockProperties.php
+++ b/src/Adapter/Product/Combination/Update/CombinationStockProperties.php
@@ -84,7 +84,6 @@ class CombinationStockProperties
         $this->lowStockThreshold = $lowStockThreshold;
         $this->lowStockAlertEnabled = $lowStockAlertEnabled;
         $this->availableDate = $availableDate;
-        $this->stockModification = $stockModification;
     }
 
     /**

--- a/src/Adapter/Product/Stock/CommandHandler/UpdateProductStockInformationHandler.php
+++ b/src/Adapter/Product/Stock/CommandHandler/UpdateProductStockInformationHandler.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Stock\CommandHandler;
 
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Update\ProductStockProperties;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Update\ProductStockUpdater;
@@ -51,15 +52,23 @@ final class UpdateProductStockInformationHandler implements UpdateProductStockIn
     private $movementReasonRepository;
 
     /**
+     * @var CombinationRepository
+     */
+    private $combinationRepository;
+
+    /**
      * @param ProductStockUpdater $productStockUpdater
      * @param MovementReasonRepository $movementReasonRepository
+     * @param CombinationRepository $combinationRepository
      */
     public function __construct(
         ProductStockUpdater $productStockUpdater,
-        MovementReasonRepository $movementReasonRepository
+        MovementReasonRepository $movementReasonRepository,
+        CombinationRepository $combinationRepository
     ) {
         $this->productStockUpdater = $productStockUpdater;
         $this->movementReasonRepository = $movementReasonRepository;
+        $this->combinationRepository = $combinationRepository;
     }
 
     /**
@@ -91,5 +100,9 @@ final class UpdateProductStockInformationHandler implements UpdateProductStockIn
             ),
             $command->getShopConstraint()
         );
+
+        if (null !== $command->getOutOfStockType()) {
+            $this->combinationRepository->updateCombinationStock($command->getProductId(), $command->getOutOfStockType(), $command->getShopConstraint());
+        }
     }
 }

--- a/src/Core/Repository/ShopConstraintTrait.php
+++ b/src/Core/Repository/ShopConstraintTrait.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Repository;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+trait ShopConstraintTrait
+{
+    protected function applyShopConstraint(
+        QueryBuilder $queryBuilder,
+        ?ShopConstraint $shopConstraint = null
+    ): QueryBuilder {
+        if (null === $shopConstraint) {
+            return $queryBuilder;
+        }
+
+        if ($shopConstraint->getShopId() !== null) {
+            $queryBuilder
+                ->andWhere('id_shop = :shop')
+                ->setParameter('shop', $shopConstraint->getShopId()->getValue())
+            ;
+        }
+
+        if ($shopConstraint->getShopGroupId() !== null) {
+            $queryBuilder
+                ->andWhere('id_shop_group = :shop_group')
+                ->setParameter('shop_group', $shopConstraint->getShopGroupId()->getValue())
+            ;
+        }
+
+        return $queryBuilder;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
@@ -35,6 +35,7 @@ services:
     arguments:
       - '@prestashop.adapter.product.stock.update.product_stock_updater'
       - '@prestashop.adapter.product.stock.repository.movement_reason_repository'
+      - '@prestashop.adapter.product.combination.repository.combination_repository'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\UpdateProductStockInformationCommand

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCust
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\CustomizationField;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use RuntimeException;
@@ -310,6 +311,23 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         return $propertyAccessor->getValue($productForEditing, $pathsByNames[$propertyName]);
+    }
+
+    /**
+     * @param string $outOfStock
+     *
+     * @return int
+     */
+    protected function convertOutOfStockToInt(string $outOfStock): int
+    {
+        $intValues = [
+            'default' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
+            'available' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+            'not_available' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
+            'invalid' => 42, // This random number is hardcoded intentionally to reflect invalid stock type
+        ];
+
+        return $intValues[$outOfStock];
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateStockFeatureContext.php
@@ -41,7 +41,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstr
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Query\GetEmployeesStockMovements;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\QueryResult\EmployeeStockMovement;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\QueryResult\StockMovement;
-use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShopBundle\Api\QueryStockMovementParamsCollection;
@@ -446,23 +445,6 @@ class UpdateStockFeatureContext extends AbstractProductFeatureContext
         }
 
         return $data;
-    }
-
-    /**
-     * @param string $outOfStock
-     *
-     * @return int
-     */
-    private function convertOutOfStockToInt(string $outOfStock): int
-    {
-        $intValues = [
-            'default' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
-            'available' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
-            'not_available' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
-            'invalid' => 42, // This random number is hardcoded intentionally to reflect invalid stock type
-        ];
-
-        return $intValues[$outOfStock];
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -234,3 +234,16 @@ Feature: Update product combination stock information in Back Office (BO)
       | location                   |       |
       | available date             |       |
     And product "product1" should have no stock movements
+
+  Scenario: I update product out of stock
+    And product "product1" should have following stock information:
+      | out_of_stock_type | default |
+    When I update product "product1" stock with following information:
+      | out_of_stock_type | available |
+    Then all combinations of product "product1" should have the stock policy to "available"
+    When I update product "product1" stock with following information:
+      | out_of_stock_type | default |
+    Then all combinations of product "product1" should have the stock policy to "default"
+    When I update product "product1" stock with following information:
+      | out_of_stock_type | not_available |
+    Then all combinations of product "product1" should have the stock policy to "not_available"


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x 
| Description?      | Product out of stock policy is not propagated in product attributes
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #28958
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.

