### PR TITLE
ShopConstraint parameter is deprecated since version 1.7.8.0 

### DIFF
--- a/.github/workflows/sanity/setup-apache.sh
+++ b/.github/workflows/sanity/setup-apache.sh
@@ -12,6 +12,9 @@ apt update && apt install -y apache2 libapache2-mod-php$PHP_VERSION
 # Enable rewrite mode
 a2enmod rewrite actions alias
 
+# Disable mpm_event (mpm_prefork should be already loaded)
+a2dismod mpm_event
+
 # Copy apache vhost and set Documentroot
 cp -f $WORKSPACE/.github/workflows/sanity/apache-vhost /etc/apache2/sites-available/000-default.conf
 sed -e "s?%BUILD_DIR%?$(echo $WORKSPACE)?g" --in-place /etc/apache2/sites-available/000-default.conf

--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -231,6 +231,7 @@ $(document).ready(() => {
       unbuildMobileMenu();
     } else if (!$('body').hasClass('mobile') && $(window).width() <= MAX_MOBILE_WIDTH) {
       mobileNav();
+      $('nav.nav-bar ul.main-menu').removeClass('sidebar-closed');
     }
   });
 

--- a/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/product-line.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/stock/components/overview/product-line.vue
@@ -105,7 +105,7 @@
         :title="lowStockLevel"
       >!</span>
     </td>
-    <td class="qty-spinner text-right">
+    <td class="qty-spinner">
       <Spinner
         :product="product"
         @updateProductQty="updateProductQty"

--- a/admin-dev/themes/new-theme/js/components/navbar-transition-handler.js
+++ b/admin-dev/themes/new-theme/js/components/navbar-transition-handler.js
@@ -33,7 +33,10 @@
  * @method toggle - Add the listener if there is no transition launched yet.
  * @return {Object} The object with methods wich permit to toggle on specific event.
 */
-function NavbarTransitionHandler($navBar, $mainMenu, endTransitionEvent, $body) {
+
+export const MAX_MOBILE_WIDTH = 1023;
+
+export function NavbarTransitionHandler($navBar, $mainMenu, endTransitionEvent, $body) {
   this.$body = $body;
   this.transitionFired = false;
   this.$navBar = $navBar.get(0);
@@ -47,7 +50,10 @@ function NavbarTransitionHandler($navBar, $mainMenu, endTransitionEvent, $body) 
 
     this.$navBar.removeEventListener(this.endTransitionEvent, this.showNavBarContent);
     const isSidebarClosed = this.$body.hasClass('page-sidebar-closed');
-    this.$mainMenu.toggleClass('sidebar-closed', isSidebarClosed);
+
+    if ($(window).width() > MAX_MOBILE_WIDTH) {
+      this.$mainMenu.toggleClass('sidebar-closed', isSidebarClosed);
+    }
     this.transitionFired = false;
   };
 
@@ -61,5 +67,3 @@ function NavbarTransitionHandler($navBar, $mainMenu, endTransitionEvent, $body) 
     this.transitionFired = !this.transitionFired;
   };
 }
-
-export default NavbarTransitionHandler;

--- a/admin-dev/themes/new-theme/js/nav_bar.js
+++ b/admin-dev/themes/new-theme/js/nav_bar.js
@@ -26,7 +26,7 @@
 import PerfectScrollbar from 'perfect-scrollbar';
 import 'perfect-scrollbar/css/perfect-scrollbar.css';
 import getAnimationEvent from './app/utils/animations';
-import NavbarTransitionHandler from './components/navbar-transition-handler';
+import {MAX_MOBILE_WIDTH, NavbarTransitionHandler} from './components/navbar-transition-handler';
 
 const {$} = window;
 
@@ -154,7 +154,6 @@ export default class NavBar {
         });
 
         addMobileBodyClickListener();
-        const MAX_MOBILE_WIDTH = 1023;
 
         if ($(window).width() <= MAX_MOBILE_WIDTH) {
           this.mobileNav(MAX_MOBILE_WIDTH);
@@ -165,6 +164,7 @@ export default class NavBar {
             this.unbuildMobileMenu();
           } else if (!$('body').hasClass('mobile') && $(window).width() <= MAX_MOBILE_WIDTH) {
             this.mobileNav(MAX_MOBILE_WIDTH);
+            $('nav.nav-bar ul.main-menu').removeClass('sidebar-closed');
           }
         });
       }

