### PR TITLE
Fix module upgrade button menu

### DIFF
--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -360,7 +360,7 @@ export default class ModuleCard {
     callback = () => true,
   ): boolean {
     const self = this;
-    const jqElementObj = element.closest(this.moduleItemActionsSelector);
+    let jqElementObj = element.closest(this.moduleItemActionsSelector);
     const form = element.closest('form');
     const spinnerObj = $(
       '<button class="btn-primary-reverse onclick unbind spinner "></button>',
@@ -450,7 +450,11 @@ export default class ModuleCard {
           BOEvent.emitEvent('Module Installed', 'CustomEvent', mainElement);
         };
 
-        jqElementObj.replaceWith(result[moduleTechName].action_menu_html);
+        // Since we replace the DOM content
+        // we need to update the jquery object reference to target the new content,
+        // and we need to hide the new content which is not hidden by default
+        jqElementObj = $(result[moduleTechName].action_menu_html).replaceAll(jqElementObj);
+        jqElementObj.hide();
       })
       .fail(() => {
         const moduleItem = jqElementObj.closest('module-item-list');

--- a/src/Adapter/Presenter/Module/ModulePresenter.php
+++ b/src/Adapter/Presenter/Module/ModulePresenter.php
@@ -109,11 +109,12 @@ class ModulePresenter implements PresenterInterface
      */
     public function presentCollection($modules)
     {
-        $presentedProducts = [];
-        foreach ($modules as $name => $product) {
-            $presentedProducts[$name] = $this->present($product);
+        $presentedModules = [];
+
+        foreach ($modules as $name => $module) {
+            $presentedModules[$name] = $this->present($module);
         }
 
-        return $presentedProducts;
+        return $presentedModules;
     }
 }

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -71,6 +71,9 @@ class ModuleRepository implements ModuleRepositoryInterface
     /** @var array|null */
     private $installedModules;
 
+    /** @var Module[] */
+    private $modulesFromHook;
+
     public function __construct(
         ModuleDataProvider $moduleDataProvider,
         AdminModuleDataProvider $adminModuleDataProvider,
@@ -103,7 +106,7 @@ class ModuleRepository implements ModuleRepositoryInterface
             $modules[] = $this->getModule($moduleName);
         }
 
-        return ModuleCollection::createFrom($this->mergeWithModulesFromHook($modules));
+        return ModuleCollection::createFrom($this->addModulesFromHook($modules));
     }
 
     public function getInstalledModules(): ModuleCollection
@@ -146,7 +149,7 @@ class ModuleRepository implements ModuleRepositoryInterface
             /** @var Module $module */
             $module = $this->cacheProvider->fetch($cacheKey);
             if ($module->getDiskAttributes()->get('filemtime') === $filemtime) {
-                return $module;
+                return $this->enrichModuleAttributesFromHook($module);
             }
         }
 
@@ -159,9 +162,10 @@ class ModuleRepository implements ModuleRepositoryInterface
         $disk = $this->getModuleDiskAttributes($moduleName, $isValid, $filemtime);
         $database = $this->getModuleDatabaseAttributes($moduleName);
 
-        $this->cacheProvider->save($cacheKey, new Module($attributes, $disk, $database));
+        $coreModule = new Module($attributes, $disk, $database);
+        $this->cacheProvider->save($cacheKey, $coreModule);
 
-        return $this->cacheProvider->fetch($cacheKey);
+        return $this->enrichModuleAttributesFromHook($coreModule);
     }
 
     public function getModulePath(string $moduleName): ?string
@@ -271,23 +275,32 @@ class ModuleRepository implements ModuleRepositoryInterface
     }
 
     /**
+     * @return array
+     */
+    private function getModulesFromHook()
+    {
+        if ($this->modulesFromHook === null) {
+            $modulesFromHook = $this->hookManager->exec('actionListModules', [], null, true);
+            $modulesFromHook = array_values($modulesFromHook ?? []);
+            $this->modulesFromHook = empty($modulesFromHook) ? $modulesFromHook : array_merge(...$modulesFromHook);
+        }
+
+        return $this->modulesFromHook;
+    }
+
+    /**
      * @param Module[] $modules
      *
      * @return Module[]
      */
