### PR TITLE
Handle multishop for packed products in product page V2

### DIFF
--- a/classes/Combination.php
+++ b/classes/Combination.php
@@ -179,6 +179,10 @@ class CombinationCore extends ObjectModel
      */
     public function deleteFromSupplier($idProduct)
     {
+        if ($this->hasMultishopEntries()) {
+            return true;
+        }
+
         return Db::getInstance()->delete('product_supplier', 'id_product = ' . (int) $idProduct
             . ' AND id_product_attribute = ' . (int) $this->id);
     }
@@ -190,6 +194,10 @@ class CombinationCore extends ObjectModel
      */
     protected function deleteFromPack(): bool
     {
+        if ($this->hasMultishopEntries()) {
+            return true;
+        }
+
         return Db::getInstance()->delete('pack', 'id_product_item = ' . (int) $this->id_product
             . ' AND id_product_attribute_item = ' . (int) $this->id);
     }
@@ -301,6 +309,12 @@ class CombinationCore extends ObjectModel
     {
         if ((int) $this->id === 0) {
             return false;
+        }
+
+        if ($this->hasMultishopEntries()) {
+            $shopIdList = $this->getShopIdsList();
+
+            return Db::getInstance()->delete('cart_product', 'id_product_attribute = ' . (int) $this->id . ' AND id_shop IN (' . implode(',', $shopIdList) . ')');
         }
 
         return Db::getInstance()->delete('cart_product', 'id_product_attribute = ' . (int) $this->id);
@@ -545,19 +559,5 @@ class CombinationCore extends ObjectModel
 			' . Shop::addSqlAssociation('product_attribute', 'pa') . '
 			WHERE pa.`id_product_attribute` = ' . (int) $idProductAttribute
         );
-    }
-
-    /**
-     * @return int[]
-     */
-    private function getShopIdsList(): array
-    {
-        if (count($this->id_shop_list)) {
-            $shopIdsList = $this->id_shop_list;
-        } else {
-            $shopIdsList = Shop::getContextListShopID();
-        }
-
-        return $shopIdsList;
     }
 }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -2305,4 +2305,18 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         return self::$htmlFields[$this->def['table']];
     }
+
+    /**
+     * @return int[]
+     */
+    protected function getShopIdsList(): array
+    {
+        if (count($this->id_shop_list)) {
+            $shopIdsList = $this->id_shop_list;
+        } else {
+            $shopIdsList = Shop::getContextListShopID();
+        }
+
+        return $shopIdsList;
+    }
 }

--- a/classes/Pack.php
+++ b/classes/Pack.php
@@ -447,9 +447,14 @@ class PackCore extends Product
         return $array_result;
     }
 
-    public static function deleteItems($id_product)
+    public static function deleteItems($id_product, $refreshCache = true)
     {
-        return Db::getInstance()->update('product', ['cache_is_pack' => 0], 'id_product = ' . (int) $id_product) &&
+        $result = true;
+        if ($refreshCache) {
+            $result = Db::getInstance()->update('product', ['cache_is_pack' => 0], 'id_product = ' . (int) $id_product);
+        }
+
+        return $result &&
             Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'pack` WHERE `id_product_pack` = ' . (int) $id_product) &&
             Configuration::updateGlobalValue('PS_PACK_FEATURE_ACTIVE', Pack::isCurrentlyUsed());
     }

