### PR TITLE
Fix subtitle default position on module configure page

### DIFF
--- a/admin-dev/themes/default/scss/partials/_toolbar.scss
+++ b/admin-dev/themes/default/scss/partials/_toolbar.scss
@@ -44,6 +44,10 @@
     color: #363a41;
     white-space: nowrap;
 
+    @at-root .adminmodules & {
+      margin: 0 0 1.25rem;
+    }
+
     a {
       border-bottom: dotted 1px #fff;
 
@@ -64,9 +68,13 @@
     position: absolute;
     margin-top: 60px;
     font-family: $url-font-content-name;
-    @include left($widthSidebarNav + 20px);
+    @include left($widthSidebarNav + 17px);
     @media (max-width: $screen-tablet) {
       @include left(70px);
+    }
+
+    @at-root .adminmodules & {
+      margin-top: 67px;
     }
   }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Subtitle default position on configuring module page is wrong, and I found some other problems that we should probably fix in the near future (the whole header could be really improved)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yno
| Fixed ticket?     | Fixes #29825
| How to test?      | See issue
| Possible impacts? | Subtitle position on module configure page


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
