### PR TITLE
Fix body classes for content_only and module front controllers

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1284,7 +1284,7 @@ class FrontControllerCore extends Controller
     }
 
     /**
-     * Returns the layout corresponding to the current page by using the override system
+     * Returns the layout's full path corresponding to the current page by using the override system
      * Ex:
      * On the url: http://localhost/index.php?id_product=1&controller=product, this method will
      * check if the layout exists in the following files (in that order), and return the first found:
@@ -1298,15 +1298,20 @@ class FrontControllerCore extends Controller
      */
     public function getLayout()
     {
+        // Primary identifier to search for a template is php_self property,
+        // For modules, we will use page_name
         $entity = $this->php_self;
         if (empty($entity)) {
             $entity = $this->getPageName();
         }
 
-        $layout = $this->context->shop->theme->getLayoutRelativePathForPage($entity);
+        // Get layout set in prestashop configuration
+        $layout = $this->context->shop->theme->getLayoutNameForPage($entity);
 
+        // Check if we are in content_only mode (used for displaying terms and conditions in a popup for example)
         $content_only = (int) Tools::getValue('content_only');
 
+        // If a module provides its own custom layout, we ignore what is set in configuration
         if ($overridden_layout = Hook::exec(
             'overrideLayoutTemplate',
             [
@@ -1320,11 +1325,22 @@ class FrontControllerCore extends Controller
             return $overridden_layout;
         }
 
+        // When using content_only, there will be no header, footer and sidebars
         if ($content_only) {
-            $layout = 'layouts/layout-content-only.tpl';
+            $layout = 'layout-content-only';
         }
 
-        return $layout;
+        return $this->context->shop->theme->getLayoutPath($layout);
+    }
+
+    /**
+     * Returns layout name for the current controller. Used to display layout name in <body> tag.
+     *
+     * @return string layout name
+     */
+    protected function getLayoutName()
+    {
+        return str_replace(['.tpl'], '', basename($this->getLayout()));
     }
 
     /**
@@ -1674,7 +1690,7 @@ class FrontControllerCore extends Controller
             'lang-rtl' => (bool) $this->context->language->is_rtl,
             'country-' . $this->context->country->iso_code => true,
             'currency-' . $this->context->currency->iso_code => true,
-            $this->context->shop->theme->getLayoutNameForPage($this->php_self) => true,
+            $this->getLayoutName() => true,
             'page-' . $this->php_self => true,
             'tax-display-' . ($this->getDisplayTaxesLabel() ? 'enabled' : 'disabled') => true,
             'page-customer-account' => false,

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -199,6 +199,13 @@ class Theme implements AddonInterface
         return $this->attributes->get('meta.available_layouts');
     }
 
+    /**
+     * Returns layout name for page from theme configuration
+     *
+     * @param string $page page identifier
+     *
+     * @return string layout name
+     */
     public function getLayoutNameForPage($page)
     {
         $layout_name = $this->get('theme_settings.default_layout');
@@ -210,9 +217,28 @@ class Theme implements AddonInterface
         return $layout_name;
     }
 
+    /**
+     * Returns layout relative path for provided page identifier
+     *
+     * @param string $page page identifier
+     *
+     * @return string layout relative path
+     */
     public function getLayoutRelativePathForPage($page)
     {
-        return 'layouts/' . $this->getLayoutNameForPage($page) . '.tpl';
+        return $this->getLayoutPath($this->getLayoutNameForPage($page));
+    }
+
+    /**
+     * Returns relative path for provided layout name
+     *
+     * @param string $layoutName layout name
+     *
+     * @return string layout relative path
+     */
+    public function getLayoutPath($layoutName)
+    {
+        return 'layouts/' . $layoutName . '.tpl';
     }
 
     private function getPageSpecificCss($pageId)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Front controller didn't provide correct body classes for styling in case of content_only parameter and custom module front controllers. There are no BC breaks in this PR.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Resolves #29265, resolves #29266
| How to test?      | Test using steps to reproduce in related issues.
| Possible impacts? | no

### Information for devs approving this
There were multiple problems when getting the body class.

Firstly, `$this->context->shop->theme->getLayoutNameForPage` was always called with `$this->php_self` parameter, which is not used in case of module front controllers. We need to use `$this->getPageName()` in that case.

Also, when calling a page with `?content_only=1`, a different layout is used, but this logic was not respected at all when getting the layout for body class purposes.

**Now, there is just one source of truth for the layout name, for any purpose.**

### How to test - module controllers
1. Install this module [tox_layouttest.zip](https://github.com/PrestaShop/PrestaShop/files/9293465/tox_layouttest.zip)
2. Go to backoffice > **Theme & logo** > bottom of the page **Choose layouts** and check that `category` and `layouttest` pages have both set the same left column layout.
3. Go to any category on your shop, check source code of the page, find `<body>` tag, and see that there is correct `layout-left-column` class on it.
4. Go to `/layouttest` in the front office of your shop, check source code of the page, find `<body>` tag, and see that there is `layout-left-column`.
5. Before this PR, there is `layout-full-width` (wrong) instead of `layout-left-column`.

### How to test - content only
1. Get default prestashop installation. It should have CMS pages set with left column.
2. When you inspect source code of any CMS page and check `<body>` tag, it should have `layout-left-column` class.
3. Now add `?content_only=1` to the end of the URL to get only the content. Check source code again.
4. Prestashop will use correct layout `layouts/layout-content-only.tpl`, but the class in body tag will not change and still be `layout-left-column` - wrong :red. It should be `layout-content-only`.
5. Apply this PR, see the issue is gone.