### PR TITLE
Remove US/Pacific-New timezone

### DIFF
--- a/install-dev/data/xml/timezone.xml
+++ b/install-dev/data/xml/timezone.xml
@@ -558,7 +558,6 @@
     <timezone id="US_Michigan" name="US/Michigan"/>
     <timezone id="US_Mountain" name="US/Mountain"/>
     <timezone id="US_Pacific" name="US/Pacific"/>
-    <timezone id="US_Pacific-New" name="US/Pacific-New"/>
     <timezone id="US_Samoa" name="US/Samoa"/>
     <timezone id="UTC" name="UTC"/>
     <timezone id="W-SU" name="W-SU"/>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove obsolete timezone choice on install.
| Type?             | improvement
| Category?         | IN
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #14411.
| How to test?      | See that install will not give you anymore this choice while choosing  "United States" country.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
