### PR TITLE
Fix issue 29937 - Array to string conversion in information of cli installation command

### DIFF
--- a/install-dev/classes/controllerConsole.php
+++ b/install-dev/classes/controllerConsole.php
@@ -91,7 +91,12 @@ abstract class InstallControllerConsole
             echo 'Arguments available:' . PHP_EOL;
             foreach ($available_arguments as $key => $arg) {
                 $name = isset($arg['name']) ? $arg['name'] : $key;
-                echo '--' . $name . "\t" . (isset($arg['help']) ? $arg['help'] : '') . (isset($arg['default']) ? "\t" . '(Default: ' . $arg['default'] . ')' : '') . PHP_EOL;
+                echo '--'
+                    . $name
+                    . "\t"
+                    . (isset($arg['help']) ? $arg['help'] : '')
+                    . (isset($arg['default']) ? "\t" . '(Default: ' . (is_array($arg['default']) ? '[' . implode(',', $arg['default']) . ']' : $arg['default']) . ')' : '')
+                    . PHP_EOL;
             }
             exit;
         }

--- a/install-dev/classes/controllerConsole.php
+++ b/install-dev/classes/controllerConsole.php
@@ -91,18 +91,18 @@ abstract class InstallControllerConsole
             echo 'Arguments available:' . PHP_EOL;
             foreach ($available_arguments as $key => $arg) {
                 $name = isset($arg['name']) ? $arg['name'] : $key;
-$help = isset($arg['help']) ? $arg['help'] : '';
-$default = '';
+                $help = isset($arg['help']) ? $arg['help'] : '';
+                $default = '';
 
-if(isset($arg['default'])) {
-    if(is_array($arg['default'])) {
-        $default = '(Default: [' . implode(',', $arg['default']) . '])';
-    } else {
-        $default = '(Default: ' . $arg['default'] . ')';
-    }
-}
+                if (isset($arg['default'])) {
+                    if (is_array($arg['default'])) {
+                        $default = '(Default: [' . implode(',', $arg['default']) . '])';
+                    } else {
+                        $default = '(Default: ' . $arg['default'] . ')';
+                    }
+                }
 
-echo '--' . $name . "\t" . $help . "\t" . $default . PHP_EOL;
+                echo '--' . $name . "\t" . $help . "\t" . $default . PHP_EOL;
             }
             exit;
         }

--- a/install-dev/classes/controllerConsole.php
+++ b/install-dev/classes/controllerConsole.php
@@ -91,12 +91,18 @@ abstract class InstallControllerConsole
             echo 'Arguments available:' . PHP_EOL;
             foreach ($available_arguments as $key => $arg) {
                 $name = isset($arg['name']) ? $arg['name'] : $key;
-                echo '--'
-                    . $name
-                    . "\t"
-                    . (isset($arg['help']) ? $arg['help'] : '')
-                    . (isset($arg['default']) ? "\t" . '(Default: ' . (is_array($arg['default']) ? '[' . implode(',', $arg['default']) . ']' : $arg['default']) . ')' : '')
-                    . PHP_EOL;
+$help = isset($arg['help']) ? $arg['help'] : '';
+$default = '';
+
+if(isset($arg['default'])) {
+    if(is_array($arg['default'])) {
+        $default = '(Default: [' . implode(',', $arg['default']) . '])';
+    } else {
+        $default = '(Default: ' . $arg['default'] . ')';
+    }
+}
+
+echo '--' . $name . "\t" . $help . "\t" . $default . PHP_EOL;
             }
             exit;
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes display of default array parameter in cli
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29937 
| How to test?      | Go to install-dev directory, run php index_cli.php


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
