### PR TITLE
Remove inifinite loop on actionObjectUpdateAfter hook

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -86,6 +86,9 @@ class CookieCore
     /** @var bool */
     protected $_secure = false;
 
+    /** @var SessionInterface|null */
+    protected $session = null;
+
     /**
      * Get data if the cookie exists and else initialize an new one.
      *
@@ -556,19 +559,21 @@ class CookieCore
      */
     public function getSession($sessionId)
     {
+        if ($this->session !== null) {
+            return $this->session;
+        }
+
         if (isset($this->id_employee)) {
-            $session = new EmployeeSession($sessionId);
+            $this->session = new EmployeeSession($sessionId);
         } elseif (isset($this->id_customer)) {
-            $session = new CustomerSession($sessionId);
+            $this->session = new CustomerSession($sessionId);
         }
 
-        if (isset($session) && Validate::isLoadedObject($session)) {
+        if (isset($this->session) && Validate::isLoadedObject($this->session)) {
             // Update session date_upd
-            $session->save();
-
-            return $session;
+            $this->session->save();
         }
 
-        return null;
+        return $this->session;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x 
| Description?      | remove inifinite loop on actionObjectUpdateAfter hook
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29560
| Related PRs       | 
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/29560
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
