### PR TITLE
Avoid deleting whole Smarty cache when loading/submitting "Price Catalog Rules" form

### DIFF
--- a/controllers/admin/AdminSpecificPriceRuleController.php
+++ b/controllers/admin/AdminSpecificPriceRuleController.php
@@ -389,11 +389,4 @@ class AdminSpecificPriceRuleControllerCore extends AdminController
             return $object;
         }
     }
-
-    public function postProcess()
-    {
-        Tools::clearSmartyCache();
-
-        return parent::postProcess();
-    }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This aims to fix timeouts of loading backoffice "Price Catalog Rules" AdminController page and prevent all front office smarty cache being deleted during AdminSpecificPriceRuleController form load / submission.
| Type?             | bug fix + improvement 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29298 
| Related PRs       | N/A
| How to test?      | Follow "Steps to reproduce" in #29298 before/after applying this PR
| Possible impacts? | In the issue comments had been mentioned the need to clear the smarty cache when saving the "Price Catalog Rules" , but I had this patch in production for a month and haven't noticed any wrong price being displayed in front office <br/>It's unclear why this commit had been added [back in the days](https://github.com/PrestaShop/PrestaShop/commit/2556d64f6e1cfd636dc4152dadc7ff61c5433cd7), anyway, it doesn't make sense for an admin controller to clear all the smarty cache for the whole site,  This is currently causing frontoffice performance decay on large sites whenever an admin enters or changes cart rules. 






