### PR TITLE
Improved structure for error message generation in configuration pages 8.0.x

### DIFF
--- a/src/Core/Form/ErrorMessage/AdministrationConfigurationError.php
+++ b/src/Core/Form/ErrorMessage/AdministrationConfigurationError.php
@@ -26,10 +26,14 @@
 
 declare(strict_types=1);
 
-namespace PrestaShopBundle\Form\Exception;
+namespace PrestaShop\PrestaShop\Core\Form\ErrorMessage;
 
-class InvalidConfigurationDataError
+/** Configuration error specific to administration page */
+class AdministrationConfigurationError implements ConfigurationErrorInterface
 {
+    public const ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED = 1;
+    public const ERROR_COOKIE_SAMESITE_NONE = 2;
+
     /**
      * @var int
      */
@@ -46,7 +50,7 @@ class InvalidConfigurationDataError
     private $languageId;
 
     /**
-     * InvalidConfigurationDataError constructor.
+     * AdministrationConfigurationError constructor.
      *
      * @param int $errorCode
      * @param string $fieldName

--- a/src/Core/Form/ErrorMessage/CommonConfigurationError.php
+++ b/src/Core/Form/ErrorMessage/CommonConfigurationError.php
@@ -26,34 +26,63 @@
 
 declare(strict_types=1);
 
-namespace PrestaShopBundle\Form\Exception;
+namespace PrestaShop\PrestaShop\Core\Form\ErrorMessage;
 
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
-use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorCollection;
-use Throwable;
-
-/**
- * Exception thrown in case error happens in data provider validation
- * should be caught in the controller and configurationErrors used to display errors
- */
-class DataProviderException extends DomainException
+/** Common configuration error that can appear in any configuration page */
+class CommonConfigurationError implements ConfigurationErrorInterface
 {
-    /**
-     * @var ConfigurationErrorCollection
-     */
-    private $configurationErrors;
+    public const ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO = 1;
 
-    public function __construct($message = '', $code = 0, Throwable $previous = null, ?ConfigurationErrorCollection $configurationErrors = null)
+    /**
+     * @var int
+     */
+    private $errorCode;
+
+    /**
+     * @var string
+     */
+    private $fieldName;
+
+    /**
+     * @var int|null
+     */
+    private $languageId;
+
+    /**
+     * AdministrationConfigurationError constructor.
+     *
+     * @param int $errorCode
+     * @param string $fieldName
+     * @param int|null $languageId
+     */
+    public function __construct(int $errorCode, string $fieldName, ?int $languageId = null)
     {
-        parent::__construct($message, $code, $previous);
-        $this->configurationErrors = $configurationErrors ?: new ConfigurationErrorCollection();
+        $this->errorCode = $errorCode;
+        $this->fieldName = $fieldName;
+        $this->languageId = $languageId;
     }
 
     /**
-     * @return ConfigurationErrorCollection
+     * @return int
      */
-    public function getInvalidConfigurationDataErrors(): ConfigurationErrorCollection
+    public function getErrorCode(): int
     {
-        return $this->configurationErrors;
+        return $this->errorCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFieldName(): string
+    {
+        return $this->fieldName;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLanguageId(): ?int
+    {
+        return $this->languageId;
     }
 }

--- a/src/Core/Form/ErrorMessage/ConfigurationErrorCollection.php
+++ b/src/Core/Form/ErrorMessage/ConfigurationErrorCollection.php
@@ -26,14 +26,15 @@
 
 declare(strict_types=1);
 
-namespace PrestaShopBundle\Form\Exception;
+namespace PrestaShop\PrestaShop\Core\Form\ErrorMessage;
 
 use PrestaShop\PrestaShop\Core\Data\AbstractTypedCollection;
 
-class InvalidConfigurationDataErrorCollection extends AbstractTypedCollection
+/** Collection of configuration form errors */
+class ConfigurationErrorCollection extends AbstractTypedCollection
 {
     protected function getType(): string
     {
-        return InvalidConfigurationDataError::class;
+        return ConfigurationErrorInterface::class;
     }
 }

--- a/src/Core/Form/ErrorMessage/ConfigurationErrorInterface.php
+++ b/src/Core/Form/ErrorMessage/ConfigurationErrorInterface.php
@@ -24,36 +24,23 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-declare(strict_types=1);
+namespace PrestaShop\PrestaShop\Core\Form\ErrorMessage;
 
-namespace PrestaShopBundle\Form\Exception;
-
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
-use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorCollection;
-use Throwable;
-
-/**
- * Exception thrown in case error happens in data provider validation
- * should be caught in the controller and configurationErrors used to display errors
- */
-class DataProviderException extends DomainException
+/** Interface for configuration errors which can happen when saving configuration forms */
+interface ConfigurationErrorInterface
 {
     /**
-     * @var ConfigurationErrorCollection
+     * @return int
      */
-    private $configurationErrors;
-
-    public function __construct($message = '', $code = 0, Throwable $previous = null, ?ConfigurationErrorCollection $configurationErrors = null)
-    {
-        parent::__construct($message, $code, $previous);
-        $this->configurationErrors = $configurationErrors ?: new ConfigurationErrorCollection();
-    }
+    public function getErrorCode(): int;
 
     /**
-     * @return ConfigurationErrorCollection
+     * @return string
      */
-    public function getInvalidConfigurationDataErrors(): ConfigurationErrorCollection
-    {
-        return $this->configurationErrors;
-    }
+    public function getFieldName(): string;
+
+    /**
+     * @return int|null
+     */
+    public function getLanguageId(): ?int;
 }

--- a/src/Core/Form/ErrorMessage/Factory/ConfigurationErrorMessageProviderInterface.php
+++ b/src/Core/Form/ErrorMessage/Factory/ConfigurationErrorMessageProviderInterface.php
@@ -24,36 +24,18 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-declare(strict_types=1);
+namespace PrestaShop\PrestaShop\Core\Form\ErrorMessage\Factory;
 
-namespace PrestaShopBundle\Form\Exception;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorInterface;
 
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
-use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorCollection;
-use Throwable;
-
-/**
- * Exception thrown in case error happens in data provider validation
- * should be caught in the controller and configurationErrors used to display errors
- */
-class DataProviderException extends DomainException
+/** Interface for configuration error factories which are responsible for returning error messages for configuration errors */
+interface ConfigurationErrorMessageProviderInterface
 {
     /**
-     * @var ConfigurationErrorCollection
+     * @param ConfigurationErrorInterface $error
+     * @param string $label
+     *
+     * @return string|null
      */
-    private $configurationErrors;
-
-    public function __construct($message = '', $code = 0, Throwable $previous = null, ?ConfigurationErrorCollection $configurationErrors = null)
-    {
-        parent::__construct($message, $code, $previous);
-        $this->configurationErrors = $configurationErrors ?: new ConfigurationErrorCollection();
-    }
-
-    /**
-     * @return ConfigurationErrorCollection
-     */
-    public function getInvalidConfigurationDataErrors(): ConfigurationErrorCollection
-    {
-        return $this->configurationErrors;
-    }
+    public function getErrorMessageForConfigurationError(ConfigurationErrorInterface $error, string $label): ?string;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
@@ -28,14 +28,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use PrestaShopBundle\Controller\Exception\FieldNotFoundException;
-use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\FormDataProvider;
-use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\GeneralDataProvider;
-use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\GeneralType;
-use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\UploadQuotaType;
 use PrestaShopBundle\Form\Exception\DataProviderException;
-use PrestaShopBundle\Form\Exception\InvalidConfigurationDataError;
-use PrestaShopBundle\Form\Exception\InvalidConfigurationDataErrorCollection;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -171,7 +164,8 @@ class AdministrationController extends FrameworkBundleAdminController
             try {
                 $formHandler->save($data);
             } catch (DataProviderException $e) {
-                $this->flashErrors($this->getErrorMessages($e->getInvalidConfigurationDataErrors()));
+                $errorMessageFactory = $this->get('prestashop.form.error_message.configuration_error_factory');
+                $this->flashErrors($errorMessageFactory->getErrorMessages($e->getInvalidConfigurationDataErrors(), $form));
 
                 return $this->redirectToRoute('admin_administration');
             }
@@ -204,112 +198,5 @@ class AdministrationController extends FrameworkBundleAdminController
     protected function getNotificationsFormHandler(): FormHandlerInterface
     {
         return $this->get('prestashop.adapter.administration.notifications.form_handler');
-    }
-
-    /**
-     * @param InvalidConfigurationDataErrorCollection $errors
-     *
-     * @return array<int, string>
-     */
-    private function getErrorMessages(InvalidConfigurationDataErrorCollection $errors): array
-    {
-        $messages = [];
-
-        foreach ($errors as $error) {
-            $messages[] = $this->getErrorMessage($error);
-        }
-
-        return $messages;
-    }
-
-    /**
-     * @param InvalidConfigurationDataError $error
-     *
-     * @return string
-     *
-     * @throws FieldNotFoundException
-     */
-    private function getErrorMessage(InvalidConfigurationDataError $error): string
-    {
-        switch ($error->getErrorCode()) {
-            case FormDataProvider::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO:
-                return $this->trans(
-                    '%s is invalid. Please enter an integer greater than or equal to 0.',
-                    'Admin.Notifications.Error',
-                    [$this->getFieldLabel($error->getFieldName())]
-                );
-            case FormDataProvider::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED:
-                return $this->trans(
-                    '%s is invalid. Please enter an integer lower than %s.',
-                    'Admin.Notifications.Error',
-                    [
-                        $this->getFieldLabel($error->getFieldName()),
-                        GeneralDataProvider::MAX_COOKIE_VALUE,
-                    ]
-                );
-            case FormDataProvider::ERROR_COOKIE_SAMESITE_NONE:
-                return $this->trans(
-                    'The SameSite=None is only available in secure mode.',
-                    'Admin.Advparameters.Notification'
-                );
-        }
-
-        return $this->trans(
-            '%s is invalid.',
-            'Admin.Notifications.Error',
-            [
-                $this->getFieldLabel($error->getFieldName()),
-                GeneralDataProvider::MAX_COOKIE_VALUE,
-            ]
-        );
-    }
-
-    /**
-     * @param string $fieldName
-     *
-     * @return string
-     */
-    private function getFieldLabel(string $fieldName): string
-    {
-        /*
-         * Reusing same translated string as in UploadQuotaType, ideally I would take strings from there instead
-         * Because if somebody changes name in UploadQuotaType it won't be changed here. Not sure how to do that,
-         * building the whole form just to retrieve labels sound like an overhead.
-         * Maybe move labels to some other service and then retrieve them in both UploadQuotaType and here.
-         */
-        switch ($fieldName) {
-            case UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES:
-                return $this->trans(
-                    'Maximum size for attached files',
-                    'Admin.Advparameters.Feature'
-                );
-            case UploadQuotaType::FIELD_MAX_SIZE_DOWNLOADABLE_FILE:
-                return $this->trans(
-                    'Maximum size for a downloadable product',
-                    'Admin.Advparameters.Feature'
-                );
-            case UploadQuotaType::FIELD_MAX_SIZE_PRODUCT_IMAGE:
-                return $this->trans(
-                    'Maximum size for a product\'s image',
-                    'Admin.Advparameters.Feature'
-                );
-            case GeneralType::FIELD_FRONT_COOKIE_LIFETIME:
-                return $this->trans(
-                    'Lifetime of front office cookies',
-                    'Admin.Advparameters.Feature'
-                );
-            case GeneralType::FIELD_BACK_COOKIE_LIFETIME:
-                return $this->trans(
-                    'Lifetime of back office cookies',
-                    'Admin.Advparameters.Feature'
-                );
-        }
-
-        throw new FieldNotFoundException(
-            sprintf(
-                'Field name for field %s not found',
-                $fieldName
-            )
-        );
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/FormDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/FormDataProvider.php
@@ -35,10 +35,6 @@ use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
  */
 final class FormDataProvider implements FormDataProviderInterface
 {
-    public const ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO = 1;
-    public const ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED = 2;
-    public const ERROR_COOKIE_SAMESITE_NONE = 3;
-
     /**
      * @var DataConfigurationInterface
      */

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralDataProvider.php
@@ -30,10 +30,11 @@ namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administratio
 
 use Cookie;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\AdministrationConfigurationError;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\CommonConfigurationError;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorCollection;
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use PrestaShopBundle\Form\Exception\DataProviderException;
-use PrestaShopBundle\Form\Exception\InvalidConfigurationDataError;
-use PrestaShopBundle\Form\Exception\InvalidConfigurationDataErrorCollection;
 
 /**
  * This class is responsible of managing the data manipulated using general form
@@ -99,32 +100,32 @@ final class GeneralDataProvider implements FormDataProviderInterface
      */
     private function validate(array $data): void
     {
-        $errors = new InvalidConfigurationDataErrorCollection();
+        $errors = new ConfigurationErrorCollection();
         if (isset($data[GeneralType::FIELD_FRONT_COOKIE_LIFETIME])) {
             $frontOfficeLifeTimeCookie = $data[GeneralType::FIELD_FRONT_COOKIE_LIFETIME];
             if (!is_numeric($frontOfficeLifeTimeCookie) || $frontOfficeLifeTimeCookie < 0) {
-                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, GeneralType::FIELD_FRONT_COOKIE_LIFETIME));
+                $errors->add(new CommonConfigurationError(CommonConfigurationError::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, GeneralType::FIELD_FRONT_COOKIE_LIFETIME));
             }
 
             if ($frontOfficeLifeTimeCookie > self::MAX_COOKIE_VALUE) {
-                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED, GeneralType::FIELD_FRONT_COOKIE_LIFETIME));
+                $errors->add(new AdministrationConfigurationError(AdministrationConfigurationError::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED, GeneralType::FIELD_FRONT_COOKIE_LIFETIME));
             }
         }
 
         if (isset($data[GeneralType::FIELD_BACK_COOKIE_LIFETIME])) {
             $backOfficeLifeTimeCookie = $data[GeneralType::FIELD_BACK_COOKIE_LIFETIME];
             if (!is_numeric($backOfficeLifeTimeCookie) || $backOfficeLifeTimeCookie < 0) {
-                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, GeneralType::FIELD_BACK_COOKIE_LIFETIME));
+                $errors->add(new CommonConfigurationError(CommonConfigurationError::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, GeneralType::FIELD_BACK_COOKIE_LIFETIME));
             }
 
             if ($backOfficeLifeTimeCookie > self::MAX_COOKIE_VALUE) {
-                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED, GeneralType::FIELD_BACK_COOKIE_LIFETIME));
+                $errors->add(new AdministrationConfigurationError(AdministrationConfigurationError::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED, GeneralType::FIELD_BACK_COOKIE_LIFETIME));
             }
         }
 
         if (isset($data[GeneralType::FIELD_COOKIE_SAMESITE])) {
             if (!$this->validateSameSite($data[GeneralType::FIELD_COOKIE_SAMESITE])) {
-                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_COOKIE_SAMESITE_NONE, GeneralType::FIELD_COOKIE_SAMESITE));
+                $errors->add(new AdministrationConfigurationError(AdministrationConfigurationError::ERROR_COOKIE_SAMESITE_NONE, GeneralType::FIELD_COOKIE_SAMESITE));
             }
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
@@ -29,10 +29,10 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\CommonConfigurationError;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorCollection;
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
 use PrestaShopBundle\Form\Exception\DataProviderException;
