### PR TITLE
Fix broken icon-font on RTL after upgrade

### DIFF
--- a/admin-dev/themes/default/webpack.config.js
+++ b/admin-dev/themes/default/webpack.config.js
@@ -117,7 +117,7 @@ module.exports = (env, argv) => {
         extensions: ['woff2'],
         filter: /preload/,
         // eslint-disable-next-line
-        replaceCallback: ({indexSource, linksAsString}) => indexSource.replace('{{{preloadLinks}}}', linksAsString.replace(/href="auto/g, 'href="{"`$admin_dir`"}')),
+        replaceCallback: ({indexSource, linksAsString}) => indexSource.replace('{{{preloadLinks}}}', linksAsString.replace(/href="/g, 'href="{$admin_dir}')),
       }),
       new CssoWebpackPlugin({
         forceMediaMerge: true,

--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -406,7 +406,7 @@ module.exports = {
       extensions: ['woff2'],
       filter: /preload/,
       // eslint-disable-next-line
-      replaceCallback: ({indexSource, linksAsString}) => indexSource.replace('{{{preloadLinks}}}', linksAsString.replace(/href="auto/g, 'href="{"`$admin_dir`"}')),
+      replaceCallback: ({indexSource, linksAsString}) => indexSource.replace('{{{preloadLinks}}}', linksAsString.replace(/href="/g, 'href="{$admin_dir}')),
     }),
     new CssoWebpackPlugin({
       forceMediaMerge: true,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | after upgrade to 8.0.0, icon fonts were not properly preloaded in RTL mode
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29398
| Related PRs       |
| How to test?      | create a PrestaShop 8.0.0 release from this PR and follow the steps in issue #29398
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