-    private function mergeWithModulesFromHook(array $modules): array
+    protected function addModulesFromHook(array $modules): array
     {
-        $actionListModules = $this->hookManager->exec('actionListModules', [], null, true);
-        $externalModules = array_values($actionListModules ?? []);
-        if (empty(reset($externalModules))) {
-            return $modules;
-        }
+        $externalModules = $this->getModulesFromHook();
 
-        foreach (array_merge(...$externalModules) as $externalModule) {
+        foreach ($externalModules as $externalModule) {
             $merged = false;
             foreach ($modules as $module) {
                 if ($module->get('name') === $externalModule['name']) {
-                    $module->getAttributes()->add($externalModule);
                     $merged = true;
                     break;
                 }
@@ -298,5 +311,22 @@ class ModuleRepository implements ModuleRepositoryInterface
         }
 
         return $modules;
+    }
+
+    /**
+     * @param Module $module
+     *
+     * @return Module
+     */
+    protected function enrichModuleAttributesFromHook(Module $module): ModuleInterface
+    {
+        $modulesFromHook = $this->getModulesFromHook();
+        foreach ($modulesFromHook as $moduleFromHook) {
+            if ($module->get('name') === $moduleFromHook['name']) {
+                $module->getAttributes()->add($moduleFromHook);
+            }
+        }
+
+        return $module;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -248,11 +248,15 @@ class ModuleController extends ModuleAbstractController
             }
 
             $collection = ModuleCollection::createFrom([$moduleInstance]);
+            $collectionWithActionUrls = $modulesProvider->setActionUrls($collection);
+
+            $modulePresenter = $this->get('prestashop.adapter.presenter.module');
+            $collectionPresented = $modulePresenter->presentCollection($collectionWithActionUrls);
+
             $response[$module]['action_menu_html'] = $this->container->get('twig')->render(
                 '@PrestaShop/Admin/Module/Includes/action_menu.html.twig',
                 [
-                    'module' => $this->container->get('prestashop.adapter.presenter.module')
-                        ->presentCollection($modulesProvider->setActionUrls($collection))[0],
+                    'module' => $collectionPresented[0],
                     'level' => $this->authorizationLevel(self::CONTROLLER_NAME),
                 ]
             );

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/UpdatesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/UpdatesController.php
@@ -41,11 +41,18 @@ class UpdatesController extends ModuleAbstractController
      */
     public function indexAction()
     {
-        $moduleRepository = $this->getModuleRepository();
+        $moduleList = $this->getModuleRepository()->getUpgradableModules();
+        $pageData = $this->getNotificationPageData($moduleList);
 
-        return $this->render(
-            '@PrestaShop/Admin/Module/updates.html.twig',
-            $this->getNotificationPageData($moduleRepository->getUpgradableModules())
-        );
+        // In update view, the only available action for module is update.
+        // Can't use AdminModuleDataProvider::setActionUrls $specific_action attribute while abstract definition isn't clear.
+        foreach ($pageData['modules'] as $key => $module) {
+            if (isset($module['attributes']['urls']['upgrade'])) {
+                $pageData['modules'][$key]['attributes']['urls'] = ['upgrade' => $module['attributes']['urls']['upgrade']];
+                $pageData['modules'][$key]['attributes']['url_active'] = 'upgrade';
+            }
+        }
+
+        return $this->render('@PrestaShop/Admin/Module/updates.html.twig', $pageData);
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | In "update notifications" view, action buttons don't update properly after some actions. As discussed in #28612, I removed button menu for update action under update menu. 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28433.
| Related PRs       | #28612
| How to test?      | Cf. #28433. :point_up: Please notice that to reproduce / test the bug you need to have modules that require to be updated so you may have to downgrade manually a module (in module folder and in db).  
| Possible impacts? | All actions menu in module manager and any code that depends on `ModuleRepository::getModule(...)`

As mentioned in #28433 , after upgrading or uninstalling a module, the module is not removed from update list without a page refresh (F5). I fixed this problem with some js refactoring (`refreshNeeded` part)

Then the main problem was linked to [ModuleController](https://github.com/PrestaShop/PrestaShop/blob/ed982dc0966bd5e9c1e902685bef075191b14c9e/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php#L251) that recreate action menu dynamically. But it uses directly ``ModuleRepository::getModule()`` method that does not apply 'actionListModules' hook for Module description (I suspect it is linked to autoupgrade module).
