### PR TITLE
Add min height on alert to center icons vertically

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/_alert.scss
+++ b/admin-dev/themes/new-theme/scss/components/_alert.scss
@@ -1,0 +1,6 @@
+.alert {
+  > a {
+    padding: 0;
+  }
+  min-height: 55px;
+}

--- a/admin-dev/themes/new-theme/scss/components/_alert.scss
+++ b/admin-dev/themes/new-theme/scss/components/_alert.scss
@@ -1,6 +1,7 @@
 .alert {
+  min-height: 55px;
+
   > a {
     padding: 0;
   }
-  min-height: 55px;
 }

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -23,6 +23,7 @@
 @import "~bootstrap/scss/mixins/border-radius";
 
 // Components
+@import "components/alert";
 @import "components/layout/content_div";
 @import "components/layout/header_toolbar";
 @import "components/layout/main_header";


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Add min height on alert class to center icons vertically
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28990
| Related PRs       | 
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/28990
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