--- a/admin-dev/themes/new-theme/public/theme.rtlfix
+++ b/admin-dev/themes/new-theme/public/theme.rtlfix
@@ -1,3 +1,5 @@
+/* This comment avoid some weird behavior with preceding unclosed comment */
+
 @keyframes showcase-img-appearance-rtl {
   from {
     -webkit-transform: translate(-20px) translateX(-1);
@@ -137,3 +139,60 @@
 .nav-bar-overflow .ps__rail-y {
   left: 0 !important;
 }
+
+/**
+ * Fix some RTL problem with `admin-dev/themes/new-theme/scss/pages/stock/stock_page.scss` page
+ * for details, take a look at https://github.com/PrestaShop/PrestaShop/issues/27864 
+ */
+
+.adminstockmanagement .stock-app #search .search-input.tags-input:not(.search-with-icon) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.adminstockmanagement .stock-app #search .alert-box {
+    right: auto;
+    left: 5px;
+}
+
+.adminstockmanagement .stock-app #search #filters-container .collapse-button {
+    text-align: right;
+}
+
+.adminstockmanagement .stock-app #search #filters-container .filter-container.filter-suppliers  ul {
+    padding-right: 0;
+}
+
+.adminstockmanagement .stock-app #filters-container #filters {
+    box-shadow: -1px 2px 3px 0 rgba(108, 134, 142, 0.3);
+}
+
+.adminstockmanagement .stock-app .qty-spinner form.qty:hover input[type="number"],
+.adminstockmanagement .stock-app .qty-spinner form.qty.active input[type="number"] {
+    padding-right: 16px;
+}
+
+.adminstockmanagement .stock-app .qty-spinner form.qty:hover .ps-number-spinner, .adminstockmanagement .stock-app .qty-spinner form.qty.active .ps-number-spinner {
+    right: auto;
+    left: 34px;
+    text-align: left;
+}
+
+.adminstockmanagement .stock-app .qty-spinner form.qty .check-button {
+    right: auto;
+    left: 1px;
+    border-radius: 4px 0 0 4px;
+}
+
+.adminstockmanagement .stock-app .card .stock-overview .table thead th.product-title {
+    padding-right: 6rem;
+}
+
+.adminstockmanagement .stock-app .card .stock-overview .table thead th:last-child .material-icons {
+    margin-left: 5px;
+}
+
+.adminstockmanagement .stock-app .card .stock-overview .product-actions .qty {
+    padding-right: 20px;
+}
+

--- a/admin-dev/themes/new-theme/scss/components/_alert.scss
+++ b/admin-dev/themes/new-theme/scss/components/_alert.scss
@@ -1,0 +1,6 @@
+.alert {
+  > a {
+    padding: 0;
+  }
+  min-height: 55px;
+}

--- a/admin-dev/themes/new-theme/scss/components/_alert.scss
+++ b/admin-dev/themes/new-theme/scss/components/_alert.scss
@@ -1,6 +1,7 @@
 .alert {
+  min-height: 55px;
+
   > a {
     padding: 0;
   }
-  min-height: 55px;
 }

--- a/admin-dev/themes/new-theme/scss/components/_toggable_field.scss
+++ b/admin-dev/themes/new-theme/scss/components/_toggable_field.scss
@@ -53,6 +53,7 @@
 #attributes-generator {
   .tokenfield {
     .token-input {
+      /* stylelint-disable-next-line declaration-no-important */
       width: 100% !important;
     }
   }

--- a/admin-dev/themes/new-theme/scss/components/_toggable_field.scss
+++ b/admin-dev/themes/new-theme/scss/components/_toggable_field.scss
@@ -50,6 +50,14 @@
   }
 }
 
