### PR TITLE
BO - Modules - Bad display of the title after resizing the screen

### DIFF
--- a/admin-dev/themes/default/scss/partials/_toolbar.scss
+++ b/admin-dev/themes/default/scss/partials/_toolbar.scss
@@ -102,7 +102,7 @@
 
       .toolbar_btn {
         position: relative;
-        padding: 8px 16px;
+        padding: 8px 13px;
         overflow: hidden;
         font-size: 14px;
         font-weight: 600;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x 
| Description?      | With this pull request we change the .toolbar_btn padding from 16px to 13px. This change is not noticeable on large screens, but on small screens it is just enough for the buttons to be displayed correctly.
| Type?             | bug fix 
| Category?         |  BO 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26618
| How to test?      | GO to BO>Modules>Module manager then click in Configure ps_customtext module or other module like payments by check and then Resize the screen to 425x878


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

**Before**
![image](https://user-images.githubusercontent.com/100702024/187654816-d5e85bf5-4786-4224-86a5-3201714c8034.png)

**After**
![image](https://user-images.githubusercontent.com/100702024/187654728-a7234497-b510-441a-8384-32e5615455e3.png)

