### PR TITLE
Fix price formatting in MoneyType

### DIFF
--- a/src/Adapter/Currency/CommandHandler/AbstractCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AbstractCurrencyHandler.php
@@ -75,7 +75,7 @@ abstract class AbstractCurrencyHandler extends AbstractObjectModelHandler
 
     /**
      * @param LocaleRepository $localeRepoCLDR
-     * @param array $languages
+     * @param LanguageInterface[] $languages
      * @param CurrencyCommandValidator $validator
      * @param PatternTransformer $patternTransformer
      */

--- a/src/Adapter/Currency/CommandHandler/AbstractCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AbstractCurrencyHandler.php
@@ -69,18 +69,26 @@ abstract class AbstractCurrencyHandler extends AbstractObjectModelHandler
     protected $validator;
 
     /**
+     * @var PatternTransformer
+     */
+    protected $patternTransformer;
+
+    /**
      * @param LocaleRepository $localeRepoCLDR
-     * @param LanguageInterface[] $languages
+     * @param array $languages
      * @param CurrencyCommandValidator $validator
+     * @param PatternTransformer $patternTransformer
      */
     public function __construct(
         LocaleRepository $localeRepoCLDR,
         array $languages,
-        CurrencyCommandValidator $validator
+        CurrencyCommandValidator $validator,
+        PatternTransformer $patternTransformer
     ) {
         $this->localeRepoCLDR = $localeRepoCLDR;
         $this->languages = $languages;
         $this->validator = $validator;
+        $this->patternTransformer = $patternTransformer;
     }
 
     /**
@@ -129,7 +137,6 @@ abstract class AbstractCurrencyHandler extends AbstractObjectModelHandler
      */
     protected function applyPatternTransformations(Currency $entity, array $localizedTransformations)
     {
-        $transformer = new PatternTransformer();
         $localizedPatterns = [];
         foreach ($localizedTransformations as $langId => $transformationType) {
             if (empty($transformationType)) {
@@ -137,7 +144,7 @@ abstract class AbstractCurrencyHandler extends AbstractObjectModelHandler
             }
 
             $languageCurrencyPattern = $this->getCurrencyPatternByLanguageId($langId);
-            $localizedPatterns[$langId] = $transformer->transform($languageCurrencyPattern, $transformationType);
+            $localizedPatterns[$langId] = $this->patternTransformer->transform($languageCurrencyPattern, $transformationType);
         }
         $entity->setLocalizedPatterns($localizedPatterns);
     }

--- a/src/Adapter/Currency/CommandHandler/AddOfficialCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddOfficialCurrencyHandler.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundExcepti
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\Locale;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
+use PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShopException;
 
@@ -63,9 +64,10 @@ final class AddOfficialCurrencyHandler extends AbstractCurrencyHandler implement
         LocaleRepository $localeRepoCLDR,
         array $languages,
         CurrencyCommandValidator $validator,
-        CurrencyDataProviderInterface $currencyDataProvider
+        CurrencyDataProviderInterface $currencyDataProvider,
+        PatternTransformer $patternTransformer
     ) {
-        parent::__construct($localeRepoCLDR, $languages, $validator);
+        parent::__construct($localeRepoCLDR, $languages, $validator, $patternTransformer);
         $this->currencyDataProvider = $currencyDataProvider;
     }
 

--- a/src/Adapter/Currency/CommandHandler/AddUnofficialCurrencyHandler.php
+++ b/src/Adapter/Currency/CommandHandler/AddUnofficialCurrencyHandler.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
 use PrestaShop\PrestaShop\Core\Language\LanguageInterface;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository;
+use PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShopException;
 
@@ -62,9 +63,10 @@ final class AddUnofficialCurrencyHandler extends AbstractCurrencyHandler impleme
         LocaleRepository $localeRepoCLDR,
         array $languages,
         CurrencyCommandValidator $validator,
-        CurrencyDataProviderInterface $currencyDataProvider
+        CurrencyDataProviderInterface $currencyDataProvider,
+        PatternTransformer $patternTransformer
     ) {
-        parent::__construct($localeRepoCLDR, $languages, $validator);
+        parent::__construct($localeRepoCLDR, $languages, $validator, $patternTransformer);
         $this->currencyDataProvider = $currencyDataProvider;
     }
 

