### PR TITLE
Replace AppKernel version constants by prestashop versions

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -26,17 +26,19 @@
 
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Version;
+use PrestaShop\TranslationToolsBundle\TranslationToolsBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
 class AppKernel extends Kernel
 {
-    const VERSION = '8.0.0';
-    const MAJOR_VERSION_STRING = '8';
-    const MAJOR_VERSION = 8;
-    const MINOR_VERSION = 0;
-    const RELEASE_VERSION = 0;
+    const VERSION = Version::VERSION;
+    const MAJOR_VERSION_STRING = Version::MAJOR_VERSION_STRING;
+    const MAJOR_VERSION = Version::MAJOR_VERSION;
+    const MINOR_VERSION = Version::MINOR_VERSION;
+    const RELEASE_VERSION = Version::RELEASE_VERSION;
 
     /**
      * {@inheritdoc}
@@ -54,7 +56,7 @@ class AppKernel extends Kernel
             // PrestaShop Core bundle
             new PrestaShopBundle\PrestaShopBundle(),
             // PrestaShop Translation parser
-            new PrestaShop\TranslationToolsBundle\TranslationToolsBundle(),
+            new TranslationToolsBundle(),
             new League\Tactician\Bundle\TacticianBundle(),
             new FOS\JsRoutingBundle\FOSJsRoutingBundle(),
         );

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -34,7 +34,7 @@ services:
 
 framework:
   assets:
-    version: !php/const \AppKernel::VERSION
+    version: !php/const PrestaShop\PrestaShop\Core\Version::VERSION
 
   # esi: ~
   secret: "%secret%"

--- a/config/autoload.php
+++ b/config/autoload.php
@@ -23,9 +23,12 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+use PrestaShop\PrestaShop\Core\Version;
+
 require_once __DIR__.'/../vendor/autoload.php';
 
-define('_PS_VERSION_', AppKernel::VERSION);
+define('_PS_VERSION_', Version::VERSION);
 
 require_once _PS_CONFIG_DIR_.'alias.php';
 require_once _PS_CLASS_DIR_.'PrestaShopAutoload.php';

--- a/src/Adapter/Admin/PagePreference.php
+++ b/src/Adapter/Admin/PagePreference.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Admin;
 
-use AppKernel;
 use Db;
+use PrestaShop\PrestaShop\Core\Version;
 use PrestaShopBundle\Service\TransitionalBehavior\AdminPagePreferenceInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage;
@@ -108,7 +108,7 @@ class PagePreference implements AdminPagePreferenceInterface
             return false;
         }
         $installVersion = explode('.', $version);
-        $currentVersion = explode('.', AppKernel::VERSION);
+        $currentVersion = explode('.', Version::VERSION);
 
         // Prod mode, depends on the page
         switch ($page) {

--- a/src/Adapter/Hook/HookDispatcher.php
+++ b/src/Adapter/Hook/HookDispatcher.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Hook\Hook;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookInterface;
 use PrestaShop\PrestaShop\Core\Hook\RenderedHook;
+use PrestaShop\PrestaShop\Core\Version;
 use PrestaShopBundle\Service\Hook\HookEvent;
 use PrestaShopBundle\Service\Hook\RenderingHookEvent;
 use Symfony\Component\EventDispatcher\Event;
@@ -224,7 +225,7 @@ class HookDispatcher extends EventDispatcher implements HookDispatcherInterface
      */
     private function getHookEventContextParameters(): array
     {
-        $globalParameters = ['_ps_version' => \AppKernel::VERSION];
+        $globalParameters = ['_ps_version' => Version::VERSION];
 
         if (null === $this->requestStack) {
             return $globalParameters;

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
-use AppKernel;
 use Configuration;
 use Context;
 use Currency;
@@ -37,6 +36,7 @@ use Hook;
 use PrestaShop\PrestaShop\Adapter\Admin\AbstractAdminQueryBuilder;
 use PrestaShop\PrestaShop\Adapter\ImageManager;
 use PrestaShop\PrestaShop\Adapter\Validate;
+use PrestaShop\PrestaShop\Core\Version;
 use PrestaShopBundle\Entity\AdminFilter;
 use PrestaShopBundle\Service\DataProvider\Admin\ProductInterface;
 use Product;
@@ -339,7 +339,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
 
         // exec legacy hook but with different parameters (retro-compat < 1.7 is broken here)
         Hook::exec('actionAdminProductsListingFieldsModifier', [
-            '_ps_version' => AppKernel::VERSION,
+            '_ps_version' => Version::VERSION,
             'sql_select' => &$sqlSelect,
             'sql_table' => &$sqlTable,
             'sql_where' => &$sqlWhere,
@@ -394,7 +394,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         // post treatment by hooks
         // exec legacy hook but with different parameters (retro-compat < 1.7 is broken here)
         Hook::exec('actionAdminProductsListingResultsModifier', [
-            '_ps_version' => AppKernel::VERSION,
+            '_ps_version' => Version::VERSION,
             'products' => &$products,
             'total' => $total,
         ]);

--- a/src/Adapter/Requirement/CheckMissingOrUpdatedFiles.php
+++ b/src/Adapter/Requirement/CheckMissingOrUpdatedFiles.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Requirement;
 
-use AppKernel;
+use PrestaShop\PrestaShop\Core\Version;
 
 /**
  * Part of requirements for a PrestaShop website
@@ -48,7 +48,7 @@ class CheckMissingOrUpdatedFiles
         ];
 
         if (null === $dir) {
-            $xml = @simplexml_load_file(_PS_API_URL_ . '/xml/md5-' . AppKernel::MAJOR_VERSION . '/' . AppKernel::VERSION . '.xml');
+            $xml = @simplexml_load_file(_PS_API_URL_ . '/xml/md5-' . Version::MAJOR_VERSION . '/' . Version::VERSION . '.xml');
             if (!$xml) {
                 return $fileList;
             }

--- a/src/Adapter/Shop/ShopInformation.php
+++ b/src/Adapter/Shop/ShopInformation.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Shop;
 
-use AppKernel;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Version;
 use Tools;
 
 /**
@@ -56,7 +56,7 @@ class ShopInformation
     public function getShopInformation()
     {
         return [
-            'version' => AppKernel::VERSION,
+            'version' => Version::VERSION,
             'url' => $this->context->shop->getBaseURL(),
             'path' => _PS_ROOT_DIR_,
             'theme' => $this->context->shop->theme->getName(),

--- a/src/Core/Version.php
+++ b/src/Core/Version.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core;
+
+/**
+ * This class contains the current prestashop version constants.
+ * This will be updated everytime we release a new version.
+ */
+final class Version
+{
+    public const VERSION = '8.0.0';
+    public const MAJOR_VERSION_STRING = '8';
+    public const MAJOR_VERSION = 8;
+    public const MINOR_VERSION = 0;
+    public const RELEASE_VERSION = 0;
+
+    // This class should not be instanciated
+    private function __construct()
+    {
+    }
+}

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShopBundle\Install;
 
-use AppKernel;
 use Language as LanguageLegacy;
 use PhpEncryption;
 use PrestaShop\PrestaShop\Adapter\Entity\Cache;
@@ -58,6 +57,7 @@ use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShop\PrestaShop\Core\Module\ConfigReader as ModuleConfigReader;
 use PrestaShop\PrestaShop\Core\Theme\ConfigReader as ThemeConfigReader;
+use PrestaShop\PrestaShop\Core\Version;
 use PrestaShopBundle\Cache\LocalizationWarmer;
 use PrestaShopBundle\Service\Database\Upgrade as UpgradeDatabase;
 use PrestaShopException;
@@ -432,7 +432,7 @@ class Install extends AbstractInstall
             if (!$all_languages) {
                 $iso_codes_to_install = [$this->language->getLanguageIso()];
                 if ($iso_country) {
-                    $version = str_replace('.', '', AppKernel::VERSION);
+                    $version = str_replace('.', '', Version::VERSION);
                     $version = substr($version, 0, 2);
                     $localization_file_content = $this->getLocalizationPackContent($version, $iso_country);
 
@@ -836,7 +836,7 @@ class Install extends AbstractInstall
         Db::getInstance()->execute('UPDATE ' . _DB_PREFIX_ . 'country SET active = 0 WHERE id_country != ' . (int) $id_country);
 
         // Set localization configuration
-        $version = str_replace('.', '', AppKernel::VERSION);
+        $version = str_replace('.', '', Version::VERSION);
         $version = substr($version, 0, 2);
         $localization_file_content = $this->getLocalizationPackContent($version, $data['shop_country']);
 

--- a/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/foundation.yml
@@ -5,8 +5,8 @@ services:
   prestashop.core.foundation.version:
     class: PrestaShop\PrestaShop\Core\Foundation\Version
     arguments:
-      - !php/const AppKernel::VERSION
-      - !php/const AppKernel::MAJOR_VERSION_STRING
-      - !php/const AppKernel::MAJOR_VERSION
-      - !php/const AppKernel::MINOR_VERSION
-      - !php/const AppKernel::RELEASE_VERSION
+      - !php/const PrestaShop\PrestaShop\Core\Version::VERSION
+      - !php/const PrestaShop\PrestaShop\Core\Version::MAJOR_VERSION_STRING
+      - !php/const PrestaShop\PrestaShop\Core\Version::MAJOR_VERSION
+      - !php/const PrestaShop\PrestaShop\Core\Version::MINOR_VERSION
+      - !php/const PrestaShop\PrestaShop\Core\Version::RELEASE_VERSION

--- a/tests/Resources/DatabaseDump.php
+++ b/tests/Resources/DatabaseDump.php
@@ -27,10 +27,10 @@
 
 namespace Tests\Resources;
 
-use AppKernel;
 use Cache;
 use Db;
 use Exception;
+use PrestaShop\PrestaShop\Core\Version;
 use Tools;
 
 class DatabaseDump
@@ -111,7 +111,7 @@ class DatabaseDump
 
         $this->databaseName = _DB_NAME_;
         if ($dumpFile === null) {
-            $this->dumpFile = sprintf('%s/ps_dump_%s_%s.sql', sys_get_temp_dir(), $this->databaseName, AppKernel::VERSION);
+            $this->dumpFile = sprintf('%s/ps_dump_%s_%s.sql', sys_get_temp_dir(), $this->databaseName, Version::VERSION);
         } else {
             $this->dumpFile = $dumpFile;
         }
@@ -248,7 +248,7 @@ class DatabaseDump
             '%s/ps_dump_%s_%s_%s.sql',
             sys_get_temp_dir(),
             $this->databaseName,
-            AppKernel::VERSION,
+            Version::VERSION,
             $table
         );
     }
@@ -259,7 +259,7 @@ class DatabaseDump
             '%s/ps_dump_%s_%s_%s.md5',
             sys_get_temp_dir(),
             $this->databaseName,
-            AppKernel::VERSION,
+            Version::VERSION,
             $table
         );
     }

--- a/tests/Unit/PrestaShopBundle/AppKernelTest.php
+++ b/tests/Unit/PrestaShopBundle/AppKernelTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Unit\PrestaShopBundle;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Version;
+
+class AppKernelTest extends TestCase
+{
+    public function testVersion(): void
+    {
+        self::assertSame(\AppKernel::VERSION, Version::VERSION);
+    }
+}


### PR DESCRIPTION


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR aims to replaces all AppKernel references by a new Prestashop that contains the version. There is some services inside the prestashop bundle that contains AppKernel references and will throw errors if the bundle is used without AppKernel. AppKernel constants will not depend on this constants instead of defining it.
| Type?             | improvement
| Category?         | IN
| BC breaks?        |  no
| Deprecations?     | no
