### PR TITLE
Do not clear system cache on bulk install,remove,upgrade module

### DIFF
--- a/src/Core/Module/EventSubscriber.php
+++ b/src/Core/Module/EventSubscriber.php
@@ -75,7 +75,7 @@ class EventSubscriber implements EventSubscriberInterface
     public function onModuleInstalledOrUninstalled(ModuleManagementEvent $event): void
     {
         $this->onModuleStateChanged($event);
-        if (!$this->cleared) {
+        if (!$this->cleared && $event->getSystemClearCache()) {
             $this->cacheClearer->clear();
             $this->cleared = true;
         }

--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -65,6 +65,9 @@ class ModuleManager implements ModuleManagerInterface
     /** @var Filesystem */
     private $filesystem;
 
+    /** @var bool */
+    private $systemClearCache = true;
+
     public function __construct(
         ModuleRepository $moduleRepository,
         ModuleDataProvider $moduleDataProvider,
@@ -369,6 +372,11 @@ class ModuleManager implements ModuleManagerInterface
 
     private function dispatch(string $event, ModuleInterface $module): void
     {
-        $this->eventDispatcher->dispatch(new ModuleManagementEvent($module), $event);
+        $this->eventDispatcher->dispatch(new ModuleManagementEvent($module, $this->systemClearCache), $event);
+    }
+
+    public function disableSystemClearCache(): void
+    {
+        $this->systemClearCache = false;
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -209,9 +209,16 @@ class ModuleController extends ModuleAbstractController
 
         try {
             $args = [$module];
-            if ($action === 'uninstall') {
+            if ($action === ModuleAdapter::ACTION_UNINSTALL) {
                 $args[] = (bool) ($request->request->get('actionParams', [])['deletion'] ?? false);
                 $response[$module]['refresh_needed'] = $this->moduleNeedsReload($moduleRepository->getModule($module));
+            }
+            $systemCacheClearEnabled = filter_var(
+                $request->request->get('actionParams', [])['cacheClearEnabled'] ?? true,
+                FILTER_VALIDATE_BOOLEAN
+            );
+            if (!$systemCacheClearEnabled) {
+                $moduleManager->disableSystemClearCache();
             }
             $response[$module]['status'] = call_user_func([$moduleManager, $action], ...$args);
         } catch (Exception $e) {

--- a/src/PrestaShopBundle/Event/ModuleManagementEvent.php
+++ b/src/PrestaShopBundle/Event/ModuleManagementEvent.php
@@ -41,15 +41,25 @@ class ModuleManagementEvent extends Event
     public const UPGRADE = 'module.upgrade';
     public const RESET = 'module.reset';
 
+    /** @var ModuleInterface */
     private $module;
 
-    public function __construct(ModuleInterface $module)
+    /** @var bool */
+    private $systemClearCache;
+
+    public function __construct(ModuleInterface $module, bool $systemClearCache = true)
     {
         $this->module = $module;
+        $this->systemClearCache = $systemClearCache;
     }
 
-    public function getModule()
+    public function getModule(): ModuleInterface
     {
         return $this->module;
+    }
+
+    public function getSystemClearCache(): bool
+    {
+        return $this->systemClearCache;
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | In the module manager, when you install,remove or upgrade multiple modules through bulk action, the cache is cleared for each modules instead of being clearing only once at the end of the process.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29121
| Related PRs       | 
| How to test?      | See #29121
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
