### PR TITLE
Add possibility for modules to return custom order number

### DIFF
--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1829,13 +1829,13 @@ class OrderCore extends ObjectModel
      * Generate a unique reference for orders generated with the same cart id
      * This reference is the primary order identifier for public use.
      *
-     * Modules can return their own number.
+     * Modules can return their own reference.
      *
      * @return string
      */
     public static function generateReference()
     {
-        $reference = Hook::exec('actionGenerateDocumentNumber', [
+        $reference = Hook::exec('actionGenerateDocumentReference', [
             'type' => 'order',
         ]);
 

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1827,13 +1827,19 @@ class OrderCore extends ObjectModel
 
     /**
      * Generate a unique reference for orders generated with the same cart id
-     * This references, is useful for check payment.
+     * This reference is the primary order identifier for public use.
+     *
+     * Modules can return their own number.
      *
      * @return string
      */
     public static function generateReference()
     {
-        return strtoupper(Tools::passwdGen(9, 'NO_NUMERIC'));
+        $reference = Hook::exec('actionGenerateDocumentNumber', [
+            'type' => 'order',
+        ]);
+
+        return !empty($reference) ? $reference : strtoupper(Tools::passwdGen(9, 'NO_NUMERIC'));
     }
 
     public function orderContainProduct($id_product)

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4254,8 +4254,8 @@
       <title>Modify title grid template data</title>
       <description>This hook allows to modify data which is about to be used in template for title grid</description>
     </hook>
-    <hook id="actionGenerateDocumentNumber">
-      <name>actionGenerateDocumentNumber</name>
+    <hook id="actionGenerateDocumentReference">
+      <name>actionGenerateDocumentReference</name>
       <title>Modify document reference</title>
       <description>This hook allows modules to return custom document number for orders.</description>
     </hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4257,7 +4257,7 @@
     <hook id="actionGenerateDocumentReference">
       <name>actionGenerateDocumentReference</name>
       <title>Modify document reference</title>
-      <description>This hook allows modules to return custom document number for orders.</description>
+      <description>This hook allows modules to return custom document references</description>
     </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4254,5 +4254,10 @@
       <title>Modify title grid template data</title>
       <description>This hook allows to modify data which is about to be used in template for title grid</description>
     </hook>
+    <hook id="actionGenerateDocumentNumber">
+      <name>actionGenerateDocumentNumber</name>
+      <title>Modify document reference</title>
+      <description>This hook allows modules to return custom document number for orders.</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allows module developers to return their own order reference. This can be QA by a developer I think.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Resolves #24845, Resolves #13212, Resolves #19688, Partially resolves #18295
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/564/
| How to test?      | -
| Possible impacts? | -

Ping @kpodemski 