+#attributes-generator {
+  .tokenfield {
+    .token-input {
+      width: 100% !important;
+    }
+  }
+}
+
 .locale-input-group:not(.d-flex) {
   .js-taggable-field {
     width: 80%;

--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -23,6 +23,7 @@
 @import "~bootstrap/scss/mixins/border-radius";
 
 // Components
+@import "components/alert";
 @import "components/layout/content_div";
 @import "components/layout/header_toolbar";
 @import "components/layout/main_header";

--- a/classes/RequestSql.php
+++ b/classes/RequestSql.php
@@ -464,7 +464,7 @@ class RequestSqlCore extends ObjectModel
         $nb = count($select);
         for ($i = 0; $i < $nb; ++$i) {
             $attribut = $select[$i];
-            if ($attribut['base_expr'] != '*' && !preg_match('/\.*$/', $attribut['base_expr'])) {
+            if ($attribut['base_expr'] != '*' && !preg_match('/\.\*$/', $attribut['base_expr'])) {
                 if ($attribut['expr_type'] == 'colref') {
                     if ($attr = $this->cutAttribute(trim($attribut['base_expr']), $from)) {
                         if (!$this->attributExistInTable($attr['attribut'], $attr['table'])) {
@@ -508,7 +508,7 @@ class RequestSqlCore extends ObjectModel
         $nb = count($where);
         for ($i = 0; $i < $nb; ++$i) {
             $attribut = $where[$i];
-            if ($attribut['expr_type'] == 'colref' || $attribut['expr_type'] == 'reserved') {
+            if ($attribut['expr_type'] == 'colref') {
                 if ($attr = $this->cutAttribute(trim($attribut['base_expr']), $from)) {
                     if (!$this->attributExistInTable($attr['attribut'], $attr['table'])) {
                         $this->error_sql['checkedWhere']['attribut'] = [$attr['attribut'], implode(', ', $attr['table'])];
@@ -516,15 +516,15 @@ class RequestSqlCore extends ObjectModel
                         return false;
                     }
                 } else {
-                    if (isset($this->error_sql['returnNameTable'])) {
-                        $this->error_sql['checkedWhere'] = $this->error_sql['returnNameTable'];
+                    $this->error_sql['checkedWhere'] = $this->error_sql['returnNameTable'] ?? false;
 
-                        return false;
-                    } else {
-                        $this->error_sql['checkedWhere'] = false;
+                    return false;
+                }
+            } elseif ($attribut['expr_type'] == 'reserved') {
+                if ($attribut['base_expr'] !== 'EXISTS' || !isset($where[$i + 1]) || $where[$i + 1]['expr_type'] !== 'subquery') {
+                    $this->error_sql['checkedWhere'] = $this->error_sql['returnNameTable'] ?? false;
 
-                        return false;
-                    }
+                    return false;
                 }
             } elseif ($attribut['expr_type'] == 'operator') {
                 if (!in_array(strtoupper($attribut['base_expr']), $this->tested['operator'])) {

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -49,6 +49,9 @@ if (!defined('_PS_DEBUG_PROFILING_')) {
 if (!defined('_PS_MODE_DEMO_')) {
     define('_PS_MODE_DEMO_', false);
 }
+if (!defined('_PS_SMARTY_CACHING_TYPE_')) {
+    define('_PS_SMARTY_CACHING_TYPE_', 'filesystem');
+}
 
 $currentDir = dirname(__FILE__);
 

--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -40,7 +40,7 @@ $smarty->use_sub_dirs = true;
 $smarty->setConfigDir(_PS_SMARTY_DIR_.'configs');
 $smarty->caching = false;
 
-if (Configuration::get('PS_SMARTY_CACHING_TYPE') == 'mysql') {
+if (_PS_SMARTY_CACHING_TYPE_ == 'mysql') {
     include _PS_CLASS_DIR_.'Smarty/SmartyCacheResourceMysql.php';
     $smarty->caching_type = 'mysql';
 }

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
+use PrestaShopBundle\Utils\Tree;
 
 class AdminShopControllerCore extends AdminController
 {
@@ -217,30 +218,26 @@ class AdminShopControllerCore extends AdminController
     public function displayAjaxGetCategoriesFromRootCategory()
     {
         if (Tools::isSubmit('id_category')) {
-            // Array responsible of selected categories storage.
-            // To make this array construction easier, we use [ (int) 'category_id' => (int) 'category_id'] format.
-            $selected_categories = [];
-
-            // This recursive anonymous function is in charge of building categories tree.
-            $add_children_categories = function (int $category_id) use (&$selected_categories, &$add_children_categories): void {
-                $children = Category::getChildren($category_id, $this->context->language->id);
-                foreach ($children as $child) {
-                    $child_id = (int) $child['id_category'];
-                    // Test made to ensure avoiding unecessary recursive call
-                    if (!isset($selected_categories[$child_id])) {
-                        $selected_categories[$child_id] = $child_id;
-                        $add_children_categories($child_id);
-                    }
-                }
+            $getId = function ($category) {
+                return (int) $category['id_category'];
             };
 
-            $root_category_id = (int) Tools::getValue('id_category');
-            $selected_categories[$root_category_id] = $root_category_id;
+            $languageId = $this->context->language->id;
+            $getChildren = function (array $category) use ($languageId, $getId) {
+                return Category::getChildren($getId($category), $languageId);
+            };
 
-            $add_children_categories($root_category_id);
+            // selected categories ids.
+            $selectedCategories = Tree::extractChildrenId(
+                [
+                    ['id_category' => (int) Tools::getValue('id_category')],
+                ],
+                $getChildren,
+                $getId
+            );
 
             $helper = new HelperTreeCategories('categories-tree', null, (int) Tools::getValue('id_category'), null, false);
-            $this->content = $helper->setSelectedCategories($selected_categories)->setUseSearch(true)->setUseCheckBox(true)
+            $this->content = $helper->setSelectedCategories($selectedCategories)->setUseSearch(true)->setUseCheckBox(true)
                 ->render();
         }
         parent::displayAjax();

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -217,14 +217,30 @@ class AdminShopControllerCore extends AdminController
     public function displayAjaxGetCategoriesFromRootCategory()
     {
         if (Tools::isSubmit('id_category')) {
-            $selected_cat = [(int) Tools::getValue('id_category')];
-            $children = Category::getChildren((int) Tools::getValue('id_category'), $this->context->language->id);
-            foreach ($children as $child) {
-                $selected_cat[] = $child['id_category'];
-            }
+            // Array responsible of selected categories storage.
+            // To make this array construction easier, we use [ (int) 'category_id' => (int) 'category_id'] format.
+            $selected_categories = [];
+
+            // This recursive anonymous function is in charge of building categories tree.
+            $add_children_categories = function (int $category_id) use (&$selected_categories, &$add_children_categories): void {
+                $children = Category::getChildren($category_id, $this->context->language->id);
+                foreach ($children as $child) {
+                    $child_id = (int) $child['id_category'];
+                    // Test made to ensure avoiding unecessary recursive call
+                    if (!isset($selected_categories[$child_id])) {
+                        $selected_categories[$child_id] = $child_id;
+                        $add_children_categories($child_id);
+                    }
+                }
+            };
+
+            $root_category_id = (int) Tools::getValue('id_category');
+            $selected_categories[$root_category_id] = $root_category_id;
+
+            $add_children_categories($root_category_id);
 
             $helper = new HelperTreeCategories('categories-tree', null, (int) Tools::getValue('id_category'), null, false);
-            $this->content = $helper->setSelectedCategories($selected_cat)->setUseSearch(true)->setUseCheckBox(true)
+            $this->content = $helper->setSelectedCategories($selected_categories)->setUseSearch(true)->setUseCheckBox(true)
                 ->render();
         }
         parent::displayAjax();

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -146,24 +146,9 @@ class OrderControllerCore extends FrontController
     protected function saveDataToPersist(CheckoutProcess $process)
     {
         $data = $process->getDataToPersist();
-        $addressValidator = new AddressValidator($this->context);
-        $customer = $this->context->customer;
         $cart = $this->context->cart;
 
-        $shouldGenerateChecksum = false;
-
-        if ($customer->isGuest()) {
-            $shouldGenerateChecksum = true;
-        } else {
-            $invalidAddressIds = $addressValidator->validateCartAddresses($cart);
-            if (empty($invalidAddressIds)) {
-                $shouldGenerateChecksum = true;
-            }
-        }
-
-        $data['checksum'] = $shouldGenerateChecksum
-            ? $this->cartChecksum->generateChecksum($cart)
-            : null;
+        $data['checksum'] = $this->cartChecksum->generateChecksum($cart);
 
         Db::getInstance()->execute(
             'UPDATE ' . _DB_PREFIX_ . 'cart SET checkout_session_data = "' . pSQL(json_encode($data)) . '"
@@ -201,10 +186,6 @@ class OrderControllerCore extends FrontController
                     'Shop.Notifications.Error'
                 ),
             ];
-
-            $checksum = null;
-        } else {
-            $checksum = $this->cartChecksum->generateChecksum($cart);
         }
 
         // Prevent check for guests
@@ -215,7 +196,7 @@ class OrderControllerCore extends FrontController
             $this->checkoutWarning['invalid_addresses'] = $allInvalidAddressIds;
         }
 
-        if (isset($data['checksum']) && $data['checksum'] === $checksum) {
+        if (isset($data['checksum']) && $data['checksum'] === $this->cartChecksum->generateChecksum($cart)) {
             $process->restorePersistedData($data);
         }
     }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -351,7 +351,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
 
             $this->context->smarty->assign('packItems', $presentedPackItems);
             $this->context->smarty->assign('noPackPrice', $this->product->getNoPackPrice());
-            $this->context->smarty->assign('displayPackPrice', ($pack_items && $productPrice < $this->product->getNoPackPrice()) ? true : false);
+            $this->context->smarty->assign('displayPackPrice', ($pack_items && $productPrice < Pack::noPackPrice((int) $this->product->id)));
             $this->context->smarty->assign('priceDisplay', $priceDisplay);
             $this->context->smarty->assign('packs', Pack::getPacksTable($this->product->id, $this->context->language->id, true, 1));
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -481,6 +481,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             'product_minimal_quantity' => $minimalProductQuantity,
             'product_has_combinations' => !empty($this->combinations),
             'id_product_attribute' => $product['id_product_attribute'],
+            'id_customization' => $product['id_customization'],
             'product_title' => $this->getProductPageTitle(
                 $this->getTemplateVarPage()['meta'] ?? []
             ),

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -23,8 +23,10 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShopBundle\Install\Database;
 use PrestaShopBundle\Install\Install;
+use Symfony\Component\Filesystem\Filesystem;
 
 class InstallControllerConsoleProcess extends InstallControllerConsole implements HttpConfigureInterface
 {
@@ -170,6 +172,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         }
 
         // Update fixtures lang
+        $this->rebootWithoutTranslationsCache();
         foreach (Language::getLanguages() as $lang) {
             Language::updateMultilangTable($lang['iso_code']);
         }
@@ -345,5 +348,18 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
         global $kernel;
         $kernel = new AppKernel(_PS_ENV_, _PS_MODE_DEV_);
         $kernel->boot();
+    }
+
+    /**
+     * Delete translations cache and reboot the kernel so newly installed languages are took into account
+     *
+     * This method is only useful in CLI as everything is done in a single call but not with the web ui
+     * because the whole cache gets cleared before translating the fixtures
+     */
+    private function rebootWithoutTranslationsCache()
+    {
+        global $kernel;
+        (new Filesystem())->remove($kernel->getCacheDir() . 'translations');
+        $kernel->reboot($kernel->getCacheDir());
     }
 }

--- a/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForViewingHandler.php
@@ -221,7 +221,8 @@ final class GetCartForViewingHandler implements GetCartForViewingHandlerInterfac
                 'unit_price' => $product['product_price'],
                 'total_price_formatted' => $this->locale->formatPrice($product['product_total'], $currency->iso_code),
                 'unit_price_formatted' => $this->locale->formatPrice($product['product_price'], $currency->iso_code),
-                'image' => $this->imageManager->getThumbnailForListing($image['id_image']),
+                // it is possible that there is no image for product, so we don't show anything, but at least avoid breaking whole page
+                'image' => isset($image['id_image']) ? $this->imageManager->getThumbnailForListing($image['id_image']) : '',
             ];
 
             if (isset($product['customizationQuantityTotal'])) {

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -1088,7 +1088,6 @@ class Install extends AbstractInstall
         }
 
         Module::updateTranslationsAfterInstall(true);
-        EntityLanguage::updateModulesTranslations($modules);
 
         return true;
     }

--- a/src/PrestaShopBundle/Utils/Tree.php
+++ b/src/PrestaShopBundle/Utils/Tree.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Utils;
+
+class Tree
+{
+    /**
+     * @param array $elementlist
+     * @param callable $getChildren; must return an array of children for the given element; signature function($element): array
+     * @param callable $getId; must return the id of the given element; signature function($element): int
+     * @param array $idStorage; store found ids (ensure recursion optimisation and avoiding infinite loop)
+     *
+     * @return array [ (int) 'id' => (int) 'id'] (make array construction easier)
+     */
+    public static function extractChildrenId(array $elementlist, callable $getChildren, callable $getId, array &$idStorage = []): array
+    {
+        foreach ($elementlist as $child) {
+            $childId = $getId($child);
+            // Test made to ensure avoiding unecessary recursive call
+            if (!isset($idStorage[$childId])) {
+                $idStorage[$childId] = $childId;
+                static::extractChildrenId($getChildren($child), $getChildren, $getId, $idStorage);
+            }
+        }
+
+        return $idStorage;
+    }
+}

--- a/tests/Unit/Classes/RequestSqlTest.php
+++ b/tests/Unit/Classes/RequestSqlTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+// Create a fake Db class on the global namespace
+
+namespace {
+    abstract class Db extends \DbCore
+    {
+        public static function getInstance($master = true)
+        {
+            return new FakeDb();
+        }
+    }
+    class FakeDb extends Db
+    {
+        public function __construct()
+        {
+        }
+
+        public function connect()
+        {
+        }
+
+        public function disconnect()
+        {
+        }
+
+        protected function _query($sql)
+        {
+            return true;
+        }
+
+        protected function _numRows($result)
+        {
+        }
+
+        public function Insert_ID()
+        {
+        }
+
+        public function Affected_Rows()
+        {
+        }
+
+        public function nextRow($result = false)
+        {
+        }
+
+        protected function getAll($result = false)
+        {
+            return true;
+        }
+
+        public function getVersion()
+        {
+        }
+
+        public function _escape($str)
+        {
+        }
+
+        public function getMsgError()
+        {
+        }
+
+        public function getNumberError()
+        {
+        }
+
+        public function set_db($db_name)
+        {
+        }
+
+        public function getBestEngine()
+        {
+        }
+    }
+}
+
+namespace Tests\Unit\Classes {
+    use PHPUnit\Framework\TestCase;
+    use RequestSql;
+
+    class RequestSqlTest extends TestCase
+    {
+        /**
+         * @dataProvider provider
+         */
+        public function testValidateSql(string $sql, bool $valid): void
+        {
+            $requestSql = $this->createRequestSqlMock();
+            $parser = $requestSql->parsingSql($sql);
+            $this->assertSame($valid, $requestSql->validateParser($parser, false, $sql));
+        }
+
+        public function provider(): iterable
+        {
+            yield ['select * from ps_table', true];
+            yield ['select * from ps_notexistingtable', false];
+            yield ['select * from ps_table WHERE EXISTS (select 1 from ps_table)', true];
+            yield ['select * from ps_table WHERE EXISTS 1', false];
+            yield ['wrong * from ps_table', false];
+        }
+
+        private function createRequestSqlMock()
+        {
+            $requestSql = $this->getMockBuilder(RequestSql::class)
+                ->setMethods(['getTables'])
+                ->getMock()
+            ;
+
+            $requestSql->method('getTables')->willReturn([
+                'ps_table',
+            ]);
+
+            return $requestSql;
+        }
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Utils/TreeTest.php
+++ b/tests/Unit/PrestaShopBundle/Utils/TreeTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Utils;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Utils\Tree;
+
+class TreeTest extends TestCase
+{
+    public function testItListsChildrenIds(): void
+    {
+        $tree = [
+            [
+                'element_id' => 1,
+                'children' => [
+                    [
+                        'element_id' => 2,
+                        'children' => [
+                            [
+                                'element_id' => '4',
+                                'children' => [],
+                            ],
+                            [
+                                'element_id' => 6,
+                                'children' => [],
+                            ],
+                            [
+                                'element_id' => 7,
+                            ],
+                        ],
+                    ],
+                    [
+                        'element_id' => 10,
+                        'children' => [
+                            [
+                                'element_id' => 12,
+                                'children' => [],
+                            ],
+                            [
+                                'element_id' => 13,
+                                'children' => [],
+                            ],
+                        ],
+                    ],
+                    [
+                        'element_id' => 15,
+                        'children' => [
+                            [
+                                'element_id' => 13,
+                                'children' => [],
+                            ],
+                            [
+                                'element_id' => 20,
+                                'children' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $idList = [
+            1 => 1,
+            2 => 2,
+            4 => 4,
+            6 => 6,
+            7 => 7,
+            10 => 10,
+            12 => 12,
+            13 => 13,
+            15 => 15,
+            20 => 20,
+        ];
+
+        $getChildren = function (array $element) {
+            return isset($element['children']) ? $element['children'] : [];
+        };
+
+        $getId = function ($element) {
+            return (int) $element['element_id'];
+        };
+
+        $this->assertSame($idList, Tree::extractChildrenId($tree, $getChildren, $getId));
+    }
+}

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -230,7 +230,7 @@ function updateProduct(event, eventType, updateUrl) {
           .replaceWith(data.product_customization);
 
         // refill customizationId input value when updating quantity or combination
-        if (eventType === 'updatedProductQuantity' || eventType === 'updatedProductCombination' && data.id_customization) {
+        if ((eventType === 'updatedProductQuantity' || eventType === 'updatedProductCombination') && data.id_customization) {
           $(prestashop.selectors.cart.productCustomizationId).val(data.id_customization);
         } else {
           $(prestashop.selectors.product.inputCustomization).val(0);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -229,8 +229,8 @@ function updateProduct(event, eventType, updateUrl) {
           .first()
           .replaceWith(data.product_customization);
 
-        // refill customizationId input value when updating quantity
-        if (eventType === 'updatedProductQuantity' && data.id_customization) {
+        // refill customizationId input value when updating quantity or combination
+        if (eventType === 'updatedProductQuantity' || eventType === 'updatedProductCombination' && data.id_customization) {
           $(prestashop.selectors.cart.productCustomizationId).val(data.id_customization);
         } else {
           $(prestashop.selectors.product.inputCustomization).val(0);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -230,7 +230,10 @@ function updateProduct(event, eventType, updateUrl) {
           .replaceWith(data.product_customization);
 
         // refill customizationId input value when updating quantity or combination
-        if ((eventType === 'updatedProductQuantity' || eventType === 'updatedProductCombination') && data.id_customization) {
+        if (
+          (eventType === 'updatedProductQuantity' || eventType === 'updatedProductCombination')
+          && data.id_customization
+        ) {
           $(prestashop.selectors.cart.productCustomizationId).val(data.id_customization);
         } else {
           $(prestashop.selectors.product.inputCustomization).val(0);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -228,7 +228,6 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
-        $(prestashop.selectors.product.inputCustomization).val(0);
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -228,6 +228,14 @@ function updateProduct(event, eventType, updateUrl) {
         $(prestashop.selectors.product.customization)
           .first()
           .replaceWith(data.product_customization);
+
+        // refill customizationId input value when updating quantity
+        if (eventType === 'updatedProductQuantity' && data.id_customization) {
+          $(prestashop.selectors.cart.productCustomizationId).val(data.id_customization);
+        } else {
+          $(prestashop.selectors.product.inputCustomization).val(0);
+        }
+
         $(prestashop.selectors.product.variantsUpdate)
           .first()
           .replaceWith(data.product_variants);

--- a/themes/classic/_dev/js/customer.js
+++ b/themes/classic/_dev/js/customer.js
@@ -26,9 +26,9 @@ import $ from 'jquery';
 import prestashop from 'prestashop';
 
 function initRmaItemSelector() {
-  $(`${prestashop.themeSelectors.order.returnForm} table thead input[type=checkbox]`).on('click', function () {
+  $(`${prestashop.themeSelectors.order.returnFormHeadCheckboxes}`).on('click', function () {
     const checked = $(this).prop('checked');
-    $(`${prestashop.themeSelectors.order.returnForm} table tbody input[type=checkbox]`).each((_, checkbox) => {
+    $(`${prestashop.themeSelectors.order.returnFormContentCheckboxes}`).each((_, checkbox) => {
       $(checkbox).prop('checked', checked);
     });
   });

--- a/themes/classic/_dev/js/customer.js
+++ b/themes/classic/_dev/js/customer.js
@@ -28,7 +28,7 @@ import prestashop from 'prestashop';
 function initRmaItemSelector() {
   $(prestashop.themeSelectors.order.returnFormHeadCheckboxes).on('click', function () {
     const checked = $(this).prop('checked');
-    $(`${prestashop.themeSelectors.order.returnFormContentCheckboxes}`).each((_, checkbox) => {
+    $(prestashop.themeSelectors.order.returnFormContentCheckboxes).each((_, checkbox) => {
       $(checkbox).prop('checked', checked);
     });
   });

--- a/themes/classic/_dev/js/customer.js
+++ b/themes/classic/_dev/js/customer.js
@@ -26,7 +26,7 @@ import $ from 'jquery';
 import prestashop from 'prestashop';
 
 function initRmaItemSelector() {
-  $(`${prestashop.themeSelectors.order.returnFormHeadCheckboxes}`).on('click', function () {
+  $(prestashop.themeSelectors.order.returnFormHeadCheckboxes).on('click', function () {
     const checked = $(this).prop('checked');
     $(`${prestashop.themeSelectors.order.returnFormContentCheckboxes}`).each((_, checkbox) => {
       $(checkbox).prop('checked', checked);

--- a/themes/classic/_dev/js/listing.js
+++ b/themes/classic/_dev/js/listing.js
@@ -229,11 +229,13 @@ function updateProductListDOM(data) {
   );
 
   const renderedProducts = $(data.rendered_products);
-  const productSelectors = $(prestashop.themeSelectors.listing.product, renderedProducts);
+  const productSelectors = $(prestashop.themeSelectors.listing.product);
 
   if (productSelectors.length > 0) {
-    productSelectors.removeClass().addClass($(prestashop.themeSelectors.listing.product).first().attr('class'));
-  }
+    productSelectors.removeClass().addClass(productSelectors.first().attr('class'));
+  } else {
+    productSelectors.removeClass().addClass(renderedProducts.first().attr('class'));
+  }  
 
   $(prestashop.themeSelectors.listing.list).replaceWith(renderedProducts);
 

--- a/themes/classic/_dev/js/listing.js
+++ b/themes/classic/_dev/js/listing.js
@@ -235,7 +235,7 @@ function updateProductListDOM(data) {
     productSelectors.removeClass().addClass(productSelectors.first().attr('class'));
   } else {
     productSelectors.removeClass().addClass(renderedProducts.first().attr('class'));
-  }  
+  }
 
   $(prestashop.themeSelectors.listing.list).replaceWith(renderedProducts);
 

--- a/themes/classic/_dev/js/selectors.js
+++ b/themes/classic/_dev/js/selectors.js
@@ -54,7 +54,10 @@ prestashop.themeSelectors = {
     searchLink: '.js-search-link',
   },
   order: {
-    returnForm: '#order-return-form, .js-order-return-form',
+    returnFormHeadCheckboxes:
+      '#order-return-form table thead input[type=checkbox], .js-order-return-form table thead input[type=checkbox]',
+    returnFormContentCheckboxes:
+      '#order-return-form table tbody input[type=checkbox], .js-order-return-form table tbody input[type=checkbox]',
   },
   arrowDown: '.arrow-down, .js-arrow-down',
   arrowUp: '.arrow-up, .js-arrow-up',


### PR DESCRIPTION
description: Hi and my first pull request, forgive me if I do something wrong. I have prestashop 1.7.8.7 in which I have the logs file full of the optional deprecated ShopConstraint parameter is obsolete from version 1.7.8.0 public_html / src / Adapter / Configuration.php: 418.
How can I solve?
My environment
PS 1.7.8.7
Apache Version 2.4.54
PHP Version 7.4.30
extension = php_mysql.dll
extension = php_gd2.dll
allow_url_fopen = On
allow_url_include = Off
realpath_cache_size = 4096k
realpath_cache_ttl = 600
short_open_tag = off
display_errors = Off
max_execution_time = 300
max_input_time = 300
max_input_vars = 20000
memory_limit = 512M
post_max_size = 128M
session.gc_maxlifetime = 1440
session.save_path = "/ var / cpanel / php / sessions / ea-php74"
upload_max_filesize = 128M
zlib.output_compression = Off

type:
category: BO

![1](https://user-images.githubusercontent.com/47488488/191691396-c77f9942-159e-4273-b20f-045e410f945e.PNG)
