### PR TITLE
Add a column id_shop in product_sale

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -560,7 +560,7 @@ abstract class PaymentModuleCore extends Module
 
             foreach ($this->context->cart->getProducts() as $product) {
                 if ($order_status->logable) {
-                    ProductSale::addProductSale((int) $product['id_product'], (int) $product['cart_quantity']);
+                    ProductSale::addProductSale((int) $product['id_product'], $this->context->shop->id, (int) $product['cart_quantity']);
                 }
             }
 

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -560,7 +560,7 @@ abstract class PaymentModuleCore extends Module
 
             foreach ($this->context->cart->getProducts() as $product) {
                 if ($order_status->logable) {
-                    ProductSale::addProductSale((int) $product['id_product'], $this->context->shop->id, (int) $product['cart_quantity']);
+                    ProductSale::addProductSale((int) $product['id_product'], (int) $product['cart_quantity'], $order->id_shop);
                 }
             }
 

--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -241,6 +241,7 @@ class ProductSaleCore
     public static function addProductSale($productId, $qty = 1)
     {
         $idShop = Context::getContext()->shop->id;
+
         return Db::getInstance()->execute('
 			INSERT INTO ' . _DB_PREFIX_ . 'product_sale
 			(`id_product`, `id_shop`, `quantity`, `sale_nbr`, `date_upd`)
@@ -286,7 +287,7 @@ class ProductSaleCore
 				WHERE `id_product` = ' . (int) $idProduct . ' and `id_shop` = ' . (int) $idShop
             );
         } elseif ($totalSales == 1) {
-            return Db::getInstance()->delete('product_sale', 'id_product = ' . (int) $idProduct) . ' and `id_shop` = ' . (int) $idShop;
+            return Db::getInstance()->delete('product_sale', 'id_product = ' . (int) $idProduct . ' and `id_shop` = ' . (int) $idShop);
         }
 
         return true;

--- a/classes/ProductSale.php
+++ b/classes/ProductSale.php
@@ -234,14 +234,13 @@ class ProductSaleCore
      * Add Product sale.
      *
      * @param int $productId Product ID
+     * @param int $idShop Shop ID
      * @param int $qty Quantity
      *
      * @return bool Indicates whether the sale was successfully added
      */
