### PR TITLE
Save Smarty caching type setting in file instead of DB

### DIFF
--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -49,6 +49,9 @@ if (!defined('_PS_DEBUG_PROFILING_')) {
 if (!defined('_PS_MODE_DEMO_')) {
     define('_PS_MODE_DEMO_', false);
 }
+if (!defined('_PS_SMARTY_CACHING_TYPE_')) {
+    define('_PS_SMARTY_CACHING_TYPE_', 'filesystem');
+}
 
 $currentDir = dirname(__FILE__);
 

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -40,7 +40,7 @@ $smarty->use_sub_dirs = true;
 $smarty->setConfigDir(_PS_SMARTY_DIR_.'configs');
 $smarty->caching = false;
 
-if (Configuration::get('PS_SMARTY_CACHING_TYPE') == 'mysql') {
+if (_PS_SMARTY_CACHING_TYPE_ == 'mysql') {
     include _PS_CLASS_DIR_.'Smarty/SmartyCacheResourceMysql.php';
     $smarty->caching_type = 'mysql';
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | As an extra security, this PR change the place where the settings of `PS_SMARTY_CACHING_TYPE` is saved, from the DB to the file `config/defines.inc.php`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | PrestaShop/autoupgrade#495
| How to test?      | Nothing should have changed in the behavior of the Smarty cache settings in configure, advanced parameters, performance. When you change the value of the `Caching type` to `mysql` and you refresh the home page of the FO, you should see new entries in the table `ps_smarty_cache`. If you put back the setting to `filesystem`, you delete the entries of the table `ps_smarty_cache` and you refresh the home page of the FO, the table `ps_smarty_cache` should still be empty.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
