### PR TITLE
Lock sebastian/comparator to 4.0.6

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Update phpunit version
         if: ${{ startsWith(matrix.php, '8.') }}
-        run: composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit
+        run: composer update -w --ignore-platform-reqs --no-interaction phpunit/phpunit sebastian/comparator:4.0.6
 
       - name: Run phpunit
         run: ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | This PR aims to fix the CI by locking the package sebastian/comparator to the version 4.0.6
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29641
| Related PRs       | 
| How to test?      | CI should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
