### PR TITLE
Fix subcategories for multishop

### DIFF
--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
+use PrestaShopBundle\Utils\Tree;
 
 class AdminShopControllerCore extends AdminController
 {
@@ -217,30 +218,26 @@ class AdminShopControllerCore extends AdminController
     public function displayAjaxGetCategoriesFromRootCategory()
     {
         if (Tools::isSubmit('id_category')) {
-            // Array responsible of selected categories storage.
-            // To make this array construction easier, we use [ (int) 'category_id' => (int) 'category_id'] format.
-            $selected_categories = [];
-
-            // This recursive anonymous function is in charge of building categories tree.
-            $add_children_categories = function (int $category_id) use (&$selected_categories, &$add_children_categories): void {
-                $children = Category::getChildren($category_id, $this->context->language->id);
-                foreach ($children as $child) {
-                    $child_id = (int) $child['id_category'];
-                    // Test made to ensure avoiding unecessary recursive call
-                    if (!isset($selected_categories[$child_id])) {
-                        $selected_categories[$child_id] = $child_id;
-                        $add_children_categories($child_id);
-                    }
-                }
+            $getId = function ($category) {
+                return (int) $category['id_category'];
             };
 
-            $root_category_id = (int) Tools::getValue('id_category');
-            $selected_categories[$root_category_id] = $root_category_id;
+            $languageId = $this->context->language->id;
+            $getChildren = function (array $category) use ($languageId, $getId) {
+                return Category::getChildren($getId($category), $languageId);
+            };
 
-            $add_children_categories($root_category_id);
+            // selected categories ids.
+            $selectedCategories = Tree::extractChildrenId(
+                [
+                    ['id_category' => (int) Tools::getValue('id_category')],
+                ],
+                $getChildren,
+                $getId
+            );
 
             $helper = new HelperTreeCategories('categories-tree', null, (int) Tools::getValue('id_category'), null, false);
-            $this->content = $helper->setSelectedCategories($selected_categories)->setUseSearch(true)->setUseCheckBox(true)
+            $this->content = $helper->setSelectedCategories($selectedCategories)->setUseSearch(true)->setUseCheckBox(true)
                 ->render();
         }
         parent::displayAjax();

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -217,14 +217,30 @@ class AdminShopControllerCore extends AdminController
     public function displayAjaxGetCategoriesFromRootCategory()
     {
         if (Tools::isSubmit('id_category')) {
-            $selected_cat = [(int) Tools::getValue('id_category')];
-            $children = Category::getChildren((int) Tools::getValue('id_category'), $this->context->language->id);
-            foreach ($children as $child) {
-                $selected_cat[] = $child['id_category'];
-            }
+            // Array responsible of selected categories storage.
+            // To make this array construction easier, we use [ (int) 'category_id' => (int) 'category_id'] format.
+            $selected_categories = [];
+
+            // This recursive anonymous function is in charge of building categories tree.
+            $add_children_categories = function (int $category_id) use (&$selected_categories, &$add_children_categories): void {
+                $children = Category::getChildren($category_id, $this->context->language->id);
+                foreach ($children as $child) {
+                    $child_id = (int) $child['id_category'];
+                    // Test made to ensure avoiding unecessary recursive call
+                    if (!isset($selected_categories[$child_id])) {
+                        $selected_categories[$child_id] = $child_id;
+                        $add_children_categories($child_id);
+                    }
+                }
+            };
+
+            $root_category_id = (int) Tools::getValue('id_category');
+            $selected_categories[$root_category_id] = $root_category_id;
+
+            $add_children_categories($root_category_id);
 
             $helper = new HelperTreeCategories('categories-tree', null, (int) Tools::getValue('id_category'), null, false);
-            $this->content = $helper->setSelectedCategories($selected_cat)->setUseSearch(true)->setUseCheckBox(true)
+            $this->content = $helper->setSelectedCategories($selected_categories)->setUseSearch(true)->setUseCheckBox(true)
                 ->render();
         }
         parent::displayAjax();

--- a/src/PrestaShopBundle/Utils/Tree.php
+++ b/src/PrestaShopBundle/Utils/Tree.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Utils;
+
+class Tree
+{
+    /**
+     * @param array $elementlist
+     * @param callable $getChildren; must return an array of children for the given element; signature function($element): array
+     * @param callable $getId; must return the id of the given element; signature function($element): int
+     * @param array $idStorage; store found ids (ensure recursion optimisation and avoiding infinite loop)
+     *
+     * @return array [ (int) 'id' => (int) 'id'] (make array construction easier)
+     */
+    public static function extractChildrenId(array $elementlist, callable $getChildren, callable $getId, array &$idStorage = []): array
+    {
+        foreach ($elementlist as $child) {
+            $childId = $getId($child);
+            // Test made to ensure avoiding unecessary recursive call
+            if (!isset($idStorage[$childId])) {
+                $idStorage[$childId] = $childId;
+                static::extractChildrenId($getChildren($child), $getChildren, $getId, $idStorage);
+            }
+        }
+
+        return $idStorage;
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Utils/TreeTest.php
+++ b/tests/Unit/PrestaShopBundle/Utils/TreeTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Utils;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Utils\Tree;
+
+class TreeTest extends TestCase
+{
+    public function testItListsChildrenIds(): void
+    {
+        $tree = [
+            [
+                'element_id' => 1,
+                'children' => [
+                    [
+                        'element_id' => 2,
+                        'children' => [
+                            [
+                                'element_id' => '4',
+                                'children' => [],
+                            ],
+                            [
+                                'element_id' => 6,
+                                'children' => [],
+                            ],
+                            [
+                                'element_id' => 7,
+                            ],
+                        ],
+                    ],
+                    [
+                        'element_id' => 10,
+                        'children' => [
+                            [
+                                'element_id' => 12,
+                                'children' => [],
+                            ],
+                            [
+                                'element_id' => 13,
+                                'children' => [],
+                            ],
+                        ],
+                    ],
+                    [
+                        'element_id' => 15,
+                        'children' => [
+                            [
+                                'element_id' => 13,
+                                'children' => [],
+                            ],
+                            [
+                                'element_id' => 20,
+                                'children' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $idList = [
+            1 => 1,
+            2 => 2,
+            4 => 4,
+            6 => 6,
+            7 => 7,
+            10 => 10,
+            12 => 12,
+            13 => 13,
+            15 => 15,
+            20 => 20,
+        ];
+
+        $getChildren = function (array $element) {
+            return isset($element['children']) ? $element['children'] : [];
+        };
+
+        $getId = function ($element) {
+            return (int) $element['element_id'];
+        };
+
+        $this->assertSame($idList, Tree::extractChildrenId($tree, $getChildren, $getId));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | In shop configuration for multishop, categories tree was broken which induced some weird behavior when creating / editing a shop.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Closes #29159
| Related PRs       | Na.
| How to test?      | Cf. #29159 :point_up: Please notice that "color" edition isn't important. The problem is that subcategories are not properly checked in creation/edition form. 
| Possible impacts? | Shop creation/edition for multishop.
