### PR TITLE
Combination fields list updated for partial update in Product::updateAttribute

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2225,7 +2225,15 @@ class ProductCore extends ObjectModel
                 'unit_price_impact' => null !== $unit,
                 'default_on' => null !== $default,
                 'minimal_quantity' => null !== $minimal_quantity,
+                'reference' => null !== $reference,
+                'ean13' => null !== $ean13,
+                'upc' => null !== $upc,
+                'isbn' => null !== $isbn,
+                'mpn' => null !== $mpn,
                 'available_date' => null !== $available_date,
+                'low_stock_threshold' => null !== $low_stock_threshold,
+                'low_stock_alert' => null !== $low_stock_alert,
+                'id_shop_list' => !empty($id_shop_list),
             ]);
         }
 
@@ -2248,7 +2256,7 @@ class ProductCore extends ObjectModel
         $combination->low_stock_alert = !empty($low_stock_alert);
         $combination->available_date = $available_date ? pSQL($available_date) : '0000-00-00';
 
-        if (count($id_shop_list)) {
+        if (!empty($id_shop_list)) {
             $combination->id_shop_list = $id_shop_list;
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Since partial update was fixed in 8.0.x the combination form processing was missing some field updates because it didn't specify all the fields that may require some updates, this PR updates the list of potential updates in the `Product::updateAttribute` so that it is matching all the method parameters. Here are the fields that were forgotten:<br>- `reference`<br>- `ean13`<br>- `upc`<br>- `isbn`<br>- `mpn`<br>- `low_stock_threshold`<br>- `low_stock_alert`
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Closes #28981
| Related PRs       | ~
| How to test?      | Try and update the references related fields on a combination in product page v1 (ean13, mpn, ...) then refresh the whole page to make sure the data has correctly been saved in DB. I also noticed some other fields were ignored (see the detailed list in the PR description).
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
