### PR TITLE
Fix duplicate / wrongly pluralized error message on field length in BO

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,6 +35,7 @@ parameters:
     - install-dev/theme/config.php
     - tests/Resources
     - tests/Unit/Core/Foundation/IoC/Fixtures
+    - */node_modules/*
   ignoreErrors:
     - '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition\:\:#'
     - '#^Unsafe usage of new static\(\)\.$#'

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -122,13 +122,13 @@ class FrameworkBundleAdminController extends AbstractController
                     $error->getMessageTemplate(),
                     $error->getMessagePluralization(),
                     $error->getMessageParameters(),
-                    'form_error'
+                    'validators'
                 );
             } else {
                 $errors[$formId][] = $translator->trans(
                     $error->getMessageTemplate(),
                     $error->getMessageParameters(),
-                    'form_error'
+                    'validators'
                 );
             }
         }

--- a/tests/Integration/PrestaShopBundle/TranslationIntegrationTest.php
+++ b/tests/Integration/PrestaShopBundle/TranslationIntegrationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Integration\PrestaShopBundle;
+
+use PrestaShopBundle\Translation\PrestaShopTranslatorTrait;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The purpose of this test is not to test that translation works for a specific language, but to check
+ * that the different type of wordings (with parameters, plural, legacy placeholders, ...) can all be used
+ * with the Symfony translator. It also validates that the modification from the PrestaShopTranslatorTrait
+ * that handle the legacy use case don't break the native Symfony translator behaviour.
+ */
+class TranslationIntegrationTest extends KernelTestCase
+{
+    private $translator;
+
+    public function setUp(): void
+    {
+        self::bootKernel();
+        $this->translator = self::$kernel->getContainer()->get('translator');
+    }
+
+    /**
+     * @dataProvider getExpectedTranslations
+     *
+     * @param string $expectedTranslatedMessage
+     * @param string $message
+     * @param string $domain
+     * @param array $parameters
+     */
+    public function testTranslator(string $expectedTranslatedMessage, string $message, string $domain, array $parameters): void
+    {
+        self::assertEquals($expectedTranslatedMessage, $this->translator->trans($message, $parameters, $domain));
+    }
+
+    public function getExpectedTranslations(): iterable
+    {
+        yield 'simple translation' => [
+            'A new order has been placed on your shop',
+            'A new order has been placed on your shop',
+            'Admin.Navigation.Header',
+            [],
+        ];
+        yield 'simple translation with htmlspecialchars' => [
+            'Succesful deletion',
+            'Succesful deletion',
+            'Admin.Notifications.Success',
+            ['legacy' => 'htmlspecialchars'],
+        ];
+        yield 'translation with placeholder' => [
+            'The root category of the shop myshop',
+            'The root category of the shop %shop%',
+            'Admin.Catalog.Notification',
+            ['%shop%' => 'myshop'],
+        ];
+        yield 'translation with sprintf placeholders identified with index' => [
+            'Image is too large (10 kB). Maximum allowed: 5 kB',
+            'Image is too large (%1$d kB). Maximum allowed: %2$d kB',
+            'Admin.Navigation.Search',
+            [10, 5],
+        ];
+        yield 'translation with sprintf typed placeholders' => [
+            '10 results match your query "stringTest".',
+            '%d results match your query "%s".',
+            'Admin.Navigation.Header',
+            [10, 'stringTest'],
+        ];
+        yield 'translation with plural format' => [
+            'This value is too short. It should have 3 characters or more.',
+            'This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.',
+            'validators',
+            // transChoice has been deprecated trans should be used instead with a %count% parameter
+            ['{{ limit }}' => 3, '%count%' => 3],
+        ];
+    }
+
+    /**
+     * @dataProvider getExpectedTransChoices
+     *
+     * @param string $expectedTranslatedMessage
+     * @param string $message
+     * @param string $domain
+     * @param array $parameters
+     */
+    public function testTranslatorChoice(string $expectedTranslatedMessage, string $message, int $number, string $domain, array $parameters): void
+    {
+        self::assertEquals($expectedTranslatedMessage, $this->translator->transChoice($message, $number, $parameters, $domain));
+    }
+
+    public function getExpectedTransChoices(): iterable
+    {
+        yield 'translation with plural format' => [
+            'This value is too short. It should have 3 characters or more.',
+            'This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.',
+            3,
+            'validators',
+            ['{{ limit }}' => 3],
+        ];
+    }
+}

