### PR TITLE
Add support for other file extensions in rewrite rules

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2503,30 +2503,27 @@ class ToolsCore
                     if (Configuration::get('PS_LEGACY_IMAGES')) {
                         fwrite($write_fd, $media_domains);
                         fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/p/$1-$2$3$4.jpg [L]' . PHP_EOL);
+                        fwrite($write_fd, 'RewriteRule ^([a-z0-9]+\-[a-z0-9]+\-[-\w]*)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/p/$1$2.jpg [L]' . PHP_EOL);
                         fwrite($write_fd, $media_domains);
                         fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^([0-9]+)\-([0-9]+)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/p/$1-$2$3.jpg [L]' . PHP_EOL);
+                        fwrite($write_fd, 'RewriteRule ^([\d]+(?:\-[\d]+){1,2})/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/p/$1$2.jpg [L]' . PHP_EOL);
                     }
 
                     // Rewrite product images < 10 millions
-                    for ($i = 1; $i <= 7; ++$i) {
-                        $img_path = $img_name = '';
-                        for ($j = 1; $j <= $i; ++$j) {
-                            $img_path .= '$' . $j . '/';
-                            $img_name .= '$' . $j;
-                        }
-                        $img_name .= '$' . $j;
+                    $path_components = [];
+                    for ($i = 1; $i <= 7; $i++) {
+                        $path_components[] = "$" . ($i + 1); // paths start on 2
+                        $path = implode('/', $path_components);
                         fwrite($write_fd, $media_domains);
                         fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^' . str_repeat('([0-9])', $i) . '(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/p/' . $img_path . $img_name . '$' . ($j + 1) . ".jpg [L]\n");
+                        fwrite($write_fd, 'RewriteRule ^(' . str_repeat('([\d])', $i) . '(?:\-[\w-]*)?)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/p/' . $path . '/$1$' . ($i + 2) . " [L]\n");
                     }
                     fwrite($write_fd, $media_domains);
                     fwrite($write_fd, $domain_rewrite_cond);
-                    fwrite($write_fd, 'RewriteRule ^c/([0-9]+)(\-[\.*_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2$3.jpg [L]' . PHP_EOL);
+                    fwrite($write_fd, 'RewriteRule ^c/([\d]+)(\-[\.*\w-]*)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/c/$1$2 [L]' . PHP_EOL);
                     fwrite($write_fd, $media_domains);
                     fwrite($write_fd, $domain_rewrite_cond);
-                    fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-]+)(-[0-9]+)?/.+\.jpg$ %{ENV:REWRITEBASE}img/c/$1$2.jpg [L]' . PHP_EOL);
+                    fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-]+)(-[\d]+)?/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/c/$1$2$3 [L]' . PHP_EOL);
                 }
 
                 fwrite($write_fd, "# AlphaImageLoader for IE and fancybox\n");

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2530,7 +2530,7 @@ class ToolsCore
                 if (Shop::isFeatureActive()) {
                     fwrite($write_fd, $domain_rewrite_cond);
                 }
-                fwrite($write_fd, 'RewriteRule ^images_ie/?([^/]+)\.(jpe?g|png|gif)$ js/jquery/plugins/fancybox/images/$1.$2 [L]' . PHP_EOL);
+                fwrite($write_fd, 'RewriteRule ^images_ie/?([^/]+)\.(jpe?g|png|gif)$ %{ENV:REWRITEBASE}js/jquery/plugins/fancybox/images/$1.$2 [L]' . PHP_EOL);
             }
             // Redirections to dispatcher
             if ($rewrite_settings) {

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2520,7 +2520,7 @@ class ToolsCore
                     }
                     fwrite($write_fd, $media_domains);
                     fwrite($write_fd, $domain_rewrite_cond);
-                    fwrite($write_fd, 'RewriteRule ^c/([\d]+)(\-[\.*\w-]*)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/c/$1$2 [L]' . PHP_EOL);
+                    fwrite($write_fd, 'RewriteRule ^c/([\d]+)(\-[\.*\w-]*)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/c/$1$2$3 [L]' . PHP_EOL);
                     fwrite($write_fd, $media_domains);
                     fwrite($write_fd, $domain_rewrite_cond);
                     fwrite($write_fd, 'RewriteRule ^c/([a-zA-Z_-]+)(-[\d]+)?/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/c/$1$2$3 [L]' . PHP_EOL);

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2511,8 +2511,8 @@ class ToolsCore
 
                     // Rewrite product images < 10 millions
                     $path_components = [];
