### PR TITLE
Add more options for discontinued products

### DIFF
--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -2213,7 +2213,13 @@ window.seo = (function () {
   /** Hide or show the input product selector */
   function hideShowRedirectToProduct() {
     redirectTypeValue = redirectTypeElem.val();
-    if (redirectTypeValue === '404' || redirectTypeValue === '410') {
+    if (redirectTypeValue === '404'
+      || redirectTypeValue === '410'
+      || redirectTypeValue === 'default'
+      || redirectTypeValue === '200-displayed'
+      || redirectTypeValue === '404-displayed'
+      || redirectTypeValue === '410-displayed'
+    ) {
       $('#id-product-redirected').hide();
     } else {
       updateRemoteUrl();

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -212,7 +212,7 @@ class ProductCore extends ObjectModel
      *
      * @see RedirectType
      */
-    public $redirect_type = RedirectType::TYPE_NOT_FOUND;
+    public $redirect_type = RedirectType::TYPE_DEFAULT;
 
     /**
      * @var int Product identifier or Category identifier depends on redirect_type

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1636,9 +1636,10 @@ CREATE TABLE `PREFIX_product` (
   `text_fields` tinyint(4) NOT NULL DEFAULT '0',
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `redirect_type` ENUM(
-    '404', '410', '301-product', '302-product',
-    '301-category', '302-category'
-  ) NOT NULL DEFAULT '404',
+    '', '404', '410', '301-product', '302-product',
+    '301-category', '302-category', '200-displayed', 
+    '404-displayed', '410-displayed', 'default'
+  ) NOT NULL DEFAULT 'default',
   `id_type_redirected` int(10) unsigned NOT NULL DEFAULT '0',
   `available_for_order` tinyint(1) NOT NULL DEFAULT '1',
   `available_date` date DEFAULT NULL,
@@ -1696,8 +1697,9 @@ CREATE TABLE IF NOT EXISTS `PREFIX_product_shop` (
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `redirect_type` ENUM(
     '', '404', '410', '301-product', '302-product',
-    '301-category', '302-category'
-  ) NOT NULL DEFAULT '',
+    '301-category', '302-category', '200-displayed', 
+    '404-displayed', '410-displayed', 'default'
+  ) NOT NULL DEFAULT 'default',
   `id_type_redirected` int(10) unsigned NOT NULL DEFAULT '0',
   `available_for_order` tinyint(1) NOT NULL DEFAULT '1',
   `available_date` date DEFAULT NULL,

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -892,5 +892,8 @@ Country</value>
     <configuration id="PS_ENABLE_BACKORDER_STATUS" name="PS_ENABLE_BACKORDER_STATUS">
       <value>0</value>
     </configuration>
+    <configuration id="PS_PRODUCT_REDIRECTION_DEFAULT" name="PS_PRODUCT_REDIRECTION_DEFAULT">
+      <value>404</value>
+    </configuration>
   </entities>
 </entity_configuration>

--- a/js/admin.js
+++ b/js/admin.js
@@ -536,7 +536,12 @@ function showRedirectProductOptions(show)
 function redirectSelectChange()
 {
   redirectTypeValue = $('#redirect_type :selected').val();
-  if (redirectTypeValue == '404' || redirectTypeValue == '410' )
+  if (redirectTypeValue == '404' || 
+      redirectTypeValue == '410' || 
+      redirectTypeValue == 'default' || 
+      redirectTypeValue == '200-displayed' || 
+      redirectTypeValue == '404-displayed' || 
+      redirectTypeValue == '410-displayed')
     showRedirectProductSelectOptions(false);
   else
     showRedirectProductSelectOptions(true);

--- a/src/Adapter/Presenter/Object/ObjectPresenter.php
+++ b/src/Adapter/Presenter/Object/ObjectPresenter.php
@@ -55,13 +55,6 @@ class ObjectPresenter implements PresenterInterface
 
         $presentedObject['id'] = $object->id;
 
-        $mustRemove = ['deleted', 'active'];
-        foreach ($mustRemove as $fieldName) {
-            if (isset($presentedObject[$fieldName])) {
-                unset($presentedObject[$fieldName]);
-            }
-        }
-
         $this->filterHtmlContent($object::$definition['table'], $presentedObject, $object->getHtmlFields());
 
         return $presentedObject;

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -386,7 +386,11 @@ class ProductLazyArray extends AbstractLazyArray
     public function getSeoAvailability()
     {
         $seoAvailability = 'https://schema.org/';
-        if ($this->product['quantity'] > 0) {
+
+        // Availability for displaying discontinued products, if enabled
+        if ($this->product['active'] != 1) {
+            $seoAvailability .= 'Discontinued';
+        } elseif ($this->product['quantity'] > 0) {
             $seoAvailability .= 'InStock';
         } elseif ($this->product['quantity'] <= 0 && $this->product['allow_oosp']) {
             $seoAvailability .= 'PreOrder';
@@ -813,6 +817,11 @@ class ProductLazyArray extends AbstractLazyArray
      */
     protected function shouldEnableAddToCartButton(array $product, ProductPresentationSettings $settings)
     {
+        // If the product is disabled, we disable add to cart button
+        if ($product['active'] != 1) {
+            return false;
+        }
+
         if (($product['customizable'] == 2 || !empty($product['customization_required']))) {
             $shouldEnable = false;
 
@@ -924,6 +933,18 @@ class ProductLazyArray extends AbstractLazyArray
 
         // If we don't want to show availability, we return immediately
         if (!$show_availability) {
+            return;
+        }
+
+        // If the product is disabled, but still displayed, we display a proper message
+        if ($this->product['active'] != 1) {
+            $this->product['availability_message'] = $this->translator->trans(
+                'This product is no longer for sale',
+                [],
+                'Shop.Notifications.Error'
+            );
+            $this->product['availability'] = 'discontinued';
+
             return;
         }
 

--- a/src/Adapter/Product/GeneralConfiguration.php
+++ b/src/Adapter/Product/GeneralConfiguration.php
@@ -74,6 +74,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             'force_friendly_url' => $this->configuration->getBoolean('PS_FORCE_FRIENDLY_PRODUCT'),
             'default_status' => $this->configuration->getBoolean('PS_PRODUCT_ACTIVATION_DEFAULT'),
             'specific_price_priorities' => $this->getPrioritiesData(),
+            'disabled_products_behavior' => $this->configuration->get('PS_PRODUCT_REDIRECTION_DEFAULT'),
         ];
     }
 
@@ -93,6 +94,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             $this->configuration->set('PS_QTY_DISCOUNT_ON_COMBINATION', (int) $config['quantity_discount']);
             $this->configuration->set('PS_FORCE_FRIENDLY_PRODUCT', (int) $config['force_friendly_url']);
             $this->configuration->set('PS_PRODUCT_ACTIVATION_DEFAULT', (int) $config['default_status']);
+            $this->configuration->set('PS_PRODUCT_REDIRECTION_DEFAULT', (string) $config['disabled_products_behavior']);
             try {
                 $this->specificPricePriorityUpdater->updateDefaultPriorities(new PriorityList($config['specific_price_priorities']));
             } catch (SpecificPriceConstraintException $e) {
@@ -126,6 +128,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             'force_friendly_url',
             'default_status',
             'specific_price_priorities',
+            'disabled_products_behavior',
         ]);
 
         $resolver->resolve($configuration);

--- a/src/Core/Domain/Product/ValueObject/RedirectType.php
+++ b/src/Core/Domain/Product/ValueObject/RedirectType.php
@@ -36,14 +36,34 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintExcepti
 class RedirectType
 {
     /**
+     * Represents default configuration.
+     */
+    public const TYPE_DEFAULT = 'default';
+
+    /**
+     * Represents value of no redirection. Product page with "Discontinued" message will be displayed, along with HTTP 200 response.
+     */
+    public const TYPE_SUCCESS_DISPLAYED = '200-displayed';
+
+    /**
      * Represents value of no redirection. Page not found (404) will be displayed.
      */
     public const TYPE_NOT_FOUND = '404';
 
     /**
+     * Represents value of no redirection. Product page with "Discontinued" message will be displayed, along with HTTP 404 response.
+     */
+    public const TYPE_NOT_FOUND_DISPLAYED = '404-displayed';
+
+    /**
      * Represents value of no redirection. Page gone (410) will be displayed.
      */
     public const TYPE_GONE = '410';
+
+    /**
+     * Represents value of no redirection. Product page with "Discontinued" message will be displayed, along with HTTP 410 response.
+     */
+    public const TYPE_GONE_DISPLAYED = '410-displayed';
 
     /**
      * Represents value of permanent redirection to a category
@@ -69,12 +89,16 @@ class RedirectType
      * Available redirection types
      */
     public const AVAILABLE_REDIRECT_TYPES = [
+        self::TYPE_DEFAULT => self::TYPE_DEFAULT,
         self::TYPE_NOT_FOUND => self::TYPE_NOT_FOUND,
         self::TYPE_GONE => self::TYPE_GONE,
         self::TYPE_CATEGORY_PERMANENT => self::TYPE_CATEGORY_PERMANENT,
         self::TYPE_CATEGORY_TEMPORARY => self::TYPE_CATEGORY_TEMPORARY,
         self::TYPE_PRODUCT_PERMANENT => self::TYPE_PRODUCT_PERMANENT,
         self::TYPE_PRODUCT_TEMPORARY => self::TYPE_PRODUCT_TEMPORARY,
+        self::TYPE_SUCCESS_DISPLAYED => self::TYPE_SUCCESS_DISPLAYED,
+        self::TYPE_NOT_FOUND_DISPLAYED => self::TYPE_NOT_FOUND_DISPLAYED,
+        self::TYPE_GONE_DISPLAYED => self::TYPE_GONE_DISPLAYED,
     ];
 
     /**

--- a/src/Core/Product/ProductInterface.php
+++ b/src/Core/Product/ProductInterface.php
@@ -40,4 +40,8 @@ interface ProductInterface
     public const REDIRECT_TYPE_PRODUCT_FOUND = RedirectType::TYPE_PRODUCT_TEMPORARY;
     public const REDIRECT_TYPE_NOT_FOUND = RedirectType::TYPE_NOT_FOUND;
     public const REDIRECT_TYPE_GONE = RedirectType::TYPE_GONE;
+    public const REDIRECT_TYPE_DEFAULT = RedirectType::TYPE_DEFAULT;
+    public const REDIRECT_TYPE_NOT_FOUND_DISPLAYED = RedirectType::TYPE_NOT_FOUND_DISPLAYED;
+    public const REDIRECT_TYPE_GONE_DISPLAYED = RedirectType::TYPE_GONE_DISPLAYED;
+    public const REDIRECT_TYPE_SUCCESS_DISPLAYED = RedirectType::TYPE_SUCCESS_DISPLAYED;
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\ProductPreferences;
 
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPricePriorityType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -159,6 +160,26 @@ class GeneralType extends TranslatorAwareType
                     'If a customer meets multiple conditions, specific prices will be applied in this order of priority, unless a different order has been set for a particular product.',
                     'Admin.Shopparameters.Help'
                 ),
+                'required' => false,
+            ])
+            ->add('disabled_products_behavior', ChoiceType::class, [
+                'label' => $this->trans(
+                    'Default behavior for disabled products',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'You can specify the default behavior for all disabled products. The product page can display a "Discontinued" message or an error page. You can also specify which HTTP response is sent to users. This can be set specifically for each product.',
+                    'Admin.Shopparameters.Help'
+                ),
+                'choices' => [
+                    'Display error page with 404 response' => RedirectType::TYPE_NOT_FOUND,
+                    'Display error page with 410 response' => RedirectType::TYPE_GONE,
+                    'Display product as discontinued with 200 response' => RedirectType::TYPE_SUCCESS_DISPLAYED,
+                    'Display product as discontinued with 404 response' => RedirectType::TYPE_NOT_FOUND_DISPLAYED,
+                    'Display product as discontinued with 410 response' => RedirectType::TYPE_GONE_DISPLAYED,
+                ],
+                'choice_translation_domain' => 'Admin.Global',
+                'placeholder' => false,
                 'required' => false,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductSeo.php
@@ -159,12 +159,16 @@ class ProductSeo extends CommonAbstractType
                 FormType\ChoiceType::class,
                 [
                     'choices' => [
+                        $this->translator->trans('Default behavior from configuration', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_DEFAULT,
+                        $this->translator->trans('No redirection (200), display product', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_SUCCESS_DISPLAYED,
+                        $this->translator->trans('No redirection (404), display product', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_NOT_FOUND_DISPLAYED,
+                        $this->translator->trans('No redirection (410), display product', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_GONE_DISPLAYED,
+                        $this->translator->trans('No redirection (404), display error page', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_NOT_FOUND,
+                        $this->translator->trans('No redirection (410), display error page', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_GONE,
                         $this->translator->trans('Permanent redirection to a category (301)', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_CATEGORY_PERMANENT,
                         $this->translator->trans('Temporary redirection to a category (302)', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_CATEGORY_TEMPORARY,
                         $this->translator->trans('Permanent redirection to a product (301)', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_PRODUCT_PERMANENT,
                         $this->translator->trans('Temporary redirection to a product (302)', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_PRODUCT_TEMPORARY,
-                        $this->translator->trans('No redirection (410)', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_GONE,
-                        $this->translator->trans('No redirection (404)', [], 'Admin.Catalog.Feature') => RedirectType::TYPE_NOT_FOUND,
                     ],
                     'choice_attr' => function ($val, $key, $index) use ($remoteUrls) {
                         if (array_key_exists($index, $remoteUrls)) {

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/RedirectOptionListener.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/EventListener/RedirectOptionListener.php
@@ -80,7 +80,9 @@ class RedirectOptionListener implements EventSubscriberInterface
         $targetOptions['help'] = $this->getEntityAttribute($targetOptions, $entityType, 'help');
         $targetOptions['remote_url'] = $this->getEntityAttribute($targetOptions, $entityType, 'search-url');
         $targetOptions['filtered_identities'] = json_decode($this->getEntityAttribute($targetOptions, $entityType, 'filtered'));
-        if (RedirectType::TYPE_NOT_FOUND === $dataType || RedirectType::TYPE_GONE === $dataType) {
+        if (RedirectType::TYPE_NOT_FOUND === $dataType || RedirectType::TYPE_GONE === $dataType ||
+            RedirectType::TYPE_DEFAULT === $dataType || RedirectType::TYPE_GONE_DISPLAYED === $dataType ||
+            RedirectType::TYPE_SUCCESS_DISPLAYED === $dataType || RedirectType::TYPE_NOT_FOUND_DISPLAYED === $dataType) {
             $targetOptions['row_attr']['class'] = 'd-none';
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/SEO/RedirectOptionType.php
@@ -125,14 +125,22 @@ class RedirectOptionType extends TranslatorAwareType
                 'required' => false,
                 'placeholder' => false, // Guaranties that no empty value is added in options
                 'choices' => [
-                    $this->trans('No redirection (404)', 'Admin.Catalog.Feature') => RedirectType::TYPE_NOT_FOUND,
-                    $this->trans('No redirection (410)', 'Admin.Catalog.Feature') => RedirectType::TYPE_GONE,
+                    $this->trans('Default behavior from configuration', 'Admin.Catalog.Feature') => RedirectType::TYPE_DEFAULT,
+                    $this->trans('No redirection (200), display product', 'Admin.Catalog.Feature') => RedirectType::TYPE_SUCCESS_DISPLAYED,
+                    $this->trans('No redirection (404), display product', 'Admin.Catalog.Feature') => RedirectType::TYPE_NOT_FOUND_DISPLAYED,
+                    $this->trans('No redirection (410), display product', 'Admin.Catalog.Feature') => RedirectType::TYPE_GONE_DISPLAYED,
+                    $this->trans('No redirection (404), display error page', 'Admin.Catalog.Feature') => RedirectType::TYPE_NOT_FOUND,
+                    $this->trans('No redirection (410), display error page', 'Admin.Catalog.Feature') => RedirectType::TYPE_GONE,
                     $this->trans('Permanent redirection to a category (301)', 'Admin.Catalog.Feature') => RedirectType::TYPE_CATEGORY_PERMANENT,
                     $this->trans('Temporary redirection to a category (302)', 'Admin.Catalog.Feature') => RedirectType::TYPE_CATEGORY_TEMPORARY,
                     $this->trans('Permanent redirection to a product (301)', 'Admin.Catalog.Feature') => RedirectType::TYPE_PRODUCT_PERMANENT,
                     $this->trans('Temporary redirection to a product (302)', 'Admin.Catalog.Feature') => RedirectType::TYPE_PRODUCT_TEMPORARY,
                 ],
                 'modify_all_shops' => true,
+                'external_link' => [
+                    'text' => $this->trans('[1]Edit default behavior[/1]', 'Admin.Catalog.Feature'),
+                    'href' => $this->router->generate('admin_product_preferences') . '#configuration_fieldset_products',
+                ],
             ])
             ->add('target', EntitySearchInputType::class, [
                 'required' => false,
@@ -198,8 +206,12 @@ class RedirectOptionType extends TranslatorAwareType
     private function getRedirectionAlertMessages(): array
     {
         return [
-            $this->trans('No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.', 'Admin.Catalog.Help'),
-            $this->trans('No redirection (410) = Do not redirect anywhere and display a 410 "Gone" page.', 'Admin.Catalog.Help'),
+            $this->trans('Default behavior is specified in the Shop Parameters > Product settings page.', 'Admin.Catalog.Help'),
+            $this->trans('No redirection (200), display product = Do not redirect anywhere, display product as discontinued and return normal 200 response.', 'Admin.Catalog.Help'),
+            $this->trans('No redirection (404), display product = Do not redirect anywhere, display product as discontinued and return 404 "Not Found" response.', 'Admin.Catalog.Help'),
+            $this->trans('No redirection (410), display product = Do not redirect anywhere, display product as discontinued and return 410 "Gone" response.', 'Admin.Catalog.Help'),
+            $this->trans('No redirection (404), display error page = Do not redirect anywhere and display a 404 "Not Found" page.', 'Admin.Catalog.Help'),
+            $this->trans('No redirection (410), display error page = Do not redirect anywhere and display a 410 "Gone" page.', 'Admin.Catalog.Help'),
             $this->trans('Permanent redirection (301) = Permanently display another product or category instead.', 'Admin.Catalog.Help'),
             $this->trans('Temporary redirection (302) = Temporarily display another product or category instead.', 'Admin.Catalog.Help'),
         ];

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -257,22 +257,55 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             $form_data['is_virtual'] = 0;
         }
 
-        // Product redirection
+        // Product redirection type and object ID
         $form_data['redirect_type'] = (string) $form_data['redirect_type'];
-        if ($form_data['redirect_type'] != RedirectType::TYPE_NOT_FOUND) {
-            if (isset($form_data['id_type_redirected']) && !empty($form_data['id_type_redirected']['data'])) {
+
+        /**
+         * In case of categories, we will use the category ID, but if it's missing,
+         * it can be assigned to zero. Product default category will be used.
+         */
+        if (RedirectType::TYPE_CATEGORY_PERMANENT == $form_data['redirect_type'] ||
+            RedirectType::TYPE_CATEGORY_TEMPORARY == $form_data['redirect_type']) {
+            if (!empty($form_data['id_type_redirected']['data'][0])) {
                 $form_data['id_type_redirected'] = $form_data['id_type_redirected']['data'][0];
-            } elseif (RedirectType::TYPE_CATEGORY_PERMANENT == $form_data['redirect_type'] || RedirectType::TYPE_CATEGORY_TEMPORARY == $form_data['redirect_type']) {
+            } else {
                 $form_data['id_type_redirected'] = 0;
-            } elseif (RedirectType::TYPE_GONE == $form_data['redirect_type']) {
-                $form_data['id_type_redirected'] = 0;
-                $form_data['redirect_type'] = RedirectType::TYPE_GONE;
+            }
+        /**
+         * For redirects to products, we need that ID. If its missing and it was still submitted
+         * somehow, we will fall back to default category redirect with no object ID.
+         */
+        } elseif (RedirectType::TYPE_PRODUCT_PERMANENT == $form_data['redirect_type'] ||
+            RedirectType::TYPE_PRODUCT_TEMPORARY == $form_data['redirect_type']) {
+            if (!empty($form_data['id_type_redirected']['data'][0])) {
+                $form_data['id_type_redirected'] = $form_data['id_type_redirected']['data'][0];
             } else {
                 $form_data['id_type_redirected'] = 0;
                 $form_data['redirect_type'] = RedirectType::TYPE_CATEGORY_PERMANENT;
             }
+        /**
+         * For all other redirection types that don't need any other object ID.
+         */
         } else {
             $form_data['id_type_redirected'] = 0;
+        }
+
+        // If redirection is set to category and we have proper data, we assign it
+        if ((RedirectType::TYPE_CATEGORY_PERMANENT == $form_data['redirect_type'] ||
+            RedirectType::TYPE_CATEGORY_TEMPORARY == $form_data['redirect_type']) &&
+            !empty($form_data['id_type_redirected']['data'][0])) {
+            $form_data['id_type_redirected'] = $form_data['id_type_redirected']['data'][0];
+        }
+
+        // If redirection is set to product and we have proper data, we assign it
+        // Otherwise, we fallback to category permament redirect
+        if (RedirectType::TYPE_PRODUCT_PERMANENT == $form_data['redirect_type'] ||
+            RedirectType::TYPE_PRODUCT_TEMPORARY == $form_data['redirect_type']) {
+            if (!empty($form_data['id_type_redirected']['data'][0])) {
+                $form_data['id_type_redirected'] = $form_data['id_type_redirected']['data'][0];
+            } else {
+                $form_data['redirect_type'] = RedirectType::TYPE_CATEGORY_PERMANENT;
+            }
         }
 
         //map inputPackItems

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -260,7 +260,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         // Product redirection type and object ID
         $form_data['redirect_type'] = (string) $form_data['redirect_type'];
 
-        /**
+        /*
          * In case of categories, we will use the category ID, but if it's missing,
          * it can be assigned to zero. Product default category will be used.
          */
@@ -271,10 +271,10 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             } else {
                 $form_data['id_type_redirected'] = 0;
             }
-        /**
-         * For redirects to products, we need that ID. If its missing and it was still submitted
-         * somehow, we will fall back to default category redirect with no object ID.
-         */
+            /*
+             * For redirects to products, we need that ID. If its missing and it was still submitted
+             * somehow, we will fall back to default category redirect with no object ID.
+             */
         } elseif (RedirectType::TYPE_PRODUCT_PERMANENT == $form_data['redirect_type'] ||
             RedirectType::TYPE_PRODUCT_TEMPORARY == $form_data['redirect_type']) {
             if (!empty($form_data['id_type_redirected']['data'][0])) {
@@ -283,9 +283,9 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
                 $form_data['id_type_redirected'] = 0;
                 $form_data['redirect_type'] = RedirectType::TYPE_CATEGORY_PERMANENT;
             }
-        /**
-         * For all other redirection types that don't need any other object ID.
-         */
+            /*
+             * For all other redirection types that don't need any other object ID.
+             */
         } else {
             $form_data['id_type_redirected'] = 0;
         }

--- a/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/ProductPage/Forms/form_seo.html.twig
@@ -124,8 +124,12 @@
   <div class="col-md-9">
     <div class="alert alert-info" role="alert">
       <p class="alert-text">
-        {{ 'No redirection (404) = Do not redirect anywhere and display a 404 "Not Found" page.'|trans({}, 'Admin.Catalog.Help') }}<br>
-        {{ 'No redirection (410) = Do not redirect anywhere and display a 410 "Gone" page.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'Default behavior is specified in the Shop Parameters > Product settings page.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'No redirection (200), display product = Do not redirect anywhere, display product as discontinued and return normal 200 response.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'No redirection (404), display product = Do not redirect anywhere, display product as discontinued and return 404 "Not Found" response.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'No redirection (410), display product = Do not redirect anywhere, display product as discontinued and return 410 "Gone" response.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'No redirection (404), display error page = Do not redirect anywhere and display a 404 "Not Found" page.'|trans({}, 'Admin.Catalog.Help') }}<br>
+        {{ 'No redirection (410), display error page = Do not redirect anywhere and display a 410 "Gone" page.'|trans({}, 'Admin.Catalog.Help') }}<br>
         {{ 'Permanent redirection (301) = Permanently display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}<br>
         {{ 'Temporary redirection (302) = Temporarily display another product or category instead.'|trans({}, 'Admin.Catalog.Help') }}
       </p>

--- a/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
+++ b/tests/Integration/Adapter/Presenter/Product/ProductLazyArrayTest.php
@@ -92,8 +92,10 @@ class ProductLazyArrayTest extends TestCase
         'pack' => 0,
         'out_of_stock' => OutOfStockType::OUT_OF_STOCK_DEFAULT,
         'customizable' => 0,
+        'active' => 1,
     ];
 
+    private const PRODUCT_DISCONTINUED = 'This product is no longer for sale';
     private const PRODUCT_AVAILABLE_NOW = 'This product is available now';
     private const PRODUCT_AVAILABLE_LATER = 'This product is available on backorder';
     private const CONFIGURATION_AVAILABLE_NOW_LABEL = 'This product is available now - default';
@@ -412,6 +414,22 @@ class ProductLazyArrayTest extends TestCase
                 ]
             ),
             self::PRODUCT_WITH_NOT_ENOUGH_STOCK,
+        ];
+
+        // Discontinued product
+        yield [
+            array_merge(
+                $product,
+                [
+                    'cache_default_attribute' => 0,
+                    'quantity_wanted' => 0,
+                    'stock_quantity' => 0,
+                    'quantity' => 0,
+                    'allow_oosp' => OutOfStockType::OUT_OF_STOCK_NOT_AVAILABLE,
+                    'active' => 0,
+                ]
+            ),
+            self::PRODUCT_DISCONTINUED,
         ];
 
         // Product out stock, backorders disabled

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_seo.feature
@@ -17,7 +17,7 @@ Feature: Update product SEO options from Back Office (BO)
       | name[en-US] | just boots |
       | type        | standard   |
     And product product1 should have following seo options:
-      | redirect_type | 404 |
+      | redirect_type | default |
     And product product1 should not have a redirect target
     And product "product1" localized "meta_title" is:
       | locale | value |
@@ -32,7 +32,7 @@ Feature: Update product SEO options from Back Office (BO)
       | name[en-US] | magical boots |
       | type        | virtual       |
     And product product2 should have following seo options:
-      | redirect_type | 404 |
+      | redirect_type | default |
     And product product2 should not have a redirect target
     And product "product2" localized "meta_title" is:
       | locale | value |
@@ -164,14 +164,14 @@ Feature: Update product SEO options from Back Office (BO)
       | redirect_target | men              |
     Then I should get error that product redirect_type is invalid
     And product product2 should have following seo options:
-      | redirect_type | 404 |
+      | redirect_type | default |
     And product product2 should not have a redirect target
     When I update product product2 SEO information with following values:
       | redirect_type   | 303-product1 |
       | redirect_target | product1     |
     Then I should get error that product redirect_type is invalid
     And product product2 should have following seo options:
-      | redirect_type | 404 |
+      | redirect_type | default |
     And product product2 should not have a redirect target
     Then product "product2" localized "meta_title" should be:
       | locale | value               |

--- a/tests/Integration/Core/Product/ProductPresenterTest.php
+++ b/tests/Integration/Core/Product/ProductPresenterTest.php
@@ -82,6 +82,7 @@ class ProductPresenterTest extends TestCase
             'new' => false,
             'pack' => false,
             'show_price' => true,
+            'active' => true,
         ];
     }
 

--- a/tests/Integration/PrestaShopBundle/Form/AdvancedFormType.php
+++ b/tests/Integration/PrestaShopBundle/Form/AdvancedFormType.php
@@ -57,8 +57,12 @@ class AdvancedFormType extends TranslatorAwareType
                 'required' => false,
                 'placeholder' => false, // Guaranties that no empty value is added in options
                 'choices' => [
-                    $this->trans('No redirection (404)', 'Admin.Catalog.Feature') => RedirectType::TYPE_NOT_FOUND,
-                    $this->trans('No redirection (410)', 'Admin.Catalog.Feature') => RedirectType::TYPE_GONE,
+                    $this->trans('Default behavior from configuration', 'Admin.Catalog.Feature') => RedirectType::TYPE_DEFAULT,
+                    $this->trans('No redirection (200), display product', 'Admin.Catalog.Feature') => RedirectType::TYPE_SUCCESS_DISPLAYED,
+                    $this->trans('No redirection (404), display product', 'Admin.Catalog.Feature') => RedirectType::TYPE_NOT_FOUND_DISPLAYED,
+                    $this->trans('No redirection (410), display product', 'Admin.Catalog.Feature') => RedirectType::TYPE_GONE_DISPLAYED,
+                    $this->trans('No redirection (404), display error page', 'Admin.Catalog.Feature') => RedirectType::TYPE_NOT_FOUND,
+                    $this->trans('No redirection (410), display error page', 'Admin.Catalog.Feature') => RedirectType::TYPE_GONE,
                     $this->trans('Permanent redirection to a category (301)', 'Admin.Catalog.Feature') => RedirectType::TYPE_CATEGORY_PERMANENT,
                     $this->trans('Temporary redirection to a category (302)', 'Admin.Catalog.Feature') => RedirectType::TYPE_CATEGORY_TEMPORARY,
                     $this->trans('Permanent redirection to a product (301)', 'Admin.Catalog.Feature') => RedirectType::TYPE_PRODUCT_PERMANENT,


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See description below
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #23533
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/538
| How to test?      | -
| Possible impacts? | -

# Description
### Improved configuration
- Currently, every product had a hardcoded 404 redirection settings by default.
- If you wanted to change behavior for all products, you would have to run DB query or you click yourself to death.
- This PR adds a new field into Prestashop settings, where you can configure this behavior. Also, every new product has this new `default` type.
- You can then customize the settings per product as you are used to.

![default](https://user-images.githubusercontent.com/6097524/195653598-98becf5d-8a8b-41e4-8d50-a29223388d4c.jpg)

### New options on what to do with discontinued products
- This PR adds a possibility to keep discontinued products disabled with "SALE ENDED" message.
- The products have proper structured data availability `Discontinued`, a nice message that it's no longer in sale and disabled add to cart button.
- You are able to set your desired HTTP response depending on your SEO strategy. Some people want to keep sending 200 and keep products indexed. Some people would like to send 410 and tell google to remove this product from index. 404 is also an option, although I would not recommend using it.

### Technical
- Works on old and new product page perfectly.
- New functions of this PR work standalone even without a template modification.
- Products with empty values in database will work fine and use the default value from configuration. Even if there was some nonsense in the database like custom ENUMs, it will still fall back on 404 at least in the switch.
- It can be made more beautiful by just using `{if $product.active != 1}` on some places in your template, but that's up to every shop owner on what he wants to hide on discontinued products or how to customize the product page in that case.

# How does it look and work
This is a template without any modification:
![no template mod](https://user-images.githubusercontent.com/6097524/195651728-0dea3aaa-870f-453f-9cac-4900f74a0eca.jpg)
Proper response if wanted:
![response](https://user-images.githubusercontent.com/6097524/195653062-3336d598-6eb0-487f-b236-8bd9603091db.jpg)
Proper structured data:
![structured](https://user-images.githubusercontent.com/6097524/195653079-f22890ad-79e7-4ad4-9e35-d91eeb332f0f.jpg)

# How to test
- Clone this PR.
- Reinstall Prestashop or execute this script to alter the product table.
```sql
ALTER TABLE `ps_product` CHANGE `redirect_type` `redirect_type` ENUM('','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'default';
ALTER TABLE `ps_product_shop` CHANGE `redirect_type` `redirect_type` ENUM('','404','410','301-product','302-product','301-category','302-category','200-displayed','404-displayed','410-displayed','default') CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT 'default';
```
- Choose a product, edit it and set product redirect type to `Default`. Visit this product in FO. Disable this product in BO. Keep page open.
- Go to `Shop settings > Product settings` and try to play around with default option. See that if you go to FO and hit F5, the product respects it. You can see the response (200/404/410) if you open F12 in Chrome, go to network tab and click the request.
- Then try setting a specific redirect type on the product page, see that it takes priority over the default one set in prestashop settings.
- Then try going to phpadmin and try to change `redirect_type` to `''` in both `ps_product` and `ps_product_shop` for this product. See that it still works fine and prestashop will respect the default value set in configuration.


