### PR TITLE
Fix specific price creation for dedicated customer

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
@@ -49,6 +49,7 @@ class SearchedCustomerType extends CommonAbstractType
             ])
             ->add('fullname_and_email', TextPreviewType::class, [
                 'label' => false,
+                'block_prefix' => 'searched_customer_fullname_and_email',
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/SearchedCustomerType.php
@@ -45,6 +45,7 @@ class SearchedCustomerType extends CommonAbstractType
         $builder
             ->add('id_customer', HiddenType::class, [
                 'label' => false,
+                'block_prefix' => 'searched_customer_id_customer',
             ])
             ->add('fullname_and_email', TextPreviewType::class, [
                 'label' => false,

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
@@ -36,6 +36,11 @@
   </li>
 {% endblock %}
 
+{#
+  these widgets are the prototype templates (that are handled by js later) and they are rendered as disabled by default
+  on page load because of disablingSwitch component behavior. But they must not be disabled
+  or else will not be submitted to the form, so we remove "disabled" attribute if it exists.
+#}
 {% block searched_customer_id_customer_widget %}
   {% set attr = attr|filter((value, key) => key != 'disabled') %}
   {{ block('hidden_widget') }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
@@ -36,6 +36,11 @@
   </li>
 {% endblock %}
 
+{% block searched_customer_id_customer_widget %}
+  {% set attr = attr|filter((value, key) => key != 'disabled') %}
+  {{ block('hidden_widget') }}
+{% endblock %}
+
 {% block specific_price_impact_row %}
   {{ form_label(form) }}
   {{ form_errors(form) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/FormTheme/specific_price.html.twig
@@ -41,6 +41,11 @@
   {{ block('hidden_widget') }}
 {% endblock %}
 
+{% block searched_customer_fullname_and_email_widget %}
+  {% set attr = attr|filter((value, key) => key != 'disabled') %}
+  {{ block('text_preview_widget') }}
+{% endblock %}
+
 {% block specific_price_impact_row %}
   {{ form_label(form) }}
   {{ form_errors(form) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When we use the `disabling_switch` option based on the initial data it automatically adds the disabled attribute, coupled with the EntitySearchInput it results in the disabled attribute being integrated in the prototype. SO when a new customer is selected it is always disabled and cannot be saved. This PR integrates a quick fix by overriding the form themes for the customer input so that the disabled attribute is NEVER added. It's a quick solution but we may have to find a better and more generic one later.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29296
| Related PRs       | 
| How to test?      | refer to https://github.com/PrestaShop/PrestaShop/issues/29296
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
![Screenshot from 2022-08-11 13-04-13](https://user-images.githubusercontent.com/31609858/184110529-070e56ff-49fb-4721-b5f9-2922ec0c08de.png)
![Screenshot from 2022-08-11 13-04-19](https://user-images.githubusercontent.com/31609858/184110523-5734cc2b-2934-456f-9104-49088c7f4b8e.png)