### PR TITLE
[FO]: Add a display hook in the address step just like other checkout step

### DIFF
--- a/themes/classic/templates/checkout/_partials/steps/addresses.tpl
+++ b/themes/classic/templates/checkout/_partials/steps/addresses.tpl
@@ -120,7 +120,7 @@
         {/if}
 
       {/if}
-
+      {hook h='displayAddressSelectorBottom'}
       {if !$form_has_continue_button}
         <div class="clearfix">
           <button type="submit" class="btn btn-primary continue float-xs-right" name="confirm-addresses" value="1">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | There is no possibility to add something (message) on address step of checkout.<br> So we suggest please add a display hook in the address step also just like other checkout steps. We have added a hook but you can suggest better hook name,
| Type?             |  improvement 
| Category?         | FO 
| Deprecations?     |  no 
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
