### PR TITLE
Fix used static property name

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2476,7 +2476,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getModulesAccessesByIdProfile($idProfile)
     {
-        if (empty(static::$cache_modules_roles)) {
+        if (empty(static::cache_lgc_access)) {
             self::warmupRolesCache();
         }
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2476,7 +2476,7 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getModulesAccessesByIdProfile($idProfile)
     {
-        if (empty(static::cache_lgc_access)) {
+        if (empty(static::$cache_lgc_access)) {
             self::warmupRolesCache();
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `$cache_modules_roles` doesn't exists. The used property is `$cache_lgc_access` inside this method and the one called if not yet setted.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
