### PR TITLE
Fix validateSql method not accepting EXISTS after WHERE

### DIFF
--- a/classes/RequestSql.php
+++ b/classes/RequestSql.php
@@ -464,7 +464,7 @@ class RequestSqlCore extends ObjectModel
         $nb = count($select);
         for ($i = 0; $i < $nb; ++$i) {
             $attribut = $select[$i];
-            if ($attribut['base_expr'] != '*' && !preg_match('/\.*$/', $attribut['base_expr'])) {
+            if ($attribut['base_expr'] != '*' && !preg_match('/\.\*$/', $attribut['base_expr'])) {
                 if ($attribut['expr_type'] == 'colref') {
                     if ($attr = $this->cutAttribute(trim($attribut['base_expr']), $from)) {
                         if (!$this->attributExistInTable($attr['attribut'], $attr['table'])) {
@@ -508,7 +508,7 @@ class RequestSqlCore extends ObjectModel
         $nb = count($where);
         for ($i = 0; $i < $nb; ++$i) {
             $attribut = $where[$i];
-            if ($attribut['expr_type'] == 'colref' || $attribut['expr_type'] == 'reserved') {
+            if ($attribut['expr_type'] == 'colref') {
                 if ($attr = $this->cutAttribute(trim($attribut['base_expr']), $from)) {
                     if (!$this->attributExistInTable($attr['attribut'], $attr['table'])) {
                         $this->error_sql['checkedWhere']['attribut'] = [$attr['attribut'], implode(', ', $attr['table'])];
@@ -516,15 +516,15 @@ class RequestSqlCore extends ObjectModel
                         return false;
                     }
                 } else {
-                    if (isset($this->error_sql['returnNameTable'])) {
-                        $this->error_sql['checkedWhere'] = $this->error_sql['returnNameTable'];
+                    $this->error_sql['checkedWhere'] = $this->error_sql['returnNameTable'] ?? false;
 
-                        return false;
-                    } else {
-                        $this->error_sql['checkedWhere'] = false;
+                    return false;
+                }
+            } elseif ($attribut['expr_type'] == 'reserved') {
+                if ($attribut['base_expr'] !== 'EXISTS' || !isset($where[$i + 1]) || $where[$i + 1]['expr_type'] !== 'subquery') {
+                    $this->error_sql['checkedWhere'] = $this->error_sql['returnNameTable'] ?? false;
 
-                        return false;
-                    }
+                    return false;
                 }
             } elseif ($attribut['expr_type'] == 'operator') {
                 if (!in_array(strtoupper($attribut['base_expr']), $this->tested['operator'])) {

--- a/tests/Unit/Classes/RequestSqlTest.php
+++ b/tests/Unit/Classes/RequestSqlTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+// Create a fake Db class on the global namespace
+
+namespace {
+    abstract class Db extends \DbCore
+    {
+        public static function getInstance($master = true)
+        {
+            return new FakeDb();
+        }
+    }
+    class FakeDb extends Db
+    {
+        public function __construct()
+        {
+        }
+
+        public function connect()
+        {
+        }
+
+        public function disconnect()
+        {
+        }
+
+        protected function _query($sql)
+        {
+            return true;
+        }
+
+        protected function _numRows($result)
+        {
+        }
+
+        public function Insert_ID()
+        {
+        }
+
+        public function Affected_Rows()
+        {
+        }
+
+        public function nextRow($result = false)
+        {
+        }
+
+        protected function getAll($result = false)
+        {
+            return true;
+        }
+
+        public function getVersion()
+        {
+        }
+
+        public function _escape($str)
+        {
+        }
+
+        public function getMsgError()
+        {
+        }
+
+        public function getNumberError()
+        {
+        }
+
+        public function set_db($db_name)
+        {
+        }
+
+        public function getBestEngine()
+        {
+        }
+    }
+}
+
+namespace Tests\Unit\Classes {
+    use PHPUnit\Framework\TestCase;
+    use RequestSql;
+
+    class RequestSqlTest extends TestCase
+    {
+        /**
+         * @dataProvider provider
+         */
+        public function testValidateSql(string $sql, bool $valid): void
+        {
+            $requestSql = $this->createRequestSqlMock();
+            $parser = $requestSql->parsingSql($sql);
+            $this->assertSame($valid, $requestSql->validateParser($parser, false, $sql));
+        }
+
+        public function provider(): iterable
+        {
+            yield ['select * from ps_table', true];
+            yield ['select * from ps_notexistingtable', false];
+            yield ['select * from ps_table WHERE EXISTS (select 1 from ps_table)', true];
+            yield ['select * from ps_table WHERE EXISTS 1', false];
+            yield ['wrong * from ps_table', false];
+        }
+
+        private function createRequestSqlMock()
+        {
+            $requestSql = $this->getMockBuilder(RequestSql::class)
+                ->setMethods(['getTables'])
+                ->getMock()
+            ;
+
+            $requestSql->method('getTables')->willReturn([
+                'ps_table',
+            ]);
+
+            return $requestSql;
+        }
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Because of a wrong sql validation method, an exception was raised when trying to save an sql query in the sql manager. This PR aims to fix the wrong sql validation method.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29424
| Related PRs       | 
| How to test?      | Please see #29424
| Possible impacts? | It might affect other SQL query saving


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
