### PR TITLE
make postcode field optional in BO

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Address/CustomerAddressType.php
@@ -315,7 +315,7 @@ class CustomerAddressType extends TranslatorAwareType
                 ],
             ])
             ->add('postcode', TextType::class, [
-                'required' => true,
+                'required' => false,
                 'label' => $this->trans('Zip/Postal code', 'Admin.Global'),
                 'empty_data' => '',
                 'constraints' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      |make postcode field optional in BO
| Type?             | bug fix 
| Category?         |BO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29625
| Related PRs       | 
| How to test?      | Try to edit customer Address in BO, postcode should not be required anymore
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
