### PR TITLE
Changed message when PHP version is not correct

### DIFF
--- a/install-dev/index_cli.php
+++ b/install-dev/index_cli.php
@@ -30,14 +30,7 @@ require_once 'install_version.php';
 if ((!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_) || (PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_) ) {
     echo 'Your server is running PHP ' . PHP_VERSION . ', but PrestaShop requires a PHP version between PHP ' . _PS_INSTALL_MINIMUM_PHP_VERSION_ . ' and PHP ' . _PS_INSTALL_MAXIMUM_PHP_VERSION_ . '.';
     echo PHP_EOL;
-    echo 'To install PrestaShop ' . _PS_INSTALL_VERSION_ . ' you need to update your server\'s PHP version.';
-    echo PHP_EOL;
-    die();
-}
-if (PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_) {
-    echo 'Your server is running PHP ' . PHP_VERSION . ', but PrestaShop requires PHP ' . _PS_INSTALL_MAXIMUM_PHP_VERSION_ . ' or lower.';
-    echo PHP_EOL;
-    echo 'To install PrestaShop ' . _PS_INSTALL_VERSION_ . ' you need to downgrade your server\'s PHP version.';
+    echo 'To install PrestaShop ' . _PS_INSTALL_VERSION_ . ' you need to change your server\'s PHP version.';
     echo PHP_EOL;
     die();
 }

--- a/install-dev/index_cli.php
+++ b/install-dev/index_cli.php
@@ -27,8 +27,8 @@
 require_once 'install_version.php';
 
 // Check PHP version
-if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_) {
-    echo 'Your server is running PHP ' . PHP_VERSION . ', but PrestaShop requires PHP ' . _PS_INSTALL_MINIMUM_PHP_VERSION_ . ' or newer.';
+if ((!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_) || (PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_) ) {
+    echo 'Your server is running PHP ' . PHP_VERSION . ', but PrestaShop requires a PHP version between PHP ' . _PS_INSTALL_MINIMUM_PHP_VERSION_ . ' and PHP ' . _PS_INSTALL_MAXIMUM_PHP_VERSION_ . '.';
     echo PHP_EOL;
     echo 'To install PrestaShop ' . _PS_INSTALL_VERSION_ . ' you need to update your server\'s PHP version.';
     echo PHP_EOL;

--- a/install-dev/missing_requirement.php
+++ b/install-dev/missing_requirement.php
@@ -108,7 +108,7 @@
     <?php if ((!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_) || (PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_)): ?>
         <li>
             Your server is running PHP <?php echo PHP_VERSION ?>, but PrestaShop requires a PHP version between PHP <?php echo _PS_INSTALL_MINIMUM_PHP_VERSION_ ?> and PHP <?php echo _PS_INSTALL_MAXIMUM_PHP_VERSION_ ?>.
-            <i>To install PrestaShop <?php echo _PS_INSTALL_VERSION_ ?> you need to update your server's PHP version.</i>
+            <i>To install PrestaShop <?php echo _PS_INSTALL_VERSION_ ?> you need to change your server's PHP version.</i>
         </li>
     <?php endif; ?>
         <?php if (!is_writable(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'cache')): ?>

--- a/install-dev/missing_requirement.php
+++ b/install-dev/missing_requirement.php
@@ -105,17 +105,11 @@
           PrestaShop installation requires the <b>Zip PHP extension</b> to be enabled.
       </li>
     <?php endif; ?>
-    <?php if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_): ?>
-      <li>
-          Your server is running PHP <?php echo PHP_VERSION ?>, but PrestaShop requires PHP <?php echo _PS_INSTALL_MINIMUM_PHP_VERSION_ ?> or newer.
-          <i>To install PrestaShop <?php echo _PS_INSTALL_VERSION_ ?> you need to update your server's PHP version.</i>
-      </li>
-    <?php endif; ?>
-    <?php if (PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_): ?>
-      <li>
-          Your server is running PHP <?php echo PHP_VERSION ?>, but PrestaShop requires PHP <?php echo _PS_INSTALL_MAXIMUM_PHP_VERSION_ ?> or lower.
-          <i>To install PrestaShop <?php echo _PS_INSTALL_VERSION_ ?> you need to downgrade your server's PHP version.</i>
-      </li>
+    <?php if ((!defined('PHP_VERSION_ID') || PHP_VERSION_ID < _PS_INSTALL_MINIMUM_PHP_VERSION_ID_) || (PHP_VERSION_ID > _PS_INSTALL_MAXIMUM_PHP_VERSION_ID_)): ?>
+        <li>
+            Your server is running PHP <?php echo PHP_VERSION ?>, but PrestaShop requires a PHP version between PHP <?php echo _PS_INSTALL_MINIMUM_PHP_VERSION_ ?> and PHP <?php echo _PS_INSTALL_MAXIMUM_PHP_VERSION_ ?>.
+            <i>To install PrestaShop <?php echo _PS_INSTALL_VERSION_ ?> you need to update your server's PHP version.</i>
+        </li>
     <?php endif; ?>
         <?php if (!is_writable(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'cache')): ?>
       <li>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  develop
| Description?      | The installer was not very clear about PHP version
| Type?             | new feature 
| Category?         | IN 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29730
| Related PRs       | 
| How to test?      | Try to install PHP with an unsupported PHP version. 
| Possible impacts? | 

Now the installer is more clear: 

<img width="1080" alt="Capture d’écran 2022-09-27 à 09 36 51" src="https://user-images.githubusercontent.com/121870/192465455-34139dbe-d7f7-4ab7-9721-27d1558cc240.png">
<img width="1080" alt="Capture d’écran 2022-09-27 à 09 37 42" src="https://user-images.githubusercontent.com/121870/192465465-7dc877a8-0fed-40a9-b7de-f4800380ea2b.png">
