### PR TITLE
Product V1: Update product combination reference when it is set

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2226,6 +2226,7 @@ class ProductCore extends ObjectModel
                 'default_on' => null !== $default,
                 'minimal_quantity' => null !== $minimal_quantity,
                 'available_date' => null !== $available_date,
+                'reference' => null !== $reference,
             ]);
         }
 

--- a/tests/Integration/Behaviour/Features/Context/LegacyProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LegacyProductFeatureContext.php
@@ -37,13 +37,13 @@ use Context;
 use Customization;
 use CustomizationField;
 use Pack;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationDetails;
 use PrestaShop\PrestaShop\Core\Foundation\IoC\Exception;
 use Product;
 use RuntimeException;
 use SpecificPrice;
 use StockAvailable;
 use TaxRulesGroup;
-use Tests\Integration\Behaviour\Features\Context\Util\CombinationDetails;
 use Tests\Integration\Behaviour\Features\Context\Util\ProductCombinationFactory;
 
 class LegacyProductFeatureContext extends AbstractPrestaShopFeatureContext
@@ -994,5 +994,28 @@ class LegacyProductFeatureContext extends AbstractPrestaShopFeatureContext
     public static function clearProductPrices()
     {
         Product::flushPriceCache();
+    }
+
+    /**
+     * @When I update combination :combinationReference details the legacy way with following values:
+     *
+     * @param string $combinationReference
+     * @param TableNode $tableNode
+     */
+    public function updateDetails(string $combinationReference, TableNode $tableNode): void
+    {
+        $expectedDetails = $tableNode->getRowsHash();
+
+        $scalarDetailNames = ['ean13', 'isbn', 'mpn', 'reference', 'upc', 'weight'];
+
+        $combinationId = SharedStorage::getStorage()->get($combinationReference);
+
+        $combination = new Combination($combinationId);
+
+        foreach ($scalarDetailNames as $property) {
+            $combination->{$property} = $expectedDetails[$property];
+        }
+
+        $combination->update();
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/legacy_update_product_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/legacy_update_product_combination.feature
@@ -1,0 +1,53 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s legacy_product --tags legacy-product-combination
+@restore-products-before-feature
+@clear-cache-before-feature
+@clear-cache-after-feature
+@legacy-product-type
+@legacy-update-product-combination
+Feature: Product can exist in different combinations (BO)
+  As a BO user
+  I want to be able to edit combination properties
+
+  Background:
+    Given language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "White" named "White" in en language exists
+
+  Scenario: I add a reference name to a product combination
+    Given I add product "product1" with following information:
+      | name[en-US] | universal T-shirt |
+      | type        | combinations      |
+    And product product1 type should be combinations
+    And I generate combinations for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White]            |
+    Then product "product1" should have following combinations:
+      | id reference   | combination name        | reference  | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |            | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1MWhite | Size - M, Color - White |            | [Size:M,Color:White] | 0               | 0        | false      |
+    And combination "product1SWhite" should have following details:
+      | combination detail | value |
+      | ean13              |       |
+      | isbn               |       |
+      | mpn                |       |
+      | reference          |       |
+      | upc                |       |
+      | impact on weight   | 0     |
+    When I update combination "product1SWhite" details the legacy way with following values:
+      | ean13            | 978020137962      |
+      | isbn             | 978-3-16-148410-0 |
+      | mpn              | mpn1              |
+      | reference        | ref1              |
+      | upc              | 72527273070       |
+      | weight           | 17.25             |
+    Then combination "product1SWhite" should have following details:
+      | combination detail | value             |
+      | ean13              | 978020137962      |
+      | isbn               | 978-3-16-148410-0 |
+      | mpn                | mpn1              |
+      | reference          | ref1              |
+      | upc                | 72527273070       |
+      | impact on weight   | 17.25             |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -302,6 +302,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\FeatureFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\FeatureValueFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LegacyProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ManufacturerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
@@ -363,6 +364,10 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\AttributeFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationListingFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationDetailsFeatureContext
         shop:
             paths:
                 - "%paths.base%/Features/Scenario/Shop"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Following a fix in the object model, the reference of a product combination was not updated anymore.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28981
| Related PRs       | See steps in #28981
Please indicate how to best verify that this PR is correct.
| Possible impacts? |


@jolelievre the bug happened following [your fix here](https://github.com/Anhjean/prestashop/commit/66a6843bfca2d056896858c5b11a91c85eb16b7f#diff-f34cade537421fbb780ea5cb4c4787b35ad5fece4e1bb01c32bc4ecff93535aeR422).
Your fix is not the problem, it's just that before that `reference` was saved despite not being present in the `fieldsToUpdate` list.
Don't hesitate to tell me if I'm wrong 👍 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
