### PR TITLE
Fix bug in Mail::send when trying to find the module name it is sending from

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -412,7 +412,7 @@ class MailCore extends ObjectModel
             // get templatePath
             $templatePathDirectories = explode(DIRECTORY_SEPARATOR, $templatePath);
             $pos = array_search('modules', $templatePathDirectories);
-            if ( $pos && array_key_exists($pos + 1, $templatePathDirectories)){
+            if ($pos && array_key_exists($pos + 1, $templatePathDirectories)) {
                 $moduleName = $templatePathDirectories[$pos + 1];
             }
 

--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -410,10 +410,10 @@ class MailCore extends ObjectModel
             $moduleName = false;
 
             // get templatePath
-            if (preg_match('#' . $shop->physical_uri . 'modules/#', str_replace(DIRECTORY_SEPARATOR, '/', $templatePath)) &&
-                preg_match('#modules/([a-z0-9_-]+)/#ui', str_replace(DIRECTORY_SEPARATOR, '/', $templatePath), $res)
-            ) {
-                $moduleName = $res[1];
+            $templatePathDirectories = explode(DIRECTORY_SEPARATOR, $templatePath);
+            $pos = array_search('modules', $templatePathDirectories);
+            if ( $pos && array_key_exists($pos + 1, $templatePathDirectories)){
+                $moduleName = $templatePathDirectories[$pos + 1];
             }
 
             $isoTemplate = '';


### PR DESCRIPTION
Getting the module name by finding the directory next to modules/ in the templatePath, instead of replacing things in it. As far as i understand how it works, it should be more reliable.

Looks like it works in most of the cases, but i'm no PS expert so i might be missing something ... 

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes a bug in the mail sending function for modules when PS is installed using symlinks a deployment tool. 
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29734.
| Related PRs       | 
| How to test?      | Check emails in various conditions : from core code, from modules code, in a standard PS configuration, in CI/CD workflow, etc. It's also important to test it on Microsoft systems (i was not able to do so)
| Possible impacts? | Emails sending


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
