### PR TITLE
Put product v2 feature flag in the beta form instead of stable

### DIFF
--- a/install-dev/data/xml/feature_flag.xml
+++ b/install-dev/data/xml/feature_flag.xml
@@ -10,7 +10,7 @@
     <field name="stability"/>
   </fields>
   <entities>
-    <feature_flag id="product_page_v2" name="product_page_v2" label_wording="New product page - Single store" label_domain="Admin.Advparameters.Feature" description_wording="This page benefits from increased performance and includes new features such as a new combination management system." description_domain="Admin.Advparameters.Help" state="0" stability="stable" />
+    <feature_flag id="product_page_v2" name="product_page_v2" label_wording="New product page - Single store" label_domain="Admin.Advparameters.Feature" description_wording="This page benefits from increased performance and includes new features such as a new combination management system." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
     <feature_flag id="product_page_v2_multi_shop" name="product_page_v2_multi_shop" label_wording="New product page - Multi store" label_domain="Admin.Advparameters.Feature" description_wording="Access the new product page, even in a multistore context. This is a work in progress and some features are not available." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
   </entities>
 </entity_feature_flag>

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/FeatureFlagController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/FeatureFlagController.php
@@ -31,6 +31,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -95,8 +96,12 @@ class FeatureFlagController extends FrameworkBundleAdminController
             'layoutTitle' => $this->trans('New & Experimental Features', 'Admin.Advparameters.Feature'),
             'requireBulkActions' => false,
             'showContentHeader' => true,
-            'stableFeatureFlagsForm' => $stableFeatureFlagsForm->createView(),
-            'betaFeatureFlagsForm' => $betaFeatureFlagsForm->createView(),
+            'stableFeatureFlagsForm' => $this->isFormEmpty($stableFeatureFlagsForm)
+                ? null
+                : $stableFeatureFlagsForm->createView(),
+            'betaFeatureFlagsForm' => $this->isFormEmpty($betaFeatureFlagsForm)
+                ? null
+                : $betaFeatureFlagsForm->createView(),
             'multistoreInfoTip' => $this->trans(
                 'Note that this page is available in all shops context only, this is why your context has just switched.',
                 'Admin.Notifications.Info'
@@ -104,5 +109,10 @@ class FeatureFlagController extends FrameworkBundleAdminController
             'multistoreIsUsed' => ($this->get('prestashop.adapter.multistore_feature')->isUsed()
                 && $this->get('prestashop.adapter.shop.context')->isShopContext()),
         ]);
