### PR TITLE
Refacto frontend sitemap and add hook to modify it

### DIFF
--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -35,21 +35,63 @@ class SitemapControllerCore extends FrontController
      */
     public function initContent()
     {
+        $urls = [
+            'our_offers' => [
+                'name' => $this->trans('Our Offers', [], 'Shop.Theme.Global'),
+                'links' => $this->getOffersLinks(),
+            ],
+            'categories' => [
+                'name' => $this->trans('Categories', [], 'Shop.Theme.Catalog'),
+                'links' => $this->getCategoriesLinks(),
+            ],
+            'your_account' => [
+                'name' => $this->trans('Your account', [], 'Shop.Theme.Customeraccount'),
+                'links' => $this->getUserAccountLinks(),
+            ],
+            'pages' => [
+                'name' => $this->trans('Pages', [], 'Shop.Theme.Catalog'),
+                'links' => $this->getPagesLinks(),
+            ],
+        ];
+
+        /*
+         * Backward compatibility with older themes.
+         * Intentionally not modifiable by a hook, so somebody doesn't remove a group completely.
+         * (this would break the theme relying on the var on being there)
+         * This should be removed as soon as possible, because $pages variable is overwriting
+         * our global template variable assigned in FrontController.
+         */
         $this->context->smarty->assign(
             [
-                'our_offers' => $this->trans('Our Offers', [], 'Shop.Theme.Global'),
-                'categories' => $this->trans('Categories', [], 'Shop.Theme.Catalog'),
-                'your_account' => $this->trans('Your account', [], 'Shop.Theme.Customeraccount'),
-                'pages' => $this->trans('Pages', [], 'Shop.Theme.Catalog'),
+                'our_offers' => $urls['our_offers']['name'],
+                'categories' => $urls['categories']['name'],
+                'your_account' => $urls['your_account']['name'],
+                'pages' => $urls['pages']['name'],
                 'links' => [
-                    'offers' => $this->getOffersLinks(),
-                    'pages' => $this->getPagesLinks(),
-                    'user_account' => $this->getUserAccountLinks(),
-                    'categories' => $this->getCategoriesLinks(),
+                    'offers' => $urls['our_offers']['links'],
+                    'pages' => $urls['pages']['links'],
+                    'user_account' => $urls['your_account']['links'],
+                    'categories' => $urls['categories']['links'],
                 ],
             ]
         );
 
+        /*
+         * Allows modules to add own urls (even whole new groups) to frontend sitemap.
+         * For example landing pages, blog posts and others.
+         */
+        Hook::exec(
+            'actionModifyFrontendSitemap',
+            ['urls' => &$urls],
+            null,
+            false,
+            true,
+            false,
+            null,
+            true
+        );
+
+        $this->context->smarty->assign('urls', $urls);
         parent::initContent();
         $this->setTemplate('cms/sitemap');
     }

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4259,5 +4259,10 @@
       <title>Modify document reference</title>
       <description>This hook allows modules to return custom document references</description>
     </hook>
+    <hook id="actionModifyFrontendSitemap">
+      <name>actionModifyFrontendSitemap</name>
+      <title>Add or remove links on sitemap page</title>
+      <description>This hook allows to modify links on sitemap page of your shop. Useful to improve indexation of your modules.</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allows modules to add/modify/remove links on sitemap page. For example, when creating blog or landingpage module. It also fixes the issue of overriden variable `$page`.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | Resolves #29796, Resolves #10374
| Related PRs       | Autoupgrade PR - https://github.com/PrestaShop/autoupgrade/pull/527, https://github.com/PrestaShop/hummingbird/pull/464, https://github.com/PrestaShop/classic-theme/pull/110
| How to test?      | -
| Possible impacts? | Theme must be updated to use this new hook. Old URLS will be removed in 9.0
