### PR TITLE
No longer allow spaces go through Tools::isEmpty method

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1755,7 +1755,7 @@ class ToolsCore
 
     public static function isEmpty($field)
     {
-        return $field === '' || $field === null;
+        return $field === '' || $field === null || trim($field) === '';
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | added `trim($field)` to disallow spaces. Normally we could use `ctype_space` but we don't know if the value would be a string
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9662.
| Related PRs       | n/a
| How to test?      | Follow the issue
| Possible impacts? | Should not be any, we have the same behavior in BO on the migrated pages for Addresses, etc. We don't allow ` ` to go through


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
