### PR TITLE
Fix undefined quantity index in light product list

### DIFF
--- a/src/Adapter/Product/Grid/Data/Factory/ProductLightGridDataFactoryDecorator.php
+++ b/src/Adapter/Product/Grid/Data/Factory/ProductLightGridDataFactoryDecorator.php
@@ -58,6 +58,11 @@ class ProductLightGridDataFactoryDecorator implements GridDataFactoryInterface
     private $defaultCurrencyId;
 
     /**
+     * @var bool
+     */
+    private $stockManagementEnabled;
+
+    /**
      * @param GridDataFactoryInterface $productGridDataFactory
      * @param Repository $localeRepository
      * @param string $contextLocale
@@ -67,13 +72,15 @@ class ProductLightGridDataFactoryDecorator implements GridDataFactoryInterface
         GridDataFactoryInterface $productGridDataFactory,
         Repository $localeRepository,
         string $contextLocale,
-        int $defaultCurrencyId
+        int $defaultCurrencyId,
+        bool $stockManagementEnabled
     ) {
         $this->productGridDataFactory = $productGridDataFactory;
         $this->locale = $localeRepository->getLocale(
             $contextLocale
         );
         $this->defaultCurrencyId = $defaultCurrencyId;
+        $this->stockManagementEnabled = $stockManagementEnabled;
     }
 
     /**
@@ -110,7 +117,7 @@ class ProductLightGridDataFactoryDecorator implements GridDataFactoryInterface
                 $currency->iso_code
             );
 
-            if ($products[$i]['quantity'] <= 0) {
+            if ($this->stockManagementEnabled && $products[$i]['quantity'] <= 0) {
                 $products[$i]['quantity_color'] = 'danger';
             }
         }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -102,6 +102,7 @@ services:
       - '@prestashop.core.localization.locale.repository'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.getLocale()'
       - '@=service("prestashop.adapter.legacy.configuration").get("PS_CURRENCY_DEFAULT")'
+      - '@=service("prestashop.adapter.legacy.configuration").get("PS_STOCK_MANAGEMENT")'
 
   prestashop.adapter.product.command_handler.get_product_for_editing_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductForEditingHandler


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | #29270
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Closes #29270
| Related PRs       | 
| How to test?      | Refer to #29270. Note if PS_STOCK_MANAGEMENT setting is off, then list won't have quantity column at all.
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
Stock management on:
![Screenshot from 2022-08-09 11-56-55](https://user-images.githubusercontent.com/31609858/183608371-e1d55b6c-2906-4658-928e-207d2f370104.png)

Stock management off:
![Screenshot from 2022-08-09 11-55-32](https://user-images.githubusercontent.com/31609858/183608065-ce163a63-9a33-460f-9400-79109657a081.png)

