### PR TITLE
Convert 1.7.9 to 8.0.0 in deprecation message

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1777,7 +1777,7 @@ services:
 
   form.type.sell.product.data_transformer.typeahead_redirection_target_transformer:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\DataTransformer\TypeaheadRedirectionTargetTransformer'
-    deprecated: 'The "%service_id%" service is deprecated since 1.7.9 and will be removed in next major.'
+    deprecated: 'The "%service_id%" service is deprecated since 8.0.0 and will be removed in next major.'
     public: true
 
   form.type.sell.product.data_transformer.redirection_target_transformer:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When PR https://github.com/PrestaShop/PrestaShop/pull/24878 was merged we thought we were going to release PS 1.7.9 . History changed and instead this work became 8.0.0. This PR fixes the deprecation message.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | Only a deprecation message is modified, no behavior is changed.
| Possible impacts? | Only a deprecation message is modified, no behavior is changed.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
