### PR TITLE
Fix bad selector to fix checkbox issues on RMA

### DIFF
--- a/themes/classic/_dev/js/customer.js
+++ b/themes/classic/_dev/js/customer.js
@@ -26,9 +26,9 @@ import $ from 'jquery';
 import prestashop from 'prestashop';
 
 function initRmaItemSelector() {
-  $(`${prestashop.themeSelectors.order.returnForm} table thead input[type=checkbox]`).on('click', function () {
+  $(`${prestashop.themeSelectors.order.returnFormHeadCheckboxes}`).on('click', function () {
     const checked = $(this).prop('checked');
-    $(`${prestashop.themeSelectors.order.returnForm} table tbody input[type=checkbox]`).each((_, checkbox) => {
+    $(`${prestashop.themeSelectors.order.returnFormContentCheckboxes}`).each((_, checkbox) => {
       $(checkbox).prop('checked', checked);
     });
   });

--- a/themes/classic/_dev/js/customer.js
+++ b/themes/classic/_dev/js/customer.js
@@ -28,7 +28,7 @@ import prestashop from 'prestashop';
 function initRmaItemSelector() {
   $(prestashop.themeSelectors.order.returnFormHeadCheckboxes).on('click', function () {
     const checked = $(this).prop('checked');
-    $(`${prestashop.themeSelectors.order.returnFormContentCheckboxes}`).each((_, checkbox) => {
+    $(prestashop.themeSelectors.order.returnFormContentCheckboxes).each((_, checkbox) => {
       $(checkbox).prop('checked', checked);
     });
   });

--- a/themes/classic/_dev/js/customer.js
+++ b/themes/classic/_dev/js/customer.js
@@ -26,7 +26,7 @@ import $ from 'jquery';
 import prestashop from 'prestashop';
 
 function initRmaItemSelector() {
-  $(`${prestashop.themeSelectors.order.returnFormHeadCheckboxes}`).on('click', function () {
+  $(prestashop.themeSelectors.order.returnFormHeadCheckboxes).on('click', function () {
     const checked = $(this).prop('checked');
     $(`${prestashop.themeSelectors.order.returnFormContentCheckboxes}`).each((_, checkbox) => {
       $(checkbox).prop('checked', checked);

--- a/themes/classic/_dev/js/selectors.js
+++ b/themes/classic/_dev/js/selectors.js
@@ -54,7 +54,10 @@ prestashop.themeSelectors = {
     searchLink: '.js-search-link',
   },
   order: {
-    returnForm: '#order-return-form, .js-order-return-form',
+    returnFormHeadCheckboxes:
+      '#order-return-form table thead input[type=checkbox], .js-order-return-form table thead input[type=checkbox]',
+    returnFormContentCheckboxes:
+      '#order-return-form table tbody input[type=checkbox], .js-order-return-form table tbody input[type=checkbox]',
   },
   arrowDown: '.arrow-down, .js-arrow-down',
   arrowUp: '.arrow-up, .js-arrow-up',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | The current selector select too many elements in customer.js (form + checkbox) because of the comma. Without the comma, it select only the checkbox as expected
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28963
| Related PRs       | 
| How to test?      | See issue #28963
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