-                    for ($i = 1; $i <= 7; $i++) {
-                        $path_components[] = "$" . ($i + 1); // paths start on 2
+                    for ($i = 1; $i <= 7; ++$i) {
+                        $path_components[] = '$' . ($i + 1); // paths start on 2
                         $path = implode('/', $path_components);
                         fwrite($write_fd, $media_domains);
                         fwrite($write_fd, $domain_rewrite_cond);

--- a/tests/Unit/Classes/ToolsTest.php
+++ b/tests/Unit/Classes/ToolsTest.php
@@ -830,6 +830,8 @@ class ToolsTest extends TestCase
     /**
      * This test verifies the rewrite rules to be written in the .htaccess file against the expected url segments
      *
+     * @see Tools::generateHtaccess
+     *
      * @dataProvider provideHtaccessRules
      */
     public function testHtaccessRewriteRules(string $rule, string $replacement, array $testCases)
@@ -853,8 +855,8 @@ class ToolsTest extends TestCase
     {
         return [
             'legacy product images 1' => [
-                '^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$',
-                '%{ENV:REWRITEBASE}img/p/$1-$2$3.jpg',
+                '^([a-z\d]+\-[a-z\d]+\-[-\w]*)/.+(\.(?:jpe?g|webp|png|avif))$',
+                '%{ENV:REWRITEBASE}img/p/$1$2',
                 [
                     [
                         'uri' => '123-something-foobar/totally-ignored.jpg',
@@ -914,8 +916,8 @@ class ToolsTest extends TestCase
             ],
 
             'legacy product images 2' => [
-                '^([0-9]+)\-([0-9]+)(-[0-9]+)?/.+\.jpg$',
-                '%{ENV:REWRITEBASE}img/p/$1-$2$3.jpg',
+                '^([\d]+(?:\-[\d]+){1,2})/.+(\.(?:jpe?g|webp|png|avif))$',
+                '%{ENV:REWRITEBASE}img/p/$1$2',
                 [
                     [
                         'uri' => '123-456-7/totally-ignored.jpg',
@@ -939,8 +941,8 @@ class ToolsTest extends TestCase
             ],
 
             'product images (single digit)' => [
-                '^([0-9])(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+\.jpg$',
-                '%{ENV:REWRITEBASE}img/p/$1/$1$2$3.jpg',
+                '^(([\d])(?:\-[\w-]*)?)/.+(\.(?:jpe?g|webp|png|avif))$$',
+                '%{ENV:REWRITEBASE}img/p/$2/$1$3',
                 [
                     [
                         'uri' => '1-soMeTh1ng_cool22-99/totally-ignored.jpg',
@@ -971,8 +973,8 @@ class ToolsTest extends TestCase
             ],
 
             'product images (7 digits)' => [
-                '^([0-9])([0-9])([0-9])([0-9])([0-9])([0-9])([0-9])(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+\.jpg$',
-                '%{ENV:REWRITEBASE}img/p/$1/$2/$3/$4/$5/$6/$7/$1$2$3$4$5$6$7$8$9.jpg',
+                '^(([\d])([\d])([\d])([\d])([\d])([\d])([\d])(?:\-[\w-]*)?)/.+(\.(?:jpe?g|webp|png|avif))$',
+                '%{ENV:REWRITEBASE}img/p/$2/$3/$4/$5/$6/$7/$8/$1$9',
                 [
                     [
                         'uri' => '1234567-soMeTh1ng_cool22-99/totally-ignored.jpg',
@@ -1007,8 +1009,8 @@ class ToolsTest extends TestCase
             ],
 
             'category images 1' => [
-                '^c/([0-9]+)(\-[\.*_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$',
-                '%{ENV:REWRITEBASE}img/c/$1$2$3.jpg',
+                '^c/([\d]+)(\-[\.*\w-]*)/.+(\.(?:jpe?g|webp|png|avif))$',
+                '%{ENV:REWRITEBASE}img/c/$1$2.jpg',
                 [
                     [
                         'uri' => 'c/1234567-soMe.Th1n*g_cool22-99/totally-ignored.jpg',
@@ -1051,8 +1053,8 @@ class ToolsTest extends TestCase
             ],
 
             'category images 2' => [
-                '^c/([a-zA-Z_-]+)(-[0-9]+)?/.+\.jpg$',
-                '%{ENV:REWRITEBASE}img/c/$1$2.jpg',
+                '^c/([a-zA-Z_-]+)(-[\d]+)?/.+(\.(?:jpe?g|webp|png|avif))$',
+                '%{ENV:REWRITEBASE}img/c/$1$2$3',
                 [
                     [
                         'uri' => 'c/soMeThing_cool-test-99/totally-ignored.jpg',

--- a/tests/Unit/Classes/ToolsTest.php
+++ b/tests/Unit/Classes/ToolsTest.php
@@ -826,4 +826,268 @@ class ToolsTest extends TestCase
             'field4',
         ];
     }
+
+    /**
+     * This test verifies the rewrite rules to be written in the .htaccess file against the expected url segments
+     *
+     * @dataProvider provideHtaccessRules
+     */
+    public function testHtaccessRewriteRules(string $rule, string $replacement, array $testCases)
+    {
+        $rule = "~$rule~";
+        foreach ($testCases as $setName => $case) {
+            if ($case['shouldMatch']) {
+                $this->assertRegExp($rule, $case['uri'], "The uri segment is expected to match the pattern, but it doesn't");
+            } else {
+                $this->assertNotRegExp($rule, $case['uri'], 'The uri segment is expected NOT to match the pattern, but it does');
+            }
+
+            if ($case['shouldMatch']) {
+                $result = preg_replace($rule, $replacement, $case['uri']);
+                $this->assertSame($case['rewritten'], $result);
+            }
+        }
+    }
+
+    public function provideHtaccessRules()
+    {
+        return [
+            'legacy product images 1' => [
+                '^([a-z0-9]+)\-([a-z0-9]+)(\-[_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$',
+                '%{ENV:REWRITEBASE}img/p/$1-$2$3.jpg',
+                [
+                    [
+                        'uri' => '123-something-foobar/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/123-something-foobar.jpg',
+                    ],
+                    [
+                        'uri' => '123-something-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/123-something-.jpg',
+                    ],
+                    [
+                        'uri' => '123-something/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => 'test-99/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => 'test-99-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/test-99-.jpg',
+                    ],
+                    [
+                        'uri' => 'test123-foo2bar1-someThing_with_underscores-9-123/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/test123-foo2bar1-someThing_with_underscores-9-123.jpg',
+                    ],
+                    [
+                        'uri' => 'test123-foo2bar1-someThing_with_underscores-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/test123-foo2bar1-someThing_with_underscores-.jpg',
+                    ],
+                    [
+                        'uri' => '123-Something-foobar/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => 'r-f-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/r-f-.jpg',
+                    ],
+                    [
+                        'uri' => 'r-f/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => '99/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => 'test/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                ],
+            ],
+
+            'legacy product images 2' => [
+                '^([0-9]+)\-([0-9]+)(-[0-9]+)?/.+\.jpg$',
+                '%{ENV:REWRITEBASE}img/p/$1-$2$3.jpg',
+                [
+                    [
+                        'uri' => '123-456-7/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/123-456-7.jpg',
+                    ],
+                    [
+                        'uri' => '123-456/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/123-456.jpg',
+                    ],
+                    [
+                        'uri' => '123-/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => '123/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                ],
+            ],
+
+            'product images (single digit)' => [
+                '^([0-9])(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+\.jpg$',
+                '%{ENV:REWRITEBASE}img/p/$1/$1$2$3.jpg',
+                [
+                    [
+                        'uri' => '1-soMeTh1ng_cool22-99/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/1/1-soMeTh1ng_cool22-99.jpg',
+                    ],
+                    [
+                        'uri' => '9-soMeTh1ng_cool22-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/9/9-soMeTh1ng_cool22-.jpg',
+                    ],
+                    [
+                        'uri' => '9-soMeTh1ng_cool22/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/9/9-soMeTh1ng_cool22.jpg',
+                    ],
+                    [
+                        'uri' => '1-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/1/1-.jpg',
+                    ],
+                    [
+                        'uri' => '1/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/1/1.jpg',
+                    ],
+                ],
+            ],
+
+            'product images (7 digits)' => [
+                '^([0-9])([0-9])([0-9])([0-9])([0-9])([0-9])([0-9])(\-[_a-zA-Z0-9-]*)?(-[0-9]+)?/.+\.jpg$',
+                '%{ENV:REWRITEBASE}img/p/$1/$2/$3/$4/$5/$6/$7/$1$2$3$4$5$6$7$8$9.jpg',
+                [
+                    [
+                        'uri' => '1234567-soMeTh1ng_cool22-99/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/1/2/3/4/5/6/7/1234567-soMeTh1ng_cool22-99.jpg',
+                    ],
+                    [
+                        'uri' => '7654321-soMeTh1ng_cool22-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/7/6/5/4/3/2/1/7654321-soMeTh1ng_cool22-.jpg',
+                    ],
+                    [
+                        'uri' => '7654321-soMeTh1ng_cool22/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/7/6/5/4/3/2/1/7654321-soMeTh1ng_cool22.jpg',
+                    ],
+                    [
+                        'uri' => '1234567-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/1/2/3/4/5/6/7/1234567-.jpg',
+                    ],
+                    [
+                        'uri' => '1234567/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/p/1/2/3/4/5/6/7/1234567.jpg',
+                    ],
+                    [
+                        'uri' => '1234-soMeTh1ng_cool22-99/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                ],
+            ],
+
+            'category images 1' => [
+                '^c/([0-9]+)(\-[\.*_a-zA-Z0-9-]*)(-[0-9]+)?/.+\.jpg$',
+                '%{ENV:REWRITEBASE}img/c/$1$2$3.jpg',
+                [
+                    [
+                        'uri' => 'c/1234567-soMe.Th1n*g_cool22-99/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/c/1234567-soMe.Th1n*g_cool22-99.jpg',
+                    ],
+                    [
+                        'uri' => 'c/1-foo-99/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/c/1-foo-99.jpg',
+                    ],
+                    [
+                        'uri' => 'c/1-foo-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/c/1-foo-.jpg',
+                    ],
+                    [
+                        'uri' => 'c/1-foo/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/c/1-foo.jpg',
+                    ],
+                    [
+                        'uri' => 'c/1-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/c/1-.jpg',
+                    ],
+                    [
+                        'uri' => 'c/1/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => '1-foo-99/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => 'c/foo-99/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                ],
+            ],
+
+            'category images 2' => [
+                '^c/([a-zA-Z_-]+)(-[0-9]+)?/.+\.jpg$',
+                '%{ENV:REWRITEBASE}img/c/$1$2.jpg',
+                [
+                    [
+                        'uri' => 'c/soMeThing_cool-test-99/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/c/soMeThing_cool-test-99.jpg',
+                    ],
+                    [
+                        'uri' => 'c/foo-99/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/c/foo-99.jpg',
+                    ],
+                    [
+                        'uri' => 'c/foo-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/c/foo-.jpg',
+                    ],
+                    [
+                        'uri' => 'c/-/totally-ignored.jpg',
+                        'shouldMatch' => true,
+                        'rewritten' => '%{ENV:REWRITEBASE}img/c/-.jpg',
+                    ],
+                    [
+                        'uri' => 'c/1-1/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => 'c/1/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                    [
+                        'uri' => '1-foo-99/totally-ignored.jpg',
+                        'shouldMatch' => false,
+                    ],
+                ],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Read below
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | I don't know
| Related PRs       | ~
| How to test?      | Read below
| Possible impacts? | ~

## What this is about

There is a known issue where even if your choose to use a format different than jpg, thumbnails will be generated with the `.jpg` extension. This PR doesn't fix that. It updates rewrite rules so that this will be possible in the future (when the thumbnails will use the appropriate file extension.

This PR also simplifies the rewrite rules, because there's a limit of 9 capturing groups and I needed one more to capture the file's extension. To be safe, I added tests. It was not easy because not only `Tools::generateHtaccess()` is not unit testable, but it also does much more than the scope of this change required. So I copied the rules into the unit test. You could argue that this is cheating because it's not actually testing the real code – I did the best that I could with the time I had.

Interesting: I noticed that the original rewrite rules for categories accept URLs which are probably not wanted, like `img/c/-.jpg` or `img/c/1234567-soMe.Th1n*g_cool22-99.jpg`. This should probably be subject to a fix in another PR.

## How to test

1. Install the shop. Alternatively, go to Advanced parameters > performance, then toggle [this switch](https://user-images.githubusercontent.com/1009343/183975960-ded468dd-050a-4600-b013-30dd27d45f17.png) on or off, and save to trigger the regeneration of the .htaccess file at the root of the project. If you do that, switch the toggle again to leave it as it was (or else it could produce side effects that you might blame on my PR).
2. Product and category images on FO should show up normally (as opposed to be 404 not found).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
