### PR TITLE
Use relative urls for Quick Access menu

### DIFF
--- a/classes/QuickAccess.php
+++ b/classes/QuickAccess.php
@@ -94,13 +94,14 @@ class QuickAccessCore extends ObjectModel
             return false;
         }
 
+        $context = Context::getContext();
         foreach ($quickAccess as $index => $quick) {
             // first, clean url to have a real quickLink
-            $quick['link'] = Context::getContext()->link->getQuickLink($quick['link']);
+            $quick['link'] = $context->link->getQuickLink($quick['link']);
             $tokenString = $idEmployee;
 
             if ('../' === $quick['link'] && Shop::getContext() == Shop::CONTEXT_SHOP) {
-                $url = Context::getContext()->shop->getBaseURL();
+                $url = $context->shop->getBaseURL();
                 if (!$url) {
                     unset($quickAccess[$index]);
 
@@ -117,11 +118,11 @@ class QuickAccessCore extends ObjectModel
 
                     $tokenString = $admin_tab[1] . (int) Tab::getIdFromClassName($admin_tab[1]) . $idEmployee;
                 }
-                $quickAccess[$index]['link'] = Context::getContext()->link->getBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . $quick['link'];
+                $quickAccess[$index]['link'] = $context->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . $quick['link'];
                 if ($quick['link'] === self::NEW_PRODUCT_LINK || $quick['link'] === self::NEW_PRODUCT_V2_LINK) {
                     //if new product page feature is enabled we create new product v2 modal popup
                     if (self::productPageV2Enabled()) {
-                        $quickAccess[$index]['link'] = Context::getContext()->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . self::NEW_PRODUCT_V2_LINK;
+                        $quickAccess[$index]['link'] = $context->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . self::NEW_PRODUCT_V2_LINK;
                         $quickAccess[$index]['class'] = 'new-product-button';
                     }
                 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Change the Quick Access links to use relative URLs. This assures that the employee does not get logged out when using a Quick access link in multishop environment
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29763
| Related PRs       | None
| How to test?      | Check #29763. Bug should not be reproducible after merging
| Possible impacts? | Is there a use case, when a Quick Access link should use an absolute URL? The only one I can imagine is a link to the FO, and this case is already addressed in the preexisting if-then-clause.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
