### PR TITLE
Fix hook registration and module enabling/disabling processes

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1079,6 +1079,7 @@ class HookCore extends ObjectModel
         }
         $sql->innerJoin('hook_module', 'hm', 'hm.`id_module` = m.`id_module`');
         $sql->innerJoin('hook', 'h', 'hm.`id_hook` = h.`id_hook`');
+        $sql->innerJoin('module_shop', 'mshop', 'mshop.`id_module` = m.`id_module`');
         if ($hookName !== 'paymentOptions') {
             $sql->where('h.`name` != "paymentOptions" and m.active = 1');
         } elseif ($frontend) {

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1075,13 +1075,12 @@ class HookCore extends ObjectModel
                     'module_shop.enable_device & ' . (int) Context::getContext()->getDevice()
                 )
             );
-            $sql->innerJoin('module_shop', 'ms', 'ms.`id_module` = m.`id_module`');
         }
         $sql->innerJoin('hook_module', 'hm', 'hm.`id_module` = m.`id_module`');
         $sql->innerJoin('hook', 'h', 'hm.`id_hook` = h.`id_hook`');
         $sql->innerJoin('module_shop', 'mshop', 'mshop.`id_module` = m.`id_module`');
         if ($hookName !== 'paymentOptions') {
-            $sql->where('h.`name` != "paymentOptions" and m.active = 1');
+            $sql->where('h.`name` != "paymentOptions"');
         } elseif ($frontend) {
             // For payment modules, we check that they are available in the contextual country
             if (Validate::isLoadedObject($context->country)) {

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1080,7 +1080,7 @@ class HookCore extends ObjectModel
         $sql->innerJoin('hook_module', 'hm', 'hm.`id_module` = m.`id_module`');
         $sql->innerJoin('hook', 'h', 'hm.`id_hook` = h.`id_hook`');
         if ($hookName !== 'paymentOptions') {
-            $sql->where('h.`name` != "paymentOptions"');
+            $sql->where('h.`name` != "paymentOptions" and m.active = 1');
         } elseif ($frontend) {
             // For payment modules, we check that they are available in the contextual country
             if (Validate::isLoadedObject($context->country)) {

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -880,7 +880,7 @@ abstract class ModuleCore implements ModuleInterface
         }
 
         // set active to 1 in the module table
-        Db::getInstance()->update('module', ['active' => 1], 'id_module = '. (int) $this->id);
+        Db::getInstance()->update('module', ['active' => 1], 'id_module = ' . (int) $this->id);
 
         if ($moduleActivated) {
             $this->loadBuiltInTranslations();
@@ -984,14 +984,14 @@ abstract class ModuleCore implements ModuleInterface
         }
 
         // Disable module for all shops
-        $result &= Db::getInstance()->delete('module_shop', '`id_module` = ' . (int) $this->id );
+        $result &= Db::getInstance()->delete('module_shop', '`id_module` = ' . (int) $this->id);
 
         // if module has no more shop associations, set module.active = 0
         if (!$this->hasShopAssociations()) {
-            $result &= Db::getInstance()->update('module', ['active' => 0], 'id_module = '. (int) $this->id);
+            $result &= Db::getInstance()->update('module', ['active' => 0], 'id_module = ' . (int) $this->id);
         }
 
-        return $result;
+        return (bool) $result;
     }
 
     public function hasShopAssociations(): bool

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -879,6 +879,9 @@ abstract class ModuleCore implements ModuleInterface
             }
         }
 
+        // set active to 1 in the module table
+        Db::getInstance()->update('module', ['active' => 1], 'id_module = '. (int) $this->id);
+
         if ($moduleActivated) {
             $this->loadBuiltInTranslations();
         }
@@ -981,9 +984,22 @@ abstract class ModuleCore implements ModuleInterface
         }
 
         // Disable module for all shops
-        $sql = 'DELETE FROM `' . _DB_PREFIX_ . 'module_shop` WHERE `id_module` = ' . (int) $this->id . ' ' . ((!$force_all) ? ' AND `id_shop` IN(' . implode(', ', Shop::getContextListShopID()) . ')' : '');
+        $result &= Db::getInstance()->delete('module_shop', '`id_module` = ' . (int) $this->id );
 
