### PR TITLE
Update material icons lib to fix the slow npm installation

### DIFF
--- a/admin-dev/themes/default/package-lock.json
+++ b/admin-dev/themes/default/package-lock.json
@@ -6684,10 +6684,10 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
-    "material-design-icons": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/material-design-icons/-/material-design-icons-2.2.3.tgz",
-      "integrity": "sha1-toFzZKeAOwUJqAAjBbf+IBsP2p8=",
+    "material-design-icons-iconfont": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-6.7.0.tgz",
+      "integrity": "sha512-lSj71DgVv20kO0kGbs42icDzbRot61gEDBLQACzkUuznRQBUYmbxzEkGU6dNBb5fRWHMaScYlAXX96HQ4/cJWA==",
       "dev": true
     },
     "math-expression-evaluator": {

--- a/admin-dev/themes/default/package.json
+++ b/admin-dev/themes/default/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-html": "^6.0.0",
     "eslint-plugin-import": "^2.20.0",
     "file-loader": "^1.1.11",
-    "material-design-icons": "^2",
+    "material-design-icons-iconfont": "^6.7.0",
     "mini-css-extract-plugin": "^0.8.0",
     "node-sass": "^4.14.1",
     "optimize-css-assets-webpack-plugin": "^6.0.0",

--- a/admin-dev/themes/default/scss/font.scss
+++ b/admin-dev/themes/default/scss/font.scss
@@ -3,11 +3,11 @@
   font-family: "Material Icons";
   font-style: normal;
   font-weight: 400;
-  src: url(../node_modules/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.eot"); /* For IE6-8 */
   src:
-    local("Material Icons"), local("MaterialIcons-Regular"), url(../node_modules/material-design-icons/iconfont//MaterialIcons-Regular.woff2) format("woff2"),
-  url(../node_modules/material-design-icons/iconfont//MaterialIcons-Regular.woff) format("woff"),
-  url(../node_modules/material-design-icons/iconfont//MaterialIcons-Regular.ttf) format("truetype");
+    local("Material Icons"), local("MaterialIcons-Regular"), url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff2") format("woff2"),
+  url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.woff") format("woff"),
+  url("~material-design-icons-iconfont/dist/fonts/MaterialIcons-Regular.ttf") format("truetype");
 }
 
 .material-icons {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | As we will maintain this version for a long time, it won't be really cool to wait like 2 mins on every `default` build, to fix this, we need to change our material-icon library, it shouldn't introduce BCs so, it should be acceptable!
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Material icons inside the BO, on legacy pages, should works as expected!
| Possible impacts? | Material icons of the BO inside legacy pages


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