-use PrestaShopBundle\Form\Exception\InvalidConfigurationDataError;
-use PrestaShopBundle\Form\Exception\InvalidConfigurationDataErrorCollection;
 
 /**
  * This class is responsible of managing the data manipulated using Upload Quota form
@@ -76,19 +76,19 @@ final class UploadQuotaDataProvider implements FormDataProviderInterface
      */
     private function validate(array $data): void
     {
-        $errors = new InvalidConfigurationDataErrorCollection();
+        $errors = new ConfigurationErrorCollection();
 
         if (isset($data[UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES])) {
             $maxSizeAttachedFile = $data[UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES];
             if (!is_numeric($maxSizeAttachedFile) || $maxSizeAttachedFile < 0) {
-                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES));
+                $errors->add(new CommonConfigurationError(CommonConfigurationError::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, UploadQuotaType::FIELD_MAX_SIZE_ATTACHED_FILES));
             }
         }
 
         if (isset($data[UploadQuotaType::FIELD_MAX_SIZE_DOWNLOADABLE_FILE])) {
             $maxSizeDownloadableProduct = $data[UploadQuotaType::FIELD_MAX_SIZE_DOWNLOADABLE_FILE];
             if (!is_numeric($maxSizeDownloadableProduct) || $maxSizeDownloadableProduct < 0) {
-                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, UploadQuotaType::FIELD_MAX_SIZE_DOWNLOADABLE_FILE));
+                $errors->add(new CommonConfigurationError(CommonConfigurationError::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, UploadQuotaType::FIELD_MAX_SIZE_DOWNLOADABLE_FILE));
             }
         }
 
