### PR TITLE
Remove querySelector casting in favour of its generic

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -36,11 +36,11 @@ export default class CategoriesManager {
 
   categoryTreeSelector: CategoryTreeSelector;
 
-  categoriesContainer: HTMLElement;
+  categoriesContainer: HTMLElement | null;
 
-  defaultCategoryInput: HTMLInputElement;
+  defaultCategoryInput: HTMLInputElement | null | undefined;
 
-  addCategoriesBtn: HTMLElement;
+  addCategoriesBtn: HTMLElement | null | undefined;
 
   tagsRenderer: TagsRenderer;
 
@@ -54,8 +54,8 @@ export default class CategoriesManager {
     }
     this.categoriesContainer = categoriesContainer;
 
-    const addCategoriesBtn = this.categoriesContainer.querySelector<HTMLElement>(ProductCategoryMap.addCategoriesBtn);
-    const defaultCategoryInput = this.categoriesContainer
+    const addCategoriesBtn = this.categoriesContainer?.querySelector<HTMLElement>(ProductCategoryMap.addCategoriesBtn);
+    const defaultCategoryInput = this.categoriesContainer?
       .querySelector<HTMLInputElement>(ProductCategoryMap.defaultCategorySelectInput);
 
     if (!addCategoriesBtn || !defaultCategoryInput) {
@@ -76,7 +76,7 @@ export default class CategoriesManager {
   }
 
   private initCategoryTreeModal(): void {
-    this.addCategoriesBtn.addEventListener('click', () => this.categoryTreeSelector.showModal(
+    this.addCategoriesBtn?.addEventListener('click', () => this.categoryTreeSelector.showModal(
       this.collectCategories(),
       this.getDefaultCategoryId(),
     ));
@@ -88,16 +88,16 @@ export default class CategoriesManager {
 
   private collectCategories(): Array<Category> {
     // these are at first rendered on page load and later updated dynamically
-    const tagsContainer = this.categoriesContainer.querySelector<HTMLElement>(ProductCategoryMap.tagsContainer);
+    const tagsContainer = this.categoriesContainer?.querySelector<HTMLElement>(ProductCategoryMap.tagsContainer);
 
     if (!tagsContainer) {
       throw new Error(`Essential element was not found for categories manager: ${ProductCategoryMap.tagsContainer}`);
     }
 
-    const tags = tagsContainer.querySelectorAll(ProductCategoryMap.tagItem);
+    const tags = tagsContainer?.querySelectorAll(ProductCategoryMap.tagItem);
     const categories: Array<Category> = [];
 
-    tags.forEach((tag: Element) => {
+    tags?.forEach((tag: Element) => {
       if (tag instanceof HTMLElement) {
         const idInput = tag.querySelector<HTMLInputElement>(ProductCategoryMap.tagCategoryIdInput);
 
@@ -139,7 +139,7 @@ export default class CategoriesManager {
   private renderDefaultCategorySelection(): void {
     const categories = this.collectCategories();
 
-    const selectElement = this.categoriesContainer.querySelector<HTMLElement>(ProductCategoryMap.defaultCategorySelectInput);
+    const selectElement = this.categoriesContainer?.querySelector<HTMLElement>(ProductCategoryMap.defaultCategorySelectInput);
 
     if (!selectElement) {
       console.error(`${ProductCategoryMap.defaultCategorySelectInput} element was not found.`);
@@ -148,7 +148,10 @@ export default class CategoriesManager {
     }
 
     const defaultCategoryId = this.getDefaultCategoryId();
-    selectElement.innerHTML = '';
+
+    if (selectElement !== null && selectElement !== undefined) {
+      selectElement.innerHTML = '';
+    }
 
     categories.forEach((category) => {
       const optionElement = document.createElement('option');
@@ -156,13 +159,13 @@ export default class CategoriesManager {
       optionElement.innerHTML = category.displayName;
       optionElement.selected = category.id === defaultCategoryId;
 
-      selectElement.append(optionElement);
+      selectElement?.append(optionElement);
     });
   }
 
   private listenDefaultCategorySelect(): void {
-    $(`#${this.defaultCategoryInput.id}`).on('change', (e) => {
-      const {currentTarget} = e;
+    this.defaultCategoryInput?.addEventListener('change', (e) => {
+      const currentTarget = e.currentTarget as HTMLInputElement;
 
       if (!(currentTarget instanceof HTMLSelectElement)) {
         console.error('currentTarget expected to be HTMLSelectElement');
@@ -182,6 +185,6 @@ export default class CategoriesManager {
   }
 
   private getDefaultCategoryId(): number {
-    return Number(this.defaultCategoryInput.value);
+    return Number(this.defaultCategoryInput?.value);
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -55,8 +55,8 @@ export default class CategoriesManager {
     this.categoriesContainer = categoriesContainer;
 
     const addCategoriesBtn = this.categoriesContainer?.querySelector<HTMLElement>(ProductCategoryMap.addCategoriesBtn);
-    const defaultCategoryInput = this.categoriesContainer?
-      .querySelector<HTMLInputElement>(ProductCategoryMap.defaultCategorySelectInput);
+    const defaultCategoryInput = this.categoriesContainer
+      ?.querySelector<HTMLInputElement>(ProductCategoryMap.defaultCategorySelectInput);
 
     if (!addCategoriesBtn || !defaultCategoryInput) {
       throw new Error('Failed to find some essential elements to run categories manager.');

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -149,7 +149,7 @@ export default class CategoriesManager {
 
     const defaultCategoryId = this.getDefaultCategoryId();
 
-    if (selectElement !== null && selectElement !== undefined) {
+    if (selectElement) {
       selectElement.innerHTML = '';
     }
 
@@ -164,8 +164,8 @@ export default class CategoriesManager {
   }
 
   private listenDefaultCategorySelect(): void {
-    this.defaultCategoryInput?.addEventListener('change', (e) => {
-      const currentTarget = e.currentTarget as HTMLInputElement;
+    this.defaultCategoryInput?.addEventListener('change', (e: {currentTarget: HTMLInputElement}) => {
+      const {currentTarget} = e;
 
       if (!(currentTarget instanceof HTMLSelectElement)) {
         console.error('currentTarget expected to be HTMLSelectElement');

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -233,7 +233,7 @@ export default class CategoryTreeSelector {
       const inputsContainer = categoryNode.querySelector<HTMLElement>(ProductCategoryMap.treeElementInputs);
       const childrenCheckboxInput = inputsContainer?.querySelector<HTMLInputElement>(ProductCategoryMap.treeCheckboxInput);
 
-      if (childrenCheckboxInput !== null && childrenCheckboxInput !== undefined) {
+      if (childrenCheckboxInput) {
         childrenCheckboxInput.value = String(treeCategory.id);
       }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -49,13 +49,13 @@ export default class CategoryTreeSelector {
 
   defaultCategoryId: number;
 
-  modalContentContainer: HTMLElement|null;
+  modalContentContainer: HTMLElement | null;
 
-  modal: ModalType|null;
+  modal: ModalType | null;
 
-  categoryTree: HTMLElement|null;
+  categoryTree: HTMLElement | null | undefined;
 
-  tagsRenderer: TagsRenderer|null;
+  tagsRenderer: TagsRenderer | null;
 
   constructor(eventEmitter: EventEmitter) {
     this.eventEmitter = eventEmitter;
@@ -109,7 +109,7 @@ export default class CategoryTreeSelector {
     }
 
     this.modalContentContainer = modalContentContainer;
-    this.categoryTree = this.modalContentContainer.querySelector<HTMLElement>(ProductCategoryMap.categoryTree);
+    this.categoryTree = this.modalContentContainer?.querySelector<HTMLElement>(ProductCategoryMap.categoryTree);
     this.tagsRenderer = new TagsRenderer(
       this.eventEmitter,
       `${ProductCategoryMap.modalContentContainer} ${ProductCategoryMap.tagsContainer}`,
@@ -213,7 +213,7 @@ export default class CategoryTreeSelector {
    * Used to recursively create items of the category tree
    */
   private generateCategoryTree(treeCategory: TreeCategory): HTMLElement {
-    const categoryNode = this.generateTreeElement(treeCategory);
+    const categoryNode = this.generateTreeElement(treeCategory) as HTMLElement;
     const childrenList = categoryNode.querySelector<HTMLElement>(ProductCategoryMap.childrenList);
     const hasChildren = treeCategory.children && treeCategory.children.length > 0;
 
@@ -231,7 +231,11 @@ export default class CategoryTreeSelector {
 
     if (hasChildren) {
       const inputsContainer = categoryNode.querySelector<HTMLElement>(ProductCategoryMap.treeElementInputs);
-      checkboxInput.value = String(treeCategory.id);
+      const checkboxInput = inputsContainer?.querySelector<HTMLInputElement>(ProductCategoryMap.treeCheckboxInput);
+
+      if (checkboxInput !== null && checkboxInput !== undefined) {
+        checkboxInput.value = String(treeCategory.id);
+      }
 
       inputsContainer?.addEventListener('click', (event) => {
         // We don't want to mess with the inputs behaviour (no toggle when checkbox or radio is clicked)

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -231,10 +231,10 @@ export default class CategoryTreeSelector {
 
     if (hasChildren) {
       const inputsContainer = categoryNode.querySelector<HTMLElement>(ProductCategoryMap.treeElementInputs);
-      const checkboxInput = inputsContainer?.querySelector<HTMLInputElement>(ProductCategoryMap.treeCheckboxInput);
+      const childrenCheckboxInput = inputsContainer?.querySelector<HTMLInputElement>(ProductCategoryMap.treeCheckboxInput);
 
-      if (checkboxInput !== null && checkboxInput !== undefined) {
-        checkboxInput.value = String(treeCategory.id);
+      if (childrenCheckboxInput !== null && childrenCheckboxInput !== undefined) {
+        childrenCheckboxInput.value = String(treeCategory.id);
       }
 
       inputsContainer?.addEventListener('click', (event) => {

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
@@ -121,7 +121,7 @@ export default class TagsRenderer {
         const tagItem = clickedBtn.closest<HTMLElement>(ProductCategoryMap.tagItem);
 
         if (tagItem) {
-          const idInput = tagItem?.querySelector(ProductCategoryMap.tagCategoryIdInput) as HTMLInputElement;
+          const idInput = tagItem?.querySelector<HTMLInputElement>(ProductCategoryMap.tagCategoryIdInput);
           tagItem.remove();
           this.eventEmitter.emit(this.tagRemovedEventName, Number(idInput.value));
         }

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
@@ -31,7 +31,7 @@ const ProductCategoryMap = ProductMap.categories;
 export default class TagsRenderer {
   eventEmitter: EventEmitter;
 
-  container: HTMLElement;
+  container: HTMLElement | null;
 
   tagRemovedEventName: string;
 
@@ -41,12 +41,17 @@ export default class TagsRenderer {
     tagRemovedEventName: string,
   ) {
     this.eventEmitter = eventEmitter;
-    this.container = document.querySelector(containerSelector) as HTMLElement;
+    this.container = document.querySelector<HTMLElement>(containerSelector);
     this.tagRemovedEventName = tagRemovedEventName;
     this.listenTagRemoval();
   }
 
   public render(categories: Array<Category>, defaultCategoryId: number): void {
+    if (!this.container) {
+      console.error('The container is undefined or invalid');
+      return;
+    }
+
     this.container.innerHTML = '';
     const tagTemplate = this.container.dataset.prototype;
     const {prototypeName} = this.container.dataset;
@@ -67,13 +72,13 @@ export default class TagsRenderer {
         const idInput = frag.querySelector(ProductCategoryMap.tagCategoryIdInput) as HTMLInputElement;
         idInput.value = String(category.id);
 
-        const tagRemoveBtn = frag.querySelector(ProductCategoryMap.tagRemoveBtn) as HTMLElement;
+        const tagRemoveBtn = frag.querySelector<HTMLElement>(ProductCategoryMap.tagRemoveBtn);
 
-        // don't show the tag removal element for main category or when it is the last category
-        if (category.id === defaultCategoryId || categories.length === 1) {
-          tagRemoveBtn.classList.add('d-none');
+        if (category.id === defaultCategoryId) {
+          // don't show the tag removal element for main category
+          tagRemoveBtn?.classList.add('d-none');
         } else {
-          tagRemoveBtn.classList.remove('d-none');
+          tagRemoveBtn?.classList.remove('d-none');
         }
 
         const namePreviewElement = frag.querySelector(ProductCategoryMap.categoryNamePreview);
@@ -94,7 +99,7 @@ export default class TagsRenderer {
           namePreviewInput.value = category.displayName;
         }
 
-        this.container.append(frag);
+        this.container?.append(frag);
       }
 
       index += 1;
@@ -104,15 +109,19 @@ export default class TagsRenderer {
   }
 
   private listenTagRemoval(): void {
+    if (!this.container) {
+      console.error('The container is undefined or invalid');
+      return;
+    }
     this.container.querySelectorAll(ProductCategoryMap.tagRemoveBtn).forEach((element) => {
       element.addEventListener('click', (event) => {
         event.preventDefault();
         event.stopImmediatePropagation();
         const clickedBtn = event.currentTarget as HTMLElement;
-        const tagItem = clickedBtn.closest(ProductCategoryMap.tagItem) as HTMLElement;
+        const tagItem = clickedBtn.closest<HTMLElement>(ProductCategoryMap.tagItem);
 
         if (tagItem) {
-          const idInput = tagItem.querySelector(ProductCategoryMap.tagCategoryIdInput) as HTMLInputElement;
+          const idInput = tagItem?.querySelector(ProductCategoryMap.tagCategoryIdInput) as HTMLInputElement;
           tagItem.remove();
           this.eventEmitter.emit(this.tagRemovedEventName, Number(idInput.value));
         }

--- a/admin-dev/themes/new-theme/js/pages/product/components/specific-price/specific-price-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/specific-price/specific-price-list-renderer.ts
@@ -64,7 +64,7 @@ export default class SpecificPriceListRenderer implements RendererType {
     const trTemplateContainer = this.listContainer?.querySelector<HTMLScriptElement>(SpecificPriceMap.listRowTemplate);
     const trTemplate = trTemplateContainer?.innerHTML as string;
 
-    if (tbody !== null && tbody !== undefined) {
+    if (tbody) {
       tbody.innerHTML = '';
     }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/specific-price/specific-price-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/specific-price/specific-price-list-renderer.ts
@@ -120,8 +120,8 @@ export default class SpecificPriceListRenderer implements RendererType {
     this.listContainer?.classList.toggle('d-none', !show);
   }
 
-  private selectListField(templateTrClone: HTMLElement, selector: string): HTMLElement | null | undefined {
-    return templateTrClone.querySelector<HTMLElement>(selector);
+  private selectListField(templateTrClone: HTMLElement, selector: string): HTMLElement {
+    return templateTrClone.querySelector(selector) as HTMLElement;
   }
 
   private addEventListenerForDeleteBtn(deleteBtn: HTMLElement): void {

--- a/admin-dev/themes/new-theme/js/pages/product/components/specific-price/specific-price-list-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/specific-price/specific-price-list-renderer.ts
@@ -37,7 +37,7 @@ export default class SpecificPriceListRenderer implements RendererType {
 
   private productId: number;
 
-  private listContainer: HTMLElement;
+  private listContainer: HTMLElement | null;
 
   private $loadingSpinner: JQuery;
 
@@ -47,7 +47,7 @@ export default class SpecificPriceListRenderer implements RendererType {
     productId: number,
   ) {
     this.productId = productId;
-    this.listContainer = document.querySelector(SpecificPriceMap.listContainer) as HTMLElement;
+    this.listContainer = document.querySelector<HTMLElement>(SpecificPriceMap.listContainer);
     this.eventEmitter = window.prestashop.instance.eventEmitter;
     this.$loadingSpinner = $(ProductMap.specificPrice.loadingSpinner);
     this.$listTable = $(ProductMap.specificPrice.listTable);
@@ -60,10 +60,13 @@ export default class SpecificPriceListRenderer implements RendererType {
 
   public render(data: Record<string, any>): void {
     const {listFields} = SpecificPriceMap;
-    const tbody = this.listContainer.querySelector(`${SpecificPriceMap.listContainer} tbody`) as HTMLElement;
-    const trTemplateContainer = this.listContainer.querySelector(SpecificPriceMap.listRowTemplate) as HTMLScriptElement;
-    const trTemplate = trTemplateContainer.innerHTML as string;
-    tbody.innerHTML = '';
+    const tbody = this.listContainer?.querySelector<HTMLElement>(`${SpecificPriceMap.listContainer} tbody`);
+    const trTemplateContainer = this.listContainer?.querySelector<HTMLScriptElement>(SpecificPriceMap.listRowTemplate);
+    const trTemplate = trTemplateContainer?.innerHTML as string;
+
+    if (tbody !== null && tbody !== undefined) {
+      tbody.innerHTML = '';
+    }
 
     const specificPrices = data.specificPrices as Array<SpecificPriceForListing>;
     this.toggleListVisibility(specificPrices.length > 0);
@@ -102,23 +105,23 @@ export default class SpecificPriceListRenderer implements RendererType {
       editBtn.dataset.specificPriceId = String(specificPrice.id);
 
       if (!specificPrice.period) {
-        periodField.textContent = String(periodField.dataset.unlimitedText);
+        periodField.textContent = String(periodField?.dataset.unlimitedText);
       } else {
         periodFromField.textContent = specificPrice.period.from;
         periodToField.textContent = specificPrice.period.to;
       }
 
-      tbody.append(trClone);
+      tbody?.append(trClone);
       this.addEventListenerForDeleteBtn(deleteBtn);
     });
   }
 
   private toggleListVisibility(show: boolean): void {
-    this.listContainer.classList.toggle('d-none', !show);
+    this.listContainer?.classList.toggle('d-none', !show);
   }
 
-  private selectListField(templateTrClone: HTMLElement, selector: string): HTMLElement {
-    return templateTrClone.querySelector(selector) as HTMLElement;
+  private selectListField(templateTrClone: HTMLElement, selector: string): HTMLElement | null | undefined {
+    return templateTrClone.querySelector<HTMLElement>(selector);
   }
 
   private addEventListenerForDeleteBtn(deleteBtn: HTMLElement): void {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Changing `document.querySelector('.test') as HTMLElement` in favour of `document.querySelector<HTMLElement>('.test');`
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #27743 
| Related PRs       | ~
| How to test?      | Categories manager, category tree, tags and specific prices on the product page v2 should be working as expected
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
