### PR TITLE
Adjust combination quantity size on mobile

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -964,6 +964,10 @@ $product-page-padding-bottom: 80px !default;
       .attribute-price,
       .attribute-quantity {
         width: 15%;
+
+        input {
+          min-width: 4rem;
+        }
       }
 
       .attribute-finalprice {

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_combination.html.twig
@@ -58,9 +58,22 @@
     {% endif %}
 
     <td class="attribute-actions">
-        <div class="btn-group btn-group-sm" role="group">
+        <div class="btn-group btn-group-sm d-none d-md-block" role="group">
             <a href="#combination_form_{{ form.vars.value.id_product_attribute }}" class="btn btn-open tooltip-link btn-sm"><i class="material-icons">mode_edit</i></a>
         </div>
+
+        <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate d-inline-block px-0 d-md-none"
+          data-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+        >
+        </a>
+
+        <div class="dropdown-menu dropdown-menu-right">
+          <a href="#combination_form_{{ form.vars.value.id_product_attribute }}" class="btn btn-open tooltip-link dropdown-item"><i class="material-icons">mode_edit</i> {{ 'Edit'|trans({}, 'Admin.Actions') }}</a>
+          <a href="{{ path('admin_delete_attribute', {'idProduct': form.vars.value.id_product}) }}" class="btn tooltip-link delete dropdown-item" data="{{ form.vars.value.id_product_attribute }}"><i class="material-icons">delete</i> {{ 'Delete'|trans({}, 'Admin.Actions') }}</a>
+        </div>
+
         <div id="combination_form_{{ form.vars.value.id_product_attribute }}" data="{{ form.vars.value.id_product_attribute }}" class="combination-form hide row">
             <div class="col-sm-12 nav">
                 {# "Prev." is short for "Previous" #}
@@ -272,7 +285,7 @@
             </div>
         </div>
     </td>
-    <td width="5%">
+    <td width="5%" class="d-none d-md-table-cell">
       <a href="{{ path('admin_delete_attribute', {'idProduct': form.vars.value.id_product}) }}" class="btn tooltip-link btn-sm delete" data="{{ form.vars.value.id_product_attribute }}"><i class="material-icons">delete</i></a>
     </td>
     <td>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Combination's quantity on product page v1 wasn't readable on mobile 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29459.
| How to test?      | See issue
| Possible impacts? | Combination quantity product page v1

<img width="188" alt="image" src="https://user-images.githubusercontent.com/14963751/191524682-c5c4d343-b1ee-4f43-854e-8db926479e81.png">



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
