### PR TITLE
Add entity param to displayOverrideTemplate hook

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1357,6 +1357,7 @@ class FrontControllerCore extends Controller
             [
                 'controller' => $this,
                 'template_file' => $template,
+                'entity' => $params['entity'],
                 'id' => $params['id'],
                 'locale' => $locale,
             ]


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add `entity`  parameter to hook `displayOverrideTemplate` execution.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below

## How to test?

Before, the hook `displayOverrideTemplate ` had the following parameters:
- 'controller'
- 'template_file',
- 'id',
- 'locale'

After adding this PR, the hook `displayOverrideTemplate ` will have the following parameters:
- 'controller'
- 'template_file',
- 'entity'
- 'id',
- 'locale'

Use a module that uses `displayOverrideTemplate` hook and check the above given params are correct. Module https://github.com/PrestaShop/ps_qualityassurance can be useful


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
