### PR TITLE
Fix decorating controllers from module

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -24,6 +24,7 @@ services:
   PrestaShopBundle\Controller\:
     resource: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/*"
     exclude: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/Api"
+    public: true
     tags:
       - !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -25,6 +25,7 @@ services:
     resource: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/*"
     exclude: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/Api"
     tags:
+      - 'controller.service_arguments'
       - !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG
 
   logger:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -25,7 +25,6 @@ services:
     resource: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/*"
     exclude: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/Api"
     tags:
-      - 'controller.service_arguments'
       - !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG
 
   logger:

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -83,30 +83,5 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
                 $loader->load('services.yml');
             }
         }
-
-        //@todo: POC proposal. If accepted it probably needs to be moved to dedicated pass, but priority is important
-        //       (it should probably be after this ModulesPass. e.g. using same in ContainerInjectionPass doesn't work)
-        // we find all definitions in order to search all decorated services
-        // @todo: find a way to optimize and find all decorated services or all controllers (cannot find decorated controllers by tags)
-        $allDefinitions = $container->getDefinitions();
-        foreach ($allDefinitions as $definition) {
-            $decoratedService = $definition->getDecoratedService();
-            if (!$decoratedService || !$container->hasDefinition($decoratedService[0])) {
-                // skip service if it is not a decorator
-                continue;
-            }
-
-            $decoratedServiceDefinition = $container->getDefinition($decoratedService[0]);
-            // if the decorator service is controller
-            if ($decoratedServiceDefinition->hasTag('controller.service_arguments')) {
-                // then we remove controller.service_arguments tag from the decorated class and add it to the decorator
-                $decoratedServiceDefinition->clearTag('controller.service_arguments');
-                if ($definition->hasTag('controller.service_arguments')) {
-                    continue;
-                }
-
-                $definition->addTag('controller.service_arguments');
-            }
-        }
     }
 }

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/LoadServicesFromModulesPass.php
@@ -83,5 +83,30 @@ class LoadServicesFromModulesPass implements CompilerPassInterface
                 $loader->load('services.yml');
             }
         }
+
+        //@todo: POC proposal. If accepted it probably needs to be moved to dedicated pass, but priority is important
+        //       (it should probably be after this ModulesPass. e.g. using same in ContainerInjectionPass doesn't work)
+        // we find all definitions in order to search all decorated services
+        // @todo: find a way to optimize and find all decorated services or all controllers (cannot find decorated controllers by tags)
+        $allDefinitions = $container->getDefinitions();
+        foreach ($allDefinitions as $definition) {
+            $decoratedService = $definition->getDecoratedService();
+            if (!$decoratedService || !$container->hasDefinition($decoratedService[0])) {
+                // skip service if it is not a decorator
+                continue;
+            }
+
+            $decoratedServiceDefinition = $container->getDefinition($decoratedService[0]);
+            // if the decorator service is controller
+            if ($decoratedServiceDefinition->hasTag('controller.service_arguments')) {
+                // then we remove controller.service_arguments tag from the decorated class and add it to the decorator
+                $decoratedServiceDefinition->clearTag('controller.service_arguments');
+                if ($definition->hasTag('controller.service_arguments')) {
+                    continue;
+                }
+
+                $definition->addTag('controller.service_arguments');
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | refer to https://github.com/PrestaShop/PrestaShop/issues/29286. Caused by changes in symfony configs after version upgrade probably. **EDIT**- after some discussion and exploration, we decided to make core controllers public and remove tag "controller.service_arguments". This way nothing really changes in modules (note that the **route for decorated controller doesn't need to be defined**, in fact, if you define the route you will probably get error mentioning that your controller is private. If for some reason you still need to modify the route, then you explicitly need to make your controller public in services.yml)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/29286
| Related PRs       | docs adjustment https://github.com/PrestaShop/docs/pull/1482
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/29286
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
![Screenshot from 2022-08-12 13-23-14](https://user-images.githubusercontent.com/31609858/184335687-cde3f382-3d59-4099-8853-c19fb0f3b857.png)