### PR TITLE
Hide suppliers if there are no suppliers on product v2

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
@@ -98,10 +98,7 @@ class ProductTypeListener implements EventSubscriberInterface
             // Don't display the suppliers part if there are no suppliers
             if (count($suppliers) <= 0) {
                 $this->removeSuppliers($form);
-
-                if ($optionsField->has('product_suppliers')) {
-                  $this->removeProductSuppliers($form);
-                }
+                $this->removeProductSuppliers($form);
             }
         }
 
@@ -137,7 +134,10 @@ class ProductTypeListener implements EventSubscriberInterface
     {
         if ($form->has('options')) {
             $optionsForm = $form->get('options');
-            $optionsForm->remove('product_suppliers');
+
+            if ($optionsForm->has('product_suppliers')) {
+                $optionsForm->remove('product_suppliers');
+            }
         }
     }
 
@@ -145,7 +145,10 @@ class ProductTypeListener implements EventSubscriberInterface
     {
         if ($form->has('options')) {
             $optionsForm = $form->get('options');
-            $optionsForm->remove('suppliers');
+
+            if ($optionsForm->has('suppliers')) {
+                $optionsForm->remove('suppliers');
+            }
         }
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
@@ -87,6 +87,18 @@ class ProductTypeListener implements EventSubscriberInterface
             $this->removeStock($form);
         } elseif ($initialProductType !== ProductType::TYPE_COMBINATIONS) {
             $this->removeCombinations($form);
+
+            $optionsField = $form->get('options');
+
+            // As this is also executed on pre-submit, we need to verify that suppliers exist before removing it
+            if ($optionsField->has('suppliers')) {
+                $suppliers = $optionsField->get('suppliers')->get('supplier_ids')->getConfig()->getOptions()['choices'];
+
+                // Don't display the suppliers part if there are no suppliers
+                if (count($suppliers) <= 0) {
+                    $this->removeSuppliers($form);
+                }
+            }
         }
 
         if (ProductType::TYPE_PACK !== $productType) {
@@ -121,6 +133,7 @@ class ProductTypeListener implements EventSubscriberInterface
     {
         if ($form->has('options')) {
             $optionsForm = $form->get('options');
+            $optionsForm->remove('suppliers');
             $optionsForm->remove('product_suppliers');
         }
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
@@ -83,21 +83,22 @@ class ProductTypeListener implements EventSubscriberInterface
         }
 
         if (ProductType::TYPE_COMBINATIONS === $productType) {
-            $this->removeSuppliers($form);
+            $this->removeProductSuppliers($form);
             $this->removeStock($form);
         } elseif ($initialProductType !== ProductType::TYPE_COMBINATIONS) {
             $this->removeCombinations($form);
+        }
 
-            $optionsField = $form->get('options');
+        $optionsField = $form->get('options');
 
-            // As this is also executed on pre-submit, we need to verify that suppliers exist before removing it
-            if ($optionsField->has('suppliers')) {
-                $suppliers = $optionsField->get('suppliers')->get('supplier_ids')->getConfig()->getOptions()['choices'];
+        // As this is also executed on pre-submit, we need to verify that suppliers exist before removing it
+        if ($optionsField->has('suppliers')) {
+            $suppliers = $optionsField->get('suppliers')->get('supplier_ids')->getConfig()->getOptions()['choices'];
 
-                // Don't display the suppliers part if there are no suppliers
-                if (count($suppliers) <= 0) {
-                    $this->removeSuppliers($form);
-                }
+            // Don't display the suppliers part if there are no suppliers
+            if (count($suppliers) <= 0) {
+                $this->removeSuppliers($form);
+                $this->removeProductSuppliers($form);
             }
         }
 
@@ -129,12 +130,19 @@ class ProductTypeListener implements EventSubscriberInterface
         }
     }
 
+    protected function removeProductSuppliers(FormInterface $form): void
+    {
+        if ($form->has('options')) {
+            $optionsForm = $form->get('options');
+            $optionsForm->remove('product_suppliers');
+        }
+    }
+
     protected function removeSuppliers(FormInterface $form): void
     {
         if ($form->has('options')) {
             $optionsForm = $form->get('options');
             $optionsForm->remove('suppliers');
-            $optionsForm->remove('product_suppliers');
         }
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/ProductTypeListener.php
@@ -98,7 +98,10 @@ class ProductTypeListener implements EventSubscriberInterface
             // Don't display the suppliers part if there are no suppliers
             if (count($suppliers) <= 0) {
                 $this->removeSuppliers($form);
-                $this->removeProductSuppliers($form);
+
+                if ($optionsField->has('product_suppliers')) {
+                  $this->removeProductSuppliers($form);
+                }
             }
         }
 

