### PR TITLE
Avoid possibility to create product with combinations when combinations feature is disabled

### DIFF
--- a/src/Core/Form/ChoiceProvider/ProductTypeChoiceProvider.php
+++ b/src/Core/Form/ChoiceProvider/ProductTypeChoiceProvider.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\ChoiceProvider;
 
+use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceAttributeProviderInterface;
 use PrestaShop\PrestaShop\Core\Form\FormChoiceProviderInterface;
@@ -41,12 +42,20 @@ class ProductTypeChoiceProvider implements FormChoiceProviderInterface, FormChoi
     private $translator;
 
     /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
      * @param TranslatorInterface $translator
+     * @param Configuration $configuration
      */
     public function __construct(
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        Configuration $configuration
     ) {
         $this->translator = $translator;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -79,12 +88,18 @@ class ProductTypeChoiceProvider implements FormChoiceProviderInterface, FormChoi
      */
     public function getChoices()
     {
-        return [
+        $choices = [
             $this->trans('Standard product', 'Admin.Catalog.Feature') => ProductType::TYPE_STANDARD,
             $this->trans('Product with combinations', 'Admin.Catalog.Feature') => ProductType::TYPE_COMBINATIONS,
             $this->trans('Pack of products', 'Admin.Catalog.Feature') => ProductType::TYPE_PACK,
             $this->trans('Virtual product', 'Admin.Catalog.Feature') => ProductType::TYPE_VIRTUAL,
         ];
+
+        if (!$this->configuration->combinationIsActive()) {
+            unset($choices[$this->trans('Product with combinations', 'Admin.Catalog.Feature')]);
+        }
+
+        return $choices;
     }
 
     /**

--- a/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/choice_provider.yml
@@ -284,6 +284,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\ChoiceProvider\ProductTypeChoiceProvider'
     arguments:
       - '@translator'
+      - '@prestashop.adapter.legacy.configuration'
 
   prestashop.core.form.choice_provider.zone_by_id:
     class: 'PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\ZoneByIdChoiceProvider'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Avoid possibility to create product with combinations when combinations feature is disabled
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28967
| Related PRs       | 
| How to test?      | See #28967
| Possible impacts? |  


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
