### PR TITLE
Remove french helptext

### DIFF
--- a/controllers/admin/AdminSearchConfController.php
+++ b/controllers/admin/AdminSearchConfController.php
@@ -125,8 +125,6 @@ class AdminSearchConfControllerCore extends AdminController
             'search' => [
                 'title' => $this->trans('Search', [], 'Admin.Shopparameters.Feature'),
                 'icon' => 'icon-search',
-                'info' => '<p><a href="https://github.com/PrestaShop/PrestaShop/issues/new?template=bug_report.md" target="_blank" class="btn-link"><i class="icon-external-link-sign"></i> Signaler un problème sur GitHub</a><br>'
-                    . '<a href="https://github.com/PrestaShop/PrestaShop/issues/new?template=feature_request.md" target="_blank"><i class="icon-external-link-sign"></i> Proposer une idée d\'amélioration sur GitHub</a>',
                 'fields' => [
                     'PS_SEARCH_START' => [
                         'title' => $this->trans('Search within word', [], 'Admin.Shopparameters.Feature'),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removes nontranslatable helptext from a place where it should not be.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29761
| Related PRs       | -
| How to test?      | -
| Possible impacts? | -

ping @PrestaShop/prestashop-maintainers Can this be validated by Mateus for example without QA?
ping @MatShir


![search](https://user-images.githubusercontent.com/6097524/192447120-b27ac4ec-f705-434d-93c0-15249df26a11.jpg)