### PR TITLE
Webservice: honor maximum image upload size

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementImages.php
+++ b/classes/webservice/WebserviceSpecificManagementImages.php
@@ -63,11 +63,6 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
     protected $imageType = null;
 
     /**
-     * @var int The maximum size supported when uploading images, in bytes
-     */
-    protected $imgMaxUploadSize = 3000000;
-
-    /**
      * @var array The list of supported mime types
      */
     protected $acceptedImgMimeTypes = ['image/gif', 'image/jpg', 'image/jpeg', 'image/pjpeg', 'image/png', 'image/x-png'];
@@ -1032,11 +1027,12 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
      */
     protected function writePostedImageOnDisk($reception_path, $dest_width = null, $dest_height = null, $image_types = null, $parent_path = null)
     {
+        $imgMaxUploadSize = ((int) Configuration::get('PS_LIMIT_UPLOAD_IMAGE_VALUE')) * 1000 * 1000;
         if ($this->wsObject->method == 'PUT') {
             if (isset($_FILES['image']['tmp_name']) && $_FILES['image']['tmp_name']) {
                 $file = $_FILES['image'];
-                if ($file['size'] > $this->imgMaxUploadSize) {
-                    throw new WebserviceException(sprintf('The image size is too large (maximum allowed is %d KB)', ($this->imgMaxUploadSize / 1000)), [72, 400]);
+                if ($file['size'] > $imgMaxUploadSize) {
+                    throw new WebserviceException(sprintf('The image size is too large (maximum allowed is %d KB)', ($imgMaxUploadSize / 1000)), [72, 400]);
                 }
                 // Get mime content type
                 $mime_type = false;
@@ -1082,8 +1078,8 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
         } elseif ($this->wsObject->method == 'POST') {
             if (isset($_FILES['image']['tmp_name']) && $_FILES['image']['tmp_name']) {
                 $file = $_FILES['image'];
-                if ($file['size'] > $this->imgMaxUploadSize) {
-                    throw new WebserviceException(sprintf('The image size is too large (maximum allowed is %d KB)', ($this->imgMaxUploadSize / 1000)), [72, 400]);
+                if ($file['size'] > $imgMaxUploadSize) {
+                    throw new WebserviceException(sprintf('The image size is too large (maximum allowed is %d KB)', ($imgMaxUploadSize / 1000)), [72, 400]);
                 }
                 if ($error = ImageManager::validateUpload($file)) {
                     throw new WebserviceException('Image upload error : ' . $error, [76, 400]);
@@ -1115,7 +1111,7 @@ class WebserviceSpecificManagementImagesCore implements WebserviceSpecificManage
                     if (!isset($file['tmp_name'])) {
                         return false;
                     }
-                    if ($error = ImageManager::validateUpload($file, $this->imgMaxUploadSize)) {
+                    if ($error = ImageManager::validateUpload($file, $imgMaxUploadSize)) {
                         throw new WebserviceException('Bad image : ' . $error, [76, 400]);
                     }
 


### PR DESCRIPTION
- webservice: honor maximum image upload size

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The webservice does not respect the image upload size limit set in back-office. This pull request addresses that.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | `imgMaxUploadSize` property removed from `classes/webservice/WebserviceSpecificManagementImages.php`
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28157
| Related PRs       | no
| How to test?      | Upload a image through the webservice, compare its size with the maximum image upload size configured in back-office.
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
