### PR TITLE
Only show active CMS categories in breadcrumb

### DIFF
--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -168,11 +168,13 @@ class CmsControllerCore extends FrontController
 
         if ($cmsCategory->id_parent != 0) {
             foreach (array_reverse($cmsCategory->getParentsCategories()) as $category) {
-                $cmsSubCategory = new CMSCategory($category['id_cms_category']);
-                $breadcrumb['links'][] = [
-                    'title' => $cmsSubCategory->getName(),
-                    'url' => $this->context->link->getCMSCategoryLink($cmsSubCategory),
-                ];
+                if ($category['active']) {
+                    $cmsSubCategory = new CMSCategory($category['id_cms_category']);
+                    $breadcrumb['links'][] = [
+                        'title' => $cmsSubCategory->getName(),
+                        'url' => $this->context->link->getCMSCategoryLink($cmsSubCategory),
+                    ];
+                }
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | An inactive CMS category must not be displayed in the CMS page's breadcrumb.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29539
| Related PRs       | None
| How to test?      | Follow the setup instruction in #29539. The breadcrumb must show up correctly (without hidden category).
| Possible impacts? | Visual change in FO only.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
