### PR TITLE
WS : Handle PATCH requests for attachments

### DIFF
--- a/classes/webservice/WebserviceSpecificManagementAttachments.php
+++ b/classes/webservice/WebserviceSpecificManagementAttachments.php
@@ -232,6 +232,7 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
                     break;
                 case 'PUT':
                     $this->getWsObject()->executeEntityPut();
+                    break;
                 case 'PATCH':
                     $this->getWsObject()->executeEntityPatch();
                     break;

--- a/classes/webservice/WebserviceSpecificManagementAttachments.php
+++ b/classes/webservice/WebserviceSpecificManagementAttachments.php
@@ -209,6 +209,7 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
                     break;
                 case 'POST':
                 case 'PUT':
+                case 'PATCH':
                     $this->executeFileAddAndEdit();
 
                     // Emulate get/head to return output
@@ -231,6 +232,8 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
                     break;
                 case 'PUT':
                     $this->getWsObject()->executeEntityPut();
+                case 'PATCH':
+                    $this->getWsObject()->executeEntityPatch();
                     break;
                 case 'DELETE':
                     $this->getWsObject()->executeEntityDelete();

--- a/classes/webservice/WebserviceSpecificManagementAttachments.php
+++ b/classes/webservice/WebserviceSpecificManagementAttachments.php
@@ -302,7 +302,7 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
      * Handles file upload
      *
      * Creates new attachment or replaces existing with a new file.
-     * [PUT] update existing attachment file
+     * [PUT] and [PATCH] update existing attachment file
      * [POST] create new attachment
      */
     public function executeFileAddAndEdit(): void
@@ -336,10 +336,14 @@ class WebserviceSpecificManagementAttachmentsCore implements WebserviceSpecificM
                 unlink(_PS_DOWNLOAD_DIR_ . $attachment->file);
             }
 
+            $defaultLanguage = Configuration::get('PS_LANG_DEFAULT');
+
             $attachment->file = $file['id'];
             $attachment->file_name = $file['file_name'];
             $attachment->mime = $file['mime_type'];
-            $attachment->name[Configuration::get('PS_LANG_DEFAULT')] = $_POST['name'] ?? $file['file_name'];
+            if ($attachment->name[$defaultLanguage] === null) {
+                $attachment->name[$defaultLanguage] = $_POST['name'] ?? $file['file_name'];
+            }
 
             if (!empty($attachment->id)) {
                 $attachment->update();


### PR DESCRIPTION
This PR continues the work started in #28747 by @nsorosac 

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      |This PR enables the use of PATCH for endpoint /api/attachments/file/{id} . In order to make sure the weird behavior described [here](https://github.com/PrestaShop/PrestaShop/pull/28747#issuecomment-1182203278) is fixed, in the PR I only modify the filename if we use POST (not PUT or PATCH).
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?      | Fixes #28748
| Related PRs       | 
| How to test?      | Please see the Postman calls listed and explained at the bottom of  #28748


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