+    }
+
+    private function isFormEmpty(FormInterface $form): bool
+    {
+        return $form->get('feature_flags')->count() === 0;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagListType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagListType.php
@@ -62,6 +62,7 @@ class FeatureFlagListType extends TranslatorAwareType
         $resolver
             ->setDefaults([
                 'label' => false,
+                'form_theme' => '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig',
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagsFormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/FeatureFlag/FeatureFlagsFormDataProvider.php
@@ -66,15 +66,13 @@ class FeatureFlagsFormDataProvider implements FormDataProviderInterface
     {
         $featureFlags = $this->doctrineEntityManager->getRepository(FeatureFlag::class)->findBy(['stability' => $this->stability]);
 
-        // We disable product v2 switch based on multishop state and stability, someday we will need
-        // to implement a more generic feature for any feature flag
-        $isDisabled = false;
-        if ($this->stability === 'stable' && $this->isMultiShopUsed || $this->stability === 'beta' && !$this->isMultiShopUsed) {
-            $isDisabled = true;
-        }
-
         $featureFlagsData = [];
         foreach ($featureFlags as $featureFlag) {
+            // We disable product v2 switch based on multishop state and feature name, someday we will need
+            // to implement a more generic feature for any feature flag
+            $isDisabled = strpos($featureFlag->getName(), '_multi_shop') !== false && !$this->isMultiShopUsed
+                || strpos($featureFlag->getName(), '_multi_shop') === false && $this->isMultiShopUsed
+            ;
             $featureFlagsData[$featureFlag->getName()] = [
                 'enabled' => $featureFlag->isEnabled(),
                 'name' => $featureFlag->getName(),
@@ -123,7 +121,7 @@ class FeatureFlagsFormDataProvider implements FormDataProviderInterface
                 return false;
             }
 
-            if (!is_bool($flagData['enabled'])) {
+            if ($flagData['enabled'] !== null && !is_bool($flagData['enabled'])) {
                 return false;
             }
         }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/FeatureFlag/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/FeatureFlag/index.html.twig
@@ -24,73 +24,74 @@
  *#}
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% form_theme stableFeatureFlagsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
-{% form_theme betaFeatureFlagsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
-
 {% block content %}
   {% include '@PrestaShop/Admin/Common/multistore-infotip.html.twig' %}
 
   {# Stable feature flags form #}
-  {{ form_start(stableFeatureFlagsForm, {attr : {class: 'form'} }) }}
-  {% block stable_feature_flag_form %}
-    <div class="card" id="configuration_fieldset_general">
-      <h3 class="card-header">
-        <i class="material-icons">settings</i>
-        {{ 'New features'|trans({}, 'Admin.Advparameters.Feature') }}
-      </h3>
+  {% if stableFeatureFlagsForm %}
+    {{ form_start(stableFeatureFlagsForm, {attr : {class: 'form'} }) }}
+    {% block stable_feature_flag_form %}
+      <div class="card" id="configuration_fieldset_general">
+        <h3 class="card-header">
+          <i class="material-icons">settings</i>
+          {{ 'New features'|trans({}, 'Admin.Advparameters.Feature') }}
+        </h3>
 
-      <div class="card-body">
-        <div class="form-wrapper">
-          <div class="alert alert-info alert-experimental" role="alert">
-            {{ 'New features are available. Feel free to try them out!'|trans({}, 'Admin.Advparameters.Notification') }}
+        <div class="card-body">
+          <div class="form-wrapper">
+            <div class="alert alert-info alert-experimental" role="alert">
+              {{ 'New features are available. Feel free to try them out!'|trans({}, 'Admin.Advparameters.Notification') }}
+            </div>
+            {{ form_widget(stableFeatureFlagsForm.feature_flags) }}
           </div>
-          {{ form_widget(stableFeatureFlagsForm.feature_flags) }}
         </div>
+          <div class="card-footer">
+            <div class="d-flex justify-content-end">
+              {{ form_widget(stableFeatureFlagsForm.submit) }}
+            </div>
+          </div>
       </div>
-        <div class="card-footer">
-          <div class="d-flex justify-content-end">
-            {{ form_widget(stableFeatureFlagsForm.submit) }}
-          </div>
-        </div>
-    </div>
-  {% endblock %}
-  {{ form_end(stableFeatureFlagsForm) }}
+    {% endblock %}
+    {{ form_end(stableFeatureFlagsForm) }}
+  {% endif %}
 
   {# Beta feature flags form #}
-  {{ form_start(betaFeatureFlagsForm, {attr : {class: 'form'} }) }}
-  {% block beta_feature_flag_form %}
-    <div class="card" id="configuration_fieldset_general">
-      <h3 class="card-header">
-        <i class="material-icons">settings</i>
-        {{ 'Experimental features'|trans({}, 'Admin.Advparameters.Feature') }}
-      </h3>
+  {% if betaFeatureFlagsForm %}
+    {{ form_start(betaFeatureFlagsForm, {attr : {class: 'form'} }) }}
+    {% block beta_feature_flag_form %}
+      <div class="card" id="configuration_fieldset_general">
+        <h3 class="card-header">
+          <i class="material-icons">settings</i>
+          {{ 'Experimental features'|trans({}, 'Admin.Advparameters.Feature') }}
+        </h3>
 
-      <div class="card-body">
-        <div class="form-wrapper">
-          <div class="alert medium-alert alert-warning" role="alert">
-            {{ 'Testing a feature before its official release can be exciting. However, you must be aware of the potential risks of such experiments:'|trans({}, 'Admin.Advparameters.Notification') }}
-            <ul>
-              <li>{{ 'Experimental features are still under development. Enabling them could therefore have unintended consequences and cause data loss.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
-              <li>{{ 'In any case, you should never experiment in production.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
-            </ul>
+        <div class="card-body">
+          <div class="form-wrapper">
+            <div class="alert medium-alert alert-warning" role="alert">
+              {{ 'Testing a feature before its official release can be exciting. However, you must be aware of the potential risks of such experiments:'|trans({}, 'Admin.Advparameters.Notification') }}
+              <ul>
+                <li>{{ 'Experimental features are still under development. Enabling them could therefore have unintended consequences and cause data loss.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
+                <li>{{ 'In any case, you should never experiment in production.'|trans({}, 'Admin.Advparameters.Notification') }}</li>
+              </ul>
+            </div>
+            {{ form_widget(betaFeatureFlagsForm.feature_flags) }}
           </div>
-          {{ form_widget(betaFeatureFlagsForm.feature_flags) }}
+        </div>
+        <div class="card-footer">
+          <div class="d-flex justify-content-end">
+            {% set widgetVars = betaFeatureFlagsForm.submit.vars|merge({'attr': {
+              'data-modal-title': 'Are you sure you want to enable this experimental feature?'|trans({}, 'Admin.Advparameters.Notification'),
+              'data-modal-message': 'You are about to enable a feature that is not stable yet. This should only be done in a test environment or in full knowledge of the potential risks.'|trans({}, 'Admin.Advparameters.Notification'),
+              'data-modal-apply': 'Enable'|trans({}, 'Admin.Actions'),
+              'data-modal-cancel': 'Cancel'|trans({}, 'Admin.Actions'),
+            }}) %}
+            {{ form_widget(betaFeatureFlagsForm.submit, widgetVars) }}
+          </div>
         </div>
       </div>
-      <div class="card-footer">
-        <div class="d-flex justify-content-end">
-          {% set widgetVars = betaFeatureFlagsForm.submit.vars|merge({'attr': {
-            'data-modal-title': 'Are you sure you want to enable this experimental feature?'|trans({}, 'Admin.Advparameters.Notification'),
-            'data-modal-message': 'You are about to enable a feature that is not stable yet. This should only be done in a test environment or in full knowledge of the potential risks.'|trans({}, 'Admin.Advparameters.Notification'),
-            'data-modal-apply': 'Enable'|trans({}, 'Admin.Actions'),
-            'data-modal-cancel': 'Cancel'|trans({}, 'Admin.Actions'),
-          }}) %}
-          {{ form_widget(betaFeatureFlagsForm.submit, widgetVars) }}
-        </div>
-      </div>
-    </div>
-  {% endblock %}
-  {{ form_end(betaFeatureFlagsForm) }}
+    {% endblock %}
+    {{ form_end(betaFeatureFlagsForm) }}
+  {% endif %}
 {% endblock %}
 
 {% block javascripts %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | This PR puts the switch for the product page v2 in the `experimental` part of the feature flag form instead of the `new` part.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29407
| Related PRs       | 
| How to test?      | After a clean install, go on the `Configure > Advanced Parameters > New & Experimental Features` page and check that there's only the `Experimental features` form and that the switch for the `New product page - Single store` is inside. Check that both `New product page - Single store` & `New product page - Multi store` are enable/disable according to the multistore configuration of the shop.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
