### PR TITLE
Updating default combination is now take into account when submitting the form

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataFormatter/CombinationListFormDataFormatter.php
+++ b/src/Core/Form/IdentifiableObject/DataFormatter/CombinationListFormDataFormatter.php
@@ -47,7 +47,7 @@ class CombinationListFormDataFormatter extends AbstractFormDataFormatter
             '[impact_on_price_te]' => '[price_impact][price_tax_excluded]',
             '[impact_on_price_ti]' => '[price_impact][price_tax_included]',
             '[delta_quantity][delta]' => '[stock][quantities][delta_quantity][delta]',
-            '[is_default]' => '[is_default]',
+            '[is_default]' => '[header][is_default]',
         ];
 
         return $this->formatByPath($formData, $pathAssociations);

--- a/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/CombinationListFormDataFormatterTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/CombinationListFormDataFormatterTest.php
@@ -105,5 +105,16 @@ class CombinationListFormDataFormatterTest extends TestCase
                 ],
             ],
         ];
+
+        yield 'is_default data' => [
+            [
+                'is_default' => true,
+            ],
+            [
+                'header' => [
+                    'is_default' => true,
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
… the form

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update condition in `PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\DefaultCombinationCommandsBuilder` to create the appropriate command in terms of the data from the form. 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | Fixes #29889 
| Related PRs       | 
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/29889
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
