### PR TITLE
Extract missing modules translations

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7244,16 +7244,16 @@
         },
         {
             "name": "prestashop/translationtools-bundle",
-            "version": "v5.0.3",
+            "version": "v5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/TranslationToolsBundle.git",
-                "reference": "d7ad81008913ec1d988acdbb1a342e19f569e74d"
+                "reference": "4aaef89ee0b4913157a76559bed52f4f35b2fb70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/TranslationToolsBundle/zipball/d7ad81008913ec1d988acdbb1a342e19f569e74d",
-                "reference": "d7ad81008913ec1d988acdbb1a342e19f569e74d",
+                "url": "https://api.github.com/repos/PrestaShop/TranslationToolsBundle/zipball/4aaef89ee0b4913157a76559bed52f4f35b2fb70",
+                "reference": "4aaef89ee0b4913157a76559bed52f4f35b2fb70",
                 "shasum": ""
             },
             "require": {
@@ -7300,9 +7300,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PrestaShop/TranslationToolsBundle/issues",
-                "source": "https://github.com/PrestaShop/TranslationToolsBundle/tree/v5.0.3"
+                "source": "https://github.com/PrestaShop/TranslationToolsBundle/tree/v5.0.4"
             },
-            "time": "2022-03-16T07:57:53+00:00"
+            "time": "2022-09-01T08:33:26+00:00"
         },
         {
             "name": "psr/cache",

--- a/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
+++ b/src/Core/Translation/Storage/Provider/ModuleCatalogueLayersProvider.php
@@ -157,12 +157,19 @@ class ModuleCatalogueLayersProvider implements CatalogueLayersProviderInterface
         // For non native modules, the catalogue is built from templates
 
         // First we search in translation directory in case the module is native
-        // If no translation file is found, we extract the catalogue from the module's templates
-
         try {
             $defaultCatalogue = $this->getDefaultCatalogueFinder()->getCatalogue($locale);
         } catch (TranslationFilesNotFoundException $e) {
-            $defaultCatalogue = $this->getDefaultCatalogueExtractedFromTemplates($locale);
+            $defaultCatalogue = new MessageCatalogue($locale);
+        }
+
+        // Then we extract the catalogue from the module's templates and add it to the initial default catalogue, this way
+        // even native modules will display wordings that may not be present in the XLF files
+        $extractedCatalogue = $this->getDefaultCatalogueExtractedFromTemplates($locale);
+
+        // We merge both catalogues
+        foreach ($extractedCatalogue->getDomains() as $domain) {
+            $defaultCatalogue->add($extractedCatalogue->all($domain), $domain);
         }
 
         return $defaultCatalogue;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When displaying the modules translations we combine the XLF default ones with the extracted ones from templates We do this even for native modules so that wordings present in templates but absent from the XLK catalog are still visible. Also this required updating the dependency from the TranslationToolsBundle because it had a bug in the extractor see this PR https://github.com/PrestaShop/TranslationToolsBundle/pull/107
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28418
| Related PRs       | Fix in bundle https://github.com/PrestaShop/TranslationToolsBundle/pull/107
| How to test?      | See below for more details
| Possible impacts? | Check that module's translation interface still works well and does not miss any wordings.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


### How to test

#### Step 1

First test with the 8.0.x branch and install [this module](https://github.com/PrestaShop/PrestaShop/files/9463723/ps_linklist.zip) on your shop, it is a modification from the original `ps_linklist` native module that includes three new wordings:
- `New super link block` (domain `Modules.Linklist.Admin`)
- `My link grid` (domain `Modules.Linklist.Admin`)
- `My link block` (domain `Modules.Linklist.Shop`)

Then try to edit the module's translation (see the following video to do so):


https://user-images.githubusercontent.com/13801017/187744581-f2a3d370-1115-49eb-99e7-c397f995be64.mp4



With the 8.0.x branch, you should see none of those new wordings:

![Capture d’écran 2022-08-31 à 19 47 23](https://user-images.githubusercontent.com/13801017/187745348-eeddebaf-12be-4793-a07a-68200ba7f0fe.png)

#### Step 2

Now switch to this PR's branch but don't run `composer install` yet (you may need to remove Symfony cache though)
Try to edit the wordings again, you should now see one new wording for Shop and one new wording for Admin. `My link grid` is missing:

![Capture d’écran 2022-08-31 à 19 45 48](https://user-images.githubusercontent.com/13801017/187745017-d601360b-2751-40b7-b183-e1ca6ca45feb.png)

This validates the fix in the Core code from this PR, new wordings are now extracted all the time even if they are not in the XLF catalogue. But one wording is still missing, this is fixed in the bundle, now proceed to step 3.

#### Step 3

Run `composer install` to get the update from the translation bundle and edit the wordings again, you should now see correctly the three new wordings. This validates the fix in the bundle from this PR https://github.com/PrestaShop/TranslationToolsBundle/pull/107

![Capture d’écran 2022-08-31 à 19 25 01](https://user-images.githubusercontent.com/13801017/187741189-52bd9fcb-5ef1-439b-ad6c-6a1c64ef152b.png)
