### PR TITLE
Handle KPI configuration properly for the dashgoals module

### DIFF
--- a/classes/ConfigurationKPI.php
+++ b/classes/ConfigurationKPI.php
@@ -39,6 +39,10 @@ class ConfigurationKPICore extends Configuration
         ConfigurationKPI::$definition_backup = Configuration::$definition;
         Configuration::$definition['table'] = 'configuration_kpi';
         Configuration::$definition['primary'] = 'id_configuration_kpi';
+
+        if (empty(static::$_cache[Configuration::$definition['table']])) {
+            parent::loadConfiguration();
+        }
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I kinda like the idea that `dashgoals` module author had when he introduced `ConfigurationKPI`, splitting configuration makes sense, maybe it is not the best what could be done, but I managed to fix the wanted behavior and fix `dashgoals` module. FYI: everything is all right with the performance, it produces one additional query to load configuration from the `_kpi` table
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9662.
| Related PRs       | n/a
| How to test?      | Test `dashgoals` module before and after this change.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
| Sponsor company | impSolutions


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
