### PR TITLE
Fix overflow of combination history

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/History.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-modal/History.vue
@@ -174,6 +174,7 @@
   .card-block {
     padding: 0;
     height: calc(100% - 7rem);
+    overflow: auto;
   }
 
   &-empty {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | bugfix #29267
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Closes #29267
| Related PRs       | I
| How to test?      | Refer to #29267. Now if there are a little more combinations than could fit to screen, there should appear a scrollbar, so they are correctly shown and doesn't cover the pagination block.
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
![Screenshot from 2022-08-09 12-47-19](https://user-images.githubusercontent.com/31609858/183619379-cc0cc81b-2530-40d7-807e-d3bde37fc777.png)
