### PR TITLE
POC multiple image types (jpg, webp, avif)

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -688,6 +688,12 @@ class ImageManagerCore
 
                 break;
 
+            case 'avif':
+                // @phpstan-ignore-next-line
+                $success = imageavif($resource, $filename);
+
+                break;
+
             case 'jpg':
             case 'jpeg':
             default:
@@ -721,6 +727,7 @@ class ImageManagerCore
             'image/png' => ['png'],
             'image/webp' => ['webp'],
             'image/svg+xml' => ['svg'],
+            'image/avif' => ['avif'],
         ];
         $extension = substr($fileName, strrpos($fileName, '.') + 1);
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -1009,6 +1009,7 @@ class LinkCore
             }
         }
 
+        dump($uriPath);
         return $this->protocol_content . Tools::getMediaServer($uriPath) . $uriPath;
     }
 

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -982,7 +982,7 @@ class LinkCore
      *
      * @return string
      */
-    public function getImageLink($name, $ids, $type = null)
+    public function getImageLink($name, $ids, $type = null, $extension = '.jpg')
     {
         $notDefault = false;
         $psLegacyImages = Configuration::get('PS_LEGACY_IMAGES');
@@ -990,12 +990,12 @@ class LinkCore
         // legacy mode or default image
         $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . '-' . Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
         if (($psLegacyImages
-                && (file_exists(_PS_PRODUCT_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . $theme . '.jpg')))
+                && (file_exists(_PS_PRODUCT_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . $theme . $extension)))
             || ($notDefault = strpos($ids, 'default') !== false)) {
             if ($this->allow && !$notDefault) {
-                $uriPath = __PS_BASE_URI__ . $ids . ($type ? '-' . $type : '') . $theme . '/' . $name . '.jpg';
+                $uriPath = __PS_BASE_URI__ . $ids . ($type ? '-' . $type : '') . $theme . '/' . $name . $extension;
             } else {
-                $uriPath = _THEME_PROD_DIR_ . $ids . ($type ? '-' . $type : '') . $theme . '.jpg';
+                $uriPath = _THEME_PROD_DIR_ . $ids . ($type ? '-' . $type : '') . $theme . $extension;
             }
         } else {
             // if ids if of the form id_product-id_image, we want to extract the id_image part
@@ -1003,9 +1003,9 @@ class LinkCore
             $idImage = (isset($splitIds[1]) ? $splitIds[1] : $splitIds[0]);
             $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . '-' . (int) Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
             if ($this->allow) {
-                $uriPath = __PS_BASE_URI__ . $idImage . ($type ? '-' . $type : '') . $theme . '/' . $name . '.jpg';
+                $uriPath = __PS_BASE_URI__ . $idImage . ($type ? '-' . $type : '') . $theme . '/' . $name . $extension;
             } else {
-                $uriPath = _THEME_PROD_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . $theme . '.jpg';
+                $uriPath = _THEME_PROD_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . $theme . $extension;
             }
         }
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3362,7 +3362,7 @@ abstract class ModuleCore implements ModuleInterface
 
     protected function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
-        $parameters['legacy'] = 'htmlspecialchars';
+            $parameters['legacy'] = 'htmlspecialchars';
 
         return $this->getTranslator()->trans($id, $parameters, $domain, $locale);
     }

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -507,6 +507,8 @@ class AdminImagesControllerCore extends AdminController
         }
 
         $generate_hight_dpi_images = (bool) Configuration::get('PS_HIGHT_DPI');
