### PR TITLE
Invalid characters are being saved as Social titles

### DIFF
--- a/classes/Gender.php
+++ b/classes/Gender.php
@@ -47,7 +47,7 @@ class GenderCore extends ObjectModel
             'type' => ['type' => self::TYPE_INT, 'required' => true],
 
             /* Lang fields */
-            'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isString', 'required' => true, 'size' => 20],
+            'name' => ['type' => self::TYPE_STRING, 'lang' => true, 'validate' => 'isCatalogName', 'required' => true, 'size' => 20],
         ],
     ];
 

--- a/controllers/admin/AdminGendersController.php
+++ b/controllers/admin/AdminGendersController.php
@@ -130,7 +130,7 @@ class AdminGendersControllerCore extends AdminController
                     'name' => 'name',
                     'lang' => true,
                     'col' => 4,
-                    'hint' => $this->trans('Invalid characters:', [], 'Admin.Shopparameters.Help') . ' <>;=#{}:',
+                    'hint' => $this->trans('Invalid characters:', [], 'Admin.Shopparameters.Help') . ' <>;=#{}',
                     'required' => true,
                 ],
                 [

--- a/controllers/admin/AdminGendersController.php
+++ b/controllers/admin/AdminGendersController.php
@@ -130,7 +130,7 @@ class AdminGendersControllerCore extends AdminController
                     'name' => 'name',
                     'lang' => true,
                     'col' => 4,
-                    'hint' => $this->trans('Invalid characters:', [], 'Admin.Shopparameters.Help') . ' 0-9!&lt;&gt;,;?=+()@#"�{}_$%:',
+                    'hint' => $this->trans('Invalid characters:', [], 'Admin.Shopparameters.Help') . ' <>;=#{}:',
                     'required' => true,
                 ],
                 [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  9.0.x
| Description?      | When creating or editing an existing social title, the tool tip shows the invalid characters as: "0-9!<>,;?=+()@#"{}_$%:". <br/> However when entering any of these characters, they are still getting saved, only the max length limit works in this field. <br/> So to fix it I use the class Validate "isCatalogName" to validate the social title, if it's ok to be Catalog Name and show in front office it will be ok to be Social Title.  Also I update the hint to "Invalid characters: <>;=#{}:"
| Type?             | bug fix
| Category?         |  BO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #28320
| How to test?      | Go to Shop parameters -> Customer settings -> Titles.<br/>Press "Add new social title".<br/>Check the "Social title" tool tip.<br/>Enter the invalid characters in to the same field.<br/>Press "Save"



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