--- a/src/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandler.php
+++ b/src/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandler.php
@@ -54,7 +54,7 @@ final class GetCurrencyForEditingHandler implements GetCurrencyForEditingHandler
      * @param int $contextShopId
      */
     public function __construct(
-        $contextShopId,
+        int $contextShopId,
         PatternTransformer $patternTransformer
     ) {
         $this->contextShopId = $contextShopId;

--- a/src/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandler.php
+++ b/src/Adapter/Currency/QueryHandler/GetCurrencyForEditingHandler.php
@@ -46,11 +46,19 @@ final class GetCurrencyForEditingHandler implements GetCurrencyForEditingHandler
     private $contextShopId;
 
     /**
+     * @var PatternTransformer
+     */
+    private $patternTransformer;
+
+    /**
      * @param int $contextShopId
      */
-    public function __construct($contextShopId)
-    {
+    public function __construct(
+        $contextShopId,
+        PatternTransformer $patternTransformer
+    ) {
         $this->contextShopId = $contextShopId;
+        $this->patternTransformer = $patternTransformer;
     }
 
     /**
@@ -68,10 +76,9 @@ final class GetCurrencyForEditingHandler implements GetCurrencyForEditingHandler
             throw new CurrencyNotFoundException(sprintf('Currency object with id "%s" was not found for editing', $query->getCurrencyId()->getValue()));
         }
 
-        $transformer = new PatternTransformer();
         $transformations = [];
         foreach ($entity->getLocalizedPatterns() as $langId => $pattern) {
-            $transformations[$langId] = !empty($pattern) ? $transformer->getTransformationType($pattern) : '';
+            $transformations[$langId] = !empty($pattern) ? $this->patternTransformer->getTransformationType($pattern) : '';
         }
 
         return new EditableCurrency(

--- a/src/Adapter/Currency/Repository/CurrencyRepository.php
+++ b/src/Adapter/Currency/Repository/CurrencyRepository.php
@@ -33,7 +33,6 @@ use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyNotFoundExcepti
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
-use PrestaShopException;
 
 /**
  * Methods to access data source of Currency
@@ -74,27 +73,10 @@ class CurrencyRepository extends AbstractObjectModelRepository
     /**
      * @param CurrencyId $currencyId
      *
-     * @return string|null
+     * @return string
      */
-    public function findIsoCode(CurrencyId $currencyId): ?string
+    public function getIsoCode(CurrencyId $currencyId): string
     {
-        try {
-            $isoCode = Currency::getIsoCodeById($currencyId->getValue());
-        } catch (PrestaShopException $e) {
-            throw new CoreException(
-                sprintf(
-                    'Error occurred when trying to get currency Iso code by id [%s]',
-                    $e->getMessage()
-                ),
-                0,
-                $e
-            );
-        }
-
-        if (empty($isoCode)) {
-            return null;
-        }
-
-        return $isoCode;
+        return $this->get($currencyId)->iso_code;
     }
 }

--- a/src/Adapter/Currency/Repository/CurrencyRepository.php
+++ b/src/Adapter/Currency/Repository/CurrencyRepository.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyNotFoundExcepti
 use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
+use PrestaShopException;
 
 /**
  * Methods to access data source of Currency
@@ -68,5 +69,32 @@ class CurrencyRepository extends AbstractObjectModelRepository
         );
 
         return $currency;
+    }
+
+    /**
+     * @param CurrencyId $currencyId
+     *
+     * @return string|null
+     */
+    public function findIsoCode(CurrencyId $currencyId): ?string
+    {
+        try {
+            $isoCode = Currency::getIsoCodeById($currencyId->getValue());
+        } catch (PrestaShopException $e) {
+            throw new CoreException(
+                sprintf(
+                    'Error occurred when trying to get currency Iso code by id [%s]',
+                    $e->getMessage()
+                ),
+                0,
+                $e
+            );
+        }
+
+        if (empty($isoCode)) {
+            return null;
+        }
+
+        return $isoCode;
     }
 }

