### PR TITLE
Uncheck truncate input if its hidden

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/import/FormFieldToggle.ts
+++ b/admin-dev/themes/new-theme/js/pages/import/FormFieldToggle.ts
@@ -82,6 +82,7 @@ export default class FormFieldToggle {
 
     if (entityStoreContacts === selectedEntity) {
       $truncateFormGroup.hide();
+      $truncateFormGroup.find('input[name="truncate"]').first().trigger('click');
     } else {
       $truncateFormGroup.show();
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the BO > Import page > Enable the option "Delete all categories before import" and then select "Stores contact", there is no option "Delete all stores before import", but when we click on the "Next step" button, the alert Are you sure you want to delete this entity: store contacts?" is displayed
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #22372
| Related PRs       | no
| How to test?      | In the BO > Import page > Enable the option "Delete all categories before import" and then select "Stores contact", click on "Next Step" and check if there is still an Alert
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