--- a/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
@@ -253,6 +253,38 @@ class ProductTypeListenerTest extends FormListenerTestCase
     }
 
     /**
+     * @dataProvider getExpectedSuppliers
+     *
+     * @param string $formType
+     * @param array $suppliers
+     * @param bool $suppliersExpected
+     * @param bool $productSuppliersExpected
+     */
+    public function testSuppliers(string $formType, array $suppliers, bool $suppliersExpected, bool $productSuppliersExpected): void
+    {
+        $form = $this->createForm(TestProductFormType::class, ['suppliers' => $suppliers]);
+
+        $this->assertFormTypeExistsInForm($form, 'options.suppliers', true);
+        $this->assertFormTypeExistsInForm($form, 'options.product_suppliers', true);
+        $this->adaptProductFormBasedOnProductType($form, $formType);
+        $this->assertFormTypeExistsInForm($form, 'options.suppliers', $suppliersExpected);
+        $this->assertFormTypeExistsInForm($form, 'options.product_suppliers', $productSuppliersExpected);
+    }
+
+    public function getExpectedSuppliers(): iterable
+    {
+        yield 'standard type with suppliers' => [ProductType::TYPE_STANDARD, [42, 69], true, true];
+        yield 'virtual type with suppliers' => [ProductType::TYPE_VIRTUAL, [42, 69], true, true];
+        yield 'pack type with suppliers' => [ProductType::TYPE_PACK, [42, 69], true, true];
+        yield 'combinations type with suppliers' => [ProductType::TYPE_COMBINATIONS, [42, 69], true, false];
+
+        yield 'standard type without suppliers' => [ProductType::TYPE_STANDARD, [], false, false];
+        yield 'virtual type without suppliers' => [ProductType::TYPE_VIRTUAL, [], false, false];
+        yield 'pack type without suppliers' => [ProductType::TYPE_PACK, [], false, false];
+        yield 'combination type without suppliers' => [ProductType::TYPE_COMBINATIONS, [], false, false];
+    }
+
+    /**
      * @dataProvider getProductTypes
      *
      * @param string $productType

--- a/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
+++ b/tests/Integration/PrestaShopBundle/Form/EventListener/ProductTypeListenerTest.php
@@ -67,9 +67,10 @@ class ProductTypeListenerTest extends FormListenerTestCase
 
     public function getFormTypeExpectationsBasedOnProductType(): iterable
     {
-        yield 'product_supplier in standard context' => [ProductType::TYPE_STANDARD, 'options.product_suppliers', true];
-        yield 'product_supplier in pack context' => [ProductType::TYPE_PACK, 'options.product_suppliers', true];
-        yield 'product_supplier in virtual context' => [ProductType::TYPE_VIRTUAL, 'options.product_suppliers', true];
+        // Since data is empty all product types remove this field see testSuppliers for more details
+        yield 'product_supplier in standard context' => [ProductType::TYPE_STANDARD, 'options.product_suppliers', false];
+        yield 'product_supplier in pack context' => [ProductType::TYPE_PACK, 'options.product_suppliers', false];
+        yield 'product_supplier in virtual context' => [ProductType::TYPE_VIRTUAL, 'options.product_suppliers', false];
         yield 'product_supplier in combination context' => [ProductType::TYPE_COMBINATIONS, 'options.product_suppliers', false];
 
         yield 'stock in standard context' => [ProductType::TYPE_STANDARD, 'stock', true];

--- a/tests/Integration/PrestaShopBundle/Form/TestProductFormType.php
+++ b/tests/Integration/PrestaShopBundle/Form/TestProductFormType.php
@@ -33,6 +33,7 @@ use PrestaShopBundle\Form\Admin\Type\UnavailableType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * This form type is not used in the project but in the tests, it allows to build a simple
@@ -64,6 +65,12 @@ class TestProductFormType extends CommonAbstractType
         $quantities->add('stock_movements', FormType::class);
 
         $optionsForm = $builder->get('options');
+
+        $optionsForm->add('suppliers', FormType::class);
+        $suppliersForm = $optionsForm->get('suppliers');
+        $suppliersForm->add('supplier_ids', ChoiceType::class, [
+            'choices' => $options['suppliers'],
+        ]);
         $optionsForm->add('product_suppliers', ChoiceType::class);
 
         $pricingForm = $builder->get('pricing');
@@ -72,5 +79,19 @@ class TestProductFormType extends CommonAbstractType
         $retailPricingForm = $pricingForm->get('retail_price');
         $retailPricingForm->add('ecotax_tax_excluded', UnavailableType::class);
         $retailPricingForm->add('ecotax_tax_included', UnavailableType::class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+        $resolver
+            ->setDefaults([
+                'suppliers' => [],
+            ])
+            ->setAllowedTypes('suppliers', 'array')
+        ;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Suppliers shouldn't be displayed if there are no suppliers in the shop
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29348.
| How to test?      | See issue
| Possible impacts? | Product v2 suppliers


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
