### PR TITLE
Limit min date and max date of the movements page

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters.vue
@@ -155,6 +155,7 @@
   import PSSelect from '@app/widgets/ps-select.vue';
   import PSDatePicker from '@app/widgets/ps-datepicker.vue';
   import PSRadio from '@app/widgets/ps-radio.vue';
+  import {Moment} from 'moment';
   import FilterComponent, {FilterComponentInstanceType} from './filters/filter-component.vue';
 
   export interface StockCategory {
@@ -172,6 +173,10 @@
     [key:string]: number;
   }
 
+  type DatepickerEvent ={dateType: string, date: Moment, oldDate: Moment}
+
+  // sup is the starting date while inf is the end date
+  // Cf: src/PrestaShopBundle/Api/QueryParamsCollection::appendSqlDateAddFilter
   const DATE_TYPE_SUP = 'sup';
   const DATE_TYPE_INF = 'inf';
 
@@ -245,18 +250,18 @@
         }
         this.applyFilter();
       },
-      onDpChange(event: any) {
+      onDpChange(event: DatepickerEvent) {
         if (event.dateType === DATE_TYPE_SUP) {
           event.date.minutes(0).hours(0).seconds(1);
+          $(`.datepicker-${DATE_TYPE_INF}`).data('DateTimePicker').minDate(event.date);
         } else if (event.dateType === DATE_TYPE_INF) {
           event.date.minutes(59).hours(23).seconds(59);
+          $(`.datepicker-${DATE_TYPE_SUP}`).data('DateTimePicker').maxDate(event.date);
         }
 
-        this.date_add[<string>event.dateType] = <number>event.date.unix();
+        this.date_add[event.dateType] = event.date.unix();
 
-        if (event.oldDate) {
-          this.applyFilter();
-        }
+        this.applyFilter();
       },
       onRadioChange(value: any): void {
         this.active = value;

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/header/filters.vue
@@ -173,7 +173,11 @@
     [key:string]: number;
   }
 
-  type DatepickerEvent ={dateType: string, date: Moment, oldDate: Moment}
+  type DatepickerEvent = {
+    dateType: string;
+    date: Moment;
+    oldDate: Moment;
+  }
 
   // sup is the starting date while inf is the end date
   // Cf: src/PrestaShopBundle/Api/QueryParamsCollection::appendSqlDateAddFilter

--- a/admin-dev/themes/new-theme/js/app/widgets/ps-datepicker.vue
+++ b/admin-dev/themes/new-theme/js/app/widgets/ps-datepicker.vue
@@ -27,7 +27,7 @@
     <input
       ref="datepicker"
       type="text"
-      class="form-control"
+      :class="['form-control', `datepicker-${type}`]"
     >
     <div class="input-group-append">
       <span class="input-group-text">
@@ -56,6 +56,7 @@
       $(<HTMLInputElement> this.$refs.datepicker).datetimepicker({
         format: 'YYYY-MM-DD',
         showClear: true,
+        useCurrent: false,
       }).on('dp.change', (infos: Record<string, any>) => {
         infos.dateType = this.type;
         this.$emit(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If one of the dates on the movements page is set, the other should be limited in order to avoid wrong filters
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29151.
| How to test?      | See issue
| Possible impacts? | Movements page


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
