### PR TITLE
Fix error on patch method because of php 8.0 throw a fatal error

### DIFF
--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -204,7 +204,7 @@ class CurrencyCore extends ObjectModel
             'name' => [
                 'getter' => 'getName',
                 'modifier' => [
-                    'http_method' => WebserviceRequest::HTTP_POST | WebserviceRequest::HTTP_PUT,
+                    'http_method' => WebserviceRequest::HTTP_POST | WebserviceRequest::HTTP_PUT | WebserviceRequest::HTTP_PATCH,
                     'modifier' => 'setNameForWebservice',
                 ],
             ],
@@ -213,7 +213,7 @@ class CurrencyCore extends ObjectModel
             ],
             'iso_code' => [
                 'modifier' => [
-                    'http_method' => WebserviceRequest::HTTP_POST | WebserviceRequest::HTTP_PUT,
+                    'http_method' => WebserviceRequest::HTTP_POST | WebserviceRequest::HTTP_PUT | WebserviceRequest::HTTP_PATCH,
                     'modifier' => 'setIsoCodeForWebService',
                 ],
             ],

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -28,6 +28,7 @@ class WebserviceRequestCore
     public const HTTP_GET = 1;
     public const HTTP_POST = 2;
     public const HTTP_PUT = 4;
+    public const HTTP_PATCH = 8;
 
     protected $_available_languages = null;
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fix error on patch method  when tring to update product / category because of php 8.0 throw a fatal error when a constant is not defined (php < 8.0 raised a warning)
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29666 
| Related PRs       | 
| How to test?      | see #29666 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
