### PR TITLE
Remove shops from multistore header shop list if they are not associated with current employee

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
@@ -97,7 +97,7 @@ class MultistoreController extends FrameworkBundleAdminController
 
         foreach ($groupList as $group) {
             foreach ($group->getShops() as $key => $shop) {
-                if(!in_array($shop->getId(), $associatedShops)) {
+                if (!in_array($shop->getId(), $associatedShops)) {
                     $group->getShops()->offsetUnset($key);
                 }
             }

--- a/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
@@ -96,7 +96,6 @@ class MultistoreController extends FrameworkBundleAdminController
         $associatedShops = $this->getContext()->employee->getAssociatedShops();
 
         foreach ($groupList as $group) {
-            $group = $group;
             foreach ($group->getShops() as $key => $shop) {
                 if(!in_array($shop->getId(), $associatedShops)) {
                     $group->getShops()->offsetUnset($key);

--- a/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
+++ b/src/PrestaShopBundle/Controller/Admin/MultistoreController.php
@@ -93,6 +93,17 @@ class MultistoreController extends FrameworkBundleAdminController
             $groupList = $this->entityManager->getRepository(ShopGroup::class)->findBy(['active' => true]);
         }
 
+        $associatedShops = $this->getContext()->employee->getAssociatedShops();
+
+        foreach ($groupList as $group) {
+            $group = $group;
+            foreach ($group->getShops() as $key => $shop) {
+                if(!in_array($shop->getId(), $associatedShops)) {
+                    $group->getShops()->offsetUnset($key);
+                }
+            }
+        }
+
         $colorBrightnessCalculator = $this->get('prestashop.core.util.color_brightness_calculator');
 
         return $this->render('@PrestaShop/Admin/Multistore/header.html.twig', [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Check issues descriptions. When you create a new employee that is associated to a list of specific shops and not all of them, you expect that employee has access to those shops only and not all the shops. But if you login with the new employee account, you can see in the multistore header that all shops are available. This PR is a fix for this issue.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes  #27704 and #27377
| Related PRs       | No
| How to test?      | Enable multistore and create an extra shop. Create a new profile other in BO > Configure > Advanced Parameters > Team > Profiles. Then create give all permissions to that profile. And finally create a new employee with that profile and associate to the new shop you just created. Do not associate to the main shop. Then login via that new employee account and check multistore header. You should see only the associated shops in the create employee form that you have selected. You can also verify this by manually altering the `ps_employee_shop` table
| Possible impacts? | Not sure


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
