### PR TITLE
Fix shipping cost on order details page

### DIFF
--- a/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderDetailLazyArray.php
@@ -229,7 +229,7 @@ class OrderDetailLazyArray extends AbstractLazyArray
                     ($shipping['weight'] > 0) ? sprintf('%.3f', $shipping['weight']) . ' ' .
                         Configuration::get('PS_WEIGHT_UNIT') : '-';
                 $shippingCost =
-                    (!$order->getTaxCalculationMethod()) ? $shipping['shipping_cost_tax_excl']
+                    ($order->getTaxCalculationMethod()) ? $shipping['shipping_cost_tax_excl']
                         : $shipping['shipping_cost_tax_incl'];
                 $orderShipping[$shippingId]['shipping_cost'] =
                     ($shippingCost > 0) ? $this->locale->formatPrice($shippingCost, (Currency::getIsoCodeById((int) $order->id_currency)))


### PR DESCRIPTION
Bug fix for order shipping cost displaying wrong price.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There are different shipping costs in the order history page (FO) when order is placed with tax. In the subtotal table is shipping cost correct with tax. But in the next table is cost without tax. This fix makes the costs the same.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19132.
| How to test?      | Verify that shipping cost is the same in both places on order details page
| Possible impacts? | Check dependance on customer group (prices with / without tax)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
