### PR TITLE
Wrong error message display on NumberType symfony input

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_horizontal_layout.html.twig
@@ -145,7 +145,7 @@
   {%- set type = type|default('text') -%}
   <div class="input-group">
     {{- block('form_unit_prepend') -}}
-    {{- block('form_widget_simple') -}}
+    <div class="w-100">{{- block('form_widget_simple') -}}</div>
     {{- block('form_unit') -}}
   </div>
   {{ block('form_help') }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x 
| Description?      | Fix error message display on NumberType symfony input
| Type?             | bug fix 
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #29583
| Related PRs       | 
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/29583
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