--- a/src/Core/Localization/Currency/PatternTransformer.php
+++ b/src/Core/Localization/Currency/PatternTransformer.php
@@ -27,9 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Localization\Currency;
 
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
-use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
-use PrestaShop\PrestaShop\Core\Localization\Locale\RepositoryInterface as LocaleRepositoryInterface;
-use PrestaShop\PrestaShop\Core\Localization\Specification\Price;
 
 /**
  * Transform a currency pattern by moving the symbol position, with or without
@@ -69,20 +66,6 @@ class PatternTransformer
     ];
 
     /**
-     * @var LocaleRepositoryInterface
-     */
-    private $localeRepository;
-
-    /**
-     * @param LocaleRepositoryInterface $localeRepository
-     */
-    public function __construct(
-        LocaleRepositoryInterface $localeRepository
-    ) {
-        $this->localeRepository = $localeRepository;
-    }
-
-    /**
      * @param string $currencyPattern
      * @param string $transformationType
      *
@@ -103,55 +86,6 @@ class PatternTransformer
         }
 
         return implode(';', $transformedPatterns);
-    }
-
-    /**
-     * Provides currency pattern understandable to symfony, but uses prestashop Locale.
-     * E.g. when passing options to render MoneyType widget
-     *
-     * @param string $localeIsoCode e.g. fr-FR, en-US
-     * @param string $currencyCode e.g. EUR, USD
-     * @param bool $isPatternPositive if false, then "-" is prepended to the pattern
-     *
-     * @return string|null
-     *
-     * @throws InvalidArgumentException
-     * @throws LocalizationException
-     */
-    public function getFrameworkPattern(string $localeIsoCode, string $currencyCode, bool $isPatternPositive): ?string
-    {
-        $priceSpecification = $this->localeRepository->getLocale($localeIsoCode)->getPriceSpecification($currencyCode);
-
-        if (!($priceSpecification instanceof Price)) {
-            throw new InvalidArgumentException(sprintf('Expected instance of %s', Price::class));
-        }
-
-        $patternType = $this->getTransformationType($priceSpecification->getPositivePattern());
-
-        $positivePatternMap = [
-            self::TYPE_LEFT_SYMBOL_WITH_SPACE => sprintf(
-                '%s%s{{ widget }}',
-                self::CURRENCY_SYMBOL,
-                self::NO_BREAK_SPACE
-            ),
-            self::TYPE_RIGHT_SYMBOL_WITH_SPACE => sprintf(
-                '{{ widget }}%s%s',
-                self::NO_BREAK_SPACE,
-                self::CURRENCY_SYMBOL
-            ),
-            self::TYPE_LEFT_SYMBOL_WITHOUT_SPACE => sprintf('%s{{ widget }}', self::CURRENCY_SYMBOL),
-            self::TYPE_RIGHT_SYMBOL_WITHOUT_SPACE => sprintf('{{ widget }}%s', self::CURRENCY_SYMBOL),
-        ];
-
-        if (empty($positivePatternMap[$patternType])) {
-            return null;
-        }
-
-        return str_replace(
-            self::CURRENCY_SYMBOL,
-            $priceSpecification->getCurrencySymbol(),
-            $isPatternPositive ? $positivePatternMap[$patternType] : sprintf('-%s', $positivePatternMap[$patternType])
-        );
     }
 
     /**

--- a/src/Core/Localization/Currency/PatternTransformer.php
+++ b/src/Core/Localization/Currency/PatternTransformer.php
@@ -27,6 +27,9 @@
 namespace PrestaShop\PrestaShop\Core\Localization\Currency;
 
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
+use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
+use PrestaShop\PrestaShop\Core\Localization\Locale\RepositoryInterface as LocaleRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Localization\Specification\Price;
 
 /**
  * Transform a currency pattern by moving the symbol position, with or without
@@ -66,6 +69,20 @@ class PatternTransformer
     ];
 
     /**
+     * @var LocaleRepositoryInterface
+     */
+    private $localeRepository;
+
+    /**
+     * @param LocaleRepositoryInterface $localeRepository
+     */
+    public function __construct(
+        LocaleRepositoryInterface $localeRepository
+    ) {
+        $this->localeRepository = $localeRepository;
+    }
+
+    /**
      * @param string $currencyPattern
      * @param string $transformationType
      *
@@ -86,6 +103,55 @@ class PatternTransformer
         }
 
         return implode(';', $transformedPatterns);
+    }
+
+    /**
+     * Provides currency pattern understandable to symfony, but uses prestashop Locale.
+     * E.g. when passing options to render MoneyType widget
+     *
+     * @param string $localeIsoCode e.g. fr-FR, en-US
+     * @param string $currencyCode e.g. EUR, USD
+     * @param bool $isPatternPositive if false, then "-" is prepended to the pattern
+     *
+     * @return string|null
+     *
+     * @throws InvalidArgumentException
+     * @throws LocalizationException
+     */
+    public function getFrameworkPattern(string $localeIsoCode, string $currencyCode, bool $isPatternPositive): ?string
+    {
+        $priceSpecification = $this->localeRepository->getLocale($localeIsoCode)->getPriceSpecification($currencyCode);
+
+        if (!($priceSpecification instanceof Price)) {
+            throw new InvalidArgumentException(sprintf('Expected instance of %s', Price::class));
+        }
+
+        $patternType = $this->getTransformationType($priceSpecification->getPositivePattern());
+
+        $positivePatternMap = [
+            self::TYPE_LEFT_SYMBOL_WITH_SPACE => sprintf(
+                '%s%s{{ widget }}',
+                self::CURRENCY_SYMBOL,
+                self::NO_BREAK_SPACE
+            ),
+            self::TYPE_RIGHT_SYMBOL_WITH_SPACE => sprintf(
+                '{{ widget }}%s%s',
+                self::NO_BREAK_SPACE,
+                self::CURRENCY_SYMBOL
+            ),
+            self::TYPE_LEFT_SYMBOL_WITHOUT_SPACE => sprintf('%s{{ widget }}', self::CURRENCY_SYMBOL),
+            self::TYPE_RIGHT_SYMBOL_WITHOUT_SPACE => sprintf('{{ widget }}%s', self::CURRENCY_SYMBOL),
+        ];
+
+        if (empty($positivePatternMap[$patternType])) {
+            return null;
+        }
+
+        return str_replace(
+            self::CURRENCY_SYMBOL,
+            $priceSpecification->getCurrencySymbol(),
+            $isPatternPositive ? $positivePatternMap[$patternType] : sprintf('-%s', $positivePatternMap[$patternType])
+        );
     }
 
     /**

--- a/src/Core/Localization/Specification/Price.php
+++ b/src/Core/Localization/Specification/Price.php
@@ -47,6 +47,11 @@ class Price extends NumberSpecification
     public const CURRENCY_DISPLAY_CODE = 'code';
 
     /**
+     * Price value placeholder without symbols
+     */
+    public const PATTERN_BASE_PLACEHOLDER = '#,##0.00';
+
+    /**
      * Type of display for currency symbol
      * cf. self::CURRENCY_DISPLAY_SYMBOL and self::CURRENCY_DISPLAY_CODE constants.
      *

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -220,6 +220,8 @@ class CurrencyController extends FrameworkBundleAdminController
         $localeRepository = $this->get('prestashop.core.localization.locale.repository');
         /** @var CldrLocaleRepository $cldrLocaleRepository */
         $cldrLocaleRepository = $this->get('prestashop.core.localization.cldr.locale_repository');
