### PR TITLE
Bugfix/28924 fix large module upgrade from zip

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -728,14 +728,24 @@ class AdminModuleController {
         self.displayOnUploadError(message);
       },
       complete: (file) => {
-        if (file.status !== 'error') {
-          const responseObject = $.parseJSON(file.xhr.response);
 
-          if (typeof responseObject.is_configurable === 'undefined') responseObject.is_configurable = null;
-          if (typeof responseObject.module_name === 'undefined') responseObject.module_name = null;
+        try {
+          const responseObject = JSON.parse(file.xhr.response);
 
-          self.displayOnUploadDone(responseObject);
+          if (file.status !== 'error') {
+            if (typeof responseObject.is_configurable === 'undefined') responseObject.is_configurable = null;
+            if (typeof responseObject.module_name === 'undefined') responseObject.module_name = null;
+  
+            self.displayOnUploadDone(responseObject);
+          } else {
+            self.displayOnUploadError(responseObject);
+          }
+
+        } catch(e) {
+          // Same as dropzone error message.
+          self.displayOnUploadError('Invalid JSON response from server.');
         }
+
         // State that we have finish the process to unlock some actions
         self.isUploadStarted = false;
       },

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -728,20 +728,18 @@ class AdminModuleController {
         self.displayOnUploadError(message);
       },
       complete: (file) => {
-
         try {
           const responseObject = JSON.parse(file.xhr.response);
 
           if (file.status !== 'error') {
             if (typeof responseObject.is_configurable === 'undefined') responseObject.is_configurable = null;
             if (typeof responseObject.module_name === 'undefined') responseObject.module_name = null;
-  
+
             self.displayOnUploadDone(responseObject);
           } else {
             self.displayOnUploadError(responseObject);
           }
-
-        } catch(e) {
+        } catch (e) {
           // Same as dropzone error message.
           self.displayOnUploadError('Invalid JSON response from server.');
         }

--- a/src/PrestaShopBundle/DataCollector/HookDataCollector.php
+++ b/src/PrestaShopBundle/DataCollector/HookDataCollector.php
@@ -125,15 +125,26 @@ final class HookDataCollector extends DataCollector
     {
         foreach ($hooksList as &$hookList) {
             foreach ($hookList as &$hook) {
+                // Symfony Request object is quite heavy and is already given by debug tooling. Don't clone it again.
+                if (isset($hook['args']['request'])) {
+                    $hook['args']['request'] = 'Hook use client request as argument. For more details, cf. "Request/Response panel".';
+                }
+
                 $hook['args'] = $this->cloneVar($hook['args']);
 
                 foreach ($hook['modules'] as &$modulesByType) {
                     foreach ($modulesByType as $type => &$module) {
                         if (empty($module)) {
                             unset($modulesByType[$type]);
+                            continue;
                         }
 
                         if (array_key_exists('args', $module)) {
+                            // Symfony Request object is quite heavy and is already given by debug tooling. Don't clone it again.
+                            if (isset($module['args']['request'])) {
+                                $module['args']['request'] = 'Module use client request as argument. For more details, cf. "Request/Response panel".';
+                            }
+
                             $module['args'] = $this->cloneVar($module['args']);
                         }
                     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Error message was wrong when tried to upload too big module zip file. (See below for more details)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28924 .
| Related PRs       | Las working commit was [ea89268](https://github.com/PrestaShop/PrestaShop/commit/ea89268) but at this time, check was done by a front end default value of module size limit. Did back-end check ever worked ? Then front-end has to manage bad error message as well.   
| How to test?      | Cf. #28924 
| Possible impacts? | Please check "Hooks" panel (debug toolbar) for all important pages.

> :metal: special thanks to @FabienPapet for the hand about symfony profiler / datacollector architecture and to @jolelievre for last "serialize" analysis xD.

Without this fix, my development environment throw a `Symfony\\Component\\ErrorHandler\\Error\\OutOfMemoryError` exception due to profiler / data collector tooling that induced some weird json response.

My environment :
```ini
; Maximum amount of memory a script may consume (128MB)
; http://php.net/memory-limit
memory_limit = 256M
```
After some analysis, we can see that symfony request object is given as hook and module arguments.
Cf. [HookManager](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Adapter/HookManager.php#L71) and [HookDispatcher](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Adapter/Hook/HookDispatcher.php#L238)

## Detailed description

> :point_up:  In fact this bug as probably always been there.

It has been revealed when module size check has stopped being done by front-end.
Cf. https://github.com/PrestaShop/PrestaShop/commit/8a6765299a1c586c774f130e43ce024ca8cc6dad : DropZone library configuration changed when this line has been removed : `maxFilesize: 50, // can't be greater than 50Mb because it's an addons limitation`

Then the back end returned a valid error message but during [`index.php` `kernel::terminate()` operation](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/admin-dev/index.php#L83), an error occurred during [Profiler](https://symfony.com/doc/4.4/profiler.html) data collected [serialization](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php#L160) and added some weird json stack trace to API response.
> Then the response looked like : 
> ```json
> {
>     API expected error message
> } {
>     kernel::terminate() error stack trace (OutOfMemory)
> }
> ```

Two problems were found there : 
1. Front end didn't manage properly invalid json response from API.
2. The custom [HookDataCollector](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/PrestaShopBundle/DataCollector/HookDataCollector.php) added all called and not called hooks and modules with their parameters. The main element that as been identified as memory waste is the "request" argument that is already given in debug bar and given by default to all modules and hooks (cf. [HookManager](https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Adapter/HookManager.php#L71) and [HookDispatcher]https://github.com/PrestaShop/PrestaShop/blob/8.0.x/src/Adapter/Hook/HookDispatcher.php#L238))

> :warning: Even if this change fix the problem and guaranty some memory usage optimization for debug, it is not normal that an Exception could break API response. I recommend some further explorations about error handling management with API. 

