### PR TITLE
Disable "Features" section in Product Page when Features are disabled

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/FeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/FeaturesType.php
@@ -33,29 +33,9 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Translation\TranslatorInterface;
 
 class FeaturesType extends TranslatorAwareType
 {
-    /**
-     * @var bool
-     */
-    protected $isFeatureEnabled;
-
-    /**
-     * @param TranslatorInterface $translator
-     * @param array $locales
-     * @param bool $isFeatureEnabled
-     */
-    public function __construct(
-        TranslatorInterface $translator,
-        array $locales,
-        bool $isFeatureEnabled
-    ) {
-        parent::__construct($translator, $locales);
-        $this->isFeatureEnabled = $isFeatureEnabled;
-    }
-
     /**
      * {@inheritDoc}
      */
@@ -68,18 +48,15 @@ class FeaturesType extends TranslatorAwareType
                 'allow_add' => true,
                 'allow_delete' => true,
                 'prototype_name' => '__FEATURE_VALUE_INDEX__',
-            ]);
-        if ($this->isFeatureEnabled) {
-            $builder
-                ->add('add_feature', IconButtonType::class, [
-                    'label' => $this->trans('Add a feature', 'Admin.Catalog.Feature'),
-                    'icon' => 'add_circle',
-                    'attr' => [
-                        'class' => 'btn-outline-primary feature-value-add-button',
-                    ],
-                ])
-            ;
-        }
+            ])
+            ->add('add_feature', IconButtonType::class, [
+                'label' => $this->trans('Add a feature', 'Admin.Catalog.Feature'),
+                'icon' => 'add_circle',
+                'attr' => [
+                    'class' => 'btn-outline-primary feature-value-add-button',
+                ],
+            ])
+        ;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/FeaturesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/FeaturesType.php
@@ -33,9 +33,29 @@ use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FeaturesType extends TranslatorAwareType
 {
+    /**
+     * @var bool
+     */
+    protected $isFeatureEnabled;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param array $locales
+     * @param bool $isFeatureEnabled
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        bool $isFeatureEnabled
+    ) {
+        parent::__construct($translator, $locales);
+        $this->isFeatureEnabled = $isFeatureEnabled;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -48,15 +68,18 @@ class FeaturesType extends TranslatorAwareType
                 'allow_add' => true,
                 'allow_delete' => true,
                 'prototype_name' => '__FEATURE_VALUE_INDEX__',
-            ])
-            ->add('add_feature', IconButtonType::class, [
-                'label' => $this->trans('Add a feature', 'Admin.Catalog.Feature'),
-                'icon' => 'add_circle',
-                'attr' => [
-                    'class' => 'btn-outline-primary feature-value-add-button',
-                ],
-            ])
-        ;
+            ]);
+        if ($this->isFeatureEnabled) {
+            $builder
+                ->add('add_feature', IconButtonType::class, [
+                    'label' => $this->trans('Add a feature', 'Admin.Catalog.Feature'),
+                    'icon' => 'add_circle',
+                    'attr' => [
+                        'class' => 'btn-outline-primary feature-value-add-button',
+                    ],
+                ])
+            ;
+        }
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsType.php
@@ -40,6 +40,11 @@ use Symfony\Component\Translation\TranslatorInterface;
 class SpecificationsType extends TranslatorAwareType
 {
     /**
+     * @var bool
+     */
+    protected $isFeatureEnabled;
+
+    /**
      * @var FormChoiceProviderInterface
      */
     private $productConditionChoiceProvider;
@@ -48,14 +53,17 @@ class SpecificationsType extends TranslatorAwareType
      * @param TranslatorInterface $translator
      * @param array $locales
      * @param FormChoiceProviderInterface $productConditionChoiceProvider
+     * @param bool $isFeatureEnabled
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        FormChoiceProviderInterface $productConditionChoiceProvider
+        FormChoiceProviderInterface $productConditionChoiceProvider,
+        bool $isFeatureEnabled
     ) {
         parent::__construct($translator, $locales);
         $this->productConditionChoiceProvider = $productConditionChoiceProvider;
+        $this->isFeatureEnabled = $isFeatureEnabled;
     }
 
     /**
@@ -63,9 +71,13 @@ class SpecificationsType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $builder->add('references', ReferencesType::class);
+
+        if ($this->isFeatureEnabled) {
+            $builder->add('features', FeaturesType::class);
+        }
+
         $builder
-            ->add('references', ReferencesType::class)
-            ->add('features', FeaturesType::class)
             ->add('attachments', ProductAttachmentsType::class)
             ->add('show_condition', SwitchType::class, [
                 'required' => false,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1448,6 +1448,7 @@ services:
     public: true
     arguments:
       - '@prestashop.core.form.choice_provider.product_condition_choice_provider'
+      - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_FEATURE_FEATURE_ACTIVE')"
     tags:
       - { name: form.type }
 
@@ -1455,8 +1456,6 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\Specification\FeaturesType'
     parent: 'form.type.translatable.aware'
     public: true
-    arguments:
-      - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_FEATURE_FEATURE_ACTIVE')"
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1455,6 +1455,8 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\Specification\FeaturesType'
     parent: 'form.type.translatable.aware'
     public: true
+    arguments:
+      - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_FEATURE_FEATURE_ACTIVE')"
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/features.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/features.html.twig
@@ -24,7 +24,7 @@
  *#}
 
 {%- block features_row -%}
-  <h2>{{ 'Features'|trans({}, 'Admin.Catalog.Feature') }}</h2>
+  <h3>{{ 'Features'|trans({}, 'Admin.Catalog.Feature') }}</h3>
 
   {{ form_errors(form) }}
   {{- block('form_rows') -}}

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Product/Specification/FeaturesTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Product/Specification/FeaturesTypeTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PrestaShopBundle\Form\Admin\Sell\Product\Specification;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Form\Admin\Sell\Product\Specification\FeaturesType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class FeaturesTypeTest extends TestCase
+{
+    /**
+     * @dataProvider providerBuildForm
+     *
+     * @param bool $isFeatureEnabled
+     * @param array $expectedChildren
+     *
+     * @return void
+     */
+    public function testBuildForm(bool $isFeatureEnabled, array $expectedChildren): void
+    {
+        $mockTranslatorInterface = $this
+            ->getMockBuilder(TranslatorInterface::class)
+            ->getMock();
+        $mockFormBuilder = $this
+            ->getMockBuilder(FormBuilderInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $children = [];
+
+        $mockFormBuilder->method('add')->willReturnCallback(function (string $child) use (&$children) {
+            $children[] = $child;
+        });
+        $mockFormBuilder->method('all')->willReturnCallback(function () use (&$children) {
+            return $children;
+        });
+
+        $formType = new FeaturesType($mockTranslatorInterface, [], $isFeatureEnabled);
+        $formType->buildForm($mockFormBuilder, []);
+
+        $this->assertEquals($expectedChildren, $mockFormBuilder->all());
+    }
+
+    /**
+     * @return array<array<bool|array<string>>>
+     */
+    public function providerBuildForm(): array
+    {
+        return [
+            [
+                true,
+                [
+                    'feature_values',
+                    'add_feature',
+                ],
+            ],
+            [
+                false,
+                [
+                    'feature_values',
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsTypeTest.php
+++ b/tests/Unit/PrestaShopBundle/Form/Admin/Sell/Product/Specification/SpecificationsTypeTest.php
@@ -29,26 +29,32 @@ declare(strict_types=1);
 namespace Tests\Unit\PrestaShopBundle\Form\Admin\Sell\Product\Specification;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShopBundle\Form\Admin\Sell\Product\Specification\FeaturesType;
+use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
+use PrestaShopBundle\Form\Admin\Sell\Product\Specification\SpecificationsType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class FeaturesTypeTest extends TestCase
+class SpecificationsTypeTest extends TestCase
 {
     /**
      * @dataProvider providerBuildForm
      *
+     * @param bool $isFeatureEnabled
      * @param array $expectedChildren
      *
      * @return void
      */
-    public function testBuildForm(array $expectedChildren): void
+    public function testBuildForm(bool $isFeatureEnabled, array $expectedChildren): void
     {
         $mockTranslatorInterface = $this
             ->getMockBuilder(TranslatorInterface::class)
             ->getMock();
         $mockFormBuilder = $this
             ->getMockBuilder(FormBuilderInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mockFormChoiceProviderInterface = $this
+            ->getMockBuilder(FormChoiceProviderInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -63,7 +69,7 @@ class FeaturesTypeTest extends TestCase
             return $children;
         });
 
-        $formType = new FeaturesType($mockTranslatorInterface, []);
+        $formType = new SpecificationsType($mockTranslatorInterface, [], $mockFormChoiceProviderInterface, $isFeatureEnabled);
         $formType->buildForm($mockFormBuilder, []);
 
         $this->assertEquals($expectedChildren, $mockFormBuilder->all());
@@ -76,9 +82,24 @@ class FeaturesTypeTest extends TestCase
     {
         return [
             [
+                true,
                 [
-                    'feature_values',
-                    'add_feature',
+                    'references',
+                    'features',
+                    'attachments',
+                    'show_condition',
+                    'condition',
+                    'customizations',
+                ],
+            ],
+            [
+                false,
+                [
+                    'references',
+                    'attachments',
+                    'show_condition',
+                    'condition',
+                    'customizations',
                 ],
             ],
         ];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Disable "Features" section in Product Page when Features are disabled
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #21689
| Related PRs       | N/A
| How to test?      | * Go to Advanced parameters > Performance<br>* Disable "Features"<br>* Enable the Product Page v2<br>* Go to Catalog > Products<br>* Go to a product with previously set features (like "Mountain fox notebook")<br>* **BEFORE :** The section "Features" exists<br>* **AFTER :** The section "Features" is removed
| Possible impacts? | Fixed only on Product v2 Page
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
