### PR TITLE
Upgrade Smarty to 3.1.47

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -455,6 +455,7 @@
             "support": {
                 "source": "https://github.com/PrestaShop/php-cssjanus/tree/patch-1"
             },
+            "abandoned": true,
             "time": "2018-01-08T09:57:29+00:00"
         },
         {
@@ -7022,20 +7023,20 @@
         },
         {
             "name": "smarty/smarty",
-            "version": "v3.1.43",
+            "version": "v3.1.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/smarty-php/smarty.git",
-                "reference": "273f7e00fec034f6d61112552e9caf08d19565b7"
+                "reference": "a09364fe1706cb465e910eb040e592053d7effb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/273f7e00fec034f6d61112552e9caf08d19565b7",
-                "reference": "273f7e00fec034f6d61112552e9caf08d19565b7",
+                "url": "https://api.github.com/repos/smarty-php/smarty/zipball/a09364fe1706cb465e910eb040e592053d7effb8",
+                "reference": "a09364fe1706cb465e910eb040e592053d7effb8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2"
+                "php": "^5.2 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^7.5 || ^6.5 || ^5.7 || ^4.8",
@@ -7075,13 +7076,7 @@
             "keywords": [
                 "templating"
             ],
-            "support": {
-                "forum": "http://www.smarty.net/forums/",
-                "irc": "irc://irc.freenode.org/smarty",
-                "issues": "https://github.com/smarty-php/smarty/issues",
-                "source": "https://github.com/smarty-php/smarty/tree/v3.1.43"
-            },
-            "time": "2022-01-10T09:52:40+00:00"
+            "time": "2022-09-14T11:29:00+00:00"
         },
         {
             "name": "soundasleep/html2text",
@@ -7202,6 +7197,7 @@
                 "issues": "https://github.com/swiftmailer/swiftmailer/issues",
                 "source": "https://github.com/swiftmailer/swiftmailer/tree/v6.2.3"
             },
+            "abandoned": "symfony/mailer",
             "time": "2019-11-12T09:31:26+00:00"
         },
         {
@@ -8608,6 +8604,7 @@
                 "issues": "https://github.com/symfony/swiftmailer-bundle/issues",
                 "source": "https://github.com/symfony/swiftmailer-bundle/tree/master"
             },
+            "abandoned": "symfony/mailer",
             "time": "2019-04-18T15:52:54+00:00"
         },
         {
@@ -9844,6 +9841,7 @@
                 "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
                 "source": "https://github.com/PHP-CS-Fixer/diff/tree/master"
             },
+            "abandoned": true,
             "time": "2018-02-15T16:58:55+00:00"
         },
         {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Upgrade Smarty to 3.1.47 : <br>- Fixes illegal characters warning in math. <br>- Prevent PHP injection through malicious block name or include file name. This addresses https://github.com/advisories/GHSA-634x-pc3q-cf4c. <br>- Fixed replace modifier by converting encoding if needed. <br>- Fixed second param of unescape. <br>- Applied appropriate javascript and html escaping in mailto plugin to counter injection attacks <br>- Fixed use of rand() without a parameter in math function <br>- Fixed unselected year/month/day not working in html_select_date 
| Type?             | improvement
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       |
| How to test?      | CI is green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
