### PR TITLE
Respect password configuration in backoffice customer form, unify with employee form

### DIFF
--- a/src/Core/ConstraintValidator/Constraints/Password.php
+++ b/src/Core/ConstraintValidator/Constraints/Password.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\PasswordValidator;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class Password is responsible of validating customer name according to several patterns.
+ */
+final class Password extends Constraint
+{
+  public $invalidLengthMessage = 'Password length must be between %min% and %max% characters.';
+
+  public $tooWeakMessage = 'The password doesn\'t meet required strength requirement.';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validatedBy()
+    {
+        return PasswordValidator::class;
+    }
+}

--- a/src/Core/ConstraintValidator/Constraints/Password.php
+++ b/src/Core/ConstraintValidator/Constraints/Password.php
@@ -34,19 +34,19 @@ use Symfony\Component\Validator\Constraint;
  */
 final class Password extends Constraint
 {
-  public $invalidLengthMessage = 'Password length must be between %min% and %max% characters.';
+    public $invalidLengthMessage = 'Password length must be between %min% and %max% characters.';
 
-  public $tooWeakMessage = 'The password doesn\'t meet required strength requirement.';
+    public $tooWeakMessage = 'The password doesn\'t meet required strength requirement.';
 
-  public $emptyMessage = 'This field cannot be empty.';
+    public $emptyMessage = 'This field cannot be empty.';
 
-  public $minScore;
+    public $minScore;
 
-  public $minLength;
+    public $minLength;
 
-  public $maxLength;
+    public $maxLength;
 
-  public $passwordRequired = true;
+    public $passwordRequired = true;
 
     /**
      * {@inheritdoc}

--- a/src/Core/ConstraintValidator/Constraints/Password.php
+++ b/src/Core/ConstraintValidator/Constraints/Password.php
@@ -38,11 +38,22 @@ final class Password extends Constraint
 
   public $tooWeakMessage = 'The password doesn\'t meet required strength requirement.';
 
+  public $minScore;
+
+  public $minLength;
+
+  public $maxLength;
+
     /**
      * {@inheritdoc}
      */
     public function validatedBy()
     {
         return PasswordValidator::class;
+    }
+
+    public function getRequiredOptions()
+    {
+        return ['minScore', 'minLength', 'maxLength'];
     }
 }

--- a/src/Core/ConstraintValidator/Constraints/Password.php
+++ b/src/Core/ConstraintValidator/Constraints/Password.php
@@ -46,7 +46,7 @@ final class Password extends Constraint
 
   public $maxLength;
 
-  public $passwordRequired = false;
+  public $passwordRequired = true;
 
     /**
      * {@inheritdoc}

--- a/src/Core/ConstraintValidator/Constraints/Password.php
+++ b/src/Core/ConstraintValidator/Constraints/Password.php
@@ -38,11 +38,15 @@ final class Password extends Constraint
 
   public $tooWeakMessage = 'The password doesn\'t meet required strength requirement.';
 
+  public $emptyMessage = 'This field cannot be empty.';
+
   public $minScore;
 
   public $minLength;
 
   public $maxLength;
+
+  public $passwordRequired = false;
 
     /**
      * {@inheritdoc}

--- a/src/Core/ConstraintValidator/PasswordValidator.php
+++ b/src/Core/ConstraintValidator/PasswordValidator.php
@@ -46,21 +46,16 @@ final class PasswordValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, PasswordConstraint::class);
         }
 
-        // temp
-        $maxLength = 72;
-        $minLength = 8;
-        $minScore = 3;
-
         // Check password length
         $length = mb_strlen($value, 'UTF-8');
-        if ($minLength > $length || $length > $maxLength) {
+        if ($constraint->minLength > $length || $length > $constraint->maxLength) {
           $this->context->buildViolation($constraint->invalidLengthMessage)->addViolation();
         }
 
         // Check password security
         $zxcvbn = new Zxcvbn();
         $result = $zxcvbn->passwordStrength($value);
-        if (isset($result['score']) && $result['score'] < $minScore) {
+        if (isset($result['score']) && $result['score'] < $constraint->minScore) {
           $this->context->buildViolation($constraint->tooWeakMessage)->addViolation();
         }
     }

--- a/src/Core/ConstraintValidator/PasswordValidator.php
+++ b/src/Core/ConstraintValidator/PasswordValidator.php
@@ -46,6 +46,16 @@ final class PasswordValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, PasswordConstraint::class);
         }
 
+        // Do not allow empty value, if password is required
+        if (empty($value)) {
+          if ($constraint->passwordRequired) {
+            $this->context->buildViolation($constraint->emptyMessage)->addViolation();
+            return;
+          } else {
+            return;
+          }
+        }
+
         // Check password length
         $length = mb_strlen($value, 'UTF-8');
         if ($constraint->minLength > $length || $length > $constraint->maxLength) {

--- a/src/Core/ConstraintValidator/PasswordValidator.php
+++ b/src/Core/ConstraintValidator/PasswordValidator.php
@@ -50,10 +50,9 @@ final class PasswordValidator extends ConstraintValidator
         if (empty($value)) {
           if ($constraint->passwordRequired) {
             $this->context->buildViolation($constraint->emptyMessage)->addViolation();
-            return;
-          } else {
-            return;
           }
+
+          return;
         }
 
         // Check password length

--- a/src/Core/ConstraintValidator/PasswordValidator.php
+++ b/src/Core/ConstraintValidator/PasswordValidator.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\ConstraintValidator;
+
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Password as PasswordConstraint;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use ZxcvbnPhp\Zxcvbn;
+
+/**
+ * Validates password strength
+ */
+final class PasswordValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof PasswordConstraint) {
+            throw new UnexpectedTypeException($constraint, PasswordConstraint::class);
+        }
+
+        // temp
+        $maxLength = 72;
+        $minLength = 8;
+        $minScore = 3;
+
+        // Check password length
+        $length = mb_strlen($value, 'UTF-8');
+        if ($minLength > $length || $length > $maxLength) {
+          $this->context->buildViolation($constraint->invalidLengthMessage)->addViolation();
+        }
+
+        // Check password security
+        $zxcvbn = new Zxcvbn();
+        $result = $zxcvbn->passwordStrength($value);
+        if (isset($result['score']) && $result['score'] < $minScore) {
+          $this->context->buildViolation($constraint->tooWeakMessage)->addViolation();
+        }
+    }
+}

