### PR TITLE
Eco tax fixed for combination price

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -282,10 +282,8 @@ export default class CombinationsListRenderer {
 
     let ecoTax;
 
-    if (combinationEcoTax !== undefined) {
-      ecoTax = combinationEcoTax > 0
-        ? new BigNumber(combinationEcoTax.toString())
-        : this.productFormModel.getBigNumber('price.ecotaxTaxExcluded') ?? new BigNumber(0);
+    if (combinationEcoTax !== undefined && combinationEcoTax > 0) {
+      ecoTax = new BigNumber(combinationEcoTax.toString());
     } else {
       ecoTax = this.productFormModel.getBigNumber('price.ecotaxTaxExcluded') ?? new BigNumber(0);
     }

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -279,7 +279,7 @@ export default class CombinationsListRenderer {
     const $finalPricePreview = $finalPrice.siblings(CombinationsMap.list.finalPricePreview);
     let combinationPrice = productPrice.plus(priceImpactTaxExcluded);
 
-    const ecoTax = $(ProductPriceMap.ecoTaxTaxIncluded).val();
+    const ecoTax = $(ProductPriceMap.ecoTaxTaxExcluded).val();
 
     if (ecoTax) {
       combinationPrice = combinationPrice.plus(new BigNumber(ecoTax.toString()));

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -278,7 +278,17 @@ export default class CombinationsListRenderer {
     const $finalPricePreview = $finalPrice.siblings(CombinationsMap.list.finalPricePreview);
     let combinationPrice = productPrice.plus(priceImpactTaxExcluded);
 
-    const ecoTax = this.productFormModel.getBigNumber('price.ecotaxTaxExcluded') ?? new BigNumber(0);
+    const combinationEcoTax = $(CombinationsMap.list.ecoTax, $row).val();
+
+    let ecoTax;
+
+    if (combinationEcoTax !== undefined) {
+      ecoTax = combinationEcoTax > 0
+        ? new BigNumber(combinationEcoTax.toString())
+        : this.productFormModel.getBigNumber('price.ecotaxTaxExcluded') ?? new BigNumber(0);
+    } else {
+      ecoTax = this.productFormModel.getBigNumber('price.ecotaxTaxExcluded') ?? new BigNumber(0);
+    }
 
     if (!ecoTax.isNaN()) {
       combinationPrice = combinationPrice.plus(new BigNumber(ecoTax.toString()));

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -280,7 +280,7 @@ export default class CombinationsListRenderer {
 
     const ecoTax = this.productFormModel.getBigNumber('price.ecotaxTaxExcluded') ?? new BigNumber(0);
 
-    if (ecoTax) {
+    if (!ecoTax.isNaN()) {
       combinationPrice = combinationPrice.plus(new BigNumber(ecoTax.toString()));
     }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -34,7 +34,6 @@ import ChangeEvent = JQuery.ChangeEvent;
 
 const {$} = window;
 const CombinationsMap = ProductMap.combinations;
-const ProductPriceMap = ProductMap.price;
 
 export type SortGridCallback = (sortColumn: string, sortOrder: string) => void;
 export type EmptyStateCallback = (isEmpty: boolean) => void;
@@ -279,7 +278,7 @@ export default class CombinationsListRenderer {
     const $finalPricePreview = $finalPrice.siblings(CombinationsMap.list.finalPricePreview);
     let combinationPrice = productPrice.plus(priceImpactTaxExcluded);
 
-    const ecoTax = $(ProductPriceMap.ecoTaxTaxExcluded).val();
+    const ecoTax = this.productFormModel.getBigNumber('price.ecotaxTaxExcluded') ?? new BigNumber(0);
 
     if (ecoTax) {
       combinationPrice = combinationPrice.plus(new BigNumber(ecoTax.toString()));

--- a/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/combination-list/combinations-list-renderer.ts
@@ -34,6 +34,7 @@ import ChangeEvent = JQuery.ChangeEvent;
 
 const {$} = window;
 const CombinationsMap = ProductMap.combinations;
+const ProductPriceMap = ProductMap.price;
 
 export type SortGridCallback = (sortColumn: string, sortOrder: string) => void;
 export type EmptyStateCallback = (isEmpty: boolean) => void;
@@ -276,7 +277,15 @@ export default class CombinationsListRenderer {
     const productPrice = this.productFormModel.getPriceTaxExcluded();
     const $finalPrice = $(CombinationsMap.list.finalPrice, $row);
     const $finalPricePreview = $finalPrice.siblings(CombinationsMap.list.finalPricePreview);
-    const finalPrice = this.productFormModel.displayPrice(productPrice.plus(priceImpactTaxExcluded));
+    let combinationPrice = productPrice.plus(priceImpactTaxExcluded);
+
+    const ecoTax = $(ProductPriceMap.ecoTaxTaxIncluded).val();
+
+    if (ecoTax) {
+      combinationPrice = combinationPrice.plus(new BigNumber(ecoTax.toString()));
+    }
+
+    const finalPrice = this.productFormModel.displayPrice(combinationPrice);
 
     if (typeof $finalPrice !== 'undefined') {
       $finalPrice.val(finalPrice);

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -51,6 +51,9 @@ export default {
       typeDescription: '.product-type-description-content',
     },
   },
+  price: {
+    ecoTaxTaxIncluded: '#product_pricing_retail_price_ecotax_tax_included',
+  },
   create: {
     newProductButton: '.new-product-button',
     createModalSelector: '#create_product_type',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -51,9 +51,6 @@ export default {
       typeDescription: '.product-type-description-content',
     },
   },
-  price: {
-    ecoTaxTaxExcluded: '#product_pricing_retail_price_ecotax_tax_excluded',
-  },
   create: {
     newProductButton: '.new-product-button',
     createModalSelector: '#create_product_type',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -52,7 +52,7 @@ export default {
     },
   },
   price: {
-    ecoTaxTaxIncluded: '#product_pricing_retail_price_ecotax_tax_included',
+    ecoTaxTaxExcluded: '#product_pricing_retail_price_ecotax_tax_excluded',
   },
   create: {
     newProductButton: '.new-product-button',

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -132,6 +132,7 @@ export default {
       priceImpactTaxExcluded: '.combination-impact-on-price-tax-excluded',
       priceImpactTaxIncluded: '.combination-impact-on-price-tax-included',
       isDefault: '.combination-is-default-input',
+      ecoTax: '.combination-eco-tax',
       finalPrice: '.combination-final-price',
       finalPricePreview: '.text-preview',
       modifiedFieldClass: 'combination-value-changed',

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -182,14 +182,13 @@ final class GetEditableCombinationsListHandler implements GetEditableCombination
                 );
             }
 
-            $impactOnPrice = new DecimalNumber($combination['price']);
             $combinationsForEditing[] = new EditableCombinationForListing(
                 $combinationId,
                 $this->combinationNameBuilder->buildName($attributesInformationByCombinationId[$combinationId]),
                 $combination['reference'],
                 $attributesInformationByCombinationId[$combinationId],
                 (bool) $combination['default_on'],
-                $impactOnPrice,
+                new DecimalNumber($combination['price']),
                 (int) $combination['quantity'],
                 $imagePath,
                 new DecimalNumber($combination['ecotax'])

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -192,7 +192,7 @@ final class GetEditableCombinationsListHandler implements GetEditableCombination
                 $impactOnPrice,
                 (int) $combination['quantity'],
                 $imagePath,
-                (float) $combination['ecotax']
+                new DecimalNumber( $combination['ecotax'])
             );
         }
 

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -191,7 +191,8 @@ final class GetEditableCombinationsListHandler implements GetEditableCombination
                 (bool) $combination['default_on'],
                 $impactOnPrice,
                 (int) $combination['quantity'],
-                $imagePath
+                $imagePath,
+                (float) $combination['ecotax']
             );
         }
 

--- a/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetEditableCombinationsListHandler.php
@@ -192,7 +192,7 @@ final class GetEditableCombinationsListHandler implements GetEditableCombination
                 $impactOnPrice,
                 (int) $combination['quantity'],
                 $imagePath,
-                new DecimalNumber( $combination['ecotax'])
+                new DecimalNumber($combination['ecotax'])
             );
         }
 

--- a/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
@@ -77,7 +77,7 @@ class EditableCombinationForListing
     private $imageUrl;
 
     /**
-     * @var float
+     * @var DecimalNumber
      */
     private $ecoTax;
 
@@ -90,7 +90,7 @@ class EditableCombinationForListing
      * @param DecimalNumber $impactOnPrice
      * @param int $quantity
      * @param string $imageUrl
-     * @param float $ecoTax
+     * @param DecimalNumber $ecoTax
      */
     public function __construct(
         int $combinationId,
@@ -101,7 +101,7 @@ class EditableCombinationForListing
         DecimalNumber $impactOnPrice,
         int $quantity,
         string $imageUrl,
-        float $ecoTax
+        DecimalNumber $ecoTax
     ) {
         $this->combinationId = $combinationId;
         $this->attributesInformation = $attributesInformation;
@@ -179,9 +179,9 @@ class EditableCombinationForListing
     }
 
     /**
-     * @return float
+     * @return DecimalNumber
      */
-    public function getEcoTax(): float
+    public function getEcoTax(): DecimalNumber
     {
         return $this->ecoTax;
     }

--- a/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
+++ b/src/Core/Domain/Product/Combination/QueryResult/EditableCombinationForListing.php
@@ -77,6 +77,11 @@ class EditableCombinationForListing
     private $imageUrl;
 
     /**
+     * @var float
+     */
+    private $ecoTax;
+
+    /**
      * @param int $combinationId
      * @param string $combinationName
      * @param string $reference
@@ -85,6 +90,7 @@ class EditableCombinationForListing
      * @param DecimalNumber $impactOnPrice
      * @param int $quantity
      * @param string $imageUrl
+     * @param float $ecoTax
      */
     public function __construct(
         int $combinationId,
@@ -94,7 +100,8 @@ class EditableCombinationForListing
         bool $default,
         DecimalNumber $impactOnPrice,
         int $quantity,
-        string $imageUrl
+        string $imageUrl,
+        float $ecoTax
     ) {
         $this->combinationId = $combinationId;
         $this->attributesInformation = $attributesInformation;
@@ -104,6 +111,7 @@ class EditableCombinationForListing
         $this->impactOnPrice = $impactOnPrice;
         $this->quantity = $quantity;
         $this->imageUrl = $imageUrl;
+        $this->ecoTax = $ecoTax;
     }
 
     /**
@@ -168,5 +176,13 @@ class EditableCombinationForListing
     public function getImageUrl(): string
     {
         return $this->imageUrl;
+    }
+
+    /**
+     * @return float
+     */
+    public function getEcoTax(): float
+    {
+        return $this->ecoTax;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -569,7 +569,7 @@ class CombinationController extends FrameworkBundleAdminController
     /**
      * @param CombinationListForEditing $combinationListForEditing
      *
-     * @return array<string, array<int, array<string,bool|int|string>>|int>
+     * @return array<string, array<int, array<string,bool|int|string|float>>|int>
      */
     private function formatListForPresentation(CombinationListForEditing $combinationListForEditing): array
     {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -589,7 +589,7 @@ class CombinationController extends FrameworkBundleAdminController
                 'quantity' => $combination->getQuantity(),
                 'is_default' => $combination->isDefault(),
                 'image_url' => $combination->getImageUrl() ?: $fallbackImageUrl,
-                'eco_tax' => $combination->getEcoTax(),
+                'eco_tax' => (string) $combination->getEcoTax(),
             ];
         }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -589,6 +589,7 @@ class CombinationController extends FrameworkBundleAdminController
                 'quantity' => $combination->getQuantity(),
                 'is_default' => $combination->isDefault(),
                 'image_url' => $combination->getImageUrl() ?: $fallbackImageUrl,
+                'eco_tax' => $combination->getEcoTax(),
             ];
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationItemType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationItemType.php
@@ -37,6 +37,7 @@ use PrestaShopBundle\Form\Admin\Type\ImagePreviewType;
 use PrestaShopBundle\Form\Admin\Type\TextPreviewType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\RadioType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -126,6 +127,11 @@ class CombinationItemType extends TranslatorAwareType
                 ],
                 'label' => $this->trans('Impact on price (tax incl.)', 'Admin.Catalog.Feature'),
                 'currency' => $this->defaultCurrency->iso_code,
+            ])
+            ->add('eco_tax', HiddenType::class, [
+                'attr' => [
+                    'class' => 'combination-eco-tax',
+                ],
             ])
             ->add('final_price_te', TextPreviewType::class, [
                 'attr' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x
| Description?      | Added logic where eco tax is added to combinations total price ![image](https://user-images.githubusercontent.com/51944825/187414966-25638b70-f4cd-4243-a5a0-2c5285508e04.png)
| Type?             | improvement 
| Category?         |  BO 
| BC breaks?        | no
| Fixed ticket?     | Fixes #29330
| How to test?      | When eco tax is added, it should be added on combination total price in admin product page


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
