### PR TITLE
Don't register `module` on `hook` if already registered

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -583,8 +583,8 @@ class HookCore extends ObjectModel
 
             foreach ($shop_list as $shop_id) {
                 $isModuleAlreadyRegisteredOnHook = static::isModuleRegisteredOnHook(
-                    $module_instance, 
-                    $hook_name, 
+                    $module_instance,
+                    $hook_name,
                     (int) $shop_id
                 );
 

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -592,15 +592,6 @@ class HookCore extends ObjectModel
                     continue;
                 }
 
-                // Check if already registered
-                $sql = 'SELECT hm.`id_module`
-                    FROM `' . _DB_PREFIX_ . 'hook_module` hm, `' . _DB_PREFIX_ . 'hook` h
-                    WHERE hm.`id_module` = ' . (int) $module_instance->id . ' AND h.`id_hook` = ' . $id_hook . '
-                    AND h.`id_hook` = hm.`id_hook` AND `id_shop` = ' . (int) $shop_id;
-                if (Db::getInstance()->getRow($sql)) {
-                    continue;
-                }
-
                 // Get module position in hook
                 $sql = 'SELECT MAX(`position`) AS position
                     FROM `' . _DB_PREFIX_ . 'hook_module`

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -582,6 +582,16 @@ class HookCore extends ObjectModel
             $shop_list_employee = Shop::getShops(true, null, true);
 
             foreach ($shop_list as $shop_id) {
+                $isModuleAlreadyRegisteredOnHook = static::isModuleRegisteredOnHook(
+                    $module_instance, 
+                    $hook_name, 
+                    (int)$shop_id
+                );
+
+                if ($isModuleAlreadyRegisteredOnHook) {
+                    continue;
+                }
+
                 // Check if already registered
                 $sql = 'SELECT hm.`id_module`
                     FROM `' . _DB_PREFIX_ . 'hook_module` hm, `' . _DB_PREFIX_ . 'hook` h

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -585,7 +585,7 @@ class HookCore extends ObjectModel
                 $isModuleAlreadyRegisteredOnHook = static::isModuleRegisteredOnHook(
                     $module_instance, 
                     $hook_name, 
-                    (int)$shop_id
+                    (int) $shop_id
                 );
 
                 if ($isModuleAlreadyRegisteredOnHook) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Don't register `module` on `hook` if already registered.
| Type?             | improvement 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A.
| Related PRs       | N/A
| How to test?      | N/A
| Possible impacts? | Make sure that you can register you module to a hook `$this->registerHook('yourHookName')`.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
