### PR TITLE
Add CMS page view and duplicate functionality

### DIFF
--- a/classes/CMS.php
+++ b/classes/CMS.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\CmsPageSettings;
+
 /**
  * Class CMSCore.
  */
@@ -61,7 +63,7 @@ class CMSCore extends ObjectModel
             'meta_description' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 512],
             'meta_keywords' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 255],
             'meta_title' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'required' => true, 'size' => 255],
-            'head_seo_title' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => 255],
+            'head_seo_title' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isGenericName', 'size' => CmsPageSettings::MAX_TITLE_LENGTH],
             'link_rewrite' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isLinkRewrite', 'required' => true, 'size' => 128],
             'content' => ['type' => self::TYPE_HTML, 'lang' => true, 'validate' => 'isCleanHtml', 'size' => 3999999999999],
         ],

--- a/src/Adapter/CMS/Page/CommandHandler/DuplicateCmsPageHandler.php
+++ b/src/Adapter/CMS/Page/CommandHandler/DuplicateCmsPageHandler.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\DuplicateCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\CommandHandler\DuplicateCmsPageHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+use PrestaShopBundle\Entity\Repository\CmsPageRepository;
+
+/**
+ * Duplicates given cms page.
+ */
+final class DuplicateCmsPageHandler extends AbstractCmsPageHandler implements DuplicateCmsPageHandlerInterface
+{
+    /**
+     * @var CmsPageRepository
+     */
+    private $repository;
+
+    /**
+     * @param CmsPageRepository $repository
+     */
+    public function __construct(
+      CmsPageRepository $repository
+    ) {
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(DuplicateCmsPageCommand $command): CmsPageId
+    {
+        return $this->repository->duplicate($command->getCmsPageId());
+    }
+}

--- a/src/Adapter/Util/Entity/EntityNameDuplicator.php
+++ b/src/Adapter/Util/Entity/EntityNameDuplicator.php
@@ -77,7 +77,7 @@ class EntityNameDuplicator
     public function getNewLocalizedNames(array $currentLocalizedNames, int $maxLength): array
     {
         if (empty($this->locales)) {
-            $this->buildLanguages();
+            $this->buildLocales();
         }
 
         $newLocalizedNames = [];
@@ -107,7 +107,7 @@ class EntityNameDuplicator
     public function getNewName(string $currentName, int $maxLength, int $langId): string
     {
         if (empty($this->locales)) {
-            $this->buildLanguages();
+            $this->buildLocales();
         }
 
         // Add copy word to the string
@@ -123,7 +123,7 @@ class EntityNameDuplicator
      *
      * @return void
      */
-    private function buildLanguages(): void
+    private function buildLocales(): void
     {
         foreach ($this->languages as $language) {
             $this->locales[(int) $language['id_lang']] = $language['locale'];

--- a/src/Adapter/Util/Entity/EntityNameDuplicator.php
+++ b/src/Adapter/Util/Entity/EntityNameDuplicator.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Util\Entity;
+
+use PrestaShop\PrestaShop\Core\Util\String\StringModifierInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class EntityNameDuplicator
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var StringModifierInterface
+     */
+    private $stringModifier;
+
+    /**
+     * @var array
+     */
+    protected $languages;
+
+    /**
+     * @var array
+     */
+    protected $locales;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param StringModifierInterface $stringModifier
+     * @param array $languages
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        StringModifierInterface $stringModifier,
+        array $languages
+    ) {
+        $this->translator = $translator;
+        $this->stringModifier = $stringModifier;
+        $this->languages = $languages;
+    }
+
+    /**
+     * Adds a "copy" word to localized entity names
+     *
+     * @param array<int, string> $currentLocalizedNames Array with localized names, IdLang => Name
+     * @param int $maxLength max length of a new name, will be cut if it doesn't fit with the new "copy" word
+     *
+     * @return array<int, string>
+     */
+    public function getNewLocalizedNames(array $currentLocalizedNames, int $maxLength): array
+    {
+        if (empty($this->locales)) {
+            $this->buildLanguages();
+        }
+
+        $newLocalizedNames = [];
+        foreach ($currentLocalizedNames as $langId => $currentName) {
+            $langId = (int) $langId;
+
+            // Add copy word to the string
+            $namePattern = $this->translator->trans('copy of %s', [], 'Admin.Catalog.Feature', $this->locales[$langId]);
+            $newName = sprintf($namePattern, $currentName);
+
+            // Save and cut the end if it doesn't fit to the limit
+            $newLocalizedNames[$langId] = $this->stringModifier->cutEnd($newName, $maxLength);
+        }
+
+        return $newLocalizedNames;
+    }
+
+    /**
+     * Appends a "copy" to simple entity name
+     *
+     * @param string $currentName Current name of the entity
+     * @param int $maxLength max length of a new name, will be cut if it doesn't fit with the new "copy" word
+     * @param int $langId
+     *
+     * @return string
+     */
+    public function getNewName(string $currentName, int $maxLength, int $langId): string
+    {
+        if (empty($this->locales)) {
+            $this->buildLanguages();
+        }
+
+        // Add copy word to the string
+        $namePattern = $this->translator->trans('copy of %s', [], 'Admin.Catalog.Feature', $this->locales[$langId]);
+        $newName = sprintf($namePattern, $currentName);
+
+        // Cut the end if it doesn't fit to the limit and return
+        return $this->stringModifier->cutEnd($newName, $maxLength);
+    }
+
+    /**
+     * Builds the locale array
+     *
+     * @return void
+     */
+    private function buildLanguages(): void
+    {
+        foreach ($this->languages as $language) {
+            $this->locales[(int) $language['id_lang']] = $language['locale'];
+        }
+    }
+}

--- a/src/Core/Domain/CmsPage/CmsPageSettings.php
+++ b/src/Core/Domain/CmsPage/CmsPageSettings.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage;
+
+/**
+ * Defines settings for CMS page.
+ * If related Value Object does not exist, then various settings (e.g. regex, length constraints) are saved here
+ */
+class CmsPageSettings
+{
+    /**
+     * Class not supposed to be initialized, it only serves as static storage
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Bellow constants define maximum allowed length of cms page properties
+     */
+    public const MAX_TITLE_LENGTH = 255;
+}

--- a/src/Core/Domain/CmsPage/Command/AddCmsPageCommand.php
+++ b/src/Core/Domain/CmsPage/Command/AddCmsPageCommand.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\Command;
 
-use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageException;
 use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\ValueObject\CmsPageCategoryId;
 
 /**
@@ -96,7 +96,7 @@ class AddCmsPageCommand
      * @param bool $displayed
      * @param array $shopAssociation
      *
-     * @throws CmsPageCategoryException
+     * @throws CmsPageException
      */
     public function __construct(
         $cmsPageCategoryId,

--- a/src/Core/Domain/CmsPage/Command/DuplicateCmsPageCommand.php
+++ b/src/Core/Domain/CmsPage/Command/DuplicateCmsPageCommand.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+
+/**
+ * Duplicates given cms page.
+ */
+class DuplicateCmsPageCommand
+{
+    /**
+     * @var CmsPageId
+     */
+    private $cmsPageId;
+
+    /**
+     * @param int $cmsPageId
+     */
+    public function __construct(int $cmsPageId)
+    {
+        $this->cmsPageId = new CmsPageId($cmsPageId);
+    }
+
+    /**
+     * @return CmsPageId
+     */
+    public function getCmsPageId()
+    {
+        return $this->cmsPageId;
+    }
+}

--- a/src/Core/Domain/CmsPage/CommandHandler/DuplicateCmsPageHandlerInterface.php
+++ b/src/Core/Domain/CmsPage/CommandHandler/DuplicateCmsPageHandlerInterface.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\DuplicateCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+
+/**
+ * Defines contract for DuplicateCmsPageHandler.
+ */
+interface DuplicateCmsPageHandlerInterface
+{
+    /**
+     * @param DuplicateCmsPageCommand $command
+     *
+     * @return CmsPageId
+     */
+    public function handle(DuplicateCmsPageCommand $command): CmsPageId;
+}

--- a/src/Core/Domain/CmsPage/Exception/CannotDuplicateCmsPageException.php
+++ b/src/Core/Domain/CmsPage/Exception/CannotDuplicateCmsPageException.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception;
+
+/**
+ * Is thrown on failure when duplicating cms page
+ */
+class CannotDuplicateCmsPageException extends CmsPageException
+{
+    /**
+     * When fails to duplicate single cms page
+     */
+    public const FAILED_DUPLICATE = 10;
+}

--- a/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CmsPageDefinitionFactory.php
@@ -31,8 +31,10 @@ use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageCategoryNa
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\BulkActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Bulk\Type\SubmitBulkAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\GridActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\ModalOptions;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
 use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\SubmitRowAction;
 use PrestaShop\PrestaShop\Core\Grid\Action\Type\SimpleGridAction;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
@@ -166,6 +168,17 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
             ->setName($this->trans('Actions', [], 'Admin.Global'))
             ->setOptions([
                 'actions' => (new RowActionCollection())
+                    ->add((new LinkRowAction('view'))
+                    ->setName($this->trans('View', [], 'Admin.Actions'))
+                    ->setIcon('visibility')
+                    ->setOptions([
+                        'route' => 'admin_cms_pages_view',
+                        'route_param_name' => 'cmsPageId',
+                        'route_param_field' => 'id_cms',
+                        'use_inline_display' => true,
+                        'target' => '_blank',
+                    ])
+                    )
                     ->add((new LinkRowAction('edit'))
                     ->setName($this->trans('Edit', [], 'Admin.Actions'))
                     ->setIcon('edit')
@@ -174,6 +187,21 @@ class CmsPageDefinitionFactory extends AbstractGridDefinitionFactory
                         'route_param_name' => 'cmsPageId',
                         'route_param_field' => 'id_cms',
                         'clickable_row' => true,
+                    ])
+                    )
+                    ->add((new SubmitRowAction('duplicate'))
+                    ->setName($this->trans('Duplicate', [], 'Admin.Actions'))
+                    ->setIcon('content_copy')
+                    ->setOptions([
+                        'method' => 'POST',
+                        'route' => 'admin_cms_pages_duplicate',
+                        'route_param_name' => 'cmsPageId',
+                        'route_param_field' => 'id_cms',
+                        'modal_options' => new ModalOptions([
+                            'title' => $this->trans('Duplicate page', [], 'Admin.Actions'),
+                            'confirm_button_label' => $this->trans('Duplicate', [], 'Admin.Actions'),
+                            'close_button_label' => $this->trans('Cancel', [], 'Admin.Actions'),
+                        ]),
                     ])
                     )
                     ->add(

--- a/src/PrestaShopBundle/Entity/Repository/CmsPageRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/CmsPageRepository.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\Entity\Repository;
+
+use CMS;
+use PrestaShop\PrestaShop\Adapter\Util\Entity\EntityNameDuplicator;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\CmsPageSettings;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotDuplicateCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\ValueObject\CmsPageId;
+use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
+
+class CmsPageRepository extends AbstractObjectModelRepository
+{
+    /**
+     * @var EntityNameDuplicator
+     */
+    private $entityNameDuplicator;
+
+    /**
+     * @param EntityNameDuplicator $entityNameDuplicator
+     */
+    public function __construct(
+      EntityNameDuplicator $entityNameDuplicator
+    ) {
+        $this->entityNameDuplicator = $entityNameDuplicator;
+    }
+
+    /**
+     * Duplicates a CMS page
+     *
+     * @param CmsPageId $cmsPageId
+     *
+     * @return CmsPageId
+     *
+     * @throws CmsPageNotFoundException
+     * @throws CannotDuplicateCmsPageException
+     */
+    public function duplicate(CmsPageId $cmsPageId): CmsPageId
+    {
+        /** @var Cms $cms */
+        $cms = $this->getObjectModel(
+          $cmsPageId->getValue(),
+          Cms::class,
+          CmsPageNotFoundException::class
+        );
+
+        // Reset object ID, make it inactive and save it
+        $cms->id = null;
+        $cms->meta_title = $this->entityNameDuplicator->getNewLocalizedNames(
+            $cms->meta_title,
+            CmsPageSettings::MAX_TITLE_LENGTH
+        );
+        $cms->active = false;
+        $id = $this->addObjectModel($cms, CannotDuplicateCmsPageException::class);
+
+        return new CmsPageId($id);
+    }
+}

--- a/src/PrestaShopBundle/Entity/Repository/CmsPageRepository.php
+++ b/src/PrestaShopBundle/Entity/Repository/CmsPageRepository.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Entity\Repository;
 
-use CMS;
+use CMS as CmsObjectModel;
 use PrestaShop\PrestaShop\Adapter\Util\Entity\EntityNameDuplicator;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\CmsPageSettings;
 use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotDuplicateCmsPageException;
@@ -65,7 +65,7 @@ class CmsPageRepository extends AbstractObjectModelRepository
         /** @var Cms $cms */
         $cms = $this->getObjectModel(
           $cmsPageId->getValue(),
-          Cms::class,
+          CmsObjectModel::class,
           CmsPageNotFoundException::class
         );
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/design/cms_pages.yml
@@ -34,6 +34,23 @@ admin_cms_pages_edit:
   requirements:
     cmsPageId: \d+
 
+admin_cms_pages_duplicate:
+  path: /{cmsPageId}/duplicate
+  methods: [ POST ]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\CmsPageController::duplicateAction'
+    _legacy_controller: AdminCmsContent
+  requirements:
+    productId: \d+
+
+admin_cms_pages_view:
+  path: /{cmsPageId}/view
+  methods: GET
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Improve\Design\CmsPageController::viewAction'
+  requirements:
+    cmsPageId: \d+
+
 admin_cms_pages_toggle:
   path: /{cmsId}/toggle-status
   methods: POST

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cms_page.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cms_page.yml
@@ -32,6 +32,14 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\DeleteCmsPageCommand
 
+  prestashop.adapter.cms_page.command_handler.duplicate_cms_page_handler:
+    class: PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler\DuplicateCmsPageHandler
+    arguments:
+      - "@prestashop.core.api.cmspage.repository"
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\DuplicateCmsPageCommand
+
   prestashop.adapter.cms_page.command_handler.bulk_delete_cms_page:
     class: PrestaShop\PrestaShop\Adapter\CMS\Page\CommandHandler\BulkDeleteCmsPageHandler
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/repository.yml
@@ -143,3 +143,8 @@ services:
     arguments:
       - PrestaShopBundle\Entity\AuthorizedApplication
     public: true
+
+  prestashop.core.api.cmspage.repository:
+    class: PrestaShopBundle\Entity\Repository\CmsPageRepository
+    arguments:
+      - '@PrestaShop\PrestaShop\Adapter\Util\Entity\EntityNameDuplicator'

--- a/src/PrestaShopBundle/Resources/config/services/core/util/entity.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/entity.yml
@@ -1,0 +1,10 @@
+services:
+  _defaults:
+    public: false
+
+  PrestaShop\PrestaShop\Adapter\Util\Entity\EntityNameDuplicator:
+    autowire: true
+    arguments:
+      - "@translator"
+      - '@prestashop.core.util.string.string_modifier'
+      - "@=service('prestashop.adapter.legacy.context').getLanguages(false)"

--- a/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Improve/Design/Cms/Blocks/form.html.twig
@@ -42,8 +42,13 @@
     </a>
 
     <div class="d-none d-lg-flex ml-auto ">
-      <button type="submit" class="btn btn-primary" name="save-and-preview" id="save-and-preview-button">
-        {{ 'Save and preview'|trans({}, 'Admin.Actions') }}
+      {% if previewUrl is defined %}
+        <a class="btn btn-secondary" href="{{ previewUrl }}" role="button" target="_blank">{{ 'View'|trans({}, 'Admin.Actions') }}</a>
+      {% else %}
+        <a class="btn btn-secondary disabled" href="#" role="button" aria-disabled="true">{{ 'View'|trans({}, 'Admin.Actions') }}</a>
+      {% endif %}
+      <button type="submit" class="btn btn-primary ml-3" name="save-and-preview" id="save-and-preview-button">
+        {{ 'Save and view'|trans({}, 'Admin.Actions') }}
       </button>
       <button type="submit" class="btn btn-primary ml-3" id="save-button">{{ 'Save'|trans({}, 'Admin.Actions') }}</button>
     </div>
@@ -55,7 +60,12 @@
           <span class="sr-only">{{ 'Toggle dropdown'|trans({}, 'Admin.Modules.Feature') }}</span>
         </button>
         <div class="dropdown-menu dropdown-menu-right">
-          <button type="submit" class="dropdown-item" name="save-and-preview" id="save-and-preview-button-mobile">{{ 'Save and preview'|trans({}, 'Admin.Actions') }}</button>
+          {% if previewUrl is defined %}
+            <a class="dropdown-item" href="{{ previewUrl }}" target="_blank">{{ 'View'|trans({}, 'Admin.Actions') }}</a>
+          {% else %}
+            <a class="dropdown-item disabled" href="#" aria-disabled="true">{{ 'View'|trans({}, 'Admin.Actions') }}</a>
+          {% endif %}
+          <button type="submit" class="dropdown-item" name="save-and-preview" id="save-and-preview-button-mobile">{{ 'Save and view'|trans({}, 'Admin.Actions') }}</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Read below
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28079, Fixes #29674
| Related PRs       | -
| How to test?      | -
| Possible impacts? | No
| Sponsor company   | [TRENDO s.r.o.](https://www.trendo.cz)

### Description
- Adds functionality to view CMS page in front office from admin CMS edit screen.
  - It adds a view icon to CMS page list.
  - It adds a view icon to CMS edit page header.
- Adds functionality to duplicate a CMS page. 
  - Click hamburger menu next to CMS page, click duplicate, confirm.
  - A copy of the page with a new title `copy of pagename` will get saved and you will get redirected to edit screen of this CMS page
- It introduces a CmsRepository where this duplication is handled. 
- It introduces EntityNameDuplicator which handles prepending the "Copy " word before product and CMS names.

### READ THIS QA
- The misaligned icon in CMS page list is not in a scope of this PR, will be solved separately. Issue https://github.com/PrestaShop/PrestaShop/issues/29692

**How does it look**
![192231866-2fada57d-0aa5-45de-af0e-470c077a180e](https://user-images.githubusercontent.com/6097524/197173194-f4fd1c2f-1eb3-4500-baf0-ffaed7130bfd.jpg)
![192231871-16bec2de-eac8-4571-8ea9-4d4fbd22ef73](https://user-images.githubusercontent.com/6097524/197173196-934e592c-8dfa-41a2-9b2e-be482e40468f.jpg)
![191951574-9a568e33-2881-4493-8434-d474d842ece2](https://user-images.githubusercontent.com/6097524/197173319-db51bb12-bc48-4e82-b240-8d047947b8ae.png)
