### PR TITLE
Hide the current user's profile checkbox for bulk actions

### DIFF
--- a/src/Adapter/Profile/CommandHandler/BulkDeleteProfileHandler.php
+++ b/src/Adapter/Profile/CommandHandler/BulkDeleteProfileHandler.php
@@ -69,6 +69,7 @@ final class BulkDeleteProfileHandler extends AbstractProfileHandler implements B
     public function handle(BulkDeleteProfileCommand $command)
     {
         $entityIds = $command->getProfileIds();
+        $exceptionToThrowLater = null;
 
         foreach ($entityIds as $entityId) {
             $entityIdValue = $entityId->getValue();
@@ -95,7 +96,17 @@ final class BulkDeleteProfileHandler extends AbstractProfileHandler implements B
                 }
             } catch (PrestaShopException $e) {
                 throw new ProfileException(sprintf('Unexpected error occurred when deleting Profile with id %s', var_export($entityIdValue, true)), 0, $e);
+            } catch (FailedToDeleteProfileException $e) {
+                if ($e->getCode() === FailedToDeleteProfileException::PROFILE_IS_ASSIGNED_TO_CONTEXT_EMPLOYEE) {
+                    $exceptionToThrowLater = $e;
+                    continue;
+                }
+                throw $e;
             }
+        }
+
+        if ($exceptionToThrowLater) {
+            throw $exceptionToThrowLater;
         }
     }
 }

--- a/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
@@ -1,5 +1,5 @@
 <?php
-/**
+/*
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -53,7 +53,6 @@ final class ProfileGridDataFactoryDecorator implements GridDataFactoryInterface
     public function __construct(
         GridDataFactoryInterface $profileGridDataFactory,
         Security $security
-
     ) {
         $this->profileGridDataFactory = $profileGridDataFactory;
         $this->security = $security;
@@ -86,6 +85,10 @@ final class ProfileGridDataFactoryDecorator implements GridDataFactoryInterface
 
         /** @var Employee $user */
         $user = $this->security->getUser();
+        if (!$user) {
+            return new RecordCollection($modifiedProfiles);
+        }
+
         $currentUserIdProfile = $user->getData()->id_profile;
         foreach ($profiles as $profile) {
             if ($profile['id_profile'] === $currentUserIdProfile) {

--- a/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
@@ -1,5 +1,5 @@
 <?php
-/*
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -83,9 +83,9 @@ final class ProfileGridDataFactoryDecorator implements GridDataFactoryInterface
     {
         $modifiedProfiles = [];
 
-        /** @var Employee $user */
+        /** @var Employee|null $user */
         $user = $this->security->getUser();
-        if (!$user) {
+        if (null === $user) {
             return new RecordCollection($modifiedProfiles);
         }
 

--- a/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use Symfony\Component\Security\Core\Security;
+
+/**
+ * Class ProfileGridDataFactory decorates data from profile doctrine data factory.
+ */
+final class ProfileGridDataFactoryDecorator implements GridDataFactoryInterface
+{
+    /**
+     * @var GridDataFactoryInterface
+     */
+    private $profileGridDataFactory;
+
+    /**
+     * @var Security
+     */
+    private $security;
+
+    public function __construct(
+        GridDataFactoryInterface $profileGridDataFactory,
+        Security $security
+
+    ) {
+        $this->profileGridDataFactory = $profileGridDataFactory;
+        $this->security = $security;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria)
+    {
+        $profileData = $this->profileGridDataFactory->getData($searchCriteria);
+
+        $profileRecords = $this->applyModifications($profileData->getRecords());
+
+        return new GridData(
+            $profileRecords,
+            $profileData->getRecordsTotal(),
+            $profileData->getQuery()
+        );
+    }
+
+    /**
+     * @param RecordCollectionInterface $profiles
+     *
+     * @return RecordCollection
+     */
+    private function applyModifications(RecordCollectionInterface $profiles)
+    {
+        $modifiedProfiles = [];
+
+        $currentUserIdProfile = $this->security->getUser()->getData()->id_profile;
+        foreach ($profiles as $profile) {
+            if ($profile['id_profile'] === $currentUserIdProfile) {
+                $profile['disableBulkCheckbox'] = true;
+            }
+
+            $modifiedProfiles[] = $profile;
+        }
+
+        return new RecordCollection($modifiedProfiles);
+    }
+}

--- a/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/ProfileGridDataFactoryDecorator.php
@@ -24,12 +24,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShopBundle\Security\Admin\Employee;
 use Symfony\Component\Security\Core\Security;
 
 /**
@@ -81,7 +84,9 @@ final class ProfileGridDataFactoryDecorator implements GridDataFactoryInterface
     {
         $modifiedProfiles = [];
 
-        $currentUserIdProfile = $this->security->getUser()->getData()->id_profile;
+        /** @var Employee $user */
+        $user = $this->security->getUser();
+        $currentUserIdProfile = $user->getData()->id_profile;
         foreach ($profiles as $profile) {
             if ($profile['id_profile'] === $currentUserIdProfile) {
                 $profile['disableBulkCheckbox'] = true;

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -186,11 +186,11 @@ services:
       - '@prestashop.core.grid.query.doctrine_query_parser'
       - 'profile'
 
-  prestashop.core.grid.data_factory.profiles_decorator:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\ProfileGridDataFactoryDecorator'
+  PrestaShop\PrestaShop\Core\Grid\Data\Factory\ProfileGridDataFactoryDecorator:
+    autowire: true
+    public: false
     arguments:
-      - '@prestashop.core.grid.data_factory.profiles'
-      - '@security.helper'
+      $profileGridDataFactory: '@prestashop.core.grid.data_factory.profiles'
 
   prestashop.core.grid.data_provider.cms_page_category:
     class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -186,6 +186,12 @@ services:
       - '@prestashop.core.grid.query.doctrine_query_parser'
       - 'profile'
 
+  prestashop.core.grid.data_factory.profiles_decorator:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\ProfileGridDataFactoryDecorator'
+    arguments:
+      - '@prestashop.core.grid.data_factory.profiles'
+      - '@security.helper'
+
   prestashop.core.grid.data_provider.cms_page_category:
     class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -148,7 +148,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
     arguments:
       - '@prestashop.core.grid.definition.factory.profile'
-      - '@prestashop.core.grid.data_factory.profiles'
+      - '@prestashop.core.grid.data_factory.profiles_decorator'
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
 

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -148,7 +148,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
     arguments:
       - '@prestashop.core.grid.definition.factory.profile'
-      - '@prestashop.core.grid.data_factory.profiles_decorator'
+      - '@PrestaShop\PrestaShop\Core\Grid\Data\Factory\ProfileGridDataFactoryDecorator'
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/bulk_action.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Common/Grid/Columns/Content/bulk_action.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% if column.options.disabled_field is empty or not record[column.options.disabled_field] %}
+{% if (column.options.disabled_field is empty or not record[column.options.disabled_field]) and (record.disableBulkCheckbox is not defined or not record.disableBulkCheckbox) %}
 <div class="md-checkbox">
   <label>
     <input type="checkbox"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Hide the checkbox for the current user's profile when trying to bulk delete profiles
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/29838
| Related PRs       | N/A
| How to test?      | In the BackOffice, go to Advanced Parameters > Team, click the Profiles tab, check all the profiles boxes and then bulk delete them.
| Possible impacts? | Profiles

