### PR TITLE
When there no module upgrade script to run, make module upgrade succeed

### DIFF
--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -345,7 +345,7 @@ class ModuleManager implements ModuleManagerInterface
                 return !count($legacy_instance->getErrors());
             }
 
-            return LegacyModule::getUpgradeStatus($name);
+            return true;
         }
 
         return false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x 
| Description?      | This PR fixes an error when we upload a zip containing the same version as a module already installed. This PR brings back the behavior of 1.7.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29241
| Related PRs       | N/A
| How to test?      | Upload two times the same zip. It should always work
| Possible impacts? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

As a reminder, here is the code we had on PS 1.7.
https://github.com/PrestaShop/PrestaShop/blob/14cb6a4c6e72c55c16a95cfbe4aeb8e44fe73ab5/src/Adapter/Module/ModuleDataUpdater.php#L113-L117
