### PR TITLE
Add available_now & available_later labels constraints

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -546,8 +546,8 @@ class ProductCore extends ObjectModel
             'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCatalogName', 'required' => false, 'size' => ProductSettings::MAX_NAME_LENGTH],
             'description' => ['type' => self::TYPE_HTML, 'lang' => true, 'validate' => 'isCleanHtml'],
             'description_short' => ['type' => self::TYPE_HTML, 'lang' => true, 'validate' => 'isCleanHtml'],
-            'available_now' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 255],
-            'available_later' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'IsGenericName', 'size' => 255],
+            'available_now' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => ProductSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH],
+            'available_later' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'IsGenericName', 'size' => ProductSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH],
         ],
         'associations' => [
             'manufacturer' => ['type' => self::HAS_ONE],

--- a/src/Core/Domain/Product/ProductSettings.php
+++ b/src/Core/Domain/Product/ProductSettings.php
@@ -48,7 +48,8 @@ class ProductSettings
     public const MAX_MPN_LENGTH = 40;
     public const MAX_META_TITLE_LENGTH = 70;
     public const MAX_META_DESCRIPTION_LENGTH = 160;
-
     public const MAX_DESCRIPTION_SHORT_LENGTH = 800;
     public const MAX_DESCRIPTION_LENGTH = 21844;
+    public const MAX_AVAILABLE_NOW_LABEL_LENGTH = 255;
+    public const MAX_AVAILABLE_LATER_LABEL_LENGTH = 255;
 }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -28,6 +28,8 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Stock;
 
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Domain\Product\ProductSettings;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
@@ -37,6 +39,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Validator\Constraints\Length;
 
 class AvailabilityType extends TranslatorAwareType
 {
@@ -75,6 +78,14 @@ class AvailabilityType extends TranslatorAwareType
                 'type' => TextType::class,
                 'label' => $this->trans('Label when in stock', 'Admin.Catalog.Feature'),
                 'required' => false,
+                'options' => [
+                    'constraints' => [
+                        new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
+                        new Length([
+                            'max' => ProductSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH,
+                        ])
+                    ],
+                ],
             ])
             ->add('available_later_label', TranslatableType::class, [
                 'type' => TextType::class,
@@ -83,6 +94,14 @@ class AvailabilityType extends TranslatorAwareType
                     'Admin.Catalog.Feature'
                 ),
                 'required' => false,
+                'options' => [
+                    'constraints' => [
+                        new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
+                        new Length([
+                            'max' => ProductSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH,
+                        ])
+                    ],
+                ],
             ])
             ->add('available_date', DatePickerType::class, [
                 'label' => $this->trans('Availability date', 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -105,7 +105,7 @@ class AvailabilityType extends TranslatorAwareType
                         new Length([
                             'max' => ProductSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH,
                             'maxMessage' => $this->trans(
-                                'This field cannot be longer than %limit% characters',
+                                'This field cannot be longer than %limit% characters.',
                                 'Admin.Notifications.Error',
                                 ['%limit%' => ProductSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH]
                             ),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -84,7 +84,7 @@ class AvailabilityType extends TranslatorAwareType
                         new Length([
                             'max' => ProductSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH,
                             'maxMessage' => $this->trans(
-                                'This field cannot be longer than %limit% characters',
+                                'This field cannot be longer than %limit% characters.',
                                 'Admin.Notifications.Error',
                                 ['%limit%' => ProductSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH]
                             ),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Stock/AvailabilityType.php
@@ -83,7 +83,12 @@ class AvailabilityType extends TranslatorAwareType
                         new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
                         new Length([
                             'max' => ProductSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH,
-                        ])
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => ProductSettings::MAX_AVAILABLE_NOW_LABEL_LENGTH]
+                            ),
+                        ]),
                     ],
                 ],
             ])
@@ -99,7 +104,12 @@ class AvailabilityType extends TranslatorAwareType
                         new TypedRegex(TypedRegex::TYPE_GENERIC_NAME),
                         new Length([
                             'max' => ProductSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH,
-                        ])
+                            'maxMessage' => $this->trans(
+                                'This field cannot be longer than %limit% characters',
+                                'Admin.Notifications.Error',
+                                ['%limit%' => ProductSettings::MAX_AVAILABLE_LATER_LABEL_LENGTH]
+                            ),
+                        ]),
                     ],
                 ],
             ])


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | refer to https://github.com/PrestaShop/PrestaShop/issues/29454 . Once 178 is merged to 8.0.x next time then 8.0.x will be also fixed automatically.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29454
| Related PRs       | 
| How to test?      | refer to https://github.com/PrestaShop/PrestaShop/issues/29454
| Possible impacts? | 

:warning: Note - in 1.7.8.x there are no error message yet and correct behavior looks like this
![Screenshot from 2022-08-29 13-44-23](https://user-images.githubusercontent.com/31609858/187184098-aee132fa-5b31-431b-b870-75a895c6b26e.png)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
