### PR TITLE
Set access of FrontController "maintenance" variable to "public"

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -102,7 +102,7 @@ class FrontControllerCore extends Controller
     protected $restrictedCountry = Country::GEOLOC_ALLOWED;
 
     /** @var bool If true, forces display to maintenance page. */
-    protected $maintenance = false;
+    public $maintenance = false;
 
     /** @var string[] Adds excluded `$_GET` keys for redirection */
     protected $redirectionExtraExcludedKeys = [];


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow public access to the $maintenance value so it can be altered through hooks.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Visit frontend. Change the value through a hook called *before* FrontController::displayMaintenancePage() and verify the maintenance page is displayed.
| Possible impacts? | FrontController maintenance display. 

This change  would allow module developers a simpler control of the maintenance mode, since the flag is used in the first condition of `displayMaintenancePage()`. Ie: The controller is passed as a param in the `actionFrontControllerInitBefore` hook.