### PR TITLE
Making PHP8.1 implicit conversion explicit

### DIFF
--- a/admin-dev/filemanager/include/php_image_magician.php
+++ b/admin-dev/filemanager/include/php_image_magician.php
@@ -450,7 +450,7 @@ class imageLib
     // *** Crop this bad boy
     $crop = imagecreatetruecolor($newWidth, $newHeight);
         $this->keepTransparancy($optimalWidth, $optimalHeight, $crop);
-        imagecopyresampled($crop, $this->imageResized, 0, 0, $cropStartX, $cropStartY, $newWidth, $newHeight, $newWidth, $newHeight);
+        imagecopyresampled($crop, $this->imageResized, 0, 0, (int) $cropStartX, (int) $cropStartY, (int) $newWidth, (int) $newHeight, (int) $newWidth, (int) $newHeight);
 
         $this->imageResized = $crop;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x 
| Description?      | This add explicit conversion to int. Before PHP 8.1 conversion were implicit and this is now deprecated
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #29268


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
