### PR TITLE
Allow to configure if order should switch to backorder

### DIFF
--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -576,6 +576,7 @@ abstract class PaymentModuleCore extends Module
 
             // Switch to back order if needed
             if (Configuration::get('PS_STOCK_MANAGEMENT') &&
+                    Configuration::get('PS_ENABLE_BACKORDER_STATUS') &&
                     ($order_detail->getStockState() ||
                     $order_detail->product_quantity_in_stock < 0)) {
                 $history = new OrderHistory();

--- a/src/Adapter/Order/GeneralConfiguration.php
+++ b/src/Adapter/Order/GeneralConfiguration.php
@@ -47,6 +47,7 @@ class GeneralConfiguration extends AbstractMultistoreConfiguration
         'allow_delayed_shipping',
         'enable_tos',
         'tos_cms_id',
+        'enable_backorder_status',
     ];
 
     /**
@@ -66,6 +67,7 @@ class GeneralConfiguration extends AbstractMultistoreConfiguration
             'allow_delayed_shipping' => (bool) $this->configuration->get('PS_SHIP_WHEN_AVAILABLE', false, $shopConstraint),
             'enable_tos' => (bool) $this->configuration->get('PS_CONDITIONS', false, $shopConstraint),
             'tos_cms_id' => (int) $this->configuration->get('PS_CONDITIONS_CMS_ID', 0, $shopConstraint),
+            'enable_backorder_status' => (bool) $this->configuration->get('PS_ENABLE_BACKORDER_STATUS', false, $shopConstraint),
         ];
     }
 
@@ -86,6 +88,7 @@ class GeneralConfiguration extends AbstractMultistoreConfiguration
             $this->updateConfigurationValue('PS_SHIP_WHEN_AVAILABLE', 'allow_delayed_shipping', $configuration, $shopConstraint);
             $this->updateConfigurationValue('PS_CONDITIONS', 'enable_tos', $configuration, $shopConstraint);
             $this->updateConfigurationValue('PS_CONDITIONS_CMS_ID', 'tos_cms_id', $configuration, $shopConstraint);
+            $this->updateConfigurationValue('PS_ENABLE_BACKORDER_STATUS', 'enable_backorder_status', $configuration, $shopConstraint);
         }
 
         return [];
@@ -106,7 +109,8 @@ class GeneralConfiguration extends AbstractMultistoreConfiguration
             ->setAllowedTypes('allow_multishipping', 'bool')
             ->setAllowedTypes('allow_delayed_shipping', 'bool')
             ->setAllowedTypes('enable_tos', 'bool')
-            ->setAllowedTypes('tos_cms_id', 'int');
+            ->setAllowedTypes('tos_cms_id', 'int')
+            ->setAllowedTypes('enable_backorder_status', 'bool');
 
         return $resolver;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -143,8 +143,8 @@ class GeneralType extends TranslatorAwareType
             ])
             ->add('enable_backorder_status', SwitchType::class, [
                 'required' => false,
-                'label' => $this->trans('Assign backorder status to the order, if products are not in stock', 'Admin.Shopparameters.Feature'),
-                'help' => $this->trans('"On backorder" status will be assigned to new orders, if it contains some products that are out of stock.', 'Admin.Shopparameters.Help'),
+                'label' => $this->trans('Set backorder status', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('The order status will be set to "On backorder" for new orders containing products that are out of stock.', 'Admin.Shopparameters.Help'),
                 'multistore_configuration_key' => 'PS_ENABLE_BACKORDER_STATUS',
             ]);
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -140,6 +140,12 @@ class GeneralType extends TranslatorAwareType
                     'data-toggle' => 'select2',
                     'data-minimumResultsForSearch' => '7',
                 ],
+            ])
+            ->add('enable_backorder_status', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans('Assign backorder status to the order, if products are not in stock', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('"On backorder" status will be assigned to new orders, if it contains some products that are out of stock.', 'Admin.Shopparameters.Help'),
+                'multistore_configuration_key' => 'PS_ENABLE_BACKORDER_STATUS',
             ]);
     }
 

--- a/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
+++ b/tests/Unit/Adapter/Order/GeneralConfigurationTest.php
@@ -48,6 +48,7 @@ class GeneralConfigurationTest extends AbstractConfigurationTestCase
         'allow_delayed_shipping' => true,
         'enable_tos' => true,
         'tos_cms_id' => 3,
+        'enable_backorder_status' => true,
     ];
 
     /**
@@ -80,6 +81,7 @@ class GeneralConfigurationTest extends AbstractConfigurationTestCase
                     ['PS_SHIP_WHEN_AVAILABLE', false, $shopConstraint, true],
                     ['PS_CONDITIONS', false, $shopConstraint, true],
                     ['PS_CONDITIONS_CMS_ID', 0, $shopConstraint, 3],
+                    ['PS_ENABLE_BACKORDER_STATUS', false, $shopConstraint, true],
                 ]
             );
 
@@ -121,6 +123,7 @@ class GeneralConfigurationTest extends AbstractConfigurationTestCase
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['allow_delayed_shipping' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_tos' => 'wrong_type'])],
             [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['tos_cms_id' => 'wrong_type'])],
+            [InvalidOptionsException::class, array_merge(self::VALID_CONFIGURATION, ['enable_backorder_status' => 'wrong_type'])],
         ];
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | More details below
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #21766
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/526, https://github.com/PrestaShop/PrestaShop/pull/30310
| How to test?      | More details below
| Possible impacts? | None

### Description
- Number one behavior change that clients in my environment want is to disable order jumping to `On backorder` status, and I was not alone - https://github.com/PrestaShop/PrestaShop/issues/21766.
- When you order something that is not in stock, Prestashop changes status of that order to `On backorder`, for many merchants, that serves no purpose and they want the order to remain in the state the payment module has assigned, `Processing` for example.
- This PR adds new configuration line to **Shop Parameters > Order settings**, where you can enable or disable this behavior.

![config](https://user-images.githubusercontent.com/6097524/192297388-c7d6e24a-9aea-40c3-b48b-8795cb0c0eac.jpg)

### How to test
- Make 2 products:
  - Product A - 10 pieces in stock
  - Product B - 0 pieces in stock, ordering when not in stock enabled
- Enable new switch and you will get original behavior:
  - When you order only product A, order **won't** get switched to backorder.
  - When you order product B is in the order, order **will** be switched to backorder.
- Disable new switch and order and you get new behavior:
  - When you order only product A, order **won't** get switched to backorder.
  - When you order product B is in the order, order **won't** get switched to backorder.
