### PR TITLE
Clean-up the base object presenter

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1117,7 +1117,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['minimal_quantity'] = $this->getProductMinimalQuantity($product);
         $product['quantity_wanted'] = $this->getRequiredQuantity($product);
         $product['extraContent'] = $extraContentFinder->addParams(['product' => $this->product])->present();
-
+        $product['ecotax_tax_inc'] = $this->product->getEcotax(null, true, true);
         $product['ecotax'] = Tools::convertPrice($this->getProductEcotax($product), $this->context->currency, true, $this->context);
 
         $product_full = Product::getProductProperties($this->context->language->id, $product, $this->context);

--- a/src/Adapter/Presenter/Object/ObjectPresenter.php
+++ b/src/Adapter/Presenter/Object/ObjectPresenter.php
@@ -30,7 +30,6 @@ use Exception;
 use Hook;
 use ObjectModel;
 use PrestaShop\PrestaShop\Adapter\Presenter\PresenterInterface;
-use Product;
 
 class ObjectPresenter implements PresenterInterface
 {
@@ -52,10 +51,6 @@ class ObjectPresenter implements PresenterInterface
         $fields = $object::$definition['fields'];
         foreach ($fields as $fieldName => $null) {
             $presentedObject[$fieldName] = $object->{$fieldName};
-        }
-
-        if ($object instanceof Product) {
-            $presentedObject['ecotax_tax_inc'] = $object->getEcotax(null, true, true);
         }
 
         $presentedObject['id'] = $object->id;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In ObjectPresenter, there was an ugly code related to some product price, it was added to fix one issue in https://github.com/PrestaShop/PrestaShop/pull/20499, but it's not used anymore. I moved it to ProductController just to be sure.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Related PRs       | -
| How to test?      | Check that ecotax displays correctly on product page. This issue should be still fixed. https://github.com/PrestaShop/PrestaShop/issues/18835
| Possible impacts? | 3rd party code that used this property in other places than product page. I doubt that something like this exists, nobody shows ecotax in product miniature.

Ping @zuk3975 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
