### PR TITLE
Add availability labels to combinations

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/combination/bulk.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/bulk.ts
@@ -32,6 +32,8 @@ const {$} = window;
 
 $(() => {
   window.prestashop.component.initComponents([
+    'TranslatableField',
+    'TranslatableInput',
     'EventEmitter',
     'DeltaQuantityInput',
     'DisablingSwitch',

--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/DropzoneWindow.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/DropzoneWindow.vue
@@ -126,7 +126,7 @@
           {{ selectedLocale.iso_code }}
         </button>
         <div
-          class="dropdown-menu locale-dropdown-menu"
+          class="dropdown-menu dropdown-menu-right locale-dropdown-menu"
           aria-labelledby="form_invoice_prefix"
         >
           <span

--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -181,6 +181,7 @@
     margin-bottom: 0;
     border: none;
     box-shadow: none;
+    overflow: initial;
 
     .card-header {
       padding: 0;

--- a/admin-dev/themes/new-theme/scss/components/_form.scss
+++ b/admin-dev/themes/new-theme/scss/components/_form.scss
@@ -179,9 +179,9 @@
 .accordion-form {
   .card {
     margin-bottom: 0;
+    overflow: initial;
     border: none;
     box-shadow: none;
-    overflow: initial;
 
     .card-header {
       padding: 0;

--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\PrestaShop\Core\Domain\Combination\CombinationSettings;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 
 /**
@@ -70,12 +71,19 @@ class CombinationCore extends ObjectModel
 
     public $available_date = '0000-00-00';
 
+    /** @var string|array Text when in stock or array of text by id_lang */
+    public $available_now;
+
+    /** @var string|array Text when not in stock but available to order or array of text by id_lang */
+    public $available_later;
+
     /**
      * @see ObjectModel::$definition
      */
     public static $definition = [
         'table' => 'product_attribute',
         'primary' => 'id_product_attribute',
+        'multilang' => true,
         'fields' => [
             'id_product' => ['type' => self::TYPE_INT, 'shop' => 'both', 'validate' => 'isUnsignedId', 'required' => true],
             'ean13' => ['type' => self::TYPE_STRING, 'validate' => 'isEan13', 'size' => 13],
@@ -96,6 +104,10 @@ class CombinationCore extends ObjectModel
             'low_stock_alert' => ['type' => self::TYPE_BOOL, 'shop' => true, 'validate' => 'isBool'],
             'default_on' => ['type' => self::TYPE_BOOL, 'allow_null' => true, 'shop' => true, 'validate' => 'isBool'],
             'available_date' => ['type' => self::TYPE_DATE, 'shop' => true, 'validate' => 'isDateFormat'],
+
+            /* Lang fields */
+            'available_now' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => CombinationSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH],
+            'available_later' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'IsGenericName', 'size' => CombinationSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH],
         ],
     ];
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1881,6 +1881,8 @@ class ProductCore extends ObjectModel
             if ($id_combination) {
                 $obj->minimal_quantity = 1;
                 $obj->available_date = '0000-00-00';
+                $obj->available_now = '';
+                $obj->available_later = '';
             }
 
             foreach ($combination as $field => $value) {
@@ -1947,6 +1949,8 @@ class ProductCore extends ObjectModel
      * @param int|null $low_stock_threshold Low stock for mail alert
      * @param bool $low_stock_alert Low stock mail alert activated
      * @param string|null $mpn
+     * @param string[]|string $available_now Combination available now labels
+     * @param string[]|string $available_later Combination available later labels
      *
      * @return int|false Attribute identifier if success, false if it fail
      */
@@ -1970,7 +1974,9 @@ class ProductCore extends ObjectModel
         $isbn = '',
         $low_stock_threshold = null,
         $low_stock_alert = false,
-        $mpn = null
+        $mpn = null,
+        $available_now = [],
+        $available_later = []
     ) {
         $id_product_attribute = $this->addAttribute(
             $price,
@@ -1990,7 +1996,9 @@ class ProductCore extends ObjectModel
             $isbn,
             $low_stock_threshold,
             $low_stock_alert,
-            $mpn
+            $mpn,
+            $available_now,
+            $available_later
         );
         $this->addSupplierReference($id_supplier, $id_product_attribute);
         $result = ObjectModel::updateMultishopTable('Combination', [
@@ -2097,6 +2105,8 @@ class ProductCore extends ObjectModel
      * @param int|null $low_stock_threshold Low stock for mail alert
      * @param bool $low_stock_alert Low stock mail alert activated
      * @param string|null $mpn
+     * @param string[]|string|null $available_now Combination available now labels
+     * @param string[]|string|null $available_later Combination available later labels
      *
      * @return bool
      */
@@ -2119,7 +2129,9 @@ class ProductCore extends ObjectModel
         $isbn = '',
         $low_stock_threshold = null,
         $low_stock_alert = false,
-        $mpn = null
+        $mpn = null,
+        $available_now = null,
+        $available_later = null
     ) {
         Tools::displayAsDeprecated('Use updateAttribute() instead');
 
@@ -2143,7 +2155,9 @@ class ProductCore extends ObjectModel
             $isbn,
             $low_stock_threshold,
             $low_stock_alert,
-            $mpn = null
+            $mpn = null,
+            $available_now,
+            $available_later
         );
         $this->addSupplierReference($id_supplier, $id_product_attribute);
 
@@ -2208,6 +2222,8 @@ class ProductCore extends ObjectModel
      * @param int|null $low_stock_threshold Low stock for mail alert
      * @param bool $low_stock_alert Low stock mail alert activated
      * @param string $mpn MPN
+     * @param string[]|string|null $available_now Combination available now labels
+     * @param string[]|string|null $available_later Combination available later labels
      *
      * @return bool Update result
      */
@@ -2231,12 +2247,14 @@ class ProductCore extends ObjectModel
         $isbn = '',
         $low_stock_threshold = null,
         $low_stock_alert = false,
-        $mpn = null
+        $mpn = null,
+        $available_now = null,
+        $available_later = null
     ) {
         $combination = new Combination($id_product_attribute);
 
         if (!$update_all_fields) {
-            $combination->setFieldsToUpdate([
+            $fieldsToUpdate = [
                 'price' => null !== $price,
                 'wholesale_price' => null !== $wholesale_price,
                 'ecotax' => null !== $ecotax,
@@ -2253,7 +2271,23 @@ class ProductCore extends ObjectModel
                 'low_stock_threshold' => null !== $low_stock_threshold,
                 'low_stock_alert' => null !== $low_stock_alert,
                 'id_shop_list' => !empty($id_shop_list),
-            ]);
+                'available_now' => is_string($available_now),
+                'available_later' => is_string($available_later),
+            ];
+            // Labels can be passed into this function both as array and string, as does the object model itself.
+            // If these values are passed as strings, they will be updated in all languages of the object.
+            if (is_array($available_now)) {
+                foreach ($available_now as $id_lang => $value) {
+                    $fieldsToUpdate['available_now'][$id_lang] = true;
+                }
+            }
+            if (is_array($available_later)) {
+                foreach ($available_later as $id_lang => $value) {
+                    $fieldsToUpdate['available_later'][$id_lang] = true;
+                }
+            }
+
+            $combination->setFieldsToUpdate($fieldsToUpdate);
         }
 
         $price = (float) str_replace(',', '.', (string) $price);
@@ -2274,6 +2308,8 @@ class ProductCore extends ObjectModel
         $combination->low_stock_threshold = empty($low_stock_threshold) && '0' != $low_stock_threshold ? null : (int) $low_stock_threshold;
         $combination->low_stock_alert = !empty($low_stock_alert);
         $combination->available_date = $available_date ? pSQL($available_date) : '0000-00-00';
+        $combination->available_now = $available_now;
+        $combination->available_later = $available_later;
 
         if (!empty($id_shop_list)) {
             $combination->id_shop_list = $id_shop_list;
@@ -2330,6 +2366,8 @@ class ProductCore extends ObjectModel
      * @param int|null $low_stock_threshold Low stock for mail alert
      * @param bool $low_stock_alert Low stock mail alert activated
      * @param string|null $mpn
+     * @param string[]|string $available_now Combination available now labels
+     * @param string[]|string $available_later Combination available later labels
      *
      * @return int|false|void Attribute identifier if success, false if failed to add Combination, void if Product identifier not set
      */
@@ -2351,7 +2389,9 @@ class ProductCore extends ObjectModel
         $isbn = '',
         $low_stock_threshold = null,
         $low_stock_alert = false,
-        $mpn = null
+        $mpn = null,
+        $available_now = [],
+        $available_later = []
     ) {
         if (!$this->id) {
             return;
@@ -2376,6 +2416,8 @@ class ProductCore extends ObjectModel
         $combination->low_stock_threshold = empty($low_stock_threshold) && '0' != $low_stock_threshold ? null : (int) $low_stock_threshold;
         $combination->low_stock_alert = !empty($low_stock_alert);
         $combination->available_date = $available_date;
+        $combination->available_now = $available_now;
+        $combination->available_later = $available_later;
 
         if (count($id_shop_list)) {
             $combination->id_shop_list = array_unique($id_shop_list);
@@ -4493,10 +4535,15 @@ class ProductCore extends ObjectModel
                     a.`id_attribute`, al.`name` AS attribute_name, a.`color` AS attribute_color, product_attribute_shop.`id_product_attribute`,
                     IFNULL(stock.quantity, 0) as quantity, product_attribute_shop.`price`, product_attribute_shop.`ecotax`, product_attribute_shop.`weight`,
                     product_attribute_shop.`default_on`, pa.`reference`, pa.`ean13`, pa.`mpn`, pa.`upc`, pa.`isbn`, product_attribute_shop.`unit_price_impact`,
-                    product_attribute_shop.`minimal_quantity`, product_attribute_shop.`available_date`, ag.`group_type`
+                    product_attribute_shop.`minimal_quantity`, product_attribute_shop.`available_date`, ag.`group_type`,
+                    pal.`available_now`, pal.`available_later`
                 FROM `' . _DB_PREFIX_ . 'product_attribute` pa
                 ' . Shop::addSqlAssociation('product_attribute', 'pa') . '
                 ' . Product::sqlStock('pa', 'pa') . '
+                LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_lang` pal
+                    ON (
+                        pa.`id_product_attribute` = pal.`id_product_attribute` AND 
+                        pal.`id_lang` = ' . (int) Context::getContext()->language->id . ')
                 LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac ON (pac.`id_product_attribute` = pa.`id_product_attribute`)
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute` a ON (a.`id_attribute` = pac.`id_attribute`)
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag ON (ag.`id_attribute_group` = a.`id_attribute_group`)
@@ -7377,7 +7424,9 @@ class ProductCore extends ObjectModel
 
         if (!Cache::isStored($cache_id)) {
             $result = Db::getInstance()->executeS('
-            SELECT a.`id_attribute`, a.`id_attribute_group`, al.`name`, agl.`name` as `group`, pa.`reference`, pa.`ean13`, pa.`isbn`, pa.`upc`, pa.`mpn`
+            SELECT a.`id_attribute`, a.`id_attribute_group`, al.`name`, agl.`name` as `group`, 
+            pa.`reference`, pa.`ean13`, pa.`isbn`, pa.`upc`, pa.`mpn`,
+            pal.`available_now`, pal.`available_later`
             FROM `' . _DB_PREFIX_ . 'attribute` a
             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al
                 ON (al.`id_attribute` = a.`id_attribute` AND al.`id_lang` = ' . (int) $id_lang . ')
@@ -7386,6 +7435,8 @@ class ProductCore extends ObjectModel
             LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute` pa
                 ON (pa.`id_product_attribute` = pac.`id_product_attribute`)
             ' . Shop::addSqlAssociation('product_attribute', 'pa') . '
+            LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_lang` pal
+                ON (pal.`id_product_attribute` = pac.`id_product_attribute` AND pal.`id_lang` = ' . (int) $id_lang . ')
             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl
                 ON (a.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int) $id_lang . ')
             WHERE pa.`id_product` = ' . (int) $id_product . '

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -4553,6 +4553,7 @@ class AdminImportControllerCore extends AdminController
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_shop`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_combination`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_image`');
+                Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_lang`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'pack`');
                 Image::deleteAllImages(_PS_PRODUCT_IMG_DIR_);
                 if (!file_exists(_PS_PRODUCT_IMG_DIR_)) {
@@ -4571,6 +4572,7 @@ class AdminImportControllerCore extends AdminController
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_shop`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_combination`');
                 Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_image`');
+                Db::getInstance()->execute('TRUNCATE TABLE `' . _DB_PREFIX_ . 'product_attribute_lang`');
                 Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'stock_available` WHERE id_product_attribute != 0');
 
                 break;

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -676,6 +676,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 } else {
                     $this->combinations[$row['id_product_attribute']]['available_date'] = $this->combinations[$row['id_product_attribute']]['date_formatted'] = '';
                 }
+                $this->combinations[$row['id_product_attribute']]['available_now'] = $row['available_now'];
+                $this->combinations[$row['id_product_attribute']]['available_later'] = $row['available_later'];
 
                 if (!isset($combination_images[$row['id_product_attribute']][0]['id_image'])) {
                     $this->combinations[$row['id_product_attribute']]['id_image'] = -1;

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1753,6 +1753,15 @@ CREATE TABLE `PREFIX_product_attribute` (
   )
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
+/* Localized combination information */
+CREATE TABLE `PREFIX_product_attribute_lang` (
+  `id_product_attribute` int(10) unsigned NOT NULL,
+  `id_lang` int(10) unsigned NOT NULL,
+  `available_now` varchar(255) DEFAULT NULL,
+  `available_later` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id_product_attribute`, `id_lang`)
+) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
+
 /* shop specific attribute info */
 CREATE TABLE `PREFIX_product_attribute_shop` (
   `id_product` int(10) unsigned NOT NULL,

--- a/src/Adapter/Import/ImportEntityDeleter.php
+++ b/src/Adapter/Import/ImportEntityDeleter.php
@@ -232,6 +232,7 @@ final class ImportEntityDeleter implements ImportEntityDeleterInterface
             'product_attribute_shop',
             'product_attribute_combination',
             'product_attribute_image',
+            'product_attribute_lang',
             'pack',
         ];
 
@@ -263,6 +264,7 @@ final class ImportEntityDeleter implements ImportEntityDeleterInterface
             'product_attribute_shop',
             'product_attribute_combination',
             'product_attribute_image',
+            'product_attribute_lang',
         ];
 
         $this->truncateTables($truncateTables);

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -581,7 +581,7 @@ class ProductLazyArray extends AbstractLazyArray
 
         foreach ($referenceTypes as $type) {
             // First, we try to get the references of combination.
-            if (isset($combinationData[$type]) && !empty($combinationData[$type])) {
+            if (!empty($combinationData[$type])) {
                 $specificReference = $combinationData[$type];
             // Otherwise, we check if something is set on the product itself
             } elseif (!empty($this->product[$type])) {

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -948,7 +948,7 @@ class ProductLazyArray extends AbstractLazyArray
                 // We will primarily use label from combination if set, then label on product, then the default label from PS settings
                 if (!empty($combinationData['available_now'])) {
                     $this->product['availability_message'] = $combinationData['available_now'];
-                } elseif ($product['available_now']) {
+                } elseif (!empty($product['available_now'])) {
                     $this->product['availability_message'] = $product['available_now'];
                 } else {
                     $config = $this->configuration->get('PS_LABEL_IN_STOCK_PRODUCTS');
@@ -964,7 +964,7 @@ class ProductLazyArray extends AbstractLazyArray
             // We will primarily use label from combination if set, then label on product, then the default label from PS settings
             if (!empty($combinationData['available_later'])) {
                 $this->product['availability_message'] = $combinationData['available_later'];
-            } elseif ($product['available_now']) {
+            } elseif (!empty($product['available_later'])) {
                 $this->product['availability_message'] = $product['available_later'];
             } else {
                 $config = $this->configuration->get('PS_LABEL_OOS_PRODUCTS_BOA');

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -572,21 +572,26 @@ class ProductLazyArray extends AbstractLazyArray
         }
 
         $specificReferences = null;
-        $referenceTypes = ['isbn', 'upc', 'ean13', 'mpn'];
+
+        // Get data of this combination, it contains other stuff, we will extract only what we need
         $combinationData = $this->getCombinationSpecificData();
 
-        foreach ($referenceTypes as $key) {
+        // Keys we want to extract from the combination data
+        $referenceTypes = ['isbn', 'upc', 'ean13', 'mpn'];
+
+        foreach ($referenceTypes as $type) {
             // First, we try to get the references of combination.
-            if (isset($combinationData[$key]) && !empty($combinationData[$key])) {
-                $value = $combinationData[$key];
+            if (isset($combinationData[$type]) && !empty($combinationData[$type])) {
+                $specificReference = $combinationData[$type];
             // Otherwise, we check if something is set on the product itself
-            } elseif (!empty($this->product[$key])) {
-                $value = $this->product[$key];
+            } elseif (!empty($this->product[$type])) {
+                $specificReference = $this->product[$type];
             } else {
                 continue;
             }
 
-            $specificReferences[$this->getTranslatedKey($key)] = $value;
+            // Get a nice readable label for this reference and save it
+            $specificReferences[$this->getTranslatedKey($type)] = $specificReference;
         }
 
         return $specificReferences;

--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockHandler.php
@@ -97,7 +97,9 @@ final class UpdateCombinationStockHandler implements UpdateCombinationStockHandl
             $command->getLocation(),
             $command->getLowStockThreshold(),
             $command->getLowStockAlertEnabled(),
-            $command->getAvailableDate()
+            $command->getAvailableDate(),
+            $command->getLocalizedAvailableNowLabels(),
+            $command->getLocalizedAvailableLaterLabels()
         );
 
         $this->combinationStockUpdater->update($command->getCombinationId(), $properties);

--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -284,7 +284,9 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
             (int) $combination->low_stock_threshold,
             (bool) $combination->low_stock_alert,
             $stockAvailable->location,
-            DateTimeUtil::buildDateTimeOrNull($combination->available_date)
+            DateTimeUtil::buildDateTimeOrNull($combination->available_date),
+            (array) $combination->available_now,
+            (array) $combination->available_later
         );
     }
 

--- a/src/Adapter/Product/Combination/Update/CombinationStockProperties.php
+++ b/src/Adapter/Product/Combination/Update/CombinationStockProperties.php
@@ -58,6 +58,16 @@ class CombinationStockProperties
     private $lowStockAlertEnabled;
 
     /**
+     * @var string[]|null key value pairs where key is the id of language
+     */
+    private $localizedAvailableNowLabels;
+
+    /**
+     * @var string[]|null key value pairs where key is the id of language
+     */
+    private $localizedAvailableLaterLabels;
+
+    /**
      * @var DateTimeInterface|null
      */
     private $availableDate;
@@ -69,6 +79,8 @@ class CombinationStockProperties
      * @param int|null $lowStockThreshold
      * @param bool|null $lowStockAlertEnabled
      * @param DateTimeInterface|null $availableDate
+     * @param string[]|null $localizedAvailableNowLabels
+     * @param string[]|null $localizedAvailableLaterLabels
      */
     public function __construct(
         ?StockModification $stockModification = null,
@@ -76,7 +88,9 @@ class CombinationStockProperties
         ?string $location = null,
         ?int $lowStockThreshold = null,
         ?bool $lowStockAlertEnabled = null,
-        ?DateTimeInterface $availableDate = null
+        ?DateTimeInterface $availableDate = null,
+        ?array $localizedAvailableNowLabels = null,
+        ?array $localizedAvailableLaterLabels = null
     ) {
         $this->stockModification = $stockModification;
         $this->minimalQuantity = $minimalQuantity;
@@ -85,6 +99,8 @@ class CombinationStockProperties
         $this->lowStockAlertEnabled = $lowStockAlertEnabled;
         $this->availableDate = $availableDate;
         $this->stockModification = $stockModification;
+        $this->localizedAvailableNowLabels = $localizedAvailableNowLabels;
+        $this->localizedAvailableLaterLabels = $localizedAvailableLaterLabels;
     }
 
     /**
@@ -133,5 +149,21 @@ class CombinationStockProperties
     public function getAvailableDate(): ?DateTimeInterface
     {
         return $this->availableDate;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedAvailableNowLabels(): ?array
+    {
+        return $this->localizedAvailableNowLabels;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedAvailableLaterLabels(): ?array
+    {
+        return $this->localizedAvailableLaterLabels;
     }
 }

--- a/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
@@ -110,6 +110,18 @@ class CombinationStockUpdater
     {
         $updatableProperties = [];
 
+        $localizedLaterLabels = $properties->getLocalizedAvailableLaterLabels();
+        if (null !== $localizedLaterLabels) {
+            $combination->available_later = $localizedLaterLabels;
+            $updatableProperties['available_later'] = array_keys($localizedLaterLabels);
+        }
+
+        $localizedNowLabels = $properties->getLocalizedAvailableNowLabels();
+        if (null !== $localizedNowLabels) {
+            $combination->available_now = $localizedNowLabels;
+            $updatableProperties['available_now'] = array_keys($localizedNowLabels);
+        }
+
         if (null !== $properties->getAvailableDate()) {
             $combination->available_date = $properties->getAvailableDate()->format(DateTime::DEFAULT_DATE_FORMAT);
             $updatableProperties[] = 'available_date';

--- a/src/Adapter/Product/Combination/Validate/CombinationValidator.php
+++ b/src/Adapter/Product/Combination/Validate/CombinationValidator.php
@@ -90,6 +90,8 @@ class CombinationValidator extends AbstractObjectModelValidator
         $this->validateCombinationProperty($combination, 'low_stock_threshold', ProductConstraintException::INVALID_LOW_STOCK_THRESHOLD);
         $this->validateCombinationProperty($combination, 'low_stock_alert', ProductConstraintException::INVALID_LOW_STOCK_ALERT);
         $this->validateCombinationProperty($combination, 'available_date', ProductConstraintException::INVALID_AVAILABLE_DATE);
+        $this->validateCombinationLocalizedProperty($combination, 'available_later', ProductConstraintException::INVALID_AVAILABLE_LATER);
+        $this->validateCombinationLocalizedProperty($combination, 'available_now', ProductConstraintException::INVALID_AVAILABLE_NOW);
     }
 
     /**
@@ -103,5 +105,22 @@ class CombinationValidator extends AbstractObjectModelValidator
     private function validateCombinationProperty(Combination $combination, string $property, int $errorCode): void
     {
         $this->validateObjectModelProperty($combination, $property, ProductConstraintException::class, $errorCode);
+    }
+
+    /**
+     * @param Combination $combination
+     * @param string $property
+     * @param int $errorCode
+     *
+     * @throws ProductConstraintException
+     */
+    private function validateCombinationLocalizedProperty(Combination $combination, string $property, int $errorCode = 0): void
+    {
+        $this->validateObjectModelLocalizedProperty(
+            $combination,
+            $property,
+            ProductConstraintException::class,
+            $errorCode
+        );
     }
 }

--- a/src/Core/Domain/Combination/CombinationSettings.php
+++ b/src/Core/Domain/Combination/CombinationSettings.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Combination;
+
+/**
+ * Defines settings for combination.
+ * If related Value Object does not exist, then various settings (e.g. regex, length constraints) are saved here
+ */
+class CombinationSettings
+{
+    /**
+     * Class not supposed to be initialized, it only serves as static storage
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Bellow constants define maximum allowed length of combination properties
+     */
+    public const MAX_AVAILABLE_NOW_LABEL_LENGTH = 255;
+    public const MAX_AVAILABLE_LATER_LABEL_LENGTH = 255;
+}

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockCommand.php
@@ -78,6 +78,16 @@ class UpdateCombinationStockCommand
     private $availableDate;
 
     /**
+     * @var string[]|null key value pairs where key is the id of language
+     */
+    private $localizedAvailableNowLabels;
+
+    /**
+     * @var string[]|null key value pairs where key is the id of language
+     */
+    private $localizedAvailableLaterLabels;
+
+    /**
      * @param int $combinationId
      */
     public function __construct(
@@ -248,5 +258,45 @@ class UpdateCombinationStockCommand
     public function getLowStockAlertEnabled(): ?bool
     {
         return $this->lowStockAlertEnabled;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedAvailableNowLabels(): ?array
+    {
+        return $this->localizedAvailableNowLabels;
+    }
+
+    /**
+     * @param string[] $localizedAvailableNowLabels
+     *
+     * @return UpdateCombinationStockCommand
+     */
+    public function setLocalizedAvailableNowLabels(array $localizedAvailableNowLabels): UpdateCombinationStockCommand
+    {
+        $this->localizedAvailableNowLabels = $localizedAvailableNowLabels;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedAvailableLaterLabels(): ?array
+    {
+        return $this->localizedAvailableLaterLabels;
+    }
+
+    /**
+     * @param string[] $localizedAvailableLaterLabels
+     *
+     * @return UpdateCombinationStockCommand
+     */
+    public function setLocalizedAvailableLaterLabels(array $localizedAvailableLaterLabels): UpdateCombinationStockCommand
+    {
+        $this->localizedAvailableLaterLabels = $localizedAvailableLaterLabels;
+
+        return $this;
     }
 }

--- a/src/Core/Domain/Product/Combination/QueryResult/CombinationStock.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/CombinationStock.php
@@ -63,6 +63,16 @@ class CombinationStock
     private $availableDate;
 
     /**
+     * @var string[] key value pairs where key is the id of language
+     */
+    private $localizedAvailableNowLabels;
+
+    /**
+     * @var string[] key value pairs where key is the id of language
+     */
+    private $localizedAvailableLaterLabels;
+
+    /**
      * @param int $quantity
      * @param int $minimalQuantity
      * @param int $lowStockThreshold
@@ -76,7 +86,9 @@ class CombinationStock
         int $lowStockThreshold,
         bool $lowStockAlertEnabled,
         string $location,
-        ?DateTimeInterface $availableDate
+        ?DateTimeInterface $availableDate,
+        array $localizedAvailableNowLabels,
+        array $localizedAvailableLaterLabels
     ) {
         $this->quantity = $quantity;
         $this->minimalQuantity = $minimalQuantity;
@@ -84,6 +96,8 @@ class CombinationStock
         $this->lowStockThreshold = $lowStockThreshold;
         $this->lowStockAlertEnabled = $lowStockAlertEnabled;
         $this->availableDate = $availableDate;
+        $this->localizedAvailableNowLabels = $localizedAvailableNowLabels;
+        $this->localizedAvailableLaterLabels = $localizedAvailableLaterLabels;
     }
 
     /**
@@ -132,5 +146,21 @@ class CombinationStock
     public function getAvailableDate(): ?DateTimeInterface
     {
         return $this->availableDate;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedAvailableNowLabels(): array
+    {
+        return $this->localizedAvailableNowLabels;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedAvailableLaterLabels(): array
+    {
+        return $this->localizedAvailableLaterLabels;
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationStockCommandsBuilder.php
@@ -53,6 +53,8 @@ final class CombinationStockCommandsBuilder implements CombinationCommandsBuilde
             ->addField('[stock][options][disabling_switch_low_stock_threshold]', 'setLowStockAlert', DataField::TYPE_BOOL)
             ->addField('[stock][pack_stock_type]', 'setPackStockType', DataField::TYPE_INT)
             ->addField('[stock][available_date]', 'setAvailableDate', DataField::TYPE_DATETIME)
+            ->addField('[stock][available_now_label]', 'setLocalizedAvailableNowLabels', DataField::TYPE_ARRAY)
+            ->addField('[stock][available_later_label]', 'setLocalizedAvailableLaterLabels', DataField::TYPE_ARRAY)
         ;
 
         $commandBuilder = new CommandBuilder($config);

--- a/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
+++ b/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
@@ -62,6 +62,8 @@ class BulkCombinationFormDataFormatter extends AbstractFormDataFormatter
             '[stock][low_stock_threshold]' => '[stock][options][low_stock_threshold]',
             '[stock][low_stock_alert]' => '[stock][options][low_stock_alert]',
             '[stock][available_date]' => '[stock][available_date]',
+            '[stock][available_now_label]' => '[stock][available_now_label]',
+            '[stock][available_later_label]' => '[stock][available_later_label]',
         ];
         $formattedData = $this->formatByPath($formData, $pathAssociations);
 

--- a/src/Core/Form/IdentifiableObject/DataProvider/BulkCombinationFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/BulkCombinationFormDataProvider.php
@@ -48,6 +48,8 @@ class BulkCombinationFormDataProvider implements FormDataProviderInterface
                 'low_stock_threshold' => 0,
                 'low_stock_alert' => '',
                 'available_date' => '',
+                'available_now_label' => [],
+                'available_later_label' => [],
             ],
             'price' => [
                 'wholesale_price' => 0,

--- a/src/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProvider.php
@@ -126,6 +126,8 @@ class CombinationFormDataProvider implements FormDataProviderInterface
                 'low_stock_alert' => $stockInformation->isLowStockAlertEnabled(),
             ],
             'available_date' => DateTime::isNull($availableDate) ? '' : $availableDate->format(DateTime::DEFAULT_DATE_FORMAT),
+            'available_now_label' => $stockInformation->getLocalizedAvailableNowLabels(),
+            'available_later_label' => $stockInformation->getLocalizedAvailableLaterLabels(),
         ];
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -165,7 +165,6 @@ class BulkCombinationStockType extends TranslatorAwareType
                 'label' => $this->trans('Label when in stock', 'Admin.Catalog.Feature'),
                 'required' => false,
                 'disabling_switch' => true,
-                'modify_all_shops' => true,
                 'options' => [
                     'constraints' => [
                         new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
@@ -188,7 +187,6 @@ class BulkCombinationStockType extends TranslatorAwareType
                 ),
                 'required' => false,
                 'disabling_switch' => true,
-                'modify_all_shops' => true,
                 'options' => [
                     'constraints' => [
                         new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -28,9 +28,12 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Domain\Combination\CombinationSettings;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\DeltaQuantityType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
@@ -39,6 +42,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -155,6 +159,49 @@ class BulkCombinationStockType extends TranslatorAwareType
                     'placeholder' => 'YYYY-MM-DD',
                 ],
                 'disabling_switch' => true,
+            ])
+            ->add('available_now_label', TranslatableType::class, [
+                'type' => TextType::class,
+                'label' => $this->trans('Label when in stock', 'Admin.Catalog.Feature'),
+                'required' => false,
+                'disabling_switch' => true,
+                'modify_all_shops' => true,
+                'options' => [
+                    'constraints' => [
+                        new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
+                        new Length([
+                            'max' => CombinationSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters.',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => CombinationSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH]
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
+            ->add('available_later_label', TranslatableType::class, [
+                'type' => TextType::class,
+                'label' => $this->trans(
+                    'Label when out of stock (and backorders allowed)',
+                    'Admin.Catalog.Feature'
+                ),
+                'required' => false,
+                'disabling_switch' => true,
+                'modify_all_shops' => true,
+                'options' => [
+                    'constraints' => [
+                        new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
+                        new Length([
+                            'max' => CombinationSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters.',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => CombinationSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH]
+                            ),
+                        ]),
+                    ],
+                ],
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
@@ -63,7 +63,6 @@ class CombinationStockType extends TranslatorAwareType
                 'type' => TextType::class,
                 'label' => $this->trans('Label when in stock', 'Admin.Catalog.Feature'),
                 'required' => false,
-                'modify_all_shops' => true,
                 'options' => [
                     'constraints' => [
                         new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
@@ -85,7 +84,6 @@ class CombinationStockType extends TranslatorAwareType
                     'Admin.Catalog.Feature'
                 ),
                 'required' => false,
-                'modify_all_shops' => true,
                 'options' => [
                     'constraints' => [
                         new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationStockType.php
@@ -28,12 +28,17 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Domain\Combination\CombinationSettings;
 use PrestaShopBundle\Form\Admin\Sell\Product\Stock\QuantityType;
 use PrestaShopBundle\Form\Admin\Sell\Product\Stock\StockOptionsType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
+use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
 
 class CombinationStockType extends TranslatorAwareType
 {
@@ -52,6 +57,47 @@ class CombinationStockType extends TranslatorAwareType
                 'required' => false,
                 'attr' => [
                     'placeholder' => 'YYYY-MM-DD',
+                ],
+            ])
+            ->add('available_now_label', TranslatableType::class, [
+                'type' => TextType::class,
+                'label' => $this->trans('Label when in stock', 'Admin.Catalog.Feature'),
+                'required' => false,
+                'modify_all_shops' => true,
+                'options' => [
+                    'constraints' => [
+                        new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
+                        new Length([
+                            'max' => CombinationSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters.',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => CombinationSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH]
+                            ),
+                        ]),
+                    ],
+                ],
+            ])
+            ->add('available_later_label', TranslatableType::class, [
+                'type' => TextType::class,
+                'label' => $this->trans(
+                    'Label when out of stock (and backorders allowed)',
+                    'Admin.Catalog.Feature'
+                ),
+                'required' => false,
+                'modify_all_shops' => true,
+                'options' => [
+                    'constraints' => [
+                        new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
+                        new Length([
+                            'max' => CombinationSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH,
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters.',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => CombinationSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH]
+                            ),
+                        ]),
+                    ],
                 ],
             ])
         ;

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -281,7 +281,7 @@
                 {{ form.vars.default_locale.iso_code }}
             </button>
 
-            <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+            <div class="dropdown-menu dropdown-menu-right locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
                 {% for locale in locales %}
                     <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
                 {% endfor %}
@@ -319,7 +319,7 @@
           {{ form.vars.default_locale.iso_code }}
         </button>
 
-        <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+        <div class="dropdown-menu dropdown-menu-right locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
           {% for locale in locales %}
             <span class="dropdown-item js-locale-item"
                   data-locale="{{ locale.iso_code }}"
@@ -695,7 +695,7 @@
         >
           {{ form.vars.default_locale.iso_code }}
         </button>
-        <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}_dropdown">
+        <div class="dropdown-menu dropdown-menu-right locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}_dropdown">
           {% for locale in locales %}
             <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
           {% endfor %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -466,7 +466,7 @@
           {{ form.vars.default_locale.iso_code }}
         </button>
 
-        <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+        <div class="dropdown-menu dropdown-menu-right locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
           {% for locale in locales %}
             <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
           {% endfor %}
@@ -504,7 +504,7 @@
           {{ form.vars.default_locale.iso_code }}
         </button>
 
-        <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
+        <div class="dropdown-menu dropdown-menu-right locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}">
           {% for locale in locales %}
             <span class="dropdown-item js-locale-item"
                   data-locale="{{ locale.iso_code }}"
@@ -951,7 +951,7 @@
           >
             {{ form.vars.default_locale.iso_code }}
           </button>
-          <div class="dropdown-menu locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}_dropdown">
+          <div class="dropdown-menu dropdown-menu-right locale-dropdown-menu" aria-labelledby="{{ form.vars.id }}_dropdown">
             {% for locale in locales %}
               <span class="dropdown-item js-locale-item" data-locale="{{ locale.iso_code }}">{{ locale.name }}</span>
             {% endfor %}

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -96,9 +96,14 @@ class ProductLazyArrayTest extends TestCase
 
     private const PRODUCT_AVAILABLE_NOW = 'This product is available now';
     private const PRODUCT_AVAILABLE_LATER = 'This product is available on backorder';
-    private const PRODUCT_NOT_AVAILABLE = 'This product is not available for order';
+    private const CONFIGURATION_AVAILABLE_NOW_LABEL = 'This product is available now - default';
+    private const CONFIGURATION_AVAILABLE_LATER_LABEL = 'This product is available on backorder - default';
+    private const CONFIGURATION_NOT_AVAILABLE_LABEL = 'This product is not available for order';
     private const PRODUCT_ATTRIBUTE_NOT_AVAILABLE = 'Product available with different options';
     private const PRODUCT_WITH_NOT_ENOUGH_STOCK = 'There are not enough products in stock';
+
+    private const COMBINATION_AVAILABLE_NOW = 'This combination is available now';
+    private const COMBINATION_AVAILABLE_LATER = 'This combination is available on backorder';
 
     private const PRODUCT_DELIVERY_TIME_AVAILABLE = '1-2 weeks - product in stock';
     private const PRODUCT_DELIVERY_TIME_OOSBOA = '2-4 weeks - backorder';
@@ -186,12 +191,23 @@ class ProductLazyArrayTest extends TestCase
             ->method('shouldShowPrice')
             ->willReturn(true);
 
+        // We will need to fake Prestashop default labels set in configuration
         $this->mockConfiguration
             ->method('get')
             ->willReturnCallback(function (string $key) use ($language) {
                 if ('PS_LABEL_OOS_PRODUCTS_BOD' === $key) {
                     return [
-                        $language->id => self::PRODUCT_NOT_AVAILABLE,
+                        $language->id => self::CONFIGURATION_NOT_AVAILABLE_LABEL,
+                    ];
+                }
+                if ('PS_LABEL_OOS_PRODUCTS_BOA' === $key) {
+                    return [
+                        $language->id => self::CONFIGURATION_AVAILABLE_LATER_LABEL,
+                    ];
+                }
+                if ('PS_LABEL_IN_STOCK_PRODUCTS' === $key) {
+                    return [
+                        $language->id => self::CONFIGURATION_AVAILABLE_NOW_LABEL,
                     ];
                 }
 
@@ -334,7 +350,10 @@ class ProductLazyArrayTest extends TestCase
             $this->baseProduct, ['show_price' => 1]
         );
 
-        // Product page: in stock
+        /* PRODUCTS WITHOUT COMBINATIONS */
+        // Product in stock, backorders enabled
+        // Product labels filled
+        // Should return available now label filled on product
         yield [
             array_merge(
                 $product,
@@ -353,7 +372,30 @@ class ProductLazyArrayTest extends TestCase
             self::PRODUCT_AVAILABLE_NOW,
         ];
 
-        // not enough stock, not allowed to order when out of stock
+        // Product in stock
+        // Product labels NOT filled
+        // Should return available now label from PS configuration
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 0,
+                    'quantity_wanted' => 1,
+                    'stock_quantity' => 1000,
+                    'quantity' => 1000,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => [],
+                    'available_later' => [],
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
+                ]
+            ),
+            self::CONFIGURATION_AVAILABLE_NOW_LABEL,
+        ];
+
+        // Product in stock, backorders disabled, user requesting more than in stock
+        // Product labels filled
+        // Should return 'not enough in stock message' hardcoded in the lazy array
         yield [
             array_merge(
                 $product,
@@ -372,7 +414,10 @@ class ProductLazyArrayTest extends TestCase
             self::PRODUCT_WITH_NOT_ENOUGH_STOCK,
         ];
 
-        // completely out of stock, not allowed to order when out of stock
+        // Product out stock, backorders disabled
+        // Product labels filled
+        // Should return not available label from PS configuration
+        // (this label is not configurable per product or per combination)
         yield [
             array_merge(
                 $product,
@@ -388,10 +433,12 @@ class ProductLazyArrayTest extends TestCase
                     'allow_oosp' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
                 ]
             ),
-            self::PRODUCT_NOT_AVAILABLE,
+            self::CONFIGURATION_NOT_AVAILABLE_LABEL,
         ];
 
-        // out of stock, but allowed to order when out of stock
+        // Product out stock, backorders enabled
+        // Product labels filled
+        // Should return available later label from product
         yield [
             array_merge(
                 $product,
@@ -410,9 +457,31 @@ class ProductLazyArrayTest extends TestCase
             self::PRODUCT_AVAILABLE_LATER,
         ];
 
-        // the combination is out of stock,
-        // product is not available in different one,
-        // not allowed to order when out of stock
+        // Product out stock, backorders enabled
+        // Product labels NOT filled
+        // Should return available later label from PS configuration
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 0,
+                    'quantity_wanted' => 11,
+                    'stock_quantity' => 10,
+                    'quantity' => 10,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => [],
+                    'available_later' => [],
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                ]
+            ),
+            self::CONFIGURATION_AVAILABLE_LATER_LABEL,
+        ];
+
+        /* PRODUCTS WITH COMBINATIONS */
+        // Combination in stock, backorders disabled, user requesting more than in stock
+        // Product labels filled
+        // Should return 'not enough in stock message' hardcoded in lazy array
         yield [
             array_merge(
                 $product,
@@ -433,9 +502,9 @@ class ProductLazyArrayTest extends TestCase
             self::PRODUCT_WITH_NOT_ENOUGH_STOCK,
         ];
 
-        // combinations is out of stock,
-        // product is available in different one (higher "quantity_all_versions"),
-        // allowed to order when out of stock
+        // Combination in stock, backorders enabled, user requesting more than in stock
+        // Product labels filled
+        // Should return available later label from product
         yield [
             array_merge(
                 $product,
@@ -456,10 +525,188 @@ class ProductLazyArrayTest extends TestCase
             self::PRODUCT_AVAILABLE_LATER,
         ];
 
-        // product with combinations
-        // the one we want is out of stock, other combinations too
-        // not allowed to order when out of stock
-        // it should show the availability message for the "out of stock" status
+        // Combination in stock, backorders enabled, user requesting more than in stock
+        // Product labels NOT filled
+        // Should return available later label from PS configuration
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 1,
+                    'quantity_all_versions' => 1000,
+                    'quantity_wanted' => 11,
+                    'stock_quantity' => 10,
+                    'quantity' => 10,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => [],
+                    'available_later' => [],
+                    'availability_message' => self::PRODUCT_ATTRIBUTE_NOT_AVAILABLE,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                ]
+            ),
+            self::CONFIGURATION_AVAILABLE_LATER_LABEL,
+        ];
+
+        // Combination in stock, backorders disabled, user requesting more than in stock
+        // Product labels filled
+        // Should return not available label from PS configuration
+        // (this label is not configurable per product or per combination)
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 1,
+                    'quantity_wanted' => 5,
+                    'stock_quantity' => 4,
+                    'quantity' => 4,
+                    'quantity_all_versions' => 4,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => self::PRODUCT_AVAILABLE_NOW,
+                    'available_later' => self::PRODUCT_AVAILABLE_LATER,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
+                ]
+            ),
+            self::PRODUCT_WITH_NOT_ENOUGH_STOCK,
+        ];
+
+        /* PRODUCTS WITH COMBINATIONS AND COMBINATION SPECIFIC DATA */
+        // Data in front office have following structure, let's fake it for our product
+        $product['attributes'] = [
+            1 => [
+                'id_attribute' => 1,
+                'id_attribute_group' => 1,
+                'available_now' => self::COMBINATION_AVAILABLE_NOW,
+                'available_later' => self::COMBINATION_AVAILABLE_LATER,
+            ],
+            2 => [
+                'id_attribute' => 8,
+                'id_attribute_group' => 2,
+                'available_now' => self::COMBINATION_AVAILABLE_NOW,
+                'available_later' => self::COMBINATION_AVAILABLE_LATER,
+            ],
+        ];
+
+        // Combination in stock
+        // Product labels filled, combination labels filled
+        // Should return available now label from combination
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 1,
+                    'quantity_all_versions' => 1000,
+                    'quantity_wanted' => 1,
+                    'stock_quantity' => 1000,
+                    'quantity' => 1000,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => self::PRODUCT_AVAILABLE_NOW,
+                    'available_later' => self::PRODUCT_AVAILABLE_LATER,
+                    'availability_message' => self::PRODUCT_ATTRIBUTE_NOT_AVAILABLE,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                ]
+            ),
+            self::COMBINATION_AVAILABLE_NOW,
+        ];
+
+        // Combination in stock
+        // Product labels NOT filled, combination labels filled
+        // Should return available now label from combination
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 1,
+                    'quantity_all_versions' => 1000,
+                    'quantity_wanted' => 1,
+                    'stock_quantity' => 1000,
+                    'quantity' => 1000,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => [],
+                    'available_later' => [],
+                    'availability_message' => self::PRODUCT_ATTRIBUTE_NOT_AVAILABLE,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                ]
+            ),
+            self::COMBINATION_AVAILABLE_NOW,
+        ];
+
+        // Combination in stock, backorders disabled, user requesting more than in stock
+        // Product labels filled, combination labels filled
+        // Should return 'not enough in stock message' hardcoded in lazy array
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 1,
+                    'quantity_all_versions' => 10,
+                    'quantity_wanted' => 11,
+                    'stock_quantity' => 10,
+                    'quantity' => 10,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => self::PRODUCT_AVAILABLE_NOW,
+                    'available_later' => self::PRODUCT_AVAILABLE_LATER,
+                    'availability_message' => self::PRODUCT_ATTRIBUTE_NOT_AVAILABLE,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
+                ]
+            ),
+            self::PRODUCT_WITH_NOT_ENOUGH_STOCK,
+        ];
+
+        // Combination in stock, backorders enabled, user requesting more than in stock
+        // Product labels filled, combination labels filled
+        // Should return available later label from combination
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 1,
+                    'quantity_all_versions' => 1000,
+                    'quantity_wanted' => 11,
+                    'stock_quantity' => 10,
+                    'quantity' => 10,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => self::PRODUCT_AVAILABLE_NOW,
+                    'available_later' => self::PRODUCT_AVAILABLE_LATER,
+                    'availability_message' => self::PRODUCT_ATTRIBUTE_NOT_AVAILABLE,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                ]
+            ),
+            self::COMBINATION_AVAILABLE_LATER,
+        ];
+
+        // Combination in stock, backorders enabled, user requesting more than in stock
+        // Product labels NOT filled, combination labels filled
+        // Should return available later label from combination
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 1,
+                    'quantity_all_versions' => 1000,
+                    'quantity_wanted' => 11,
+                    'stock_quantity' => 10,
+                    'quantity' => 10,
+                    'show_availability' => 1,
+                    'available_date' => false,
+                    'available_now' => [],
+                    'available_later' => [],
+                    'availability_message' => self::PRODUCT_ATTRIBUTE_NOT_AVAILABLE,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
+                ]
+            ),
+            self::COMBINATION_AVAILABLE_LATER,
+        ];
+
+        // Combination in stock, backorders disabled, user requesting more than in stock
+        // Product labels filled, combination labels filled
+        // Should return not available label from PS configuration
+        // (this label is not configurable per product or per combination)
         yield [
             array_merge(
                 $product,

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -234,3 +234,51 @@ Feature: Update product combination stock information in Back Office (BO)
       | location                   |       |
       | available date             |       |
     And product "product1" should have no stock movements
+
+  Scenario: I should be able to fill product availability labels
+    Given combination "product1SBlack" should have following stock details:
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    When I update combination "product1SBlack" stock with following details:
+      | available now labels[en-US]   | Get it now    |
+      | available later labels[en-US] | Too late dude |
+    Then combination "product1SBlack" should have following stock details:
+      | combination stock detail      | value         |
+      | quantity                      | 0             |
+      | minimal quantity              | 1             |
+      | low stock threshold           | 0             |
+      | low stock alert is enabled    | false         |
+      | location                      |               |
+      | available date                |               |
+      | available now labels[en-US]   | Get it now    |
+      | available later labels[en-US] | Too late dude |
+
+  Scenario: I should be able to delete product availability labels
+    Given combination "product1SBlack" should have following stock details:
+      | combination stock detail      | value         |
+      | quantity                      | 0             |
+      | minimal quantity              | 1             |
+      | low stock threshold           | 0             |
+      | low stock alert is enabled    | false         |
+      | location                      |               |
+      | available date                |               |
+      | available now labels[en-US]   | Get it now    |
+      | available later labels[en-US] | Too late dude |
+    When I update combination "product1SBlack" stock with following details:
+      | available now labels[en-US]   |               |
+      | available later labels[en-US] |               |
+    Then combination "product1SBlack" should have following stock details:
+      | combination stock detail      | value         |
+      | quantity                      | 0             |
+      | minimal quantity              | 1             |
+      | low stock threshold           | 0             |
+      | low stock alert is enabled    | false         |
+      | location                      |               |
+      | available date                |               |
+      | available now labels[en-US]   |               |
+      | available later labels[en-US] |               |

--- a/tests/Resources/ProductResetter.php
+++ b/tests/Resources/ProductResetter.php
@@ -41,6 +41,7 @@ class ProductResetter
             'product_attribute',
             'product_attribute_combination',
             'product_attribute_image',
+            'product_attribute_lang',
             'product_attribute_shop',
             'product_carrier',
             'product_country_tax',

--- a/tests/Unit/Classes/ToolsTest.php
+++ b/tests/Unit/Classes/ToolsTest.php
@@ -320,6 +320,7 @@ class ToolsTest extends TestCase
             ['product_attribute', 'productAttribute', false],
             ['product_attribute_combination', 'productAttributeCombination', false],
             ['product_attribute_image', 'productAttributeImage', false],
+            ['product_attribute_lang', 'productAttributeLang', false],
             ['product_lang', 'productLang', false],
             ['product_supplier', 'productSupplier', false],
             ['profile_lang', 'profileLang', false],

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/CombinationFormDataProviderTest.php
@@ -120,6 +120,11 @@ class CombinationFormDataProviderTest extends TestCase
             $expectedOutputData,
         ];
 
+        $localizedValues = [
+            1 => 'english',
+            2 => 'french',
+        ];
+
         $expectedOutputData = $this->getDefaultOutputData();
         $combinationData = [
             'quantity' => 42,
@@ -180,6 +185,8 @@ class CombinationFormDataProviderTest extends TestCase
                     'delta_quantity' => -17,
                 ],
             ],
+            'available_now' => $localizedValues,
+            'available_later' => $localizedValues,
         ];
         $expectedOutputData['stock']['quantities']['delta_quantity']['quantity'] = 42;
         $expectedOutputData['stock']['quantities']['minimal_quantity'] = 7;
@@ -219,6 +226,8 @@ class CombinationFormDataProviderTest extends TestCase
                 'delta_quantity' => -17,
             ],
         ];
+        $expectedOutputData['stock']['available_now_label'] = $localizedValues;
+        $expectedOutputData['stock']['available_later_label'] = $localizedValues;
 
         $datasets[] = [
             $combinationData,
@@ -525,7 +534,9 @@ class CombinationFormDataProviderTest extends TestCase
             $combination['low_stock_threshold'] ?? 0,
             $combination['low_stock_alert'] ?? false,
             $combination['location'] ?? 'location',
-            $combination['available_date'] ?? null
+            $combination['available_date'] ?? null,
+            $combination['available_now'] ?? [],
+            $combination['available_later'] ?? []
         );
     }
 
@@ -654,6 +665,8 @@ class CombinationFormDataProviderTest extends TestCase
                     'low_stock_alert' => false,
                 ],
                 'available_date' => '',
+                'available_now_label' => [],
+                'available_later_label' => [],
             ],
             'price_impact' => [
                 'price_tax_excluded' => 51.00,

--- a/tools/foreignkeyGenerator/relations.php
+++ b/tools/foreignkeyGenerator/relations.php
@@ -861,6 +861,15 @@ $relations = array(
         ),
     ),
 
+    'product_attribute_lang' => array(
+        'id_lang' => array(
+            'lang' => 'id_lang',
+        ),
+        'id_product_attribute' => array(
+            'product_attribute' => 'id_product_attribute',
+        ),
+    ),
+
     'product_download' => array(
         'id_product' => array(
             'product' => 'id_product',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | new feature
| Category?         | CO
| BC breaks?        | No BC breaks
| Deprecations?     | no
| Fixed ticket?     | Resolves #20536
| Related PRs       | Autougprade: https://github.com/PrestaShop/autoupgrade/pull/534
| How to test?      | See below
| Possible impacts? | -


#### Availability labels
- **NO BC BREAKS**
- Adds possibility to set specific availability labels to combinations. This availability label takes priority over the label set on product. So we can precisely specify, which combination are in suppliers warehouse and which are available only on request.
- Enable experimental product page and go edit any product combination. See that you can now set individual availability labels to any combination.
- You can also edit the labels via bulk edit tool.
- If no label is set on combination > product label is used. If no label on product > PS settings label is used. If no label in PS settings, nothing is shown.

#### ProductLazyArray refacto
- I refactored product lazy array a bit.
- Now there is one function that loads selected combination specific data. It retains original logic (a bit weird), but at least there is one source of truth in this class. _We can further improve this sometime, it contains different data in cart and product page._
- I simplified a bit the code that loads specific references, because it was loading other data from the combination. Now it will just take the 4 references and not care on anything else.
- I simplified code that loads reference to display.
- I improved the code that loads availability - we started it here originally (https://github.com/PrestaShop/PrestaShop/pull/25062/)

#### Database structure
- Lang table was added to Combination object - `product_attribute_lang`
- This table needs to be added in autoupgrade module and filled with empty entries, but according to my tests, it should work just fine even without the entries.

### How to test on existing install
- Create new table
```sql
CREATE TABLE `PREFIX_product_attribute_lang` (
  `id_product_attribute` int(10) unsigned NOT NULL,
  `id_lang` int(10) unsigned NOT NULL,
  `available_now` varchar(255) DEFAULT NULL,
  `available_later` varchar(255) DEFAULT NULL,
  PRIMARY KEY (`id_product_attribute`, `id_lang`)
) ENGINE='InnoDB' COLLATE 'utf8_general_ci';
```
And fill it for every language
```sql
INSERT INTO ps_product_attribute_lang (id_product_attribute, id_lang, available_now, available_later)
SELECT ps_product_attribute.id_product_attribute, 1, '', ''
FROM ps_product_attribute;
```

- Enable experimental product page. The new functionality will not be implemented for the legacy page.

#### Automated tests
- `tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php` was extended and improved to test all availability cases I could think of. This checks that it returns correct data - combination label, product label, ps config label.
- `tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature` - added tests that check if combination labels can be edited and deleted properly.