### PR TITLE
Disable execution of multiple statements in a single SQL query

### DIFF
--- a/app/config/doctrine.yml
+++ b/app/config/doctrine.yml
@@ -16,7 +16,10 @@ doctrine:
           enum: string
 
         options:
+          # PDO::MYSQL_ATTR_INIT_COMMAND
           1002: "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''))"
+          # PDO::MYSQL_ATTR_MULTI_STATEMENTS
+          1013: '%env(const:runtime:_PS_ALLOW_MULTI_STATEMENTS_QUERIES_)%'
 
   orm:
     auto_generate_proxy_classes: "%kernel.debug%"

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -89,6 +89,7 @@ class DbPDOCore extends Db
                 PDO::ATTR_TIMEOUT => $timeout,
                 PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true,
                 PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
+                PDO::MYSQL_ATTR_MULTI_STATEMENTS => _PS_ALLOW_MULTI_STATEMENTS_QUERIES_,
             ]
         );
     }

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -52,6 +52,9 @@ if (!defined('_PS_MODE_DEMO_')) {
 if (!defined('_PS_SMARTY_CACHING_TYPE_')) {
     define('_PS_SMARTY_CACHING_TYPE_', 'filesystem');
 }
+if (!defined('_PS_ALLOW_MULTI_STATEMENTS_QUERIES_')) {
+    define('_PS_ALLOW_MULTI_STATEMENTS_QUERIES_', false);
+}
 
 $currentDir = dirname(__FILE__);
 

--- a/config/services/common.yml
+++ b/config/services/common.yml
@@ -18,3 +18,7 @@ services:
 
     annotation_reader:
         class: Doctrine\Common\Annotations\AnnotationReader
+
+    PrestaShopBundle\DependencyInjection\RuntimeConstEnvVarProcessor:
+        public: false
+        tags: ['container.env_var_processor']

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,6 +20,8 @@ parameters:
 		- Order
 		- OrderInvoice
 		- Product
+	dynamicConstantNames:
+		- _PS_ALLOW_MULTI_STATEMENTS_QUERIES_
 
 
 services:

--- a/src/PrestaShopBundle/DependencyInjection/RuntimeConstEnvVarProcessor.php
+++ b/src/PrestaShopBundle/DependencyInjection/RuntimeConstEnvVarProcessor.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\DependencyInjection;
+
+use Closure;
+use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
+use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
+
+final class RuntimeConstEnvVarProcessor implements EnvVarProcessorInterface
+{
+    public function getEnv($prefix, $name, Closure $getEnv)
+    {
+        $exploded = explode(':', $name);
+        if (count($exploded) !== 2 || $exploded[0] !== 'runtime' || !defined($exploded[1])) {
+            throw new EnvNotFoundException($name);
+        }
+
+        return constant($exploded[1]);
+    }
+
+    public static function getProvidedTypes()
+    {
+        return [
+            'const' => 'bool|int|float|string|array',
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestSettingsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/RequestSql/SqlRequestSettingsType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\RequestSql;
 
 use PrestaShop\PrestaShop\Core\Encoding\CharsetEncoding;
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -46,6 +47,14 @@ class SqlRequestSettingsType extends TranslatorAwareType
                     CharsetEncoding::ISO_8859_1 => CharsetEncoding::ISO_8859_1,
                 ],
                 'translation_domain' => false,
-            ]);
+            ])
+            ->add('enable_multi_statements', SwitchType::class, [
+                'label' => $this->trans('Enable multi-statements queries', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans(
+                    'Enabling multi-statements queries increases the risk of SQL injection vulnerability to be exploited',
+                    'Admin.Advparameters.Help'
+                ),
+            ])
+        ;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/services.yml
@@ -110,3 +110,7 @@ services:
         class: PrestaShopBundle\Service\Multistore\CustomizedConfigurationChecker
         arguments:
             - "@prestashop.adapter.legacy.configuration"
+
+    PrestaShopBundle\DependencyInjection\RuntimeConstEnvVarProcessor:
+        public: false
+        tags: ['container.env_var_processor']


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | This PR aims to prevent multi statements with PDO driver to be more secure against SQL injection
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes - Module cannot execute multiple queries in `Db::execute()`
| Deprecations?     | no
| Fixed ticket?     | Fixes #29157
| Related PRs       | 
| How to test?      | CI should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
