### PR TITLE
Deprecate Customer::validateController

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1346,11 +1346,13 @@ class CustomerCore extends ObjectModel
     }
 
     /**
-     * Validate controller.
+     * Validate controller and check password
      *
      * @param bool $htmlentities
      *
      * @return array
+     * 
+     * @deprecated The password check has been moved in controllers and this method is not called anywhere.
      */
     public function validateController($htmlentities = true)
     {

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1352,7 +1352,7 @@ class CustomerCore extends ObjectModel
      *
      * @return array
      * 
-     * @deprecated The password check has been moved in controllers and this method is not called anywhere.
+     * @deprecated 8.1.0 The password check has been moved in controllers and this method is not called anywhere since 1.7.0
      */
     public function validateController($htmlentities = true)
     {

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1351,7 +1351,7 @@ class CustomerCore extends ObjectModel
      * @param bool $htmlentities
      *
      * @return array
-     * 
+     *
      * @deprecated 8.1.0 The password check has been moved in controllers and this method is not called anywhere since 1.7.0
      */
     public function validateController($htmlentities = true)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Deprecate Customer::validateController, it's not called anymore in the core. This method used to check password in 1.6
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/26293
| How to test?      | N/A
| Possible impacts? | None
| Sponsor company   | Creabilis.com

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
