### PR TITLE
Draft - Fix new product name error message

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -219,13 +219,13 @@ class ProductInformation extends CommonAbstractType
                             'pattern' => '/[<>;=#{}]/',
                             'match' => false,
                         ]),
-                        new Assert\NotBlank(),
                         new Assert\Length(['min' => 3, 'max' => 128]),
                     ],
                     'attr' => [
                         'placeholder' => $this->translator->trans('Enter your product name', [], 'Admin.Catalog.Help'),
                         'class' => 'edit js-edit serp-default-title',
                     ],
+                    'default_empty_data' => ' ', // This is made to ensure no blank value given ( Assert\Length won't be applied if empty field )
                 ],
                 'locales' => $this->locales,
                 'hideTabs' => true,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fix some weird product creation error message
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29163.
| Related PRs       | #28877
| How to test?      | Create a new product with blank name. Cf. #29163 
| Possible impacts? | This may impact product creation.

:warning: This fix is only about error message consistency across blank / minimum size constraints for name.

Cf. https://github.com/PrestaShop/PrestaShop/issues/29163#issuecomment-1198348630

The other part should be fixed with #28877.