### PR TITLE
29593: fixed issue where module would be overriden with test module

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/ModuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ModuleFeatureContext.php
@@ -28,7 +28,6 @@ namespace Tests\Integration\Behaviour\Features\Context;
 
 use Module;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Filesystem\Filesystem;
 
 class ModuleFeatureContext extends AbstractPrestaShopFeatureContext
 {
@@ -37,11 +36,6 @@ class ModuleFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function theModuleIsInstalled(string $module): void
     {
-        if (!is_dir(_PS_MODULE_DIR_ . '/' . $module)) {
-            $fs = new Filesystem();
-            $fs->mirror(self::MODULES_DIRECTORY . '/' . $module, _PS_MODULE_DIR_ . '/' . $module);
-        }
-
         // Enable the module if needed
         if (!Module::isEnabled($module)) {
             Module::getInstanceByName($module)->enable();

--- a/tests/Integration/Behaviour/Features/Context/ModuleFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ModuleFeatureContext.php
@@ -37,8 +37,10 @@ class ModuleFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function theModuleIsInstalled(string $module): void
     {
-        $fs = new Filesystem();
-        $fs->mirror(self::MODULES_DIRECTORY . '/' . $module, _PS_MODULE_DIR_ . '/' . $module);
+        if (!is_dir(_PS_MODULE_DIR_ . '/' . $module)) {
+            $fs = new Filesystem();
+            $fs->mirror(self::MODULES_DIRECTORY . '/' . $module, _PS_MODULE_DIR_ . '/' . $module);
+        }
 
         // Enable the module if needed
         if (!Module::isEnabled($module)) {

--- a/tests/Integration/Behaviour/Features/Scenario/Profile/profile_permissions.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Profile/profile_permissions.feature
@@ -109,35 +109,35 @@ Feature: Manage profile permissions from BO
 
   Scenario: I can get profile module permissions for profiles
     Then profile super_admin should have the following permissions for modules:
-      | ps_banner      | view,configure,uninstall |
-      | ps_wirepayment | view,configure,uninstall |
+      | ps_banner            | view,configure,uninstall |
+      | ps_emailsubscription | view,configure,uninstall |
     Then profile logistician should have the following permissions for modules:
-      | ps_banner      |                          |
-      | ps_wirepayment |                          |
+      | ps_banner            |  |
+      | ps_emailsubscription |  |
     Then profile translator should have the following permissions for modules:
-      | ps_banner      |                          |
-      | ps_wirepayment |                          |
+      | ps_banner            |  |
+      | ps_emailsubscription |  |
     Then profile salesman should have the following permissions for modules:
-      | ps_banner      |                          |
-      | ps_wirepayment |                          |
+      | ps_banner            |  |
+      | ps_emailsubscription |  |
 
   Scenario: I can edit module permission for a profile
     When I enable view permission for module ps_banner for profile logistician
     And I enable configure permission for module ps_banner for profile logistician
     And I enable uninstall permission for module ps_banner for profile logistician
     Then profile logistician should have the following permissions for modules:
-      | ps_banner      | view,configure,uninstall |
-      | ps_wirepayment |                          |
+      | ps_banner            | view,configure,uninstall |
+      | ps_emailsubscription |                          |
     When I disable view permission for module ps_banner for profile logistician
     And I disable configure permission for module ps_banner for profile logistician
     And I disable uninstall permission for module ps_banner for profile logistician
     Then profile logistician should have the following permissions for modules:
-      | ps_banner      |                          |
-      | ps_wirepayment |                          |
+      | ps_banner            |  |
+      | ps_emailsubscription |  |
     # SuperAdmin role has all permissions hard coded even if you try to disable them
     When I disable view permission for module ps_banner for profile super_admin
     And I disable configure permission for module ps_banner for profile super_admin
     And I disable uninstall permission for module ps_banner for profile super_admin
     Then profile super_admin should have the following permissions for modules:
-      | ps_banner      | view,configure,uninstall |
-      | ps_wirepayment | view,configure,uninstall |
+      | ps_banner            | view,configure,uninstall |
+      | ps_emailsubscription | view,configure,uninstall |

--- a/tests/Integration/Behaviour/bootstrap.php
+++ b/tests/Integration/Behaviour/bootstrap.php
@@ -31,7 +31,7 @@
 $rootDirectory = __DIR__ . '/../../../';
 
 define('_PS_IN_TEST_', true);
-define('_PS_MODULE_DIR_', __DIR__ . '/../..' . '/Resources/modules/');
+define('_PS_MODULE_DIR_', __DIR__ . '/../../Resources/modules/');
 if (!defined('_PS_ADMIN_DIR_')) {
     define('_PS_ADMIN_DIR_', __DIR__);
 }

--- a/tests/Integration/Behaviour/bootstrap.php
+++ b/tests/Integration/Behaviour/bootstrap.php
@@ -31,6 +31,7 @@
 $rootDirectory = __DIR__ . '/../../../';
 
 define('_PS_IN_TEST_', true);
+define('_PS_MODULE_DIR_', __DIR__ . '/../..' . '/Resources/modules/');
 if (!defined('_PS_ADMIN_DIR_')) {
     define('_PS_ADMIN_DIR_', __DIR__);
 }

--- a/tests/Resources/modules/ps_emailsubscription/ps_emailsubscription.php
+++ b/tests/Resources/modules/ps_emailsubscription/ps_emailsubscription.php
@@ -60,7 +60,7 @@ class Ps_Emailsubscription extends Module
 
     public function install()
     {
-        if (!parent::install() || !Configuration::updateValue('PS_NEWSLETTER_RAND', mt_rand(0, mt_getrandmax()) . mt_rand(0, mt_getrandmax())) || !$this->registerHook(['displayFooterBefore', 'actionCustomerAccountAdd'])) {
+        if (!parent::install() || !Configuration::updateValue('PS_NEWSLETTER_RAND', mt_rand(0, mt_getrandmax()) . mt_rand(0, mt_getrandmax()))) {
             return false;
         }
 

--- a/tests/Resources/modules/ps_featuredproducts/ps_featuredproducts.php
+++ b/tests/Resources/modules/ps_featuredproducts/ps_featuredproducts.php
@@ -51,11 +51,6 @@ class Ps_FeaturedProducts extends Module
 
     public function install()
     {
-        return parent::install()
-            && $this->registerHook('addproduct')
-            && $this->registerHook('updateproduct')
-            && $this->registerHook('deleteproduct')
-            && $this->registerHook('actionCategoryUpdate')
-            && $this->registerHook('displayHome');
+        return parent::install();
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x 
| Description?      | Behavior tests would override few modules with old not working version from test folder, now if the module already exists its not overriden
| Type?             | bug fix 
| Category?         | TE
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #29593 
| How to test?      | Running behavior test with ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s module --tags module will skip override of the module from test modules. See also https://github.com/PrestaShop/PrestaShop/pull/29708#issuecomment-1357798885

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
