### PR TITLE
Fix delivery time for multishop

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -119,6 +119,8 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         'low_stock_alert',
         'available_date',
         'ecotax',
+        'additional_shipping_cost',
+        'additional_delivery_times',
     ];
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | See https://github.com/PrestaShop/PrestaShop/issues/28998 comments.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28998 .
| Related PRs       | [#25913](https://github.com/PrestaShop/PrestaShop/pull/25913) and especially this commit : https://github.com/PrestaShop/PrestaShop/commit/66a6843bfca2d056896858c5b11a91c85eb16b7f
| How to test?      | See below
| Possible impacts? | As I changed `ObjectModel` all basic CRUDs may be impacted. 

:point_up: I observed another problem, when changing shop, page isn't refreshed and shop selection form stay stuck on the top of the page. I should investigate if an issue already created about this problem.



## Steps to reproduce
1. Enable multistore : Configure > Shop Parameters > General > Enable Multistore : Yes 
2. Configure multistore :
   - Advanced Parameters > Multistore > Add a new shop > Shop name / Color > Save
   - Add an url to your new shop > save
3. Go to a product shipping configuration : Sell > Catalog > Products > select a product > Shipping
4. Edit `Delivery Time` and `Shipping fees` fields for one shop > refresh (without cache)
   - You can see that `Delivery Time` is changed for all shops and `Shipping fees` is well updated for given shop.
   - :question: Is it expected behavior as `Delivery Time` isn't a multishop field ? Maybe it can wait product v2 page.
5. Edit `Delivery Time` and `Shipping fees` fields for "all shops" > refresh (without cache)
   - You can see that none of the fields are up to date