--- a/src/Core/ConstraintValidator/PasswordValidator.php
+++ b/src/Core/ConstraintValidator/PasswordValidator.php
@@ -48,24 +48,24 @@ final class PasswordValidator extends ConstraintValidator
 
         // Do not allow empty value, if password is required
         if (empty($value)) {
-          if ($constraint->passwordRequired) {
-            $this->context->buildViolation($constraint->emptyMessage)->addViolation();
-          }
+            if ($constraint->passwordRequired) {
+                $this->context->buildViolation($constraint->emptyMessage)->addViolation();
+            }
 
-          return;
+            return;
         }
 
         // Check password length
         $length = mb_strlen($value, 'UTF-8');
         if ($constraint->minLength > $length || $length > $constraint->maxLength) {
-          $this->context->buildViolation($constraint->invalidLengthMessage)->addViolation();
+            $this->context->buildViolation($constraint->invalidLengthMessage)->addViolation();
         }
 
         // Check password security
         $zxcvbn = new Zxcvbn();
         $result = $zxcvbn->passwordStrength($value);
         if (isset($result['score']) && $result['score'] < $constraint->minScore) {
-          $this->context->buildViolation($constraint->tooWeakMessage)->addViolation();
+            $this->context->buildViolation($constraint->tooWeakMessage)->addViolation();
         }
     }
 }

--- a/src/Core/Domain/Customer/Command/AddCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/AddCustomerCommand.php
@@ -140,9 +140,9 @@ class AddCustomerCommand
      * @param bool $isEnabled
      * @param bool $isPartnerOffersSubscribed
      * @param string|null $birthday
