### PR TITLE
Use the same cookie filter prefix on module  admin controller override (legacy)

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -849,7 +849,7 @@ class AdminControllerCore extends Controller
      */
     protected function getCookieFilterPrefix()
     {
-        return str_replace(['admin', 'controller'], '', Tools::strtolower(get_class($this)));
+        return str_replace(['admin', 'controller', 'override'], '', Tools::strtolower(get_class($this)));
     }
 
     public function processFilter()

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3411,7 +3411,7 @@ class AdminControllerCore extends Controller
      */
     protected function getCookieOrderByPrefix()
     {
-        return str_replace(['admin', 'controller'], '', Tools::strtolower(get_class($this)));
+        return str_replace(['admin', 'controller', 'override'], '', Tools::strtolower(get_class($this)));
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Filter not work properly on module admin controller override (legacy).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29326
| Related PRs       | N/A
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/29326
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
