### PR TITLE
Fix improper cache path for YAML config of child theme

### DIFF
--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -51,11 +51,11 @@ class Theme implements AddonInterface
     ) {
         if (isset($attributes['parent'])) {
             if (null === $configurationCacheDirectory) {
-                $configurationCacheDirectory = (new Configuration())->get('_PS_CACHE_DIR_');
+                $configurationCacheDirectory = _PS_CACHE_DIR_;
             }
 
             $yamlParser = new YamlParser($configurationCacheDirectory);
-            $parentAttributes = $yamlParser->parse($themesDirectory . '/' . $attributes['parent'] . '/config/theme.yml');
+            $parentAttributes = $yamlParser->parse($themesDirectory . $attributes['parent'] . '/config/theme.yml');
             $parentAttributes['preview'] = 'themes/' . $attributes['parent'] . '/preview.png';
             $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/') . '/';
             $attributes = array_merge($parentAttributes, $attributes);

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -55,7 +55,7 @@ class Theme implements AddonInterface
             }
 
             $yamlParser = new YamlParser($configurationCacheDirectory);
-            $parentAttributes = $yamlParser->parse($themesDirectory . $attributes['parent'] . '/config/theme.yml');
+            $parentAttributes = $yamlParser->parse($themesDirectory . '/' . $attributes['parent'] . '/config/theme.yml');
             $parentAttributes['preview'] = 'themes/' . $attributes['parent'] . '/preview.png';
             $parentAttributes['parent_directory'] = rtrim($attributes['directory'], '/') . '/';
             $attributes = array_merge($parentAttributes, $attributes);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When you have a theme with children, cache of yaml config file of the theme is created in the root path of PrestaShop instead of var/cache/yaml directory.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30081
| How to test?      | 1. Create a PrestaShop<br>2. Install a theme and a child theme<br>3. Go to the home page of PrestaShop<br>4. In the root path of the PrestaShop you'll see a new folder "yaml" with  the yaml parser cache generated.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.