### PR TITLE
fix (BO): replace exception message by custom message on invalid avatar extension

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -46,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\EmployeeFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -476,6 +477,10 @@ class EmployeeController extends FrameworkBundleAdminController
     protected function getErrorMessages(Exception $e)
     {
         return [
+            UploadedImageConstraintException::class => $this->trans(
+                'The file extension for the avatar is not supported. Valid ones are: gif, jpg, jpeg, jpe, png, webp.',
+                'Admin.Notifications.Error'
+            ),
             InvalidEmployeeIdException::class => $this->trans(
                 'The object cannot be loaded (the identifier is missing or invalid)',
                 'Admin.Notifications.Error'


### PR DESCRIPTION
…ar extension

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x
| Description?      | replace exception message by custom message on invalid avatar extension.
| Type?             | bug fix
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28985
| Related PRs       | 
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/28985
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
