### PR TITLE
Refactor PrestashopAutoload system

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -29,4 +29,4 @@
  * @see composer.json "files" property for custom autoloading
  */
 require_once __DIR__.'/config/defines.inc.php';
-require_once __DIR__.'/classes/PrestaShopAutoload.php';
+require_once __DIR__.'/config/autoload.php';

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2813,7 +2813,15 @@ FileETag none
 
     public static function generateIndex()
     {
-        PrestaShopAutoload::getInstance()->generateIndex();
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.1. Use PrestaShop\Autoload\PrestashopAutoload instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        \PrestaShop\Autoload\PrestashopAutoload::getInstance()->generateIndex();
     }
 
     /**

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -24,6 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\Autoload\PrestashopAutoload;
 use PrestaShop\PrestaShop\Adapter\ContainerFinder;
 use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider;
@@ -2997,7 +2998,7 @@ abstract class ModuleCore implements ModuleInterface
             file_put_contents($override_dest, preg_replace($pattern_escape_com, '', $module_file));
 
             // Re-generate the class index
-            Tools::generateIndex();
+            PrestashopAutoload::getInstance()->generateIndex();
         }
 
         return true;
@@ -3244,7 +3245,7 @@ abstract class ModuleCore implements ModuleInterface
         }
 
         // Re-generate the class index
-        Tools::generateIndex();
+        PrestashopAutoload::getInstance()->generateIndex();
 
         return true;
     }

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
         "pear/archive_tar": "^1.4.12",
         "pelago/emogrifier": "^v5.0.1",
         "phpoffice/phpspreadsheet": "^1.19",
+        "prestashop/autoload": "^1.0",
         "prestashop/blockreassurance": "^5.1",
         "prestashop/blockwishlist": "^2.0",
         "prestashop/circuit-breaker": "^4.0",
@@ -206,6 +207,10 @@
         {
             "type": "vcs",
             "url": "https://github.com/atomiix/jwt"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/PrestaShop/autoload"
         }
     ],
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6684af7be49eedd7378704180e70c04c",
+    "content-hash": "9d356e0dd0e9e2c7ff4f7f62e8cda434",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5204,6 +5204,56 @@
                 "source": "https://github.com/silexphp/Pimple/tree/v3.5.0"
             },
             "time": "2021-10-28T11:13:42+00:00"
+        },
+        {
+            "name": "prestashop/autoload",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShop/autoload.git",
+                "reference": "9b057242f67076a50e55e7cb77a65d595bfb15b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShop/autoload/zipball/9b057242f67076a50e55e7cb77a65d595bfb15b4",
+                "reference": "9b057242f67076a50e55e7cb77a65d595bfb15b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "symfony/filesystem": "~4.4|~5.4",
+                "symfony/finder": "~4.4|~5.4",
+                "symfony/polyfill-php80": "^v1.26.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^1.8.10",
+                "phpunit/phpunit": "~8.5.30|^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PrestaShop\\Autoload\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PrestaShop SA",
+                    "email": "contact@prestashop.com"
+                },
+                {
+                    "name": "PrestaShop Community",
+                    "homepage": "https://contributors.prestashop.com/"
+                }
+            ],
+            "description": "PrestaShop legacy autoloading",
+            "support": {
+                "source": "https://github.com/PrestaShop/autoload/tree/v1.0.0"
+            },
+            "time": "2022-11-29T16:54:18+00:00"
         },
         {
             "name": "prestashop/blockreassurance",

--- a/config/autoload.php
+++ b/config/autoload.php
@@ -24,12 +24,14 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\Autoload\PrestashopAutoload;
 use PrestaShop\PrestaShop\Core\Version;
 
-require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 define('_PS_VERSION_', Version::VERSION);
 
-require_once _PS_CONFIG_DIR_.'alias.php';
-require_once _PS_CLASS_DIR_.'PrestaShopAutoload.php';
-spl_autoload_register(array(PrestaShopAutoload::getInstance(), 'load'));
+require_once _PS_CONFIG_DIR_ . 'alias.php';
+
+PrestashopAutoload::create(_PS_ROOT_DIR_, _PS_CACHE_DIR_)
+    ->register();

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -2313,11 +2313,6 @@ class AdminTranslationsControllerCore extends AdminController
                 }
 
                 $class_name = substr($file, 0, -4);
-
-                if (!class_exists($class_name, false) && !class_exists($class_name . 'Core', false)) {
-                    PrestaShopAutoload::getInstance()->load($class_name);
-                }
-
                 if (!is_subclass_of($class_name . 'Core', 'ObjectModel')) {
                     continue;
                 }

--- a/install-dev/classes/controllerHttp.php
+++ b/install-dev/classes/controllerHttp.php
@@ -193,7 +193,7 @@ class InstallControllerHttp
 
         $session = InstallSession::getInstance();
         if (!$session->last_step || $session->last_step === 'welcome') {
-            Tools::generateIndex();
+            \PrestaShop\Autoload\PrestashopAutoload::getInstance()->generateIndex();
         }
 
         if (empty($session->last_step)) {

--- a/src/Adapter/Cache/Clearer/ClassIndexCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/ClassIndexCacheClearer.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Cache\Clearer;
 
+use PrestaShop\Autoload\PrestashopAutoload;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
-use PrestaShopAutoload;
 
 /**
  * Class ClassIndexCacheClearer clears current class index and generates new one.
@@ -41,6 +41,6 @@ final class ClassIndexCacheClearer implements CacheClearerInterface
      */
     public function clear()
     {
-        PrestaShopAutoload::getInstance()->generateIndex();
+        PrestashopAutoload::getInstance()->generateIndex();
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR aims to use only the class index file, other indexes are not useful and don't need to be dumped. This also fixes autoloading namespaced classes without requiring a whole file which include performance as well.
| Type?             | improvement
| Category?         | IN
| BC breaks?        |  no
| Deprecations?     | yes 
| How to test?      | Application should be running without issue, try install/remove/ update modules, overrides system should be working.

## Why refactor the autoload ? 

The current approach has some problems that can't easily be fixed.
- The autoload is *constant dependant* which means if the constants are not defined, the autoload won't work.
- The autoload contains some bugs, for example the override classes are not marked as `override: true` in the `class_index.php` file.
- The core classes folders are hard-coded.
- Many static functions that don't need to be static.
- There are very few tests
- The API is unclear, there is a public function `dumpFile()` that is a copy of the Symfony `FileSystem::dumpFile()` function.
- Autoload is slow: When you require a class from the `Prestashop\Prestashop\Adapter\Entity` namespace, the whole core classes are loaded, even if they are not required.
- Located in the old legacy classes.

## Why create a separated package ?

I've chosen to create a separate package so it can be reused in other future projects. Also, testing such a feature is complicated because you need to update the testsuite just for the autoload as it can create and load new classes. 

## Design choices.

For now, I have split the existing Autoloader into 3 files.

- The first one is the `LegacyClassLoader` which parses the core classes and controllers to build the autoload index. The new class has now configurable directories, removed constants and is fully tested. The class parser is still working as the legacy system.
- The second one is the `Autoloader`. Which loads classes from the index built by the `LegacyClassLoader`.
- The third one is the `PrestashopAutoload` which is the "modernized" autoload.

There is no support for `class_stub.php` and `namespace_class_stubs.php` because they are no more needed in this new version.

## Performance Improvements

These need to be measured with a real tool. But for what i've seen so far, is that the new autoload reduce loading time in admin pages by ~200ms.


## Current problems & next steps. 

- It is difficult to test autoloading classes because in the phpunit bootstrap file uses that same autoload. They may need to be tested separatly.
- PHPStan is based on the old autoload, switching autoload breaks phpstan checks.
- Replace all usages.