### PR TITLE
Fix wrong translation domains on notifications

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -426,7 +426,7 @@ class CombinationController extends FrameworkBundleAdminController
         foreach ($bulkCombinationException->getBulkExceptions() as $productId => $productException) {
             $errors[] = $this->trans(
                 'Error for combination %combination_id%: %error_message%',
-                'Admin.Notification.Error',
+                'Admin.Notifications.Error',
                 [
                     '%combination_id%' => $productId,
                     '%error_message%' => $this->getErrorMessageForException($productException, $this->getErrorMessages($productException)),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -716,7 +716,7 @@ class ProductController extends FrameworkBundleAdminController
         foreach ($bulkProductException->getBulkExceptions() as $productId => $productException) {
             $errors[] = $this->trans(
                 'Error for product %product_id%: %error_message%',
-                'Admin.Notification.Error',
+                'Admin.Notifications.Error',
                 [
                     '%product_id%' => $productId,
                     '%error_message%' => $this->getErrorMessageForException($productException, $this->getErrorMessages($productException)),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | There is a typo in translation domain on two notifications. Ping @Julievrz 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | -
| Possible impacts? | -

![domain](https://user-images.githubusercontent.com/6097524/183502370-45ce1316-c606-46b0-bd2f-bfd73028a5f6.jpg)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
