### PR TITLE
Remove deprecated method, not used anymore

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -524,36 +524,6 @@ class CategoryCore extends ObjectModel
     }
 
     /**
-     * @param array $categories
-     * @param int $idCategory
-     * @param int $n
-     *
-     * @return bool Indicates whether the sub tree of categories has been successfully updated
-     *
-     * @deprecated 1.7.6.0 use computeNTreeInfos + sql query instead
-     */
-    protected static function subTree(&$categories, $idCategory, &$n)
-    {
-        $left = $n++;
-        if (isset($categories[(int) $idCategory]['subcategories'])) {
-            foreach ($categories[(int) $idCategory]['subcategories'] as $idSubcategory) {
-                Category::subTree($categories, (int) $idSubcategory, $n);
-            }
-        }
-        $right = (int) $n++;
-
-        return Db::getInstance()->update(
-            'category',
-            [
-                'nleft' => (int) $left,
-                'nright' => (int) $right,
-            ],
-            '`id_category` = ' . (int) $idCategory,
-            1
-        );
-    }
-
-    /**
      * Updates `level_depth` for all children of the given `id_category`.
      *
      * @param int $idParentCategory Parent Category ID


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove an unused method, that is deprecated since 1.7.6
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| BC breaks  | Category::subTree() method is removed.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
