### PR TITLE
Fix discount detail in cart when a product has en ecotax with applied tax

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1328,12 +1328,7 @@ class CartRuleCore extends ObjectModel
                             && (($this->reduction_exclude_special && !$product['reduction_applies']) || !$this->reduction_exclude_special)) {
                             $price = $product['price'];
                             if ($use_tax) {
-                                $infos = Product::getTaxesInformations($product, $context);
-                                $tax_rate = $infos['rate'] / 100;
-                                // As the price is tax excluded but ecotax included, we need to substract the ecotax before getting the price tax included
-                                $price -= $product['ecotax'];
-                                $price *= (1 + $tax_rate);
-                                $price += $product['ecotax'];
+                                $price = $product['price_without_reduction'];
                             }
 
                             $selected_products_reduction += $price * $product['cart_quantity'];

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -430,6 +430,9 @@ class ProductCore extends ObjectModel
      */
     protected static $cacheStock = [];
 
+    /** @var int|null */
+    protected static $psEcotaxTaxRulesGroupId = null;
+
     /**
      * Product can be temporary saved in database
      */
@@ -1175,6 +1178,7 @@ class ProductCore extends ObjectModel
         static::$_pricesLevel2 = [];
         static::$_incat = [];
         static::$_combinations = [];
+        static::$psEcotaxTaxRulesGroupId = null;
     }
 
     /**
@@ -3906,14 +3910,13 @@ class ProductCore extends ObjectModel
                 $ecotax = Tools::convertPrice($ecotax, $id_currency);
             }
             if ($use_tax) {
-                static $psEcotaxTaxRulesGroupId = null;
-                if ($psEcotaxTaxRulesGroupId === null) {
-                    $psEcotaxTaxRulesGroupId = (int) Configuration::get('PS_ECOTAX_TAX_RULES_GROUP_ID');
+                if (self::$psEcotaxTaxRulesGroupId === null) {
+                    self::$psEcotaxTaxRulesGroupId = (int) Configuration::get('PS_ECOTAX_TAX_RULES_GROUP_ID');
                 }
                 // reinit the tax manager for ecotax handling
                 $tax_manager = TaxManagerFactory::getManager(
                     $address,
-                    $psEcotaxTaxRulesGroupId
+                    self::$psEcotaxTaxRulesGroupId
                 );
                 $ecotax_tax_calculator = $tax_manager->getTaxCalculator();
                 $price += $ecotax_tax_calculator->addTaxes($ecotax);

--- a/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CartFeatureContext.php
@@ -29,6 +29,7 @@ namespace Tests\Integration\Behaviour\Features\Context;
 use Cart;
 use Context;
 use LegacyTests\Unit\Core\Cart\Calculation\CartOld;
+use PHPUnit\Framework\Assert;
 
 class CartFeatureContext extends AbstractPrestaShopFeatureContext
 {
@@ -196,5 +197,15 @@ class CartFeatureContext extends AbstractPrestaShopFeatureContext
         if ($expectedTotal != $shippingFees) {
             throw new \RuntimeException(sprintf('Expects %s, got %s instead', $expectedTotal, $shippingFees));
         }
+    }
+
+    /**
+     * @Then /^I should have a voucher named "(.+)" with (\d+\.\d+) of discount$/
+     */
+    public function cartVoucher($voucherName, $discountAmount)
+    {
+        $cartRules = $this->getCurrentCart()->getCartRules();
+        Assert::assertEquals($cartRules[0]['code'], $voucherName);
+        Assert::assertEquals((float) $cartRules[0]['value_real'], (float) $discountAmount);
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/TaxFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/TaxFeatureContext.php
@@ -195,4 +195,14 @@ class TaxFeatureContext extends AbstractPrestaShopFeatureContext
         $carrier = $this->carrierFeatureContext->getCarrierWithName($carrierName);
         $carrier->setTaxRulesGroup($this->taxRuleGroups[$taxName]->id);
     }
