### PR TITLE
Improve PDF templates for RTL

### DIFF
--- a/classes/pdf/HTMLTemplate.php
+++ b/classes/pdf/HTMLTemplate.php
@@ -146,6 +146,10 @@ abstract class HTMLTemplateCore
             $width *= $ratio;
         }
 
+        $lang_is_rtl = Context::getContext()->language->is_rtl;
+        $align_start = ($lang_is_rtl) ? 'right' : 'left';
+        $align_end = ($lang_is_rtl) ? 'left' : 'right';
+
         $this->smarty->assign([
             'logo_path' => Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_ . $logo,
             'img_ps_dir' => Tools::getShopProtocol() . Tools::getMediaServer(_PS_IMG_) . _PS_IMG_,
@@ -156,6 +160,8 @@ abstract class HTMLTemplateCore
             'shop_details' => Configuration::get('PS_SHOP_DETAILS', null, null, (int) $id_shop),
             'width_logo' => $width,
             'height_logo' => $height,
+            'align_start' => $align_start,
+            'align_end' => $align_end,
         ]);
     }
 

--- a/pdf/delivery-slip.payment-tab.tpl
+++ b/pdf/delivery-slip.payment-tab.tpl
@@ -25,12 +25,12 @@
 <table id="payment-tab" width="100%" cellpadding="4" cellspacing="0">
 	<tr>
 		<td class="payment center small grey bold" width="44%">{l s='Payment Method' d='Shop.Pdf' pdf='true'}</td>
-		<td class="payment left white" width="56%">
+		<td class="payment text-start white" width="56%">
 			<table width="100%" border="0">
 				{foreach from=$order_invoice->getOrderPaymentCollection() item=payment}
 					<tr>
-						<td class="right small">{$payment->payment_method}</td>
-						<td class="right small">{displayPrice currency=$payment->id_currency price=$payment->amount}</td>
+						<td class="text-end small">{$payment->payment_method}</td>
+						<td class="text-end small">{displayPrice currency=$payment->id_currency price=$payment->amount}</td>
 					</tr>
 				{foreachelse}
 					<tr>

--- a/pdf/delivery-slip.product-tab.tpl
+++ b/pdf/delivery-slip.product-tab.tpl
@@ -38,14 +38,14 @@
 			{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 			<tr class="product {$bgcolor_class}">
 
-				<td class="product left">
+				<td class="product text-start">
 					{if empty($order_detail.product_reference)}
 						---
 					{else}
 						{$order_detail.product_reference}
 					{/if}
 				</td>
-				<td class="product left">
+				<td class="product text-start">
 					{if $display_product_images}
 						<table width="100%">
 							<tr>

--- a/pdf/delivery-slip.style-tab.tpl
+++ b/pdf/delivery-slip.style-tab.tpl
@@ -107,7 +107,7 @@
 			height: {$height_header};
 			background-color: {$color_header};
 			vertical-align: middle;
-			text-align: right;
+			text-align: {$align_end};
 			font-weight: bold;
 		}
 
@@ -121,16 +121,16 @@
 			border-top: 1px solid #000000;
 		}
 
