### PR TITLE
Concept - Use boostrap responsivity

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationAvailabilityType.php
@@ -74,11 +74,13 @@ class CombinationAvailabilityType extends TranslatorAwareType
                 'choices' => $this->outOfStockTypeChoiceProvider->getChoices(),
                 'label' => false,
                 'expanded' => true,
-                'column_breaker' => true,
                 'modify_all_shops' => true,
                 'external_link' => [
                     'text' => $this->trans('[1]Edit default behavior[/1]', 'Admin.Catalog.Feature'),
                     'href' => $this->router->generate('admin_product_preferences') . '#configuration_fieldset_stock',
+                ],
+                'row_attr' => [
+                    'class' => 'col-12',
                 ],
             ])
             ->add('available_now_label', TranslatableType::class, [
@@ -86,6 +88,9 @@ class CombinationAvailabilityType extends TranslatorAwareType
                 'label' => $this->trans('Label when in stock', 'Admin.Catalog.Feature'),
                 'required' => false,
                 'modify_all_shops' => true,
+                'row_attr' => [
+                    'class' => 'col-md-6',
+                ],
             ])
             ->add('available_later_label', TranslatableType::class, [
                 'type' => TextType::class,
@@ -95,6 +100,9 @@ class CombinationAvailabilityType extends TranslatorAwareType
                 ),
                 'required' => false,
                 'modify_all_shops' => true,
+                'row_attr' => [
+                    'class' => 'col-md-6',
+                ],
             ])
         ;
     }
@@ -106,7 +114,9 @@ class CombinationAvailabilityType extends TranslatorAwareType
                 'label' => $this->trans('When out of stock', 'Admin.Catalog.Feature'),
                 'label_tag_name' => 'h3',
                 'required' => false,
-                'columns_number' => 3,
+                'attr' => [
+                    'class' => 'row',
+                ],
             ])
         ;
     }


### PR DESCRIPTION
I would like to propose two changes.
**1. We could use boostrap responsive classes to allow better control of sizing for each field.**
- You can set individual column sizes for each field, not be limited to column count.
- It's easier to read.
- It's easier to customize.
- Doesn't need any extra CSS to make it work.

**2. There is external_link property in one of the form fields.**
I think this is a bit short scoped. We could use `help` and `help_html` attributes for this OR we can implement our custom thing - like `html_after` and `html_before` to make it more reusable.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.0.x / 1.7.8.x
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | FO / BO / CO / IN / WS / TE / LO / ME / PM
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #{issue number here}.
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
