### PR TITLE
Collect unregistered hooks in debug toolbar

### DIFF
--- a/src/Adapter/Hook/HookDispatcher.php
+++ b/src/Adapter/Hook/HookDispatcher.php
@@ -118,6 +118,7 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
             $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 5);
 
             // Try to find the initial backtrace that was not called from the dispatcher services
+            $initialBackTrace = [];
             for ($i = 0; $i < count($backtrace); ++$i) {
                 $initialBackTrace = $backtrace[$i];
                 $isCodeFromDispatcher = (bool) strpos($initialBackTrace['file'], 'HookDispatcher');
@@ -126,7 +127,7 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
                 }
             }
 
-            $this->hookRegistry->selectHook($eventName, $event->getHookParameters(), $initialBackTrace['file'], $initialBackTrace['line']);
+            $this->hookRegistry->selectHook($eventName, $event->getHookParameters(), $initialBackTrace['file'] ?? 'unknown file', $initialBackTrace['line'] ?? 'unknown line');
             $this->hookRegistry->hookWasNotRegistered();
             $this->hookRegistry->collect();
         }

--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -54,10 +54,12 @@ final class HookDataCollector extends DataCollector
         $hooks = $this->registry->getHooks();
         $calledHooks = $this->registry->getCalledHooks();
         $notCalledHooks = $this->registry->getNotCalledHooks();
+        $notRegisteredHooks = $this->registry->getNotRegisteredHooks();
         $this->data = [
             'hooks' => $this->stringifyHookArguments($hooks),
             'calledHooks' => $this->stringifyHookArguments($calledHooks),
             'notCalledHooks' => $this->stringifyHookArguments($notCalledHooks),
+            'notRegisteredHooks' => $this->stringifyHookArguments($notRegisteredHooks),
         ];
     }
 
@@ -98,6 +100,16 @@ final class HookDataCollector extends DataCollector
     public function getNotCalledHooks()
     {
         return $this->data['notCalledHooks'];
+    }
+
+    /**
+     * Return the list of every uncalled legacy hooks during oHookne request.
+     *
+     * @return array
+     */
+    public function getNotRegisteredHooks()
+    {
+        return $this->data['notRegisteredHooks'];
     }
 
     /**

--- a/src/PrestaShopBundle/DataCollector/HookRegistry.php
+++ b/src/PrestaShopBundle/DataCollector/HookRegistry.php
@@ -44,7 +44,7 @@ final class HookRegistry
     private $currentHook = null;
 
     /**
-     * @var array the list of hooks data
+     * @var array<string, array<string, array{args: array, name:string, location: string, modules: array}>> the list of hooks data
      */
     private $hooks;
 
@@ -132,7 +132,7 @@ final class HookRegistry
      */
     public function getCalledHooks()
     {
-        return $this->hooks['called'];
+        return $this->hooks[self::HOOK_CALLED];
     }
 
     /**

--- a/src/PrestaShopBundle/DataCollector/HookRegistry.php
+++ b/src/PrestaShopBundle/DataCollector/HookRegistry.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Module\Legacy\ModuleInterface;
 final class HookRegistry
 {
     public const HOOK_NOT_CALLED = 'notCalled';
+    public const HOOK_NOT_REGISTERED = 'notRegistered';
     public const HOOK_CALLED = 'called';
 
     /**
@@ -52,6 +53,7 @@ final class HookRegistry
         $this->hooks = [
             self::HOOK_CALLED => [],
             self::HOOK_NOT_CALLED => [],
+            self::HOOK_NOT_REGISTERED => [],
         ];
     }
 
@@ -78,6 +80,14 @@ final class HookRegistry
     public function hookWasCalled()
     {
         $this->currentHook['status'] = self::HOOK_CALLED;
+    }
+
+    /**
+     * Notify the registry that the selected hook have been called.
+     */
+    public function hookWasNotRegistered()
+    {
+        $this->currentHook['status'] = self::HOOK_NOT_REGISTERED;
     }
 
     /**
@@ -130,7 +140,15 @@ final class HookRegistry
      */
     public function getNotCalledHooks()
     {
-        return $this->hooks['notCalled'];
+        return $this->hooks[self::HOOK_NOT_CALLED];
+    }
+
+    /**
+     * @return array the list of unregistered hooks
+     */
+    public function getNotRegisteredHooks()
+    {
+        return $this->hooks[self::HOOK_NOT_REGISTERED];
     }
 
     /**
@@ -138,7 +156,7 @@ final class HookRegistry
      */
     public function getHooks()
     {
-        return $this->hooks['called'] + $this->hooks['notCalled'];
+        return $this->hooks[self::HOOK_CALLED] + $this->hooks[self::HOOK_NOT_CALLED] + $this->hooks[self::HOOK_NOT_REGISTERED];
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -62,6 +62,8 @@ services:
     arguments:
       - '@request_stack'
       - !tagged core.legacy.hook.subscriber
+      - '@prestashop.hooks_registry'
+      - '@=service("prestashop.adapter.environment").isDebug()'
 
   prestashop.hook.finder:
     class: PrestaShopBundle\Service\Hook\HookFinder

--- a/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/hooks_collector.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/WebProfiler/hooks_collector.html.twig
@@ -119,6 +119,31 @@
                     {% endif %}
                 </div>
             </div>
+
+          <div class="tab">
+            <h3 class="tab-title">
+              Not registered hooks
+              <span class="badge">{{ collector.notRegisteredHooks|length }}</span>
+            </h3>
+            <p>
+              These hooks have been dispatched by PrestaShop but they are not registered in the database, meaning no modules registered them
+              and they were not added in the hook fixtures for core hooks.
+            </p>
+            <div class="tab-content">
+              {% if collector.notRegisteredHooks is empty %}
+                <div class="empty">
+                  <p>
+                    <strong>There are no unregistered hooks</strong>.
+                  </p>
+                  <p>
+                    Seems like all hooks had appropriate listeners so they were all correctly registered in the database.
+                  </p>
+                </div>
+              {% else %}
+                {{ helper.render_table(collector.notRegisteredHooks, false) }}
+              {% endif %}
+            </div>
+          </div>
         </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When a hook was called in Symfony but without being in the database it never reached Hook::exec so it was never displayed in the debug toolbar We are now able to collect those hooks in page execution
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | Go to a page with new hooks that are not in database yet and which no modules register to (like new product page right now) or remove a hook from DB to force this context You should see the hook in the debug toolbar tab that collects the hooks
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


### Screenshots

<img width="1081" alt="Capture d’écran 2022-08-11 à 18 06 45" src="https://user-images.githubusercontent.com/13801017/184179014-14add7c0-2567-4b31-8419-a2871b99e89e.png">

<img width="1110" alt="Capture d’écran 2022-08-11 à 18 03 35" src="https://user-images.githubusercontent.com/13801017/184178430-cbcbd970-2c2d-4294-8edb-7f0620902d32.png">