@@ -96,7 +96,7 @@ final class UploadQuotaDataProvider implements FormDataProviderInterface
             $maxSizeProductImage = $data[UploadQuotaType::FIELD_MAX_SIZE_PRODUCT_IMAGE];
 
             if (!is_numeric($maxSizeProductImage) || $maxSizeProductImage < 0) {
-                $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, UploadQuotaType::FIELD_MAX_SIZE_PRODUCT_IMAGE));
+                $errors->add(new CommonConfigurationError(CommonConfigurationError::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, UploadQuotaType::FIELD_MAX_SIZE_PRODUCT_IMAGE));
             }
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaDataProvider.php
@@ -94,7 +94,6 @@ final class UploadQuotaDataProvider implements FormDataProviderInterface
 
         if (isset($data[UploadQuotaType::FIELD_MAX_SIZE_PRODUCT_IMAGE])) {
             $maxSizeProductImage = $data[UploadQuotaType::FIELD_MAX_SIZE_PRODUCT_IMAGE];
-
             if (!is_numeric($maxSizeProductImage) || $maxSizeProductImage < 0) {
                 $errors->add(new CommonConfigurationError(CommonConfigurationError::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, UploadQuotaType::FIELD_MAX_SIZE_PRODUCT_IMAGE));
             }

--- a/src/PrestaShopBundle/Form/ErrorMessage/Factory/AdministrationConfigurationErrorMessageProvider.php
+++ b/src/PrestaShopBundle/Form/ErrorMessage/Factory/AdministrationConfigurationErrorMessageProvider.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\ErrorMessage\Factory;
+
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\AdministrationConfigurationError;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorInterface;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\Factory\ConfigurationErrorMessageProviderInterface;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\GeneralDataProvider;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/** Provider to get messages for errors specific to administration page */
+class AdministrationConfigurationErrorMessageProvider implements ConfigurationErrorMessageProviderInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * @var LangRepository
+     */
+    protected $langRepository;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        LangRepository $langRepository
+    ) {
+        $this->translator = $translator;
+        $this->langRepository = $langRepository;
+    }
+
+    /**
+     * @param ConfigurationErrorInterface $error
+     * @param string $label
+     *
+     * @return string|null
+     */
+    public function getErrorMessageForConfigurationError(ConfigurationErrorInterface $error, string $label): ?string
+    {
+        if (!$error instanceof AdministrationConfigurationError) {
+            return null;
+        }
+
+        switch ($error->getErrorCode()) {
+            case AdministrationConfigurationError::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED:
+                return $this->translator->trans(
+                    '%s is invalid. Please enter an integer lower than %s.',
+                    [
+                        $label,
+                        GeneralDataProvider::MAX_COOKIE_VALUE,
+                    ],
+                    'Admin.Notifications.Error'
+                );
+            case AdministrationConfigurationError::ERROR_COOKIE_SAMESITE_NONE:
+                return $this->translator->trans(
+                    'The SameSite=None is only available in secure mode.',
+                    [],
+                    'Admin.Advparameters.Notification'
+                );
+        }
+
+        return null;
+    }
+}

