### PR TITLE
Add confirmation modal before module installation

### DIFF
--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -129,12 +129,52 @@ export default class ModuleCard {
     $(document).on(
       'click',
       this.moduleActionMenuInstallLinkSelector,
-      function () {
-        return (
-          self.dispatchPreEvent('install', this)
-          && self.confirmAction('install', this)
-          && self.requestToController('install', $(this))
-        );
+      function (event) {
+        event.preventDefault();
+        const modal = $(`#${$(this).data('confirm_modal')}`);
+        const isMaintenanceMode = window.isShopMaintenance;
+
+        if (modal.length !== 1) {
+          // Modal body element
+          const maintenanceLink = document.createElement('a');
+          maintenanceLink.classList.add('btn', 'btn-primary', 'btn-lg');
+          maintenanceLink.setAttribute('href', window.moduleURLs.maintenancePage);
+          maintenanceLink.innerHTML = window.moduleTranslations.moduleModalUpdateMaintenance;
+
+          const installConfirmModal = new ConfirmModal(
+            {
+              id: 'confirm-module-install-modal',
+              confirmTitle:
+              window.moduleTranslations.singleModuleModalInstallTitle,
+              closeButtonLabel: window.moduleTranslations.moduleModalCancel,
+              confirmButtonLabel: isMaintenanceMode
+                ? window.moduleTranslations.moduleModalInstall
+                : window.moduleTranslations.installAnywayButtonText,
+              confirmButtonClass: isMaintenanceMode
+                ? 'btn-primary'
+                : 'btn-secondary',
+              confirmMessage: isMaintenanceMode
+                ? ''
+                : window.moduleTranslations.moduleModalInstallConfirmMessage,
+              closable: true,
+              customButtons: isMaintenanceMode ? [] : [maintenanceLink],
+            },
+
+            () => self.dispatchPreEvent('install', this)
+              && self.confirmAction('install', this)
+              && self.requestToController('install', $(this)),
+          );
+
+          installConfirmModal.show();
+        } else {
+          return (
+            self.dispatchPreEvent('install', this)
+            && self.confirmAction('install', this)
+            && self.requestToController('install', $(this))
+          );
+        }
+
+        return false;
       },
     );
 
@@ -225,7 +265,7 @@ export default class ModuleCard {
             id: 'confirm-module-update-modal',
             confirmTitle:
               window.moduleTranslations.singleModuleModalUpdateTitle,
-            closeButtonLabel: window.moduleTranslations.moduleModalUpdateCancel,
+            closeButtonLabel: window.moduleTranslations.moduleModalCancel,
             confirmButtonLabel: isMaintenanceMode
               ? window.moduleTranslations.moduleModalUpdateUpgrade
               : window.moduleTranslations.upgradeAnywayButtonText,

--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -155,7 +155,7 @@ export default class ModuleCard {
                 : 'btn-secondary',
               confirmMessage: isMaintenanceMode
                 ? ''
-                : window.moduleTranslations.moduleModalInstallConfirmMessage,
+                : window.moduleTranslations.moduleModalConfirmMessage,
               closable: true,
               customButtons: isMaintenanceMode ? [] : [maintenanceLink],
             },
@@ -274,7 +274,7 @@ export default class ModuleCard {
               : 'btn-secondary',
             confirmMessage: isMaintenanceMode
               ? ''
-              : window.moduleTranslations.moduleModalUpdateConfirmMessage,
+              : window.moduleTranslations.moduleModalConfirmMessage,
             closable: true,
             customButtons: isMaintenanceMode ? [] : [maintenanceLink],
           },

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -617,10 +617,44 @@ class AdminModuleController {
   }
 
   initAddModuleAction() {
-    const self = this;
-    const addModuleButton = $(self.importModalBtnSelector);
-    addModuleButton.attr('data-toggle', 'modal');
-    addModuleButton.attr('data-target', self.dropZoneModalSelector);
+    const body = $('body');
+    const isMaintenanceMode = window.isShopMaintenance;
+    const modal = $(`#${$(this).data('confirm_modal')}`);
+
+    body.on('click', this.importModalBtnSelector, () => {
+      if (modal.length !== 1) {
+        const maintenanceLink = document.createElement('a');
+        maintenanceLink.classList.add('btn', 'btn-primary', 'btn-lg');
+        maintenanceLink.setAttribute('href', window.moduleURLs.maintenancePage);
+        maintenanceLink.innerHTML = window.moduleTranslations.moduleModalUpdateMaintenance;
+
+        const importConfirmModal = new ConfirmModal(
+          {
+            id: 'confirm-module-import-modal',
+            confirmTitle:
+            window.moduleTranslations.singleModuleModalImportTitle,
+            closeButtonLabel: window.moduleTranslations.moduleModalCancel,
+            confirmButtonLabel: isMaintenanceMode
+              ? window.moduleTranslations.moduleModalImport
+              : window.moduleTranslations.importAnywayButtonText,
+            confirmButtonClass: isMaintenanceMode
+              ? 'btn-primary'
+              : 'btn-secondary',
+            confirmMessage: isMaintenanceMode
+              ? ''
+              : window.moduleTranslations.moduleModalConfirmMessage,
+            closable: true,
+            customButtons: isMaintenanceMode ? [] : [maintenanceLink],
+          },
+
+          () => $(this.dropZoneModalSelector).modal({show: true}),
+        );
+
+        importConfirmModal.show();
+      }
+
+      return false;
+    });
   }
 
   initDropzone() {

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -1060,7 +1060,7 @@ class AdminModuleController {
         {
           id: 'confirm-module-update-modal',
           confirmTitle: window.moduleTranslations.singleModuleModalUpdateTitle,
-          closeButtonLabel: window.moduleTranslations.moduleModalUpdateCancel,
+          closeButtonLabel: window.moduleTranslations.moduleModalCancel,
           confirmButtonLabel: isMaintenanceMode
             ? window.moduleTranslations.moduleModalUpdateUpgrade
             : window.moduleTranslations.upgradeAnywayButtonText,

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -631,12 +631,11 @@ class AdminModuleController {
         const importConfirmModal = new ConfirmModal(
           {
             id: 'confirm-module-import-modal',
-            confirmTitle:
-            window.moduleTranslations.singleModuleModalImportTitle,
+            confirmTitle: window.moduleTranslations.singleModuleModalImportTitle,
             closeButtonLabel: window.moduleTranslations.moduleModalCancel,
             confirmButtonLabel: isMaintenanceMode
               ? window.moduleTranslations.moduleModalImport
-              : window.moduleTranslations.importAnywayButtonText,
+              : window.moduleTranslations.uploadAnywayButtonText,
             confirmButtonClass: isMaintenanceMode
               ? 'btn-primary'
               : 'btn-secondary',
@@ -713,7 +712,7 @@ class AdminModuleController {
       event.preventDefault();
       /**
        * Trigger click on hidden file input, and pass extra data
-       * to .dropzone click handler fro it to notice it comes from here
+       * to .dropzone click handler from it to notice it comes from here
        */
       $('.dz-hidden-input').trigger('click', ['manual_select']);
     });
@@ -749,7 +748,7 @@ class AdminModuleController {
       hiddenInputContainer: self.dropZoneImportZoneSelector,
       /**
        * Add unlimited timeout. Otherwise dropzone timeout is 30 seconds
-       *  and if a module is long to install, it is not possible to install the module.
+       * and if a module is long to install, it is not possible to install the module.
        */
       timeout: 0,
       addedfile: () => {

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -35,17 +35,19 @@
     };
 
     var moduleTranslations = {
-      'singleModuleModalInstallTitle': '{{ "Are you sure you want to install this module?"|trans({}, 'Admin.Modules.Notification') }}',
-      'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module?"|trans({}, 'Admin.Modules.Notification') }}',
+      'singleModuleModalInstallTitle': '{{ "Are you sure you want to install this module ?"|trans({}, 'Admin.Modules.Notification') }}',
+      'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module ?"|trans({}, 'Admin.Modules.Notification') }}',
+      'singleModuleModalImportTitle': '{{ "Are you sure you want to upload this module ?"|trans({}, 'Admin.Modules.Notification') }}',
       'multipleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade these modules?"|trans({}, 'Admin.Modules.Notification') }}',
       'moduleModalCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateMaintenance': '{{ "Go to maintenance page"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateUpgrade': '{{ "Upgrade"|trans({}, 'Admin.Actions') }}',
       'moduleModalInstall':'{{ "Install"|trans({}, 'Admin.Actions') }}',
+      'moduleModalImport':'{{ "Import"|trans({}, 'Admin.Actions') }}',
       'upgradeAnywayButtonText': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}',
       'installAnywayButtonText': '{{ "Install anyway"|trans({}, 'Admin.Actions') }}',
-      'moduleModalUpdateConfirmMessage': '{{ "We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Notification') }}',
-      'moduleModalInstallConfirmMessage': '{{ "We strongly advise you to install the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Notification') }}',
+      'importAnywayButtonText': '{{ "Import anyway"|trans({}, 'Admin.Actions') }}',
+      'moduleModalConfirmMessage': '{{ "First things first: put your store in maintenance mode. And if several people have access to the back office, warn your team that no action should be taken on the store during the process."|trans({}, 'Admin.Modules.Notification') }}',
     };
 
     // Need to come from the backend

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -46,7 +46,7 @@
       'moduleModalImport':'{{ "Import"|trans({}, 'Admin.Actions') }}',
       'upgradeAnywayButtonText': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}',
       'installAnywayButtonText': '{{ "Install anyway"|trans({}, 'Admin.Actions') }}',
-      'importAnywayButtonText': '{{ "Import anyway"|trans({}, 'Admin.Actions') }}',
+      'uploadAnywayButtonText': '{{ "Upload anyway"|trans({}, 'Admin.Actions') }}',
       'moduleModalConfirmMessage': '{{ "First things first: put your store in maintenance mode. And if several people have access to the back office, warn your team that no action should be taken on the store during the process."|trans({}, 'Admin.Modules.Notification') }}',
     };
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -35,13 +35,17 @@
     };
 
     var moduleTranslations = {
+      'singleModuleModalInstallTitle': '{{ "Are you sure you want to install this module?"|trans({}, 'Admin.Modules.Notification') }}',
       'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module?"|trans({}, 'Admin.Modules.Notification') }}',
       'multipleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade these modules?"|trans({}, 'Admin.Modules.Notification') }}',
-      'moduleModalUpdateCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}',
+      'moduleModalCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateMaintenance': '{{ "Go to maintenance page"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateUpgrade': '{{ "Upgrade"|trans({}, 'Admin.Actions') }}',
+      'moduleModalInstall':'{{ "Install"|trans({}, 'Admin.Actions') }}',
       'upgradeAnywayButtonText': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}',