-     * @param int $minLength
-     * @param int $maxLength
-     * @param int $minScore
+     * @param int|null $minLength
+     * @param int|null $maxLength
+     * @param int|null $minScore
      */
     public function __construct(
         $firstName,
@@ -156,9 +156,9 @@ class AddCustomerCommand
         $isEnabled = true,
         $isPartnerOffersSubscribed = false,
         $birthday = null,
-        int $minLength = null,
-        int $maxLength = null,
-        int $minScore = null
+        $minLength = null,
+        $maxLength = null,
+        $minScore = null
     ) {
         $this->firstName = new FirstName($firstName);
         $this->lastName = new LastName($lastName);

--- a/src/Core/Domain/Customer/Command/AddCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/AddCustomerCommand.php
@@ -30,8 +30,8 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\ApeCode;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Birthday;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 
 /**
  * Adds new customer with provided data

--- a/src/Core/Domain/Customer/Command/AddCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/AddCustomerCommand.php
@@ -140,6 +140,9 @@ class AddCustomerCommand
      * @param bool $isEnabled
      * @param bool $isPartnerOffersSubscribed
      * @param string|null $birthday
+     * @param int $minLength
+     * @param int $maxLength
+     * @param int $minScore
      */
     public function __construct(
         $firstName,
@@ -152,12 +155,15 @@ class AddCustomerCommand
         $genderId = null,
         $isEnabled = true,
         $isPartnerOffersSubscribed = false,
-        $birthday = null
+        $birthday = null,
+        int $minLength,
+        int $maxLength,
+        int $minScore
     ) {
         $this->firstName = new FirstName($firstName);
         $this->lastName = new LastName($lastName);
         $this->email = new Email($email);
-        $this->password = new Password($password);
+        $this->password = new Password($password, $minLength, $maxLength, $minScore);
         $this->defaultGroupId = $defaultGroupId;
         $this->groupIds = $groupIds;
         $this->shopId = $shopId;

--- a/src/Core/Domain/Customer/Command/AddCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/AddCustomerCommand.php
@@ -156,9 +156,9 @@ class AddCustomerCommand
         $isEnabled = true,
         $isPartnerOffersSubscribed = false,
         $birthday = null,
-        int $minLength,
-        int $maxLength,
-        int $minScore
+        int $minLength = null,
+        int $maxLength = null,
+        int $minScore = null
     ) {
         $this->firstName = new FirstName($firstName);
         $this->lastName = new LastName($lastName);

--- a/src/Core/Domain/Customer/Command/AddCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/AddCustomerCommand.php
@@ -30,7 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\ApeCode;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Birthday;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
 
 /**

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -229,7 +229,7 @@ class EditCustomerCommand
      * @return self
      */
     public function setPassword($password, int $minLength, int $maxLength, int $minScore)
-    {        
+    {
         $this->password = new Password($password, $minLength, $maxLength, $minScore);
 
         return $this;

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -228,9 +228,9 @@ class EditCustomerCommand
      *
      * @return self
      */
-    public function setPassword($password)
-    {
-        $this->password = new Password($password);
+    public function setPassword($password, int $minLength, int $maxLength, int $minScore)
+    {        
+        $this->password = new Password($password, $minLength, $maxLength, $minScore);
 
         return $this;
     }

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -225,10 +225,13 @@ class EditCustomerCommand
 
     /**
      * @param string $password
+     * @param int|null $minLength
+     * @param int|null $maxLength
+     * @param int|null $minScore
      *
      * @return self
      */
-    public function setPassword($password, int $minLength = null, int $maxLength = null, int $minScore = null)
+    public function setPassword($password, $minLength = null, $maxLength = null, $minScore = null)
     {
         $this->password = new Password($password, $minLength, $maxLength, $minScore);
 

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -228,7 +228,7 @@ class EditCustomerCommand
      *
      * @return self
      */
-    public function setPassword($password, int $minLength, int $maxLength, int $minScore)
+    public function setPassword($password, int $minLength = null, int $maxLength = null, int $minScore = null)
     {
         $this->password = new Password($password, $minLength, $maxLength, $minScore);
 

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -31,8 +31,8 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Birthday;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 
 /**
  * Edits provided customer.

--- a/src/Core/Domain/Customer/Command/EditCustomerCommand.php
+++ b/src/Core/Domain/Customer/Command/EditCustomerCommand.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Birthday;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\CustomerId;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
 
 /**

--- a/src/Core/Domain/Customer/ValueObject/Password.php
+++ b/src/Core/Domain/Customer/ValueObject/Password.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject;
 
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
-use ZxcvbnPhp\Zxcvbn;
 
 /**
  * Stores customer's plain password
@@ -35,15 +34,11 @@ use ZxcvbnPhp\Zxcvbn;
 class Password
 {
     /**
-     * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH
-     *
      * @var int Minimum required password length for customer
      */
-    public const MIN_LENGTH = 8;
+    public const MIN_LENGTH = 5;
 
     /**
-     * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH
-     *
      * @var int Maximum allowed password length for customer.
      *
      * It's limited to 72 chars because of PASSWORD_BCRYPT algorithm
@@ -57,35 +52,13 @@ class Password
     private $password;
 
     /**
-     * @var int
-     */
-    private $minScore;
-
-    /**
-     * @var int
-     */
-    private $minLength;
-
-    /**
-     * @var int
-     */
-    private $maxLength;
-
-    /**
      * @param string $password
-     * @param int $minLength
-     * @param int $maxLength
-     * @param int $minScore
      */
-    public function __construct(string $password, int $minLength = 8, int $maxLength = 72, int $minScore = 0)
+    public function __construct($password)
     {
-        $this->password = $password;
-        $this->minLength = $minLength;
-        $this->maxLength = $maxLength;
-        $this->minScore = $minScore;
-
         $this->assertPasswordIsWithinAllowedLength($password);
-        $this->assertPasswordScoreIsAllowed($password);
+
+        $this->password = $password;
     }
 
     /**
@@ -99,31 +72,12 @@ class Password
     /**
      * @param string $password
      */
-    private function assertPasswordIsWithinAllowedLength(string $password): void
+    private function assertPasswordIsWithinAllowedLength($password)
     {
         $length = mb_strlen($password, 'UTF-8');
 
-        if ($this->minLength > $length || $length > $this->maxLength) {
-            throw new CustomerConstraintException(
-                sprintf(
-                    'Customer password length must be between %d and %d',
-                    $this->minLength,
-                    $this->maxLength
-                ),
-                CustomerConstraintException::INVALID_PASSWORD
-            );
-        }
-    }
-
-    /**
-     * @param string $password
-     */
-    private function assertPasswordScoreIsAllowed(string $password): void
-    {
-        $zxcvbn = new Zxcvbn();
-        $result = $zxcvbn->passwordStrength($password);
-        if (isset($result['score']) && $result['score'] < $this->minScore) {
-            throw new CustomerConstraintException('Employee password is too weak', CustomerConstraintException::INVALID_PASSWORD);
+        if (self::MIN_LENGTH > $length || $length > self::MAX_LENGTH) {
+            throw new CustomerConstraintException(sprintf('Customer password length must be between %s and %s', self::MIN_LENGTH, self::MAX_LENGTH), CustomerConstraintException::INVALID_PASSWORD);
         }
     }
 }

--- a/src/Core/Domain/Customer/ValueObject/Password.php
+++ b/src/Core/Domain/Customer/ValueObject/Password.php
@@ -39,7 +39,7 @@ class Password
      *
      * @var int Minimum required password length for customer
      */
-    public const MIN_LENGTH = 5;
+    public const MIN_LENGTH = 8;
 
     /**
      * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH
@@ -77,7 +77,7 @@ class Password
      * @param int $maxLength
      * @param int $minScore
      */
-    public function __construct(string $password, int $minLength, int $maxLength, int $minScore)
+    public function __construct(string $password, int $minLength = 8, int $maxLength = 72, int $minScore = 0)
     {
         $this->password = $password;
         $this->minLength = $minLength;

--- a/src/Core/Domain/Customer/ValueObject/Password.php
+++ b/src/Core/Domain/Customer/ValueObject/Password.php
@@ -36,14 +36,14 @@ class Password
 {
     /**
      * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH
-     * 
+     *
      * @var int Minimum required password length for customer
      */
     public const MIN_LENGTH = 5;
 
     /**
      * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH
-     * 
+     *
      * @var int Maximum allowed password length for customer.
      *
      * It's limited to 72 chars because of PASSWORD_BCRYPT algorithm

--- a/src/Core/Domain/Customer/ValueObject/Password.php
+++ b/src/Core/Domain/Customer/ValueObject/Password.php
@@ -29,6 +29,9 @@ namespace PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
 
 /**
+ * @deprecated since 8.0 and will be removed in next major version.
+ * @see \PrestaShop\PrestaShop\Core\Domain\ValueObject\Password
+ *
  * Stores customer's plain password
  */
 class Password

--- a/src/Core/Domain/Employee/Command/AddEmployeeCommand.php
+++ b/src/Core/Domain/Employee/Command/AddEmployeeCommand.php
@@ -28,8 +28,8 @@ namespace PrestaShop\PrestaShop\Core\Domain\Employee\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 
 /**
  * Adds new employee with given data

--- a/src/Core/Domain/Employee/Command/AddEmployeeCommand.php
+++ b/src/Core/Domain/Employee/Command/AddEmployeeCommand.php
@@ -28,7 +28,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Employee\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\Password;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
 
 /**

--- a/src/Core/Domain/Employee/Command/EditEmployeeCommand.php
+++ b/src/Core/Domain/Employee/Command/EditEmployeeCommand.php
@@ -29,8 +29,8 @@ namespace PrestaShop\PrestaShop\Core\Domain\Employee\Command;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\EmployeeId;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 
 /**
  * Edit employee with given data.

--- a/src/Core/Domain/Employee/Command/EditEmployeeCommand.php
+++ b/src/Core/Domain/Employee/Command/EditEmployeeCommand.php
@@ -29,7 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Employee\Command;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\EmployeeId;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\Password;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
 
 /**

--- a/src/Core/Domain/Employee/ValueObject/Password.php
+++ b/src/Core/Domain/Employee/ValueObject/Password.php
@@ -30,6 +30,9 @@ use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeConstraintExcep
 use ZxcvbnPhp\Zxcvbn;
 
 /**
+ * @deprecated since 8.0 and will be removed in next major version.
+ * @see \PrestaShop\PrestaShop\Core\Domain\ValueObject\Password
+ *
  * Stores employee's plain password.
  */
 class Password

--- a/src/Core/Domain/Exception/PasswordConstraintException.php
+++ b/src/Core/Domain/Exception/PasswordConstraintException.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Exception\CoreException;
  */
 class PasswordConstraintException extends CoreException
 {
-
     /**
      * @var int Code is used when password doesn't meet length requirements
      */

--- a/src/Core/Domain/Exception/PasswordConstraintException.php
+++ b/src/Core/Domain/Exception/PasswordConstraintException.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Exception;
+
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+
+/**
+ * Will be used when invalid password is provided
+ */
+class PasswordConstraintException extends CoreException
+{
+
+    /**
+     * @var int Code is used when password doesn't meet length requirements
+     */
+    public const INVALID_LENGTH = 1;
+
+    /**
+     * @var int Code is used when password doesn't meet strength requirements
+     */
+    public const WEAK_PASSWORD = 2;
+}

--- a/src/Core/Domain/ValueObject/Password.php
+++ b/src/Core/Domain/ValueObject/Password.php
@@ -30,27 +30,10 @@ use PrestaShop\PrestaShop\Core\Domain\Exception\PasswordConstraintException;
 use ZxcvbnPhp\Zxcvbn;
 
 /**
- * Stores customer's plain password
+ * Stores plain password
  */
 class Password
 {
-    /**
-     * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH
-     *
-     * @var int Minimum required password length
-     */
-    public const MIN_LENGTH = 8;
-
-    /**
-     * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH
-     *
-     * @var int Maximum allowed password length
-     *
-     * It's limited to 72 chars because of PASSWORD_BCRYPT algorithm
-     * used in password_hash() function.
-     */
-    public const MAX_LENGTH = 72;
-
     /**
      * @var string
      */

--- a/src/Core/Domain/ValueObject/Password.php
+++ b/src/Core/Domain/ValueObject/Password.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Core\Domain\ValueObject;
 
 use PrestaShop\PrestaShop\Core\Domain\Exception\PasswordConstraintException;
+use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use ZxcvbnPhp\Zxcvbn;
 
 /**
@@ -56,16 +57,16 @@ class Password
 
     /**
      * @param string $password
-     * @param int $minLength
-     * @param int $maxLength
-     * @param int $minScore
+     * @param int|null $minLength
+     * @param int|null $maxLength
+     * @param int|null $minScore
      */
-    public function __construct(string $password, int $minLength = 8, int $maxLength = 72, int $minScore = 0)
+    public function __construct(string $password, $minLength = null, $maxLength = null, $minScore = null)
     {
         $this->password = $password;
-        $this->minLength = $minLength;
-        $this->maxLength = $maxLength;
-        $this->minScore = $minScore;
+        $this->minLength = (is_int($minLength) ? $minLength : PasswordPolicyConfiguration::DEFAULT_MINIMUM_LENGTH);
+        $this->maxLength = (is_int($maxLength) ? $maxLength : PasswordPolicyConfiguration::DEFAULT_MAXIMUM_LENGTH);
+        $this->minScore = (is_int($minScore) ? $minScore : 0);
 
         $this->assertPasswordIsWithinAllowedLength($password);
         $this->assertPasswordScoreIsAllowed($password);

--- a/src/Core/Domain/ValueObject/Password.php
+++ b/src/Core/Domain/ValueObject/Password.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\ValueObject;
+
+use PrestaShop\PrestaShop\Core\Domain\Exception\PasswordConstraintException;
+use ZxcvbnPhp\Zxcvbn;
+
+/**
+ * Stores customer's plain password
+ */
+class Password
+{
+    /**
+     * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH
+     *
+     * @var int Minimum required password length
+     */
+    public const MIN_LENGTH = 8;
+
+    /**
+     * @deprecated since 8.0.0 use PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH
+     *
+     * @var int Maximum allowed password length
+     *
+     * It's limited to 72 chars because of PASSWORD_BCRYPT algorithm
+     * used in password_hash() function.
+     */
+    public const MAX_LENGTH = 72;
+
+    /**
+     * @var string
+     */
+    private $password;
+
+    /**
+     * @var int
+     */
+    private $minScore;
+
+    /**
+     * @var int
+     */
+    private $minLength;
+
+    /**
+     * @var int
+     */
+    private $maxLength;
+
+    /**
+     * @param string $password
+     * @param int $minLength
+     * @param int $maxLength
+     * @param int $minScore
+     */
+    public function __construct(string $password, int $minLength = 8, int $maxLength = 72, int $minScore = 0)
+    {
+        $this->password = $password;
+        $this->minLength = $minLength;
+        $this->maxLength = $maxLength;
+        $this->minScore = $minScore;
+
+        $this->assertPasswordIsWithinAllowedLength($password);
+        $this->assertPasswordScoreIsAllowed($password);
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->password;
+    }
+
+    /**
+     * @param string $password
+     */
+    private function assertPasswordIsWithinAllowedLength(string $password): void
+    {
+        $length = mb_strlen($password, 'UTF-8');
+
+        if ($this->minLength > $length || $length > $this->maxLength) {
+            throw new PasswordConstraintException(
+                sprintf(
+                    'Password length must be between %d and %d',
+                    $this->minLength,
+                    $this->maxLength
+                ),
+                PasswordConstraintException::INVALID_LENGTH
+            );
+        }
+    }
+
+    /**
+     * @param string $password
+     */
+    private function assertPasswordScoreIsAllowed(string $password): void
+    {
+        $zxcvbn = new Zxcvbn();
+        $result = $zxcvbn->passwordStrength($password);
+        if (isset($result['score']) && $result['score'] < $this->minScore) {
+            throw new PasswordConstraintException('Employee password is too weak', PasswordConstraintException::WEAK_PASSWORD);
+        }
+    }
+}

--- a/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
@@ -53,18 +53,42 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
     private $isB2bFeatureEnabled;
 
     /**
+     * @var int
+     */
+    private $minScore;
+
+    /**
+     * @var int
+     */
+    private $minLength;
+
+    /**
+     * @var int
+     */
+    private $maxLength;
+
+    /**
      * @param CommandBusInterface $bus
      * @param int $contextShopId
      * @param bool $isB2bFeatureEnabled
+     * @param int $minLength
+     * @param int $maxLength
+     * @param int $minScore
      */
     public function __construct(
         CommandBusInterface $bus,
         $contextShopId,
-        $isB2bFeatureEnabled
+        $isB2bFeatureEnabled,
+        int $minLength,
+        int $maxLength,
+        int $minScore
     ) {
         $this->bus = $bus;
         $this->contextShopId = $contextShopId;
         $this->isB2bFeatureEnabled = $isB2bFeatureEnabled;
+        $this->minLength = $minLength;
+        $this->maxLength = $maxLength;
+        $this->minScore = $minScore;
     }
 
     /**
@@ -112,7 +136,10 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
             (int) $data['gender_id'],
             (bool) $data['is_enabled'],
             (bool) $data['is_partner_offers_subscribed'],
-            $data['birthday'] ?: Birthday::EMPTY_BIRTHDAY
+            $data['birthday'] ?: Birthday::EMPTY_BIRTHDAY,
+            $this->minLength,
+            $this->maxLength,
+            $this->minScore
         );
 
         if (!$this->isB2bFeatureEnabled) {
@@ -157,7 +184,7 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
         ;
 
         if (null !== $data['password']) {
-            $command->setPassword($data['password']);
+            $command->setPassword($data['password'], $this->minLength, $this->maxLength, $this->minScore);
         }
 
         if ($this->isB2bFeatureEnabled) {

--- a/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
@@ -79,9 +79,9 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
         CommandBusInterface $bus,
         $contextShopId,
         $isB2bFeatureEnabled,
-        int $minLength,
-        int $maxLength,
-        int $minScore
+        int $minLength = null,
+        int $maxLength = null,
+        int $minScore = null
     ) {
         $this->bus = $bus;
         $this->contextShopId = $contextShopId;

--- a/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CustomerFormDataHandler.php
@@ -53,17 +53,17 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
     private $isB2bFeatureEnabled;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $minScore;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $minLength;
 
     /**
-     * @var int
+     * @var int|null
      */
     private $maxLength;
 
@@ -71,17 +71,17 @@ final class CustomerFormDataHandler implements FormDataHandlerInterface
      * @param CommandBusInterface $bus
      * @param int $contextShopId
      * @param bool $isB2bFeatureEnabled
-     * @param int $minLength
-     * @param int $maxLength
-     * @param int $minScore
+     * @param int|null $minLength
+     * @param int|null $maxLength
+     * @param int|null $minScore
      */
     public function __construct(
         CommandBusInterface $bus,
         $contextShopId,
         $isB2bFeatureEnabled,
-        int $minLength = null,
-        int $maxLength = null,
-        int $minScore = null
+        $minLength = null,
+        $maxLength = null,
+        $minScore = null
     ) {
         $this->bus = $bus;
         $this->contextShopId = $contextShopId;

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -485,11 +485,11 @@ class EmployeeController extends FrameworkBundleAdminController
                     [
                         '%min%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH),
                         '%max%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH),
-                    ]                
+                    ]
                 ),
                 PasswordConstraintException::WEAK_PASSWORD => $this->trans(
                     'The password doesn\'t meet required strength requirement.',
-                    'Admin.Notifications.Error',
+                    'Admin.Notifications.Error'
                 ),
             ],
             InvalidEmployeeIdException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -480,9 +480,12 @@ class EmployeeController extends FrameworkBundleAdminController
         return [
             PasswordConstraintException::class => [
                 PasswordConstraintException::INVALID_LENGTH => $this->trans(
-                    'Password should be at least %length% characters long.',
+                    'Password length must be between %min% and %max% characters.',
                     'Admin.Notifications.Error',
-                    ['%length%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH)]
+                    [
+                        '%min%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH),
+                        '%max%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH),
+                    ]                
                 ),
                 PasswordConstraintException::WEAK_PASSWORD => $this->trans(
                     'The password doesn\'t meet required strength requirement.',

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -481,7 +481,7 @@ class EmployeeController extends FrameworkBundleAdminController
             PasswordConstraintException::class => [
                 PasswordConstraintException::INVALID_LENGTH => $this->trans(
                     'Password should be at least %length% characters long.',
-                    'Admin.Orderscustomers.Help',
+                    'Admin.Notifications.Error',
                     ['%length%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH)]
                 ),
                 PasswordConstraintException::WEAK_PASSWORD => $this->trans(
@@ -534,7 +534,7 @@ class EmployeeController extends FrameworkBundleAdminController
             ),
             EmployeeConstraintException::class => [
                 EmployeeConstraintException::INCORRECT_PASSWORD => $this->trans(
-                    'Your current password is invalid.',
+                    'Old and new passwords do not match.',
                     'Admin.Advparameters.Notification'
                 ),
                 EmployeeConstraintException::INVALID_EMAIL => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -42,11 +42,13 @@ use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidEmployeeIdExcept
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\InvalidProfileException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\MissingShopAssociationException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Exception\PasswordConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler;
 use PrestaShop\PrestaShop\Core\Search\Filters\EmployeeFilters;
+use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -476,6 +478,17 @@ class EmployeeController extends FrameworkBundleAdminController
     protected function getErrorMessages(Exception $e)
     {
         return [
+            PasswordConstraintException::class => [
+                PasswordConstraintException::INVALID_LENGTH => $this->trans(
+                    'Password should be at least %length% characters long.',
+                    'Admin.Orderscustomers.Help',
+                    ['%length%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH)]
+                ),
+                PasswordConstraintException::WEAK_PASSWORD => $this->trans(
+                    'The password doesn\'t meet required strength requirement.',
+                    'Admin.Notifications.Error',
+                ),
+            ],
             InvalidEmployeeIdException::class => $this->trans(
                 'The object cannot be loaded (the identifier is missing or invalid)',
                 'Admin.Notifications.Error'
@@ -538,10 +551,6 @@ class EmployeeController extends FrameworkBundleAdminController
                     'The %s field is invalid.',
                     'Admin.Notifications.Error',
                     [sprintf('"%s"', $this->trans('Last name', 'Admin.Global'))]
-                ),
-                EmployeeConstraintException::INVALID_PASSWORD => $this->trans(
-                    'The password doesn\'t meet the password policy requirements.',
-                    'Admin.Notifications.Error'
                 ),
             ],
         ];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -914,9 +914,12 @@ class CustomerController extends AbstractAdminController
         return [
             PasswordConstraintException::class => [
                 PasswordConstraintException::INVALID_LENGTH => $this->trans(
-                    'Password should be at least %length% characters long.',
+                    'Password length must be between %min% and %max% characters.',
                     'Admin.Notifications.Error',
-                    ['%length%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH)]
+                    [
+                        '%min%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH),
+                        '%max%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH),
+                    ]
                 ),
                 PasswordConstraintException::WEAK_PASSWORD => $this->trans(
                     'The password doesn\'t meet required strength requirement.',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -923,7 +923,7 @@ class CustomerController extends AbstractAdminController
                 ),
                 PasswordConstraintException::WEAK_PASSWORD => $this->trans(
                     'The password doesn\'t meet required strength requirement.',
-                    'Admin.Notifications.Error',
+                    'Admin.Notifications.Error'
                 ),
             ],
             CustomerNotFoundException::class => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -53,7 +53,6 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\AddressCreationCustomerInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\EditableCustomer;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\ViewableCustomer;
-use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGridDefinitionFactory;
@@ -74,7 +73,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Tools;
 
 /**
  * Class CustomerController manages "Sell > Customers" page.

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -53,6 +53,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Query\SearchCustomers;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\AddressCreationCustomerInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\EditableCustomer;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\ViewableCustomer;
+use PrestaShop\PrestaShop\Core\Domain\Exception\PasswordConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGridDefinitionFactory;
@@ -911,6 +912,17 @@ class CustomerController extends AbstractAdminController
     private function getErrorMessages(Exception $e)
     {
         return [
+            PasswordConstraintException::class => [
+                PasswordConstraintException::INVALID_LENGTH => $this->trans(
+                    'Password should be at least %length% characters long.',
+                    'Admin.Orderscustomers.Help',
+                    ['%length%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH)]
+                ),
+                PasswordConstraintException::WEAK_PASSWORD => $this->trans(
+                    'The password doesn\'t meet required strength requirement.',
+                    'Admin.Notifications.Error',
+                ),
+            ],
             CustomerNotFoundException::class => $this->trans(
                 'This customer does not exist.',
                 'Admin.Orderscustomers.Notification'
@@ -929,11 +941,6 @@ class CustomerController extends AbstractAdminController
                 'Admin.Orderscustomers.Notification'
             ),
             CustomerConstraintException::class => [
-                CustomerConstraintException::INVALID_PASSWORD => $this->trans(
-                    'Password should be at least %length% characters long.',
-                    'Admin.Orderscustomers.Help',
-                    ['%length%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH)]
-                ),
                 CustomerConstraintException::INVALID_FIRST_NAME => $this->trans(
                     'The %s field is invalid.',
                     'Admin.Notifications.Error',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -60,6 +60,7 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGridDefinitionFac
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerAddressFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerDiscountFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
+use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Customer\DeleteCustomersType;
@@ -73,6 +74,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Tools;
 
 /**
  * Class CustomerController manages "Sell > Customers" page.
@@ -189,9 +191,10 @@ class CustomerController extends AbstractAdminController
         return $this->render('@PrestaShop/Admin/Sell/Customer/create.html.twig', [
             'customerForm' => $customerForm->createView(),
             'isB2bFeatureActive' => $this->get('prestashop.core.b2b.b2b_feature')->isActive(),
-            'minPasswordLength' => Password::MIN_LENGTH,
+            'minPasswordLength' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH),
             'displayInIframe' => $request->query->has('submitFormAjax'),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
+            'guest_group' => (int) $this->get('prestashop.adapter.legacy.configuration')->get('PS_GUEST_GROUP'),
         ]);
     }
 
@@ -245,7 +248,7 @@ class CustomerController extends AbstractAdminController
             'customerForm' => $customerForm->createView(),
             'customerInformation' => $customerInformation,
             'isB2bFeatureActive' => $this->get('prestashop.core.b2b.b2b_feature')->isActive(),
-            'minPasswordLength' => Password::MIN_LENGTH,
+            'minPasswordLength' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
         ]);
     }
@@ -931,7 +934,7 @@ class CustomerController extends AbstractAdminController
                 CustomerConstraintException::INVALID_PASSWORD => $this->trans(
                     'Password should be at least %length% characters long.',
                     'Admin.Orderscustomers.Help',
-                    ['%length%' => Password::MIN_LENGTH]
+                    ['%length%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH)]
                 ),
                 CustomerConstraintException::INVALID_FIRST_NAME => $this->trans(
                     'The %s field is invalid.',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -915,7 +915,7 @@ class CustomerController extends AbstractAdminController
             PasswordConstraintException::class => [
                 PasswordConstraintException::INVALID_LENGTH => $this->trans(
                     'Password should be at least %length% characters long.',
-                    'Admin.Orderscustomers.Help',
+                    'Admin.Notifications.Error',
                     ['%length%' => (int) $this->get('prestashop.adapter.legacy.configuration')->get(PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH)]
                 ),
                 PasswordConstraintException::WEAK_PASSWORD => $this->trans(

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -162,12 +162,14 @@ final class EmployeeType extends AbstractType
                     'data-minscore' => $minScore,
                     'data-minlength' => $minLength,
                     'data-maxlength' => $maxLength,
+                    'autocomplete' => 'new-password',
                 ],
                 'constraints' => [
                     new Password([
                         'minScore' => $minScore,
                         'minLength' => $minLength,
                         'maxLength' => $maxLength,
+                        'passwordRequired' => !$options['is_for_editing'],
                         'invalidLengthMessage' => $this->trans(
                             'Password length must be between %min% and %max% characters.',
                             [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -176,7 +176,7 @@ final class EmployeeType extends AbstractType
                                 '%min%' => $minLength,
                                 '%max%' => $maxLength,
                             ],
-                            'Admin.Notifications.Error',
+                            'Admin.Notifications.Error'
                         ),
                         'tooWeakMessage' => $this->trans(
                             'The password doesn\'t meet required strength requirement.',

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Password;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\LastName;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email as EmployeeEmail;
@@ -48,7 +49,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Password;
 
 /**
  * Class EmployeeType defines an employee form.

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -29,7 +29,6 @@ namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Employee;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email as EmployeeEmail;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use PrestaShopBundle\Form\Admin\Type\ChangePasswordType;

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -181,7 +181,7 @@ final class EmployeeType extends AbstractType
                         'tooWeakMessage' => $this->trans(
                             'The password doesn\'t meet required strength requirement.',
                             [],
-                            'Admin.Notifications.Error',
+                            'Admin.Notifications.Error'
                         ),
                         'emptyMessage' => $this->trans('This field cannot be empty.', [], 'Admin.Notifications.Error'),
                     ]),

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -181,6 +181,7 @@ final class EmployeeType extends AbstractType
                             [],
                             'Admin.Notifications.Error',
                         ),
+                        'emptyMessage' => $this->trans('This field cannot be empty.', [], 'Admin.Notifications.Error'),
                     ]),
                 ],
             ]);

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -165,6 +165,9 @@ final class EmployeeType extends AbstractType
                 ],
                 'constraints' => [
                     new Password([
+                        'minScore' => $minScore,
+                        'minLength' => $minLength,
+                        'maxLength' => $maxLength,
                         'invalidLengthMessage' => $this->trans(
                             'Password length must be between %min% and %max% characters.',
                             [

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeType.php
@@ -48,6 +48,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Password;
 
 /**
  * Class EmployeeType defines an employee form.
@@ -163,14 +164,21 @@ final class EmployeeType extends AbstractType
                     'data-maxlength' => $maxLength,
                 ],
                 'constraints' => [
-                    new Length(
-                        [
-                            'max' => $maxLength,
-                            'maxMessage' => $this->getMaxLengthValidationMessage($maxLength),
-                            'min' => $minLength,
-                            'minMessage' => $this->getMinLengthValidationMessage($minLength),
-                        ]
-                    ),
+                    new Password([
+                        'invalidLengthMessage' => $this->trans(
+                            'Password length must be between %min% and %max% characters.',
+                            [
+                                '%min%' => $minLength,
+                                '%max%' => $maxLength,
+                            ],
+                            'Admin.Notifications.Error',
+                        ),
+                        'tooWeakMessage' => $this->trans(
+                            'The password doesn\'t meet required strength requirement.',
+                            [],
+                            'Admin.Notifications.Error',
+                        ),
+                    ]),
                 ],
             ]);
         }

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -216,7 +216,7 @@ class CustomerType extends TranslatorAwareType
                             [
                                 '%min%' => $minLength,
                                 '%max%' => $maxLength,
-                            ],
+                            ]
                         ),
                         'tooWeakMessage' => $this->trans(
                             'The password doesn\'t meet required strength requirement.',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -30,7 +30,7 @@ use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CustomerName;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use PrestaShopBundle\Form\Admin\Type\EmailType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTableType;

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -205,6 +205,9 @@ class CustomerType extends TranslatorAwareType
                 ],
                 'constraints' => [
                     new Password([
+                        'minScore' => $minScore,
+                        'minLength' => $minLength,
+                        'maxLength' => $maxLength,
                         'invalidLengthMessage' => $this->trans(
                             'Password length must be between %min% and %max% characters.',
                             'Admin.Notifications.Error',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -220,7 +220,7 @@ class CustomerType extends TranslatorAwareType
                         ),
                     ]),
                 ],
-                // 'required' => $options['is_password_required'],
+                'required' => $options['is_password_required'],
             ])
             ->add('birthday', BirthdayType::class, [
                 'label' => $this->trans('Birthday', 'Admin.Orderscustomers.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -221,7 +221,7 @@ class CustomerType extends TranslatorAwareType
                         'tooWeakMessage' => $this->trans(
                             'The password doesn\'t meet required strength requirement.',
                             'Admin.Notifications.Error',
-                            [],
+                            []
                         ),
                         'emptyMessage' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -207,22 +207,22 @@ class CustomerType extends TranslatorAwareType
                     'Password should be at least %length% characters long.',
                     'Admin.Notifications.Info',
                     [
-                        '%length%' => Password::MIN_LENGTH,
+                        '%length%' => $minLength,
                     ]
                 ),
                 'constraints' => [
                     new Length([
-                        'max' => Password::MAX_LENGTH,
+                        'max' => $maxLength,
                         'maxMessage' => $this->trans(
                             'This field cannot be longer than %limit% characters',
                             'Admin.Notifications.Error',
-                            ['%limit%' => Password::MAX_LENGTH]
+                            ['%limit%' => $maxLength]
                         ),
-                        'min' => Password::MIN_LENGTH,
+                        'min' => $minLength,
                         'minMessage' => $this->trans(
                             'This field cannot be shorter than %limit% characters',
                             'Admin.Notifications.Error',
-                            ['%limit%' => Password::MIN_LENGTH]
+                            ['%limit%' => $minLength]
                         ),
                     ]),
                 ],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -208,6 +208,7 @@ class CustomerType extends TranslatorAwareType
                         'minScore' => $minScore,
                         'minLength' => $minLength,
                         'maxLength' => $maxLength,
+                        'passwordRequired' => $options['is_password_required'],
                         'invalidLengthMessage' => $this->trans(
                             'Password length must be between %min% and %max% characters.',
                             'Admin.Notifications.Error',
@@ -221,6 +222,7 @@ class CustomerType extends TranslatorAwareType
                             'Admin.Notifications.Error',
                             [],
                         ),
+                        'emptyMessage' => $this->trans('This field cannot be empty.', 'Admin.Notifications.Error'),
                     ]),
                 ],
                 'required' => $options['is_password_required'],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -28,9 +28,9 @@ namespace PrestaShopBundle\Form\Admin\Sell\Customer;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\CustomerName;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Password;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\LastName;
-use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use PrestaShopBundle\Form\Admin\Type\EmailType;
 use PrestaShopBundle\Form\Admin\Type\Material\MaterialChoiceTableType;
@@ -203,30 +203,24 @@ class CustomerType extends TranslatorAwareType
                     'data-minlength' => $minLength,
                     'data-maxlength' => $maxLength,
                 ],
-                'help' => $this->trans(
-                    'Password should be at least %length% characters long.',
-                    'Admin.Notifications.Info',
-                    [
-                        '%length%' => $minLength,
-                    ]
-                ),
                 'constraints' => [
-                    new Length([
-                        'max' => $maxLength,
-                        'maxMessage' => $this->trans(
-                            'This field cannot be longer than %limit% characters',
+                    new Password([
+                        'invalidLengthMessage' => $this->trans(
+                            'Password length must be between %min% and %max% characters.',
                             'Admin.Notifications.Error',
-                            ['%limit%' => $maxLength]
+                            [
+                                '%min%' => $minLength,
+                                '%max%' => $maxLength,
+                            ],
                         ),
-                        'min' => $minLength,
-                        'minMessage' => $this->trans(
-                            'This field cannot be shorter than %limit% characters',
+                        'tooWeakMessage' => $this->trans(
+                            'The password doesn\'t meet required strength requirement.',
                             'Admin.Notifications.Error',
-                            ['%limit%' => $minLength]
+                            [],
                         ),
                     ]),
                 ],
-                'required' => $options['is_password_required'],
+                // 'required' => $options['is_password_required'],
             ])
             ->add('birthday', BirthdayType::class, [
                 'label' => $this->trans('Birthday', 'Admin.Orderscustomers.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Customer/CustomerType.php
@@ -202,6 +202,7 @@ class CustomerType extends TranslatorAwareType
                     'data-minscore' => $minScore,
                     'data-minlength' => $minLength,
                     'data-maxlength' => $maxLength,
+                    'autocomplete' => 'new-password',
                 ],
                 'constraints' => [
                     new Password([

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -35,7 +35,7 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Constraints\Length;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Password;
 
 /**
  * Class ChangePasswordType is responsible for defining "change password" form type.
@@ -81,14 +81,21 @@ class ChangePasswordType extends AbstractType
                     ],
                 ],
                 'constraints' => [
-                    new Length(
-                        [
-                            'max' => $maxLength,
-                            'maxMessage' => $this->getMaxLengthValidationMessage($maxLength),
-                            'min' => $minLength,
-                            'minMessage' => $this->getMinLengthValidationMessage($minLength),
-                        ]
-                    ),
+                    new Password([
+                        'invalidLengthMessage' => $this->trans(
+                            'Password length must be between %min% and %max% characters.',
+                            [
+                                '%min%' => $minLength,
+                                '%max%' => $maxLength,
+                            ],
+                            'Admin.Notifications.Error',
+                        ),
+                        'tooWeakMessage' => $this->trans(
+                            'The password doesn\'t meet required strength requirement.',
+                            [],
+                            'Admin.Notifications.Error',
+                        ),
+                    ]),
                 ],
             ])
             ->add('cancel_button', ButtonType::class)

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Password;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
@@ -35,7 +36,6 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\Password;
 
 /**
  * Class ChangePasswordType is responsible for defining "change password" form type.
@@ -118,6 +118,8 @@ class ChangePasswordType extends AbstractType
     }
 
     /**
+     * @deprecated Since 8.0 and will be removed in the next major.
+     *
      * @param int $minLength
      *
      * @return string
@@ -132,6 +134,8 @@ class ChangePasswordType extends AbstractType
     }
 
     /**
+     * @deprecated Since 8.0 and will be removed in the next major.
+     *
      * @param int $maxLength
      *
      * @return string

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -97,7 +97,7 @@ class ChangePasswordType extends AbstractType
                         'tooWeakMessage' => $this->trans(
                             'The password doesn\'t meet required strength requirement.',
                             [],
-                            'Admin.Notifications.Error',
+                            'Admin.Notifications.Error'
                         ),
                         'emptyMessage' => $this->trans('This field cannot be empty.', [], 'Admin.Notifications.Error'),
                     ]),

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -98,6 +98,7 @@ class ChangePasswordType extends AbstractType
                             [],
                             'Admin.Notifications.Error',
                         ),
+                        'emptyMessage' => $this->trans('This field cannot be empty.', [], 'Admin.Notifications.Error'),
                     ]),
                 ],
             ])

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -92,7 +92,7 @@ class ChangePasswordType extends AbstractType
                                 '%min%' => $minLength,
                                 '%max%' => $maxLength,
                             ],
-                            'Admin.Notifications.Error',
+                            'Admin.Notifications.Error'
                         ),
                         'tooWeakMessage' => $this->trans(
                             'The password doesn\'t meet required strength requirement.',

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Form\Admin\Type;
 
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
-use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\Password;
 use PrestaShop\PrestaShop\Core\Security\PasswordPolicyConfiguration;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -78,6 +78,7 @@ class ChangePasswordType extends AbstractType
                         'data-minscore' => $minScore,
                         'data-minlength' => $minLength,
                         'data-maxlength' => $maxLength,
+                        'autocomplete' => 'new-password',
                     ],
                 ],
                 'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ChangePasswordType.php
@@ -82,6 +82,9 @@ class ChangePasswordType extends AbstractType
                 ],
                 'constraints' => [
                     new Password([
+                        'minScore' => $minScore,
+                        'minLength' => $minLength,
+                        'maxLength' => $maxLength,
                         'invalidLengthMessage' => $this->trans(
                             'Password length must be between %min% and %max% characters.',
                             [

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -13,6 +13,9 @@ services:
       - '@prestashop.core.command_bus'
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
       - '@=service("prestashop.core.b2b.b2b_feature").isActive()'
+      - '@=service("prestashop.adapter.legacy.configuration").getInt(constant("PrestaShop\\PrestaShop\\Core\\Security\\PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_LENGTH"))'
+      - '@=service("prestashop.adapter.legacy.configuration").getInt(constant("PrestaShop\\PrestaShop\\Core\\Security\\PasswordPolicyConfiguration::CONFIGURATION_MAXIMUM_LENGTH"))'
+      - '@=service("prestashop.adapter.legacy.configuration").getInt(constant("PrestaShop\\PrestaShop\\Core\\Security\\PasswordPolicyConfiguration::CONFIGURATION_MINIMUM_SCORE"))'
 
   prestashop.core.form.identifiable_object.data_handler.language_form_data_handler:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\LanguageFormDataHandler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/form.html.twig
@@ -91,12 +91,10 @@
                     }) }}
 
                   {# New password first input #}
-                  <div class="form-group row">
-                    {{ ps.label_with_help('New password'|trans({}, 'messages'), passwordHelpMessage, '', employeeForm.change_password.new_password.children.first.vars.id, true) }}
-                    <div class="col-sm">
-                      {{ ps.form_widget_with_error(employeeForm.change_password.new_password.children.first, employeeForm.change_password.new_password.children.first.vars) }}
-                    </div>
-                  </div>
+                  {{ ps.form_group_row(employeeForm.change_password.new_password.children.first, newPasswordFirstVars, {
+                    label: 'New password'|trans({}, 'messages'),
+                    required: true,
+                    }) }}
 
                   {# New password second input (confirmation) #}
                   {# Empty help text needed to render the text container for validation feedback messages #}
@@ -119,7 +117,6 @@
           {% else %}
             {{ ps.form_group_row(employeeForm.password, {}, {
               'label': 'Password'|trans({}, 'Admin.Global'),
-              'help': passwordHelpMessage,
               }) }}
           {% endif %}
 

--- a/tests/Unit/Core/Domain/Customer/ValueObject/PasswordTest.php
+++ b/tests/Unit/Core/Domain/Customer/ValueObject/PasswordTest.php
@@ -27,8 +27,8 @@
 namespace Tests\Unit\Core\Domain\Customer\ValueObject;
 
 use PHPUnit\Framework\TestCase;
-use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Customer\ValueObject\Password;
+use PrestaShop\PrestaShop\Core\Domain\Exception\PasswordConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\ValueObject\Password;
 
 class PasswordTest extends TestCase
 {
@@ -37,8 +37,8 @@ class PasswordTest extends TestCase
      */
     public function testItThrowsExceptionWhenCreatingTooShortOrTooLongPassword($password)
     {
-        $this->expectException(CustomerConstraintException::class);
-        $this->expectExceptionCode(CustomerConstraintException::INVALID_PASSWORD);
+        $this->expectException(PasswordConstraintException::class);
+        $this->expectExceptionCode(PasswordConstraintException::INVALID_LENGTH);
 
         new Password($password, 5, 72, 0);
     }

--- a/tests/Unit/Core/Domain/Customer/ValueObject/PasswordTest.php
+++ b/tests/Unit/Core/Domain/Customer/ValueObject/PasswordTest.php
@@ -40,7 +40,7 @@ class PasswordTest extends TestCase
         $this->expectException(CustomerConstraintException::class);
         $this->expectExceptionCode(CustomerConstraintException::INVALID_PASSWORD);
 
-        new Password($password);
+        new Password($password, 5, 72, 0);
     }
 
     /**
@@ -48,7 +48,7 @@ class PasswordTest extends TestCase
      */
     public function testItCreatesNewPassword($passwordValue)
     {
-        $password = new Password($passwordValue);
+        $password = new Password($passwordValue, 5, 72, 0);
 
         $this->assertEquals($passwordValue, $password->getValue());
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no - default values are used when parameters are missing from constructors
| Deprecations?     | yes - using hardcoded password constraint
| Fixed ticket?     | Fixes #29778
| Related PRs       | -
| How to test?      | See issue
| Possible impacts? | -

### Description
- Password policy set in Security section should be respected on server side validation of the form, it was not respected at all.
- There was no validation of password strength on the form itself, the stopping point was the ValueObject.
- Password ValueObject was basically duplicated between Employee and Customer.
- This PR adds new Password constraint to validate password on the form level and provide error message to the fields.
- It also improves error messages all around and unifies many things.

### Todo
- 🚧 Fix change password on employee form, some error is there all the time - need to investigate.
- ❓ Investigate BC breaks.
- 🚧 Password javascript should remove validation message after user starts to type.
- ❓I don't like passing the password settings through constructors of the commands and handlers. I think the Password class could get it internally, maybe. I am creating a customer, I care only about his data. We can add some setters maybe to override these value for testing purposes (PasswordTest).
- ❓Should the password be validated on Valueobject level at all?
