### PR TITLE
Fix product state multishop

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -1881,7 +1881,10 @@ class AdminProductsControllerCore extends AdminController
                 $object->indexed = 0;
 
                 if (Shop::isFeatureActive() && Shop::getContext() != Shop::CONTEXT_SHOP) {
-                    $object->setFieldsToUpdate((array) Tools::getValue('multishop_check', []));
+                    $values = (array) Tools::getValue('multishop_check', []);
+                    $values['state'] = Product::STATE_SAVED;
+
+                    $object->setFieldsToUpdate($values);
                 }
 
                 // Duplicate combinations if not associated to shop


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x 
| Description?      | Bug happened after  @jolelievre the bug happened following [ @jolelievre fix](https://github.com/Anhjean/prestashop/commit/66a6843bfca2d056896858c5b11a91c85eb16b7f#diff-f34cade537421fbb780ea5cb4c4787b35ad5fece4e1bb01c32bc4ecff93535aeR422) where  `state` was saved despite not being present in the fieldsToUpdate list.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27599
