### PR TITLE
Remove deprecated service

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
@@ -9,8 +9,3 @@ services:
       - !php/const _PS_MODE_DEV_
     decorates: prestashop.core.admin.page_preference_interface
     public: false
-
-  prestashop.adapter.legacy_db:
-    class: 'Db'
-    factory: [ 'Db', 'getInstance' ]
-    deprecated: '%service_id% service is deprecated and will be removed in 8.0.'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In Symfony logs, there is message ` php.INFO: User Deprecated: prestashop.adapter.legacy_db service is deprecated and will be removed in 8.0.` so this service must be removed
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
