### PR TITLE
Add contact page hooks

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -56,6 +56,11 @@
       <title>Right column blocks</title>
       <description>This hook displays new elements in the right-hand column</description>
     </hook>
+    <hook id="displayContactRightColumn">
+      <name>displayContactRightColumn</name>
+      <title>Right column blocks of the contact page</title>
+      <description>This hook displays new elements in the right-hand column of the contact page</description>
+    </hook>
     <hook id="displayWrapperTop">
       <name>displayWrapperTop</name>
       <title>Main wrapper section (top)</title>
@@ -65,6 +70,11 @@
       <name>displayWrapperBottom</name>
       <title>Main wrapper section (bottom)</title>
       <description>This hook displays new elements in the bottom of the main wrapper</description>
+    </hook>
+    <hook id="dipslayContactContent">
+      <name>dipslayContactContent</name>
+      <title>Content wrapper section of the contact page</title>
+      <description>This hook displays new elements in the content wrapper of the contact page</description>
     </hook>
     <hook id="displayContentWrapperTop">
       <name>displayContentWrapperTop</name>
@@ -80,6 +90,11 @@
       <name>displayLeftColumn</name>
       <title>Left column blocks</title>
       <description>This hook displays new elements in the left-hand column</description>
+    </hook>
+    <hook id="displayContactLeftColumn">
+      <name>displayContactLeftColumn</name>
+      <title>Left column blocks on the contact page</title>
+      <description>This hook displays new elements in the left-hand column of the contact page</description>
     </hook>
     <hook id="displayHome">
       <name>displayHome</name>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We need to add some new hook for the contact page instead of using widgets
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29198.
| Related PRs       | https://github.com/PrestaShop/hummingbird/pull/366/ , https://github.com/PrestaShop/ps_contactinfo/pull/49/ , https://github.com/PrestaShop/classic-theme/pull/52
| How to test?      | Can be tested with every related PRs, the contact page should be working as expected
| Possible impacts? | Contact page


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