+        $generateAdditionalWebP = (bool) Configuration::get('PS_ADDITIONAL_IMAGE_QUALITY_WEBP');
+        $generateAdditionalAvif = (bool) Configuration::get('PS_ADDITIONAL_IMAGE_QUALITY_AVIF');
 
         if (!$productsImages) {
             $formated_medium = ImageType::getFormattedName('medium');
@@ -522,7 +524,6 @@ class AdminImagesControllerCore extends AdminController
                         if (($dir == _PS_CAT_IMG_DIR_) && ($imageType['name'] == $formated_medium) && is_file(_PS_CAT_IMG_DIR_ . str_replace('.', '_thumb.', $image))) {
                             $image = str_replace('.', '_thumb.', $image);
                         }
-
                         if (!file_exists($newDir . substr($image, 0, -4) . '-' . stripslashes($imageType['name']) . '.jpg')) {
                             if (!file_exists($dir . $image) || !filesize($dir . $image)) {
                                 $this->errors[] = $this->trans('Source file does not exist or is empty (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
@@ -530,9 +531,23 @@ class AdminImagesControllerCore extends AdminController
                                 $this->errors[] = $this->trans('Failed to resize image file (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
                             }
 
+                            if ($generateAdditionalWebP) {
+                                ImageManager::resize($dir . $image, $newDir . substr(str_replace('_thumb.', '.', $image), 0, -4) . '-' . stripslashes($imageType['name']) . '.webp', (int) $imageType['width'], (int) $imageType['height'], 'webp', true);
+                            }
+
+                            if (version_compare(PHP_VERSION, '8.1') >= 0 && $generateAdditionalAvif) {
+                                ImageManager::resize($dir . $image, $newDir . substr(str_replace('_thumb.', '.', $image), 0, -4) . '-' . stripslashes($imageType['name']) . '.avif', (int)$imageType['width'], (int)$imageType['height'], 'avif', true);
+                            }
+
                             if ($generate_hight_dpi_images) {
                                 if (!ImageManager::resize($dir . $image, $newDir . substr($image, 0, -4) . '-' . stripslashes($imageType['name']) . '2x.jpg', (int) $imageType['width'] * 2, (int) $imageType['height'] * 2)) {
                                     $this->errors[] = $this->trans('Failed to resize image file to high resolution (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
+                                }
+                                if ($generateAdditionalWebP) {
+                                    ImageManager::resize($dir . $image, $newDir . substr(str_replace('_thumb.', '.', $image), 0, -4) . '-' . stripslashes($imageType['name']) . '2x.webp', (int) $imageType['width'] * 2, (int) $imageType['height'] * 2, 'webp', true);
+                                }
+                                if (version_compare(PHP_VERSION, '8.1') >= 0 && $generateAdditionalAvif) {
+                                    ImageManager::resize($dir . $image, $newDir . substr(str_replace('_thumb.', '.', $image), 0, -4) . '-' . stripslashes($imageType['name']) . '2x.avif', (int) $imageType['width'] * 2, (int)$imageType['height'] * 2, 'avif', true);
                                 }
                             }
                         }

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -207,7 +207,7 @@ class ImageRetriever
                         true
                     );
                 }
-
+                dump($this->link->$getImageURL($rewriteLink, $id_image, '', '.toto'));
                 $additionalSources['webp'] = $this->link->$getImageURL($rewriteLink, $id_image, $image_type['name'], '.webp');
             }
 


### PR DESCRIPTION
## This is a proof of concept, it's not meant to be merged

## How to test:

- Install prestashop, with this PR and php 8.1
- execute the two following SQL queries, this will simulate that the checkboxes webp and avif have been checked:
	- `INSERT INTO ps_configuration (id_shop_group, id_shop, name, value, date_add, date_upd)
VALUES (null, null, 'PS_ADDITIONAL_IMAGE_QUALITY_WEBP', '1', NOW(), NOW());` 
   - `INSERT INTO ps_configuration (id_shop_group, id_shop, name, value, date_add, date_upd)
VALUES (null, null, 'PS_ADDITIONAL_IMAGE_QUALITY_AVIF', '1', NOW(), NOW());` 

- in the BO's image administration page, regenerate all images

- In FO, visit a product page, and see the dump, a new `sources` array appears in `by_size` 's different formats:

![Capture d’écran du 2022-10-07 15-57-34](https://user-images.githubusercontent.com/1784781/194581860-42568ce5-9e5a-455a-aa42-bf13f462dd03.png)


## TODO 

@nicosomb, here are some informations that will help you

-  Do not use this PR as is, it's just a proof of concept, there's code that could be refactored, since I had little time I remained by legacy's logic when there's actually quite some refactoring needed

-  I just noticed that when checking **Delete previous images**, it only works for jpg, not for webp (and not for avif), I think it can be fixed in the `AdminImagesController` in the `_deleteOldImages` method, there's a regex that doesn't take webp and avif into account.

- Investigate problems with AVIF:
	- We use PHP's GD extension, and this extension is only compatible with AVIF with php 8.1 and above... and also, `libavif-dev` package must be installed on the OS, and GD must be compiled with AVIF support, [see explanations here](https://php.watch/versions/8.1/gd-avif)
	- Another way would be to use ImageMagick, there's an extension for PHP, but then it means adding a new mandatory dependency for prestashop, I don't know if we can do that in a minor prestashop version? That would need to be discussed with @MatShir 

- Adding the checkboxes
	- You can add the checkboxes for additional image type support in `AdminImagesController`'s constructor, see how the form is built using the legacy `HelperForm` component, [it is documented here](https://devdocs.prestashop-project.org/1.7/development/components/helpers/helperform/) 
	- New fields's value will be stored in the `PS_CONFIGURATION` table, here are the keys I used: `PS_ADDITIONAL_IMAGE_QUALITY_WEBP` and `PS_ADDITIONAL_IMAGE_QUALITY_AVIF`, feel free to change this if you want :+1: 







