### PR TITLE
Fix php 8.1 Filemanager

### DIFF
--- a/admin-dev/filemanager/dialog.php
+++ b/admin-dev/filemanager/dialog.php
@@ -424,12 +424,12 @@ if (isset($_POST['submit'])) {
 
     function filenameSort($x, $y)
     {
-        return $x['file'] < $y['file'];
+        return $x['file'] <=> $y['file'];
     }
 
     function dateSort($x, $y)
     {
-        return $x['date'] < $y['date'];
+        return $x['date'] <=> $y['date'];
     }
 
     function sizeSort($x, $y)
@@ -439,7 +439,7 @@ if (isset($_POST['submit'])) {
 
     function extensionSort($x, $y)
     {
-        return $x['extension'] < $y['extension'];
+        return $x['extension'] <=> $y['extension'];
     }
 
     switch ($sort_by) {


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fixes usort usage that no longer accept boolean return values.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #29543 .
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | See the issue, plus test all sorting options as they have the same issue.
