### PR TITLE
Use INTL_IDNA_VARIANT_2003 when INTL_IDNA_VARIANT_UTS46 is not defined (servers whith ICU < 4.6)

### DIFF
--- a/src/Core/Util/InternationalizedDomainNameConverter.php
+++ b/src/Core/Util/InternationalizedDomainNameConverter.php
@@ -52,5 +52,7 @@ class InternationalizedDomainNameConverter
 		if (defined('INTL_IDNA_VARIANT_2003')) {
 			return $parts[0] . '@' . idn_to_utf8($parts[1], 0, INTL_IDNA_VARIANT_2003);
 		}
+        
+        return $parts[0] . '@' . idn_to_utf8($parts[1]);
     }
 }

--- a/src/Core/Util/InternationalizedDomainNameConverter.php
+++ b/src/Core/Util/InternationalizedDomainNameConverter.php
@@ -44,7 +44,6 @@ class InternationalizedDomainNameConverter
             return $email;
         }
 
-
         if (defined('INTL_IDNA_VARIANT_UTS46')) {
             return $parts[0] . '@' . idn_to_utf8($parts[1], 0, INTL_IDNA_VARIANT_UTS46);
         }

--- a/src/Core/Util/InternationalizedDomainNameConverter.php
+++ b/src/Core/Util/InternationalizedDomainNameConverter.php
@@ -44,6 +44,13 @@ class InternationalizedDomainNameConverter
             return $email;
         }
 
-        return $parts[0] . '@' . idn_to_utf8($parts[1], 0, INTL_IDNA_VARIANT_UTS46);
+        
+		if (defined('INTL_IDNA_VARIANT_UTS46')) {
+			return $parts[0] . '@' . idn_to_utf8($parts[1], 0, INTL_IDNA_VARIANT_UTS46);
+		}
+		
+		if (defined('INTL_IDNA_VARIANT_2003')) {
+			return $parts[0] . '@' . idn_to_utf8($parts[1], 0, INTL_IDNA_VARIANT_2003);
+		}
     }
 }

--- a/src/Core/Util/InternationalizedDomainNameConverter.php
+++ b/src/Core/Util/InternationalizedDomainNameConverter.php
@@ -44,15 +44,15 @@ class InternationalizedDomainNameConverter
             return $email;
         }
 
-        
-		if (defined('INTL_IDNA_VARIANT_UTS46')) {
-			return $parts[0] . '@' . idn_to_utf8($parts[1], 0, INTL_IDNA_VARIANT_UTS46);
-		}
-		
-		if (defined('INTL_IDNA_VARIANT_2003')) {
-			return $parts[0] . '@' . idn_to_utf8($parts[1], 0, INTL_IDNA_VARIANT_2003);
-		}
-        
+
+        if (defined('INTL_IDNA_VARIANT_UTS46')) {
+            return $parts[0] . '@' . idn_to_utf8($parts[1], 0, INTL_IDNA_VARIANT_UTS46);
+        }
+
+        if (defined('INTL_IDNA_VARIANT_2003')) {
+            return $parts[0] . '@' . idn_to_utf8($parts[1], 0, INTL_IDNA_VARIANT_2003);
+        }
+
         return $parts[0] . '@' . idn_to_utf8($parts[1]);
     }
 }


### PR DESCRIPTION
Questions| Answers
--- | ---
Branch? | develop
Description? | It is not possible to log in the BO due to an error in INTL_IDNA_VARIANT_UTS46 with ICU < 4.6 (see https://github.com/PrestaShop/PrestaShop/issues/22300, https://github.com/PrestaShop/PrestaShop/issues/22989, https://github.com/PrestaShop/PrestaShop/issues/23729, https://github.com/PrestaShop/PrestaShop/issues/24538, https://github.com/PrestaShop/PrestaShop/issues/29622)
Type? | bug fix
Category? | BO
BC breaks? | no (I think)
Deprecations? | no
Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/22300, https://github.com/PrestaShop/PrestaShop/issues/22989, https://github.com/PrestaShop/PrestaShop/issues/23729, https://github.com/PrestaShop/PrestaShop/issues/24538, https://github.com/PrestaShop/PrestaShop/issues/29622, etc...
How to test? | In ICU < 4.6 (for instance in CentOS 6)

Other libraries that use it include checks for its existence, falling back to INTL_IDNA_VARIANT_2003. See https://github.com/bcit-ci/CodeIgniter/commit/4541bf930e715917622dc2d225bf5517f99db35a for example.

The solution is the same that the prestashop file `classes/Mail.php` see: https://github.com/PrestaShop/PrestaShop/blob/24fc145d36f84c4340170c392237e348d32b4284/classes/Mail.php#L936