### PR TITLE
 Do not reset customization in FO when changing combination

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -487,6 +487,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_minimal_quantity' => $minimalProductQuantity,
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
+            'id_customization' => $product['id_customization'],
             'product_title' => $this->getProductPageTitle(
                 $this->getTemplateVarPage()['meta'] ?? []
             ),

--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -226,7 +226,8 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
                 'unit_price' => $product['product_price'],
                 'total_price_formatted' => $this->locale->formatPrice($product['product_total'], $currency->iso_code),
                 'unit_price_formatted' => $this->locale->formatPrice($product['product_price'], $currency->iso_code),
-                'image' => $this->imageManager->getThumbnailForListing($image['id_image']),
+                // it is possible that there is no image for product, so we don't show anything, but at least avoid breaking whole page
+                'image' => isset($image['id_image']) ? $this->imageManager->getThumbnailForListing($image['id_image']) : '',
             ];
 
             if (isset($product['customizationQuantityTotal'])) {

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -229,8 +229,8 @@ function updateProduct(event, eventType, updateUrl) {
           .first()
           .replaceWith(data.product_customization);
 
-        // refill customizationId input value when updating quantity
-        if (eventType === 'updatedProductQuantity' && data.id_customization) {
+        // refill customizationId input value when updating quantity or combination
+        if (eventType === 'updatedProductQuantity' || eventType === 'updatedProductCombination' && data.id_customization) {
           $(prestashop.selectors.cart.productCustomizationId).val(data.id_customization);
         } else {
           $(prestashop.selectors.product.inputCustomization).val(0);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -228,7 +228,6 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
-        $(prestashop.selectors.product.inputCustomization).val(0);
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -228,6 +228,14 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
+
+        // refill customizationId input value when updating quantity
+        if (eventType === 'updatedProductQuantity' && data.id_customization) {
+          $(prestashop.selectors.cart.productCustomizationId).val(data.id_customization);
+        } else {
+          $(prestashop.selectors.product.inputCustomization).val(0);
+        }
+
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Solves issue https://github.com/PrestaShop/PrestaShop/issues/29185. Altough its a quick solution, some backend validation of id_customization (when customization is required) is still missing
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Resolves #29185, resolves #28041
| Related PRs       | 
| How to test?      | refer to #29185. :warning: Requires recompiling front core assets to take effect (`./tools/assets/build.sh front-core`)
| Possible impacts? | I don't know if reseting customization_id was important, but for example now if you switch combination and don't add another customization data, you will have previous one's values (which seems to be normal to me, but maybe im wrong?)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
