### PR TITLE
fix hook registration query

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1079,6 +1079,7 @@ class HookCore extends ObjectModel
         }
         $sql->innerJoin('hook_module', 'hm', 'hm.`id_module` = m.`id_module`');
         $sql->innerJoin('hook', 'h', 'hm.`id_hook` = h.`id_hook`');
+        $sql->innerJoin('module_shop', 'mshop', 'mshop.`id_module` = m.`id_module`');
         if ($hookName !== 'paymentOptions') {
             $sql->where('h.`name` != "paymentOptions" and m.active = 1');
         } elseif ($frontend) {

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1080,7 +1080,7 @@ class HookCore extends ObjectModel
         $sql->innerJoin('hook_module', 'hm', 'hm.`id_module` = m.`id_module`');
         $sql->innerJoin('hook', 'h', 'hm.`id_hook` = h.`id_hook`');
         if ($hookName !== 'paymentOptions') {
-            $sql->where('h.`name` != "paymentOptions"');
+            $sql->where('h.`name` != "paymentOptions" and m.active = 1');
         } elseif ($frontend) {
             // For payment modules, we check that they are available in the contextual country
             if (Validate::isLoadedObject($context->country)) {

--- a/src/Adapter/Module/CommandHandler/BulkToggleModuleStatusHandler.php
+++ b/src/Adapter/Module/CommandHandler/BulkToggleModuleStatusHandler.php
@@ -75,8 +75,7 @@ class BulkToggleModuleStatusHandler implements BulkToggleModuleStatusHandlerInte
     public function handle(BulkToggleModuleStatusCommand $command): void
     {
         foreach ($command->getModules() as $moduleName) {
-            $module = Module::getInstanceByName($moduleName);
-            if (!Validate::isLoadedObject($module) || !$this->moduleManager->isInstalled($moduleName)) {
+            if (!$this->moduleManager->isInstalledAndActive($moduleName) || !Validate::isLoadedObject(Module::getInstanceByName($moduleName))) {
                 continue;
             }
 

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -231,16 +231,31 @@ class ModuleDataProvider
     }
 
     /**
+     * @param $name
+     *
+     * @return bool
+     */
+    public function isInstalledAndActive($name) {
+        return (bool) $this->getModuleIdByName($name, true);
+    }
+
+    /**
      * Returns the Module Id
      *
      * @param string $name The technical module name
+     * @param bool   $activeModulesOnly Should we return the module only if it's active ?
      *
      * @return int the Module Id, or 0 if not found
      */
-    public function getModuleIdByName($name)
+    public function getModuleIdByName($name, bool $activeModulesOnly = false)
     {
+        $sqlQuery = 'SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module` WHERE `name` = "' . pSQL($name) . '"';
+        if ($activeModulesOnly) {
+            $sqlQuery .= ' AND `active` = 1';
+        }
+
         return (int) Db::getInstance()->getValue(
-            'SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module` WHERE `name` = "' . pSQL($name) . '"'
+            $sqlQuery
         );
     }
 

--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -298,6 +298,11 @@ class ModuleManager implements ModuleManagerInterface
         return $this->moduleDataProvider->isInstalled($name);
     }
 
+    public function isInstalledAndActive(string $name): bool
+    {
+        return $this->moduleDataProvider->isInstalledAndActive($name);
+    }
+
     public function isEnabled(string $name): bool
     {
         return $this->moduleDataProvider->isEnabled($name);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When looking for modules using a specific hook, we should only retrieve activated modules 
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | issue coming soon
| Related PRs       | 
| How to test?      | - Make an upgrade to prestashop 8.0.0 without removing the problematic modules like ps_facebook, after the update your shop should not be broken
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
