### PR TITLE
Refacto product front controller

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -29,7 +29,6 @@ use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductColorsRetriever;
-use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\Product\ProductExtraContentFinder;
 
@@ -145,6 +144,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             header('Status: 404 Not Found');
             $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
             $this->setTemplate('errors/404');
+
             return;
         }
 
@@ -156,7 +156,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
         // Load product category
         $this->initializeCategory();
-        
+
         // Set proper template to product
         $this->setTemplate('catalog/product', [
             'entity' => 'product',
@@ -169,7 +169,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     public function checkPermissionsToViewProduct()
     {
-
         /*
         * If the product is associated to the shop
         * and is active or not active but preview mode (need token + file_exists)

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -38,6 +38,12 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     /** @var string */
     public $php_self = 'product';
 
+    /** @var int */
+    protected $id_product;
+
+    /** @var int|null */
+    protected $id_product_attribute;
+
     /** @var Product */
     protected $product;
 
@@ -52,6 +58,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     protected $combinations;
 
     protected $quantity_discounts;
+
+    /**
+     * @var array
+     */
     protected $adminNotifications = [];
 
     /**
@@ -59,30 +69,36 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      */
     protected $isQuickView = false;
 
+    /**
+     * @var bool
+     */
+    protected $isPreview = false;
+
     public function canonicalRedirection($canonical_url = '')
     {
-        if (Validate::isLoadedObject($this->product)) {
-            $idProductAttribute = Tools::getValue('id_product_attribute', null);
-            if (!$this->product->hasCombinations() || !$this->isValidCombination($idProductAttribute, $this->product->id)) {
-                //Invalid combination we redirect to the canonical url (without attribute id)
-                unset($_GET['id_product_attribute']);
-                $idProductAttribute = null;
-            }
-
-            // If the attribute id is present in the url we use it to perform the redirection, this will fix any domain
-            // or rewriting error and redirect to the appropriate url
-            // If the attribute is not present or invalid, we set it to null so that the request is redirected to the
-            // real canonical url (without any attribute)
-            parent::canonicalRedirection($this->context->link->getProductLink(
-                $this->product,
-                null,
-                null,
-                null,
-                null,
-                null,
-                $idProductAttribute
-            ));
+        // This is there to prevent error, because this function is also called
+        // in parent front controller before we have even loaded our data.
+        if (!Validate::isLoadedObject($this->product)) {
+            return;
         }
+
+        // We check if the combination is valid, if not, we reset it redirect to pure product URL without combination.
+        if (!$this->product->hasCombinations() || !$this->isValidCombination($this->id_product_attribute, $this->product->id)) {
+            unset($_GET['id_product_attribute']);
+            $this->id_product_attribute = null;
+        }
+
+        // If the attribute id is present in the url we use it to perform the redirection, this will fix any domain
+        // or rewriting error and redirect to the appropriate url.
+        parent::canonicalRedirection($this->context->link->getProductLink(
+            $this->product,
+            null,
+            null,
+            null,
+            null,
+            null,
+            $this->id_product_attribute
+        ));
     }
 
     /**
@@ -108,146 +124,171 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     {
         parent::init();
 
-        $id_product = (int) Tools::getValue('id_product');
+        // Get proper IDs
+        $this->id_product = (int) Tools::getValue('id_product');
+        $this->id_product_attribute = (int) Tools::getValue('id_product_attribute', null);
 
-        $this->setTemplate('catalog/product', [
-            'entity' => 'product',
-            'id' => $id_product,
-        ]);
-
-        if ($id_product) {
-            $this->product = new Product($id_product, true, $this->context->language->id, $this->context->shop->id);
+        // Load viewing modes
+        if ('1' === Tools::getValue('quickview')) {
+            $this->setQuickViewMode();
+        }
+        if ('1' === Tools::getValue('preview')) {
+            $this->setPreviewMode();
         }
 
+        // Try to load product object, otherwise immediately redirect to 404
+        if ($this->id_product) {
+            $this->product = new Product($this->id_product, true, $this->context->language->id, $this->context->shop->id);
+        }
         if (!Validate::isLoadedObject($this->product)) {
             header('HTTP/1.1 404 Not Found');
             header('Status: 404 Not Found');
             $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
             $this->setTemplate('errors/404');
-        } else {
-            $this->canonicalRedirection();
-            /*
-             * If the product is associated to the shop
-             * and is active or not active but preview mode (need token + file_exists)
-             * allow showing the product
-             * In all the others cases => 404 "Product is no longer available"
-             */
-            $isAssociatedToProduct = (
-                Tools::getValue('adtoken') == Tools::getAdminToken(
-                    'AdminProducts'
-                    . (int) Tab::getIdFromClassName('AdminProducts')
-                    . (int) Tools::getValue('id_employee')
-                )
-                && $this->product->isAssociatedToShop()
-            );
-            $isPreview = ('1' === Tools::getValue('preview'));
-            if ((!$this->product->isAssociatedToShop() || !$this->product->active) && !$isPreview) {
-                if ($isAssociatedToProduct) {
-                    $this->adminNotifications['inactive_product'] = [
-                        'type' => 'warning',
-                        'message' => $this->trans('This product is not visible to your customers.', [], 'Shop.Notifications.Warning'),
-                    ];
-                } else {
-                    if (!$this->product->id_type_redirected) {
-                        if (in_array($this->product->redirect_type, [RedirectType::TYPE_CATEGORY_PERMANENT, RedirectType::TYPE_CATEGORY_TEMPORARY])) {
-                            $this->product->id_type_redirected = $this->product->id_category_default;
-                        }
-                    } elseif (in_array($this->product->redirect_type, [RedirectType::TYPE_PRODUCT_PERMANENT, RedirectType::TYPE_PRODUCT_TEMPORARY]) && $this->product->id_type_redirected == $this->product->id) {
-                        $this->product->redirect_type = RedirectType::TYPE_NOT_FOUND;
-                    }
-                    switch ($this->product->redirect_type) {
-                        case RedirectType::TYPE_PRODUCT_PERMANENT:
-                            header('HTTP/1.1 301 Moved Permanently');
-                            header('Location: ' . $this->context->link->getProductLink($this->product->id_type_redirected));
-                            exit;
-                        case RedirectType::TYPE_PRODUCT_TEMPORARY:
-                            header('HTTP/1.1 302 Moved Temporarily');
-                            header('Cache-Control: no-cache');
-                            header('Location: ' . $this->context->link->getProductLink($this->product->id_type_redirected));
-                            exit;
-                        case RedirectType::TYPE_CATEGORY_PERMANENT:
-                            header('HTTP/1.1 301 Moved Permanently');
-                            header('Location: ' . $this->context->link->getCategoryLink($this->product->id_type_redirected));
-                            exit;
-                        case RedirectType::TYPE_CATEGORY_TEMPORARY:
-                            header('HTTP/1.1 302 Moved Temporarily');
-                            header('Cache-Control: no-cache');
-                            header('Location: ' . $this->context->link->getCategoryLink($this->product->id_type_redirected));
-                            exit;
-                        case RedirectType::TYPE_GONE:
-                            header('HTTP/1.1 410 Gone');
-                            header('Status: 410 Gone');
-                            $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
-                            $this->setTemplate('errors/410');
+            return;
+        }
 
-                            break;
-                        case RedirectType::TYPE_NOT_FOUND:
-                        default:
-                            header('HTTP/1.1 404 Not Found');
-                            header('Status: 404 Not Found');
-                            $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
-                            $this->setTemplate('errors/404');
+        // Check if the user is on correct URL and redirect if needed
+        $this->canonicalRedirection();
 
-                            break;
+        // Performs multiple checks and redirects user to error page if needed
+        $this->checkPermissionsToViewProduct();
+
+        // Load product category
+        $this->initializeCategory();
+        
+        // Set proper template to product
+        $this->setTemplate('catalog/product', [
+            'entity' => 'product',
+            'id' => $this->id_product,
+        ]);
+    }
+
+    /**
+     * Performs multiple checks and redirects user to error page if needed
+     */
+    public function checkPermissionsToViewProduct()
+    {
+
+        /*
+        * If the product is associated to the shop
+        * and is active or not active but preview mode (need token + file_exists)
+        * allow showing the product
+        * In all the others cases => 404 "Product is no longer available"
+        */
+        $isAdminWithToken = (
+            Tools::getValue('adtoken') == Tools::getAdminToken(
+                'AdminProducts'
+                . (int) Tab::getIdFromClassName('AdminProducts')
+                . (int) Tools::getValue('id_employee')
+            )
+            && $this->product->isAssociatedToShop()
+        );
+
+        if ((!$this->product->isAssociatedToShop() || !$this->product->active) && !$this->isPreview()) {
+            if ($isAdminWithToken) {
+                $this->adminNotifications['inactive_product'] = [
+                    'type' => 'warning',
+                    'message' => $this->trans('This product is not visible to your customers.', [], 'Shop.Notifications.Warning'),
+                ];
+            } else {
+                if (!$this->product->id_type_redirected) {
+                    if (in_array($this->product->redirect_type, [RedirectType::TYPE_CATEGORY_PERMANENT, RedirectType::TYPE_CATEGORY_TEMPORARY])) {
+                        $this->product->id_type_redirected = $this->product->id_category_default;
                     }
+                } elseif (in_array($this->product->redirect_type, [RedirectType::TYPE_PRODUCT_PERMANENT, RedirectType::TYPE_PRODUCT_TEMPORARY]) && $this->product->id_type_redirected == $this->product->id) {
+                    $this->product->redirect_type = RedirectType::TYPE_NOT_FOUND;
                 }
-            } elseif (!$this->product->checkAccess(isset($this->context->customer->id) && $this->context->customer->id ? (int) $this->context->customer->id : 0)) {
+                switch ($this->product->redirect_type) {
+                    case RedirectType::TYPE_PRODUCT_PERMANENT:
+                        header('HTTP/1.1 301 Moved Permanently');
+                        header('Location: ' . $this->context->link->getProductLink($this->product->id_type_redirected));
+                        exit;
+                    case RedirectType::TYPE_PRODUCT_TEMPORARY:
+                        header('HTTP/1.1 302 Moved Temporarily');
+                        header('Cache-Control: no-cache');
+                        header('Location: ' . $this->context->link->getProductLink($this->product->id_type_redirected));
+                        exit;
+                    case RedirectType::TYPE_CATEGORY_PERMANENT:
+                        header('HTTP/1.1 301 Moved Permanently');
+                        header('Location: ' . $this->context->link->getCategoryLink($this->product->id_type_redirected));
+                        exit;
+                    case RedirectType::TYPE_CATEGORY_TEMPORARY:
+                        header('HTTP/1.1 302 Moved Temporarily');
+                        header('Cache-Control: no-cache');
+                        header('Location: ' . $this->context->link->getCategoryLink($this->product->id_type_redirected));
+                        exit;
+                    case RedirectType::TYPE_GONE:
+                        header('HTTP/1.1 410 Gone');
+                        header('Status: 410 Gone');
+                        $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
+                        $this->setTemplate('errors/410');
+
+                        break;
+                    case RedirectType::TYPE_NOT_FOUND:
+                    default:
+                        header('HTTP/1.1 404 Not Found');
+                        header('Status: 404 Not Found');
+                        $this->errors[] = $this->trans('This product is no longer available.', [], 'Shop.Notifications.Error');
+                        $this->setTemplate('errors/404');
+
+                        break;
+                }
+            }
+        } elseif (!$this->product->checkAccess(isset($this->context->customer->id) && $this->context->customer->id ? (int) $this->context->customer->id : 0)) {
+            header('HTTP/1.1 403 Forbidden');
+            header('Status: 403 Forbidden');
+            $this->errors[] = $this->trans('You do not have access to this product.', [], 'Shop.Notifications.Error');
+            $this->setTemplate('errors/forbidden');
+        } else {
+            if (!$isAdminWithToken && $this->isPreview() && !$this->ajax) {
                 header('HTTP/1.1 403 Forbidden');
                 header('Status: 403 Forbidden');
                 $this->errors[] = $this->trans('You do not have access to this product.', [], 'Shop.Notifications.Error');
                 $this->setTemplate('errors/forbidden');
-            } else {
-                if (!$isAssociatedToProduct && $isPreview && !$this->ajax) {
-                    header('HTTP/1.1 403 Forbidden');
-                    header('Status: 403 Forbidden');
-                    $this->errors[] = $this->trans('You do not have access to this product.', [], 'Shop.Notifications.Error');
-                    $this->setTemplate('errors/forbidden');
-                }
+            }
 
-                if ($isAssociatedToProduct && $isPreview) {
-                    $this->adminNotifications['inactive_product'] = [
-                        'type' => 'warning',
-                        'message' => $this->trans('This product is not visible to your customers.', [], 'Shop.Notifications.Warning'),
-                    ];
-                }
-                // Load category
-                $id_category = false;
-                if (isset($_SERVER['HTTP_REFERER']) && $_SERVER['HTTP_REFERER'] == Tools::secureReferrer($_SERVER['HTTP_REFERER']) // Assure us the previous page was one of the shop
-                    && preg_match('~^.*(?<!\/content)\/([0-9]+)\-(.*[^\.])|(.*)id_(category|product)=([0-9]+)(.*)$~', $_SERVER['HTTP_REFERER'], $regs)) {
-                    // If the previous page was a category and is a parent category of the product use this category as parent category
-                    $id_object = false;
-                    if (isset($regs[1]) && is_numeric($regs[1])) {
-                        $id_object = (int) $regs[1];
-                    } elseif (isset($regs[5]) && is_numeric($regs[5])) {
-                        $id_object = (int) $regs[5];
-                    }
-                    if ($id_object) {
-                        $referers = [$_SERVER['HTTP_REFERER'], urldecode($_SERVER['HTTP_REFERER'])];
-                        if (in_array($this->context->link->getCategoryLink($id_object), $referers)) {
-                            $id_category = (int) $id_object;
-                        } elseif (isset($this->context->cookie->last_visited_category) && (int) $this->context->cookie->last_visited_category && in_array($this->context->link->getProductLink($id_object), $referers)) {
-                            $id_category = (int) $this->context->cookie->last_visited_category;
-                        }
-                    }
-                }
-                if (!$id_category || !Category::inShopStatic($id_category, $this->context->shop) || !Product::idIsOnCategoryId((int) $this->product->id, ['0' => ['id_category' => $id_category]])) {
-                    $id_category = (int) $this->product->id_category_default;
-                }
-                $this->category = new Category((int) $id_category, (int) $this->context->cookie->id_lang);
-                $moduleManagerBuilder = ModuleManagerBuilder::getInstance();
-                $moduleManager = $moduleManagerBuilder->build();
+            if ($isAdminWithToken && $this->isPreview()) {
+                $this->adminNotifications['inactive_product'] = [
+                    'type' => 'warning',
+                    'message' => $this->trans('This product is not visible to your customers.', [], 'Shop.Notifications.Warning'),
+                ];
+            }
+        }
+    }
 
-                if (
-                    isset($this->context->cookie)
-                    && !(
-                        $moduleManager->isInstalled('ps_categorytree')
-                        && $moduleManager->isEnabled('ps_categorytree')
-                    )
-                ) {
-                    $this->context->cookie->last_visited_category = (int) $this->category->id_category;
+    /**
+     * Loads related category to current visit. First it tries to get a category the user came from - it uses HTTP referer for this.
+     * If no category is found (or it's invalid), we use product's default category.
+     */
+    public function initializeCategory()
+    {
+        $id_category = false;
+        if (isset($_SERVER['HTTP_REFERER']) && $_SERVER['HTTP_REFERER'] == Tools::secureReferrer($_SERVER['HTTP_REFERER']) // Assure us the previous page was one of the shop
+            && preg_match('~^.*(?<!\/content)\/([0-9]+)\-(.*[^\.])|(.*)id_(category|product)=([0-9]+)(.*)$~', $_SERVER['HTTP_REFERER'], $regs)) {
+            // If the previous page was a category and is a parent category of the product use this category as parent category
+            $id_object = false;
+            if (isset($regs[1]) && is_numeric($regs[1])) {
+                $id_object = (int) $regs[1];
+            } elseif (isset($regs[5]) && is_numeric($regs[5])) {
+                $id_object = (int) $regs[5];
+            }
+            if ($id_object) {
+                $referers = [$_SERVER['HTTP_REFERER'], urldecode($_SERVER['HTTP_REFERER'])];
+                if (in_array($this->context->link->getCategoryLink($id_object), $referers)) {
+                    $id_category = (int) $id_object;
+                } elseif (isset($this->context->cookie->last_visited_category) && (int) $this->context->cookie->last_visited_category && in_array($this->context->link->getProductLink($id_object), $referers)) {
+                    $id_category = (int) $this->context->cookie->last_visited_category;
                 }
             }
         }
+        if (!$id_category || !Category::inShopStatic($id_category, $this->context->shop) || !Product::idIsOnCategoryId((int) $this->product->id, ['0' => ['id_category' => $id_category]])) {
+            $id_category = (int) $this->product->id_category_default;
+        }
+
+        // Load category and store it in cookie
+        $this->category = new Category((int) $id_category, (int) $this->context->cookie->id_lang);
+        $this->context->cookie->last_visited_category = (int) $this->category->id_category;
     }
 
     /**
@@ -276,19 +317,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             } elseif ($priceDisplay == 1) {
                 $productPrice = $this->product->getPrice(false, null, 6);
                 $productPriceWithoutReduction = $this->product->getPriceWithoutReduct(true, null);
-            }
-
-            if (Tools::isSubmit('submitCustomizedData')) {
-                // If cart has not been saved, we need to do it so that customization fields can have an id_cart
-                // We check that the cookie exists first to avoid ghost carts
-                if (!$this->context->cart->id && isset($_COOKIE[$this->context->cookie->getName()])) {
-                    $this->context->cart->add();
-                    $this->context->cookie->id_cart = (int) $this->context->cart->id;
-                }
-                $this->pictureUpload();
-                $this->textRecord();
-            } elseif (Tools::getIsset('deletePicture') && !$this->context->cart->deleteCustomizationToProduct($this->product->id, Tools::getValue('deletePicture'))) {
-                $this->errors[] = $this->trans('An error occurred while deleting the selected picture.', [], 'Shop.Notifications.Error');
             }
 
             $pictures = [];
@@ -423,6 +451,27 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         parent::initContent();
     }
 
+    /**
+     * Processes submitted customizations
+     *
+     * @see FrontController::postProcess()
+     */
+    public function postProcess()
+    {
+        if (Tools::isSubmit('submitCustomizedData')) {
+            // If cart has not been saved, we need to do it so that customization fields can have an id_cart
+            // We check that the cookie exists first to avoid ghost carts
+            if (!$this->context->cart->id && isset($_COOKIE[$this->context->cookie->getName()])) {
+                $this->context->cart->add();
+                $this->context->cookie->id_cart = (int) $this->context->cart->id;
+            }
+            $this->pictureUpload();
+            $this->textRecord();
+        } elseif (Tools::getIsset('deletePicture') && !$this->context->cart->deleteCustomizationToProduct($this->product->id, Tools::getValue('deletePicture'))) {
+            $this->errors[] = $this->trans('An error occurred while deleting the selected picture.', [], 'Shop.Notifications.Error');
+        }
+    }
+
     public function displayAjaxQuickview()
     {
         $productForTemplate = $this->getTemplateVarProduct();
@@ -446,12 +495,6 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     {
         $product = $this->getTemplateVarProduct();
         $minimalProductQuantity = $this->getProductMinimalQuantity($product);
-        $isPreview = ('1' === Tools::getValue('preview'));
-        $isQuickView = ('1' === Tools::getValue('quickview'));
-
-        if ($isQuickView) {
-            $this->setQuickViewMode();
-        }
 
         ob_end_clean();
         header('Content-Type: application/json');
@@ -482,7 +525,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 false,
                 false,
                 true,
-                $isPreview ? ['preview' => '1'] : []
+                $this->isPreview() ? ['preview' => '1'] : []
             ),
             'product_minimal_quantity' => $minimalProductQuantity,
             'product_has_combinations' => !empty($this->combinations),
@@ -490,7 +533,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_title' => $this->getProductPageTitle(
                 $this->getTemplateVarPage()['meta'] ?? []
             ),
-            'is_quick_view' => $isQuickView,
+            'is_quick_view' => $this->isQuickView(),
         ]));
     }
 
@@ -1471,5 +1514,25 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function setQuickViewMode(bool $enabled = true)
     {
         $this->isQuickView = $enabled;
+    }
+
+    /**
+     * Return information whether we are or not in preview mode.
+     *
+     * @return bool
+     */
+    public function isPreview(): bool
+    {
+        return $this->isPreview;
+    }
+
+    /**
+     * Set preview mode.
+     *
+     * @param bool $enabled
+     */
+    public function setPreviewMode(bool $enabled = true)
+    {
+        $this->isPreview = $enabled;
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Simplification and cleaning of product front controller. No changes in logic or BC breaks, just made it cleaner and easier to modify/extend/improve.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | -
| How to test?      | Check that everything works correctly
| Possible impacts? | no

### Changes
- Two new attributes saving ID of product and ID of combination.
- Removed two huge if blocks.
- Save `isPreview` to attribute the same way as `isQuickview`, so we don't have to check for it everytime.
- Put viewing checks to separate function `checkPermissionsToViewProduct()`. We want to improve it further by allowing users to view disabled products for SEO. This will make the QA easier.
- Put category assignment to separate function `initializeCategory()`. It will be easier for QA when we add some customization like "Always show full path in breadcrumb".
- Renamed `isAssociatedToProduct` to `isAdminWithToken` - easier to understand.
- Do not check if default category module is enabled to save id category to cookie - just save it. Other modules can benefit from it also. And we will get some performance gain.
- Put customization processing to `postProcess`, where it belongs.
- Remove `isQuickview` and `isPreview` from `displayAjaxQuickview` - already resolved in `init`.