### PR TITLE
Don't get info about email exists when reset admin password

### DIFF
--- a/admin-dev/themes/default/template/controllers/login/content.tpl
+++ b/admin-dev/themes/default/template/controllers/login/content.tpl
@@ -142,7 +142,7 @@
 			</div>
 
 			<div class="front forgot_confirm" style="display: none">
-				<h4 id="forgot_confirm_name">{l s='Please, check your mailbox.' d='Admin.Login.Notification'}<br/><br/>{l s='A link to reset your password has been sent to you.' d='Admin.Login.Notification'}</h4>
+				<h4 id="forgot_confirm_name">{l s='Please, check your mailbox.' d='Admin.Login.Notification'}<br/><br/>{l s='If this email address has been registered in our shop, you will receive a link to reset your password.' d='Admin.Login.Notification'}</h4>
 			</div>
 		</div>
 		{else}

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -313,9 +313,9 @@ class AdminLoginControllerCore extends AdminController
                 die(json_encode([
                     'hasErrors' => false,
                     'confirm' => $this->trans(
-                        'If this email address has been registered in our shop, you will receive a link to reset your password at %email%.', 
+                        'If this email address has been registered in our shop, you will receive a link to reset your password at %email%.',
                         [
-                            '%email%' => $email
+                            '%email%' => $email,
                         ], 
                         'Admin.Login.Notification'
                     ),

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -316,7 +316,7 @@ class AdminLoginControllerCore extends AdminController
                         'If this email address has been registered in our shop, you will receive a link to reset your password at %email%.',
                         [
                             '%email%' => $email,
-                        ], 
+                        ],
                         'Admin.Login.Notification'
                     ),
                 ]));

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -310,7 +310,16 @@ class AdminLoginControllerCore extends AdminController
         } else {
             $employee = new Employee();
             if (!$employee->getByEmail($email)) {
-                $this->errors[] = $this->trans('This account does not exist.', [], 'Admin.Login.Notification');
+                die(json_encode([
+                    'hasErrors' => false,
+                    'confirm' => $this->trans(
+                        'If this email address has been registered in our shop, you will receive a link to reset your password at %email%.', 
+                        [
+                            '%email%' => $email
+                        ], 
+                        'Admin.Login.Notification'
+                    ),
+                ]));
             } elseif ((strtotime($employee->last_passwd_gen . '+' . Configuration::get('PS_PASSWD_TIME_BACK') . ' minutes') - time()) > 0) {
                 $this->errors[] = $this->trans('You can reset your password every %interval% minute(s) only. Please try again later.', ['%interval%' => Configuration::get('PS_PASSWD_TIME_BACK')], 'Admin.Login.Notification');
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Don't get info about email exists when reset admin password.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29568
| Related PRs       | N/A
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/29568
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
