### PR TITLE
Fix update status button responsive on order page

### DIFF
--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -431,6 +431,8 @@
         .btn-primary {
           // stylelint-disable-next-line declaration-no-important
           width: 100% !important;
+          // stylelint-disable-next-line declaration-no-important
+          min-width: inherit !important;
           max-width: 100%;
         }
       }

--- a/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
+++ b/admin-dev/themes/new-theme/scss/pages/orders/_orders_view.scss
@@ -86,8 +86,7 @@
 
   // Todo: Looks like we don't have any custom select without JS to add in a form
   // Please notice that you have two different select2 component inside order view
-  .select2-container,
-  .select2-selection {
+  .select2-container {
     min-width: 36ch;
     height: 100%;
   }
@@ -425,7 +424,15 @@
 
       &-actions {
         display: flex;
+        flex-wrap: wrap;
         width: 100%;
+
+        .select2-container,
+        .btn-primary {
+          // stylelint-disable-next-line declaration-no-important
+          width: 100% !important;
+          max-width: 100%;
+        }
       }
     }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
@@ -57,22 +57,20 @@
   </tbody>
 </table>
 
-<div class="row">
-  <div class="col-sm-6 offset-xl-4 offset-xxl-6">
-    {{ form_start(updateOrderStatusForm, {'action': path('admin_orders_update_status',  {'orderId': orderForViewing.id}), 'attr': {'class': 'card-details-form'}, }) }}
-      <div class="form-group card-details-actions">
-        {{ form_widget(updateOrderStatusForm.new_order_status_id) }}
+<div class="d-flex justify-content-end">
+  {{ form_start(updateOrderStatusForm, {'action': path('admin_orders_update_status',  {'orderId': orderForViewing.id}), 'attr': {'class': 'card-details-form'}, }) }}
+    <div class="form-group card-details-actions">
+      {{ form_widget(updateOrderStatusForm.new_order_status_id) }}
 
-        <button class="btn btn-primary update-status ml-3">
-          {{ 'Update status'|trans({}, 'Admin.Orderscustomers.Feature') }}
-        </button>
-      </div>
+      <button class="btn btn-primary update-status mt-3 mt-md-0 ml-0 ml-md-3">
+        {{ 'Update status'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      </button>
+    </div>
 
-      <div class="d-none">
-        {{ form_rest(updateOrderStatusForm) }}
-      </div>
-    {{ form_end(updateOrderStatusForm) }}
-  </div>
+    <div class="d-none">
+      {{ form_rest(updateOrderStatusForm) }}
+    </div>
+  {{ form_end(updateOrderStatusForm) }}
 </div>
 
 {% include '@PrestaShop/Admin/Sell/Order/Order/Blocks/View/internal_note.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/history.html.twig
@@ -58,7 +58,7 @@
 </table>
 
 <div class="row">
-  <div class="col-sm-6 offset-sm-6">
+  <div class="col-sm-6 offset-xl-4 offset-xxl-6">
     {{ form_start(updateOrderStatusForm, {'action': path('admin_orders_update_status',  {'orderId': orderForViewing.id}), 'attr': {'class': 'card-details-form'}, }) }}
       <div class="form-group card-details-actions">
         {{ form_widget(updateOrderStatusForm.new_order_status_id) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | There was a wrong offset on the update status row on the order page
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29849
| How to test?      | See issue
| Possible impacts? | Update status button on order page position


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
