### PR TITLE
Rotate Symfony log file

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -15,7 +15,7 @@ parameters:
   prestashop_views: "%kernel.root_dir%/../src/PrestaShopBundle/Resources/views"
   admin_page: "%prestashop_views%/Admin"
   env(PS_LOG_OUTPUT): "%kernel.logs_dir%/%kernel.environment%.log"
-  env(PS_LOG_MAX_FILES): 10
+  env(PS_LOG_MAX_FILES): 30
   mail_themes_uri: "/mails/themes"
   mail_themes_dir: "%kernel.project_dir%%mail_themes_uri%"
   modules_translation_paths: [ ]

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -64,7 +64,8 @@ framework:
 monolog:
   handlers:
     main:
-      type: stream
+      type: rotating_file
+      max_files: '%env(PS_LOG_MAX_FILES)%'
       path: '%env(PS_LOG_OUTPUT)%'
       level: notice
     legacy:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -15,6 +15,7 @@ parameters:
   prestashop_views: "%kernel.root_dir%/../src/PrestaShopBundle/Resources/views"
   admin_page: "%prestashop_views%/Admin"
   env(PS_LOG_OUTPUT): "%kernel.logs_dir%/%kernel.environment%.log"
+  env(PS_LOG_MAX_FILES): 10
   mail_themes_uri: "/mails/themes"
   mail_themes_dir: "%kernel.project_dir%%mail_themes_uri%"
   modules_translation_paths: [ ]

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -14,7 +14,8 @@ web_profiler:
 monolog:
   handlers:
     main:
-      type: stream
+      type:   rotating_file
+      max_files: 5
       path: '%env(PS_LOG_OUTPUT)%'
       level: debug
       channels: [ "!event" ]

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -15,7 +15,7 @@ monolog:
   handlers:
     main:
       type: rotating_file
-      max_files: 5
+      max_files: '%env(PS_LOG_MAX_FILES)%'
       path: '%env(PS_LOG_OUTPUT)%'
       level: debug
       channels: [ "!event" ]

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -14,7 +14,7 @@ web_profiler:
 monolog:
   handlers:
     main:
-      type:   rotating_file
+      type: rotating_file
       max_files: 5
       path: '%env(PS_LOG_OUTPUT)%'
       level: debug

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -20,7 +20,8 @@ monolog:
       action_level: error
       handler: nested
     nested:
-      type: stream
+      type:  rotating_file
+      max_files: 30
       path: '%env(PS_LOG_OUTPUT)%'
       level: debug
     console:

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -20,7 +20,7 @@ monolog:
       action_level: error
       handler: nested
     nested:
-      type:  rotating_file
+      type: rotating_file
       max_files: 30
       path: '%env(PS_LOG_OUTPUT)%'
       level: debug

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -21,7 +21,7 @@ monolog:
       handler: nested
     nested:
       type: rotating_file
-      max_files: 30
+      max_files: '%env(PS_LOG_MAX_FILES)%'
       path: '%env(PS_LOG_OUTPUT)%'
       level: debug
     console:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Activate Symfony log file rotation. Log file can be huge, it's better for the planet to rotate this logs, especially dev logs. Log conservation scheme set by PS_LOG_MAX_FILES that can be overrided.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| How to test?      | Generate a notice or warning et check the generated log file.
| Possible impacts? | N/A
| Sponsor company   | Creabilis.com

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
