### PR TITLE
Fix: error when adding a product to an empty category I created using a web serviceDevelop

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7062,18 +7062,20 @@ class ProductCore extends ObjectModel
             'ORDER BY `position`'
         );
 
-        if ($position > count($result)) {
-            WebserviceRequest::getInstance()->setError(
-                500,
-                $this->trans(
-                    'You cannot set a position greater than the total number of products in the category, starting at 1.',
-                    [],
-                    'Admin.Catalog.Notification'
-                ),
-                135
-            );
+        if (count($result)!= 0) {
+            if ($position > count($result)) {
+                WebserviceRequest::getInstance()->setError(
+                    500,
+                    $this->trans(
+                        'You cannot set a position greater than the total number of products in the category, starting at 1.',
+                        [],
+                        'Admin.Catalog.Notification'
+                    ),
+                    135
+                );
 
-            return false;
+                return false;
+            }
         }
 
         // result is indexed by recordset order and not position. positions start at index 1 so we need an empty element


### PR DESCRIPTION
I'm trying to import some products to my prestashop using REST webservice. The problem is when I try to add a product to an empty category I created using webservice, I get the following response:

`<error>
<code><![CDATA[135]]></code>
<message><![CDATA[You cannot set a position greater than the total number of products in the category, minus 1 (position numbering starts at 0).]]></message>
</error>`


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | error when adding a product to an empty category I created using a web service
| Type?             | bug fix 
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes (tiket number)