### PR TITLE
Fix new translation system detection after Modules refactoring

### DIFF
--- a/src/Adapter/Translations/TranslationRouteFinder.php
+++ b/src/Adapter/Translations/TranslationRouteFinder.php
@@ -27,7 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\Translations;
 
 use Link;
-use Module;
+use PrestaShop\PrestaShop\Adapter\Module\Module;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepositoryInterface;
 use PrestaShopBundle\Exception\InvalidModuleException;
 use PrestaShopBundle\Service\TranslationService;
@@ -210,6 +210,6 @@ class TranslationRouteFinder
             throw new InvalidModuleException($moduleName);
         }
 
-        return $module->isUsingNewTranslationSystem();
+        return $module->getInstance()->isUsingNewTranslationSystem();
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | ModuleRepository::getModule now returns PrestaShop\PrestaShop\Adapter\Module\Module so we adapt the code of TranslationRouteFinder::isModuleUsingNewTranslationSystem
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29359
| Related PRs       | -
| How to test?      | Please look the issue description
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