+        /** @var PatternTransformer $transformer */
+        $transformer = $this->get('prestashop.core.localization.currency.pattern_transformer');
 
         $languagesData = [];
         /** @var LanguageInterface $language */
@@ -229,7 +231,6 @@ class CurrencyController extends FrameworkBundleAdminController
             $cldrCurrency = $cldrLocale->getCurrency($currencyIsoCode);
             $priceSpecification = $locale->getPriceSpecification($currencyIsoCode);
 
-            $transformer = new PatternTransformer();
             $transformations = [];
             foreach (PatternTransformer::ALLOWED_TRANSFORMATIONS as $transformationType) {
                 $transformations[$transformationType] = $transformer->transform(

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -98,7 +98,7 @@ class CustomMoneyType extends AbstractTypeExtension
      *
      * @param string $currencyCode e.g. EUR, USD
      *
-     * @return string|null
+     * @return string
      *
      * @throws InvalidArgumentException
      * @throws LocalizationException

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -84,13 +84,7 @@ class CustomMoneyType extends AbstractTypeExtension
     {
         parent::buildView($view, $form, $options);
 
-        $frameworkPattern = $this->getFrameworkPattern($options['currency']);
-
-        if (!$frameworkPattern) {
-            return;
-        }
-
-        $view->vars['money_pattern'] = $frameworkPattern;
+        $view->vars['money_pattern'] = $this->getFrameworkPattern($options['currency']);
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use Currency;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
@@ -47,12 +48,20 @@ class CustomMoneyType extends AbstractTypeExtension
     private $locale;
 
     /**
+     * @var int
+     */
+    private $defaultCurrencyId;
+
+    /**
      * @param Locale $locale
+     * @param int $defaultCurrencyId
      */
     public function __construct(
-        Locale $locale
+        Locale $locale,
+        int $defaultCurrencyId
     ) {
         $this->locale = $locale;
+        $this->defaultCurrencyId = $defaultCurrencyId;
     }
 
     public static function getExtendedTypes(): iterable
@@ -65,12 +74,14 @@ class CustomMoneyType extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        $defaultCurrencyIso = Currency::getIsoCodeById($this->defaultCurrencyId);
+
         $resolver->setDefaults([
             'precision' => null,
             'scale' => self::PRESTASHOP_DECIMALS,
             'grouping' => false,
             'divisor' => 1,
-            'currency' => 'EUR',
+            'currency' => !empty($defaultCurrencyIso) ? $defaultCurrencyIso : 'EUR',
             'compound' => false,
         ]);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -26,13 +26,42 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Localization\Locale;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CustomMoneyType extends AbstractTypeExtension
 {
     public const PRESTASHOP_DECIMALS = 6;
+
+    protected const PATTERN_MAP = [
+        "¤\u{a0}#,##0.00" => "¤\u{a0}{{ widget }}",
+        '¤#,##0.00' => '¤{{ widget }}',
+        "#,##0.00\u{a0}¤" => "{{ widget }}\u{a0}¤",
+        '#,##0.00¤' => '{{ widget }}¤',
+        "-¤\u{a0}#,##0.00" => "-¤\u{a0}{{ widget }}",
+        '-¤#,##0.00' => '-¤{{ widget }}',
+        "-#,##0.00\u{a0}¤" => "-{{ widget }}\u{a0}¤",
+        '-#,##0.00¤' => '-{{ widget }}¤',
+    ];
+
+    /**
+     * @var Locale
+     */
+    private $locale;
+
+    /**
+     * @param Locale $locale
+     */
+    public function __construct(
+        Locale $locale
+    ) {
+        $this->locale = $locale;
+    }
 
     public static function getExtendedTypes(): iterable
     {
@@ -54,5 +83,32 @@ class CustomMoneyType extends AbstractTypeExtension
         ]);
 
         $resolver->setAllowedTypes('scale', 'int');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        parent::buildView($view, $form, $options);
+        $currency = $options['currency'];
+        $moneyPattern = $view->vars['money_pattern'];
+
+        $priceSpecification = $this->locale->getPriceSpecification($currency);
+        $value = new DecimalNumber((string) (float) $view->vars['value']);
+        $pricePattern = $value->isPositive() ? $priceSpecification->getPositivePattern() : $priceSpecification->getNegativePattern();
+
+        // inspired by symfony MoneyType
+        preg_match('/^([^\s\xc2\xa0]*)[\s\xc2\xa0]*{{ widget }}(?:[,.]0+)?[\s\xc2\xa0]*([^\s\xc2\xa0]*)$/u', $moneyPattern, $matches);
+
+        if (!empty($matches[1])) {
+            $symbol = trim($matches[1]);
+        }
+
+        if (!isset($this::PATTERN_MAP[$pricePattern])) {
+            return;
+        }
+
+        $view->vars['money_pattern'] = str_replace('¤', $symbol ?? $currency, $this::PATTERN_MAP[$pricePattern]);
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -88,7 +88,7 @@ class CustomMoneyType extends AbstractTypeExtension
             'scale' => self::PRESTASHOP_DECIMALS,
             'grouping' => false,
             'divisor' => 1,
-            'currency' => $this->currencyRepository->findIsoCode(new CurrencyId($this->defaultCurrencyId)) ?: 'EUR',
+            'currency' => $this->currencyRepository->getIsoCode(new CurrencyId($this->defaultCurrencyId)) ?: 'EUR',
             'compound' => false,
         ]);
 

--- a/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CustomMoneyType.php
@@ -26,7 +26,8 @@
 
 namespace PrestaShopBundle\Form\Admin\Type;
 
-use Currency;
+use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
+use PrestaShop\PrestaShop\Core\Domain\Currency\ValueObject\CurrencyId;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
@@ -53,15 +54,23 @@ class CustomMoneyType extends AbstractTypeExtension
     private $defaultCurrencyId;
 
     /**
+     * @var CurrencyRepository
+     */
+    private $currencyRepository;
+
+    /**
      * @param Locale $locale
      * @param int $defaultCurrencyId
+     * @param CurrencyRepository $currencyRepository
      */
     public function __construct(
         Locale $locale,
-        int $defaultCurrencyId
+        int $defaultCurrencyId,
+        CurrencyRepository $currencyRepository
     ) {
         $this->locale = $locale;
         $this->defaultCurrencyId = $defaultCurrencyId;
+        $this->currencyRepository = $currencyRepository;
     }
 
     public static function getExtendedTypes(): iterable
@@ -74,14 +83,12 @@ class CustomMoneyType extends AbstractTypeExtension
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $defaultCurrencyIso = Currency::getIsoCodeById($this->defaultCurrencyId);
-
         $resolver->setDefaults([
             'precision' => null,
             'scale' => self::PRESTASHOP_DECIMALS,
             'grouping' => false,
             'divisor' => 1,
-            'currency' => !empty($defaultCurrencyIso) ? $defaultCurrencyIso : 'EUR',
+            'currency' => $this->currencyRepository->findIsoCode(new CurrencyId($this->defaultCurrencyId)) ?: 'EUR',
             'compound' => false,
         ]);
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
@@ -33,6 +33,7 @@ services:
       - "@=service('prestashop.core.admin.lang.repository').findAll()"
       - "@prestashop.adapter.currency.command_handler.command_validator"
       - '@prestashop.adapter.data_provider.currency'
+      - '@prestashop.core.localization.currency.pattern_transformer'
     tags:
       - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddCurrencyCommand' }
 
@@ -43,6 +44,7 @@ services:
       - "@=service('prestashop.core.admin.lang.repository').findAll()"
       - "@prestashop.adapter.currency.command_handler.command_validator"
       - '@prestashop.adapter.data_provider.currency'
+      - '@prestashop.core.localization.currency.pattern_transformer'
     tags:
       - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddUnofficialCurrencyCommand' }
 
@@ -90,6 +92,7 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Currency\QueryHandler\GetCurrencyForEditingHandler'
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
+      - '@prestashop.core.localization.currency.pattern_transformer'
     tags:
       - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Currency\Query\GetCurrencyForEditing' }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/currency.yml
@@ -54,6 +54,7 @@ services:
       - '@prestashop.core.localization.cldr.locale_repository'
       - "@=service('prestashop.core.admin.lang.repository').findAll()"
       - "@prestashop.adapter.currency.command_handler.command_validator"
+      - "@prestashop.core.localization.currency.pattern_transformer"
     tags:
       - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Currency\Command\EditCurrencyCommand' }
 
@@ -63,6 +64,7 @@ services:
       - '@prestashop.core.localization.cldr.locale_repository'
       - "@=service('prestashop.core.admin.lang.repository').findAll()"
       - "@prestashop.adapter.currency.command_handler.command_validator"
+      - "@prestashop.core.localization.currency.pattern_transformer"
     tags:
       - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Currency\Command\EditUnofficialCurrencyCommand' }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -10,7 +10,8 @@ services:
   form.type.extension.money:
     class: 'PrestaShopBundle\Form\Admin\Type\CustomMoneyType'
     arguments:
-      - '@prestashop.core.localization.locale.context_locale'
+      - '@prestashop.core.localization.currency.pattern_transformer'
+      - '@=service("prestashop.core.localization.locale.context_locale").getCode()'
     tags:
       - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\MoneyType }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -9,6 +9,8 @@ services:
 
   form.type.extension.money:
     class: 'PrestaShopBundle\Form\Admin\Type\CustomMoneyType'
