### PR TITLE
Fixed TranslatorTrait to correctly render html tags on BO

### DIFF
--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -59,17 +59,19 @@ trait PrestaShopTranslatorTrait
             $locale = null;
         }
 
+        $translated = parent::trans($id, [], $this->normalizeDomain($domain), $locale);
+
         if ($this->shouldFallbackToLegacyModuleTranslation($id, $domain)) {
             return $this->translateUsingLegacySystem($id, $parameters, $domain, $locale);
         }
 
-        $translated = parent::trans($id, $isSprintf ? [] : $parameters, $this->normalizeDomain($domain), $locale);
+        $translated = isset($legacy) ? $this->replaceSpecialCharsWithLegacyFunctions($translated, $legacy) : $translated;
 
         if ($isSprintf) {
             $translated = vsprintf($translated, $parameters);
+        } elseif (!empty($parameters)) {
+            $translated = strtr($translated, $parameters);
         }
-
-        $translated = isset($legacy) ? $this->replaceSpecialCharsWithLegacyFunctions($translated, $legacy) : $translated;
 
         return $translated;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed info alert in Customer Settings - Groups. 
| Type?             | bug fix
| Category?         | BO 
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29940 
| Related PRs       | 
| How to test?      | Go into the BO - Customer Settings - Groups page, the info alert is well displayed
| Possible impacts? | 

With @yanmakouf 

I reorder the code (to work like this version https://raw.githubusercontent.com/PrestaShop/PrestaShop/8204abff432f7d8c5d27f6f3b337f432e21ae80a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php) and I removed `$isSprintf ? [] : $parameters` in the `parent::trans` call. 