### PR TITLE
Call parent stylesheets were missing

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Permission/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Permission/index.html.twig
@@ -42,6 +42,7 @@
 {% endblock %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/permissions' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
@@ -26,6 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_suffix ~ '.css') }}"/>
 {% endblock %}
 
@@ -38,8 +39,8 @@
     <div class="mt-5">
       <div class="card">
         <div class="card-body text-center">
-          <img class="img-responsive" 
-               src="{{ asset('themes/new-theme/img/error/500.svg') }}" 
+          <img class="img-responsive"
+               src="{{ asset('themes/new-theme/img/error/500.svg') }}"
                alt="{{ 'Oops... looks like an unexpected error occurred'|trans({}, 'Admin.Notifications.Error') }}">
 
           <div class="mt-3">

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
@@ -26,6 +26,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_suffix ~ '.css') }}"/>
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/catalog.html.twig
@@ -26,6 +26,7 @@
 {% form_theme categories '@PrestaShop/Admin/Product/Themes/categories_theme.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/product.html.twig
@@ -25,6 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Security/compromised.html.twig
@@ -25,6 +25,7 @@
 {% extends '@PrestaShop/base.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/theme' ~ rtl_suffix ~ '.css') }}" />
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/bulk.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/bulk.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_suffix ~ '.css') }}" type="text/css"
         media="all">
 {% endblock %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Combination/edit.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/create.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/SpecificPrice/edit.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/create.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -25,6 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/index.html.twig
@@ -25,6 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product_catalog.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Stock/overview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Stock/overview.html.twig
@@ -25,6 +25,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/stock_page' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/create.html.twig
@@ -28,6 +28,7 @@
 {% set layoutTitle = 'Create order'|trans({}, 'Admin.Orderscustomers.Feature') %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/index.html.twig
@@ -26,6 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/view.html.twig
@@ -31,6 +31,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block stylesheets %}
+  {{ parent() }}
   <link rel="stylesheet" href="{{ asset('themes/new-theme/public/orders' ~ rtl_suffix ~ '.css') }}" type="text/css" media="all">
 {% endblock %}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | While creating example module https://github.com/PrestaShop/example-modules/pull/107 I noticed that we don't call parent() anywhere we add custom stylesheets (e.g. the orders page). That haven't raised any problems until now, because we don't have any styles added in layout, but we add them manually in every page, but it restricts the possibility to add the styles to whole layout as I tried in the module. E.g. in module Im adding my custom flash message which can be shown in any page, so I extend layout.html and add custom css into it using the module, but all the pages that overrides stylesheet block and doesn't call parent, won't get the styles adjusted.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | https://github.com/PrestaShop/example-modules/pull/107
| How to test?      | see bellow
| Possible impacts? | Some of pages might not call the parent for a reason, but I don't know if we have such?

**How to test**
Use module to test it https://github.com/PrestaShop/example-modules/pull/107 (described in PR). Also can be tested by developers by adding some css into layout.html.twig stylesheets block and checking if it is loaded in orders page.
To test this PR using the mentioned module:
1. install the module on develop branch
2. Go to orders page and open any order for viewing
3. You should see some extra texts added from the module. Pay attention to the custom flash message at the top - when on develop branch the flash will be not styled - white.
4. Now switch to my PR branch and refresh the order page.
5. You should see the flash turned to "yellow-green" color. This means my PR works because order page includes css from parent. (see screenshots how the flash should look in develop and in my PR)
with this PR changes:
![Screenshot from 2022-11-12 16-38-10](https://user-images.githubusercontent.com/31609858/201479616-a2d7a6b8-9c2c-4bdf-aa1f-1450ae4a0c7d.png)
without this PR changes:
![Screenshot from 2022-11-12 16-37-51](https://user-images.githubusercontent.com/31609858/201479619-8cc40b3d-6c63-4013-8f88-c537e9a960da.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
