### PR TITLE
Fix availability structured data

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -379,26 +379,29 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
+     * See following resources for up-to-date information
+     * https://support.google.com/merchants/answer/6324448
+     * https://schema.org/ItemAvailability
+     *
      * @arrayAccess
      *
      * @return string
      */
     public function getSeoAvailability()
     {
-        $seoAvailability = 'https://schema.org/';
-
         // Availability for displaying discontinued products, if enabled
         if ($this->product['active'] != 1) {
-            $seoAvailability .= 'Discontinued';
-        } elseif ($this->product['quantity'] > 0) {
-            $seoAvailability .= 'InStock';
+            return 'https://schema.org/Discontinued';
+        // If product is in stock or stock management is disabled (= we have everything in stock)
+        } elseif ($this->product['quantity'] > 0 || !$this->configuration->get('PS_STOCK_MANAGEMENT')) {
+            return 'https://schema.org/InStock';
+        // If it's not in stock, but available for order
         } elseif ($this->product['quantity'] <= 0 && $this->product['allow_oosp']) {
-            $seoAvailability .= 'PreOrder';
+            return 'https://schema.org/BackOrder';
+        // If it's not in stock and not available for order
         } else {
-            $seoAvailability .= 'OutOfStock';
+            return 'https://schema.org/OutOfStock';
         }
-
-        return $seoAvailability;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Resolves #23534, resolves #23199
| Related PRs       | -
| How to test?      | See below
| Possible impacts? | -
| Sponsor company   | [TRENDO s.r.o.](https://www.trendo.cz)

#### Description
- Fixes availability structured data.
- Structured data needed some tweaks, more info below. Everything is PM validated. BETTER SEO.
- Products out of stock should not have **Preorder** availability. Per google documentation: `Note: The preorder value should only be used for new products and shouldn't be used for existing products that are out of stock and will be back in stock at a later date.​`
  - Google doc: https://support.google.com/merchants/answer/6324448?hl=en
  - Discussion: https://github.com/PrestaShop/PrestaShop/issues/23534#issuecomment-796258724
- If stock management is disabled = we have everything, we should always return **In Stock**.
  - Discussion: https://github.com/PrestaShop/PrestaShop/pull/23248#issuecomment-813998975
  - Google doc: https://support.google.com/merchants/answer/6324448

#### How to test
- You will see result of this PR in the source code of product page.
- Test with stock management disabled and see that it always returns in stock.
- Test with out of stock, not available for order product.
- Test wth out of stock, orderable product.
- Test with in stock product.

![availability](https://user-images.githubusercontent.com/6097524/188891055-e85b283d-2c8e-454b-aedc-f5e2c8bb433d.jpg)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
