### PR TITLE
Show module admin tabs according to the module availability state

### DIFF
--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -314,25 +314,16 @@ class TabCore extends ObjectModel
 				ORDER BY t.`position` ASC'
             );
 
-            //not to show the admin tabs of the deactivated modules
-            foreach ($result as $index => $row) {
-                if (empty($row['module'])) {
-                    continue;
-                }
-
-                $module = Module::getInstanceByName($row['module']);
-
-                if (false == Validate::isLoadedObject($module)) {
-                    continue;
-                }
-
-                if (false == $module->isEnabledForShopContext()) {
-                    unset($result[$index]);
-                }
-            }
-
             if (is_array($result)) {
                 foreach ($result as $row) {
+                    if (!empty($row['module'])) {
+                        $module = Module::getInstanceByName($row['module']);
+                        //not to show the admin tabs of the deactivated modules
+                        if (Validate::isLoadedObject($module) && !$module->isEnabledForShopContext()) {
+                            continue;
+                        }
+                    }
+
                     if (!isset(self::$_cache_tabs[$idLang][$row['id_parent']])) {
                         self::$_cache_tabs[$idLang][$row['id_parent']] = [];
                     }

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -314,6 +314,23 @@ class TabCore extends ObjectModel
 				ORDER BY t.`position` ASC'
             );
 
+            //not to show the admin tabs of the deactivated modules
+            foreach ($result as $index => $row) {
+                if (empty($row['module'])) {
+                    continue;
+                }
+
+                $module = Module::getInstanceByName($row['module']);
+
+                if (false == Validate::isLoadedObject($module)) {
+                    continue;
+                }
+
+                if (false == $module->isEnabledForShopContext()) {
+                    unset($result[$index]);
+                }
+            }
+
             if (is_array($result)) {
                 foreach ($result as $row) {
                     if (!isset(self::$_cache_tabs[$idLang][$row['id_parent']])) {

--- a/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
+++ b/src/Adapter/Module/Tab/ModuleTabManagementSubscriber.php
@@ -58,8 +58,6 @@ class ModuleTabManagementSubscriber implements EventSubscriberInterface
         return [
             ModuleManagementEvent::INSTALL => 'onModuleInstall',
             ModuleManagementEvent::UNINSTALL => 'onModuleUninstall',
-            ModuleManagementEvent::ENABLE => 'onModuleEnable',
-            ModuleManagementEvent::DISABLE => 'onModuleDisable',
         ];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | In multistore env, after module deactivation in one store, his admin tabs hide in other stores as well. This PR is trying to take into account the module state while show the admin tabs
| Type?             | improvement 
| Category?         | BO
| BC breaks?        | 
| Deprecations?     | 
| Fixed ticket?     |  Fixes https://github.com/PrestaShop/PrestaShop/issues/29780
| Related PRs       | 
| How to test?      | In multistore env, deactivate the module in one store. The module tabs disappear in other stores.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
