### PR TITLE
Remove product image dropzone flex that was adding space

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
@@ -711,7 +711,6 @@
   }
 
   #product-images-dropzone.dropzone {
-    display: flex;
     align-items: flex-start;
     justify-content: space-between;
     border-radius: 4px;

--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
@@ -711,11 +711,6 @@
   }
 
   #product-images-dropzone.dropzone {
-    align-items: flex-start;
-    justify-content: space-between;
-    border-radius: 4px;
-    flex-wrap: wrap;
-
     @include media-breakpoint-down(xs) {
       flex-wrap: wrap;
       justify-content: space-around;

--- a/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/dropzone/Dropzone.vue
@@ -706,11 +706,13 @@
 }
 
 .product-page #product-images-container {
+  border-radius: 4px;
   @include media-breakpoint-down(xs) {
     flex-wrap: wrap;
   }
 
   #product-images-dropzone.dropzone {
+    border-radius: 4px;
     @include media-breakpoint-down(xs) {
       flex-wrap: wrap;
       justify-content: space-around;


### PR DESCRIPTION
… spaced between images

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x 
| Description?      | Removed display:flex from product images dropzone that was creating not needed spaces between images.
| Type?             |  improvement 
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #27640
| How to test?      | Add more then 7-8 images and without the change there should be big empty spaces between images.
| Possible impacts? | Maybe the flex was used for something else but while testing couldn't find anything that would have been impected.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
