### PR TITLE
Fix ps_facetedsearch - bad display after clearing a filter of no result

### DIFF
--- a/themes/classic/_dev/js/listing.js
+++ b/themes/classic/_dev/js/listing.js
@@ -229,11 +229,13 @@ function updateProductListDOM(data) {
   );
 
   const renderedProducts = $(data.rendered_products);
-  const productSelectors = $(prestashop.themeSelectors.listing.product, renderedProducts);
+  const productSelectors = $(prestashop.themeSelectors.listing.product);
 
   if (productSelectors.length > 0) {
-    productSelectors.removeClass().addClass($(prestashop.themeSelectors.listing.product).first().attr('class'));
-  }
+    productSelectors.removeClass().addClass(productSelectors.first().attr('class'));
+  } else {
+    productSelectors.removeClass().addClass(renderedProducts.first().attr('class'));
+  }  
 
   $(prestashop.themeSelectors.listing.list).replaceWith(renderedProducts);
 

--- a/themes/classic/_dev/js/listing.js
+++ b/themes/classic/_dev/js/listing.js
@@ -235,7 +235,7 @@ function updateProductListDOM(data) {
     productSelectors.removeClass().addClass(productSelectors.first().attr('class'));
   } else {
     productSelectors.removeClass().addClass(renderedProducts.first().attr('class'));
-  }  
+  }
 
   $(prestashop.themeSelectors.listing.list).replaceWith(renderedProducts);
 


### PR DESCRIPTION
Seperate `renderedProducts` and `productSelectors`, then we are safe in case `$(prestashop.themeSelectors.listing.product)` is `Undefined` after a previous filter with _No product_

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Backport of https://github.com/PrestaShop/classic-theme/pull/43.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28966.
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | See issue
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
