### PR TITLE
Select new invoice address automatically

### DIFF
--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -146,24 +146,9 @@ class OrderControllerCore extends FrontController
     protected function saveDataToPersist(CheckoutProcess $process)
     {
         $data = $process->getDataToPersist();
-        $addressValidator = new AddressValidator($this->context);
-        $customer = $this->context->customer;
         $cart = $this->context->cart;
 
-        $shouldGenerateChecksum = false;
-
-        if ($customer->isGuest()) {
-            $shouldGenerateChecksum = true;
-        } else {
-            $invalidAddressIds = $addressValidator->validateCartAddresses($cart);
-            if (empty($invalidAddressIds)) {
-                $shouldGenerateChecksum = true;
-            }
-        }
-
-        $data['checksum'] = $shouldGenerateChecksum
-            ? $this->cartChecksum->generateChecksum($cart)
-            : null;
+        $data['checksum'] = $this->cartChecksum->generateChecksum($cart);
 
         Db::getInstance()->execute(
             'UPDATE ' . _DB_PREFIX_ . 'cart SET checkout_session_data = "' . pSQL(json_encode($data)) . '"
@@ -201,10 +186,6 @@ class OrderControllerCore extends FrontController
                     'Shop.Notifications.Error'
                 ),
             ];
-
-            $checksum = null;
-        } else {
-            $checksum = $this->cartChecksum->generateChecksum($cart);
         }
 
         // Prevent check for guests
@@ -215,7 +196,7 @@ class OrderControllerCore extends FrontController
             $this->checkoutWarning['invalid_addresses'] = $allInvalidAddressIds;
         }
 
-        if (isset($data['checksum']) && $data['checksum'] === $checksum) {
+        if (isset($data['checksum']) && $data['checksum'] === $this->cartChecksum->generateChecksum($cart)) {
             $process->restorePersistedData($data);
         }
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Fix when we select "use a different address" for the invoice address. Now the new address added as invoice address is indeed assignee as invoice address to the order.
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #29289
| Related PRs       | 
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/29289
| Possible impacts? | Try the whole process of a command to see if everything work well.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
