### PR TITLE
Add a button to delete logo image on Manufacturer/Supplier form

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/supplier/supplier-form.ts
+++ b/admin-dev/themes/new-theme/js/pages/supplier/supplier-form.ts
@@ -23,6 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+import FormSubmitButton from '@components/form-submit-button';
 import SupplierMap from './supplier-map';
 
 const {$} = window;
@@ -54,4 +55,6 @@ $(document).ready(() => {
       createTokensOnBlur: true,
     },
   });
+
+  new FormSubmitButton();
 });

--- a/src/Adapter/Manufacturer/CommandHandler/DeleteManufacturerLogoImageHandler.php
+++ b/src/Adapter/Manufacturer/CommandHandler/DeleteManufacturerLogoImageHandler.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Manufacturer\CommandHandler;
+
+use ImageType;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerLogoImageCommand;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler\DeleteManufacturerLogoImageHandlerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Handles command which deletes manufacturer cover image using legacy object model
+ */
+class DeleteManufacturerLogoImageHandler extends AbstractManufacturerCommandHandler implements DeleteManufacturerLogoImageHandlerInterface
+{
+    /**
+     * @var string
+     */
+    protected $imageDir;
+
+    /**
+     * @var string
+     */
+    protected $tmpImageDir;
+
+    public function __construct(string $imageDir, string $tmpImageDir)
+    {
+        $this->imageDir = $imageDir;
+        $this->tmpImageDir = $tmpImageDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(DeleteManufacturerLogoImageCommand $command): void
+    {
+        $fs = new Filesystem();
+
+        $imageTypes = ImageType::getImagesTypes('manufacturers');
+
+        foreach ($imageTypes as $imageType) {
+            $path = sprintf(
+                '%s%s-%s.jpg',
+                $this->imageDir,
+                $command->getManufacturerId()->getValue(),
+                stripslashes($imageType['name'])
+            );
+            if ($fs->exists($path)) {
+                $fs->remove($path);
+            }
+        }
+
+        $imagePath = sprintf(
+            '%s%s.jpg',
+            $this->imageDir,
+            $command->getManufacturerId()->getValue()
+        );
+        if ($fs->exists($imagePath)) {
+            $fs->remove($imagePath);
+        }
+
+        // Delete tmp image
+        $imgTmpPath = sprintf(
+            '%smanufacturer_%s.jpg',
+            $this->tmpImageDir,
+            $command->getManufacturerId()->getValue()
+        );
+        if ($fs->exists($imgTmpPath)) {
+            $fs->remove($imgTmpPath);
+        }
+
+        // Delete tmp image mini
+        $imgMiniTmpPath = sprintf(
+            '%smanufacturer_mini_%s.jpg',
+            $this->tmpImageDir,
+            $command->getManufacturerId()->getValue()
+        );
+        if ($fs->exists($imgMiniTmpPath)) {
+            $fs->remove($imgMiniTmpPath);
+        }
+    }
+}

--- a/src/Adapter/Supplier/CommandHandler/DeleteSupplierLogoImageHandler.php
+++ b/src/Adapter/Supplier/CommandHandler/DeleteSupplierLogoImageHandler.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler;
+
+use ImageType;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierLogoImageCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler\DeleteSupplierLogoImageHandlerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Handles command which deletes supplier cover image using legacy object model
+ */
+class DeleteSupplierLogoImageHandler implements DeleteSupplierLogoImageHandlerInterface
+{
+    /**
+     * @var string
+     */
+    protected $imageDir;
+
+    /**
+     * @var string
+     */
+    protected $tmpImageDir;
+
+    public function __construct(string $imageDir, string $tmpImageDir)
+    {
+        $this->imageDir = $imageDir;
+        $this->tmpImageDir = $tmpImageDir;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(DeleteSupplierLogoImageCommand $command): void
+    {
+        $fs = new Filesystem();
+
+        $imageTypes = ImageType::getImagesTypes('suppliers');
+
+        foreach ($imageTypes as $imageType) {
+            $path = sprintf(
+                '%s%s-%s.jpg',
+                $this->imageDir,
+                $command->getSupplierId()->getValue(),
+                stripslashes($imageType['name'])
+            );
+            if ($fs->exists($path)) {
+                $fs->remove($path);
+            }
+        }
+
+        $imagePath = sprintf(
+            '%s%s.jpg',
+            $this->imageDir,
+            $command->getSupplierId()->getValue()
+        );
+        if ($fs->exists($imagePath)) {
+            $fs->remove($imagePath);
+        }
+
+        // Delete tmp image
+        $imgTmpPath = sprintf(
+            '%ssupplier_%s.jpg',
+            $this->tmpImageDir,
+            $command->getSupplierId()->getValue()
+        );
+        if ($fs->exists($imgTmpPath)) {
+            $fs->remove($imgTmpPath);
+        }
+
+        // Delete tmp image mini
+        $imgMiniTmpPath = sprintf(
+            '%ssupplier_mini_%s.jpg',
+            $this->tmpImageDir,
+            $command->getSupplierId()->getValue()
+        );
+        if ($fs->exists($imgMiniTmpPath)) {
+            $fs->remove($imgMiniTmpPath);
+        }
+    }
+}

--- a/src/Core/Domain/Manufacturer/Command/DeleteManufacturerLogoImageCommand.php
+++ b/src/Core/Domain/Manufacturer/Command/DeleteManufacturerLogoImageCommand.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,19 +22,40 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
-<figure class="figure">
-  <img src="{{ logoImage.path }}" class="figure-img img-fluid img-thumbnail">
-  <figcaption class="figure-caption">
-    <p>{{ 'File size'|trans({}, 'Admin.Advparameters.Feature') }} {{ logoImage.size }}</p>
-    <button class="btn btn-outline-danger btn-sm js-form-submit-btn"
-            data-form-submit-url="{{ path('admin_manufacturer_delete_logo_image', {'manufacturerId': app.request.get('manufacturerId')}) }}"
-            data-form-csrf-token="{{ csrf_token('delete-logo-thumbnail') }}"
-    >
-      <i class="material-icons">
-        delete_forever
-      </i>
-      {{ 'Delete'|trans({}, 'Admin.Actions') }}
-    </button>
-  </figcaption>
-</figure>
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
+
+/**
+ * Deletes manufacturer logo image
+ */
+class DeleteManufacturerLogoImageCommand
+{
+    /**
+     * @var ManufacturerId
+     */
+    private $manufacturerId;
+
+    /**
+     * @param int $manufacturerId
+     *
+     * @throws ManufacturerConstraintException
+     */
+    public function __construct(int $manufacturerId)
+    {
+        $this->manufacturerId = new ManufacturerId($manufacturerId);
+    }
+
+    /**
+     * @return ManufacturerId
+     */
+    public function getManufacturerId(): ManufacturerId
+    {
+        return $this->manufacturerId;
+    }
+}

--- a/src/Core/Domain/Manufacturer/CommandHandler/DeleteManufacturerLogoImageHandlerInterface.php
+++ b/src/Core/Domain/Manufacturer/CommandHandler/DeleteManufacturerLogoImageHandlerInterface.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,19 +22,19 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
-<figure class="figure">
-  <img src="{{ logoImage.path }}" class="figure-img img-fluid img-thumbnail">
-  <figcaption class="figure-caption">
-    <p>{{ 'File size'|trans({}, 'Admin.Advparameters.Feature') }} {{ logoImage.size }}</p>
-    <button class="btn btn-outline-danger btn-sm js-form-submit-btn"
-            data-form-submit-url="{{ path('admin_manufacturer_delete_logo_image', {'manufacturerId': app.request.get('manufacturerId')}) }}"
-            data-form-csrf-token="{{ csrf_token('delete-logo-thumbnail') }}"
-    >
-      <i class="material-icons">
-        delete_forever
-      </i>
-      {{ 'Delete'|trans({}, 'Admin.Actions') }}
-    </button>
-  </figcaption>
-</figure>
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Manufacturer\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerLogoImageCommand;
+
+/**
+ * Defines contract for DeleteManufacturerLogoImageHandler
+ */
+interface DeleteManufacturerLogoImageHandlerInterface
+{
+    /**
+     * @param DeleteManufacturerLogoImageCommand $command
+     */
+    public function handle(DeleteManufacturerLogoImageCommand $command): void;
+}

--- a/src/Core/Domain/Supplier/Command/DeleteSupplierLogoImageCommand.php
+++ b/src/Core/Domain/Supplier/Command/DeleteSupplierLogoImageCommand.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,19 +22,40 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
-<figure class="figure">
-  <img src="{{ logoImage.path }}" class="figure-img img-fluid img-thumbnail">
-  <figcaption class="figure-caption">
-    <p>{{ 'File size'|trans({}, 'Admin.Advparameters.Feature') }} {{ logoImage.size }}</p>
-    <button class="btn btn-outline-danger btn-sm js-form-submit-btn"
-            data-form-submit-url="{{ path('admin_manufacturers_delete_logo_image', {'manufacturerId': app.request.get('manufacturerId')}) }}"
-            data-form-csrf-token="{{ csrf_token('delete-logo-thumbnail') }}"
-    >
-      <i class="material-icons">
-        delete_forever
-      </i>
-      {{ 'Delete'|trans({}, 'Admin.Actions') }}
-    </button>
-  </figcaption>
-</figure>
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
+
+/**
+ * Deletes supplier logo image
+ */
+class DeleteSupplierLogoImageCommand
+{
+    /**
+     * @var SupplierId
+     */
+    private $supplierId;
+
+    /**
+     * @param int $supplierId
+     *
+     * @throws SupplierException
+     */
+    public function __construct(int $supplierId)
+    {
+        $this->supplierId = new SupplierId($supplierId);
+    }
+
+    /**
+     * @return SupplierId
+     */
+    public function getSupplierId(): SupplierId
+    {
+        return $this->supplierId;
+    }
+}

--- a/src/Core/Domain/Supplier/CommandHandler/DeleteSupplierLogoImageHandlerInterface.php
+++ b/src/Core/Domain/Supplier/CommandHandler/DeleteSupplierLogoImageHandlerInterface.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,19 +22,19 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
-<figure class="figure">
-  <img src="{{ logoImage.path }}" class="figure-img img-fluid img-thumbnail">
-  <figcaption class="figure-caption">
-    <p>{{ 'File size'|trans({}, 'Admin.Advparameters.Feature') }} {{ logoImage.size }}</p>
-    <button class="btn btn-outline-danger btn-sm js-form-submit-btn"
-            data-form-submit-url="{{ path('admin_manufacturers_delete_logo_image', {'manufacturerId': app.request.get('manufacturerId')}) }}"
-            data-form-csrf-token="{{ csrf_token('delete-logo-thumbnail') }}"
-    >
-      <i class="material-icons">
-        delete_forever
-      </i>
-      {{ 'Delete'|trans({}, 'Admin.Actions') }}
-    </button>
-  </figcaption>
-</figure>
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Supplier\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierLogoImageCommand;
+
+/**
+ * Defines contract for DeleteSupplierLogoImageHandler
+ */
+interface DeleteSupplierLogoImageHandlerInterface
+{
+    /**
+     * @param DeleteSupplierLogoImageCommand $command
+     */
+    public function handle(DeleteSupplierLogoImageCommand $command): void;
+}

--- a/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/ManufacturerFormDataHandler.php
@@ -101,7 +101,6 @@ final class ManufacturerFormDataHandler implements FormDataHandlerInterface
     {
         /** @var UploadedFile $uploadedLogo */
         $uploadedLogo = $data['logo'];
-        $logo = null;
 
         if ($uploadedLogo instanceof UploadedFile) {
             $this->imageUploader->upload($manufacturerId, $uploadedLogo);

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\BulkDeleteManufacturerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\BulkToggleManufacturerStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerLogoImageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\ToggleManufacturerStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\DeleteManufacturerException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerConstraintException;
@@ -68,6 +69,7 @@ use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Manages "Sell > Catalog > Brands & Suppliers > Brands" page
@@ -420,6 +422,46 @@ class ManufacturerController extends FrameworkBundleAdminController
     }
 
     /**
+     * Deletes manufacturer logo image.
+     *
+     * @AdminSecurity(
+     *     "is_granted(['update'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to edit this.",
+     *     redirectRoute="admin_manufacturers_edit",
+     *     redirectQueryParamsToKeep={"manufacturerId"}
+     * )
+     *
+     * @param Request $request
+     * @param int $manufacturerId
+     *
+     * @return RedirectResponse
+     */
+    public function deleteLogoImageAction(Request $request, int $manufacturerId): RedirectResponse
+    {
+        if (!$this->isCsrfTokenValid('delete-logo-thumbnail', $request->request->get('_csrf_token'))) {
+            return $this->redirectToRoute('admin_security_compromised', [
+                'uri' => $this->generateUrl('admin_manufacturers_edit', [
+                    'manufacturerId' => $manufacturerId,
+                ], UrlGeneratorInterface::ABSOLUTE_URL),
+            ]);
+        }
+
+        try {
+            $this->getCommandBus()->handle(new DeleteManufacturerLogoImageCommand($manufacturerId));
+            $this->addFlash(
+                'success',
+                $this->trans('The image was successfully deleted', 'Admin.Notifications.Success')
+            );
+        } catch (ManufacturerException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }
+
+        return $this->redirectToRoute('admin_manufacturers_edit', [
+            'manufacturerId' => $manufacturerId,
+        ]);
+    }
+
+    /**
      * Deletes address
      *
      * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
@@ -620,7 +662,7 @@ class ManufacturerController extends FrameworkBundleAdminController
      *
      * @return array
      */
-    private function getErrorMessages()
+    private function getErrorMessages(): array
     {
         $iniConfig = $this->get('prestashop.core.configuration.ini_configuration');
 
@@ -697,9 +739,9 @@ class ManufacturerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @return array
+     * @return array<int, int>
      */
-    private function getBulkManufacturersFromRequest(Request $request)
+    private function getBulkManufacturersFromRequest(Request $request): array
     {
         $manufacturerIds = $request->request->get('manufacturer_bulk');
 
@@ -715,9 +757,9 @@ class ManufacturerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @return array
+     * @return array<int, int>
      */
-    private function getBulkAddressesFromRequest(Request $request)
+    private function getBulkAddressesFromRequest(Request $request): array
     {
         $addressIds = $request->request->get('manufacturer_address_bulk');
 
@@ -735,7 +777,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * @return FormHandlerInterface
      */
-    private function getFormHandler()
+    private function getFormHandler(): FormHandlerInterface
     {
         return $this->get('prestashop.core.form.identifiable_object.handler.manufacturer_form_handler');
     }
@@ -743,7 +785,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * @return FormBuilderInterface
      */
-    private function getFormBuilder()
+    private function getFormBuilder(): FormBuilderInterface
     {
         return $this->get('prestashop.core.form.identifiable_object.builder.manufacturer_form_builder');
     }
@@ -751,7 +793,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * @return FormBuilderInterface
      */
-    private function getAddressFormBuilder()
+    private function getAddressFormBuilder(): FormBuilderInterface
     {
         return $this->get('prestashop.core.form.identifiable_object.builder.manufacturer_address_form_builder');
     }
@@ -759,12 +801,15 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * @return FormHandlerInterface
      */
-    private function getAddressFormHandler()
+    private function getAddressFormHandler(): FormHandlerInterface
     {
         return $this->get('prestashop.core.form.identifiable_object.handler.manufacturer_address_form_handler');
     }
 
-    private function getSettingsTipMessage()
+    /**
+     * @return string
+     */
+    private function getSettingsTipMessage(): string
     {
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences'));
         $urlEnding = '</a>';

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -450,7 +450,7 @@ class ManufacturerController extends FrameworkBundleAdminController
             $this->getCommandBus()->handle(new DeleteManufacturerLogoImageCommand($manufacturerId));
             $this->addFlash(
                 'success',
-                $this->trans('The image was successfully deleted', 'Admin.Notifications.Success')
+                $this->trans('The image was successfully deleted.', 'Admin.Notifications.Success')
             );
         } catch (ManufacturerException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -425,7 +425,7 @@ class ManufacturerController extends FrameworkBundleAdminController
      * Deletes manufacturer logo image.
      *
      * @AdminSecurity(
-     *     "is_granted(['update'], request.get('_legacy_controller'))",
+     *     "is_granted('update', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_manufacturers_edit",
      *     redirectQueryParamsToKeep={"manufacturerId"}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -445,7 +445,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Deletes supplier logo image.
      *
      * @AdminSecurity(
-     *     "is_granted(['update'], request.get('_legacy_controller'))",
+     *     "is_granted('update', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_suppliers_edit",
      *     redirectQueryParamsToKeep={"supplierId"}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -32,11 +32,13 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDeleteSupplierCommand
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkDisableSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\BulkEnableSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierLogoImageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\ToggleSupplierStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotDeleteSupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotToggleSupplierStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\CannotUpdateSupplierStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Query\GetSupplierForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Query\GetSupplierForViewing;
@@ -56,6 +58,7 @@ use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Class SupplierController is responsible for "Sell > Catalog > Brands & Suppliers > Suppliers" page.
@@ -439,11 +442,51 @@ class SupplierController extends FrameworkBundleAdminController
     }
 
     /**
+     * Deletes supplier logo image.
+     *
+     * @AdminSecurity(
+     *     "is_granted(['update'], request.get('_legacy_controller'))",
+     *     message="You do not have permission to edit this.",
+     *     redirectRoute="admin_suppliers_edit",
+     *     redirectQueryParamsToKeep={"supplierId"}
+     * )
+     *
+     * @param Request $request
+     * @param int $supplierId
+     *
+     * @return RedirectResponse
+     */
+    public function deleteLogoImageAction(Request $request, int $supplierId): RedirectResponse
+    {
+        if (!$this->isCsrfTokenValid('delete-logo-thumbnail', $request->request->get('_csrf_token'))) {
+            return $this->redirectToRoute('admin_security_compromised', [
+                'uri' => $this->generateUrl('admin_suppliers_edit', [
+                    'supplierId' => $supplierId,
+                ], UrlGeneratorInterface::ABSOLUTE_URL),
+            ]);
+        }
+
+        try {
+            $this->getCommandBus()->handle(new DeleteSupplierLogoImageCommand($supplierId));
+            $this->addFlash(
+                'success',
+                $this->trans('The image was successfully deleted', 'Admin.Notifications.Success')
+            );
+        } catch (SupplierException $e) {
+            $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));
+        }
+
+        return $this->redirectToRoute('admin_suppliers_edit', [
+            'supplierId' => $supplierId,
+        ]);
+    }
+
+    /**
      * Provides error messages for exceptions
      *
      * @return array
      */
-    private function getErrorMessages()
+    private function getErrorMessages(): array
     {
         $iniConfig = $this->get('prestashop.core.configuration.ini_configuration');
 
@@ -512,7 +555,7 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * @return FormBuilderInterface
      */
-    private function getFormBuilder()
+    private function getFormBuilder(): FormBuilderInterface
     {
         return $this->get('prestashop.core.form.identifiable_object.builder.supplier_form_builder');
     }
@@ -520,11 +563,14 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * @return FormHandlerInterface
      */
-    private function getFormHandler()
+    private function getFormHandler(): FormHandlerInterface
     {
         return $this->get('prestashop.core.form.identifiable_object.handler.supplier_form_handler');
     }
 
+    /**
+     * @return string
+     */
     protected function getSettingsTipMessage()
     {
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences'));

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -470,7 +470,7 @@ class SupplierController extends FrameworkBundleAdminController
             $this->getCommandBus()->handle(new DeleteSupplierLogoImageCommand($supplierId));
             $this->addFlash(
                 'success',
-                $this->trans('The image was successfully deleted', 'Admin.Notifications.Success')
+                $this->trans('The image was successfully deleted.', 'Admin.Notifications.Success')
             );
         } catch (SupplierException $e) {
             $this->addFlash('error', $this->getErrorMessageForException($e, $this->getErrorMessages()));

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
@@ -107,7 +107,7 @@ admin_manufacturers_export:
 
 admin_manufacturers_delete_logo_image:
   path: /{manufacturerId}/delete-logo-image
-  methods: [GET, POST]
+  methods: [ GET, POST ]
   defaults:
     _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Manufacturer:deleteLogoImage'
     _legacy_controller: AdminManufacturers

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
@@ -105,7 +105,7 @@ admin_manufacturers_export:
     _legacy_controller: AdminManufacturers
     _legacy_link: AdminManufacturers:exportmanufacturer
 
-admin_manufacturer_delete_logo_image:
+admin_manufacturers_delete_logo_image:
   path: /{manufacturerId}/delete-logo-image
   methods: [GET, POST]
   defaults:

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/manufacturer.yml
@@ -105,6 +105,18 @@ admin_manufacturers_export:
     _legacy_controller: AdminManufacturers
     _legacy_link: AdminManufacturers:exportmanufacturer
 
+admin_manufacturer_delete_logo_image:
+  path: /{manufacturerId}/delete-logo-image
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle:Admin/Sell/Catalog/Manufacturer:deleteLogoImage'
+    _legacy_controller: AdminManufacturers
+    _legacy_link: AdminManufacturers:deleteImage
+    _legacy_parameters:
+      id_manufacturer: manufacturerId
+  requirements:
+    manufacturerId: \d+
+
 #
 # Address routes
 #

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -103,3 +103,15 @@ admin_suppliers_export:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\SupplierController::exportAction'
     _legacy_controller: AdminSuppliers
     _legacy_link: AdminSuppliers:exportsupplier
+
+admin_suppliers_delete_logo_image:
+  path: /{supplierId}/delete-logo-image
+  methods: [GET, POST]
+  defaults:
+    _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\SupplierController::deleteLogoImageAction'
+    _legacy_controller: AdminSuppliers
+    _legacy_link: AdminSuppliers:deleteImage
+    _legacy_parameters:
+      id_supplier: supplierId
+  requirements:
+    supplierId: \d+

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/suppliers.yml
@@ -106,7 +106,7 @@ admin_suppliers_export:
 
 admin_suppliers_delete_logo_image:
   path: /{supplierId}/delete-logo-image
-  methods: [GET, POST]
+  methods: [ GET, POST ]
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\SupplierController::deleteLogoImageAction'
     _legacy_controller: AdminSuppliers

--- a/src/PrestaShopBundle/Resources/config/services/adapter/manufacturer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/manufacturer.yml
@@ -24,6 +24,15 @@ services:
     tags:
       - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerCommand' }
 
+  prestashop.adapter.manufacturer.command_handler.delete_manufacturer_logo_image_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\Manufacturer\CommandHandler\DeleteManufacturerLogoImageHandler'
+    arguments:
+      - !php/const _PS_MANU_IMG_DIR_
+      - !php/const _PS_TMP_IMG_DIR_
+    tags:
+      - name: tactician.handler
+        command: 'PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerLogoImageCommand'
+
   prestashop.adapter.manufacturer.command_handler.bulk_delete_manufacturer_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Manufacturer\CommandHandler\BulkDeleteManufacturerHandler'
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/supplier.yml
@@ -40,6 +40,15 @@ services:
         command: 'PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand'
     public: true
 
+  prestashop.adapter.supplier.command_handler.delete_supplier_logo_image_handler:
+    class: 'PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\DeleteSupplierLogoImageHandler'
+    arguments:
+      - !php/const _PS_SUPP_IMG_DIR_
+      - !php/const _PS_TMP_IMG_DIR_
+    tags:
+      - name: tactician.handler
+        command: 'PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierLogoImageCommand'
+
   prestashop.adapter.supplier.command_handler.bulk_delete_supplier_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Supplier\CommandHandler\BulkDeleteSupplierHandler'
     parent: 'prestashop.adapter.supplier.command_handler.abstract_delete_supplier_handler'

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig
@@ -42,6 +42,7 @@
           <label for="" class="form-control-label"></label>
           <div class="col-sm">
             {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/logo_image.html.twig' %}
+            {{ form_widget(manufacturerForm.logo) }}
           </div>
         </div>
       {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Manufacturer/Blocks/form.html.twig
@@ -42,7 +42,6 @@
           <label for="" class="form-control-label"></label>
           <div class="col-sm">
             {% include '@PrestaShop/Admin/Sell/Catalog/Manufacturer/logo_image.html.twig' %}
-            {{ form_widget(manufacturerForm.logo) }}
           </div>
         </div>
       {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/logo_image.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Suppliers/logo_image.html.twig
@@ -24,5 +24,16 @@
  *#}
 <figure class="figure">
   <img src="{{ logoImage.path }}" class="figure-img img-fluid img-thumbnail">
-  <figcaption class="figure-caption">{{ 'File size'|trans({}, 'Admin.Advparameters.Feature') }} {{ logoImage.size }}</figcaption>
+  <figcaption class="figure-caption">
+    <p>{{ 'File size'|trans({}, 'Admin.Advparameters.Feature') }} {{ logoImage.size }}</p>
+    <button class="btn btn-outline-danger btn-sm js-form-submit-btn"
+            data-form-submit-url="{{ path('admin_suppliers_delete_logo_image', {'supplierId': app.request.get('supplierId')}) }}"
+            data-form-csrf-token="{{ csrf_token('delete-logo-thumbnail') }}"
+    >
+      <i class="material-icons">
+        delete_forever
+      </i>
+      {{ 'Delete'|trans({}, 'Admin.Actions') }}
+    </button>
+  </figcaption>
 </figure>

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -61,6 +61,12 @@ abstract class AbstractDomainFeatureContext implements Context
      */
     private const EXPECTED_EXCEPTION_STEP_STORAGE_KEY = 'EXPECTED_EXCEPTION_STEP';
 
+    protected const JPG_IMAGE_TYPE = '.jpg';
+    protected const JPG_IMAGE_STRING = 'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl'
+    . 'BMVEUAAAD///+l2Z/dAAAASUlEQVR4XqWQUQoAIAxC2/0vXZDr'
+    . 'EX4IJTRkb7lobNUStXsB0jIXIAMSsQnWlsV+wULF4Avk9fLq2r'
+    . '8a5HSE35Q3eO2XP1A1wQkZSgETvDtKdQAAAABJRU5ErkJggg==';
+
     /**
      * @BeforeSuite
      *
@@ -425,5 +431,29 @@ abstract class AbstractDomainFeatureContext implements Context
         }
 
         return $parsedRow;
+    }
+
+    /**
+     * @param string $dirImage
+     * @param string $imageName
+     * @param int $objectId
+     *
+     * @return string
+     */
+    protected function pretendImageUploaded(string $dirImage, string $imageName, int $objectId): string
+    {
+        //@todo: refactor CategoryCoverUploader. Move uploaded file in Form handler instead of Uploader and use the uploader here in tests
+        $im = imagecreatefromstring(base64_decode(self::JPG_IMAGE_STRING));
+        if ($im !== false) {
+            header('Content-Type: image/jpg');
+            imagejpeg(
+                $im,
+                $dirImage . $objectId . self::JPG_IMAGE_TYPE,
+                0
+            );
+            imagedestroy($im);
+        }
+
+        return $imageName;
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -61,12 +61,7 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
 {
     public const EMPTY_VALUE = '';
     public const DEFAULT_ROOT_CATEGORY_ID = 1;
-    public const JPG_IMAGE_TYPE = '.jpg';
     public const THUMB0 = '0_thumb';
-    public const JPG_IMAGE_STRING = 'iVBORw0KGgoAAAANSUhEUgAAABwAAAASCAMAAAB/2U7WAAAABl'
-        . 'BMVEUAAAD///+l2Z/dAAAASUlEQVR4XqWQUQoAIAxC2/0vXZDr'
-        . 'EX4IJTRkb7lobNUStXsB0jIXIAMSsQnWlsV+wULF4Avk9fLq2r'
-        . '8a5HSE35Q3eO2XP1A1wQkZSgETvDtKdQAAAABJRU5ErkJggg==';
 
     public const CATEGORY_POSITION_WAYS_MAP = [
         0 => 'Up',
@@ -665,7 +660,11 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
             $linkRewrite = [$this->defaultLanguageId => $testCaseData['Friendly URL']];
         }
         if (isset($testCaseData['Category cover image'])) {
-            $coverImage = $this->pretendImageUploaded($testCaseData, $categoryId);
+            $coverImage = $this->pretendImageUploaded(
+                $this->psCatImgDir,
+                $testCaseData['Category cover image'],
+                $categoryId
+            );
         }
         $menuThumbNailsImages = [];
         if (isset($testCaseData['Menu thumbnails'])) {
@@ -718,31 +717,6 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
         }
 
         return $parentCategoryId;
-    }
-
-    /**
-     * @param array $testCaseData
-     * @param int $categoryId
-     *
-     * @return string
-     */
-    private function pretendImageUploaded(array $testCaseData, int $categoryId): string
-    {
-        //@todo: refactor CategoryCoverUploader. Move uploaded file in Form handler instead of Uploader and use the uploader here in tests
-        $categoryCoverImageName = $testCaseData['Category cover image'];
-        $data = base64_decode(self::JPG_IMAGE_STRING);
-        $im = imagecreatefromstring($data);
-        if ($im !== false) {
-            header('Content-Type: image/jpg');
-            imagejpeg(
-                $im,
-                $this->psCatImgDir . $categoryId . self::JPG_IMAGE_TYPE,
-                0
-            );
-            imagedestroy($im);
-        }
-
-        return $categoryCoverImageName;
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/ManufacturerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ManufacturerFeatureContext.php
@@ -408,6 +408,7 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
 
     /**
      * @param int $manufacturerId
+     *
      * @return EditableManufacturer
      */
     private function getEditableManufacturer(int $manufacturerId): EditableManufacturer

--- a/tests/Integration/Behaviour/Features/Context/Domain/ManufacturerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ManufacturerFeatureContext.php
@@ -36,11 +36,13 @@ use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\AddManufacturerComman
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\BulkDeleteManufacturerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\BulkToggleManufacturerStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerLogoImageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\EditManufacturerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\ToggleManufacturerStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Query\GetManufacturerForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Query\GetManufacturerForViewing;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\QueryResult\EditableManufacturer;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\QueryResult\ViewableManufacturer;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use RuntimeException;
@@ -126,6 +128,9 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
         }
         if (isset($data['meta_keywords'])) {
             [$this->defaultLangId => $command->setLocalizedMetaKeywords($data['meta_keywords'])];
+        }
+        if (isset($data['logo image'])) {
+            $this->pretendImageUploaded(_PS_MANU_IMG_DIR_, $data['logo image'], $manufacturerId);
         }
 
         $this->getCommandBus()->handle($command);
@@ -279,8 +284,7 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
         $manufacturer = SharedStorage::getStorage()->get($manufacturerReference);
 
         try {
-            $query = new GetManufacturerForEditing((int) $manufacturer->id);
-            $this->getQueryBus()->handle($query);
+            $this->getEditableManufacturer((int) $manufacturer->id);
 
             throw new NoExceptionAlthoughExpectedException(sprintf('Manufacturer %s exists, but it was expected to be deleted', $manufacturerReference));
         } catch (ManufacturerNotFoundException $e) {
@@ -311,6 +315,45 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
         }
 
         throw new RuntimeException(sprintf('Manufacturer %s named "%s" does not exist', $manufacturerReference, $name));
+    }
+
+    /**
+     * @When I delete the manufacturer :manufacturerReference logo image
+     *
+     * @param string $manufacturerReference
+     */
+    public function deleteCategoryLogoImage(string $manufacturerReference): void
+    {
+        $manufacturer = SharedStorage::getStorage()->get($manufacturerReference);
+
+        $this->getCommandBus()->handle(new DeleteManufacturerLogoImageCommand((int) $manufacturer->id));
+    }
+
+    /**
+     * @Given the manufacturer :manufacturerReference has logo image
+     *
+     * @param string $manufacturerReference
+     */
+    public function assertManufacturerHasLogoImage(string $manufacturerReference): void
+    {
+        $manufacturer = SharedStorage::getStorage()->get($manufacturerReference);
+
+        $editableManufacturer = $this->getEditableManufacturer((int) $manufacturer->id);
+
+        Assert::assertNotNull($editableManufacturer->getLogoImage());
+    }
+
+    /**
+     * @Then the manufacturer :manufacturerReference does not have logo image
+     *
+     * @param string $manufacturerReference
+     */
+    public function assertManufacturerHasNotLogoImage(string $manufacturerReference)
+    {
+        $manufacturer = SharedStorage::getStorage()->get($manufacturerReference);
+
+        $editableManufacturer = $this->getEditableManufacturer((int) $manufacturer->id);
+        Assert::assertNull($editableManufacturer->getLogoImage());
     }
 
     /**
@@ -361,5 +404,14 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
         Assert::assertSame($manufacturer->name, $viewableMaufacturer->getName());
         Assert::assertSame($countOfAddresses, count($viewableMaufacturer->getManufacturerAddresses()));
         Assert::assertSame($countOfProducts, count($viewableMaufacturer->getManufacturerProducts()));
+    }
+
+    /**
+     * @param int $manufacturerId
+     * @return EditableManufacturer
+     */
+    private function getEditableManufacturer(int $manufacturerId): EditableManufacturer
+    {
+        return $this->getQueryBus()->handle(new GetManufacturerForEditing($manufacturerId));
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/ManufacturerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ManufacturerFeatureContext.php
@@ -330,7 +330,7 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Given the manufacturer :manufacturerReference has logo image
+     * @Given the manufacturer :manufacturerReference has a logo image
      *
      * @param string $manufacturerReference
      */
@@ -344,7 +344,7 @@ class ManufacturerFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then the manufacturer :manufacturerReference does not have logo image
+     * @Then the manufacturer :manufacturerReference does not have a logo image
      *
      * @param string $manufacturerReference
      */

--- a/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
@@ -43,22 +43,10 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\QueryResult\ViewableSupplier;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 use RuntimeException;
 use State;
-use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class SupplierFeatureContext extends AbstractDomainFeatureContext
 {
-    /**
-     * @var int default lang id from configs
-     */
-    private $defaultLangId;
-
-    public function __construct()
-    {
-        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
-        $this->defaultLangId = (int) $configuration->get('PS_LANG_DEFAULT');
-    }
-
     /**
      * @Then /^supplier "(.+)" should have following details for product "(.+)":$/
      *

--- a/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
@@ -32,6 +32,8 @@ use Country;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\AddSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\DeleteSupplierLogoImageCommand;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\EditSupplierCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Command\ToggleSupplierStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierException;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\Query\GetSupplierForEditing;
@@ -41,10 +43,22 @@ use PrestaShop\PrestaShop\Core\Domain\Supplier\QueryResult\ViewableSupplier;
 use PrestaShop\PrestaShop\Core\Domain\Supplier\ValueObject\SupplierId;
 use RuntimeException;
 use State;
+use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class SupplierFeatureContext extends AbstractDomainFeatureContext
 {
+    /**
+     * @var int default lang id from configs
+     */
+    private $defaultLangId;
+
+    public function __construct()
+    {
+        $configuration = CommonFeatureContext::getContainer()->get('prestashop.adapter.legacy.configuration');
+        $this->defaultLangId = (int) $configuration->get('PS_LANG_DEFAULT');
+    }
+
     /**
      * @Then /^supplier "(.+)" should have following details for product "(.+)":$/
      *
@@ -122,6 +136,100 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @When I edit supplier :supplierReference with following properties:
+     *
+     * @param string $supplierReference
+     * @param TableNode $table
+     */
+    public function editSupplier(string $supplierReference, TableNode $table)
+    {
+        $supplierId = (int) $this->getSharedStorage()->get($supplierReference);
+        $data = $this->localizeByRows($table);
+
+        $editCommand = new EditSupplierCommand($supplierId);
+        if (isset($data['name'])) {
+            $editCommand->setName($data['name']);
+        }
+        if (isset($data['address'])) {
+            $editCommand->setAddress($data['address']);
+        }
+        if (isset($data['address2'])) {
+            $editCommand->setAddress2($data['address2']);
+        }
+        if (isset($data['post code'])) {
+            $editCommand->setPostCode($data['post code']);
+        }
+        if (isset($data['city'])) {
+            $editCommand->setCity($data['city']);
+        }
+        if (isset($data['state'])) {
+            $editCommand->setStateId((int) State::getIdByName($data['state']));
+        }
+        if (isset($data['country'])) {
+            $editCommand->setCountryId($this->getCountryIdByName($data['country']));
+        }
+        if (isset($data['dni'])) {
+            $editCommand->setDni($data['dni']);
+        }
+        if (isset($data['phone'])) {
+            $editCommand->setPhone($data['phone']);
+        }
+        if (isset($data['mobile phone'])) {
+            $editCommand->setMobilePhone($data['mobile phone']);
+        }
+        if (isset($data['enabled'])) {
+            $editCommand->setEnabled(PrimitiveUtils::castStringBooleanIntoBoolean($data['enabled']));
+        }
+        if (isset($data['description'])) {
+            $editCommand->setLocalizedDescriptions($data['description']);
+        }
+        if (isset($data['meta title'])) {
+            $editCommand->setLocalizedMetaTitles($data['meta title']);
+        }
+        if (isset($data['meta description'])) {
+            $editCommand->setLocalizedMetaDescriptions($data['meta description']);
+        }
+        if (isset($data['meta keywords'])) {
+            $editCommand->setLocalizedMetaKeywords($data['meta keywords']);
+        }
+        if (isset($data['shops'])) {
+            $editCommand->setAssociatedShops($this->getShopIdsByReferences($data['shops']));
+        }
+
+        try {
+            $this->getCommandBus()->handle($editCommand);
+        } catch (SupplierException $e) {
+            $this->setLastException($e);
+        }
+
+        if (isset($data['logo image'])) {
+            $this->pretendImageUploaded(_PS_SUPP_IMG_DIR_, $data['logo image'], $supplierId);
+        }
+    }
+
+    /**
+     * @Given the supplier :supplierReference has logo image
+     *
+     * @param string $supplierReference
+     */
+    public function assertManufacturerHasLogoImage(string $supplierReference): void
+    {
+        $editableSupplier = $this->getEditableSupplier($supplierReference);
+        Assert::assertNotNull($editableSupplier->getLogoImage());
+    }
+
+    /**
+     * @Then the supplier :supplierReference does not have logo image
+     *
+     * @param string $supplierReference
+     */
+    public function assertManufacturerHasNotLogoImage(string $supplierReference)
+    {
+        $editableSupplier = $this->getEditableSupplier($supplierReference);
+        Assert::assertNull($editableSupplier->getLogoImage());
+    }
+
+    /**
      * @When I toggle status for supplier :supplierReference
      *
      * @param string $supplierReference
@@ -143,6 +251,18 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
     public function deleteSupplier(string $supplierReference): void
     {
         $this->getCommandBus()->handle(new DeleteSupplierCommand($this->getSharedStorage()->get($supplierReference)));
+    }
+
+    /**
+     * @When I delete the supplier :supplierReference logo image
+     *
+     * @param string $supplierReference
+     */
+    public function deleteCategoryLogoImage(string $supplierReference): void
+    {
+        $supplierId = (int) $this->getSharedStorage()->get($supplierReference);
+
+        $this->getCommandBus()->handle(new DeleteSupplierLogoImageCommand($supplierId));
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/SupplierFeatureContext.php
@@ -88,7 +88,7 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @When I add new supplier :supplierReference with following properties:
+     * @When I add new supplier :supplierReference with the following properties:
      *
      * @param string $supplierReference
      * @param TableNode $table
@@ -124,7 +124,7 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @When I edit supplier :supplierReference with following properties:
+     * @When I edit supplier :supplierReference with the following properties:
      *
      * @param string $supplierReference
      * @param TableNode $table
@@ -196,7 +196,7 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Given the supplier :supplierReference has logo image
+     * @Given the supplier :supplierReference has a logo image
      *
      * @param string $supplierReference
      */
@@ -207,7 +207,7 @@ class SupplierFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
-     * @Then the supplier :supplierReference does not have logo image
+     * @Then the supplier :supplierReference does not have a logo image
      *
      * @param string $supplierReference
      */

--- a/tests/Integration/Behaviour/Features/Scenario/Manufacturer/manufacturer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Manufacturer/manufacturer_management.feature
@@ -46,9 +46,9 @@ Feature: Manufacturer management
       | meta_description | You'd better walk bare foot  |
       | enabled          | false                        |
       | logo image      | logo.jpg                     |
-    And the manufacturer "shoeman" has logo image
+    And the manufacturer "shoeman" has a logo image
     When I delete the manufacturer "shoeman" logo image
-    Then the manufacturer "shoeman" does not have logo image
+    Then the manufacturer "shoeman" does not have a logo image
 
   Scenario: Enable and disable manufacturer status
     Given manufacturer "shoeman" is disabled

--- a/tests/Integration/Behaviour/Features/Scenario/Manufacturer/manufacturer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Manufacturer/manufacturer_management.feature
@@ -37,6 +37,19 @@ Feature: Manufacturer management
     And manufacturer "shoeman" "meta_keywords" in default language should be "Boots, shoes, slippers"
     And manufacturer "shoeman" should be disabled
 
+  Scenario: Delete manufacturer cover image
+    Given I edit manufacturer "shoeman" with following properties:
+      | name             | worst-shoes                  |
+      | short_description| Worst slippers in EU         |
+      | meta_title       | Worst quality shoes          |
+      | description      |                              |
+      | meta_description | You'd better walk bare foot  |
+      | enabled          | false                        |
+      | logo image      | logo.jpg                     |
+    And the manufacturer "shoeman" has logo image
+    When I delete the manufacturer "shoeman" logo image
+    Then the manufacturer "shoeman" does not have logo image
+
   Scenario: Enable and disable manufacturer status
     Given manufacturer "shoeman" is disabled
     When I enable manufacturer "shoeman"

--- a/tests/Integration/Behaviour/Features/Scenario/Manufacturer/manufacturer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Manufacturer/manufacturer_management.feature
@@ -37,7 +37,7 @@ Feature: Manufacturer management
     And manufacturer "shoeman" "meta_keywords" in default language should be "Boots, shoes, slippers"
     And manufacturer "shoeman" should be disabled
 
-  Scenario: Delete manufacturer cover image
+  Scenario: Delete manufacturer logo image
     Given I edit manufacturer "shoeman" with following properties:
       | name             | worst-shoes                  |
       | short_description| Worst slippers in EU         |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_suppliers.feature
@@ -25,7 +25,7 @@ Feature: Update product combination suppliers in Back Office (BO)
     And attribute "Red" named "Red" in en language exists
 
   Scenario: I update combination suppliers:
-    Given I add new supplier supplier1 with following properties:
+    Given I add new supplier supplier1 with the following properties:
       | name                    | my supplier 1      |
       | address                 | Donelaicio st. 1   |
       | city                    | Kaunas             |
@@ -36,7 +36,7 @@ Feature: Update product combination suppliers in Back Office (BO)
       | meta description[en-US] |                    |
       | meta keywords[en-US]    | sup,1              |
       | shops                   | [shop1]            |
-    And I add new supplier supplier2 with following properties:
+    And I add new supplier supplier2 with the following properties:
       | name                    | my supplier 2      |
       | address                 | Donelaicio st. 2   |
       | city                    | Kaunas             |
@@ -47,7 +47,7 @@ Feature: Update product combination suppliers in Back Office (BO)
       | meta description[en-US] |                    |
       | meta keywords[en-US]    | sup,2              |
       | shops                   | [shop1]            |
-    And I add new supplier supplier3 with following properties:
+    And I add new supplier supplier3 with the following properties:
       | name                    | my supplier 3    |
       | address                 | Donelaicio st. 3 |
       | city                    | Kaunas           |
@@ -632,7 +632,7 @@ Feature: Update product combination suppliers in Back Office (BO)
 
   Scenario: I should be able to associate suppliers (and default supplier) even when no combinations has been created
     # We create new empty suppliers which have no other products
-    Given I add new supplier supplier4 with following properties:
+    Given I add new supplier supplier4 with the following properties:
       | name                    | my supplier 4       |
       | address                 | Donelaicio st. 4    |
       | city                    | Kaunas              |
@@ -643,7 +643,7 @@ Feature: Update product combination suppliers in Back Office (BO)
       | meta description[en-US] |                     |
       | meta keywords[en-US]    | sup,4               |
       | shops                   | [shop1]             |
-    And I add new supplier supplier5 with following properties:
+    And I add new supplier supplier5 with the following properties:
       | name                    | my supplier 5       |
       | address                 | Donelaicio st. 5    |
       | city                    | Kaunas              |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
@@ -21,7 +21,7 @@ Feature: Duplicate product from Back Office (BO).
     And language "language2" with locale "fr-FR" exists
     And carrier carrier1 named "ecoCarrier" exists
     And carrier carrier2 named "Fast carry" exists
-    And I add new supplier supplier1 with following properties:
+    And I add new supplier supplier1 with the following properties:
       | name                    | my supplier 1      |
       | address                 | Donelaicio st. 1   |
       | city                    | Kaunas             |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -85,7 +85,7 @@ Feature: Duplicate product from Back Office (BO).
     And I assign product product1 with following carriers:
       | carrier1 |
       | carrier2 |
-    And I add new supplier supplier1 with following properties:
+    And I add new supplier supplier1 with the following properties:
       | name                    | my supplier 1      |
       | address                 | Donelaicio st. 1   |
       | city                    | Kaunas             |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_suppliers.feature
@@ -15,7 +15,7 @@ Feature: Update product suppliers from Back Office (BO)
     And there is a currency named "currency3" with iso code "EUR" and exchange rate of 0.63
 
   Scenario: Update standard product suppliers
-    And I add new supplier supplier1 with following properties:
+    And I add new supplier supplier1 with the following properties:
       | name                    | my supplier 1      |
       | address                 | Donelaicio st. 1   |
       | city                    | Kaunas             |
@@ -26,7 +26,7 @@ Feature: Update product suppliers from Back Office (BO)
       | meta description[en-US] |                    |
       | meta keywords[en-US]    | sup,1              |
       | shops                   | [shop1]            |
-    And I add new supplier supplier2 with following properties:
+    And I add new supplier supplier2 with the following properties:
       | name                    | my supplier 2      |
       | address                 | Donelaicio st. 2   |
       | city                    | Kaunas             |
@@ -37,7 +37,7 @@ Feature: Update product suppliers from Back Office (BO)
       | meta description[en-US] |                    |
       | meta keywords[en-US]    | sup,2              |
       | shops                   | [shop1]            |
-    And I add new supplier supplier3 with following properties:
+    And I add new supplier supplier3 with the following properties:
       | name                    | my supplier 3    |
       | address                 | Donelaicio st. 3 |
       | city                    | Kaunas           |
@@ -405,7 +405,7 @@ Feature: Update product suppliers from Back Office (BO)
       | product6supplier2 | supplier2 | my second supplier for product6 | EUR      | 11                 |
 
     Scenario: I delete a supplier the default suppliers are updated for affected products
-      Given I add new supplier supplier3 with following properties:
+      Given I add new supplier supplier3 with the following properties:
         | name                    | my supplier 3        |
         | address                 | Donelaicio st. 3     |
         | city                    | Kaunas               |
@@ -416,7 +416,7 @@ Feature: Update product suppliers from Back Office (BO)
         | meta description[en-US] |                      |
         | meta keywords[en-US]    | sup,3                |
         | shops                   | [shop1]              |
-      And I add new supplier supplier4 with following properties:
+      And I add new supplier supplier4 with the following properties:
         | name                    | my supplier 4       |
         | address                 | Donelaicio st. 4    |
         | city                    | Kaunas              |
@@ -484,7 +484,7 @@ Feature: Update product suppliers from Back Office (BO)
         | default supplier reference | |
 
     Scenario: I disable a supplier associated to a product
-      Given I add new supplier supplier5 with following properties:
+      Given I add new supplier supplier5 with the following properties:
         | name                    | my supplier 5       |
         | address                 | Donelaicio st. 5    |
         | city                    | Kaunas              |

--- a/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
@@ -11,7 +11,7 @@ Feature: Supplier management
     And single shop context is loaded
 
   Scenario: Adding new supplier
-    When I add new supplier supplier1 with following properties:
+    When I add new supplier supplier1 with the following properties:
       | name                    | my supplier 1      |
       | address                 | Donelaicio st. 1   |
       | city                    | Kaunas             |
@@ -41,7 +41,7 @@ Feature: Supplier management
 #@todo: finish up create with optional params too, different cases + update and delete scenarios.
 
   Scenario: Delete manufacturer logo image
-    Given I edit supplier "supplier1" with following properties:
+    Given I edit supplier "supplier1" with the following properties:
       | name                    | my supplier 1      |
       | address                 | Donelaicio st. 1   |
       | city                    | Kaunas             |
@@ -57,9 +57,9 @@ Feature: Supplier management
       | meta keywords[fr-FR]    |                    |
       | shops                   | [shop1]            |
       | logo image              | logo.jpg           |
-    And the supplier "supplier1" has logo image
+    And the supplier "supplier1" has a logo image
     When I delete the supplier "supplier1" logo image
-    Then the supplier "supplier1" does not have logo image
+    Then the supplier "supplier1" does not have a logo image
 
   Scenario: Viewing supplier
     Given supplier "acc1" with name "Accessories supplier" exists

--- a/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Supplier/supplier_management.feature
@@ -40,6 +40,27 @@ Feature: Supplier management
       | shops                   | [shop1]            |
 #@todo: finish up create with optional params too, different cases + update and delete scenarios.
 
+  Scenario: Delete manufacturer logo image
+    Given I edit supplier "supplier1" with following properties:
+      | name                    | my supplier 1      |
+      | address                 | Donelaicio st. 1   |
+      | city                    | Kaunas             |
+      | country                 | Lithuania          |
+      | enabled                 | true               |
+      | description[en-US]      | just a supplier    |
+      | description[fr-FR]      | la supplier :D     |
+      | meta title[en-US]       | my supplier nr one |
+      | meta title[fr-FR]       |                    |
+      | meta description[en-US] |                    |
+      | meta description[fr-FR] |                    |
+      | meta keywords[en-US]    | sup,1              |
+      | meta keywords[fr-FR]    |                    |
+      | shops                   | [shop1]            |
+      | logo image              | logo.jpg           |
+    And the supplier "supplier1" has logo image
+    When I delete the supplier "supplier1" logo image
+    Then the supplier "supplier1" does not have logo image
+
   Scenario: Viewing supplier
     Given supplier "acc1" with name "Accessories supplier" exists
     Then supplier "acc1" should have 17 products associated


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a button to delete logo image on Manufacturer form
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #20857
| Related PRs       | N/A
| How to test?      | Add a manufacturer logo image on Edit form. You can now remove the logo image.<br />Add a supplier logo image on Edit form. You can now remove the logo image.

| Possible impacts? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
