### PR TITLE
Update product / product_shop "date_upd" field after a stock movement

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -524,6 +524,13 @@ class StockAvailableCore extends ObjectModel
         );
         $this->setQuantity($this->id_product, 0, $total_quantity, $id_shop, false);
 
+        // ensure product date update after a stock movement
+        Db::getInstance()->execute('UPDATE ' . _DB_PREFIX_ . 'product
+                                    SET `date_upd` = "' . pSQL(date('Y-m-d H:i:s')) . '" WHERE id_product = ' . (int) $this->id_product);
+        Db::getInstance()->execute('UPDATE ' . _DB_PREFIX_ . 'product_shop
+                                    SET `date_upd` = "' . pSQL(date('Y-m-d H:i:s')) . '" WHERE id_product = ' . (int) $this->id_product . '
+                                        AND id_shop = ' . (int) $this->id_shop);
+
         return true;
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | make sure to perform product date_upd update queries after placing order or after a stock movement to keep track of product modification. This aims to fix 3 party software or modules not being able to recognize those products as modified for incremental updates - See also comments in #20465 issue
| Type?             | bug fix 
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #20465
| Related PRs       |  N/A
| How to test?      | check product date_upd getting updated correctly after a stock movement or WS quantity update
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
