### PR TITLE
Disable product type button when new changes are not saved

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
@@ -27,7 +27,7 @@ import _ from 'lodash';
 import ProductEventMap from '@pages/product/product-event-map';
 import {EventEmitter} from 'events';
 import ProductTypeSwitcher from '@pages/product/edit/product-type-switcher';
-import ProductMap from "@pages/product/product-map";
+import ProductMap from '@pages/product/product-map';
 
 const {$} = window;
 

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
@@ -26,6 +26,8 @@
 import _ from 'lodash';
 import ProductEventMap from '@pages/product/product-event-map';
 import {EventEmitter} from 'events';
+import ProductTypeSwitcher from '@pages/product/edit/product-type-switcher';
+import ProductMap from "@pages/product/product-map";
 
 const {$} = window;
 
@@ -55,6 +57,10 @@ export default class ProductPartialUpdater {
   private $productFormGoToCatalogButton: JQuery;
 
   private $productFormCancelButton: JQuery;
+
+  private $productTypeSwitcher: ProductTypeSwitcher;
+
+  private $productTypePreview: JQuery;
 
   private initialData: Record<string, any>;
 
@@ -88,6 +94,8 @@ export default class ProductPartialUpdater {
     this.$productFormNewProductButton = $productFormNewProductButton;
     this.$productFormGoToCatalogButton = $productFormGoToCatalogButton;
     this.$productFormCancelButton = $productFormCancelButton;
+    this.$productTypeSwitcher = new ProductTypeSwitcher($(ProductMap.productForm));
+    this.$productTypePreview = $(ProductMap.productType.headerPreviewButton);
     this.initialData = {};
 
     this.watch();
@@ -233,6 +241,8 @@ export default class ProductPartialUpdater {
       this.$productFormPreviewButton.addClass('disabled');
       this.$productFormDuplicateButton.addClass('disabled');
       this.$productFormNewProductButton.addClass('disabled');
+      this.$productTypePreview.off('click');
+      this.$productTypePreview.addClass('disabled');
     } else if (updatedData === null) {
       this.$productFormSubmitButton.prop('disabled', true);
       this.$productFormCancelButton.addClass('disabled');
@@ -240,6 +250,8 @@ export default class ProductPartialUpdater {
       this.$productFormPreviewButton.removeClass('disabled');
       this.$productFormDuplicateButton.removeClass('disabled');
       this.$productFormNewProductButton.removeClass('disabled');
+      this.$productTypeSwitcher.registerProductTypePreviewOnClickEvent();
+      this.$productTypePreview.removeClass('disabled');
     } else {
       this.$productFormSubmitButton.prop('disabled', false);
       this.$productFormCancelButton.removeClass('disabled');
@@ -247,6 +259,8 @@ export default class ProductPartialUpdater {
       this.$productFormPreviewButton.addClass('disabled');
       this.$productFormDuplicateButton.addClass('disabled');
       this.$productFormNewProductButton.addClass('disabled');
+      this.$productTypePreview.off('click');
+      this.$productTypePreview.addClass('disabled');
     }
   }
 
@@ -267,11 +281,7 @@ export default class ProductPartialUpdater {
     Object.keys(this.initialData).forEach((fieldName) => {
       const fieldValue = this.initialData[fieldName];
 
-      // Field is absent in the new data (it was not in the initial) we force it to empty string (not null
-      // or it will be ignored)
-      if (!Object.prototype.hasOwnProperty.call(currentData, fieldName)) {
-        currentData[fieldName] = '';
-      } else if (_.isEqual(currentData[fieldName], fieldValue)) {
+      if (_.isEqual(currentData[fieldName], fieldValue)) {
         delete currentData[fieldName];
       }
     });

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
@@ -250,7 +250,6 @@ export default class ProductPartialUpdater {
       this.$productFormPreviewButton.removeClass('disabled');
       this.$productFormDuplicateButton.removeClass('disabled');
       this.$productFormNewProductButton.removeClass('disabled');
-      this.$productTypeSwitcher.registerProductTypePreviewOnClickEvent();
       this.$productTypePreview.removeClass('disabled');
     } else {
       this.$productFormSubmitButton.prop('disabled', false);
@@ -281,7 +280,11 @@ export default class ProductPartialUpdater {
     Object.keys(this.initialData).forEach((fieldName) => {
       const fieldValue = this.initialData[fieldName];
 
-      if (_.isEqual(currentData[fieldName], fieldValue)) {
+      // Field is absent in the new data (it was not in the initial) we force it to empty string (not null
+      // or it will be ignored)
+      if (!Object.prototype.hasOwnProperty.call(currentData, fieldName)) {
+        currentData[fieldName] = '';
+      } else if (_.isEqual(currentData[fieldName], fieldValue)) {
         delete currentData[fieldName];
       }
     });

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
@@ -26,7 +26,6 @@
 import _ from 'lodash';
 import ProductEventMap from '@pages/product/product-event-map';
 import {EventEmitter} from 'events';
-import ProductTypeSwitcher from '@pages/product/edit/product-type-switcher';
 import ProductMap from '@pages/product/product-map';
 
 const {$} = window;
@@ -57,8 +56,6 @@ export default class ProductPartialUpdater {
   private $productFormGoToCatalogButton: JQuery;
 
   private $productFormCancelButton: JQuery;
-
-  private $productTypeSwitcher: ProductTypeSwitcher;
 
   private $productTypePreview: JQuery;
 
@@ -94,7 +91,6 @@ export default class ProductPartialUpdater {
     this.$productFormNewProductButton = $productFormNewProductButton;
     this.$productFormGoToCatalogButton = $productFormGoToCatalogButton;
     this.$productFormCancelButton = $productFormCancelButton;
-    this.$productTypeSwitcher = new ProductTypeSwitcher($(ProductMap.productForm));
     this.$productTypePreview = $(ProductMap.productType.headerPreviewButton);
     this.initialData = {};
 

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-type-switcher.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-type-switcher.ts
@@ -57,13 +57,6 @@ export default class ProductTypeSwitcher {
 
     this.productId = parseInt($productForm.data('productId'), 10);
     this.initialType = <string> this.$typeSelector.val();
-    this.registerProductTypePreviewOnClickEvent();
-  }
-
-  public registerProductTypePreviewOnClickEvent(): void {
-    // to avoid duplicated modal calls, we make sure that previews on click events are off.
-    this.$productTypePreview.off('click');
-    this.$productTypePreview.on('click', () => this.showSelectionModal());
   }
 
   private showSelectionModal() {

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-type-switcher.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-type-switcher.ts
@@ -59,6 +59,10 @@ export default class ProductTypeSwitcher {
     this.initialType = <string> this.$typeSelector.val();
 
     this.$productTypePreview.on('click', () => this.showSelectionModal());
+    $('input').on('change', () => {
+      this.$productTypePreview.off('click');
+      this.$productTypePreview.addClass('disabled');
+    });
   }
 
   private showSelectionModal() {

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-type-switcher.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-type-switcher.ts
@@ -57,6 +57,8 @@ export default class ProductTypeSwitcher {
 
     this.productId = parseInt($productForm.data('productId'), 10);
     this.initialType = <string> this.$typeSelector.val();
+
+    this.$productTypePreview.on('click', () => this.showSelectionModal());
   }
 
   private showSelectionModal() {

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-type-switcher.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-type-switcher.ts
@@ -57,12 +57,13 @@ export default class ProductTypeSwitcher {
 
     this.productId = parseInt($productForm.data('productId'), 10);
     this.initialType = <string> this.$typeSelector.val();
+    this.registerProductTypePreviewOnClickEvent();
+  }
 
+  public registerProductTypePreviewOnClickEvent(): void {
+    // to avoid duplicated modal calls, we make sure that previews on click events are off.
+    this.$productTypePreview.off('click');
     this.$productTypePreview.on('click', () => this.showSelectionModal());
-    $('input').on('change', () => {
-      this.$productTypePreview.off('click');
-      this.$productTypePreview.addClass('disabled');
-    });
   }
 
   private showSelectionModal() {

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -189,11 +189,11 @@ $product-page-padding-bottom: 80px !default;
       }
 
       .product-type-preview.disabled {
-        color: #6c868e;
+        color: $gray-500;
         cursor: not-allowed;
 
         &:hover {
-          color: #6c868e;
+          color: $gray-500;
         }
       }
     }

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -187,6 +187,15 @@ $product-page-padding-bottom: 80px !default;
           color: $primary;
         }
       }
+
+      .product-type-preview.disabled {
+        color: #6c868e;
+        cursor: not-allowed;
+
+        &:hover {
+          color: #6c868e;
+        }
+      }
     }
 
     .product-header-details {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | In admin product page the product type button is disabled if any inputs where changed.
| Type?             |  improvement 
| Category?         | BO 
| BC breaks?        | no
| Fixed ticket?     | Fixes #28738
| How to test?      | Change any input in product page and the product type button should be disabled.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