--- a/src/PrestaShopBundle/Form/ErrorMessage/Factory/CommonConfigurationErrorMessageProvider.php
+++ b/src/PrestaShopBundle/Form/ErrorMessage/Factory/CommonConfigurationErrorMessageProvider.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\ErrorMessage\Factory;
+
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\CommonConfigurationError;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorInterface;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\Factory\ConfigurationErrorMessageProviderInterface;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/** Provider to get messages for common configuration errors */
+class CommonConfigurationErrorMessageProvider implements ConfigurationErrorMessageProviderInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * @var LangRepository
+     */
+    protected $langRepository;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        LangRepository $langRepository
+    ) {
+        $this->translator = $translator;
+        $this->langRepository = $langRepository;
+    }
+
+    /**
+     * @param ConfigurationErrorInterface $error
+     * @param string $label
+     *
+     * @return string|null
+     */
+    public function getErrorMessageForConfigurationError(ConfigurationErrorInterface $error, string $label): ?string
+    {
+        if (!$error instanceof CommonConfigurationError) {
+            return null;
+        }
+
+        switch ($error->getErrorCode()) {
+            case CommonConfigurationError::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO:
+                return $this->translator->trans(
+                    '%s is invalid. Please enter an integer greater than or equal to 0.',
+                    [
+                        $label,
+                    ],
+                    'Admin.Notifications.Error'
+                );
+        }
+
+        return null;
+    }
+}

