### PR TITLE
Fix 29341 - Rate impact calculation

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/combination/bulk.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/bulk.ts
@@ -37,4 +37,35 @@ $(() => {
   ]);
   new ImageSelector();
   new QuantityModeSwitcher();
+
+  const priceExcludedTaxId = 'bulk_combination_price_price_tax_excluded';
+  const priceIncludedTaxId = 'bulk_combination_price_price_tax_included';
+  const vatRate = 'bulk_combination_price';
+  const priceDiv: HTMLDivElement = document.getElementById(vatRate) as HTMLDivElement;
+  const priceExcludedTaxInput: HTMLInputElement = document.getElementById(priceExcludedTaxId) as HTMLInputElement;
+  const priceIncludedTaxInput: HTMLInputElement = document.getElementById(priceIncludedTaxId) as HTMLInputElement;
+  const rate: number = 1 + parseFloat((priceDiv.dataset.rate as string));
+
+  priceExcludedTaxInput.addEventListener('keyup', () => {
+    let value;
+
+    if (priceExcludedTaxInput.value === '') {
+      value = 0;
+    } else {
+      value = parseFloat(priceExcludedTaxInput.value);
+    }
+    priceIncludedTaxInput.value = (value * rate).toString();
+  });
+
+  priceIncludedTaxInput.addEventListener('keyup', () => {
+    let value;
+
+    if (priceIncludedTaxInput.value === '') {
+      value = 0;
+    } else {
+      value = parseFloat(priceIncludedTaxInput.value);
+    }
+    priceExcludedTaxInput.value = (value / rate).toString();
+  });
+
 });

--- a/src/Adapter/LegacyContext.php
+++ b/src/Adapter/LegacyContext.php
@@ -112,6 +112,11 @@ class LegacyContext
         return __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_) . '/';
     }
 
+    public function getCountryId(): int
+    {
+        return $this->getContext()->country->id;
+    }
+
     /**
      * Adapter to get Admin HTTP link.
      *

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -546,4 +546,19 @@ class ProductRepository extends AbstractObjectModelRepository
 
         return $product;
     }
+
+    public function getProductTaxRulesGroupId(ProductId $productId): TaxRulesGroupId
+    {
+        $qb = $this->connection->createQueryBuilder();
+        $result = $qb
+            ->addSelect('p.id_tax_rules_group')
+            ->from($this->dbPrefix . 'product', 'p')
+            ->where('id_product = :productId')
+            ->setParameter('productId', $productId->getValue())
+            ->execute()
+            ->fetchOne()
+        ;
+
+        return new TaxRulesGroupId((int) $result);
+    }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -190,6 +190,7 @@ class CombinationController extends FrameworkBundleAdminController
     {
         $bulkCombinationForm = $this->getBulkCombinationFormBuilder()->getForm([], [
             'product_id' => $productId,
+            'country_id' => $this->get('prestashop.adapter.legacy.context')->getCountryId(),
             'method' => Request::METHOD_PATCH,
         ]);
         $bulkCombinationForm->handleRequest($request);
@@ -224,6 +225,7 @@ class CombinationController extends FrameworkBundleAdminController
                 $bulkCombinationForm = $this->getBulkCombinationFormBuilder()->getFormFor($combinationId, [], [
                     'method' => Request::METHOD_PATCH,
                     'product_id' => $productId,
+                    'country_id' => $this->get('prestashop.adapter.legacy.context')->getCountryId(),
                 ]);
             } catch (CombinationNotFoundException $e) {
                 $errors[] = $this->getErrorMessageForException($e, $this->getErrorMessages($e));

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationType.php
@@ -44,7 +44,10 @@ class BulkCombinationType extends TranslatorAwareType
     {
         $builder
             ->add('stock', BulkCombinationStockType::class)
-            ->add('price', BulkCombinationPriceType::class)
+            ->add('price', BulkCombinationPriceType::class, [
+                'product_id' => $options['product_id'],
+                'country_id' => $options['country_id'],
+            ])
             ->add('references', BulkCombinationReferencesType::class)
             ->add('images', BulkCombinationImagesType::class, [
                 'label' => $this->trans('Images', 'Admin.Global'),
@@ -70,6 +73,7 @@ class BulkCombinationType extends TranslatorAwareType
             ])
             ->setRequired([
                 'product_id',
+                'country_id',
             ])
             ->setAllowedTypes('product_id', 'int')
         ;

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1919,8 +1919,10 @@ services:
     parent: 'form.type.translatable.aware'
     public: true
     arguments:
-      - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrency()'
+      - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrency().iso_code'
       - "@=service('prestashop.adapter.legacy.configuration').get('PS_WEIGHT_UNIT')"
+      - '@prestashop.adapter.product.repository.product_repository'
+      - '@prestashop.adapter.tax.tax_computer'
     tags:
       - { name: form.type }
 


### PR DESCRIPTION


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | This PR adds front end calculation for both prices (inc. taxes & ex. taxes) on product v2 page.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29341.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
