### PR TITLE
Fix a problem with invalid filtering on the Modules -> Positions page

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/improve/design_positions/positions-list-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/improve/design_positions/positions-list-handler.ts
@@ -48,6 +48,8 @@ class PositionsListHandler {
 
   $moduleButtonsUpdate: JQuery;
 
+  $transplantModuleButton: JQuery;
+
   $hooksList: Array<Record<string, any>>;
 
   constructor() {
@@ -72,6 +74,7 @@ class PositionsListHandler {
     this.$moduleUnhookButton = $('#unhook-button-position-bottom');
     this.$moduleButtonsUpdate = $('.module-buttons-update .btn');
     this.$hooksList = [];
+    this.$transplantModuleButton = $('.transplant-module-button');
 
     this.handleList();
     this.handleSortable();
@@ -150,6 +153,9 @@ class PositionsListHandler {
     self.$hookSearch.on('input', () => {
       self.modulesPositionFilterHooks();
     });
+
+    // Filter modules list on the page load
+    self.modulesPositionFilterHooks();
 
     self.$hookSearch.on('keypress', (e) => {
       const keyCode = e.keyCode || e.which;
@@ -264,8 +270,13 @@ class PositionsListHandler {
   modulesPositionFilterHooks(): void {
     const self = this;
     const $hookName = <string>self.$hookSearch.val();
-    const $moduleId = self.$showModules.val();
+    const $moduleId = <string>self.$showModules.val();
     const $regex = new RegExp(`(${$hookName})`, 'gi');
+
+    // Update "Transplant module" button
+    const transplantModuleHref = new URL(this.$transplantModuleButton.prop('href'));
+    transplantModuleHref.searchParams.set('show_modules', $moduleId);
+    this.$transplantModuleButton.attr('href', transplantModuleHref.toString());
 
     for (let $id = 0; $id < self.$hooksList.length; $id += 1) {
       self.$hooksList[$id].container.toggle(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -92,8 +92,7 @@ class PositionsController extends FrameworkBundleAdminController
         $hooks = $hookProvider->getHooks();
         foreach ($hooks as $key => $hook) {
             $hooks[$key]['modules'] = $hookProvider->getModulesFromHook(
-                $hook['id_hook'],
-                $this->selectedModule
+                $hook['id_hook']
             );
             // No module found, no need to continue
             if (!is_array($hooks[$key]['modules'])) {
@@ -131,6 +130,7 @@ class PositionsController extends FrameworkBundleAdminController
         return [
             'layoutHeaderToolbarBtn' => [
                 'save' => [
+                    'class' => 'btn-primary transplant-module-button',
                     'href' => $saveUrl,
                     'desc' => $this->trans('Transplant a module', 'Admin.Design.Feature'),
                 ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I've fixed filtering + "Transplant module" button is also working as expected now
| Type?             | bug fix
| Category?         |BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9823.
| Related PRs       | n/a
| How to test?      | Configure `ps_brandlist`, click "Manage hooks", and change to a different module from the list. Check this behavior before and after this PR.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