-    public static function addProductSale($productId, $qty = 1)
+    public static function addProductSale($productId, $idShop, $qty = 1)
     {
-        $idShop = Context::getContext()->shop->id;
-
         return Db::getInstance()->execute('
 			INSERT INTO ' . _DB_PREFIX_ . 'product_sale
 			(`id_product`, `id_shop`, `quantity`, `sale_nbr`, `date_upd`)
@@ -253,12 +252,12 @@ class ProductSaleCore
      * Get number of sales.
      *
      * @param int $idProduct Product ID
+     * @param int $idShop Shop ID
      *
      * @return int Number of sales for the given Product
      */
-    public static function getNbrSales($idProduct)
+    public static function getNbrSales($idProduct, $idShop)
     {
-        $idShop = Context::getContext()->shop->id;
         $result = Db::getInstance()->getRow('SELECT `sale_nbr` FROM ' . _DB_PREFIX_ . 'product_sale WHERE `id_product` = ' . (int) $idProduct . ' and `id_shop` = ' . (int) $idShop);
         if (empty($result) || !array_key_exists('sale_nbr', $result)) {
             return -1;
@@ -271,14 +270,14 @@ class ProductSaleCore
      * Remove a Product sale.
      *
      * @param int $idProduct Product ID
+     * @param int $idShop Shop ID
      * @param int $qty Quantity
      *
      * @return bool Indicates whether the product sale has been successfully removed
      */
-    public static function removeProductSale($idProduct, $qty = 1)
+    public static function removeProductSale($idProduct, $idShop, $qty = 1)
     {
-        $idShop = Context::getContext()->shop->id;
-        $totalSales = ProductSale::getNbrSales($idProduct);
+        $totalSales = ProductSale::getNbrSales($idProduct, $idShop);
         if ($totalSales > 1) {
             return Db::getInstance()->execute(
                 '

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -221,7 +221,7 @@ class OrderHistoryCore extends ObjectModel
                 if (Validate::isLoadedObject($old_os)) {
                     // if becoming logable => adds sale
                     if ($new_os->logable && !$old_os->logable) {
-                        ProductSale::addProductSale($product['product_id'], (int) $order->id_shop, $product['product_quantity']);
+                        ProductSale::addProductSale($product['product_id'], $product['product_quantity'], (int) $order->id_shop);
                         // @since 1.5.0 - Stock Management
                         if (!Pack::isPack($product['product_id']) &&
                             in_array($old_os->id, $error_or_canceled_statuses) &&
@@ -230,7 +230,7 @@ class OrderHistoryCore extends ObjectModel
                         }
                     } elseif (!$new_os->logable && $old_os->logable) {
                         // if becoming unlogable => removes sale
-                        ProductSale::removeProductSale($product['product_id'], (int) $order->id_shop, $product['product_quantity']);
+                        ProductSale::removeProductSale($product['product_id'], $product['product_quantity'], (int) $order->id_shop);
 
                         // @since 1.5.0 - Stock Management
                         if (!Pack::isPack($product['product_id']) &&

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -221,7 +221,7 @@ class OrderHistoryCore extends ObjectModel
                 if (Validate::isLoadedObject($old_os)) {
                     // if becoming logable => adds sale
                     if ($new_os->logable && !$old_os->logable) {
-                        ProductSale::addProductSale($product['product_id'], $product['product_quantity']);
+                        ProductSale::addProductSale($product['product_id'], (int) $order->id_shop, $product['product_quantity']);
                         // @since 1.5.0 - Stock Management
                         if (!Pack::isPack($product['product_id']) &&
                             in_array($old_os->id, $error_or_canceled_statuses) &&
@@ -230,7 +230,7 @@ class OrderHistoryCore extends ObjectModel
                         }
                     } elseif (!$new_os->logable && $old_os->logable) {
                         // if becoming unlogable => removes sale
-                        ProductSale::removeProductSale($product['product_id'], $product['product_quantity']);
+                        ProductSale::removeProductSale($product['product_id'], (int) $order->id_shop, $product['product_quantity']);
 
                         // @since 1.5.0 - Stock Management
                         if (!Pack::isPack($product['product_id']) &&

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1838,10 +1838,11 @@ CREATE TABLE `PREFIX_product_lang` (
 /* info about number of products sold */
 CREATE TABLE `PREFIX_product_sale` (
   `id_product` int(10) unsigned NOT NULL,
+  `id_shop` int(10) unsigned NOT NULL,
   `quantity` int(10) unsigned NOT NULL DEFAULT '0',
   `sale_nbr` int(10) unsigned NOT NULL DEFAULT '0',
   `date_upd` date DEFAULT NULL,
-  PRIMARY KEY (`id_product`),
+  PRIMARY KEY (`id_product`, `id_shop`),
   KEY `quantity` (`quantity`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Distinct best sales for each shop. Add column `id_shop` to table `PREFIX_product_sale` and adapt all queries
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29538.
| Related PRs       | A PR in autoupdate module will follow.
| How to test?      | The list of best sales is now distinct in each shop and reflects the orders passed in the current shop.
| Possible impacts? | Three functions in class `ProductSaleCore` change their signature.

These queries must be run in order to test this PR:

```
ALTER TABLE `ps_product_sale` ADD `id_shop` INT(10) UNSIGNED NOT NULL AFTER `id_product`;
ALTER TABLE `ps_product_sale` DROP PRIMARY KEY, ADD PRIMARY KEY (`id_product`, `id_shop`) USING BTREE;
TRUNCATE TABLE `ps_product_sale`;
INSERT INTO ps_product_sale (`id_product`, `id_shop`,`quantity`, `sale_nbr`, `date_upd`)
  SELECT od.product_id, od.id_shop, SUM(od.product_quantity), COUNT(od.product_id), NOW()
  FROM ps_order_detail od GROUP BY od.product_id, od.id_shop;
```

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
