### PR TITLE
Fix prefilling non-default lang product name

### DIFF
--- a/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductBasicInformationHandler.php
@@ -110,7 +110,7 @@ class UpdateProductBasicInformationHandler implements UpdateProductBasicInformat
             // Go through all the product languages and make sure name is filled for each of them
             $productLanguages = array_keys($product->name);
             foreach ($productLanguages as $languageId) {
-                if (empty($product->name[$languageId]) && empty($localizedNames[$languageId])) {
+                if (empty($localizedNames[$languageId])) {
                     $localizedNames[$languageId] = $defaultName;
                 }
             }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
@@ -106,6 +106,13 @@ Feature: Update product basic information from Back Office (BO)
       | locale | value        |
       | en-US  | english name |
       | fr-FR  | english name |
+    When I update product "empty_product" basic information with following values:
+      | name[en-US] | english name |
+      | name[fr-FR] |              |
+    Then product "empty_product" localized "name" should be:
+      | locale | value        |
+      | en-US  | english name |
+      | fr-FR  | english name |
 
   Scenario: When product name is updated, empty friendly-urls are auto-filled
     Given language "fr" with locale "fr-FR" exists


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | refer to https://github.com/PrestaShop/PrestaShop/issues/28530. Now when it should be impossible to have empty product name in any language (its prefilled with default language name)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Closes https://github.com/PrestaShop/PrestaShop/issues/28530
| Related PRs       | 
| How to test?      | refer to https://github.com/PrestaShop/PrestaShop/issues/28530 (NOTE - the bug only occured when only the non-default name value was emptied, but default name was not changed in same request)
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
