### PR TITLE
Fix module translations

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2718,7 +2718,12 @@ class AdminControllerCore extends Controller
     {
         @trigger_error(__FUNCTION__ . 'is deprecated. Use AdminController::trans instead.', E_USER_DEPRECATED);
 
-        return $this->translator->trans($string);
+        $parameters = [];
+        if ($htmlentities) {
+            $parameters['legacy'] = 'htmlspecialchars';
+        }
+
+        return $this->translator->trans($string, $parameters);
     }
 
     /**

--- a/classes/controller/ModuleAdminController.php
+++ b/classes/controller/ModuleAdminController.php
@@ -112,11 +112,7 @@ abstract class ModuleAdminControllerCore extends AdminController
                 $class = get_class($this);
             }
 
-            $translated = Translate::getModuleTranslation($this->module->name, $string, $class, null, $addslashes);
-        }
-
-        if ($htmlentities) {
-            $translated = htmlspecialchars($translated, ENT_QUOTES, 'utf-8');
+            $translated = Translate::getModuleTranslation($this->module->name, $string, $class, null, $addslashes, null, true, $htmlentities);
         }
 
         return $translated;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | See #29236 and comments below
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29236.
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/24401
| How to test?      | See #29236 
| Possible impacts? | All module translations. :point_up: I updated ModuleFrontController as well but I think it is not well tested by original given module.

It looks that legacy `Controller` child classes that used `l(...)` function haven't been well updated during the migration process.
That induced some weird behavior with inheritance.

I reinforced deprecation notifications and checked all legacy controller `l(...)` functions definitions.

