### PR TITLE
Fix alert spacing inside modal content of product page v2

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_light_display.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_light_display.scss
@@ -4,6 +4,10 @@ body {
 }
 
 .light_display_layout {
+  .-notoolbar > .alert {
+    margin: 1rem;
+  }
+
   form {
     /*
      * When the form is displayed in a card there is a default margin bottom which messes with the estimated height


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Spacing of the alert of a modal content iframe was wrong because it's outside of the form
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29329
| How to test?      | See issue
| Possible impacts? | Modal content iframe alert spacing

<img width="953" alt="image" src="https://user-images.githubusercontent.com/14963751/194880024-1d94512b-9604-4f00-a310-d85de2e37f81.png">



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
