### PR TITLE
Fix bug where the custom value is not saved if its value is a string equal to "0"

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -893,7 +893,7 @@ class AdminProductsControllerCore extends AdminController
                     foreach ($features as $feature) {
                         if (!empty($feature['value'])) {
                             $product->addFeaturesToDB($feature['feature'], $feature['value']);
-                        } elseif ($defaultValue = $this->checkFeatures($languages, $feature)) {
+                        } elseif ($defaultValue = $this->checkFeatures($languages, $feature) !== 0) {
                             $idValue = $product->addFeaturesToDB($feature['feature'], 0, 1);
                             foreach ($languages as $language) {
                                 $valueToAdd = (isset($feature['custom_value'][$language['id_lang']]))


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.0.x / 1.7.8.x
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | FO / BO / CO / IN / WS / TE / LO / ME / PM
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #{issue number here}.
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
