### PR TITLE
Change formula to calculate unit price tax included 

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5702,7 +5702,7 @@ class ProductCore extends ObjectModel
         $unitPriceRatio = self::computeUnitPriceRatio($row, $id_product_attribute, $quantity, $context);
         $row['unit_price_ratio'] = $unitPriceRatio;
         $row['unit_price_tax_excluded'] = $unitPriceRatio != 0 ? $priceTaxExcluded / $unitPriceRatio : 0.0;
-        $row['unit_price_tax_included'] = $unitPriceRatio != 0 ? $priceTaxIncluded / $unitPriceRatio : 0.0;
+        $row['unit_price_tax_included'] = $row['unit_price'] * (1 + $row['rate'] / 100);
 
         Hook::exec('actionGetProductPropertiesAfterUnitPrice', [
             'id_lang' => $id_lang,


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x
| Description?      | The formula to calculate unit price tax included has been changed. It's now based on the unit price instead of using unit price ratio.
| Type?             | bug fix 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #29338
| Related PRs       | 
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/29338
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