+    arguments:
+      - '@prestashop.core.localization.locale.context_locale'
     tags:
       - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\MoneyType }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -11,6 +11,7 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Type\CustomMoneyType'
     arguments:
       - '@prestashop.core.localization.locale.context_locale'
+      - '@=service("prestashop.adapter.legacy.configuration").get("PS_CURRENCY_DEFAULT")'
     tags:
       - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\MoneyType }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -12,6 +12,7 @@ services:
     arguments:
       - '@prestashop.core.localization.locale.context_locale'
       - '@=service("prestashop.adapter.legacy.configuration").get("PS_CURRENCY_DEFAULT")'
+      - '@prestashop.adapter.currency.repository.currency_repository'
     tags:
       - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\MoneyType }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_extension.yml
@@ -10,8 +10,7 @@ services:
   form.type.extension.money:
     class: 'PrestaShopBundle\Form\Admin\Type\CustomMoneyType'
     arguments:
-      - '@prestashop.core.localization.currency.pattern_transformer'
-      - '@=service("prestashop.core.localization.locale.context_locale").getCode()'
+      - '@prestashop.core.localization.locale.context_locale'
     tags:
       - { name: form.type_extension, extended_type: Symfony\Component\Form\Extension\Core\Type\MoneyType }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/currency.yml
