### PR TITLE
Update PHP-CS-Fixer to make it compatible with PHP 8.1

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -44,6 +44,7 @@ return (new PhpCsFixer\Config())
         'protected_to_private' => false,
         'psr_autoloading' => false,
         'self_accessor' => false,
+        'yoda_style' => false,
         'single_line_throw' => false,
         'no_alias_language_construct_call' => false,
     ])

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -42,9 +42,8 @@ return (new PhpCsFixer\Config())
         ],
         'phpdoc_summary' => false,
         'protected_to_private' => false,
-        'psr4' => false,
+        'psr_autoloading' => false,
         'self_accessor' => false,
-        'yoda_style' => null,
         'single_line_throw' => false,
         'no_alias_language_construct_call' => false,
     ])

--- a/classes/AddressChecksumCore.php
+++ b/classes/AddressChecksumCore.php
@@ -29,7 +29,7 @@
  */
 class AddressChecksumCore implements ChecksumInterface
 {
-    const SEPARATOR = '_';
+    public const SEPARATOR = '_';
 
     /**
      * Generate a checksum.

--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -30,7 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressException;
  */
 class AddressFormatCore extends ObjectModel
 {
-    const FORMAT_NEW_LINE = "\n";
+    public const FORMAT_NEW_LINE = "\n";
 
     /** @var int Address format */
     public $id_address_format;
@@ -115,7 +115,7 @@ class AddressFormatCore extends ObjectModel
         'Supplier',
     ];
 
-    const _CLEANING_REGEX_ = '#([^\w:_]+)#i';
+    public const _CLEANING_REGEX_ = '#([^\w:_]+)#i';
 
     /**
      * Check if the the association of the field name and a class name

--- a/classes/Carrier.php
+++ b/classes/Carrier.php
@@ -30,26 +30,26 @@ class CarrierCore extends ObjectModel
     /**
      * getCarriers method filter.
      */
-    const PS_CARRIERS_ONLY = 1;
-    const CARRIERS_MODULE = 2;
-    const CARRIERS_MODULE_NEED_RANGE = 3;
-    const PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE = 4;
-    const ALL_CARRIERS = 5;
+    public const PS_CARRIERS_ONLY = 1;
+    public const CARRIERS_MODULE = 2;
+    public const CARRIERS_MODULE_NEED_RANGE = 3;
+    public const PS_CARRIERS_AND_CARRIER_MODULES_NEED_RANGE = 4;
+    public const ALL_CARRIERS = 5;
 
-    const SHIPPING_METHOD_DEFAULT = 0;
-    const SHIPPING_METHOD_WEIGHT = 1;
-    const SHIPPING_METHOD_PRICE = 2;
-    const SHIPPING_METHOD_FREE = 3;
+    public const SHIPPING_METHOD_DEFAULT = 0;
+    public const SHIPPING_METHOD_WEIGHT = 1;
+    public const SHIPPING_METHOD_PRICE = 2;
+    public const SHIPPING_METHOD_FREE = 3;
 
-    const SHIPPING_PRICE_EXCEPTION = 0;
-    const SHIPPING_WEIGHT_EXCEPTION = 1;
-    const SHIPPING_SIZE_EXCEPTION = 2;
+    public const SHIPPING_PRICE_EXCEPTION = 0;
+    public const SHIPPING_WEIGHT_EXCEPTION = 1;
+    public const SHIPPING_SIZE_EXCEPTION = 2;
 
-    const SORT_BY_PRICE = 0;
-    const SORT_BY_POSITION = 1;
+    public const SORT_BY_PRICE = 0;
+    public const SORT_BY_POSITION = 1;
 
-    const SORT_BY_ASC = 0;
-    const SORT_BY_DESC = 1;
+    public const SORT_BY_ASC = 0;
+    public const SORT_BY_DESC = 1;
 
     /** @var int common id for carrier historization */
     public $id_reference;

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -175,16 +175,16 @@ class CartCore extends ObjectModel
 
     protected $shouldExcludeGiftsDiscount = false;
 
-    const ONLY_PRODUCTS = 1;
-    const ONLY_DISCOUNTS = 2;
-    const BOTH = 3;
-    const BOTH_WITHOUT_SHIPPING = 4;
-    const ONLY_SHIPPING = 5;
-    const ONLY_WRAPPING = 6;
+    public const ONLY_PRODUCTS = 1;
+    public const ONLY_DISCOUNTS = 2;
+    public const BOTH = 3;
+    public const BOTH_WITHOUT_SHIPPING = 4;
+    public const ONLY_SHIPPING = 5;
+    public const ONLY_WRAPPING = 6;
 
     /** @deprecated since 1.7 **/
-    const ONLY_PRODUCTS_WITHOUT_SHIPPING = 7;
-    const ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING = 8;
+    public const ONLY_PRODUCTS_WITHOUT_SHIPPING = 7;
+    public const ONLY_PHYSICAL_PRODUCTS_WITHOUT_SHIPPING = 8;
 
     private const DEFAULT_ATTRIBUTES_KEYS = ['attributes' => '', 'attributes_small' => ''];
 

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -31,12 +31,12 @@ class CartRuleCore extends ObjectModel
 {
     /* Filters used when retrieving the cart rules applied to a cart of when calculating the value of a reduction */
 
-    const FILTER_ACTION_ALL = 1;
-    const FILTER_ACTION_SHIPPING = 2;
-    const FILTER_ACTION_REDUCTION = 3;
-    const FILTER_ACTION_GIFT = 4;
-    const FILTER_ACTION_ALL_NOCAP = 5;
-    const BO_ORDER_CODE_PREFIX = 'BO_ORDER_';
+    public const FILTER_ACTION_ALL = 1;
+    public const FILTER_ACTION_SHIPPING = 2;
+    public const FILTER_ACTION_REDUCTION = 3;
+    public const FILTER_ACTION_GIFT = 4;
+    public const FILTER_ACTION_ALL_NOCAP = 5;
+    public const BO_ORDER_CODE_PREFIX = 'BO_ORDER_';
 
     /**
      * This variable controls that a free gift is offered only once, even when multi-shippping is activated

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -137,25 +137,25 @@ class ContextCore
     protected $is_tablet = null;
 
     /** @var int */
-    const DEVICE_COMPUTER = 1;
+    public const DEVICE_COMPUTER = 1;
 
     /** @var int */
-    const DEVICE_TABLET = 2;
+    public const DEVICE_TABLET = 2;
 
     /** @var int */
-    const DEVICE_MOBILE = 4;
+    public const DEVICE_MOBILE = 4;
 
     /** @var int */
-    const MODE_STD = 1;
+    public const MODE_STD = 1;
 
     /** @var int */
-    const MODE_STD_CONTRIB = 2;
+    public const MODE_STD_CONTRIB = 2;
 
     /** @var int */
-    const MODE_HOST_CONTRIB = 4;
+    public const MODE_HOST_CONTRIB = 4;
 
     /** @var int */
-    const MODE_HOST = 8;
+    public const MODE_HOST = 8;
 
     /**
      * Sets Mobile_Detect tool object.
@@ -464,7 +464,7 @@ class ContextCore
                 $containerFinder = new ContainerFinder($this);
                 $container = $containerFinder->getContainer();
                 $translatorLoader = $container->get('prestashop.translation.translator_language_loader');
-            } catch (ContainerNotFoundException | ServiceNotFoundException $exception) {
+            } catch (ContainerNotFoundException|ServiceNotFoundException $exception) {
                 $translatorLoader = null;
             }
 

--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -44,11 +44,11 @@ use PrestaShop\PrestaShop\Core\Session\SessionInterface;
  */
 class CookieCore
 {
-    const SAMESITE_NONE = 'None';
-    const SAMESITE_LAX = 'Lax';
-    const SAMESITE_STRICT = 'Strict';
+    public const SAMESITE_NONE = 'None';
+    public const SAMESITE_LAX = 'Lax';
+    public const SAMESITE_STRICT = 'Strict';
 
-    const SAMESITE_AVAILABLE_VALUES = [
+    public const SAMESITE_AVAILABLE_VALUES = [
         self::SAMESITE_NONE => self::SAMESITE_NONE,
         self::SAMESITE_LAX => self::SAMESITE_LAX,
         self::SAMESITE_STRICT => self::SAMESITE_STRICT,

--- a/classes/Country.php
+++ b/classes/Country.php
@@ -67,11 +67,11 @@ class CountryCore extends ObjectModel
 
     protected static $_idZones = [];
 
-    const GEOLOC_ALLOWED = 0;
+    public const GEOLOC_ALLOWED = 0;
 
-    const GEOLOC_CATALOG_MODE = 1;
+    public const GEOLOC_CATALOG_MODE = 1;
 
-    const GEOLOC_FORBIDDEN = 2;
+    public const GEOLOC_FORBIDDEN = 2;
 
     /**
      * @see ObjectModel::$definition

--- a/classes/Dispatcher.php
+++ b/classes/Dispatcher.php
@@ -33,11 +33,11 @@ class DispatcherCore
     /**
      * List of available front controllers types.
      */
-    const FC_FRONT = 1;
-    const FC_ADMIN = 2;
-    const FC_MODULE = 3;
+    public const FC_FRONT = 1;
+    public const FC_ADMIN = 2;
+    public const FC_MODULE = 3;
 
-    const REWRITE_PATTERN = '[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]*?';
+    public const REWRITE_PATTERN = '[_a-zA-Z0-9\x{0600}-\x{06FF}\pL\pS-]*?';
 
     /**
      * @var Dispatcher|null

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -115,7 +115,7 @@ class HookCore extends ObjectModel
         'actionGetProductPropertiesAfter' => ['from' => '1.7.8.0'],
     ];
 
-    const MODULE_LIST_BY_HOOK_KEY = 'hook_module_exec_list_';
+    public const MODULE_LIST_BY_HOOK_KEY = 'hook_module_exec_list_';
 
     public function add($autodate = true, $null_values = false)
     {

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -33,10 +33,10 @@
  */
 class ImageManagerCore
 {
-    const ERROR_FILE_NOT_EXIST = 1;
-    const ERROR_FILE_WIDTH = 2;
-    const ERROR_MEMORY_LIMIT = 3;
-    const MIME_TYPE_SUPPORTED = [
+    public const ERROR_FILE_NOT_EXIST = 1;
+    public const ERROR_FILE_WIDTH = 2;
+    public const ERROR_MEMORY_LIMIT = 3;
+    public const MIME_TYPE_SUPPORTED = [
         'image/gif',
         'image/jpg',
         'image/jpeg',

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -40,16 +40,16 @@ use Symfony\Component\Intl\Intl;
 
 class LanguageCore extends ObjectModel implements LanguageInterface
 {
-    const ALL_LANGUAGES_FILE = '/app/Resources/all_languages.json';
-    const SF_LANGUAGE_PACK_URL = 'https://i18n.prestashop-project.org/translations/%version%/%locale%/%locale%.zip';
-    const EMAILS_LANGUAGE_PACK_URL = 'https://i18n.prestashop-project.org/mails/%version%/%locale%/%locale%.zip';
+    public const ALL_LANGUAGES_FILE = '/app/Resources/all_languages.json';
+    public const SF_LANGUAGE_PACK_URL = 'https://i18n.prestashop-project.org/translations/%version%/%locale%/%locale%.zip';
+    public const EMAILS_LANGUAGE_PACK_URL = 'https://i18n.prestashop-project.org/mails/%version%/%locale%/%locale%.zip';
     public const PACK_TYPE_EMAILS = 'emails';
     public const PACK_TYPE_SYMFONY = 'sf';
 
     /**
      * Timeout for downloading a translation pack, in seconds
      */
-    const PACK_DOWNLOAD_TIMEOUT = 20;
+    public const PACK_DOWNLOAD_TIMEOUT = 20;
 
     /**
      * Path to the local translation pack cache directory.

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -92,19 +92,19 @@ class MailCore extends ObjectModel
     /**
      * Mail content type.
      */
-    const TYPE_HTML = 1;
-    const TYPE_TEXT = 2;
-    const TYPE_BOTH = 3;
+    public const TYPE_HTML = 1;
+    public const TYPE_TEXT = 2;
+    public const TYPE_BOTH = 3;
 
     /**
      * Send mail under SMTP server.
      */
-    const METHOD_SMTP = 2;
+    public const METHOD_SMTP = 2;
 
     /**
      * Disable mail, will return immediately after calling send method.
      */
-    const METHOD_DISABLE = 3;
+    public const METHOD_DISABLE = 3;
 
     /**
      * Send Email.

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -31,27 +31,27 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     /**
      * List of field types.
      */
-    const TYPE_INT = 1;
-    const TYPE_BOOL = 2;
-    const TYPE_STRING = 3;
-    const TYPE_FLOAT = 4;
-    const TYPE_DATE = 5;
-    const TYPE_HTML = 6;
-    const TYPE_NOTHING = 7;
-    const TYPE_SQL = 8;
+    public const TYPE_INT = 1;
+    public const TYPE_BOOL = 2;
+    public const TYPE_STRING = 3;
+    public const TYPE_FLOAT = 4;
+    public const TYPE_DATE = 5;
+    public const TYPE_HTML = 6;
+    public const TYPE_NOTHING = 7;
+    public const TYPE_SQL = 8;
 
     /**
      * List of data to format.
      */
-    const FORMAT_COMMON = 1;
-    const FORMAT_LANG = 2;
-    const FORMAT_SHOP = 3;
+    public const FORMAT_COMMON = 1;
+    public const FORMAT_LANG = 2;
+    public const FORMAT_SHOP = 3;
 
     /**
      * List of association types.
      */
-    const HAS_ONE = 1;
-    const HAS_MANY = 2;
+    public const HAS_ONE = 1;
+    public const HAS_MANY = 2;
 
     /** @var int|null Object ID */
     public $id;

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -34,28 +34,28 @@ class PackCore extends Product
      *
      * @var int
      */
-    const STOCK_TYPE_PACK_ONLY = PackStockType::STOCK_TYPE_PACK_ONLY;
+    public const STOCK_TYPE_PACK_ONLY = PackStockType::STOCK_TYPE_PACK_ONLY;
 
     /**
      * Only decrement pack products quantities.
      *
      * @var int
      */
-    const STOCK_TYPE_PRODUCTS_ONLY = PackStockType::STOCK_TYPE_PRODUCTS_ONLY;
+    public const STOCK_TYPE_PRODUCTS_ONLY = PackStockType::STOCK_TYPE_PRODUCTS_ONLY;
 
     /**
      * Decrement pack quantity and pack products quantities.
      *
      * @var int
      */
-    const STOCK_TYPE_PACK_BOTH = PackStockType::STOCK_TYPE_BOTH;
+    public const STOCK_TYPE_PACK_BOTH = PackStockType::STOCK_TYPE_BOTH;
 
     /**
      * Use pack quantity default setting.
      *
      * @var int
      */
-    const STOCK_TYPE_DEFAULT = PackStockType::STOCK_TYPE_DEFAULT;
+    public const STOCK_TYPE_DEFAULT = PackStockType::STOCK_TYPE_DEFAULT;
 
     protected static $cachePackItems = [];
     protected static $cacheIsPack = [];

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -34,7 +34,7 @@ abstract class PaymentModuleCore extends Module
     public $currencies = true;
     public $currencies_mode = 'checkbox';
 
-    const DEBUG_MODE = false;
+    public const DEBUG_MODE = false;
 
     /** @var MailPartialTemplateRenderer|null */
     protected $partialRenderer;

--- a/classes/PhpEncryption.php
+++ b/classes/PhpEncryption.php
@@ -30,7 +30,7 @@ use Defuse\Crypto\Exception\EnvironmentIsBrokenException;
  */
 class PhpEncryptionCore
 {
-    const ENGINE = 'PhpEncryptionEngine';
+    public const ENGINE = 'PhpEncryptionEngine';
 
     private static $engine;
 

--- a/classes/PrestaShopBackup.php
+++ b/classes/PrestaShopBackup.php
@@ -233,7 +233,7 @@ class PrestaShopBackupCore
         }
 
         // Generate some random number, to make it extra hard to guess backup file names
-        $rand = dechex(mt_rand(0, min(0xffffffff, mt_getrandmax())));
+        $rand = dechex(mt_rand(0, min(0xFFFFFFFF, mt_getrandmax())));
         $date = time();
         $backupfile = $this->getRealBackupPath() . $date . '-' . $rand . '.sql';
 

--- a/classes/PrestaShopCollection.php
+++ b/classes/PrestaShopCollection.php
@@ -31,9 +31,9 @@
  */
 class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
 {
-    const LEFT_JOIN = 1;
-    const INNER_JOIN = 2;
-    const LEFT_OUTER_JOIN = 3;
+    public const LEFT_JOIN = 1;
+    public const INNER_JOIN = 2;
+    public const LEFT_OUTER_JOIN = 3;
 
     /**
      * @var string Object class name
@@ -91,7 +91,7 @@ class PrestaShopCollectionCore implements Iterator, ArrayAccess, Countable
     protected $join_list = [];
     protected $association_definition = [];
 
-    const LANG_ALIAS = 'l';
+    public const LANG_ALIAS = 'l';
 
     /**
      * @param string $classname

--- a/classes/PrestaShopLogger.php
+++ b/classes/PrestaShopLogger.php
@@ -32,10 +32,10 @@ class PrestaShopLoggerCore extends ObjectModel
     /**
      * List of log level types.
      */
-    const LOG_SEVERITY_LEVEL_INFORMATIVE = 1;
-    const LOG_SEVERITY_LEVEL_WARNING = 2;
-    const LOG_SEVERITY_LEVEL_ERROR = 3;
-    const LOG_SEVERITY_LEVEL_MAJOR = 4;
+    public const LOG_SEVERITY_LEVEL_INFORMATIVE = 1;
+    public const LOG_SEVERITY_LEVEL_WARNING = 2;
+    public const LOG_SEVERITY_LEVEL_ERROR = 3;
+    public const LOG_SEVERITY_LEVEL_MAJOR = 4;
 
     /** @var int Log id */
     public $id_log;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -434,8 +434,8 @@ class ProductCore extends ObjectModel
     /**
      * Product can be temporary saved in database
      */
-    const STATE_TEMP = 0;
-    const STATE_SAVED = 1;
+    public const STATE_TEMP = 0;
+    public const STATE_SAVED = 1;
 
     /**
      * @var array Contains object definition
@@ -694,15 +694,15 @@ class ProductCore extends ObjectModel
         ],
     ];
 
-    const CUSTOMIZE_FILE = 0;
-    const CUSTOMIZE_TEXTFIELD = 1;
+    public const CUSTOMIZE_FILE = 0;
+    public const CUSTOMIZE_TEXTFIELD = 1;
 
     /**
      * Note:  prefix is "PTYPE" because TYPE_ is used in ObjectModel (definition).
      */
-    const PTYPE_SIMPLE = 0;
-    const PTYPE_PACK = 1;
-    const PTYPE_VIRTUAL = 2;
+    public const PTYPE_SIMPLE = 0;
+    public const PTYPE_PACK = 1;
+    public const PTYPE_VIRTUAL = 2;
 
     /**
      * @param int|null $id_product Product identifier

--- a/classes/Profile.php
+++ b/classes/Profile.php
@@ -29,7 +29,7 @@
  */
 class ProfileCore extends ObjectModel
 {
-    const ALLOWED_PROFILE_TYPE_CHECK = [
+    public const ALLOWED_PROFILE_TYPE_CHECK = [
         'id_tab',
         'class_name',
     ];

--- a/classes/Search.php
+++ b/classes/Search.php
@@ -122,13 +122,13 @@ class SearchCore
      */
     public static $targetLengthMax;
 
-    const PS_SEARCH_MAX_WORDS_IN_TABLE = 100000; /* Max numer of words in ps_search_word, above which $coefs for target length will be everytime equal to 1 */
-    const PS_DEFAULT_SEARCH_MAX_WORD_LENGTH = 30; /* default max word length, for when we are not in fuzzy search mode */
-    const PS_SEARCH_ORDINATE_MIN = 0.5;
-    const PS_SEARCH_ORDINATE_MAX = -1;
-    const PS_SEARCH_ABSCISSA_MIN = 0.5;
-    const PS_SEARCH_ABSCISSA_MAX = 2;
-    const PS_DISTANCE_MAX = 8;
+    public const PS_SEARCH_MAX_WORDS_IN_TABLE = 100000; /* Max numer of words in ps_search_word, above which $coefs for target length will be everytime equal to 1 */
+    public const PS_DEFAULT_SEARCH_MAX_WORD_LENGTH = 30; /* default max word length, for when we are not in fuzzy search mode */
+    public const PS_SEARCH_ORDINATE_MIN = 0.5;
+    public const PS_SEARCH_ORDINATE_MAX = -1;
+    public const PS_SEARCH_ABSCISSA_MIN = 0.5;
+    public const PS_SEARCH_ABSCISSA_MAX = 2;
+    public const PS_DISTANCE_MAX = 8;
 
     public static function extractKeyWords($string, $id_lang, $indexation = false, $iso_code = false)
     {

--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -28,8 +28,8 @@ use PrestaShop\PrestaShop\Adapter\Product\SpecificPrice\Update\SpecificPricePrio
  */
 class SpecificPriceCore extends ObjectModel
 {
-    const ORDER_DEFAULT_FROM_QUANTITY = 1;
-    const ORDER_DEFAULT_DATE = '0000-00-00 00:00:00';
+    public const ORDER_DEFAULT_FROM_QUANTITY = 1;
+    public const ORDER_DEFAULT_DATE = '0000-00-00 00:00:00';
 
     public $id_product;
     public $id_specific_price_rule = 0;

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -64,7 +64,7 @@ class TabCore extends ObjectModel
     /**
      * @deprecated Since 1.7.7
      */
-    const TAB_MODULE_LIST_URL = '';
+    public const TAB_MODULE_LIST_URL = '';
 
     /**
      * @see ObjectModel::$definition

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -36,8 +36,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ToolsCore
 {
-    const CACERT_LOCATION = 'https://curl.haxx.se/ca/cacert.pem';
-    const SERVICE_LOCALE_REPOSITORY = 'prestashop.core.localization.locale.repository';
+    public const CACERT_LOCATION = 'https://curl.haxx.se/ca/cacert.pem';
+    public const SERVICE_LOCALE_REPOSITORY = 'prestashop.core.localization.locale.repository';
     public const CACHE_LIFETIME_SECONDS = 604800;
 
     public const PASSWORDGEN_FLAG_NUMERIC = 'NUMERIC';

--- a/classes/Upgrader.php
+++ b/classes/Upgrader.php
@@ -29,7 +29,7 @@
  */
 class UpgraderCore
 {
-    const DEFAULT_CHECK_VERSION_DELAY_HOURS = 24;
+    public const DEFAULT_CHECK_VERSION_DELAY_HOURS = 24;
     public $rss_version_link;
     public $rss_md5file_link_dir;
     /**

--- a/classes/Uploader.php
+++ b/classes/Uploader.php
@@ -29,7 +29,7 @@
  */
 class UploaderCore
 {
-    const DEFAULT_MAX_SIZE = 10485760;
+    public const DEFAULT_MAX_SIZE = 10485760;
 
     /** @var bool|null */
     private $_check_file_size;

--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -49,12 +49,12 @@ class ValidateCore
     /**
      * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH
      */
-    const ADMIN_PASSWORD_LENGTH = 8;
+    public const ADMIN_PASSWORD_LENGTH = 8;
 
     /**
      * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH
      */
-    const PASSWORD_LENGTH = 5;
+    public const PASSWORD_LENGTH = 5;
 
     public static function isIp2Long($ip)
     {

--- a/classes/assets/AbstractAssetManager.php
+++ b/classes/assets/AbstractAssetManager.php
@@ -33,9 +33,9 @@ abstract class AbstractAssetManagerCore
     protected $configuration;
     protected $list = [];
 
-    const DEFAULT_MEDIA = 'all';
-    const DEFAULT_PRIORITY = 50;
-    const DEFAULT_JS_POSITION = 'bottom';
+    public const DEFAULT_MEDIA = 'all';
+    public const DEFAULT_PRIORITY = 50;
+    public const DEFAULT_JS_POSITION = 'bottom';
 
     public function __construct(array $directories, ConfigurationInterface $configuration)
     {

--- a/classes/assets/PrestashopAssetsLibraries.php
+++ b/classes/assets/PrestashopAssetsLibraries.php
@@ -26,8 +26,8 @@
  */
 class PrestashopAssetsLibraries
 {
-    const css = 'registerStylesheet';
-    const js = 'registerJavascript';
+    public const css = 'registerStylesheet';
+    public const js = 'registerJavascript';
 
     /**
      * List of libraries available.

--- a/classes/cache/Cache.php
+++ b/classes/cache/Cache.php
@@ -28,12 +28,12 @@ abstract class CacheCore
     /**
      * Name of keys index.
      */
-    const KEYS_NAME = '__keys__';
+    public const KEYS_NAME = '__keys__';
 
     /**
      * Name of SQL cache index.
      */
-    const SQL_TABLES_NAME = 'tablesCached';
+    public const SQL_TABLES_NAME = 'tablesCached';
 
     /**
      * Store the number of time a query is fetched from the cache.

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -256,16 +256,16 @@ class AdminControllerCore extends Controller
     public $override_folder;
 
     /** @var int DELETE access level */
-    const LEVEL_DELETE = 4;
+    public const LEVEL_DELETE = 4;
 
     /** @var int ADD access level */
-    const LEVEL_ADD = 3;
+    public const LEVEL_ADD = 3;
 
     /** @var int EDIT access level */
-    const LEVEL_EDIT = 2;
+    public const LEVEL_EDIT = 2;
 
     /** @var int VIEW access level */
-    const LEVEL_VIEW = 1;
+    public const LEVEL_VIEW = 1;
 
     /**
      * Actions to execute on multiple selections.
@@ -409,7 +409,7 @@ class AdminControllerCore extends Controller
     protected $tabSlug;
 
     /** @var int Auth cookie lifetime */
-    const AUTH_COOKIE_LIFETIME = 3600;
+    public const AUTH_COOKIE_LIFETIME = 3600;
 
     /** @var array */
     public $_conf;

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -34,7 +34,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 abstract class ControllerCore
 {
-    const SERVICE_LOCALE_REPOSITORY = 'prestashop.core.localization.locale.repository';
+    public const SERVICE_LOCALE_REPOSITORY = 'prestashop.core.localization.locale.repository';
     public const SERVICE_MULTISTORE_FEATURE = 'prestashop.adapter.multistore_feature';
 
     /**

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -29,16 +29,16 @@
 abstract class DbCore
 {
     /** @var int Constant used by insert() method */
-    const INSERT = 1;
+    public const INSERT = 1;
 
     /** @var int Constant used by insert() method */
-    const INSERT_IGNORE = 2;
+    public const INSERT_IGNORE = 2;
 
     /** @var int Constant used by insert() method */
-    const REPLACE = 3;
+    public const REPLACE = 3;
 
     /** @var int Constant used by insert() method */
-    const ON_DUPLICATE_KEY = 4;
+    public const ON_DUPLICATE_KEY = 4;
 
     /** @var string Server (eg. localhost) */
     protected $server;

--- a/classes/helper/HelperCalendar.php
+++ b/classes/helper/HelperCalendar.php
@@ -25,8 +25,8 @@
  */
 class HelperCalendarCore extends Helper
 {
-    const DEFAULT_DATE_FORMAT = 'Y-mm-dd';
-    const DEFAULT_COMPARE_OPTION = 1;
+    public const DEFAULT_DATE_FORMAT = 'Y-mm-dd';
+    public const DEFAULT_COMPARE_OPTION = 1;
 
     private $_actions;
     private $_compare_actions;

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -35,7 +35,7 @@ use PrestaShop\PrestaShop\Core\Routing\Exception\BuilderNotFoundException;
 class HelperListCore extends Helper
 {
     /** @var int size which is used for lists image thumbnail generation. */
-    const LIST_THUMBNAIL_SIZE = 45;
+    public const LIST_THUMBNAIL_SIZE = 45;
 
     /** @var array Cache for query results */
     protected $_list = [];

--- a/classes/helper/HelperTreeCategories.php
+++ b/classes/helper/HelperTreeCategories.php
@@ -25,9 +25,9 @@
  */
 class HelperTreeCategoriesCore extends TreeCore
 {
-    const DEFAULT_TEMPLATE = 'tree_categories.tpl';
-    const DEFAULT_NODE_FOLDER_TEMPLATE = 'tree_node_folder_radio.tpl';
-    const DEFAULT_NODE_ITEM_TEMPLATE = 'tree_node_item_radio.tpl';
+    public const DEFAULT_TEMPLATE = 'tree_categories.tpl';
+    public const DEFAULT_NODE_FOLDER_TEMPLATE = 'tree_node_folder_radio.tpl';
+    public const DEFAULT_NODE_ITEM_TEMPLATE = 'tree_node_item_radio.tpl';
 
     private $_disabled_categories;
     private $_input_name;

--- a/classes/helper/HelperTreeShops.php
+++ b/classes/helper/HelperTreeShops.php
@@ -25,9 +25,9 @@
  */
 class HelperTreeShopsCore extends TreeCore
 {
-    const DEFAULT_TEMPLATE = 'tree_shops.tpl';
-    const DEFAULT_NODE_FOLDER_TEMPLATE = 'tree_node_folder_checkbox_shops.tpl';
-    const DEFAULT_NODE_ITEM_TEMPLATE = 'tree_node_item_checkbox_shops.tpl';
+    public const DEFAULT_TEMPLATE = 'tree_shops.tpl';
+    public const DEFAULT_NODE_FOLDER_TEMPLATE = 'tree_node_folder_checkbox_shops.tpl';
+    public const DEFAULT_NODE_ITEM_TEMPLATE = 'tree_node_item_checkbox_shops.tpl';
 
     private $_lang;
     private $_selected_shops;

--- a/classes/helper/HelperUploader.php
+++ b/classes/helper/HelperUploader.php
@@ -25,12 +25,12 @@
  */
 class HelperUploaderCore extends Uploader
 {
-    const DEFAULT_TEMPLATE_DIRECTORY = 'helpers/uploader';
-    const DEFAULT_TEMPLATE = 'simple.tpl';
-    const DEFAULT_AJAX_TEMPLATE = 'ajax.tpl';
+    public const DEFAULT_TEMPLATE_DIRECTORY = 'helpers/uploader';
+    public const DEFAULT_TEMPLATE = 'simple.tpl';
+    public const DEFAULT_AJAX_TEMPLATE = 'ajax.tpl';
 
-    const TYPE_IMAGE = 'image';
-    const TYPE_FILE = 'file';
+    public const TYPE_IMAGE = 'image';
+    public const TYPE_FILE = 'file';
 
     private $_context;
     private $_drop_zone;

--- a/classes/log/AbstractLogger.php
+++ b/classes/log/AbstractLogger.php
@@ -33,10 +33,10 @@ abstract class AbstractLoggerCore
         3 => 'ERROR',
     ];
 
-    const DEBUG = 0;
-    const INFO = 1;
-    const WARNING = 2;
-    const ERROR = 3;
+    public const DEBUG = 0;
+    public const INFO = 1;
+    public const WARNING = 2;
+    public const ERROR = 3;
 
     public function __construct($level = self::INFO)
     {

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -221,11 +221,11 @@ abstract class ModuleCore implements ModuleInterface
     /** @var int Defines the multistore compatibility level of the module */
     public $multistoreCompatibility = self::MULTISTORE_COMPATIBILITY_UNKNOWN;
 
-    const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
+    public const CACHE_FILE_MODULES_LIST = '/config/xml/modules_list.xml';
 
-    const CACHE_FILE_TAB_MODULES_LIST = '/config/xml/tab_modules_list.xml';
+    public const CACHE_FILE_TAB_MODULES_LIST = '/config/xml/tab_modules_list.xml';
 
-    const CACHE_FILE_ALL_COUNTRY_MODULES_LIST = '/config/xml/modules_native_addons.xml';
+    public const CACHE_FILE_ALL_COUNTRY_MODULES_LIST = '/config/xml/modules_native_addons.xml';
 
     public const MULTISTORE_COMPATIBILITY_NO = -20;
     public const MULTISTORE_COMPATIBILITY_NOT_CONCERNED = -10;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -27,9 +27,9 @@ use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 
 class OrderCore extends ObjectModel
 {
-    const ROUND_ITEM = 1;
-    const ROUND_LINE = 2;
-    const ROUND_TOTAL = 3;
+    public const ROUND_ITEM = 1;
+    public const ROUND_LINE = 2;
+    public const ROUND_TOTAL = 3;
 
     /** @var int Delivery address id */
     public $id_address_delivery;

--- a/classes/order/OrderInvoice.php
+++ b/classes/order/OrderInvoice.php
@@ -25,9 +25,9 @@
  */
 class OrderInvoiceCore extends ObjectModel
 {
-    const TAX_EXCL = 0;
-    const TAX_INCL = 1;
-    const DETAIL = 2;
+    public const TAX_EXCL = 0;
+    public const TAX_INCL = 1;
+    public const DETAIL = 2;
 
     /** @var int */
     public $id_order;

--- a/classes/order/OrderState.php
+++ b/classes/order/OrderState.php
@@ -104,11 +104,11 @@ class OrderStateCore extends ObjectModel
         ],
     ];
 
-    const FLAG_NO_HIDDEN = 1;  /* 00001 */
-    const FLAG_LOGABLE = 2;  /* 00010 */
-    const FLAG_DELIVERY = 4;  /* 00100 */
-    const FLAG_SHIPPED = 8;  /* 01000 */
-    const FLAG_PAID = 16; /* 10000 */
+    public const FLAG_NO_HIDDEN = 1;  /* 00001 */
+    public const FLAG_LOGABLE = 2;  /* 00010 */
+    public const FLAG_DELIVERY = 4;  /* 00100 */
+    public const FLAG_SHIPPED = 8;  /* 01000 */
+    public const FLAG_PAID = 16; /* 10000 */
 
     /**
      * Get all available order statuses.

--- a/classes/pdf/PDF.php
+++ b/classes/pdf/PDF.php
@@ -59,11 +59,11 @@ class PDFCore
      */
     protected $smarty;
 
-    const TEMPLATE_INVOICE = 'Invoice';
-    const TEMPLATE_ORDER_RETURN = 'OrderReturn';
-    const TEMPLATE_ORDER_SLIP = 'OrderSlip';
-    const TEMPLATE_DELIVERY_SLIP = 'DeliverySlip';
-    const TEMPLATE_SUPPLY_ORDER_FORM = 'SupplyOrderForm';
+    public const TEMPLATE_INVOICE = 'Invoice';
+    public const TEMPLATE_ORDER_RETURN = 'OrderReturn';
+    public const TEMPLATE_ORDER_SLIP = 'OrderSlip';
+    public const TEMPLATE_DELIVERY_SLIP = 'DeliverySlip';
+    public const TEMPLATE_SUPPLY_ORDER_FORM = 'SupplyOrderForm';
 
     /**
      * @param PrestaShopCollection|ObjectModel|array $objects

--- a/classes/pdf/PDFGenerator.php
+++ b/classes/pdf/PDFGenerator.php
@@ -29,7 +29,7 @@
  */
 class PDFGeneratorCore extends TCPDF
 {
-    const DEFAULT_FONT = 'helvetica';
+    public const DEFAULT_FONT = 'helvetica';
 
     /**
      * @var string

--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -119,16 +119,16 @@ class ShopCore extends ObjectModel
     /**
      * There are 3 kinds of shop context : shop, group shop and general.
      */
-    const CONTEXT_SHOP = 1;
-    const CONTEXT_GROUP = 2;
-    const CONTEXT_ALL = 4;
+    public const CONTEXT_SHOP = 1;
+    public const CONTEXT_GROUP = 2;
+    public const CONTEXT_ALL = 4;
 
     /**
      * Some data can be shared between shops, like customers or orders.
      */
-    const SHARE_CUSTOMER = 'share_customer';
-    const SHARE_ORDER = 'share_order';
-    const SHARE_STOCK = 'share_stock';
+    public const SHARE_CUSTOMER = 'share_customer';
+    public const SHARE_ORDER = 'share_order';
+    public const SHARE_STOCK = 'share_stock';
 
     /**
      * On shop instance, get its URL data.

--- a/classes/tax/Tax.php
+++ b/classes/tax/Tax.php
@@ -25,7 +25,7 @@
  */
 class TaxCore extends ObjectModel
 {
-    const TAX_DEFAULT_PRECISION = 3;
+    public const TAX_DEFAULT_PRECISION = 3;
 
     /** @var array<int,string>|string Name */
     public $name;

--- a/classes/tax/TaxCalculator.php
+++ b/classes/tax/TaxCalculator.php
@@ -35,13 +35,13 @@ class TaxCalculatorCore
      * COMBINE_METHOD sum taxes
      * eg: 100€ * (10% + 15%).
      */
-    const COMBINE_METHOD = 1;
+    public const COMBINE_METHOD = 1;
 
     /**
      * ONE_AFTER_ANOTHER_METHOD apply taxes one after another
      * eg: (100€ * 10%) * 15%.
      */
-    const ONE_AFTER_ANOTHER_METHOD = 2;
+    public const ONE_AFTER_ANOTHER_METHOD = 2;
 
     /**
      * @var array

--- a/classes/tree/Tree.php
+++ b/classes/tree/Tree.php
@@ -28,11 +28,11 @@ use PrestaShopBundle\Translation\TranslatorComponent;
 
 class TreeCore
 {
-    const DEFAULT_TEMPLATE_DIRECTORY = 'helpers/tree';
-    const DEFAULT_TEMPLATE = 'tree.tpl';
-    const DEFAULT_HEADER_TEMPLATE = 'tree_header.tpl';
-    const DEFAULT_NODE_FOLDER_TEMPLATE = 'tree_node_folder.tpl';
-    const DEFAULT_NODE_ITEM_TEMPLATE = 'tree_node_item.tpl';
+    public const DEFAULT_TEMPLATE_DIRECTORY = 'helpers/tree';
+    public const DEFAULT_TEMPLATE = 'tree.tpl';
+    public const DEFAULT_HEADER_TEMPLATE = 'tree_header.tpl';
+    public const DEFAULT_NODE_FOLDER_TEMPLATE = 'tree_node_folder.tpl';
+    public const DEFAULT_NODE_ITEM_TEMPLATE = 'tree_node_item.tpl';
 
     protected $_attributes;
     private $_context;

--- a/classes/tree/TreeToolbar.php
+++ b/classes/tree/TreeToolbar.php
@@ -25,8 +25,8 @@
  */
 class TreeToolbarCore implements ITreeToolbarCore
 {
-    const DEFAULT_TEMPLATE_DIRECTORY = 'helpers/tree';
-    const DEFAULT_TEMPLATE = 'tree_toolbar.tpl';
+    public const DEFAULT_TEMPLATE_DIRECTORY = 'helpers/tree';
+    public const DEFAULT_TEMPLATE = 'tree_toolbar.tpl';
 
     private $_actions;
     private $_context;

--- a/classes/tree/TreeToolbarButton.php
+++ b/classes/tree/TreeToolbarButton.php
@@ -25,7 +25,7 @@
  */
 abstract class TreeToolbarButtonCore
 {
-    const DEFAULT_TEMPLATE_DIRECTORY = 'helpers/tree';
+    public const DEFAULT_TEMPLATE_DIRECTORY = 'helpers/tree';
 
     protected $_attributes;
     private $_context;

--- a/classes/webservice/WebserviceException.php
+++ b/classes/webservice/WebserviceException.php
@@ -36,8 +36,8 @@ class WebserviceExceptionCore extends Exception
     protected $available_values;
     protected $type;
 
-    const SIMPLE = 0;
-    const DID_YOU_MEAN = 1;
+    public const SIMPLE = 0;
+    public const DID_YOU_MEAN = 1;
 
     public function __construct($message, $code)
     {

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -32,8 +32,8 @@ class WebserviceOutputBuilderCore
     /**
      * @var int constant
      */
-    const VIEW_LIST = 1;
-    const VIEW_DETAILS = 2;
+    public const VIEW_LIST = 1;
+    public const VIEW_DETAILS = 2;
 
     protected $wsUrl;
     protected $output;

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -25,9 +25,9 @@
  */
 class WebserviceRequestCore
 {
-    const HTTP_GET = 1;
-    const HTTP_POST = 2;
-    const HTTP_PUT = 4;
+    public const HTTP_GET = 1;
+    public const HTTP_POST = 2;
+    public const HTTP_PUT = 4;
 
     protected $_available_languages = null;
     /**

--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,7 @@
     "require-dev": {
         "behat/behat": "^3.5",
         "ergebnis/composer-normalize": "^2.8",
-        "friendsofphp/php-cs-fixer": "^2.16.1",
+        "friendsofphp/php-cs-fixer": "^v3.2.0",
         "johnkary/phpunit-speedtrap": "^3",
         "mikey179/vfsstream": "^1.6",
         "phpstan/phpstan": "^1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ae8eba13734a89bc040a0e6e0234cb4",
+    "content-hash": "ec991e6f7b7ae6fc3d777ab6b9185c2b",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -522,16 +522,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.13.2",
+            "version": "1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08"
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5b668aef16090008790395c02c893b1ba13f7e08",
-                "reference": "5b668aef16090008790395c02c893b1ba13f7e08",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
                 "shasum": ""
             },
             "require": {
@@ -543,9 +543,10 @@
             "require-dev": {
                 "doctrine/cache": "^1.11 || ^2.0",
                 "doctrine/coding-standard": "^6.0 || ^8.1",
-                "phpstan/phpstan": "^0.12.20",
+                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
                 "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
-                "symfony/cache": "^4.4 || ^5.2"
+                "symfony/cache": "^4.4 || ^5.2",
+                "vimeo/psalm": "^4.10"
             },
             "type": "library",
             "autoload": {
@@ -588,9 +589,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.13.2"
+                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
             },
-            "time": "2021-08-05T19:00:23+00:00"
+            "time": "2022-07-02T10:48:51+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -8701,16 +8702,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
                 "shasum": ""
             },
             "require": {
@@ -8725,7 +8726,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -8764,7 +8765,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -8780,20 +8781,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-30T18:21:41+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
+                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
-                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/bf44a9fd41feaac72b074de600314a93e2ae78e2",
+                "reference": "bf44a9fd41feaac72b074de600314a93e2ae78e2",
                 "shasum": ""
             },
             "require": {
@@ -8802,7 +8803,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -8840,7 +8841,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -8856,7 +8857,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-27T09:17:38+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
@@ -8939,16 +8940,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c"
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/4407588e0d3f1f52efb65fbe92babe41f37fe50c",
-                "reference": "4407588e0d3f1f52efb65fbe92babe41f37fe50c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
                 "shasum": ""
             },
             "require": {
@@ -8957,7 +8958,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -9002,7 +9003,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -9018,20 +9019,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-04T08:16:47+00:00"
+            "time": "2022-05-10T07:21:04+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.25.0",
+            "version": "v1.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f"
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
-                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/13f6d1271c663dc5ae9fb843a8f16521db7687a1",
+                "reference": "13f6d1271c663dc5ae9fb843a8f16521db7687a1",
                 "shasum": ""
             },
             "require": {
@@ -9040,7 +9041,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.26-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -9081,7 +9082,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.25.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.26.0"
             },
             "funding": [
                 {
@@ -9097,7 +9098,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-13T13:58:11+00:00"
+            "time": "2022-05-24T11:49:31+00:00"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -10330,85 +10331,65 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.19.3",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "75ac86f33fab4714ea5a39a396784d83ae3b5ed8"
+                "reference": "47177af1cfb9dab5d1cc4daf91b7179c2efe7fad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/75ac86f33fab4714ea5a39a396784d83ae3b5ed8",
-                "reference": "75ac86f33fab4714ea5a39a396784d83ae3b5ed8",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/47177af1cfb9dab5d1cc4daf91b7179c2efe7fad",
+                "reference": "47177af1cfb9dab5d1cc4daf91b7179c2efe7fad",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^1.4 || ^2.0 || ^3.0",
-                "composer/xdebug-handler": "^1.2 || ^2.0",
-                "doctrine/annotations": "^1.2",
+                "composer/semver": "^3.2",
+                "composer/xdebug-handler": "^2.0",
+                "doctrine/annotations": "^1.12",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || ^7.0 || ^8.0",
-                "php-cs-fixer/diff": "^1.3",
-                "symfony/console": "^3.4.43 || ^4.1.6 || ^5.0",
-                "symfony/event-dispatcher": "^3.0 || ^4.0 || ^5.0",
-                "symfony/filesystem": "^3.0 || ^4.0 || ^5.0",
-                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
-                "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0",
-                "symfony/polyfill-php70": "^1.0",
-                "symfony/polyfill-php72": "^1.4",
-                "symfony/process": "^3.0 || ^4.0 || ^5.0",
-                "symfony/stopwatch": "^3.0 || ^4.0 || ^5.0"
+                "php": "^7.2.5 || ^8.0",
+                "php-cs-fixer/diff": "^2.0",
+                "symfony/console": "^4.4.20 || ^5.1.3 || ^6.0",
+                "symfony/event-dispatcher": "^4.4.20 || ^5.0 || ^6.0",
+                "symfony/filesystem": "^4.4.20 || ^5.0 || ^6.0",
+                "symfony/finder": "^4.4.20 || ^5.0 || ^6.0",
+                "symfony/options-resolver": "^4.4.20 || ^5.0 || ^6.0",
+                "symfony/polyfill-mbstring": "^1.23",
+                "symfony/polyfill-php80": "^1.23",
+                "symfony/polyfill-php81": "^1.23",
+                "symfony/process": "^4.4.20 || ^5.0 || ^6.0",
+                "symfony/stopwatch": "^4.4.20 || ^5.0 || ^6.0"
             },
             "require-dev": {
-                "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.4",
-                "mikey179/vfsstream": "^1.6",
-                "php-coveralls/php-coveralls": "^2.4.2",
-                "php-cs-fixer/accessible-object": "^1.0",
+                "justinrainbow/json-schema": "^5.2",
+                "keradus/cli-executor": "^1.5",
+                "mikey179/vfsstream": "^1.6.8",
+                "php-coveralls/php-coveralls": "^2.5.2",
+                "php-cs-fixer/accessible-object": "^1.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
+                "phpspec/prophecy": "^1.15",
                 "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.13 || ^9.5",
+                "phpunit/phpunit": "^8.5.21 || ^9.5",
                 "phpunitgoodpractices/polyfill": "^1.5",
                 "phpunitgoodpractices/traits": "^1.9.1",
-                "sanmai/phpunit-legacy-adapter": "^6.4 || ^8.2.1",
-                "symfony/phpunit-bridge": "^5.2.1",
-                "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
+                "symfony/phpunit-bridge": "^5.2.4 || ^6.0",
+                "symfony/yaml": "^4.4.20 || ^5.0 || ^6.0"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
-                "ext-mbstring": "For handling non-UTF8 characters.",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "For IsIdenticalString constraint.",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "For XmlMatchesXsd constraint.",
-                "symfony/polyfill-mbstring": "When enabling `ext-mbstring` is not possible."
+                "ext-mbstring": "For handling non-UTF8 characters."
             },
             "bin": [
                 "php-cs-fixer"
             ],
             "type": "application",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.19-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
-                },
-                "classmap": [
-                    "tests/Test/AbstractFixerTestCase.php",
-                    "tests/Test/AbstractIntegrationCaseFactory.php",
-                    "tests/Test/AbstractIntegrationTestCase.php",
-                    "tests/Test/Assert/AssertTokensTrait.php",
-                    "tests/Test/IntegrationCase.php",
-                    "tests/Test/IntegrationCaseFactory.php",
-                    "tests/Test/IntegrationCaseFactoryInterface.php",
-                    "tests/Test/InternalIntegrationCaseFactory.php",
-                    "tests/Test/IsIdenticalConstraint.php",
-                    "tests/Test/TokensWithObservedTransformers.php",
-                    "tests/TestCase.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -10427,7 +10408,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.19.3"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -10435,7 +10416,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-15T17:17:55+00:00"
+            "time": "2021-12-11T16:25:08+00:00"
         },
         {
             "name": "johnkary/phpunit-speedtrap",
@@ -10842,16 +10823,16 @@
         },
         {
             "name": "php-cs-fixer/diff",
-            "version": "v1.3.1",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/diff.git",
-                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759"
+                "reference": "29dc0d507e838c4580d018bd8b5cb412474f7ec3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/dbd31aeb251639ac0b9e7e29405c1441907f5759",
-                "reference": "dbd31aeb251639ac0b9e7e29405c1441907f5759",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/29dc0d507e838c4580d018bd8b5cb412474f7ec3",
+                "reference": "29dc0d507e838c4580d018bd8b5cb412474f7ec3",
                 "shasum": ""
             },
             "require": {
@@ -10879,21 +10860,18 @@
                 {
                     "name": "Kore Nordmann",
                     "email": "mail@kore-nordmann.de"
-                },
-                {
-                    "name": "SpacePossum"
                 }
             ],
-            "description": "sebastian/diff v2 backport support for PHP5.6",
+            "description": "sebastian/diff v3 backport support for PHP 5.6+",
             "homepage": "https://github.com/PHP-CS-Fixer",
             "keywords": [
                 "diff"
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
-                "source": "https://github.com/PHP-CS-Fixer/diff/tree/v1.3.1"
+                "source": "https://github.com/PHP-CS-Fixer/diff/tree/v2.0.2"
             },
-            "time": "2020-10-14T08:39:05+00:00"
+            "time": "2020-10-14T08:32:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -12441,74 +12419,6 @@
                 }
             ],
             "time": "2020-11-13T16:28:59+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php70",
-            "version": "v1.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/5f03a781d984aae42cebd18e7912fa80f02ee644",
-                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "metapackage",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.20-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php70/tree/v1.20.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-10-23T14:02:19+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -29,8 +29,8 @@ use PrestaShop\PrestaShop\Core\Search\SearchPanelInterface;
 
 class AdminSearchControllerCore extends AdminController
 {
-    const TOKEN_CHECK_START_POS = 34;
-    const TOKEN_CHECK_LENGTH = 8;
+    public const TOKEN_CHECK_START_POS = 34;
+    public const TOKEN_CHECK_LENGTH = 8;
 
     /**
      * @var string

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -30,8 +30,8 @@ use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem;
 class AdminTranslationsControllerCore extends AdminController
 {
     /** Name of theme by default */
-    const DEFAULT_THEME_NAME = _PS_DEFAULT_THEME_NAME_;
-    const TEXTAREA_SIZED = 70;
+    public const DEFAULT_THEME_NAME = _PS_DEFAULT_THEME_NAME_;
+    public const TEXTAREA_SIZED = 70;
 
     /** @var string : Link which list all pack of language */
     protected $link_lang_pack = 'http://i18n.prestashop-project.org/translations/%ps_version%/available_languages.json';

--- a/src/Adapter/Product/CommandHandler/UpdateProductsPositionsHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductsPositionsHandler.php
@@ -81,7 +81,7 @@ class UpdateProductsPositionsHandler implements UpdateProductsPositionsHandlerIn
         try {
             $positionUpdate = $this->positionUpdateFactory->buildPositionUpdate($positionsData, $this->positionDefinition);
             $this->positionUpdater->update($positionUpdate);
-        } catch (PositionUpdateException | PositionDataException $e) {
+        } catch (PositionUpdateException|PositionDataException $e) {
             throw new CannotUpdateProductPositionException($e->getMessage(), 0, $e);
         }
     }

--- a/src/Adapter/Product/Image/Update/ProductImageUpdater.php
+++ b/src/Adapter/Product/Image/Update/ProductImageUpdater.php
@@ -161,7 +161,7 @@ class ProductImageUpdater
         try {
             $positionUpdate = $this->positionUpdateFactory->buildPositionUpdate($positionsData, $this->positionDefinition);
             $this->positionUpdater->update($positionUpdate);
-        } catch (PositionDataException | PositionUpdateException $e) {
+        } catch (PositionDataException|PositionUpdateException $e) {
             throw new CannotUpdateProductImageException(
                 'Cannot update image position',
                 CannotUpdateProductImageException::FAILED_UPDATE_POSITION,

--- a/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
@@ -67,10 +67,10 @@ class ProductPackRepository extends AbstractObjectModelRepository
      * @param LanguageId $languageId
      *
      * @return array<array<string, string>>
-     *                             e.g [
-     *                             ['id_product_item' => '1', 'id_product_attribute_item' => '1', 'name' => 'Product name', 'reference' => 'demo15', 'quantity' => '1'],
-     *                             ['id_product_item' => '2', 'id_product_attribute_item' => '1', 'name' => 'Product name2', 'reference' => 'demo16', 'quantity' => '1'],
-     *                             ]
+     *                                      e.g [
+     *                                      ['id_product_item' => '1', 'id_product_attribute_item' => '1', 'name' => 'Product name', 'reference' => 'demo15', 'quantity' => '1'],
+     *                                      ['id_product_item' => '2', 'id_product_attribute_item' => '1', 'name' => 'Product name2', 'reference' => 'demo16', 'quantity' => '1'],
+     *                                      ]
      *
      * @throws CoreException
      */

--- a/src/Adapter/Product/ProductDuplicator.php
+++ b/src/Adapter/Product/ProductDuplicator.php
@@ -339,10 +339,10 @@ class ProductDuplicator
      * @param int $newProductId
      *
      * @return array<string, array<int, array<int, int>>> combination images
-     *                       [
-     *                       'old' => [1 {id product attribute} => [0 {index} => 1 {id image}]]
-     *                       'new' => [2 {id product attribute} => [0 {index} => 3 {id image}]]
-     *                       ]
+     *                                                    [
+     *                                                    'old' => [1 {id product attribute} => [0 {index} => 1 {id image}]]
+     *                                                    'new' => [2 {id product attribute} => [0 {index} => 3 {id image}]]
+     *                                                    ]
      *
      * @throws CannotDuplicateProductException
      * @throws CoreException

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -242,10 +242,10 @@ class ProductRepository extends AbstractObjectModelRepository
      * @param LanguageId $languageId
      *
      * @return array<array<string, string>>
-     *                             e.g [
-     *                             ['id_product' => '1', 'name' => 'Product name', 'reference' => 'demo15'],
-     *                             ['id_product' => '2', 'name' => 'Product name2', 'reference' => 'demo16'],
-     *                             ]
+     *                                      e.g [
+     *                                      ['id_product' => '1', 'name' => 'Product name', 'reference' => 'demo15'],
+     *                                      ['id_product' => '2', 'name' => 'Product name2', 'reference' => 'demo16'],
+     *                                      ]
      *
      * @throws CoreException
      */

--- a/src/Adapter/Profile/Permission/QueryHandler/GetPermissionsForConfigurationHandler.php
+++ b/src/Adapter/Profile/Permission/QueryHandler/GetPermissionsForConfigurationHandler.php
@@ -49,7 +49,7 @@ class GetPermissionsForConfigurationHandler implements GetPermissionsForConfigur
     /**
      * @internal Max nesting level for building tabs tree
      */
-    const MAX_NESTING_LEVEL = 12;
+    public const MAX_NESTING_LEVEL = 12;
 
     /**
      * @var AuthorizationCheckerInterface

--- a/src/Core/Domain/Product/Combination/Query/SearchCombinationsForAssociation.php
+++ b/src/Core/Domain/Product/Combination/Query/SearchCombinationsForAssociation.php
@@ -38,7 +38,7 @@ class SearchCombinationsForAssociation
     /**
      * This is the minimum length of search phrase
      */
-    const SEARCH_PHRASE_MIN_LENGTH = 3;
+    public const SEARCH_PHRASE_MIN_LENGTH = 3;
 
     /**
      * @var string

--- a/src/Core/Domain/Product/Query/SearchProductsForAssociation.php
+++ b/src/Core/Domain/Product/Query/SearchProductsForAssociation.php
@@ -37,7 +37,7 @@ class SearchProductsForAssociation
     /**
      * This is the minimum length of search phrase
      */
-    const SEARCH_PHRASE_MIN_LENGTH = 3;
+    public const SEARCH_PHRASE_MIN_LENGTH = 3;
 
     /**
      * @var string

--- a/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
+++ b/src/Core/Grid/Column/Type/Common/DateTimeColumn.php
@@ -36,13 +36,13 @@ final class DateTimeColumn extends AbstractColumn
      * Default date format.
      * Note the use of non-breaking hyphens (U+2011)
      */
-    const DEFAULT_FORMAT = 'Y‑m‑d H:i:s';
+    public const DEFAULT_FORMAT = 'Y‑m‑d H:i:s';
 
     /**
      * Complete datetime format, without seconds.
      * Note the use of non-breaking hyphens (U+2011)
      */
-    const DATETIME_WITHOUT_SECONDS = 'Y‑m‑d H:i';
+    public const DATETIME_WITHOUT_SECONDS = 'Y‑m‑d H:i';
 
     private const FORMAT_NORMALIZATION_MAP = [
         '-' => '‑', // convert hyphens into non-breaking hyphens

--- a/src/PrestaShopBundle/Bridge/AdminController/LegacyControllerBridgeInterface.php
+++ b/src/PrestaShopBundle/Bridge/AdminController/LegacyControllerBridgeInterface.php
@@ -31,7 +31,7 @@ namespace PrestaShopBundle\Bridge\AdminController;
  */
 interface LegacyControllerBridgeInterface
 {
-    const DEFAULT_THEME = 'default';
+    public const DEFAULT_THEME = 'default';
 
     /**
      * Sets default media list for this controller.

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -354,7 +354,7 @@ class CategoryController extends FrameworkBundleAdminController
             if (!$editableCategory->isRootCategory()) {
                 return $this->redirectToRoute('admin_categories_edit', ['categoryId' => $categoryId]);
             }
-        } catch (CannotEditRootCategoryException | CategoryNotFoundException $e) {
+        } catch (CannotEditRootCategoryException|CategoryNotFoundException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
 
             return $this->redirectToRoute('admin_categories_index');

--- a/tests/Integration/Behaviour/Features/Context/AbstractPrestaShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/AbstractPrestaShopFeatureContext.php
@@ -37,7 +37,7 @@ use Behat\Behat\Context\Context as BehatContext;
  */
 abstract class AbstractPrestaShopFeatureContext implements BehatContext
 {
-    const MODULES_DIRECTORY = __DIR__ . '/../../../../Resources/modules';
+    public const MODULES_DIRECTORY = __DIR__ . '/../../../../Resources/modules';
 
     protected function checkFixtureExists(array $fixtures, $fixtureName, $fixtureIndex)
     {

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -59,16 +59,16 @@ use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class CategoryFeatureContext extends AbstractDomainFeatureContext
 {
-    const EMPTY_VALUE = '';
-    const DEFAULT_ROOT_CATEGORY_ID = 1;
-    const JPG_IMAGE_TYPE = '.jpg';
-    const THUMB0 = '0_thumb';
-    const JPG_IMAGE_STRING = 'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl'
+    public const EMPTY_VALUE = '';
+    public const DEFAULT_ROOT_CATEGORY_ID = 1;
+    public const JPG_IMAGE_TYPE = '.jpg';
+    public const THUMB0 = '0_thumb';
+    public const JPG_IMAGE_STRING = 'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl'
         . 'BMVEUAAAD///+l2Z/dAAAASUlEQVR4XqWQUQoAIAxC2/0vXZDr'
         . 'EX4IJTRkb7lobNUStXsB0jIXIAMSsQnWlsV+wULF4Avk9fLq2r'
         . '8a5HSE35Q3eO2XP1A1wQkZSgETvDtKdQAAAABJRU5ErkJggg==';
 
-    const CATEGORY_POSITION_WAYS_MAP = [
+    public const CATEGORY_POSITION_WAYS_MAP = [
         0 => 'Up',
         1 => 'Down',
     ];

--- a/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/OrderFeatureContext.php
@@ -255,7 +255,7 @@ class OrderFeatureContext extends AbstractDomainFeatureContext
             $this->getCommandBus()->handle(
                 new DeleteProductFromOrderCommand($orderId, $orderDetailId)
             );
-        } catch (OrderException | OrderNotFoundException $e) {
+        } catch (OrderException|OrderNotFoundException $e) {
             $this->setLastException($e);
         }
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPriceContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPriceContext.php
@@ -158,7 +158,7 @@ class SpecificPriceContext extends AbstractProductFeatureContext
             $specificPriceId = $this->getCommandBus()->handle($command);
 
             $this->getSharedStorage()->set($specificPriceReference, $specificPriceId->getValue());
-        } catch (SpecificPriceException | DomainConstraintException | ProductException $e) {
+        } catch (SpecificPriceException|DomainConstraintException|ProductException $e) {
             $this->setLastException($e);
         }
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProductSuppliersFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProductSuppliersFeatureContext.php
@@ -81,7 +81,7 @@ class UpdateProductSuppliersFeatureContext extends AbstractProductFeatureContext
             );
 
             $this->getCommandBus()->handle($command);
-        } catch (ProductSupplierNotAssociatedException | InvalidProductTypeException $e) {
+        } catch (ProductSupplierNotAssociatedException|InvalidProductTypeException $e) {
             $this->setLastException($e);
         }
     }
@@ -181,7 +181,7 @@ class UpdateProductSuppliersFeatureContext extends AbstractProductFeatureContext
                 $productSupplierAssociations,
                 'Number of updated associations does not match the input number of associations'
             );
-        } catch (ProductSupplierNotAssociatedException | InvalidProductTypeException $e) {
+        } catch (ProductSupplierNotAssociatedException|InvalidProductTypeException $e) {
             $this->setLastException($e);
         }
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
@@ -86,7 +86,7 @@ class VirtualProductFileFeatureContext extends AbstractProductFeatureContext
                 $this->buildSystemFileReference($productReference, $fileReference),
                 _PS_DOWNLOAD_DIR_ . $filename
             );
-        } catch (VirtualProductFileException | InvalidProductTypeException $e) {
+        } catch (VirtualProductFileException|InvalidProductTypeException $e) {
             $this->setLastException($e);
         }
     }

--- a/tests/Integration/Behaviour/Features/Context/Util/PrimitiveUtils.php
+++ b/tests/Integration/Behaviour/Features/Context/Util/PrimitiveUtils.php
@@ -31,16 +31,16 @@ use RuntimeException;
 
 class PrimitiveUtils
 {
-    const TYPE_BOOLEAN = 'boolean';
-    const TYPE_INTEGER = 'integer';
-    const TYPE_DOUBLE = 'double';
-    const TYPE_STRING = 'string';
-    const TYPE_DATETIME = 'datetime';
-    const TYPE_ARRAY = 'array';
-    const TYPE_NULL = 'NULL';
-    const TYPE_OBJECT = 'object';
-    const TYPE_RESOURCE = 'resource';
-    const TYPE_UNKNOWN = 'unknown type';
+    public const TYPE_BOOLEAN = 'boolean';
+    public const TYPE_INTEGER = 'integer';
+    public const TYPE_DOUBLE = 'double';
+    public const TYPE_STRING = 'string';
+    public const TYPE_DATETIME = 'datetime';
+    public const TYPE_ARRAY = 'array';
+    public const TYPE_NULL = 'NULL';
+    public const TYPE_OBJECT = 'object';
+    public const TYPE_RESOURCE = 'resource';
+    public const TYPE_UNKNOWN = 'unknown type';
 
     /**
      * @param mixed $element

--- a/tests/Integration/Core/Addon/Theme/ThemeRepositoryTest.php
+++ b/tests/Integration/Core/Addon/Theme/ThemeRepositoryTest.php
@@ -36,7 +36,7 @@ use Tests\TestCase\ContextStateTestCase;
 
 class ThemeRepositoryTest extends ContextStateTestCase
 {
-    const NOTICE = '[ThemeRepository] ';
+    public const NOTICE = '[ThemeRepository] ';
     /**
      * @var ThemeRepository|null
      */

--- a/tests/Integration/PrestaShopBundle/Translation/Extractor/LegacyModuleExtractorTest.php
+++ b/tests/Integration/PrestaShopBundle/Translation/Extractor/LegacyModuleExtractorTest.php
@@ -41,8 +41,8 @@ class LegacyModuleExtractorTest extends KernelTestCase
     /**
      * @var string Domain name of the modules translations
      */
-    const DOMAIN_NAME = 'ModulesTranslationtest';
-    const MODULE_NAME = 'translationtest';
+    public const DOMAIN_NAME = 'ModulesTranslationtest';
+    public const MODULE_NAME = 'translationtest';
 
     /**
      * @var CatalogueVerifier

--- a/tests/Integration/PrestaShopBundle/Translation/Provider/ExternalModuleLegacySystemProviderTest.php
+++ b/tests/Integration/PrestaShopBundle/Translation/Provider/ExternalModuleLegacySystemProviderTest.php
@@ -37,7 +37,7 @@ use Tests\Integration\PrestaShopBundle\Translation\CatalogueVerifier;
  */
 class ExternalModuleLegacySystemProviderTest extends KernelTestCase
 {
-    const MODULE_NAME = 'translationtest';
+    public const MODULE_NAME = 'translationtest';
 
     /**
      * @var ExternalModuleLegacySystemProvider

--- a/tests/Resources/modules/cronjobs/cronjobs.php
+++ b/tests/Resources/modules/cronjobs/cronjobs.php
@@ -35,7 +35,7 @@ require_once dirname(__FILE__) . '/classes/CronJobsForms.php';
 
 class CronJobs extends Module
 {
-    const EACH = -1;
+    public const EACH = -1;
 
     protected $_successes;
     protected $_warnings;

--- a/tests/Unit/Core/Foundation/VersionTest.php
+++ b/tests/Unit/Core/Foundation/VersionTest.php
@@ -42,17 +42,17 @@ class VersionTest extends TestCase
      */
     protected $anotherVersion;
 
-    const VERSION = '1.2.3.4';
-    const MAJOR_VERSION_STRING = '1.2';
-    const MAJOR_VERSION = 2;
-    const MINOR_VERSION = 3;
-    const RELEASE_VERSION = 4;
+    public const VERSION = '1.2.3.4';
+    public const MAJOR_VERSION_STRING = '1.2';
+    public const MAJOR_VERSION = 2;
+    public const MINOR_VERSION = 3;
+    public const RELEASE_VERSION = 4;
 
-    const ANOTHER_VERSION = '1.2.0.0';
-    const ANOTHER_MAJOR_VERSION_STRING = '1.2';
-    const ANOTHER_MAJOR_VERSION = 2;
-    const ANOTHER_MINOR_VERSION = 3;
-    const ANOTHER_RELEASE_VERSION = 4;
+    public const ANOTHER_VERSION = '1.2.0.0';
+    public const ANOTHER_MAJOR_VERSION_STRING = '1.2';
+    public const ANOTHER_MAJOR_VERSION = 2;
+    public const ANOTHER_MINOR_VERSION = 3;
+    public const ANOTHER_RELEASE_VERSION = 4;
 
     protected function setUp(): void
     {

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/CacheProviderTest.php
@@ -38,7 +38,7 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class CacheProviderTest extends TestCase
 {
-    const CACHE_KEY = 'test_cache_key';
+    public const CACHE_KEY = 'test_cache_key';
 
     /**
      * @var array

--- a/tests/Unit/PrestaShopBundle/Twig/Extension/PathWithBackUrlExtensionTest.php
+++ b/tests/Unit/PrestaShopBundle/Twig/Extension/PathWithBackUrlExtensionTest.php
@@ -37,7 +37,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class PathWithBackUrlExtensionTest extends TestCase
 {
-    const FALLBACK_URL = 'https://www.prestashop.com/en';
+    public const FALLBACK_URL = 'https://www.prestashop.com/en';
 
     /**
      * @var MockObject|RoutingExtension


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Update PHPCSFixer to make it compatible with PHP 8.1
| Type?             | improvement
| Category?         | IN
| BC breaks?        |  no
| Deprecations?     | no



Changes
- Added visibility `public` to constants
- changed 0xffffff to 0xFFFFFF
- Fixed spacing in catch multiple exceptions
