### PR TITLE
Fix "undefined" error when modifying product quantity in FO product quick view 

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7453,7 +7453,7 @@ class ProductCore extends ObjectModel
         }
 
         if (empty($idProductAttribute)) {
-            throw new PrestaShopObjectNotFoundException('Can not retrieve the id_product_attribute');
+            throw new PrestaShopObjectNotFoundException('Cannot retrieve the id_product_attribute');
         }
 
         return (int) $idProductAttribute;


### PR DESCRIPTION
…t found error to throw uncatched error

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Server error when quickview product quantity changed. Do not try to retrieve product attribute if product has no combinations.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #17104
| Related PRs       |N/A.
| How to test?      | Go to FO > Open any product page > In related products footer 5already seen, or similar > Open a product's Quick View > Modify Quantity/combinations > See NO undefined error.
| Possible impacts? | FO Product Pages/ Cart features


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
