### PR TITLE
Allow blank value for mobile phone

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -417,6 +417,7 @@ class CustomerAddressType extends TranslatorAwareType
             ->add('phone_mobile', TextType::class, [
                 'label' => $this->trans('Mobile phone', 'Admin.Global'),
                 'required' => in_array('phone_mobile', $requiredFields, true),
+                'empty_data' => '',
                 'constraints' => [
                     new CleanHtml(),
                     new TypedRegex([


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow blank value for mobile phone in customer address
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29379.
| Related PRs       | N/A
| How to test?      | Edit customer address with blank mobile phone
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