--- a/tests/Integration/PrestaShopBundle/TranslationIntegrationTest.php
+++ b/tests/Integration/PrestaShopBundle/TranslationIntegrationTest.php
@@ -28,10 +28,11 @@ class TranslationIntegrationTest extends KernelTestCase
      * @param string $message
      * @param string $domain
      * @param array $parameters
+     * @param ?string $locale
      */
-    public function testTranslator(string $expectedTranslatedMessage, string $message, string $domain, array $parameters): void
+    public function testTranslator(string $expectedTranslatedMessage, string $message, string $domain, array $parameters, ?string $locale = null): void
     {
-        self::assertEquals($expectedTranslatedMessage, $this->translator->trans($message, $parameters, $domain));
+        self::assertEquals($expectedTranslatedMessage, $this->translator->trans($message, $parameters, $domain, $locale));
     }
 
     public function getExpectedTranslations(): iterable
@@ -73,6 +74,24 @@ class TranslationIntegrationTest extends KernelTestCase
             // transChoice has been deprecated trans should be used instead with a %count% parameter
             ['{{ limit }}' => 3, '%count%' => 3],
         ];
+        yield 'translation with singular format' => [
+            'This value is too short. It should have 1 character or more.',
+            'This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.',
+            'validators',
+            ['{{ limit }}' => 1, '%count%' => 1],
+        ];
+        yield 'translation fallback to legacy system' => [
+            'This is a bad idea',
+            'This is a %message%',
+            'Modules.Mymodule.Foobar',
+            ['%message%' => 'bad idea'],
+        ];
+        yield 'translation with htmlspecialchars and sprintf' => [
+            '&lt;a href="test"&gt;10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"&lt;/a&gt;',
+            '<a href="test">%d Succesful deletion "%s"</a>',
+            'Admin.Notifications.Success',
+            ['legacy' => 'htmlspecialchars', 10, '<b>stringTest</b>'],
+        ];
     }
 
     /**
@@ -96,6 +115,13 @@ class TranslationIntegrationTest extends KernelTestCase
             3,
             'validators',
             ['{{ limit }}' => 3],
+        ];
+        yield 'translation with singular format' => [
+            'This value is too short. It should have 1 character or more.',
+            'This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.',
+            1,
+            'validators',
+            ['{{ limit }}' => 1],
         ];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x 
| Description?           |  An issue was reported about an error message being duplicated. After investigation, it turned out that the message was wrongly pluralized, displaying both singular and plural versions of an error message. Symfony 4.4 is supposed to handle those messages. The problem that was found was that the PrestashopTranslatorTrait ( which is a custom Prestashop layer on top of Symfony's translation system) had some issues, mainly the fact that it would not pass the `$parameters`parameter to the parent function trans(), preventing it to get the `%count%` index in the array parameters, preventing symfony from choosing between singular and plural versions.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/28877
| Related PRs       | (https://github.com/PrestaShop/PrestaShop/pull/29040 https://github.com/PrestaShop/PrestaShop/pull/29396).
| How to test?      | Go to BO > Catalog > Products V1 > Add Product > Fill the "Name" field with less than 3 or more than 128 characters > Click Save button > See error : 'This value is too long. It should have {{ limit }} character or less.' OR 'This value is too long. It should have {{ limit }} characters or less.' with good pluralization according to context.
| Possible impacts? | All form fields with a length constraint.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
Note : I've had to make another PR cause i made a mess when rebasing the previous one and it was quicker than trying to go up the gitflow tree but there was interesting discussions please check https://github.com/PrestaShop/PrestaShop/pull/29040 AND https://github.com/PrestaShop/PrestaShop/pull/29396