-        return $result && Db::getInstance()->execute($sql);
+        // if module has no more shop associations, set module.active = 0
+        if (!$this->hasShopAssociations()) {
+            $result &= Db::getInstance()->update('module', ['active' => 0], 'id_module = '. (int) $this->id);
+        }
+
+        return $result;
+    }
+
+    public function hasShopAssociations(): bool
+    {
+        $sql = "SELECT m.id_module FROM %smodule m INNER JOIN %smodule_shop ms ON ms.id_module = m.id_module WHERE m.id_module = '%s'";
+        $result = Db::getInstance()->getRow(sprintf($sql, _DB_PREFIX_, _DB_PREFIX_, (int) $this->id));
+
+        return isset($result['id_module']);
     }
 
     /**

--- a/src/Adapter/Module/CommandHandler/BulkToggleModuleStatusHandler.php
+++ b/src/Adapter/Module/CommandHandler/BulkToggleModuleStatusHandler.php
@@ -75,7 +75,7 @@ class BulkToggleModuleStatusHandler implements BulkToggleModuleStatusHandlerInte
     public function handle(BulkToggleModuleStatusCommand $command): void
     {
         foreach ($command->getModules() as $moduleName) {
-            if (!$this->moduleManager->isInstalledAndActive($moduleName) || !Validate::isLoadedObject(Module::getInstanceByName($moduleName))) {
+            if ($this->isDisablingAlreadyDisabledModule($command->getExpectedStatus(), $moduleName) || !Validate::isLoadedObject(Module::getInstanceByName($moduleName))) {
                 continue;
             }
 
@@ -106,5 +106,10 @@ class BulkToggleModuleStatusHandler implements BulkToggleModuleStatusHandlerInte
         //    So after this loop we clear the caches (especially Symfony one but it's safer to clear them all).
         //    If you don't the modification of the status will be ignored even if the state of the DB has changed.
         $this->cacheClearer->clear();
+    }
+
+    private function isDisablingAlreadyDisabledModule(bool $expectedStatus, string $moduleName): bool
+    {
+        return !$expectedStatus && !$this->moduleManager->isInstalledAndActive($moduleName);
     }
 }

--- a/src/Adapter/Module/CommandHandler/BulkToggleModuleStatusHandler.php
+++ b/src/Adapter/Module/CommandHandler/BulkToggleModuleStatusHandler.php
@@ -75,8 +75,7 @@ class BulkToggleModuleStatusHandler implements BulkToggleModuleStatusHandlerInte
     public function handle(BulkToggleModuleStatusCommand $command): void
     {
         foreach ($command->getModules() as $moduleName) {
-            $module = Module::getInstanceByName($moduleName);
-            if (!Validate::isLoadedObject($module) || !$this->moduleManager->isInstalled($moduleName)) {
+            if (!$this->moduleManager->isInstalledAndActive($moduleName) || !Validate::isLoadedObject(Module::getInstanceByName($moduleName))) {
                 continue;
             }
 

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -231,16 +231,31 @@ class ModuleDataProvider
     }
 
     /**
+     * @param $name
+     *
+     * @return bool
+     */
+    public function isInstalledAndActive($name) {
+        return (bool) $this->getModuleIdByName($name, true);
+    }
+
+    /**
      * Returns the Module Id
      *
      * @param string $name The technical module name
+     * @param bool   $activeModulesOnly Should we return the module only if it's active ?
      *
      * @return int the Module Id, or 0 if not found
      */
-    public function getModuleIdByName($name)
+    public function getModuleIdByName($name, bool $activeModulesOnly = false)
     {
+        $sqlQuery = 'SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module` WHERE `name` = "' . pSQL($name) . '"';
+        if ($activeModulesOnly) {
+            $sqlQuery .= ' AND `active` = 1';
+        }
+
         return (int) Db::getInstance()->getValue(
-            'SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module` WHERE `name` = "' . pSQL($name) . '"'
+            $sqlQuery
         );
     }
 

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -231,11 +231,11 @@ class ModuleDataProvider
     }
 
     /**
-     * @param $name
+     * @param string $name
      *
      * @return bool
      */
-    public function isInstalledAndActive($name) {
+    public function isInstalledAndActive(string $name): bool {
         return (bool) $this->getModuleIdByName($name, true);
     }
 

--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -235,7 +235,8 @@ class ModuleDataProvider
      *
      * @return bool
      */
-    public function isInstalledAndActive(string $name): bool {
+    public function isInstalledAndActive(string $name): bool
+    {
         return (bool) $this->getModuleIdByName($name, true);
     }
 
@@ -243,7 +244,7 @@ class ModuleDataProvider
      * Returns the Module Id
      *
      * @param string $name The technical module name
-     * @param bool   $activeModulesOnly Should we return the module only if it's active ?
+     * @param bool $activeModulesOnly Should we return the module only if it's active ?
      *
      * @return int the Module Id, or 0 if not found
      */

--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -298,6 +298,11 @@ class ModuleManager implements ModuleManagerInterface
         return $this->moduleDataProvider->isInstalled($name);
     }
 
+    public function isInstalledAndActive(string $name): bool
+    {
+        return $this->moduleDataProvider->isInstalledAndActive($name);
+    }
+
     public function isEnabled(string $name): bool
     {
         return $this->moduleDataProvider->isEnabled($name);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      |  This PR does 3 related things:<br>1/ Add missing SQL join on `ps_module_shop` in hook registration process <br>2/ make sure that, when disabling a module, if it doesn't have associated shops anymore, its `active` field is set to `0`<br>3/ make sure that when enabling a module, its `active` field is set to 1
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes feedback from @khouloudbelguith  in https://github.com/PrestaShop/autoupgrade/pull/498
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/498, the related PR is WIP
| How to test?      | See this [pull request on autoupgrade](https://github.com/PrestaShop/autoupgrade/pull/498)
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
