### PR TITLE
Add source parameter to actionBeforeInstallModule & actionBeforeUpgradeModule hooks

### DIFF
--- a/src/Core/Module/ModuleManagerInterface.php
+++ b/src/Core/Module/ModuleManagerInterface.php
@@ -38,7 +38,7 @@ interface ModuleManagerInterface
 
     public function uninstall(string $name, bool $deleteFiles = false): bool;
 
-    public function upgrade(string $name): bool;
+    public function upgrade(string $name, $source = null): bool;
 
     public function enable(string $name): bool;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Without giving the source information to actionBeforeInstallModule & actionBeforeUpgradeModule hooks, it's not possible for modules listening to those hooks to know if they should download the module or not.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes partially #29594
| Related PRs       | PrestaShop/ps_distributionapiclient#10
| How to test?      | See below
| Possible impacts? | 

### How to test

⚠️ This PR needs to be tested alongside with PrestaShop/ps_distributionapiclient#10.
Once this PR and the new version of ps_distributionapiclient containing PrestaShop/ps_distributionapiclient#10 are installed, you can follow:
1. In the module manager, fully delete psgdpr
2. download [an old version of psgdpr](https://github.com/PrestaShop/psgdpr/releases/download/v1.4.0/psgdpr.zip) and install it manually
3. download [a version that is not the latest one](https://github.com/PrestaShop/psgdpr/releases/download/v1.4.1/psgdpr.zip)
4. Try to install it manually
5. The version installed should be 1.4.1

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
