### PR TITLE
Change Legacy Hook with new Hook dispatche event: actionAdminProducts

### DIFF
--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -338,7 +338,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         $sqlWhere[] = 'state = ' . Product::STATE_SAVED;
 
         // exec legacy hook but with different parameters (retro-compat < 1.7 is broken here)
-        Hook::exec('actionAdminProductsListingFieldsModifier', [
+        $this->hookDispatcher->dispatchWithParameters('actionAdminProductsListingFieldsModifier', [
             '_ps_version' => AppKernel::VERSION,
             'sql_select' => &$sqlSelect,
             'sql_table' => &$sqlTable,

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -53,7 +53,6 @@ use Tools;
  */
 class AdminProductDataProvider extends AbstractAdminQueryBuilder implements ProductInterface
 {
-    protected HookDispatcherInterface $hookDispatcher;
     /**
      * @var EntityManager
      */

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -85,7 +85,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         $employee = Context::getContext()->employee;
         $employeeId = $employee->id ?: 0;
 
-        $cachedFilters = $this->cache->getItem("app.product_filters_${employeeId}");
+        $cachedFilters = $this->cache->getItem("app.product_filters_{$employeeId}");
 
         if (!$cachedFilters->isHit()) {
             $shop = Context::getContext()->shop;
@@ -165,11 +165,11 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
 
         $this->entityManager->flush();
 
-        //Flush cache
+        // Flush cache
         $employee = Context::getContext()->employee;
         $employeeId = $employee->id ?: 0;
 
-        $this->cache->deleteItem("app.product_filters_${employeeId}");
+        $this->cache->deleteItem("app.product_filters_{$employeeId}");
     }
 
     /**

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -37,6 +37,7 @@ use Hook;
 use PrestaShop\PrestaShop\Adapter\Admin\AbstractAdminQueryBuilder;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
 use PrestaShop\PrestaShop\Adapter\Validate;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShopBundle\Entity\AdminFilter;
 use PrestaShopBundle\Service\DataProvider\Admin\ProductInterface;
 use Product;
@@ -52,6 +53,7 @@ use Tools;
  */
 class AdminProductDataProvider extends AbstractAdminQueryBuilder implements ProductInterface
 {
+    protected HookDispatcherInterface $hookDispatcher;
     /**
      * @var EntityManager
      */
@@ -67,14 +69,21 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
      */
     private $cache;
 
+    /**
+     * @var HookDispatcherInterface
+     */
+    private $hookDispatcher;
+
     public function __construct(
         EntityManager $entityManager,
         ImageManager $imageManager,
-        CacheItemPoolInterface $cache
+        CacheItemPoolInterface $cache,
+        HookDispatcherInterface $hookDispatcher
     ) {
         $this->entityManager = $entityManager;
         $this->imageManager = $imageManager;
         $this->cache = $cache;
+        $this->hookDispatcher = $hookDispatcher;
     }
 
     /**
@@ -85,7 +94,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         $employee = Context::getContext()->employee;
         $employeeId = $employee->id ?: 0;
 
-        $cachedFilters = $this->cache->getItem("app.product_filters_{$employeeId}");
+        $cachedFilters = $this->cache->getItem("app.product_filters_${employeeId}");
 
         if (!$cachedFilters->isHit()) {
             $shop = Context::getContext()->shop;
@@ -256,7 +265,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
                 'table' => 'stock_available',
                 'join' => 'LEFT JOIN',
                 'on' => 'sav.`id_product` = p.`id_product` AND sav.`id_product_attribute` = 0' .
-                StockAvailable::addSqlShopRestriction(null, $idShop, 'sav'),
+                    StockAvailable::addSqlShopRestriction(null, $idShop, 'sav'),
             ],
             'sa' => [
                 'table' => 'product_shop',
@@ -466,3 +475,4 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         return (bool) Configuration::get('PS_PRODUCT_ACTIVATION_DEFAULT');
     }
 }
+


### PR DESCRIPTION
Upgrade from Legacy Hook::exec to new Hook dispatcher

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Upgrade from Legacy Hook::exec to new Hook dispatcher
| Type?             |  improvement 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fix 28680
| Related PRs       |
| How to test?      | BO > Product > List product
| Possible impacts? |

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->