### PR TITLE
fix(address): makes address id available in actionAfterUpdateCustomer…

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -439,6 +439,7 @@ class AddressController extends FrameworkBundleAdminController
             // Address type required for EditOrderAddressCommand
             $formData = [
                 'address_type' => $addressType,
+                'id_address'   => $addressId,
             ];
             // Country needs to be preset before building form type because it is used to build state field choices
             if ($request->request->has('customer_address') && isset($request->request->get('customer_address')['id_country'])) {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -439,7 +439,7 @@ class AddressController extends FrameworkBundleAdminController
             // Address type required for EditOrderAddressCommand
             $formData = [
                 'address_type' => $addressType,
-                'id_address'   => $addressId,
+                'id_address' => $addressId,
             ];
             // Country needs to be preset before building form type because it is used to build state field choices
             if ($request->request->has('customer_address') && isset($request->request->get('customer_address')['id_country'])) {


### PR DESCRIPTION
…AddressFormHandler hook.

As the "Form is handled based on Order ID because that's the order that needs update", the actionAfterUpdateCustomerAddressFormHandler does not have the address ID available in actionAfterUpdateCustomerAddressFormHandler hook when editing an address from the Order Detail pop-in. In order to provide the needed ID, I added the id_address inside the form_data array.

@see: https://github.com/PrestaShop/PrestaShop/issues/26878


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | As the "Form is handled based on Order ID because that's the order that needs update", the actionAfterUpdateCustomerAddressFormHandler does not have the address ID available in actionAfterUpdateCustomerAddressFormHandler hook when editing an address from the Order Detail pop-in. In order to provide the needed ID, I added the id_address inside the form_data array.
| Type?             | bug fix / improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26878.
| How to test?      | Register a module with the actionAfterUpdateCustomerAddressFormHandler hook, edit an existing order and update the delivery or invoice address, in the $param['form_data'], a new `id_address` field is available with the edited Address ID.
| Possible impacts? | the module developers no longer has to instantiate the order and evaluate the addressType to retrieve by themselves the edited address with the order->id_address_delivery or id_address_invoice.

