### PR TITLE
Fix menu display for legacy pages

### DIFF
--- a/admin-dev/themes/default/scss/partials/_nav.scss
+++ b/admin-dev/themes/default/scss/partials/_nav.scss
@@ -365,10 +365,6 @@
         color: #fff;
         background: $gray-dark-active-menu;
         transition: background 300ms ease;
-
-        @include media-breakpoint-down(md) {
-          background: $gray-dark-menu;
-        }
       }
 
       &.has_submenu {
@@ -396,7 +392,6 @@
           a.link {
             padding-top: 0.5rem;
             padding-bottom: 0.5rem;
-            color: $gray-dark-secondary-link;
 
             &:hover {
               color: #fff;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Menu item aren't well displayed for mobile/tablet display on legacy pages.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28863 .
| Related PRs       |
| How to test?      | Cf. #28863 :point_up: the bug happens only under mobile/tablet screen size. 
| Possible impacts? | /
