### PR TITLE
Improve performance for massive products delete

### DIFF
--- a/src/Adapter/Product/AdminProductDataUpdater.php
+++ b/src/Adapter/Product/AdminProductDataUpdater.php
@@ -105,9 +105,10 @@ class AdminProductDataUpdater implements ProductInterface
             throw new \Exception('AdminProductDataUpdater->deleteProductIdList() should always receive at least one ID. Zero given.', 5005);
         }
 
-        $failedIdList = $productIdList; // Since we have just one call to delete all, cannot have distinctive fails.
+        Product::beginBulkDeletionMode();
         // Hooks: will trigger actionProductDelete multiple times
         $result = (new Product())->deleteSelection($productIdList);
+        $result &= Product::stopBulkDeletionMode();
 
         if ($result === 0) {
             throw new UpdateProductException('Cannot delete many requested products.', 5006);

--- a/src/Adapter/Product/CommandHandler/BulkDeleteProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/BulkDeleteProductHandler.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\BulkDeleteProductHa
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\BulkProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotBulkDeleteProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use Product;
 
 /**
  * Handles command which deletes addresses in bulk action
@@ -58,7 +59,9 @@ final class BulkDeleteProductHandler extends AbstractBulkHandler implements Bulk
      */
     public function handle(BulkDeleteProductCommand $command): void
     {
+        Product::beginBulkDeletionMode();
         $this->handleBulkAction($command->getProductIds());
+        Product::stopBulkDeletionMode();
     }
 
     protected function handleSingleAction(ProductId $productId, $command = null)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Improve masive products delete caused by recalcul of products position in categories each time a product is deleted.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19605 
| Related PRs       | 
| How to test?      | Call src/Adapter/Product/AdminProductDataUpdater::deleteProductIdList() with a huge list of products (> 100) with and without the improvment
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
