### PR TITLE
Fix cart product quantity retrieval when using customizations

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1384,7 +1384,6 @@ class CartCore extends ObjectModel
         }
         $commonWhere = '
             WHERE cp.`id_product_attribute` = ' . (int) $idProductAttribute . '
-            AND cp.`id_customization` = ' . (int) $idCustomization . '
             AND cp.`id_cart` = ' . (int) $this->id;
 
         if (Configuration::get('PS_ALLOW_MULTISHIPPING') && $this->isMultiAddressDelivery()) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `getProductQuantity` method was using customization id condition: it should not because customizations share the same stock. That led to being able to add customized products in cart even if there was not enough stock.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9974.
| Related PRs       | N/A.
| How to test?      | Set a product (which is set on "deny orders if out of stock") stock to 1, add a customized article in your cart, then add an other customized article in your cart. It is not allowed anymore.
| Possible impacts? | N/A.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
