### PR TITLE
Fix product availability check when using customizations

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1351,7 +1351,7 @@ class CartCore extends ObjectModel
      *
      * @param int $idProduct Product ID
      * @param int $idProductAttribute ProductAttribute ID
-     * @param int $idCustomization Customization ID
+     * @param int|null $idCustomization Customization ID
      * @param int $idAddressDelivery Delivery Address ID
      *
      * @return array quantity index     : number of product in cart without counting those of pack in cart
@@ -1383,8 +1383,8 @@ class CartCore extends ObjectModel
             $secondUnionSql .= $customizationJoin;
         }
         $commonWhere = '
-            WHERE cp.`id_product_attribute` = ' . (int) $idProductAttribute . '
-            AND cp.`id_customization` = ' . (int) $idCustomization . '
+            WHERE cp.`id_product_attribute` = ' . (int) $idProductAttribute .
+            ($idCustomization !== null ? ' AND cp.`id_customization` = ' . (int) $idCustomization : '') . '
             AND cp.`id_cart` = ' . (int) $this->id;
 
         if (Configuration::get('PS_ALLOW_MULTISHIPPING') && $this->isMultiAddressDelivery()) {
@@ -1405,7 +1405,7 @@ class CartCore extends ObjectModel
         $parentSql = 'SELECT
             COALESCE(SUM(first_level_quantity) + SUM(pack_quantity), 0) as deep_quantity,
             COALESCE(SUM(first_level_quantity), 0) as quantity
-          FROM (' . $firstUnionSql . ' UNION ' . $secondUnionSql . ') as q';
+          FROM (' . $firstUnionSql . ' UNION ALL ' . $secondUnionSql . ') as q';
 
         return Db::getInstance()->getRow($parentSql);
     }
@@ -1573,7 +1573,7 @@ class CartCore extends ObjectModel
                 $cartFirstLevelProductQuantity = $this->getProductQuantity(
                     (int) $id_product,
                     (int) $id_product_attribute,
-                    $id_customization
+                    (int) $id_customization
                 );
                 $updateQuantity = '- ' . $quantity;
 

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -312,7 +312,7 @@ class PackCore extends Product
                 }
             }
         } elseif (!empty($cart)) {
-            $cartProduct = $cart->getProductQuantity($idProduct, $idProductAttribute, $idCustomization);
+            $cartProduct = $cart->getProductQuantity($idProduct, $idProductAttribute, (int) $idCustomization);
 
             if (!empty($cartProduct['deep_quantity'])) {
                 $packQuantity -= $cartProduct['deep_quantity'];

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -4234,7 +4234,7 @@ class ProductCore extends ObjectModel
         // we don't substract products in cart if the cart is already attached to an order, since stock quantity
         // has already been updated, this is only useful when the order has not yet been created
         if ($cart && empty(Order::getByCartId($cart->id))) {
-            $cartProduct = $cart->getProductQuantity($idProduct, $idProductAttribute, $idCustomization);
+            $cartProduct = $cart->getProductQuantity($idProduct, $idProductAttribute, null);
 
             if (!empty($cartProduct['deep_quantity'])) {
                 $nbProductInCart = $cartProduct['deep_quantity'];

--- a/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/AddProductToCartHandler.php
@@ -84,7 +84,7 @@ final class AddProductToCartHandler extends AbstractCartHandler implements AddPr
         }
 
         $cart = $this->getCart($command->getCartId());
-        $product = $cart->getProductQuantity($productIdValue, $combinationId, $customizationId);
+        $product = $cart->getProductQuantity($productIdValue, $combinationId, (int) $customizationId);
 
         $quantity = $command->getQuantity() + (int) $product['quantity'];
         $this->assertQuantityIsPositiveInt($quantity);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `getProductQuantity` method was using customization id condition: it should not because customizations share the same stock. That led to being able to add customized articles in cart even if there was not enough stock.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #9974.
| Related PRs       | N/A.
| How to test?      | Set a product (which is set on "deny orders if out of stock") stock to 1 and add a customized article in your cart. Then try to add an other customized article in your cart. It should not be allowed anymore.
| Possible impacts? | I didn't test if it impacts product packs adding to cart. If someone who knows this better than me can test it out...


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
