### PR TITLE
BO add min height on alert css class to encapsulate icon co…

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_alert.scss
+++ b/admin-dev/themes/new-theme/scss/components/_alert.scss
@@ -2,4 +2,5 @@
   > a {
     padding: 0;
   }
+  min-height: 55px;
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x 
| Description?    |  Add. min height on css alert class to encapsulate eventually icons correctly
| Type?             | bug fix 
| Category?         |BO
| BC breaks?        |  no
| Deprecations?     |no
| Fixed ticket?     | Fixes #28990
| Related PRs       | 
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/28990
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
