### PR TITLE
Ajax update position for horizontal migration

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -179,6 +179,7 @@ class HelperListCore extends Helper
             'product' => 'AdminProducts',
             'order' => 'AdminOrders',
             'cart' => 'AdminCarts',
+            'feature' => 'AdminFeatures',
         ], $controllerMapping);
         $adminLinkBuilder = new AdminLinkBuilder(Context::getContext()->link, $controllerMapping);
         $this->linkBuilderFactory = new EntityLinkBuilderFactory([

--- a/js/admin/dnd.js
+++ b/js/admin/dnd.js
@@ -140,15 +140,29 @@ function initTableDnD(table)
 				params['selected_pagination'] = parseInt($('input[name=selected_pagination]').val());
 
 				var data = $.tableDnD.serialize().replace(/table-/g, '');
+        var updatePositionBaseUrl = typeof frameworkUpdatePositionUrl === 'string' ? frameworkUpdatePositionUrl : currentIndex + '&token=' + token;
+
 				if ((tableId == 'category') && (data.indexOf('_0&') != -1))
 					data += '&found_first=1';
 				$.ajax({
 					type: 'POST',
 					headers: { "cache-control": "no-cache" },
 					async: false,
-					url: currentIndex + '&token=' + token + '&' + 'rand=' + new Date().getTime(),
+					url: updatePositionBaseUrl + '&rand=' + new Date().getTime(),
 					data:  data + '&' + objToString(params) ,
 					success: function(data) {
+            if (data.errorMessage) {
+              console.error(data.errorMessage);
+
+              window.$.growl['error']({
+                title: 'Error',
+                size: 'large',
+                message: data.errorMessage,
+                duration: 2000,
+              });
+
+              return;
+            }
 						var nodrag_lines = $(tableDrag).find('tr:not(".nodrag")');
 						var new_pos;
 						if (come_from == 'AdminModulesPositions')

--- a/src/Adapter/Routing/AdminLinkBuilder.php
+++ b/src/Adapter/Routing/AdminLinkBuilder.php
@@ -67,7 +67,7 @@ class AdminLinkBuilder implements EntityLinkBuilderInterface
         $controller = $this->entityControllers[$entity];
         $parameters = $this->buildActionParameters('view', $entity, $parameters);
 
-        return $this->link->getAdminLink($controller, true, $parameters);
+        return $this->link->getAdminLink($controller, true, $parameters, $parameters);
     }
 
     /**
@@ -78,7 +78,7 @@ class AdminLinkBuilder implements EntityLinkBuilderInterface
         $controller = $this->entityControllers[$entity];
         $parameters = $this->buildActionParameters('update', $entity, $parameters);
 
-        return $this->link->getAdminLink($controller, true, $parameters);
+        return $this->link->getAdminLink($controller, true, $parameters, $parameters);
     }
 
     /**

--- a/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
+++ b/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
@@ -107,7 +107,8 @@ class ControllerConfigurationFactory
      */
     private function setLegacyCurrentIndex(ControllerConfiguration $controllerConfiguration): void
     {
-        $legacyCurrentIndex = $this->link->getAdminLink($controllerConfiguration->legacyControllerName);
+        // Cannot use $this->link->getAdminLink(), because it produces wrong currentIndex by relying on _legacy_link route param
+        $legacyCurrentIndex = 'index.php' . '?controller=' . $controllerConfiguration->legacyControllerName;
 
         if ($back = Tools::getValue('back')) {
             $legacyCurrentIndex .= '&back=' . urlencode($back);

--- a/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
+++ b/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
@@ -111,6 +111,7 @@ class ControllerConfigurationFactory
         // We do not use \Link->getAdminLink() because it produces wrong legacy currentIndex.
         // Even though we could solve issues with "view" and "edit" links by using AdminLinkBuilder, the same issues appears
         // with the "deletion", "duplicate", "enable" links and as it gets more complicated, it seems to be safer/easier to build the index url manually.
+        // This allows legacy components to build the URLs as usual by appending parameters after currentIndex
         $legacyCurrentIndex = 'index.php' . '?controller=' . $controllerConfiguration->legacyControllerName;
 
         if ($back = Tools::getValue('back')) {

--- a/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
+++ b/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
@@ -28,10 +28,10 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Bridge\AdminController;
 
-use Link;
 use PrestaShopBundle\Bridge\Exception\BridgeException;
 use PrestaShopBundle\Security\Admin\Employee;
 use PrestaShopBundle\Service\DataProvider\UserProvider;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Tools;
 
 /**
@@ -45,20 +45,20 @@ class ControllerConfigurationFactory
     private $userProvider;
 
     /**
-     * @var Link
+     * @var FlashBagInterface
      */
-    private $link;
+    private $flashBag;
 
     /**
      * @param UserProvider $userProvider
-     * @param Link $link
+     * @param FlashBagInterface $flashBag
      */
     public function __construct(
         UserProvider $userProvider,
-        Link $link
+        FlashBagInterface $flashBag
     ) {
         $this->userProvider = $userProvider;
-        $this->link = $link;
+        $this->flashBag = $flashBag;
     }
 
     /**
@@ -95,7 +95,8 @@ class ControllerConfigurationFactory
         );
 
         $this->setLegacyCurrentIndex($controllerConfiguration);
-        $this->initToken($controllerConfiguration);
+        $this->setToken($controllerConfiguration);
+        $this->setFlashes($controllerConfiguration);
 
         return $controllerConfiguration;
     }
@@ -120,12 +121,23 @@ class ControllerConfigurationFactory
     /**
      * @return void
      */
-    private function initToken(ControllerConfiguration $controllerConfiguration): void
+    private function setToken(ControllerConfiguration $controllerConfiguration): void
     {
         $controllerConfiguration->token = Tools::getAdminToken(
             $controllerConfiguration->legacyControllerName .
             (int) $controllerConfiguration->tabId .
             (int) $controllerConfiguration->getUser()->getData()->id
         );
+    }
+
+    /**
+     * @param ControllerConfiguration $controllerConfiguration
+     */
+    private function setFlashes(ControllerConfiguration $controllerConfiguration): void
+    {
+        $controllerConfiguration->confirmations = $this->flashBag->get('success');
+        $controllerConfiguration->warnings = $this->flashBag->get('warning');
+        $controllerConfiguration->errors = $this->flashBag->get('error');
+        $controllerConfiguration->informations = $this->flashBag->get('info');
     }
 }

--- a/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
+++ b/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Bridge\AdminController;
 
+use Link;
 use PrestaShopBundle\Bridge\Exception\BridgeException;
 use PrestaShopBundle\Security\Admin\Employee;
 use PrestaShopBundle\Service\DataProvider\UserProvider;
@@ -45,20 +46,28 @@ class ControllerConfigurationFactory
     private $userProvider;
 
     /**
+     * @var Link
+     */
+    private $link;
+
+    /**
      * @var FlashBagInterface
      */
     private $flashBag;
 
     /**
      * @param UserProvider $userProvider
+     * @param Link $link
      * @param FlashBagInterface $flashBag
      */
     public function __construct(
         UserProvider $userProvider,
+        Link $link,
         FlashBagInterface $flashBag
     ) {
         $this->userProvider = $userProvider;
         $this->flashBag = $flashBag;
+        $this->link = $link;
     }
 
     /**
@@ -108,8 +117,7 @@ class ControllerConfigurationFactory
      */
     private function setLegacyCurrentIndex(ControllerConfiguration $controllerConfiguration): void
     {
-        // Cannot use $this->link->getAdminLink(), because it produces wrong currentIndex by relying on _legacy_link route param
-        $legacyCurrentIndex = 'index.php' . '?controller=' . $controllerConfiguration->legacyControllerName;
+        $legacyCurrentIndex = $this->link->getAdminLink($controllerConfiguration->legacyControllerName);
 
         if ($back = Tools::getValue('back')) {
             $legacyCurrentIndex .= '&back=' . urlencode($back);

--- a/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
+++ b/src/PrestaShopBundle/Bridge/AdminController/ControllerConfigurationFactory.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Bridge\AdminController;
 
-use Link;
 use PrestaShopBundle\Bridge\Exception\BridgeException;
 use PrestaShopBundle\Security\Admin\Employee;
 use PrestaShopBundle\Service\DataProvider\UserProvider;
@@ -46,28 +45,20 @@ class ControllerConfigurationFactory
     private $userProvider;
 
     /**
-     * @var Link
-     */
-    private $link;
-
-    /**
      * @var FlashBagInterface
      */
     private $flashBag;
 
     /**
      * @param UserProvider $userProvider
-     * @param Link $link
      * @param FlashBagInterface $flashBag
      */
     public function __construct(
         UserProvider $userProvider,
-        Link $link,
         FlashBagInterface $flashBag
     ) {
         $this->userProvider = $userProvider;
         $this->flashBag = $flashBag;
-        $this->link = $link;
     }
 
     /**
@@ -117,7 +108,10 @@ class ControllerConfigurationFactory
      */
     private function setLegacyCurrentIndex(ControllerConfiguration $controllerConfiguration): void
     {
-        $legacyCurrentIndex = $this->link->getAdminLink($controllerConfiguration->legacyControllerName);
+        // We do not use \Link->getAdminLink() because it produces wrong legacy currentIndex.
+        // Even though we could solve issues with "view" and "edit" links by using AdminLinkBuilder, the same issues appears
+        // with the "deletion", "duplicate", "enable" links and as it gets more complicated, it seems to be safer/easier to build the index url manually.
+        $legacyCurrentIndex = 'index.php' . '?controller=' . $controllerConfiguration->legacyControllerName;
 
         if ($back = Tools::getValue('back')) {
             $legacyCurrentIndex .= '&back=' . urlencode($back);

--- a/src/PrestaShopBundle/Bridge/Helper/Listing/HelperBridge/FeatureHelperListBridge.php
+++ b/src/PrestaShopBundle/Bridge/Helper/Listing/HelperBridge/FeatureHelperListBridge.php
@@ -47,7 +47,7 @@ class FeatureHelperListBridge extends HelperListBridge
         $listSql = parent::generateListQuery($helperListConfiguration, $idLang);
 
         // adds feature_value count to evey row of feature
-        foreach ($helperListConfiguration->list as $featureRowRecord) {
+        foreach ($helperListConfiguration->list as &$featureRowRecord) {
             $featureRowRecord['value'] = $this->countFeatureValues((int) $featureRowRecord['id_feature']);
         }
 

--- a/src/PrestaShopBundle/Bridge/Helper/Listing/HelperBridge/HelperListBridge.php
+++ b/src/PrestaShopBundle/Bridge/Helper/Listing/HelperBridge/HelperListBridge.php
@@ -32,6 +32,7 @@ use Context;
 use Db;
 use Exception;
 use HelperList;
+use Media;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
@@ -114,10 +115,19 @@ class HelperListBridge
             return null;
         }
 
-        return $this
+        $listContent = $this
             ->buildHelperList($helperListConfiguration)
             ->generateList($helperListConfiguration->list, $helperListConfiguration->fieldsList)
         ;
+
+        if (!empty($helperListConfiguration->getUpdatePositionUrl())) {
+            // assign js def for ajax positioning action
+            Media::addJsDef([
+                'frameworkUpdatePositionUrl' => $helperListConfiguration->getUpdatePositionUrl(),
+            ]);
+        }
+
+        return $listContent;
     }
 
     /**

--- a/src/PrestaShopBundle/Bridge/Helper/Listing/HelperListConfiguration.php
+++ b/src/PrestaShopBundle/Bridge/Helper/Listing/HelperListConfiguration.php
@@ -374,6 +374,13 @@ class HelperListConfiguration
     private $shopShareData = false;
 
     /**
+     * Url for submitting position update action
+     *
+     * @var string|null
+     */
+    private $updatePositionUrl;
+
+    /**
      * @param int $tabId
      * @param string $tableName
      * @param string $listId
@@ -391,6 +398,7 @@ class HelperListConfiguration
      * @param string $legacyCurrentIndex
      * @param int $multiShopContext
      * @param string $indexUrl
+     * @param string|null $updatePositionUrl
      */
     public function __construct(
         int $tabId,
@@ -409,7 +417,8 @@ class HelperListConfiguration
         bool $bootstrap,
         string $legacyCurrentIndex,
         int $multiShopContext,
-        string $indexUrl
+        string $indexUrl,
+        ?string $updatePositionUrl
     ) {
         $this->tabId = $tabId;
         $this->tableName = $tableName;
@@ -428,6 +437,7 @@ class HelperListConfiguration
         $this->legacyCurrentIndex = $legacyCurrentIndex;
         $this->multiShopContext = $multiShopContext;
         $this->indexUrl = $indexUrl;
+        $this->updatePositionUrl = $updatePositionUrl;
     }
 
     /**
@@ -806,5 +816,13 @@ class HelperListConfiguration
         $this->shopShareData = $shopShareData;
 
         return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getUpdatePositionUrl(): ?string
+    {
+        return $this->updatePositionUrl;
     }
 }

--- a/src/PrestaShopBundle/Bridge/Helper/Listing/HelperListConfigurationFactory.php
+++ b/src/PrestaShopBundle/Bridge/Helper/Listing/HelperListConfigurationFactory.php
@@ -61,6 +61,7 @@ class HelperListConfigurationFactory
      * @param bool $explicitSelect @see HelperListConfiguration::$explicitSelect
      * @param bool $useFoundRows @see HelperListConfiguration::$useFoundRows
      * @param string|null $listId @see HelperListConfiguration::$listId
+     * @param string|null $updatePositionRoute Route used to generate url for position update @see HelperListConfiguration::$updatePositionUrl
      *
      * @return HelperListConfiguration
      */
@@ -74,11 +75,17 @@ class HelperListConfigurationFactory
         bool $deleted = false,
         bool $explicitSelect = false,
         bool $useFoundRows = true,
-        ?string $listId = null
+        ?string $listId = null,
+        ?string $updatePositionRoute = null
     ): HelperListConfiguration {
         if (empty($defaultOrderBy)) {
             $defaultOrderBy = $identifierKey;
         }
+
+        $updatePositionUrl = $updatePositionRoute ? $this->router->generate($updatePositionRoute, [
+            'identifierKey' => $identifierKey,
+            'className' => $controllerConfiguration->objectModelClassName,
+        ]) : null;
 
         return new HelperListConfiguration(
             $controllerConfiguration->tabId,
@@ -97,7 +104,8 @@ class HelperListConfigurationFactory
             $controllerConfiguration->bootstrap,
             $controllerConfiguration->legacyCurrentIndex,
             $controllerConfiguration->multiShopContext,
-            $this->router->generate($indexRoute)
+            $this->router->generate($indexRoute),
+            $updatePositionUrl
         );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -181,6 +181,8 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
     /**
      * @param Request $request
      *
+     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     *
      * @return JsonResponse
      */
     public function updatePositionAction(Request $request): JsonResponse

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -61,6 +61,11 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
      */
     public function indexAction(Request $request): Response
     {
+        if (!$this->isFeatureEnabled()) {
+            $this->getControllerConfiguration()->warnings[] = $this->generateDisabledFeatureWarning();
+
+            return $this->renderSmarty('');
+        }
         $this->setHeaderToolbarActions();
 
         $helperListConfiguration = $this->buildListConfiguration(
@@ -92,6 +97,7 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
         if (!$this->isFeatureEnabled()) {
             return $this->render('@PrestaShop/Admin/Sell/Catalog/Features/create.html.twig', [
                 'showDisabledFeatureWarning' => true,
+                'disabledFeatureWarning' => $this->generateDisabledFeatureWarning(),
             ]);
         }
 
@@ -142,6 +148,7 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
             return $this->renderEditForm([
                 'showDisabledFeatureWarning' => true,
                 'editableFeature' => $editableFeature,
+                'disabledFeatureWarning' => $this->generateDisabledFeatureWarning(),
             ]);
         }
 
@@ -329,5 +336,23 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
     private function isFeatureEnabled()
     {
         return $this->get('prestashop.adapter.feature.feature')->isActive();
+    }
+
+    /**
+     * @return string
+     */
+    private function generateDisabledFeatureWarning(): string
+    {
+        $adminPerformanceUrl = $this->generateUrl('admin_performance');
+
+        return $this->trans(
+            'This feature has been disabled. You can activate it here: %link%.',
+            'Admin.Catalog.Notification',
+            ['%link%' => sprintf(
+                '<a href="%s#optional_features">%s</a>',
+                $adminPerformanceUrl,
+                $this->trans('Performance', 'Admin.Global')
+            )]
+        );
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -42,6 +42,7 @@ use PrestaShopBundle\Bridge\Helper\Listing\HelperListConfiguration;
 use PrestaShopBundle\Bridge\Smarty\FrameworkControllerSmartyTrait;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Tools;
@@ -64,9 +65,9 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
 
         $helperListConfiguration = $this->buildListConfiguration(
             'id_feature',
-            //@todo: position update is still handled by legacy ajax controller action. Need to handle in dedicated PR
             'position',
             $request->attributes->get('_route'),
+            'admin_features_update_position',
             'id_feature'
         );
 
@@ -168,6 +169,16 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
             'featureForm' => $featureForm->createView(),
             'editableFeature' => $editableFeature,
         ]);
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return JsonResponse
+     */
+    public function updatePositionAction(Request $request): JsonResponse
+    {
+        return $this->updatePositionBridge($request);
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/features.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/features.yml
@@ -4,24 +4,31 @@ admin_features_index:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\FeatureController::indexAction
     _legacy_controller: AdminFeatures
-#    _legacy_link: AdminFeatures
-#
+    # _legacy_link: AdminFeatures
+
 admin_features_add:
   path: /new
   methods: [ GET, POST ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\FeatureController::createAction
     _legacy_controller: AdminFeatures
-#    _legacy_link: AdminFeatures:addfeature
-#
+    # _legacy_link: AdminFeatures:addfeature
+
 admin_features_edit:
   path: /{featureId}/edit
   methods: [ GET, POST ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\FeatureController::editAction
     _legacy_controller: AdminFeatures
-    _legacy_link: AdminFeatures:updatefeature
+    # _legacy_link: AdminFeatures:updatefeature
     _legacy_parameters:
       id_feature: featureId
   requirements:
     featureId: \d+
+
+admin_features_update_position:
+  path: /update-position
+  methods: [ POST ]
+  defaults:
+    _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\FeatureController::updatePositionAction
+    _legacy_controller: AdminFeatures

--- a/src/PrestaShopBundle/Resources/config/services/bundle/bridge/_admin_controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/bridge/_admin_controller.yml
@@ -6,7 +6,6 @@ services:
     class: PrestaShopBundle\Bridge\AdminController\ControllerConfigurationFactory
     arguments:
       - '@prestashop.user_provider'
-      - '@=service("prestashop.adapter.legacy.context").getContext().link'
       - '@session.flash_bag'
 
   prestashop.bridge.admin_controller.legacy_controller_bridge_factory:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/bridge/_admin_controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/bridge/_admin_controller.yml
@@ -6,7 +6,7 @@ services:
     class: PrestaShopBundle\Bridge\AdminController\ControllerConfigurationFactory
     arguments:
       - '@prestashop.user_provider'
-      - '@=service("prestashop.adapter.legacy.context").getContext().link'
+      - '@session.flash_bag'
 
   prestashop.bridge.admin_controller.legacy_controller_bridge_factory:
     class: PrestaShopBundle\Bridge\AdminController\LegacyControllerBridgeFactory

--- a/src/PrestaShopBundle/Resources/config/services/bundle/bridge/_admin_controller.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/bridge/_admin_controller.yml
@@ -6,6 +6,7 @@ services:
     class: PrestaShopBundle\Bridge\AdminController\ControllerConfigurationFactory
     arguments:
       - '@prestashop.user_provider'
+      - '@=service("prestashop.adapter.legacy.context").getContext().link'
       - '@session.flash_bag'
 
   prestashop.bridge.admin_controller.legacy_controller_bridge_factory:

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig
@@ -27,9 +27,5 @@
 {% set linkText = 'Performance'|trans({}, 'Admin.Global') %}
 
 <div class="alert alert-warning" role="alert">
-  <p>
-    {{ 'This feature has been disabled. You can activate it here: %url%.'|trans({
-      '%url%': "<a href=\"#{href}\">#{linkText}</a>"
-    }, 'Admin.Catalog.Notification')|raw }}
-  </p>
+  <p>{{ disabledFeatureWarning|raw }}</p>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig
@@ -23,9 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% set href = path('admin_performance') ~ '#optional_features' %}
-{% set linkText = 'Performance'|trans({}, 'Admin.Global') %}
-
 <div class="alert alert-warning" role="alert">
   <p>{{ disabledFeatureWarning|raw }}</p>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/create.html.twig
@@ -29,7 +29,7 @@
 
 {% block content %}
   {% if showDisabledFeatureWarning is defined and showDisabledFeatureWarning %}
-    {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig' %}
+    {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig' with {disabledFeatureWarning} %}
   {% else %}
     {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
       featureId: null,

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Features/edit.html.twig
@@ -29,7 +29,7 @@
 
 {% block content %}
   {% if showDisabledFeatureWarning is defined and showDisabledFeatureWarning %}
-    {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig' %}
+    {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/disabled_feature_warning.html.twig' with {disabledFeatureWarning} %}
   {% else %}
     {% include '@PrestaShop/Admin/Sell/Catalog/Features/Blocks/form.html.twig' with {
       featureId: editableFeature.featureId.getValue,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Ajax update position for horizontal migration. Its high chances that this action may be needed only for features list. Other pages that are using positions seems to be migrated already (some of them just not enabled yet). Also enabled already existing create/edit feature action that was migrated to symfony some time ago.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | This was the last PR of horizontal migration list refacto so whole features list can be QA tested now. See bellow how to do it.
| Possible impacts? | 

**How to test**
As the new page cannot yet be enabled, the legacy links are commented out. To test horizontally migrated features  uncomment the legacy links in **src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/features.yml** (make sure the indent is correct like in the screenshot 1). Then you can go to Back office Sell -> Catalog -> Attributes & Features -> Features and test the list. It should behave as in legacy page. Create and edit links should redirect to migrated pages (but these pages are migrated earlier and not related to this PR)
screenshot 1
![Screenshot from 2022-10-18 16-11-30](https://user-images.githubusercontent.com/31609858/196439022-00e74195-abd9-4850-b610-0a28dc3ff3be.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
