### PR TITLE
Prevent *.twig, config.xml & config_{lang}.xml files from direct access in modules folder

### DIFF
--- a/modules/.htaccess
+++ b/modules/.htaccess
@@ -1,4 +1,4 @@
-<FilesMatch "\.tpl|\.twig|config\.xml|config_([a-z]+)\.xml$">
+<FilesMatch "(\.tpl|\.twig|config\.xml|config_([a-z]+)\.xml)$">
     # Apache 2.2
     <IfModule !mod_authz_core.c>
         Order deny,allow

--- a/modules/.htaccess
+++ b/modules/.htaccess
@@ -1,4 +1,4 @@
-<FilesMatch "\.tpl$">
+<FilesMatch "\.tpl|\.twig|config\.xml|config_([a-z]+)\.xml$">
     # Apache 2.2
     <IfModule !mod_authz_core.c>
         Order deny,allow


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If you call a shop with URL https://www.yourshop.com/modules/module_name/config.xml (or config_en.xml) you can know with version of the module is installed.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29422
| Related PRs       | nc
| How to test?      | * Install a new PrestaShop<br>* Install the module blockwishlist (or an other)<br>* Go to URL like https://www.yourshop.com/modules/blockwishlist/config.xml
| Possible impacts? | None
