### PR TITLE
Do not add theme translation resources if theme is null

### DIFF
--- a/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
+++ b/src/PrestaShopBundle/Translation/TranslatorLanguageLoader.php
@@ -104,7 +104,6 @@ class TranslatorLanguageLoader
         }
 
         // Load the theme translations catalogue
-        $domains = [];
         foreach ($this->getTranslationResourcesDirectories($theme) as $type => $directory) {
             $finder = Finder::create()
                 ->files()
@@ -116,19 +115,15 @@ class TranslatorLanguageLoader
                 list($domain, $locale, $format) = explode('.', $file->getBasename(), 3);
                 $translator->addResource($format, $file, $locale, $domain);
                 if ($withDB) {
-                    $domains[] = $domain;
                     if ($type !== 'theme') {
                         // Load core user-translated wordings
                         $translator->addResource('db', $domain . '.' . $locale . '.db', $locale, $domain);
                     }
+                    if (!$this->isAdminContext && $theme !== null) {
+                        // Load theme user-translated wordings for core + theme wordings
+                        $translator->addResource('db.theme', $domain . '.' . $locale . '.db', $locale, $domain);
+                    }
                 }
-            }
-        }
-
-        // Load theme user-translated wordings for core + theme wordings
-        if (!$this->isAdminContext) {
-            foreach ($domains as $domain) {
-                $translator->addResource('db.theme', $domain . '.' . $locale . '.db', $locale, $domain);
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | This PR aims to not load db.theme resources files if the loader associated is not loaded
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29501
| Related PRs       | 
| How to test?      | Please see #29501 (**debug mode should be disabled**)
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