@@ -32,3 +32,8 @@ services:
       - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrencyIsoCode()'
       - '@prestashop.core.currency.exchange_rate.circuit_breaker'
       - '@cache.app'
+
+  prestashop.core.localization.currency.pattern_transformer:
+    class: PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer
+    arguments:
+      - '@prestashop.core.localization.locale.repository'

--- a/src/PrestaShopBundle/Resources/config/services/core/currency.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/currency.yml
@@ -35,5 +35,3 @@ services:
 
   prestashop.core.localization.currency.pattern_transformer:
     class: PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer
-    arguments:
-      - '@prestashop.core.localization.locale.repository'

--- a/tests/Unit/Core/Localization/Currency/PatternTransformerTest.php
+++ b/tests/Unit/Core/Localization/Currency/PatternTransformerTest.php
@@ -28,9 +28,6 @@ namespace Tests\Unit\Core\Localization\Currency;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer;
-use PrestaShop\PrestaShop\Core\Localization\Locale;
-use PrestaShop\PrestaShop\Core\Localization\Locale\RepositoryInterface;
-use PrestaShop\PrestaShop\Core\Localization\Specification\Price;
 
 class PatternTransformerTest extends TestCase
 {
@@ -42,108 +39,11 @@ class PatternTransformerTest extends TestCase
      */
     public function testTransform(string $basePattern, array $transformations)
     {
-        $transformer = new PatternTransformer($this->mockLocaleRepository());
+        $transformer = new PatternTransformer();
 
         foreach ($transformations as $transformationType => $expectedPattern) {
             $this->assertEquals($expectedPattern, $transformer->transform($basePattern, $transformationType), 'Invalid transformation ' . $transformationType);
         }
-    }
-
-    /**
-     * @dataProvider getDataForTestGetFrameworkPattern
-     *
-     * @param string $pattern
-     * @param string $currencySymbol
-     */
-    public function testGetFrameworkPattern(
-        string $pattern,
-        string $currencySymbol,
-        bool $isPatternPositive,
-        ?string $expectedResult
-    ): void {
-        $transformer = new PatternTransformer($this->mockLocaleRepository($pattern, $currencySymbol));
-
-        $this->assertSame(
-            $expectedResult,
-            $transformer->getFrameworkPattern(
-                // locale and currency code isn't relevant for this test
-            'en-US',
-                'EUR',
-                $isPatternPositive
-        ));
-    }
-
-    public function getDataForTestGetFrameworkPattern(): iterable
-    {
-        yield [
-            '#,##0.00¤',
-            '€',
-            true,
-            '{{ widget }}€',
-        ];
-
-        yield [
-            '#,##0.00¤',
-            '€',
-            false,
-            '-{{ widget }}€',
-        ];
-
-        yield [
-            '¤#,##0.00',
-            '€',
-            true,
-            '€{{ widget }}',
-        ];
-
-        yield [
-            '¤#,##0.00',
-            '€',
-            false,
-            '-€{{ widget }}',
-        ];
-
-        yield [
-            '#,##0.00¤',
-            '$',
-            true,
-            '{{ widget }}$',
-        ];
-
-        yield [
-            '#,##0.00 ¤',
-            '$',
-            false,
-            "-{{ widget }}\u{a0}\$",
-        ];
-
-        yield [
-            '¤ #,##0.00',
-            '$',
-            true,
-            "\$\u{a0}{{ widget }}",
-        ];
-
-        yield [
-            '¤ #,##0.00',
-            '$',
-            false,
-            "-\$\u{a0}{{ widget }}",
-        ];
-
-        yield [
-            '¤ #,##0.00',
-            'custom',
-            true,
-            "custom\u{a0}{{ widget }}",
-        ];
-
-        yield [
-            '#,##0.00¤',
-            'custom',
-            false,
-            '-{{ widget }}custom',
-        ];
     }
 
     /**
@@ -236,7 +136,7 @@ class PatternTransformerTest extends TestCase
      */
     public function testGetTransformationType(string $expectedTransformationType, array $patterns)
     {
-        $transformer = new PatternTransformer($this->mockLocaleRepository());
+        $transformer = new PatternTransformer();
 
         foreach ($patterns as $pattern) {
             $transformationType = $transformer->getTransformationType($pattern);
@@ -287,71 +187,5 @@ class PatternTransformerTest extends TestCase
                 ],
             ],
         ];
