### PR TITLE
Clear translations cache before translating fixtures

### DIFF
--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -23,8 +23,10 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShopBundle\Install\Database;
 use PrestaShopBundle\Install\Install;
+use Symfony\Component\Filesystem\Filesystem;
 
 class InstallControllerConsoleProcess extends InstallControllerConsole implements HttpConfigureInterface
 {
@@ -170,6 +172,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         }
 
         // Update fixtures lang
+        $this->rebootWithoutTranslationsCache();
         foreach (Language::getLanguages() as $lang) {
             Language::updateMultilangTable($lang['iso_code']);
         }
@@ -345,5 +348,18 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         global $kernel;
         $kernel = new AppKernel(_PS_ENV_, _PS_MODE_DEV_);
         $kernel->boot();
+    }
+
+    /**
+     * Delete translations cache and reboot the kernel so newly installed languages are took into account
+     *
+     * This method is only useful in CLI as everything is done in a single call but not with the web ui
+     * because the whole cache gets cleared before translating the fixtures
+     */
+    private function rebootWithoutTranslationsCache()
+    {
+        global $kernel;
+        (new Filesystem())->remove($kernel->getCacheDir() . 'translations');
+        $kernel->reboot($kernel->getCacheDir());
     }
 }

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1088,7 +1088,6 @@ class Install extends AbstractInstall
         }
 
         Module::updateTranslationsAfterInstall(true);
-        EntityLanguage::updateModulesTranslations($modules);
 
         return true;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | In CLI the whole installation process is performed in one call. As the download of translation files is performed after the kernel is booted and the container built, they were not took into account when translating fixtures later on. This PR fixes it by clearing the translations cache and rebooting the kernel before attempting to translate the fixtures.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27029
| Related PRs       | N/A
| How to test?      | 1. Be sure that you don't have any translations folders already downloaded in `app/Resources/translations` (except the folder `default`)<br>2. Perform a CLI install with at least the options `--language=fr --country=fr` (`php install-dev/index_cli.php --language=fr --country=fr`)<br>3. Check that in the BO, the side menu is in french.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
