### PR TITLE
Fix tag relation with product in Tag form

### DIFF
--- a/classes/Tag.php
+++ b/classes/Tag.php
@@ -348,8 +348,8 @@ class TagCore extends ObjectModel
             WHERE id_product=' . (int) $idProduct
         ;
         if ($langId) {
-            $removeWhere .= ' AND id_lang =' . (int) $langId;
-            $selectTagsToRemove .= ' AND id_lang =' . (int) $langId;
+            $removeWhere .= ' AND id_lang =' . $langId;
+            $selectTagsToRemove .= ' AND id_lang =' . $langId;
         }
 
         $tagsRemoved = Db::getInstance()->executeS($selectTagsToRemove);

--- a/classes/Tag.php
+++ b/classes/Tag.php
@@ -258,15 +258,18 @@ class TagCore extends ObjectModel
         }
 
         $in = $associated ? 'IN' : 'NOT IN';
+        // select not only active products when we are getting list of already associated products
+        // to avoid confusion when product is disabled, but still has the tag assigned
+        $onlyActive = $associated ? '' : 'AND product_shop.active = 1';
 
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
         SELECT pl.name, pl.id_product
         FROM `' . _DB_PREFIX_ . 'product` p
         LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON p.id_product = pl.id_product' . Shop::addSqlRestrictionOnLang('pl') . '
         ' . Shop::addSqlAssociation('product', 'p') . '
-        WHERE pl.id_lang = ' . (int) $idLang . '
-        AND product_shop.active = 1
-        ' . ($this->id ? ('AND p.id_product ' . $in . ' (SELECT pt.id_product FROM `' . _DB_PREFIX_ . 'product_tag` pt WHERE pt.id_tag = ' . (int) $this->id . ')') : '') . '
+        WHERE pl.id_lang = ' . (int) $idLang .
+        ' ' . $onlyActive . ' ' .
+        ($this->id ? ('AND p.id_product ' . $in . ' (SELECT pt.id_product FROM `' . _DB_PREFIX_ . 'product_tag` pt WHERE pt.id_tag = ' . (int) $this->id . ')') : '') . '
         ORDER BY pl.name');
     }
 

--- a/src/Adapter/Product/Update/ProductTagUpdater.php
+++ b/src/Adapter/Product/Update/ProductTagUpdater.php
@@ -124,7 +124,7 @@ class ProductTagUpdater
         }
 
         foreach ($localizedTagsList as $localizedTags) {
-            if (empty($localizedProductTags[$localizedTags->getLanguageId()->getValue()])) {
+            if (empty($localizedProductTags[$localizedTags->getLanguageId()->getValue()]) && !empty($localizedTags->getTags())) {
                 return true;
             }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | refer to https://github.com/PrestaShop/PrestaShop/issues/28296 And #28295.It used to collect only active products for shop in Tags form, so if product was disabled and had a tag, then after saving tag form the relation was gone. Now the product is shown in form even if its disabled, that way the form works as expected and relation is not deleted during edit.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Resolves https://github.com/PrestaShop/PrestaShop/issues/28296 Resolves #28295
| Related PRs       | 
| How to test?      | refer to https://github.com/PrestaShop/PrestaShop/issues/28296 and #28295
| Possible impacts? |  Im not 100% sure what was the intention to not show disabled products, but I still left the same logic for the left side of the product-tag relation table in Tag edit form, just changed some logic for the right side. So if the product is disabled, but its not related to the editable tag, then it still shouldn't be shown in right table side as before, however if it is related and disabled, it now should be shown in the right side of the relation table (previously it wasn't shown).


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
