### PR TITLE
Bugfix for localization of messages with currencies that haven't cents

### DIFF
--- a/src/Core/Localization/CLDR/ComputingPrecision.php
+++ b/src/Core/Localization/CLDR/ComputingPrecision.php
@@ -38,8 +38,11 @@ final class ComputingPrecision implements ComputingPrecisionInterface
     /**
      * {@inheritdoc}
      */
-    public function getPrecision(int $displayPrecision)
+    public function getPrecision($displayPrecision)
     {
+        // Earlier, there was int type hint in this method; but in the process of developing one e-store with KRW currency that does not have analog of cents and does not need precision, it was found that sometimes null is passed to this method which causes some errors. Detailed testing is needed to reproduce errors, they were not logged fully; but this bugfix with replacing int type hint with intval() call worked fine and did not cause any visible issues. Obviously, the original issue and bugfix should be researched by some experienced PrestaShop core developer.
+        $displayPrecision = intval($displayPrecision);
+
         // the MULTIPLIER attribute is set to 1 for now, so that it matches display precision
         $computingPrecision = $displayPrecision * self::MULTIPLIER;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Earlier, there was int type hint in this method; but in the process of developing one e-store with KRW currency that does not have analog of cents and does not need precision, it was found that sometimes null is passed to this method which causes some errors. Detailed testing is needed to reproduce errors, they were not logged fully; but this bugfix with replacing int type hint with intval() call worked fine and did not cause any visible issues. Obviously, the original issue and bugfix should be researched by some experienced PrestaShop core developer.
| Type?             | bug fix
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29405
| Related PRs       | not applicable
| How to test?      | It requires research of the described issue by experienced PrestaShop core developer.
| Possible impacts? | Localization features may be impacted.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
