### PR TITLE
Fixed the duplication of Alias when update

### DIFF
--- a/classes/Alias.php
+++ b/classes/Alias.php
@@ -137,7 +137,7 @@ class AliasCore extends ObjectModel
     }
 
     /**
-     * This method is allow to know if a feature is used or active.
+     * This method is allowed to know if a feature is used or active.
      *
      * @since 1.5.0.1
      *
@@ -149,7 +149,7 @@ class AliasCore extends ObjectModel
     }
 
     /**
-     * This method is allow to know if a alias exist for AdminImportController.
+     * This method is allowed to know if an alias exist for AdminImportController.
      *
      * @param int $idAlias Alias ID
      *

--- a/controllers/admin/AdminSearchConfController.php
+++ b/controllers/admin/AdminSearchConfController.php
@@ -462,9 +462,23 @@ class AdminSearchConfControllerCore extends AdminController
         }
 
         if (!count($this->errors)) {
-            foreach ($aliases as $alias) {
+            // Search existing aliases
+            $alias = new Alias();
+            $alias->search = trim($search);
+            $existingAliases = explode(',', $alias->getAliases());
+
+            // New alias
+            $newAliases = array_diff($aliases, $existingAliases);
+            foreach ($newAliases as $alias) {
                 $obj = new Alias(null, trim($alias), trim($search));
                 $obj->save();
+            }
+
+            // Removed alias
+            $removedAliases = array_diff($existingAliases, $aliases);
+            foreach ($removedAliases as $alias) {
+                $obj = new Alias(null, trim($alias), trim($search));
+                $obj->delete();
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed the duplication of Alias when update
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #21884
| Related PRs       | 
| How to test?       | * Go to 'Shop Parameters > Search' page<br>* Click on 'Edit' the first alias<br>* Edit for example 'blue' by 'red'<br>* **BEFORE :** See error -> a new alias is created instead to update<br>* **AFTER :** The alias is updated


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