+      'installAnywayButtonText': '{{ "Install anyway"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateConfirmMessage': '{{ "We strongly advise you to upgrade the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Notification') }}',
+      'moduleModalInstallConfirmMessage': '{{ "We strongly advise you to install the modules on maintenance mode to avoid any cache issues."|trans({}, 'Admin.Modules.Notification') }}',
     };
 
     // Need to come from the backend

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -35,9 +35,10 @@
     };
 
     var moduleTranslations = {
-      'singleModuleModalInstallTitle': '{{ "Are you sure you want to install this module ?"|trans({}, 'Admin.Modules.Notification') }}',
-      'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module ?"|trans({}, 'Admin.Modules.Notification') }}',
-      'singleModuleModalImportTitle': '{{ "Are you sure you want to upload this module ?"|trans({}, 'Admin.Modules.Notification') }}',
+      'singleModuleModalInstallTitle': '{{ "Are you sure you want to install this module?"|trans({}, 'Admin.Modules.Notification') }}',
+      'multipleModuleModalInstallTitle': '{{ "Are you sure you want to install these modules?"|trans({}, 'Admin.Modules.Notification') }}',
+      'singleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade this module?"|trans({}, 'Admin.Modules.Notification') }}',
+      'singleModuleModalImportTitle': '{{ "Are you sure you want to upload this module?"|trans({}, 'Admin.Modules.Notification') }}',
       'multipleModuleModalUpdateTitle': '{{ "Are you sure you want to upgrade these modules?"|trans({}, 'Admin.Modules.Notification') }}',
       'moduleModalCancel': '{{ "Cancel"|trans({}, 'Admin.Actions') }}',
       'moduleModalUpdateMaintenance': '{{ "Go to maintenance page"|trans({}, 'Admin.Actions') }}',
@@ -47,7 +48,7 @@
       'upgradeAnywayButtonText': '{{ "Upgrade anyway"|trans({}, 'Admin.Actions') }}',
       'installAnywayButtonText': '{{ "Install anyway"|trans({}, 'Admin.Actions') }}',
       'uploadAnywayButtonText': '{{ "Upload anyway"|trans({}, 'Admin.Actions') }}',
-      'moduleModalConfirmMessage': '{{ "First things first: put your store in maintenance mode. And if several people have access to the back office, warn your team that no action should be taken on the store during the process."|trans({}, 'Admin.Modules.Notification') }}',
+      'moduleModalConfirmMessage': '{{ "First, put your store in maintenance mode. If several people have access to the back office, let your team know that no action should be taken on the store during the process."|trans({}, 'Admin.Modules.Notification') }}',
     };
 
     // Need to come from the backend


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Add confirmation modal before install, upgrading or importing module. Warning user should go in maintenance mode before performing these actions due to cache potential issues
| Type?             | improvement 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #28304
| Related PRs       | N/A
| How to test?      | 1. Go to BO<br>2. Go to Modules<br>3. If installed, uninstall wishlist module<br>4. Click "Install" button<br>5. See confimation modal appears
| Possible impacts? | N/A.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
