### PR TITLE
Move Hook displayAdminOrder above the sources view

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -74,6 +74,8 @@
         {{ renderhook('displayAdminOrderMainBottom', {'id_order': orderForViewing.id}) }}
       </div>
     </div>
+    
+    {{ renderhook('displayAdminOrder', {'id_order': orderForViewing.id}) }}
 
     {% if orderForViewing.sources.sources is not empty %}
       <div class="product-row">
@@ -86,8 +88,6 @@
     {% if orderForViewing.linkedOrders.linkedOrders is not empty %}
       {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/linked_orders.html.twig' %}
     {% endif %}
-
-    {{ renderhook('displayAdminOrder', {'id_order': orderForViewing.id}) }}
 
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/add_order_discount_modal.html.twig' %}
     {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/Modal/update_shipping_modal.html.twig' %}


### PR DESCRIPTION
For a better visibility of hooks on the order view.
Modules are under the sources views and users can't move theme above.



| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Move the displayAdminOrder hook above the source view
| Type?             | improvement 
| Category?         |  BO 
| BC breaks?        |   no
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue number here}.
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Add a module who's registred on displayAdminOrder plugin (so nice retour for exemple)
| Possible impacts? | No impacts