-    }
-
-    /**
-     * @param string $pattern
-     * @param string $currencySymbol
-     *
-     * @return RepositoryInterface
-     */
-    private function mockLocaleRepository(
-        string $pattern = '#,##0.00¤',
-        string $currencySymbol = '€'
-    ): RepositoryInterface {
-        $localeRepository = $this->getMockBuilder(RepositoryInterface::class)
-            ->onlyMethods(['getLocale'])
-            ->getMock()
-        ;
-
-        $localeRepository->method('getLocale')
-            ->willReturn($this->mockLocale($pattern, $currencySymbol));
-
-        return $localeRepository;
-    }
-
-    /**
-     * @param string $pattern
-     * @param string $currencySymbol
-     *
-     * @return Locale
-     */
-    private function mockLocale(
-        string $pattern,
-        string $currencySymbol
-    ): Locale {
-        $locale = $this->getMockBuilder(Locale::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getCode', 'getPriceSpecification'])
-            ->getMock()
-        ;
-
-        // currency code is not relevant in this test
-        $locale->method('getCode')->willReturn('EUR');
-        $locale->method('getPriceSpecification')->willReturn($this->mockPriceSpecification($pattern, $currencySymbol));
-
-        return $locale;
-    }
-
-    /**
-     * @param string $pattern
-     * @param string $currencySymbol
-     *
-     * @return Price
-     */
-    private function mockPriceSpecification(
-        string $pattern,
-        string $currencySymbol
-    ): Price {
-        $priceSpecification = $this->getMockBuilder(Price::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getPositivePattern', 'getCurrencySymbol'])
-            ->getMock()
-        ;
-
-        $priceSpecification->method('getPositivePattern')->willReturn($pattern);
-        $priceSpecification->method('getCurrencySymbol')->willReturn($currencySymbol);
-
-        return $priceSpecification;
     }
 }

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
@@ -53,7 +53,7 @@ class CustomMoneyTypeTest extends TestCase
         string $expectedPattern
     ): void {
         $currencyRepository = $this->createMock(CurrencyRepository::class);
-        $currencyRepository->method('findIsoCode')->willReturn($currencyIso);
+        $currencyRepository->method('getIsoCode')->willReturn($currencyIso);
         $customMoneyType = new CustomMoneyType(
             $this->mockLocale($cldrPattern, $symbol),
             self::DEFAULT_CURRENCY_ID,

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace Tests\Unit\PrestaShopBundle\Form\Admin\Extension;
 
 use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Currency\Repository\CurrencyRepository;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Price;
 use PrestaShopBundle\Form\Admin\Type\CustomMoneyType;
@@ -36,6 +37,7 @@ use Symfony\Component\Form\FormView;
 
 class CustomMoneyTypeTest extends TestCase
 {
+    private const DEFAULT_CURRENCY_ID = 1;
     /**
      * @dataProvider getDataForTestBuildViewAssignsCorrectMoneyPatternVariable
      *
@@ -50,7 +52,13 @@ class CustomMoneyTypeTest extends TestCase
         string $cldrPattern,
         string $expectedPattern
     ): void {
-        $customMoneyType = new CustomMoneyType($this->mockLocale($cldrPattern, $symbol));
+        $currencyRepository = $this->createMock(CurrencyRepository::class);
+        $currencyRepository->method('findIsoCode')->willReturn($currencyIso);
+        $customMoneyType = new CustomMoneyType(
+            $this->mockLocale($cldrPattern, $symbol),
+            self::DEFAULT_CURRENCY_ID,
+            $currencyRepository
+        );
         $formView = $this->mockFormView();
 
         $customMoneyType->buildView($formView, $this->mockFormInterface(), [

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Extension;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Localization\Specification\Price;
+use PrestaShopBundle\Form\Admin\Type\CustomMoneyType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+class CustomMoneyTypeTest extends TestCase
+{
+    /**
+     * @dataProvider getDataForTestBuildViewAssignsCorrectMoneyPatternVariable
+     *
+     * @param string $currencyIso
+     * @param string $symbol
+     * @param string $cldrPattern
+     * @param string $expectedPattern
+     */
+    public function testBuildViewAssignsCorrectMoneyPatternVariable(
+        string $currencyIso,
+        string $symbol,
+        string $cldrPattern,
+        string $expectedPattern
+    ): void {
+        $customMoneyType = new CustomMoneyType($this->mockLocale($cldrPattern, $symbol));
+        $formView = $this->mockFormView();
+
+        $customMoneyType->buildView($formView, $this->mockFormInterface(), [
+            'currency' => $currencyIso,
+        ]);
+
+        $this->assertArrayHasKey('money_pattern', $formView->vars);
+        $this->assertSame($expectedPattern, $formView->vars['money_pattern']);
+    }
+
+    /**
+     * @return FormView
+     */
+    private function mockFormView(): FormView
+    {
+        return $this->getMockBuilder(FormView::class)->getMock();
+    }
+
+    /**
+     * @return FormInterface
+     */
+    private function mockFormInterface(): FormInterface
+    {
+        return $this->getMockBuilder(FormInterface::class)->getMock();
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $symbol
+     *
+     * @return Locale
+     */
+    private function mockLocale(string $pattern, string $symbol): Locale
+    {
+        $locale = $this->getMockBuilder(Locale::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getPriceSpecification'])
+            ->getMock()
+        ;
+
+        $locale->method('getPriceSpecification')->willReturn($this->mockPriceSpecification($pattern, $symbol));
+
+        return $locale;
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $symbol
+     *
+     * @return Price
+     */
+    private function mockPriceSpecification(string $pattern, string $symbol): Price
+    {
+        $price = $this->getMockBuilder(Price::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getPositivePattern', 'getCurrencySymbol'])
+            ->getMock()
+        ;
+
+        $price->method('getPositivePattern')->willReturn($pattern);
+        $price->method('getCurrencySymbol')->willReturn($symbol);
+
+        return $price;
+    }
+
+    /**
+     * @return iterable
+     */
+    public function getDataForTestBuildViewAssignsCorrectMoneyPatternVariable(): iterable
+    {
+        yield ['EUR', '€', "¤\u{00A0}#,##0.00", "€\u{00A0}{{ widget }}"];
+        yield ['USD', '$', '¤#,##0.00', '${{ widget }}'];
+        yield ['custom', 'custom', "#,##0.00\u{00A0}¤", "{{ widget }}\u{00A0}custom"];
+        yield ['SEK', 'kr', '#,##0.00¤', '{{ widget }}kr'];
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Extension/CustomMoneyTypeTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\Form\FormView;
 class CustomMoneyTypeTest extends TestCase
 {
     private const DEFAULT_CURRENCY_ID = 1;
+
     /**
      * @dataProvider getDataForTestBuildViewAssignsCorrectMoneyPatternVariable
      *


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | refer to #28430. Symfony MoneyType form never considered prestashop Locale configurations. This Pr fixes it through adjusting CustomMoneyType form extension
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #28430
| Related PRs       | 
| How to test?      | refer to #28430
| Possible impacts? | All inputs where Money type was used will be affected

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
![Screenshot from 2022-08-17 14-58-08](https://user-images.githubusercontent.com/31609858/185112942-31c2c3de-abb8-4241-9fe6-cc98457dea07.png)
![Screenshot from 2022-08-17 14-53-14](https://user-images.githubusercontent.com/31609858/185112945-b724a51b-1c10-453b-9f0e-ab33d39f0844.png)

