### PR TITLE
Fix typo inside Reference's comment

### DIFF
--- a/src/Core/Domain/Product/ValueObject/Reference.php
+++ b/src/Core/Domain/Product/ValueObject/Reference.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintExcepti
 class Reference
 {
     /**
-     * Valid ean regex pattern
+     * Valid reference regex pattern
      */
     public const VALID_PATTERN = '/^[^<>;={}]*$/u';
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix typo in comment of VALID_PATTERN const field. The regex pattern is not for a valid ean but for a valid reference.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | No ticket for this one
| Related PRs       | no
| How to test?      | check the comment is now correct
| Possible impacts? | No impact


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
