### PR TITLE
Fix Stock page style with RTL

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/product-line.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/product-line.vue
@@ -105,7 +105,7 @@
         :title="lowStockLevel"
       >!</span>
     </td>
-    <td class="qty-spinner text-right">
+    <td class="qty-spinner">
       <Spinner
         :product="product"
         @updateProductQty="updateProductQty"

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -1,3 +1,5 @@
+/* This comment avoid some weird behavior with preceding unclosed comment */
+
 @keyframes showcase-img-appearance-rtl {
   from {
     -webkit-transform: translate(-20px) translateX(-1);
@@ -137,3 +139,60 @@
 .nav-bar-overflow .ps__rail-y {
   left: 0 !important;
 }
+
+/**
+ * Fix some RTL problem with `admin-dev/themes/new-theme/scss/pages/stock/stock_page.scss` page
+ * for details, take a look at https://github.com/PrestaShop/PrestaShop/issues/27864 
+ */
+
+.adminstockmanagement .stock-app #search .search-input.tags-input:not(.search-with-icon) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.adminstockmanagement .stock-app #search .alert-box {
+    right: auto;
+    left: 5px;
+}
+
+.adminstockmanagement .stock-app #search #filters-container .collapse-button {
+    text-align: right;
+}
+
+.adminstockmanagement .stock-app #search #filters-container .filter-container.filter-suppliers  ul {
+    padding-right: 0;
+}
+
+.adminstockmanagement .stock-app #filters-container #filters {
+    box-shadow: -1px 2px 3px 0 rgba(108, 134, 142, 0.3);
+}
+
+.adminstockmanagement .stock-app .qty-spinner form.qty:hover input[type="number"],
+.adminstockmanagement .stock-app .qty-spinner form.qty.active input[type="number"] {
+    padding-right: 16px;
+}
+
+.adminstockmanagement .stock-app .qty-spinner form.qty:hover .ps-number-spinner, .adminstockmanagement .stock-app .qty-spinner form.qty.active .ps-number-spinner {
+    right: auto;
+    left: 34px;
+    text-align: left;
+}
+
+.adminstockmanagement .stock-app .qty-spinner form.qty .check-button {
+    right: auto;
+    left: 1px;
+    border-radius: 4px 0 0 4px;
+}
+
+.adminstockmanagement .stock-app .card .stock-overview .table thead th.product-title {
+    padding-right: 6rem;
+}
+
+.adminstockmanagement .stock-app .card .stock-overview .table thead th:last-child .material-icons {
+    margin-left: 5px;
+}
+
+.adminstockmanagement .stock-app .card .stock-overview .product-actions .qty {
+    padding-right: 20px;
+}
+


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | BO stock page style isn't well applied with RTL languages.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27864.
| Related PRs       | Coming soon
| How to test?      | See #27864 and check the whole page style. 
| Possible impacts? | I took original stock page style and tried to fix all right/left defined styles. I noticed that I fixed product table  description title, advanced filters position but I recommend to test all details you can. 

:warning: When 1.7.8.x branch will be merged into 8.0.x, be careful to not add `admin-dev/themes/new-theme/public/theme.rtlfix`.

:point_up: No backport required for 8.0.x branch. 