### PR TITLE
Module translations no longer take translations from another lang if its default one.

### DIFF
--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -271,11 +271,7 @@ class AdminTranslationsControllerCore extends AdminController
         if (!isset($_MODULE) && !isset($GLOBALS[$name_var])) {
             $GLOBALS[$name_var] = [];
         } elseif (isset($_MODULE)) {
-            if (is_array($GLOBALS[$name_var]) && is_array($_MODULE)) {
-                $GLOBALS[$name_var] = array_merge($GLOBALS[$name_var], $_MODULE);
-            } else {
-                $GLOBALS[$name_var] = $_MODULE;
-            }
+            $GLOBALS[$name_var] = $_MODULE;
         }
     }
 


### PR DESCRIPTION
… from default lang and not leave them empty

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x 
| Description?      | When translating module, if default lang is not English the other languages gets filled with default lang translations. For example if my module has FR translations but doesn't have LT translations and BO default lang is FR. When translating module for LT it will fill with FR translations when it should leave it empty. This PR fixes this issue.
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Translate module in one lang and in Bo user profile make language of the translated lang. Then when translating it for another lang it should no longer fill fields with another lang.
| Fixes issue | Resolves #30085 & resolves #27351

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
