### PR TITLE
Fix apply new voucher to cart

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.tpl
@@ -76,14 +76,20 @@
 		{/foreach}
 		displayFlags(languages, {$id_lang_default});
 
-    {if isset($refresh_cart) }
-      if (typeof window.parent.order_create !== "undefined") {
-        window.parent.order_create.refreshCart();
-      }
-      window.parent.$.fancybox.close();
-    {/if}
-
-  </script>
+		{if isset($created_cart_rule_id) }
+			if (typeof window.parent.order_create !== "undefined") {
+				{*
+				 * In order creation, we can add new cart rules to apply to the current cart
+				 * This cart rule creation is done through a Fancy box.
+				 * The cart rule is created and then we need to apply it to the cart
+				 * This need to be done in JS before refreshing the cart
+				 *}
+				window.parent.order_create.addCreatedCartRuleToCart({$created_cart_rule_id});
+			}
+			window.parent.$.fancybox.close();
+		{/if}
+	</script>
+	
 	<script type="text/javascript" src="themes/default/template/controllers/cart_rules/form.js"></script>
 	{include file="footer_toolbar.tpl"}
 </div>

--- a/admin-dev/themes/new-theme/js/pages/order/create.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create.js
@@ -61,10 +61,22 @@ function refreshCart() {
   orderPageManager.refreshCart();
 }
 
+/**
+ * proxy to allow other scripts within the Create Order page to refresh cart
+ */
+function addCreatedCartRuleToCart(cartRuleId) {
+  if (orderPageManager === null) {
+    console.log('Error: Cannot apply created cart rule to the current cart as orderPageManager is not available');
+    return;
+  }
+  orderPageManager.addCreatedCartRuleToCart(cartRuleId);
+}
+
 $(document).ready(() => {
   orderPageManager = new CreateOrderPage();
 });
 
+export {addCreatedCartRuleToCart};
 export {searchCustomerByString};
 export {refreshAddressesList};
 export {refreshCart};

--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.js
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.js
@@ -69,6 +69,7 @@ export default class CreateOrderPage {
     this.loadCartFromUrlParams();
 
     return {
+      addCreatedCartRuleToCart: (cartRuleId) => this.addCreatedCartRuleToCart(cartRuleId),
       refreshAddressesList: (refreshCartAddresses) => this.refreshAddressesList(refreshCartAddresses),
       refreshCart: (refreshCart) => this.refreshCart(refreshCart),
       search: (string) => this.customerManager.search(string),
@@ -640,5 +641,13 @@ export default class CreateOrderPage {
   refreshCart() {
     const cartId = $(createOrderMap.cartBlock).data('cartId');
     this.cartProvider.getCart(cartId);
+  }
+
+  /**
+   * Adds newly created cart rule to cart
+   */
+  addCreatedCartRuleToCart(cartRuleId) {
+    this.cartRuleManager.addCartRuleToCart(cartRuleId, this.cartId);
+    this.refreshCart();
   }
 }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1308,6 +1308,25 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * Test if current cart contains cart rule
+     *
+     * @param int $id_cart_rule CartRule ID
+     *
+     * @return bool true if current cart contains the CartRule
+     */
+    public function containsCartRule($id_cart_rule)
+    {
+        $return = (bool) Db::getInstance()->getValue(
+            'SELECT 1
+            FROM `' . _DB_PREFIX_ . 'cart_cart_rule`
+            WHERE `id_cart` = ' . (int) $this->id . '
+            AND `id_cart_rule` = ' . (int) $id_cart_rule
+        );
+
+        return $return;
+    }
+
+    /**
      * Add a CartRule to the Cart.
      *
      * @param int $id_cart_rule CartRule ID
@@ -1324,7 +1343,7 @@ class CartCore extends ObjectModel
             return false;
         }
 
-        if (Db::getInstance()->getValue('SELECT id_cart_rule FROM ' . _DB_PREFIX_ . 'cart_cart_rule WHERE id_cart_rule = ' . (int) $id_cart_rule . ' AND id_cart = ' . (int) $this->id)) {
+        if ($this->containsCartRule($id_cart_rule)) {
             return false;
         }
 

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -279,7 +279,7 @@ class AdminCartRulesControllerCore extends AdminController
         if (Tools::getValue('submitFormAjax')) {
             $this->redirect_after = false;
             if ($cart_rule) {
-                $this->context->smarty->assign('refresh_cart', true);
+                $this->context->smarty->assign('created_cart_rule_id', $cart_rule->id);
                 $this->display = 'edit';
             }
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | See below, #25579 and #25802 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25579.
| Related PRs       | #25802
| How to test?      | See below and #25579
| Possible impacts? | All cart rules workflows may be impacted.

Thanks to @sowbiba that worked a lot on this issue in #25802.
> ## Description (copy of [#25579 (comment)](https://github.com/PrestaShop/PrestaShop/issues/25579#issuecomment-914269727))
> 
> Before, The modal was adding the cartRule to the cart in a fancyBox : we load the addCartRule page into an iframe. Nothing says that we want to link the cartRule added to the current cart https://github.com/PrestaShop/PrestaShop/blob/1.7.8.x/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.js#L185
> 
> The totals are calculated first and then we get the discounts. When we get the discounts, we call `getCartRules` with `autoAdd = true`. This query adds all applicable cartRules to the cart given. In this way, the totals are wrong and the discounts correct https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Cart.php#L4010 https://github.com/PrestaShop/PrestaShop/blob/develop/classes/Cart.php#L4047
> 
> One solution to avoid this is a BIG bandage : we first get the cartRules with autoAdd = true. That will apply all applicable cartRules to the cart and then we calculte the totals and the discounts
> 
> The ideal solution would be to have a specific modal to add cartRules to current cart. Doing this we will be able to perform 1 - create the cart Rule 2 - Try to apply created cart rule to the current cart (I say TRY because if the cart doesnt match the cartRule rules, it won't be applied) This solution will also allow us to use the commands AddCartRuleCommand and AddCartRuleToCartCommand instead of the legacy controller like it is now
> 
> This change is [<img alt="Reviewable" height="34" src="https://camo.githubusercontent.com/a8b5f6726de4903e6ce89df24ad596326aa4f49974dbb99137f93e280f30421c/68747470733a2f2f72657669657761626c652e696f2f7265766965775f627574746f6e2e737667">](https://reviewable.io/reviews/prestashop/prestashop/25802)

:point_up: I encountered some troubles to reproduce cause behavior isn't always consistent.
Some times, I add to apply a second voucher to the cart.

Fixing some weird 500 errors due to poor cart rules workflow management, I can't reproduce the problem anymore. I think the last problem that @sowbiba didn't solve was due to some concurrencies in cart/cart_rules associations.