+
+    /**
+     * @Given /^Ecotax belongs to tax group "(.+)"$/
+     */
+    public function setEcotaxTaxRuleGroup($taxName)
+    {
+        $this->checkTaxRuleWithNameExists($taxName);
+        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
+        $configuration->set('PS_ECOTAX_TAX_RULES_GROUP_ID', $this->taxRuleGroups[$taxName]->id);
+    }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/ecotax.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Cart/Calculation/CartRule/ecotax.feature
@@ -12,6 +12,7 @@ Feature: Cart rule (percent) calculation with one cart rule
     And there is a country named "country1" and iso code "FR" in zone "zone1"
     And there is a state named "state1" with iso code "TEST-1" in country "country1" and zone "zone1"
     And there is an address named "address1" with postcode "1" in state "state1"
+    And shop configuration for "PS_USE_ECOTAX" is set to 1
 
   Scenario:
     Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
@@ -27,8 +28,8 @@ Feature: Cart rule (percent) calculation with one cart rule
     And cart rule "cartRuleFiftyPercent" is restricted on the selection of products
     And cart rule "cartRuleFiftyPercent" has a discount code "cartRuleFiftyPercent"
     ## Add product
-    When I add 1 item of product "product_without_ecotax" in my cart
-    And I select address "address1" in my cart
+    When I select address "address1" in my cart
+    And I add 1 item of product "product_without_ecotax" in my cart
     Then my cart total should be 10.400 tax included
     And my cart total should be 10.000 tax excluded
     And I use the discount "cartRuleFiftyPercent"
@@ -50,10 +51,36 @@ Feature: Cart rule (percent) calculation with one cart rule
     And cart rule "cartRuleFiftyPercent" is restricted on the selection of products
     And cart rule "cartRuleFiftyPercent" has a discount code "cartRuleFiftyPercent"
     ## Add product
-    When I add 1 item of product "product_with_ecotax" in my cart
-    And I select address "address1" in my cart
-    Then my cart total should be 10.400 tax included
-    And my cart total should be 10.000 tax excluded
+    When I select address "address1" in my cart
+    And I add 1 item of product "product_with_ecotax" in my cart
+    Then my cart total should be 12.400 tax included
+    And my cart total should be 12.000 tax excluded
     And I use the discount "cartRuleFiftyPercent"
-    Then my cart total should be 5.200 tax included
-    And my cart total should be 5.000 tax excluded
+    Then my cart total should be 6.200 tax included
+    And my cart total should be 6.000 tax excluded
+    Then I should have a voucher named "cartRuleFiftyPercent" with 6.2 of discount
+
+  Scenario:
+    Given shop configuration for "PS_CART_RULE_FEATURE_ACTIVE" is set to 1
+    And there is a tax named "tax4Percent" and rate 4.0%
+    And there is a tax rule named "taxRule4Percent" in country "country1" where tax "tax4Percent" is applied
+    And Ecotax belongs to tax group "taxRule4Percent"
+    And I have an empty default cart
+    ## Set Product
+    And there is a product in the catalog named "product_with_ecotax" with a price of 10.000 and 1000 items in stock
+    And the product "product_with_ecotax" ecotax is 2.00
+    And product "product_with_ecotax" belongs to tax group "taxRule4Percent"
+    ## Set Cart Rule
+    When there is a cart rule named "cartRuleFiftyPercent" that applies a percent discount of 50.0% with priority 2, quantity of 1000 and quantity per user 1000
+    And cart rule "cartRuleFiftyPercent" is restricted to product "product_with_ecotax"
+    And cart rule "cartRuleFiftyPercent" is restricted on the selection of products
+    And cart rule "cartRuleFiftyPercent" has a discount code "cartRuleFiftyPercent"
+    ## Add product
+    When I select address "address1" in my cart
+    And I add 1 item of product "product_with_ecotax" in my cart
+    Then my cart total should be precisely 12.48 tax included
+    And my cart total should be 12.000 tax excluded
+    And I use the discount "cartRuleFiftyPercent"
+    Then my cart total should be precisely 6.24 tax included
+    And my cart total should be 6.000 tax excluded
+    Then I should have a voucher named "cartRuleFiftyPercent" with 6.24 of discount


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | In the FO > Shopping cart page and checkout page, when we apply a cart rule "percent discount on a selected product that has an ecotax, the discount line s NOK.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29331
| Related PRs       | 
| How to test?      | See #29331
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
