### PR TITLE
BO - Import files - Do not show generated csv files from import/csvfromexcel folder in history of uploaded files

### DIFF
--- a/src/Core/Import/File/FileFinder.php
+++ b/src/Core/Import/File/FileFinder.php
@@ -59,6 +59,7 @@ final class FileFinder
         $finder
             ->files()
             ->in($this->importDirectory->getDir())
+            ->depth('0')
             ->notName('/^index\.php/i');
 
         $fileNames = [];

--- a/tests/Integration/Core/Import/File/FileFinderTest.php
+++ b/tests/Integration/Core/Import/File/FileFinderTest.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-namespace Tests\Unit\Core\Import\File;
+namespace Tests\Integration\Core\Import\File;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
@@ -82,7 +82,7 @@ class FileFinderTest extends TestCase
         $this->assertEquals($importedFileName, $this->filefinder->getImportFileNames()[0]);
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->fs->remove($this->adminDirectory);
     }

--- a/tests/Unit/Core/Import/File/FileFinderTest.php
+++ b/tests/Unit/Core/Import/File/FileFinderTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace Tests\Unit\Core\Import\File;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Import\File\FileFinder;
+use PrestaShop\PrestaShop\Core\Import\ImportDirectory;
+use Symfony\Component\Filesystem\Filesystem;
+
+class FileFinderTest extends TestCase
+{
+    /** @var string */
+    protected $adminDirectory;
+
+    /** @var string */
+    protected $importSubDirectory;
+
+    /** @var FileFinder */
+    protected $filefinder;
+
+    /** @var ImportDirectory */
+    protected $importDirectory;
+
+    /** @var Filesystem */
+    protected $fs;
+
+    protected function setUp(): void
+    {
+        $this->fs = new Filesystem();
+        $this->adminDirectory = sys_get_temp_dir() . '/' . uniqid();
+        $configuration = $this->createMock(ConfigurationInterface::class);
+        $configuration->method('set')
+            ->with('_PS_ADMIN_DIR_', $this->adminDirectory);
+        $configuration->method('get')->willReturnMap([['_PS_ADMIN_DIR_', $this->adminDirectory]]);
+        $this->importDirectory = new ImportDirectory($configuration);
+        $this->importSubDirectory = $this->importDirectory->getDir() . 'csvfromexcel/';
+        $this->filefinder = new FileFinder($this->importDirectory);
+        $this->fs->mkdir([$this->adminDirectory, $this->importDirectory->getDir(), $this->importSubDirectory]);
+    }
+
+    public function testGetImportFileNames(): void
+    {
+        $this->assertCount(0, $this->filefinder->getImportFileNames());
+
+        $importedFileName = 'imported_file.csv';
+        $importedSubdirFileName = 'imported_file_subdir.csv';
+        $indexPhpFile = 'index.php';
+
+        $this->fs->touch([
+            $this->importDirectory->getDir() . $importedFileName,
+            $this->importDirectory->getDir() . $indexPhpFile,
+            $this->importSubDirectory . $importedSubdirFileName,
+        ]
+        );
+
+        $this->assertCount(1, $this->filefinder->getImportFileNames());
+        $this->assertEquals($importedFileName, $this->filefinder->getImportFileNames()[0]);
+    }
+
+    protected function tearDown()
+    {
+        $this->fs->remove($this->adminDirectory);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Only the uploaded files by the user are listed in the 'Choose from history / FTP'. Exclude files subdirectories and especially from import/csvfromexcel.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28761 
| Related PRs       | 
| How to test?      | See #28761
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