--- a/src/PrestaShopBundle/Form/ErrorMessage/Factory/ConfigurationErrorFactory.php
+++ b/src/PrestaShopBundle/Form/ErrorMessage/Factory/ConfigurationErrorFactory.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\ErrorMessage\Factory;
+
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorCollection;
+use PrestaShopBundle\Form\ErrorMessage\LabelProvider;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Base configuration error factory which cycles trough all existing configuration error factories
+ * to create error messages based on error class and code.
+ */
+class ConfigurationErrorFactory
+{
+    /**
+     * @var iterable
+     */
+    private $configurationErrorFactories;
+
+    /**
+     * @var LabelProvider
+     */
+    private $labelProvider;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(
+        iterable $configurationErrorFactories,
+        LabelProvider $labelProvider,
+        TranslatorInterface $translator
+    ) {
+        $this->configurationErrorFactories = $configurationErrorFactories;
+        $this->labelProvider = $labelProvider;
+        $this->translator = $translator;
+    }
+
+    /**
+     * @param ConfigurationErrorCollection $errors
+     * @param FormInterface $form
+     *
+     * @return array
+     */
+    public function getErrorMessages(ConfigurationErrorCollection $errors, FormInterface $form): array
+    {
+        $messages = [];
+
+        foreach ($errors as $error) {
+            $label = $this->labelProvider->getLabel($form, $error->getFieldName());
+            $errorMessage = null;
+            foreach ($this->configurationErrorFactories as $factory) {
+                $errorMessage = $factory->getErrorMessageForConfigurationError(
+                    $error,
+                    $label
+                );
+                if ($errorMessage) {
+                    break;
+                }
+            }
+            $messages[] = $errorMessage ?: $this->getDefaultErrorMessage($label);
+        }
+
+        return $messages;
+    }
+
+    /**
+     * @param string $label
+     *
+     * @return string
+     */
+    private function getDefaultErrorMessage(string $label): string
+    {
+        return $this->translator->trans(
+            '%s is invalid.',
+            [
+                $label,
+            ],
+            'Admin.Notifications.Error'
+        );
+    }
+}

