### PR TITLE
Bugfix issue 10903

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -460,7 +460,7 @@ class CartCore extends ObjectModel
         $virtual_context->cart = $this;
 
         // If the cart has not been saved, then there can't be any cart rule applied
-        if (!CartRule::isFeatureActive() || !$this->id) {
+        if (!CartRule::isFeatureActive() || !$this->id || !$this->_products) {
             return [];
         }
         if ($autoAdd) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.0.x / 1.7.x
| Description?      | The first call of getProducts generates a recursive call to this function with no products loaded, this breaks other algorithms because of the Cache de cart rules.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #10903


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
