### PR TITLE
Add GdImage to phpDoc

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -603,7 +603,7 @@ class ImageManagerCore
      * @param string $type
      * @param string $filename
      *
-     * @return false|resource
+     * @return false|resource|GdImage
      */
     public static function create($type, $filename)
     {
@@ -644,7 +644,7 @@ class ImageManagerCore
      * Generate and write image.
      *
      * @param string $type
-     * @param resource $resource
+     * @param resource|GdImage $resource
      * @param string $filename
      *
      * @return bool

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -603,7 +603,7 @@ class ImageManagerCore
      * @param string $type
      * @param string $filename
      *
-     * @return false|resource|GdImage
+     * @return false|resource|\GdImage
      */
     public static function create($type, $filename)
     {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since PHP 8.0.0, somes methods used with GD library returns GdImage instead of ressource. Somes inside this class have the GdImage mentionned, other not.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