--- a/src/PrestaShopBundle/Form/ErrorMessage/LabelProvider.php
+++ b/src/PrestaShopBundle/Form/ErrorMessage/LabelProvider.php
@@ -26,34 +26,29 @@
 
 declare(strict_types=1);
 
-namespace PrestaShopBundle\Form\Exception;
+namespace PrestaShopBundle\Form\ErrorMessage;
 
-use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
-use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorCollection;
-use Throwable;
+use Symfony\Component\Form\FormInterface;
 
-/**
- * Exception thrown in case error happens in data provider validation
- * should be caught in the controller and configurationErrors used to display errors
- */
-class DataProviderException extends DomainException
+/** Responsible for finding what label is used for certain field in the form */
+class LabelProvider
 {
     /**
-     * @var ConfigurationErrorCollection
+     * @param FormInterface $form
+     * @param string $fieldName
+     *
+     * @return string
      */
-    private $configurationErrors;
-
-    public function __construct($message = '', $code = 0, Throwable $previous = null, ?ConfigurationErrorCollection $configurationErrors = null)
+    public function getLabel(FormInterface $form, string $fieldName): string
     {
-        parent::__construct($message, $code, $previous);
-        $this->configurationErrors = $configurationErrors ?: new ConfigurationErrorCollection();
-    }
+        $view = $form->createView();
+        foreach ($view->children as $child) {
+            if (isset($child->vars['name']) && $fieldName === $child->vars['name']) {
+                return $child->vars['label'] ?? $fieldName;
+            }
+        }
 
-    /**
-     * @return ConfigurationErrorCollection
-     */
-    public function getInvalidConfigurationDataErrors(): ConfigurationErrorCollection
-    {
-        return $this->configurationErrors;
+        /* If label not found return $fieldName as fallback */
+        return $fieldName;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/error_message.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/error_message.yml
@@ -1,0 +1,27 @@
+services:
+  _defaults:
+    public: true
+
+  prestashop.form.error_message.label_provider:
+    class: PrestaShopBundle\Form\ErrorMessage\LabelProvider
+
+  prestashop.form.error_message.configuration_error_factory:
+    class: PrestaShopBundle\Form\ErrorMessage\Factory\ConfigurationErrorFactory
+    arguments:
+      - !tagged core.configuration_error_factory
+      - '@prestashop.form.error_message.label_provider'
+      - '@translator'
+
+  prestashop.form.error_message_factory.common_configuration_error_message_provider:
+    class: PrestaShopBundle\Form\ErrorMessage\Factory\CommonConfigurationErrorMessageProvider
+    arguments:
+      - '@translator'
+      - '@prestashop.core.admin.lang.repository'
+    tags: [ 'core.configuration_error_factory' ]
+
+  prestashop.form.error_message_factory.administration_configuration_error_message_provider:
+    class: PrestaShopBundle\Form\ErrorMessage\Factory\AdministrationConfigurationErrorMessageProvider
+    arguments:
+      - '@translator'
+      - '@prestashop.core.admin.lang.repository'
+    tags: [ 'core.configuration_error_factory' ]

--- a/tests/Unit/PrestaShopBundle/Form/ErrorMessage/Factory/AdministrationConfigurationErrorMessageProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/ErrorMessage/Factory/AdministrationConfigurationErrorMessageProviderTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\ErrorMessage\Factory;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\AdministrationConfigurationError;
+use PrestaShopBundle\Entity\Lang;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\GeneralDataProvider;
+use PrestaShopBundle\Form\ErrorMessage\Factory\AdministrationConfigurationErrorMessageProvider;
+use Symfony\Component\Translation\Translator;
+
+class AdministrationConfigurationErrorMessageProviderTest extends TestCase
+{
+    private const COOKIE_FIELD_NAME = 'Max cookie value';
+
+    public function testGetErrorMessageForConfigurationError(): void
+    {
+        $translatorMock = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['trans'])
+            ->getMock();
+
+        $expectedTranslation = 'Expected translation';
+        $translatorMock->method('trans')->willReturnMap(
+            [
+                [
+                    '%s is invalid. Please enter an integer lower than %s.',
+                    [
+                        self::COOKIE_FIELD_NAME,
+                        GeneralDataProvider::MAX_COOKIE_VALUE,
+                    ],
+                    'Admin.Notifications.Error',
+                    null,
+                    $expectedTranslation,
+                ],
+            ]
+        );
+
+        $languageRepositoryMock = $this->getMockBuilder(LangRepository::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['findOneBy'])
+            ->getMock();
+
+        $language = new Lang();
+        $language->setName('English');
+        $languageRepositoryMock->method('findOneBy')->willReturn($language);
+        $administrationConfigurationErrorFactory = new AdministrationConfigurationErrorMessageProvider($translatorMock, $languageRepositoryMock);
+
+        $error = new AdministrationConfigurationError(AdministrationConfigurationError::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED, 'field', 1);
+        $result = $administrationConfigurationErrorFactory->getErrorMessageForConfigurationError($error, self::COOKIE_FIELD_NAME);
+        self::assertEquals(
+            $expectedTranslation,
+            $result
+        );
+
+        $error = new AdministrationConfigurationError(35, 'field');
+        $result = $administrationConfigurationErrorFactory->getErrorMessageForConfigurationError($error, 'field');
+
+        self::assertNull($result);
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/ErrorMessage/Factory/CommonConfigurationErrorMessageProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/ErrorMessage/Factory/CommonConfigurationErrorMessageProviderTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\ErrorMessage\Factory;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\CommonConfigurationError;
+use PrestaShopBundle\Entity\Lang;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+use PrestaShopBundle\Form\ErrorMessage\Factory\CommonConfigurationErrorMessageProvider;
+use Symfony\Component\Translation\Translator;
+
+class CommonConfigurationErrorMessageProviderTest extends TestCase
+{
+    public function testGetErrorMessageForConfigurationError(): void
+    {
+        $translatorMock = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['trans'])
+            ->getMock();
+
+        $translatorMock->method('trans')->willReturnMap(
+            [
+                [
+                    '%s is invalid. Please enter an integer greater than or equal to 0.',
+                    [
+                        'field',
+                    ],
+                    'Admin.Notifications.Error',
+                    null,
+                    'Field is invalid. Please enter an integer greater than or equal to 0.',
+                ],
+            ]
+        );
+
+        $languageRepositoryMock = $this->getMockBuilder(LangRepository::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['findOneBy'])
+            ->getMock();
+
+        $language = new Lang();
+        $language->setName('English');
+        $languageRepositoryMock->method('findOneBy')->willReturn($language);
+        $commonConfigurationErrorFactory = new CommonConfigurationErrorMessageProvider($translatorMock, $languageRepositoryMock);
+
+        $error = new CommonConfigurationError(CommonConfigurationError::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, 'field', 1);
+        $result = $commonConfigurationErrorFactory->getErrorMessageForConfigurationError($error, 'field');
+        self::assertEquals(
+            'Field is invalid. Please enter an integer greater than or equal to 0.',
+            $result
+        );
+
+        $error = new CommonConfigurationError(35, 'field');
+        $result = $commonConfigurationErrorFactory->getErrorMessageForConfigurationError($error, 'field');
+
+        self::assertNull($result);
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/ErrorMessage/Factory/ConfigurationErrorFactoryTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/ErrorMessage/Factory/ConfigurationErrorFactoryTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\ErrorMessage\Factory;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\AdministrationConfigurationError;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\CommonConfigurationError;
+use PrestaShop\PrestaShop\Core\Form\ErrorMessage\ConfigurationErrorCollection;
+use PrestaShopBundle\Entity\Lang;
+use PrestaShopBundle\Entity\Repository\LangRepository;
+use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\GeneralDataProvider;
+use PrestaShopBundle\Form\ErrorMessage\Factory\AdministrationConfigurationErrorMessageProvider;
+use PrestaShopBundle\Form\ErrorMessage\Factory\CommonConfigurationErrorMessageProvider;
+use PrestaShopBundle\Form\ErrorMessage\Factory\ConfigurationErrorFactory;
+use PrestaShopBundle\Form\ErrorMessage\LabelProvider;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Translation\Translator;
+
+class ConfigurationErrorFactoryTest extends TestCase
+{
+    public function testGetErrorMessages(): void
+    {
+        $translatorMock = $this->getMockBuilder(Translator::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['trans'])
+            ->getMock();
+
+        $translatorMock->method('trans')->willReturnMap(
+            [
+                [
+                    '%s is invalid. Please enter an integer greater than or equal to 0.',
+                    [
+                        'Field',
+                    ],
+                    'Admin.Notifications.Error',
+                    null,
+                    'Field is invalid. Please enter an integer greater than or equal to 0.',
+                ],
+                [
+                    '%s is invalid. Please enter an integer lower than %s.',
+                    [
+                        'Field',
+                        GeneralDataProvider::MAX_COOKIE_VALUE,
+                    ],
+                    'Admin.Notifications.Error',
+                    null,
+                    'Field is invalid. Please enter an integer lower than 876000.',
+                ],
+                [
+                    '%s is invalid.',
+                    [
+                        'Field',
+                    ],
+                    'Admin.Notifications.Error',
+                    null,
+                    'Field is invalid.',
+                ],
+            ]
+        );
+
+        $languageRepositoryMock = $this->getMockBuilder(LangRepository::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['findOneBy'])
+            ->getMock();
+
+        $language = new Lang();
+        $language->setName('English');
+        $languageRepositoryMock->method('findOneBy')->willReturn($language);
+        $labelProviderMock = $this
+            ->getMockBuilder(LabelProvider::class)
+            ->setMethods(['getLabel'])
+            ->getMock();
+        $labelProviderMock->method('getLabel')->willReturn('Field');
+        $errorFactoryCollection = [];
+        $errorFactoryCollection[] = new AdministrationConfigurationErrorMessageProvider($translatorMock, $languageRepositoryMock);
+        $errorFactoryCollection[] = new CommonConfigurationErrorMessageProvider($translatorMock, $languageRepositoryMock);
+        $configurationErrorFactory = new ConfigurationErrorFactory($errorFactoryCollection, $labelProviderMock, $translatorMock);
+
+        $formMock = $this->getMockBuilder(FormInterface::class)->getMock();
+
+        $errorCollection = new ConfigurationErrorCollection();
+        $errorCollection->add(new AdministrationConfigurationError(AdministrationConfigurationError::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED, 'field'));
+        $errorCollection->add(new CommonConfigurationError(CommonConfigurationError::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, 'field'));
+        $errorCollection->add(new AdministrationConfigurationError(35, 'field'));
+
+        $errorMessages = $configurationErrorFactory->getErrorMessages($errorCollection, $formMock);
+
+        self::assertContains('Field is invalid. Please enter an integer lower than 876000.', $errorMessages);
+        self::assertContains('Field is invalid. Please enter an integer greater than or equal to 0.', $errorMessages);
+        self::assertContains('Field is invalid.', $errorMessages);
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/ErrorMessage/LabelProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/ErrorMessage/LabelProviderTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\ErrorMessage;
+
+use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
+use PrestaShopBundle\Form\ErrorMessage\LabelProvider;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class LabelProviderTest extends TypeTestCase
+{
+    public function testGetLabel(): void
+    {
+        $form = $this->factory->create(TestFormType::class);
+
+        $labelProvider = new LabelProvider();
+        self::assertSame('Field', $labelProvider->getLabel($form, 'field'));
+        self::assertSame('Some field name', $labelProvider->getLabel($form, 'other_field'));
+    }
+
+    public function testThrowsFieldNotFoundException(): void
+    {
+        $form = $this->factory->create(TestFormType::class);
+
+        $labelProvider = new LabelProvider();
+        $label = $labelProvider->getLabel($form, 'non_existing_field');
+        $this->assertSame('non_existing_field', $label);
+    }
+}
+
+class TestFormType extends CommonAbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('field', TextType::class, [
+                'label' => 'Field',
+            ])
+            ->add('other_field', TextType::class, [
+                'label' => 'Some field name',
+            ]);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Refactors error generation for configuration pages. With changes error system is more streamlined allowing for pages with same error reuse the code rather then duplicating it, as well as moving code from controllers to separate factories. Also added label provider which takes label from the form, rather then having to duplicate label somewhere else.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/20243 same was done in invoice PR, but separating this, so it hopefully get's faster and is part of 8.0
| How to test?      | Test that administration page throws errors correctly, when entering wrong info.

This is for 8.0.x because it had BC breaks that are needed to finish configuration forms simplifications.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