-		.left {
-			text-align: left;
+		.text-start {
+			text-align: {$align_start};
 		}
 
-		.fright {
-			float: right;
+		.float-end {
+			float: {$align_end};
 		}
 
-		.right {
-			text-align: right;
+		.text-end {
+			text-align: {$align_end};
 		}
 
 		.center {

--- a/pdf/delivery-slip.tpl
+++ b/pdf/delivery-slip.tpl
@@ -66,7 +66,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="7" class="left">
+		<td colspan="7" class="text-start">
 
 			{$payment_tab}
 

--- a/pdf/header.tpl
+++ b/pdf/header.tpl
@@ -31,7 +31,7 @@
 			<img src="{$logo_path}" style="width:{$width_logo}px; height:{$height_logo}px;" />
 		{/if}
 	</td>
-	<td style="width: 50%; text-align: right;">
+	<td style="width: 50%; text-align: {$align_end};">
 		<table style="width: 100%">
 			<tr>
 				<td style="font-weight: bold; font-size: 14pt; color: #444; width: 100%;">{if isset($header)}{$header|escape:'html':'UTF-8'|upper}{/if}</td>

--- a/pdf/invoice-b2b.tpl
+++ b/pdf/invoice-b2b.tpl
@@ -69,14 +69,14 @@
 	<!-- TVA -->
 	<tr>
 		<!-- Code TVA -->
-		<td colspan="6" class="left">
+		<td colspan="6" class="text-start">
 
 			{$tax_tab}
 
 		</td>
 		<td colspan="1">&nbsp;</td>
 		<!-- Calcule TVA -->
-		<td colspan="5" rowspan="5" class="right">
+		<td colspan="5" rowspan="5" class="text-end">
 
 			{$total_tab}
 
@@ -88,7 +88,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="6" class="left">
+		<td colspan="6" class="text-start">
 
 			{$payment_tab}
 
@@ -101,7 +101,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="7" class="left small">
+		<td colspan="7" class="text-start small">
 
 			<table>
 				<tr>

--- a/pdf/invoice.note-tab.tpl
+++ b/pdf/invoice.note-tab.tpl
@@ -28,7 +28,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="6" class="left">
+		<td colspan="6" class="text-start">
 			<table id="note-tab" style="width: 100%">
 				<tr>
 					<td class="grey">{l s='Note' d='Shop.Pdf' pdf='true'}</td>

--- a/pdf/invoice.payment-tab.tpl
+++ b/pdf/invoice.payment-tab.tpl
@@ -25,12 +25,12 @@
 <table id="payment-tab" width="100%">
 	<tr>
 		<td class="payment center small grey bold" width="44%">{l s='Payment Method' d='Shop.Pdf' pdf='true'}</td>
-		<td class="payment left white" width="56%">
+		<td class="payment text-start white" width="56%">
 			<table width="100%" border="0">
 				{foreach from=$order_invoice->getOrderPaymentCollection() item=payment}
 					<tr>
-						<td class="right small">{$payment->payment_method}</td>
-						<td class="right small">{displayPrice currency=$payment->id_currency price=$payment->amount}</td>
+						<td class="text-end small">{$payment->payment_method}</td>
+						<td class="text-end small">{displayPrice currency=$payment->id_currency price=$payment->amount}</td>
 					</tr>
 				{/foreach}
 			</table>

--- a/pdf/invoice.product-tab.tpl
+++ b/pdf/invoice.product-tab.tpl
@@ -61,7 +61,7 @@
       <td class="product center">
         {$order_detail.product_reference}
       </td>
-      <td class="product left">
+      <td class="product text-start">
         {if $display_product_images}
           <table width="100%">
             <tr>
@@ -97,7 +97,7 @@
         </td>
       {/if}
 
-      <td class="product right">
+      <td class="product text-end">
         {displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_excl_including_ecotax}
         {if $order_detail.ecotax_tax_excl > 0}
           <br>
@@ -107,7 +107,7 @@
       <td class="product center">
         {$order_detail.product_quantity}
       </td>
-      <td  class="product right">
+      <td  class="product text-end">
         {displayPrice currency=$order->id_currency price=$order_detail.total_price_tax_excl_including_ecotax}
       </td>
     </tr>
@@ -167,10 +167,10 @@
       </tr>
     {/if}
     <tr class="discount">
-      <td class="white right" colspan="{$layout._colCount - 1}">
+      <td class="white text-end" colspan="{$layout._colCount - 1}">
         {$cart_rule.name}
       </td>
-      <td class="right white">
+      <td class="text-end white">
         - {displayPrice currency=$order->id_currency price=$cart_rule.value_tax_excl}
       </td>
     </tr>

--- a/pdf/invoice.style-tab.tpl
+++ b/pdf/invoice.style-tab.tpl
@@ -122,7 +122,7 @@
 			height: {$height_header};
 			background-color: {$color_header};
 			vertical-align: middle;
-			text-align: right;
+			text-align: {$align_end};
 			font-weight: bold;
 		}
 
@@ -143,16 +143,16 @@
 			border-top: 1px solid #000000;
 		}
 
-		.left {
-			text-align: left;
+		.text-start {
+			text-align: {$align_start};
 		}
 
-		.fright {
-			float: right;
+		.float-end {
+			float: {$align_end};
 		}
 
-		.right {
-			text-align: right;
+		.text-end {
+			text-align: {$align_end};
 		}
 
 		.center {

--- a/pdf/invoice.tax-tab.tpl
+++ b/pdf/invoice.tax-tab.tpl
@@ -76,13 +76,13 @@
             </td>
 
             {if $display_tax_bases_in_breakdowns}
-              <td class="right white">
+              <td class="text-end white">
                 {if isset($is_order_slip) && $is_order_slip}- {/if}
                 {displayPrice currency=$order->id_currency price=$line.total_tax_excl}
               </td>
             {/if}
 
-            <td class="right white">
+            <td class="text-end white">
               {if isset($is_order_slip) && $is_order_slip}- {/if}
               {displayPrice currency=$order->id_currency price=$line.total_amount}
             </td>

--- a/pdf/invoice.total-tab.tpl
+++ b/pdf/invoice.total-tab.tpl
@@ -28,7 +28,7 @@
     <td class="grey" width="50%">
       {l s='Total Products' d='Shop.Pdf' pdf='true'}
     </td>
-    <td class="white" width="50%">
+    <td class="white" style="text-align: right !important;" width="50%">
       {displayPrice currency=$order->id_currency price=$footer.products_before_discounts_tax_excl}
     </td>
   </tr>
@@ -39,7 +39,7 @@
       <td class="grey" width="50%">
         {l s='Total Discounts' d='Shop.Pdf' pdf='true'}
       </td>
-      <td class="white" width="50%">
+      <td class="white" style="text-align: right !important;" width="50%">
         - {displayPrice currency=$order->id_currency price=$footer.product_discounts_tax_excl}
       </td>
     </tr>
@@ -50,7 +50,7 @@
     <td class="grey" width="50%">
       {l s='Shipping Costs' d='Shop.Pdf' pdf='true'}
     </td>
-    <td class="white" width="50%">
+    <td class="white" style="text-align: right !important;" width="50%">
       {if $footer.shipping_tax_excl > 0}
         {displayPrice currency=$order->id_currency price=$footer.shipping_tax_excl}
       {else}
@@ -65,7 +65,7 @@
       <td class="grey">
         {l s='Wrapping Costs' d='Shop.Pdf' pdf='true'}
       </td>
-      <td class="white">{displayPrice currency=$order->id_currency price=$footer.wrapping_tax_excl}</td>
+      <td class="white" style="text-align: right !important;">{displayPrice currency=$order->id_currency price=$footer.wrapping_tax_excl}</td>
     </tr>
   {/if}
 
@@ -77,7 +77,7 @@
         {l s='Total' d='Shop.Pdf' pdf='true'}
       {/if}
     </td>
-    <td class="white">
+    <td class="white" style="text-align: right !important;">
       {displayPrice currency=$order->id_currency price=$footer.total_paid_tax_excl}
     </td>
   </tr>
@@ -87,7 +87,7 @@
         <td class="grey">
           {l s='Total Tax' d='Shop.Pdf' pdf='true'}
         </td>
-        <td class="white">
+        <td class="white" style="text-align: right !important;">
           {displayPrice currency=$order->id_currency price=$footer.total_taxes}
         </td>
       </tr>
@@ -96,7 +96,7 @@
       <td class="grey">
         {l s='Total' d='Shop.Pdf' pdf='true'}
       </td>
-      <td class="white">
+      <td class="white" style="text-align: right !important;">
         {displayPrice currency=$order->id_currency price=$footer.total_paid_tax_incl}
       </td>
     </tr>

--- a/pdf/invoice.tpl
+++ b/pdf/invoice.tpl
@@ -69,14 +69,14 @@
 	<!-- TVA -->
 	<tr>
 		<!-- Code TVA -->
-		<td colspan="6" class="left">
+		<td colspan="6" class="text-start">
 
 			{$tax_tab}
 
 		</td>
 		<td colspan="1">&nbsp;</td>
 		<!-- Calcule TVA -->
-		<td colspan="5" rowspan="5" class="right">
+		<td colspan="5" rowspan="5" class="text-end">
 
 			{$total_tab}
 
@@ -90,7 +90,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="6" class="left">
+		<td colspan="6" class="text-start">
 
 			{$payment_tab}
 
@@ -99,7 +99,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="6" class="left">
+		<td colspan="6" class="text-start">
 
 			{$shipping_tab}
 
@@ -112,7 +112,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="7" class="left small">
+		<td colspan="7" class="text-start small">
 
 			<table>
 				<tr>

--- a/pdf/order-return.conditions-tab.tpl
+++ b/pdf/order-return.conditions-tab.tpl
@@ -24,17 +24,17 @@
  *}
 <table class="product" width="100%" cellpadding="4" cellspacing="0">
 	<tr>
-		<th class="header small left" valign="middle">{l s='If the following conditions are not met, we reserve the right to refuse your package and/or refund:' d='Shop.Pdf' pdf='true'}</th>
+		<th class="header small text-start" valign="middle">{l s='If the following conditions are not met, we reserve the right to refuse your package and/or refund:' d='Shop.Pdf' pdf='true'}</th>
 	</tr>
 	<tr>
 		<td class="center small white">
-			<ul class="left">
+			<ul class="text-start">
 				<li>{l s='Please include this return reference on your return package:' d='Shop.Pdf' pdf='true'} {$order_return->id}</li>
 				<li>{l s='All products must be returned in their original package and condition, unused and without damage.' d='Shop.Pdf' pdf='true'}</li>
 				<li>{l s='Please print out this document and slip it into your package.' d='Shop.Pdf' pdf='true'}</li>
 				<li>{l s='The package should be sent to the following address:' d='Shop.Pdf' pdf='true'}</li>
 			</ul>
-			<span style="margin-left: 20px;">{$shop_address}</span>
+			<span style="margin-{$align_start}: 20px;">{$shop_address}</span>
 		</td>
 	</tr>
 </table>

--- a/pdf/order-return.product-tab.tpl
+++ b/pdf/order-return.product-tab.tpl
@@ -37,10 +37,10 @@
 		{foreach $products as $product}
 			{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 			<tr class="product {$bgcolor_class}">
-				<td class="product left">
+				<td class="product text-start">
 					{$product.product_name}
 				</td>
-				<td class="product left">
+				<td class="product text-start">
 					{if empty($product.product_reference)}
 						---
 					{else}

--- a/pdf/order-slip.payment-tab.tpl
+++ b/pdf/order-slip.payment-tab.tpl
@@ -25,7 +25,7 @@
 <table id="payment-tab" width="100%">
 	<tr>
 		<td class="payment center small grey bold" width="44%">{l s='Payment Method' d='Shop.Pdf' pdf='true'}</td>
-		<td class="payment left white" width="56%">
+		<td class="payment text-start white" width="56%">
 			{$order->payment}
 		</td>
 	</tr>

--- a/pdf/order-slip.product-tab.tpl
+++ b/pdf/order-slip.product-tab.tpl
@@ -45,20 +45,20 @@
 			{foreach $order_details as $order_detail}
 				{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 				<tr class="product {$bgcolor_class}">
-					<td class="product left">
+					<td class="product text-start">
 						{$order_detail.product_name}
 					</td>
 					<td class="product center">
 						{$order_detail.product_quantity}
 					</td>
-					<td class="product right">
+					<td class="product text-end">
 						{if $tax_excluded_display}
 							- {displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_excl}
 						{else}
 							- {displayPrice currency=$order->id_currency price=$order_detail.unit_price_tax_incl}
 						{/if}
 					</td>
-					<td class="product right">
+					<td class="product text-end">
 						{if $tax_excluded_display}
 							- {displayPrice currency=$order->id_currency price=$order_detail.total_price_tax_excl}
 						{else}
@@ -100,8 +100,8 @@
 		{if is_array($cart_rules) && count($cart_rules)}
 			{foreach $cart_rules as $cart_rule}
 				<tr class="discount">
-					<td class="white left" colspan="3">{$cart_rule.name}</td>
-					<td class="white right">
+					<td class="white text-start" colspan="3">{$cart_rule.name}</td>
+					<td class="white text-end">
 						{if $tax_excluded_display}
 							+ {$cart_rule.value_tax_excl}
 						{else}

--- a/pdf/order-slip.total-tab.tpl
+++ b/pdf/order-slip.total-tab.tpl
@@ -31,7 +31,7 @@
 			{else}
 				<td class="grey" width="70%">{l s='Shipping (Tax Incl.)' d='Shop.Pdf' pdf='true'}</td>
 			{/if}
-			<td class="white" width="30%">
+			<td class="white" style="text-align: right !important;" width="30%">
 				- {displayPrice currency=$order->id_currency price=$order_slip->shipping_cost_amount}
 			</td>
 		</tr>
@@ -44,7 +44,7 @@
 					<td class="grey" width="70%">
 						{l s='Product Total (Tax Excl.)' d='Shop.Pdf' pdf='true'}
 					</td>
-					<td class="white" width="30%">
+					<td class="white" style="text-align: right !important;" width="30%">
 						- {displayPrice currency=$order->id_currency price=$order->total_products}
 					</td>
 				</tr>
@@ -53,7 +53,7 @@
 					<td class="grey" width="70%">
 						{l s='Product Total (Tax Incl.)' d='Shop.Pdf' pdf='true'}
 					</td>
-					<td class="white" width="30%">
+					<td class="white" style="text-align: right !important;" width="30%">
 						- {displayPrice currency=$order->id_currency price=$order->total_products_wt}
 					</td>
 				</tr>
@@ -63,7 +63,7 @@
 				<td class="grey" width="70%">
 					{l s='Product Total' d='Shop.Pdf' pdf='true'}
 				</td>
-				<td class="white" width="30%">
+				<td class="white" style="text-align: right !important;" width="30%">
 					- {displayPrice currency=$order->id_currency price=$order->total_products}
 				</td>
 			</tr>
@@ -75,7 +75,7 @@
 			<td class="grey" width="70%">
 				{l s='Total Tax' d='Shop.Pdf' pdf='true'}
 			</td>
-			<td class="white" width="30%">
+			<td class="white" style="text-align: right !important;" width="30%">
 				- {displayPrice currency=$order->id_currency price=($order->total_paid_tax_incl - $order->total_paid_tax_excl)}
 			</td>
 		</tr>
@@ -86,7 +86,7 @@
       <td class="grey" width="70%">
         {l s='Total (Tax Excl.)' d='Shop.Pdf' pdf='true'}
       </td>
-      <td class="white" width="30%">
+      <td class="white" style="text-align: right !important;" width="30%">
         {if $total_cart_rule}
           {assign var=total_paid value=0}
           {$total_paid = $order->total_paid_tax_excl - $total_cart_rule}

--- a/pdf/order-slip.tpl
+++ b/pdf/order-slip.tpl
@@ -69,14 +69,14 @@
 	<!-- TVA -->
 	<tr>
 		<!-- Code TVA -->
-		<td colspan="6" class="left">
+		<td colspan="6" class="text-start">
 
 			{$tax_tab}
 
 		</td>
 		<td colspan="1">&nbsp;</td>
 		<!-- Calcule TVA -->
-		<td colspan="5" rowspan="5" class="right">
+		<td colspan="5" rowspan="5" class="text-end">
 
 			{$total_tab}
 
@@ -88,7 +88,7 @@
 	</tr>
 
 	<tr>
-		<td colspan="6" class="left">
+		<td colspan="6" class="text-start">
 
 			{$payment_tab}
 

--- a/pdf/pagination.tpl
+++ b/pdf/pagination.tpl
@@ -22,4 +22,4 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
-<p style="text-align: right; vertical-align: text-top;">{literal} {:png:} / {:ptg:} {/literal}</p>
+<p style="text-align: {$align_end}; vertical-align: text-top;">{literal} {:png:} / {:ptg:} {/literal}</p>

--- a/pdf/supply-order-footer.tpl
+++ b/pdf/supply-order-footer.tpl
@@ -24,7 +24,7 @@
  *}
 <table style="width: 100%;">
 	<tr>
-		<td style="text-align: left; font-size: 6pt; color: #444; width:87%;">
+		<td style="text-align: {$align_start}; font-size: 6pt; color: #444; width:87%;">
 			{$shop_address|escape:'html':'UTF-8'}<br />
 
 			{if !empty($shop_phone) OR !empty($shop_fax)}
@@ -49,7 +49,7 @@
 				{/foreach}
 			{/if}
 		</td>
-		<td style="text-align: right; font-size: 8pt; color: #444;  width:13%;">
+		<td style="text-align: {$align_end}; font-size: 8pt; color: #444;  width:13%;">
             {literal}{:pnp:} / {:ptp:}{/literal}
         </td>
 	</tr>

--- a/pdf/supply-order-header.tpl
+++ b/pdf/supply-order-header.tpl
@@ -33,7 +33,7 @@
 			<img src="{$logo_path}" />
 		{/if}
 	</td>
-	<td style="width: 50%; text-align: right;">
+	<td style="width: 50%; text-align: {$align_end};">
 		<table style="width: 100%">
 			<tr>
 				<td style="font-weight: bold; font-size: 13pt; color: #444; width: 100%">{$shop_name|escape:'html':'UTF-8'}</td>

--- a/pdf/supply-order.product-tab.tpl
+++ b/pdf/supply-order.product-tab.tpl
@@ -45,31 +45,31 @@
 	{foreach $supply_order_details as $supply_order_detail}
 		{cycle values=["color_line_even", "color_line_odd"] assign=bgcolor_class}
 		<tr class="product {$bgcolor_class}">
-			<td class="product left">
+			<td class="product text-start">
 				{$supply_order_detail->supplier_reference}
 			</td>
-			<td class="product left">
+			<td class="product text-start">
 				{$supply_order_detail->name}
 			</td>
-			<td  class="product right">
+			<td  class="product text-end">
 				{$supply_order_detail->quantity_expected}
 			</td>
-			<td  class="product right">
+			<td  class="product text-end">
 				{$currency->prefix} {$supply_order_detail->unit_price_te} {$currency->suffix}
 			</td>
-			<td  class="product right">
+			<td  class="product text-end">
 				{$currency->prefix} {$supply_order_detail->price_te} {$currency->suffix}
 			</td>
-			<td  class="product right">
+			<td  class="product text-end">
 				{$supply_order_detail->discount_rate}
 			</td>
-			<td  class="product right">
+			<td  class="product text-end">
 				{$currency->prefix} {$supply_order_detail->price_with_discount_te} {$currency->suffix}
 			</td>
-			<td  class="product right">
+			<td  class="product text-end">
 				{$supply_order_detail->tax_rate}
 			</td>
-			<td  class="product right">
+			<td  class="product text-end">
 				{$currency->prefix} {$supply_order_detail->price_ti} {$currency->suffix}
 			</td>
 		</tr>

--- a/pdf/supply-order.tax-tab.tpl
+++ b/pdf/supply-order.tax-tab.tpl
@@ -38,9 +38,9 @@
 		{foreach $tax_order_summary as $entry}
 			{assign var=has_line value=true}
 			<tr>
-				<td class="right white">{$currency->prefix} {$entry['base_te']} {$currency->suffix}</td>
-				<td class="right white">{$entry['tax_rate']}</td>
-				<td class="right white">{$currency->prefix} {$entry['total_tax_value']} {$currency->suffix}</td>
+				<td class="text-end white">{$currency->prefix} {$entry['base_te']} {$currency->suffix}</td>
+				<td class="text-end white">{$entry['tax_rate']}</td>
+				<td class="text-end white">{$currency->prefix} {$entry['total_tax_value']} {$currency->suffix}</td>
 			</tr>
 		{/foreach}
 

--- a/pdf/supply-order.total-tab.tpl
+++ b/pdf/supply-order.total-tab.tpl
@@ -28,37 +28,37 @@
 
 	<tr class="bold">
 		<td class="grey" width="70%">{l s='Total TE' d='Shop.Pdf' pdf='true'} <br /> {l s='(Before discount)' d='Shop.Pdf' pdf='true'}</td>
-		<td class="white" width="30%">
+		<td class="white" style="text-align: right !important;" width="30%">
 			{$currency->prefix} {$supply_order->total_te} {$currency->suffix}
 		</td>
 	</tr>
 	<tr class="bold">
 		<td class="grey" width="70%">{l s='Order Discount' d='Shop.Pdf' pdf='true'}</td>
-		<td class="white" width="30%">
+		<td class="white" style="text-align: right !important;" width="30%">
 			{$currency->prefix} {$supply_order->discount_value_te} {$currency->suffix}
 		</td>
 	</tr>
 	<tr class="bold">
 		<td class="grey" width="70%">{l s='Total TE' d='Shop.Pdf' pdf='true'} <br /> {l s='(After discount)' d='Shop.Pdf' pdf='true'}</td>
-		<td class="white" width="30%">
+		<td class="white" style="text-align: right !important;" width="30%">
 			{$currency->prefix} {$supply_order->total_with_discount_te} {$currency->suffix}
 		</td>
 	</tr>
 	<tr class="bold">
 		<td class="grey" width="70%">{l s='Tax value' d='Shop.Pdf' pdf='true'}</td>
-		<td class="white" width="30%">
+		<td class="white" style="text-align: right !important;" width="30%">
 			{$currency->prefix} {$supply_order->total_tax} {$currency->suffix}
 		</td>
 	</tr>
 	<tr class="bold">
 		<td class="grey" width="70%">{l s='Total TI' d='Shop.Pdf' pdf='true'}</td>
-		<td class="white" width="30%">
+		<td class="white" style="text-align: right !important;" width="30%">
 			{$currency->prefix} {$supply_order->total_ti} {$currency->suffix}
 		</td>
 	</tr>
 	<tr class="bold">
 		<td class="grey" width="70%">{l s='Total to pay' d='Shop.Pdf' pdf='true'}</td>
-		<td class="white" width="30%">
+		<td class="white" style="text-align: right !important;" width="30%">
 			{$currency->prefix} {$supply_order->total_ti} {$currency->suffix}
 		</td>
 	</tr>

--- a/pdf/supply-order.tpl
+++ b/pdf/supply-order.tpl
@@ -57,7 +57,7 @@
 	<!-- TVA -->
 		<tr>
 		<!-- Code TVA -->
-		<td colspan="6" class="left">
+		<td colspan="6" class="text-start">
 
 			{$tax_tab}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Replace hard-coded CSS alignment properties to the smarty variables. Currently most of them created for LTR only.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Related PRs       | -
| How to test?      | Create PDF report for orders. The PDF report MUST be as same as current report for LTR. The PDF report MUST NOT have any problems for RTL (except logo position).
| Possible impacts? | PDF reports.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
