### PR TITLE
Disable apache mpm_event module in the CI (cherry-pick)

### DIFF
--- a/.github/workflows/sanity/setup-apache.sh
+++ b/.github/workflows/sanity/setup-apache.sh
@@ -12,6 +12,9 @@ apt update && apt install -y apache2 libapache2-mod-php$PHP_VERSION
 # Enable rewrite mode
 a2enmod rewrite actions alias
 
+# Disable mpm_event (mpm_prefork should be already loaded)
+a2dismod mpm_event
+
 # Copy apache vhost and set Documentroot
 cp -f $WORKSPACE/.github/workflows/sanity/apache-vhost /etc/apache2/sites-available/000-default.conf
 sed -e "s?%BUILD_DIR%?$(echo $WORKSPACE)?g" --in-place /etc/apache2/sites-available/000-default.conf


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | See #29690
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29688 for 1.7.8.x
| Related PRs       | 
| How to test?      | CI should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
