### PR TITLE
Remove empty category blocks in module manager

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig
@@ -24,10 +24,14 @@
  *#}
 
 {% block catalog_category_empty %}
-  <div class="modules-list module-list-empty" data-name="{{ category.refMenu }}">
-    <p>
-      {{ 'You do not have module in « %categoryName% ».' | trans({'%categoryName%': category.name}, 'Admin.Modules.Feature') }}<br/>
-      {{ renderhook('displayEmptyModuleCategoryExtraMessage', {'category_name': category.name}) }}
-    </p>
-  </div>
+  {% set hookData = renderhook('displayEmptyModuleCategoryExtraMessage', {'category_name': category.name}) %}
+  {% if hookData is not empty %}
+    <div class="module-short-list">
+      <span id="{{ category.refMenu }}_modules" class="module-search-result-title">{{ category.name | trans({}, 'Admin.Modules.Feature') }}</span>
+      <div class="modules-list module-list-empty" data-name="{{ category.refMenu }}">
+        <p>{{ 'You do not have module in « %categoryName% ».' | trans({'%categoryName%': category.name}, 'Admin.Modules.Feature') }}</p>
+        {{ hookData }}
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/grid_manage_empty.html.twig
@@ -29,7 +29,6 @@
     <div class="module-short-list">
       <span id="{{ category.refMenu }}_modules" class="module-search-result-title">{{ category.name | trans({}, 'Admin.Modules.Feature') }}</span>
       <div class="modules-list module-list-empty" data-name="{{ category.refMenu }}">
-        <p>{{ 'You do not have module in « %categoryName% ».' | trans({'%categoryName%': category.name}, 'Admin.Modules.Feature') }}</p>
         {{ hookData }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/manage.html.twig
@@ -38,12 +38,12 @@
 
       {% block catalog_categories_listing %}
         {% for category in categories.subMenu %}
-          <div class="module-short-list">
-            <span id="{{ category.refMenu }}_modules" class="module-search-result-title">{{ category.name | trans({}, 'Admin.Modules.Feature') }}</span>
+          {% if category.modules is empty %}
+            {% include '@PrestaShop/Admin/Module/Includes/grid_manage_empty.html.twig' with { 'category': category, 'display_type': 'list', 'origin': 'manage' } %}
+          {% else  %}
+            <div class="module-short-list">
+              <span id="{{ category.refMenu }}_modules" class="module-search-result-title">{{ category.name | trans({}, 'Admin.Modules.Feature') }}</span>
 
-            {% if category.modules is empty %}
-              {% include '@PrestaShop/Admin/Module/Includes/grid_manage_empty.html.twig' with { 'category': category, 'display_type': 'list', 'origin': 'manage' } %}
-            {% else  %}
               {% include '@PrestaShop/Admin/Module/Includes/grid_manage_installed.html.twig' with { 'modules': category.modules, 'display_type': 'list', 'origin': 'manage', 'id': category.refMenu } %}
 
               {% block addon_card_see_more %}
@@ -51,8 +51,8 @@
                   {% include '@PrestaShop/Admin/Module/Includes/see_more.html.twig' with { 'id': category.refMenu } %}
                 {% endif %}
               {% endblock %}
-            {% endif %}
-          </div>
+            </div>
+          {% endif %}
         {% endfor %}
       {% endblock %}
     </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Whenever there is no module in a category, the block is no longer shown.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30260
| Related PRs       | #30810 (To merge together)
| How to test?      | Load module manager. See the empty blocks are no longer there
| Possible impacts? | None?

Before:
<img width="1792" alt="Before" src="https://user-images.githubusercontent.com/1009343/186205922-8b240df6-af88-4a40-bd53-69a5530b4476.png">

After:
<img width="1792" alt="After" src="https://user-images.githubusercontent.com/1009343/186205910-94f74035-6822-4191-9e05-76ca75116ac4.png">



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
