### PR TITLE
Removed `US/Pacific New` from timezone list

### DIFF
--- a/install-dev/data/xml/timezone.xml
+++ b/install-dev/data/xml/timezone.xml
@@ -558,7 +558,6 @@
     <timezone id="US_Michigan" name="US/Michigan"/>
     <timezone id="US_Mountain" name="US/Mountain"/>
     <timezone id="US_Pacific" name="US/Pacific"/>
-    <timezone id="US_Pacific-New" name="US/Pacific-New"/>
     <timezone id="US_Samoa" name="US/Samoa"/>
     <timezone id="UTC" name="UTC"/>
     <timezone id="W-SU" name="W-SU"/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed `US/Pacific New` from timezone list
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #14411
| Related PRs       | PrestaShop/autoupgrade#507
| How to test?      | Cf. #14411
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
