### PR TITLE
Fixed product_customization_id value lost after combination change

### DIFF
--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -228,7 +228,7 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
-        if (eventType !== 'updatedProductCombination') {
+        if (!eventType) { //Only when product is added to cart (eventType undefined)
           $(prestashop.selectors.product.inputCustomization).val(0);
         }
         $(prestashop.selectors.product.variantsUpdate)

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -228,7 +228,7 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
-        if (!eventType) { //Only when product is added to cart (eventType undefined)
+        if (eventType!=='updatedProductQuantity' && eventType!=='updatedProductCombination') { //Only when product is added to cart
           $(prestashop.selectors.product.inputCustomization).val(0);
         }
         $(prestashop.selectors.product.variantsUpdate)

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -228,9 +228,9 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
-		if (eventType !== 'updatedProductCombination') {
+        if (eventType !== 'updatedProductCombination') {
           $(prestashop.selectors.product.inputCustomization).val(0);
-		}
+        }
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -228,7 +228,6 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
-        $(prestashop.selectors.product.inputCustomization).val(0);
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -228,6 +228,9 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
+		if (eventType !== 'updatedProductCombination') {
+          $(prestashop.selectors.product.inputCustomization).val(0);
+		}
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We have found a issue with customization after a combination change that mixes combinations between product orders in cart.
| How to find the bug:      | Described bellow.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #29185 
| Related PRs       | No
| How to test?      |  Delete the line in this pull request and, rebuild the webpack and products will behave as expected.
| Possible impacts? | I do not know why this line is there, but if the server doesn't response with the customization ID, we shouldn't change it, specially for a hardcoded "0".

**How to find the bug:** 
Create a customizable product and add some combinations (we used sample "Customizable mug" product, and added some size combinations). Product should look like this:
![image](https://user-images.githubusercontent.com/50045374/181243297-c8a3987c-4ea8-4a39-8570-fda75bb1c74e.png)
First, add a product customization (write some text and click "save customization") and then change the combination (order is the key).
![image](https://user-images.githubusercontent.com/50045374/181248736-b44e1cef-8bf0-4c13-8156-5b2b338a0aa5.png)

If you inspect the input id="product_customization_id" you will see that value after the combination selection has changed to "0", but customization is still shown to the user in the form above. If you refresh the page, product_customization_id value will be back to normal. But it is not only that, we can manage to do some weird stuff:

Let's start again: Access the product page, add some customization, change the combination and add the product to cart. Everything should look fine. Then repeat the process again. Add to the cart the same product with other customization and size (remember, first we have to select the customization and **then change the combination**.).

Now the cart looks weird. We have two mugs but with two customizations each:

![image](https://user-images.githubusercontent.com/50045374/181244635-2dc5f660-f27f-4fe7-abd9-c8d3b64efecb.png)

If we try to delete one mug from the cart, we see that customizations dissapear, or even we can't remove one mug (at least in the interface, if we refresh the page, the cart is empty). This way we can manage to buy a customizable mug that has a mandatory customization without it.

![image](https://user-images.githubusercontent.com/50045374/181246225-69fd13d9-cd45-4e35-9471-148b818a2c5b.png)
