### PR TITLE
Fix broken position BO page after upgrade

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1698,9 +1698,14 @@ abstract class ModuleCore implements ModuleInterface
      */
     public static function getModulesInstalledAndEnabled()
     {
-        $sql = 'SELECT m.* FROM `' . _DB_PREFIX_ . 'module` m WHERE `active` = 1';
+        $id_shops = Shop::getContextListShopID();
 
-        return Db::getInstance()->executeS($sql);
+        $select = 'SELECT m.`id_module`, m.`name`, m.`version`';
+        $from = ' FROM `' . _DB_PREFIX_ . 'module` m';
+        $from .= ' INNER JOIN `' . _DB_PREFIX_ . 'module_shop` ms ON ms.`id_module` = m.`id_module`';
+        $from .= ' AND ms.`id_shop` IN (' . (implode(',', array_map('intval', $id_shops))) . ')';
+
+        return Db::getInstance()->executeS($select . $from);
     }
 
     /**

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1692,6 +1692,18 @@ abstract class ModuleCore implements ModuleInterface
     }
 
     /**
+     * Return modules that are installed AND enabled
+     *
+     * @return array Modules
+     */
+    public static function getModulesInstalledAndEnabled()
+    {
+        $sql = 'SELECT m.* FROM `' . _DB_PREFIX_ . 'module` m WHERE `active` = 1';
+
+        return Db::getInstance()->executeS($sql);
+    }
+
+    /**
      * Returns the list of the payment module associated to the current customer.
      *
      * @see PaymentModule::getInstalledPaymentModules() if you don't care about the context

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -471,7 +471,7 @@ class AdminGroupsControllerCore extends AdminController
 
     public function formatModuleListAuth($id_group)
     {
-        $modules = Module::getModulesInstalled();
+        $modules = Module::getModulesInstalledAndEnabled();
         $authorized_modules = '';
 
         $auth_modules = [];

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -513,6 +513,16 @@ class Module implements ModuleInterface
     }
 
     /**
+     * Return modules that are installed AND enabled
+     *
+     * @return array Modules
+     */
+    public function getModulesInstalledAndEnabled()
+    {
+        return LegacyModule::getModulesInstalledAndEnabled();
+    }
+
+    /**
      * Return an instance of the specified module.
      *
      * @param int $moduleId Module id

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -72,7 +72,7 @@ class PositionsController extends FrameworkBundleAdminController
 
         $moduleAdapter = $this->get('prestashop.adapter.legacy.module');
         $hookProvider = $this->get('prestashop.adapter.legacy.hook');
-        $installedModules = $moduleAdapter->getModulesInstalled();
+        $installedModules = $moduleAdapter->getModulesInstalledAndEnabled();
 
         $selectedModule = $request->get('show_modules');
         if ($selectedModule && (string) $selectedModule != 'all') {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | The welcome module would crash despite being disabled, because PotistionsController would instanciate all modules having position hooks without checking if they are disabled
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29867
| Related PRs       | 
| How to test?      | See issue #29867


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