--- a/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
+++ b/src/Adapter/Product/Pack/QueryHandler/GetPackedProductsHandler.php
@@ -106,7 +106,8 @@ class GetPackedProductsHandler implements GetPackedProductsHandlerInterface
     {
         $packedItems = $this->productRepository->getPackedProducts(
             $query->getPackId(),
-            $query->getLanguageId()
+            $query->getLanguageId(),
+            $query->getShopConstraint()
         );
         $packedProducts = [];
         $combinationIds = [];

--- a/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
+++ b/src/Adapter/Product/Pack/Repository/ProductPackRepository.php
@@ -168,7 +168,8 @@ class ProductPackRepository extends AbstractObjectModelRepository
         $packIdValue = $packId->getValue();
 
         try {
-            if (!Pack::deleteItems($packIdValue)) {
+            // We don't reset cache_is_pack for product we want to keep it tru as long as product type doesn't change
+            if (!Pack::deleteItems($packIdValue, false)) {
                 throw new ProductPackException(
                     sprintf('Failed to remove products from pack #%d', $packIdValue),
                     ProductPackException::FAILED_DELETING_PRODUCTS_FROM_PACK

--- a/src/Core/Domain/Product/Pack/Query/GetPackedProducts.php
+++ b/src/Core/Domain/Product/Pack/Query/GetPackedProducts.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query;
 
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Retrieves product from a pack
@@ -47,13 +48,15 @@ class GetPackedProducts
     protected $languageId;
 
     /**
-     * @param int $packId
-     * @param int $languageId
+     * @var ShopConstraint
      */
-    public function __construct(int $packId, int $languageId)
+    private $shopConstraint;
+
+    public function __construct(int $packId, int $languageId, ShopConstraint $shopConstraint)
     {
         $this->packId = new PackId($packId);
         $this->languageId = new LanguageId($languageId);
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -70,5 +73,13 @@ class GetPackedProducts
     public function getLanguageId(): LanguageId
     {
         return $this->languageId;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -211,17 +211,19 @@ class ProductFormDataProvider implements FormDataProviderInterface
 
     /**
      * @param int $productId
+     * @param ShopConstraint $shopConstraint
      *
      * @return array<int, array<string, int|string>>
      */
-    protected function extractPackedProducts(int $productId): array
+    protected function extractPackedProducts(int $productId, ShopConstraint $shopConstraint): array
     {
         /** @var PackedProductDetails[] $packedProductsDetails
          */
         $packedProductsDetails = $this->queryBus->handle(
             new GetPackedProducts(
                 $productId,
-                $this->contextLangId
+                $this->contextLangId,
+                $shopConstraint
             )
         );
         $packedProductsData = [];
@@ -394,7 +396,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
                 'available_later_label' => $stockInformation->getLocalizedAvailableLaterLabels(),
                 'available_date' => $availableDate ? $availableDate->format(DateTime::DEFAULT_DATE_FORMAT) : '',
             ],
-            'packed_products' => $this->extractPackedProducts($productForEditing->getProductId()),
+            'packed_products' => $this->extractPackedProducts($productForEditing->getProductId(), $shopConstraint),
         ];
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -38,8 +38,9 @@ use Product;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext;
 use Tests\Resources\DatabaseDump;
-use Tests\Resources\LanguageResetter;
-use Tests\Resources\ProductResetter;
+use Tests\Resources\Resetter\ConfigurationResetter;
+use Tests\Resources\Resetter\LanguageResetter;
+use Tests\Resources\Resetter\ProductResetter;
 
 class CommonProductFeatureContext extends AbstractProductFeatureContext
 {
@@ -62,6 +63,7 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
     {
         ProductResetter::resetProducts();
         LanguageResetter::resetLanguages();
+        ConfigurationResetter::resetConfiguration();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/CommonProductFeatureContext.php
@@ -379,8 +379,7 @@ class CommonProductFeatureContext extends AbstractProductFeatureContext
         $productId = $this->getSharedStorage()->get($productReference);
         $product = new Product($productId);
         Assert::assertEquals($productTypeName === ProductType::TYPE_VIRTUAL, (bool) $product->is_virtual);
-        // cache_is_pack is automatically updated by legacy code when removing all pack items so it's not worth testing it for now
-        // Assert::assertEquals($productTypeName === ProductType::TYPE_PACK, (bool) $product->cache_is_pack);
+        Assert::assertEquals($productTypeName === ProductType::TYPE_PACK, (bool) $product->cache_is_pack);
         if ($productTypeName !== ProductType::TYPE_COMBINATIONS) {
             Assert::assertEquals(0, $product->cache_default_attribute);
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
@@ -136,7 +136,7 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
     /**
      * @Then I should get error that product for packing quantity is invalid
      */
-    public function assertPackProductQuantityError()
+    public function assertPackProductQuantityError(): void
     {
         $this->assertLastErrorIs(
             ProductPackConstraintException::class,
@@ -147,7 +147,7 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
     /**
      * @Then I should get error that I cannot add pack into a pack
      */
-    public function assertAddingPackToPackError()
+    public function assertAddingPackToPackError(): void
     {
         $this->assertLastErrorIs(
             ProductPackConstraintException::class,
@@ -181,6 +181,15 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
                 $shopConstraint
             )
         );
+        if (count($data) !== count($packedProducts)) {
+            throw new RuntimeException(sprintf(
+                'Incorrect number of product for shop %d expected %d but got %d instead',
+                $shopConstraint->getShopId()->getValue(),
+                count($data),
+                count($packedProducts)
+            ));
+        }
+
         $notExistingProducts = [];
 
         foreach ($data as $expectedPackedProduct) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePackFeatureContext.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\SetPackProductsComman
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Exception\ProductPackConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query\GetPackedProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\QueryResult\PackedProductDetails;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use RuntimeException;
 
 class UpdatePackFeatureContext extends AbstractProductFeatureContext
@@ -96,7 +97,8 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
         $packedProducts = $this->getQueryBus()->handle(
             new GetPackedProducts(
                 $packId,
-                $this->getDefaultLangId()
+                $this->getDefaultLangId(),
+                ShopConstraint::shop($this->getDefaultShopId())
             )
         );
         Assert::assertEmpty($packedProducts);
@@ -116,7 +118,8 @@ class UpdatePackFeatureContext extends AbstractProductFeatureContext
         $packedProducts = $this->getQueryBus()->handle(
             new GetPackedProducts(
                 $packId,
-                $this->getDefaultLangId()
+                $this->getDefaultLangId(),
+                ShopConstraint::shop($this->getDefaultShopId())
             )
         );
         $notExistingProducts = [];

--- a/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/LanguageFeatureContext.php
@@ -30,7 +30,7 @@ use Configuration;
 use Language;
 use PHPUnit\Framework\Assert;
 use RuntimeException;
-use Tests\Resources\LanguageResetter;
+use Tests\Resources\Resetter\LanguageResetter;
 
 class LanguageFeatureContext extends AbstractPrestaShopFeatureContext
 {

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -44,16 +44,24 @@ use ShopGroup;
 use ShopUrl;
 use Tests\Integration\Behaviour\Features\Context\Domain\AbstractDomainFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
-use Tests\Resources\DatabaseDump;
+use Tests\Resources\Resetter\ShopResetter;
 
 class ShopFeatureContext extends AbstractDomainFeatureContext
 {
+    /**
+     * @BeforeFeature @restore-shops-before-feature
+     */
+    public static function restoreShopTablesBeforeFeature(): void
+    {
+        ShopResetter::resetShops();
+    }
+
     /**
      * @AfterFeature @restore-shops-after-feature
      */
     public static function restoreShopTablesAfterFeature(): void
     {
-        self::restoreShopTables();
+        ShopResetter::resetShops();
     }
 
     /**
@@ -426,33 +434,6 @@ class ShopFeatureContext extends AbstractDomainFeatureContext
         if (!$exceptionTriggered) {
             throw new RuntimeException('Expected SearchShopException did not happen');
         }
-    }
-
-    private static function restoreShopTables(): void
-    {
-        DatabaseDump::restoreTables([
-            'shop',
-            'shop_group',
-            'shop_url',
-        ]);
-        DatabaseDump::restoreMatchingTables('/.*_shop$/');
-
-        // We need to restore lang tables that are also multi-shop
-        DatabaseDump::restoreTables([
-            'carrier_lang',
-            'category_lang',
-            'cms_category_lang',
-            'cms_lang',
-            'cms_role_lang',
-            'customization_field_lang',
-            'info_lang',
-            'linksmenutop_lang',
-            'meta_lang',
-            'product_lang',
-        ]);
-        Shop::setContext(Shop::CONTEXT_SHOP, 1);
-        self::toggleMultiShop(false);
-        Shop::resetStaticCache();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
@@ -206,6 +206,38 @@ Feature: Copy product from shop to shop.
     And product productWithBasic is not associated to shop shop3
     And product productWithBasic is not associated to shop shop4
 
+  Scenario: I copy a pack to another shop, the product associated are in sync
+    Given I add product "productPack" to shop shop1 with following information:
+      | name[en-US] | weird sunglasses box |
+      | type        | pack                 |
+    And product "productPack" type should be pack for shop shop1
+    And I add product "product5" to shop shop1 with following information:
+      | name[en-US] | work sunglasses |
+      | type        | standard        |
+    And I add product "product6" to shop shop1 with following information:
+      | name[en-US] | personal sunglasses |
+      | type        | standard            |
+    And I add product "product7" to shop shop1 with following information:
+      | name[en-US] | casual sunglasses |
+      | type        | standard          |
+    When I update pack productPack with following product quantities:
+      | product  | quantity |
+      | product5 | 10       |
+      | product6 | 11       |
+      | product7 | 15       |
+    Then pack "productPack" should contain products with following details for shops "shop1":
+      | product  | combination | name                | quantity | image url                                              | reference |
+      | product5 |             | work sunglasses     | 10       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+      | product6 |             | personal sunglasses | 11       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+      | product7 |             | casual sunglasses   | 15       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+    When I copy product productWithBasic from shop shop1 to shop shop2
+    Then pack "productPack" should contain products with following details for shops "shop1,shop2":
+      | product  | combination | name                | quantity | image url                                              | reference |
+      | product5 |             | work sunglasses     | 10       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+      | product6 |             | personal sunglasses | 11       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+      | product7 |             | casual sunglasses   | 15       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+
+
   Scenario: I copy product to another shop that was not associated, stock data are copied
     # By default the product is created for default shop
     Given I add product "productWithStock" with following information:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_pack.feature
@@ -1,0 +1,292 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-pack
+@restore-products-before-feature
+@clear-cache-after-feature
+@restore-shops-before-feature
+@restore-shops-after-feature
+@product-multi-shop
+@update-multi-shop-pack
+Feature: Add product to pack from Back Office (BO)
+  As a BO user
+  I need to be able to add product to pack from BO
+
+  Scenario: This is not an actual scenario, it prepares the multishop required fixtures, we don't use Background here
+  to avoid creating different shops for each scenario
+    Given I enable multishop feature
+    And shop "shop1" with name "test_shop" exists
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And single shop context is loaded
+    Given language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+
+  Scenario: I add standard product to a multishop pack, all shops are synced
+    Given I add product "productPack1" to shop shop1 with following information:
+      | name[en-US] | weird sunglasses box |
+      | type        | pack                 |
+    And product "productPack1" type should be pack
+    And I copy product productPack1 from shop shop1 to shop shop2
+    And I add product "product2" to shop shop1 with following information:
+      | name[en-US] | shady sunglasses |
+      | type        | standard         |
+    And I copy product product2 from shop shop1 to shop shop2
+    And I update product "product2" details with following values:
+      | reference | ref1              |
+    And product "product2" type should be standard
+    When I update pack "productPack1" with following product quantities:
+      | product  | quantity |
+      | product2 | 5        |
+    Then product "productPack1" type should be pack
+    And pack "productPack1" should contain products with following details for shops shop1,shop2:
+      | product  | combination | name             | quantity | image url                                              | reference |
+      | product2 |             | shady sunglasses | 5        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1 |
+
+  Scenario: I add virtual products to a pack
+    Given I add product "productPack2" to shop shop1 with following information:
+      | name[en-US] | street photos |
+      | type        | pack          |
+    And product "productPack2" type should be pack
+    And I copy product productPack2 from shop shop1 to shop shop2
+    And I add product "product3" to shop shop1 with following information:
+      | name[en-US] | summerstreet |
+      | type        | virtual      |
+    And I copy product product3 from shop shop1 to shop shop2
+    And I add new image "image3" named "logo.jpg" to product "product3"
+    And I add product "product4" to shop shop1 with following information:
+      | name[en-US] | winterstreet |
+      | type        | virtual      |
+    And I copy product product4 from shop shop1 to shop shop2
+    And I add new image "image4" named "logo.jpg" to product "product4"
+    And product "product3" type should be virtual
+    And product "product4" type should be virtual
+    When I update pack "productPack2" with following product quantities:
+      | product  | quantity |
+      | product3 | 3        |
+      | product4 | 20       |
+    Then product "productPack2" type should be pack
+    And pack "productPack2" should contain products with following details for shops shop1,shop2:
+      | product  | combination | name             | quantity | image url                            |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg |
+      | product4 |             | winterstreet     | 20       | http://myshop.com/img/p/{image4}.jpg |
+
+  Scenario: I update pack by removing one of the products
+    Given pack "productPack2" should contain products with following details for shops shop1,shop2:
+      | product  | combination | name             | quantity | image url                            |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg |
+      | product4 |             | winterstreet     | 20       | http://myshop.com/img/p/{image4}.jpg |
+    When I update pack "productPack2" with following product quantities:
+      | product  | quantity |
+      | product3 | 3        |
+    And pack "productPack2" should contain products with following details for shops shop1,shop2:
+      | product  | combination | name             | quantity | image url                            |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg |
+
+  Scenario: I add virtual and standard product to the same pack
+    Given I add product productPack4 to shop shop1 with following information:
+      | name[en-US] | mixed pack |
+      | type        | pack       |
+    And I copy product productPack4 from shop shop1 to shop shop2
+    Given product "product2" type should be standard
+    And product "product3" type should be virtual
+    When I update pack productPack4 with following product quantities:
+      | product  | quantity |
+      | product2 | 2        |
+      | product3 | 3        |
+    Then product "productPack4" type should be pack
+    And pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product  | combination | name             | quantity | image url                                              |
+      | product2 |             | shady sunglasses | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | product3 |             | summerstreet     | 3        | http://myshop.com/img/p/{image3}.jpg                   |
+
+  Scenario: I remove all products from existing pack
+    Given product "productPack4" type should be pack
+    When pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product  | name             | combination | quantity | image url                                              |
+      | product2 | shady sunglasses |             | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | product3 | summerstreet     |             | 3        | http://myshop.com/img/p/{image3}.jpg                   |
+    And I remove all products from pack productPack4
+    Then product "productPack4" type should be pack
+    And pack "productPack4" should be empty for shops shop1,shop2
+
+  Scenario: Add combination product to a pack
+    Given I add product "productSkirt1" to shop shop1 with following information:
+      | name[en-US] | regular skirt |
+      | type        | combinations  |
+    And I copy product productSkirt1 from shop shop1 to shop shop2
+    When I generate combinations in shop "shop1" for product productSkirt1 using following attributes:
+      | Size  | [S,M]         |
+      | Color | [White,Black] |
+    And I generate combinations in shop "shop2" for product productSkirt1 using following attributes:
+      | Size  | [S,M]         |
+      | Color | [White,Black] |
+    Then product "productSkirt1" should have the following combinations for shops "shop1,shop2":
+      | id reference        | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | productSkirt1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | productSkirt1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | productSkirt1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | productSkirt1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+    And I update product "productSkirt1" details with following values:
+      | reference | productSkirtRef |
+    And I update combination "productSkirt1SWhite" details with following values:
+      | reference | productSkirtSWhiteRef |
+    And I add new image "skirtWhiteS" named "app_icon.png" to product "productSkirt1"
+    And I add new image "skirtWhiteM" named "logo.jpg" to product "productSkirt1"
+    And I add new image "skirtBlackS" named "app_icon.png" to product "productSkirt1"
+    And I add new image "skirtBlackM" named "logo.jpg" to product "productSkirt1"
+    And I associate "[skirtWhiteS]" to combination "productSkirt1SWhite"
+    And I associate "[skirtBlackS]" to combination "productSkirt1SBlack"
+    And I associate "[skirtWhiteM]" to combination "productSkirt1MWhite"
+    And I associate "[skirtBlackM]" to combination "productSkirt1MBlack"
+    And I add new image "image3" named "logo.jpg" to product "productSkirt1"
+    And product productSkirt1 type should be combinations
+    And product "productPack4" type should be pack
+    When I update pack productPack4 with following product quantities:
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MWhite | 11       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
+    Then product "productPack4" type should be pack
+    And pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                 | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg | Ref: productSkirtRef       |
+
+  Scenario: Add combination & standard product to a pack
+    Given product "product2" type should be standard
+    And product productSkirt1 type should be combinations
+    And product "productSkirt1" should have following combinations:
+      | id reference        | combination name        | reference             | attributes           | impact on price | quantity | is default |
+      | productSkirt1SWhite | Size - S, Color - White | productSkirtSWhiteRef | [Size:S,Color:White] | 0               | 0        | true       |
+      | productSkirt1SBlack | Size - S, Color - Black |                       | [Size:S,Color:Black] | 0               | 0        | false      |
+      | productSkirt1MWhite | Size - M, Color - White |                       | [Size:M,Color:White] | 0               | 0        | false      |
+      | productSkirt1MBlack | Size - M, Color - Black |                       | [Size:M,Color:Black] | 0               | 0        | false      |
+    When I update pack productPack4 with following product quantities:
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MWhite | 11       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
+      | product2      |                     | 2        |
+    Then product "productPack4" type should be pack
+    And pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
+
+  Scenario: I remove one combination of same product from existing pack and change another combination quantity
+    Given product "productPack4" type should be pack
+    When pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    And I update pack productPack4 with following product quantities:
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MBlack | 9        |
+      | product2      |                     | 2        |
+    Then pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    Then product "productPack4" type should be pack
+
+  Scenario: I remove all products from existing pack when it contains combination and standard products
+    Given product "productPack4" type should be pack
+    When pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                              |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 9        | http://myshop.com/img/p/{skirtBlackM}.jpg              |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    And I remove all products from pack productPack4
+    Then product "productPack4" type should be pack
+    And pack "productPack4" should be empty for shops shop1,shop2
+
+  # @todo: This scenario should be improved by delting for specific shop, the relation should remain until the product is completely removed (for all shops)
+  Scenario: I remove a product or a combination its relation should also be removed if it was associated with a pack
+    Given I update pack productPack4 with following product quantities:
+      | product       | combination         | quantity |
+      | productSkirt1 | productSkirt1SWhite | 10       |
+      | productSkirt1 | productSkirt1MWhite | 11       |
+      | productSkirt1 | productSkirt1MBlack | 12       |
+      | product2      |                     | 2        |
+    Then product "productPack4" type should be pack
+    And pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
+    When I delete product product2
+    Then pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+    When I delete combination productSkirt1MWhite
+    Then pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+
+    Scenario: I can add product to a pack regardless of their common shops (or uncommon), the name depends on the shop though
+      Given I add product "productPack5" to shop shop2 with following information:
+        | name[en-US] | weird sunglasses box |
+        | type        | pack                 |
+      And product "productPack5" type should be pack for shop shop2
+      And I add product "product5" to shop shop1 with following information:
+        | name[en-US] | work sunglasses |
+        | type        | standard        |
+      And I add product "product6" to shop shop3 with following information:
+        | name[en-US] | personal sunglasses |
+        | type        | standard            |
+      And I add product "product7" to shop shop4 with following information:
+        | name[en-US] | casual sunglasses |
+        | type        | standard          |
+      And I copy product product7 from shop shop4 to shop shop2
+      Given I update pack productPack5 with following product quantities:
+        | product  | quantity |
+        | product5 | 10       |
+        | product6 | 11       |
+        | product7 | 15       |
+      Then pack "productPack5" should contain products with following details for shops "shop1,shop2,shop4":
+        | product  | combination | name                | quantity | image url                                              | reference |
+        | product5 |             | work sunglasses     | 10       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+        | product6 |             | personal sunglasses | 11       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+        | product7 |             | casual sunglasses   | 15       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+      Given I update product "product7" basic information for shop "shop2" with following values:
+        | name[en-US]              | casual sunglasses 2 |
+      And I update product "product7" basic information for shop "shop4" with following values:
+        | name[en-US]              | casual sunglasses 4 |
+      Then product "product7" localized "name" for shops "shop4" should be:
+        | locale | value               |
+        | en-US  | casual sunglasses 4 |
+      Then product "product7" localized "name" for shops "shop2" should be:
+        | locale | value               |
+        | en-US  | casual sunglasses 2 |
+      Then pack "productPack5" should contain products with following details for shops "shop1":
+        | product  | combination | name                | quantity | image url                                              | reference |
+        | product5 |             | work sunglasses     | 10       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+        | product6 |             | personal sunglasses | 11       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+        | product7 |             | casual sunglasses   | 15       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+      Then pack "productPack5" should contain products with following details for shops "shop2":
+        | product  | combination | name                | quantity | image url                                              | reference |
+        | product5 |             | work sunglasses     | 10       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+        | product6 |             | personal sunglasses | 11       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+        | product7 |             | casual sunglasses 2 | 15       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+      Then pack "productPack5" should contain products with following details for shops "shop4":
+        | product  | combination | name                | quantity | image url                                              | reference |
+        | product5 |             | work sunglasses     | 10       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+        | product6 |             | personal sunglasses | 11       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |
+        | product7 |             | casual sunglasses 4 | 15       | http://myshop.com/img/p/{no_picture}-small_default.jpg |           |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_pack.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_pack.feature
@@ -213,8 +213,8 @@ Feature: Add product to pack from Back Office (BO)
     Then product "productPack4" type should be pack
     And pack "productPack4" should be empty for shops shop1,shop2
 
-  # @todo: This scenario should be improved by delting for specific shop, the relation should remain until the product is completely removed (for all shops)
   Scenario: I remove a product or a combination its relation should also be removed if it was associated with a pack
+    # We create a product only associated on the default shop for now because the delete command doesn't allow us to correctly remove it
     Given I update pack productPack4 with following product quantities:
       | product       | combination         | quantity |
       | productSkirt1 | productSkirt1SWhite | 10       |
@@ -228,13 +228,30 @@ Feature: Add product to pack from Back Office (BO)
       | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
       | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
       | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
-    When I delete product product2
+    When I delete product product2 from shops "shop2"
+    # Product2 still exist in shop1
     Then pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
       | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
       | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
       | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
-    When I delete combination productSkirt1MWhite
+      | product2      | shady sunglasses                       |                     | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg | Ref: ref1                  |
+    When I delete product product2 from shops "shop1"
+    # Product2 is fully removed
+    Then pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+    When I delete combination productSkirt1MWhite from shops "shop2"
+    # productSkirt1MWhite is still in shop1
+    Then pack productPack4 should contain products with following details for shops shop1,shop2:
+      | product       | name                                   | combination         | quantity | image url                                              | reference                  |
+      | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |
+      | productSkirt1 | regular skirt: Size - M, Color - White | productSkirt1MWhite | 11       | http://myshop.com/img/p/{skirtWhiteM}.jpg              | Ref: productSkirtRef       |
+      | productSkirt1 | regular skirt: Size - M, Color - Black | productSkirt1MBlack | 12       | http://myshop.com/img/p/{skirtBlackM}.jpg              | Ref: productSkirtRef       |
+    When I delete combination productSkirt1MWhite from shops "shop1"
+    # productSkirt1MWhite is fully removed
     Then pack productPack4 should contain products with following details for shops shop1,shop2:
       | product       | name                                   | combination         | quantity | image url                                              | reference                  |
       | productSkirt1 | regular skirt: Size - S, Color - White | productSkirt1SWhite | 10       | http://myshop.com/img/p/{skirtWhiteS}.jpg              | Ref: productSkirtSWhiteRef |

--- a/tests/Integration/Classes/product/SpecificPriceFormatterTest.php
+++ b/tests/Integration/Classes/product/SpecificPriceFormatterTest.php
@@ -38,7 +38,7 @@ use PrestaShopBundle\Cache\LocalizationWarmer;
 use SpecificPriceFormatter;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Tests\Integration\Utility\ContextMockerTrait;
-use Tests\Resources\LocalizationPackResetter;
+use Tests\Resources\Resetter\LocalizationPackResetter;
 
 class SpecificPriceFormatterTest extends KernelTestCase
 {

--- a/tests/Integration/Core/Localization/Locale/RepositoryTest.php
+++ b/tests/Integration/Core/Localization/Locale/RepositoryTest.php
@@ -37,7 +37,7 @@ use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShopBundle\Cache\LocalizationWarmer;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Tests\Resources\LocalizationPackResetter;
+use Tests\Resources\Resetter\LocalizationPackResetter;
 use Tests\Resources\ResourceResetter;
 
 class RepositoryTest extends KernelTestCase

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -34,7 +34,7 @@ use Symfony\Component\DomCrawler\Crawler;
 use Tests\Integration\Core\Form\IdentifiableObject\Handler\FormHandlerChecker;
 use Tests\Integration\PrestaShopBundle\Controller\FormGridControllerTestCase;
 use Tests\Integration\PrestaShopBundle\Controller\TestEntityDTO;
-use Tests\Resources\ProductResetter;
+use Tests\Resources\Resetter\ProductResetter;
 
 class ProductControllerTest extends FormGridControllerTestCase
 {

--- a/tests/Resources/Resetter/ConfigurationResetter.php
+++ b/tests/Resources/Resetter/ConfigurationResetter.php
@@ -26,9 +26,9 @@
 
 declare(strict_types=1);
 
-namespace Tests\Resources;
+namespace Tests\Resources\Resetter;
 
-use Configuration;
+use Tests\Resources\DatabaseDump;
 
 class ConfigurationResetter
 {
@@ -38,6 +38,5 @@ class ConfigurationResetter
             'configuration',
             'configuration_lang',
         ]);
-        Configuration::resetStaticCache();
     }
 }

--- a/tests/Resources/Resetter/LanguageResetter.php
+++ b/tests/Resources/Resetter/LanguageResetter.php
@@ -26,11 +26,12 @@
 
 declare(strict_types=1);
 
-namespace Tests\Resources;
+namespace Tests\Resources\Resetter;
 
 use Configuration;
 use Db;
 use Language;
+use Tests\Resources\DatabaseDump;
 
 class LanguageResetter
 {
@@ -50,8 +51,5 @@ class LanguageResetter
 
         // Reset default language
         Configuration::updateValue('PS_LANG_DEFAULT', 1);
-
-        // Restore static cache
-        Language::resetStaticCache();
     }
 }

--- a/tests/Resources/Resetter/LocalizationPackResetter.php
+++ b/tests/Resources/Resetter/LocalizationPackResetter.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Resources\Resetter;
+
+use Tests\Resources\DatabaseDump;
+
+class LocalizationPackResetter
+{
+    public static function resetLocalizationPacks(): void
+    {
+        DatabaseDump::restoreTables([
+            'country',
+            'country_lang',
+            'country_shop',
+            'state',
+            'zone',
+            'zone_shop',
+            'tax',
+            'tax_lang',
+            'tax_rule',
+            'tax_rules_group',
+            'tax_rules_group_shop',
+            'currency',
+            'currency_lang',
+            'currency_shop',
+            'module_currency',
+        ]);
+        LanguageResetter::resetLanguages();
+        ConfigurationResetter::resetConfiguration();
+    }
+}

--- a/tests/Resources/Resetter/ProductResetter.php
+++ b/tests/Resources/Resetter/ProductResetter.php
@@ -26,9 +26,9 @@
 
 declare(strict_types=1);
 
-namespace Tests\Resources;
+namespace Tests\Resources\Resetter;
 
-use Product;
+use Tests\Resources\DatabaseDump;
 
 class ProductResetter
 {
@@ -75,6 +75,5 @@ class ProductResetter
             'feature_product',
             'warehouse_product_location',
         ]);
-        Product::resetStaticCache();
     }
 }

--- a/tests/Resources/Resetter/ShopResetter.php
+++ b/tests/Resources/Resetter/ShopResetter.php
@@ -26,33 +26,37 @@
 
 declare(strict_types=1);
 
-namespace Tests\Resources;
+namespace Tests\Resources\Resetter;
 
-use Currency;
+use Shop;
+use Tests\Resources\DatabaseDump;
 
-class LocalizationPackResetter
+class ShopResetter
 {
-    public static function resetLocalizationPacks(): void
+    public static function resetShops(): void
     {
         DatabaseDump::restoreTables([
-            'country',
-            'country_lang',
-            'country_shop',
-            'state',
-            'zone',
-            'zone_shop',
-            'tax',
-            'tax_lang',
-            'tax_rule',
-            'tax_rules_group',
-            'tax_rules_group_shop',
-            'currency',
-            'currency_lang',
-            'currency_shop',
-            'module_currency',
+            // Configuration also needs to be restored since it contains the multishop configuration
+            'configuration',
+            'shop',
+            'shop_group',
+            'shop_url',
         ]);
-        Currency::resetStaticCache();
-        LanguageResetter::resetLanguages();
-        ConfigurationResetter::resetConfiguration();
+        DatabaseDump::restoreMatchingTables('/.*_shop$/');
+
+        // We need to restore lang tables that are also multi-shop
+        DatabaseDump::restoreTables([
+            'carrier_lang',
+            'category_lang',
+            'cms_category_lang',
+            'cms_lang',
+            'cms_role_lang',
+            'customization_field_lang',
+            'info_lang',
+            'linksmenutop_lang',
+            'meta_lang',
+            'product_lang',
+        ]);
+        Shop::resetContext();
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add shop id context when loading pack products to avoid a duplication of products when multishop and product page v2 are enabled
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29343 
| Related PRs       | 
| How to test?      | See #29343 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
