### PR TITLE
Fix display issues on BO employee page when cancel the modification of the password

### DIFF
--- a/admin-dev/themes/new-theme/js/components/form/change-password-control.ts
+++ b/admin-dev/themes/new-theme/js/components/form/change-password-control.ts
@@ -48,6 +48,8 @@ export default class ChangePasswordControl {
 
   generatedPasswordDisplaySelector: string;
 
+  passwordStrengthFeedbackContainerSelector: string;
+
   $newPasswordInputs: JQuery<HTMLElement>;
 
   $copyPasswordInputs: JQuery<HTMLElement>;
@@ -88,6 +90,9 @@ export default class ChangePasswordControl {
 
     // Input that displays generated random password
     this.generatedPasswordDisplaySelector = generatedPasswordDisplaySelector;
+
+    // Block that displays password strength feedback
+    this.passwordStrengthFeedbackContainerSelector = passwordStrengthFeedbackContainerSelector;
 
     // Main input for password generation
     this.$newPasswordInputs = this.$inputsBlock.find(
@@ -249,6 +254,9 @@ export default class ChangePasswordControl {
     this.$submittableInputs.removeAttr('required');
     this.$inputsBlock.find('input').val('');
     this.$inputsBlock.find('.form-text').text('');
+    this.$newPasswordInputs.popover('hide');
+    this.hide(this.$inputsBlock.find(this.passwordStrengthFeedbackContainerSelector));
+    this.$newPasswordInputs.removeClass('border-success border-danger');
   }
 
   /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fix display issues on BO employee page when cancel the modification of the password
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29491, #29626 
| Related PRs       |
| How to test?      | Cancel the 'modification of the password' and then click again on "Change password..." #29491, #29626
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
