### PR TITLE
Functional tests - Refacto the BO - Delivery Slip - Enable Disable Product Image

### DIFF
--- a/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/03_enableDisableProductImage.js
+++ b/tests/UI/campaigns/functional/BO/02_orders/04_deliverySlips/02_deliverySlipOptions/03_enableDisableProductImage.js
@@ -65,8 +65,22 @@ describe('BO - Orders - Delivery slips : Enable/Disable product image', async ()
   });
 
   const tests = [
-    {args: {action: 'Enable', enable: true, imageNumber: global.URLHasPort ? 1 : 2}},
-    {args: {action: 'Disable', enable: false, imageNumber: global.URLHasPort ? 0 : 1}},
+    {
+      args: {
+        action: 'Enable',
+        enable: true,
+        imageNumber: global.URLHasPort ? 1 : 2,
+        isProductImageDisplayed: 'a product image displayed',
+      },
+    },
+    {
+      args: {
+        action: 'Disable',
+        enable: false,
+        imageNumber: global.URLHasPort ? 0 : 1,
+        isProductImageDisplayed: 'no product image displayed',
+      },
+    },
   ];
 
   tests.forEach((test, index) => {
@@ -190,7 +204,7 @@ describe('BO - Orders - Delivery slips : Enable/Disable product image', async ()
         });
       });
 
-      describe('Generate the delivery slip and check product image', async () => {
+      describe(`Generate the delivery slip and check that there is ${test.args.isProductImageDisplayed}`, async () => {
         it('should go to \'Orders > Orders\' page', async function () {
           await testContext.addContextItem(this, 'testIdentifier', `goToOrderPage${index}`, baseContext);
 
@@ -228,7 +242,7 @@ describe('BO - Orders - Delivery slips : Enable/Disable product image', async ()
           await expect(exist).to.be.true;
         });
 
-        it('should check the product images in the PDF File', async function () {
+        it(`should check that there is ${test.args.isProductImageDisplayed} in the PDF File`, async function () {
           await testContext.addContextItem(this, 'testIdentifier', `checkProductImage${index}`, baseContext);
 
           const imageNumber = await files.getImageNumberInPDF(filePath);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Refacto the BO - Delivery Slip - Enable Disable Product Image test
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no.
| How to test?      | HEADLESS=false TEST_PATH="functional/BO/02*/04*/02*/03*" URL_FO="http://shop.com/" PASSWD="prestashop_demo" npm run test:specific
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
