### PR TITLE
Simplify Employee Options Form

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Employee/EmployeeOptionsType.php
@@ -62,15 +62,40 @@ class EmployeeOptionsType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $optionsLock = [];
+        if (!$this->canOptionsBeChanged) {
+            $optionsLock = [
+                'disabled' => true,
+                'alert_type' => 'warning',
+                'alert_message' => $this->trans(
+                    'You can\'t change the value of this configuration field in the context of this shop.',
+                    'Admin.Notifications.Warning'
+                ),
+                'block_prefix' => 'employee_options',
+                'form_theme' => '@PrestaShop/Admin/Configure/AdvancedParameters/Employee/FormTheme/employee_options.html.twig',
+            ];
+        }
+
         $builder
             ->add('password_change_time', IntegerType::class, [
+                'label' => $this->trans('Password regeneration', 'Admin.Advparameters.Feature'),
                 'required' => false,
                 'unit' => $this->trans('minutes', 'Admin.Advparameters.Feature'),
-                'disabled' => !$this->canOptionsBeChanged,
-            ])
+                'help' => $this->trans(
+                    'Security: Minimum time to wait between two password changes.',
+                    'Admin.Advparameters.Feature'
+                ),
+            ] + $optionsLock)
             ->add('allow_employee_specific_language', SwitchType::class, [
+                'label' => $this->trans(
+                    'Memorize the language used in Admin panel forms',
+                    'Admin.Advparameters.Feature'
+                ),
                 'required' => false,
-                'disabled' => !$this->canOptionsBeChanged,
-            ]);
+                'help' => $this->trans(
+                    'Allow employees to select a specific language for the Admin panel form.',
+                    'Admin.Advparameters.Feature'
+                ),
+            ] + $optionsLock);
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/Blocks/employee_options.html.twig
@@ -23,6 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
+{% form_theme employeeOptionsForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+{% trans_default_domain 'Admin.Advparameters.Feature' %}
+
 {% block employee_options_form %}
   {{ form_start(employeeOptionsForm, {'action': path('admin_employees_save_options') }) }}
   <div class="card">
@@ -32,60 +35,12 @@
     </h3>
     <div class="card-body">
       <div class="form-wrapper">
-        <div class="form-group row">
-          <label for="{{ employeeOptionsForm.password_change_time.vars.id }}" class="form-control-label">
-            {{ 'Password regeneration'|trans({}, 'Admin.Advparameters.Feature') }}
-          </label>
-
-          <div class="col-sm">
-            {{ form_errors(employeeOptionsForm.password_change_time) }}
-            {{ form_widget(employeeOptionsForm.password_change_time) }}
-            <small class="form-text">
-              {{ 'Security: Minimum time to wait between two password changes.'|trans({}, 'Admin.Advparameters.Feature') }}
-            </small>
-
-            {% if not canOptionsBeChanged %}
-            <div class="alert alert-warning mt-2 mb-0" role="alert">
-              <p class="alert-text">
-                {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
-              </p>
-            </div>
-            {% endif %}
-          </div>
-        </div>
-
-        <div class="form-group row">
-          <label for="{{ employeeOptionsForm.allow_employee_specific_language.vars.id }}" class="form-control-label">
-            {{ 'Memorize the language used in Admin panel forms'|trans({}, 'Admin.Advparameters.Feature') }}
-          </label>
-
-          <div class="col-sm">
-            {{ form_errors(employeeOptionsForm.allow_employee_specific_language) }}
-            {{ form_widget(employeeOptionsForm.allow_employee_specific_language) }}
-            <small class="form-text">
-              {{ 'Allow employees to select a specific language for the Admin panel form.'|trans({}, 'Admin.Advparameters.Feature') }}
-            </small>
-
-            {% if not canOptionsBeChanged %}
-            <div class="alert alert-warning mt-2 mb-0" role="alert">
-              <p class="alert-text">
-                {{ 'You can\'t change the value of this configuration field in the context of this shop.'|trans({}, 'Admin.Notifications.Warning') }}
-              </p>
-            </div>
-            {% endif %}
-          </div>
-        </div>
-
-        {% block employee_options_form_rest %}
-          {{ form_rest(employeeOptionsForm) }}
-        {% endblock %}
+        {{ form_widget(employeeOptionsForm) }}
       </div>
     </div>
     <div class="card-footer">
       <div class="d-flex justify-content-end">
-        <button class="btn btn-primary pull-right"
-                {% if not canOptionsBeChanged %}disabled{% endif %}
-        >
+        <button class="btn btn-primary pull-right" {% if not canOptionsBeChanged %}disabled{% endif %}>
           {{ 'Save'|trans({}, 'Admin.Actions') }}
         </button>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/FormTheme/employee_options.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Employee/FormTheme/employee_options.html.twig
@@ -1,0 +1,102 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{# Extend form_row template to move the form_alert behind the label #}
+{%- block employee_options_row -%}
+  {% apply spaceless %}
+    {# In horizontal theme when using a title for label it needs to be outside of the row div #}
+    {% if label_tag_name is defined %}
+      {{ form_label(form) }}
+    {% endif %}
+
+    {% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+    {% set disabledField = false %}
+    {% if form.vars.attr.disabled is defined and form.vars.attr.disabled %}
+      {% set disabledField = true %}
+    {% endif %}
+
+    <div class="{{ block('form_row_class') }}{{ block('widget_type_class') }}{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}{% if (attr.visible is defined and not attr.visible) %} d-none{% endif %}">
+      {% set multistoreCheckboxName = multistore_field_prefix ~ form.vars.name %}
+      {% if attribute(form.parent, multistoreCheckboxName) is defined %}
+        {{ form_errors(attribute(form.parent, multistoreCheckboxName)) }}
+        {{ form_widget(attribute(form.parent, multistoreCheckboxName)) }}
+      {% endif %}
+
+      {% if label_tag_name is not defined %}
+        {{ form_label(form) }}
+      {% endif %}
+      <div class="{{ block('form_group_class') }}{% if disabledField %} disabled{% endif %}">
+        {{ form_widget(form) }}
+        {#  #}
+        {{ form_errors(form, {'attr': {'fieldError': true}}) }}
+        {{- block('form_alert') -}}
+      </div>
+      {% if attribute(form.parent, form.vars.name) is defined and attribute(form.parent, form.vars.name).vars.multistore_dropdown != false %}
+        {{ attribute(form.parent, form.vars.name).vars.multistore_dropdown | raw }}
+      {% endif %}
+
+      {{- block('form_external_link') -}}
+    </div>
+  {% endapply %}
+
+  {% if column_breaker %}
+    <div class="form-group form-column-breaker"></div>
+  {% endif %}
+{%- endblock employee_options_row -%}
+
+{# Override form_alert template to add a class #}
+{%- block form_alert -%}
+  {% if alert_message is defined %}
+    <div class="alert alert-{{ alert_type }}{% if alert_title is defined %} expandable-alert{% endif %} mt-1" role="alert">
+      {% if alert_title is defined %}
+        <p class="alert-text">
+          {{ alert_title|raw }}
+        </p>
+      {% else %}
+        {% for message in alert_message %}
+          <p class="alert-text">
+            {{ message|raw }}
+          </p>
+        {% endfor %}
+      {% endif %}
+
+      {% if alert_title is defined %}
+        <div class="alert-more collapse" id="expandable_{{form.vars.id}}" style="">
+          {% for message in alert_message %}
+            <p>
+              {{ message|raw }}
+            </p>
+          {% endfor %}
+        </div>
+        <div class="read-more-container">
+          <button type="button" class="read-more btn-link" data-toggle="collapse" data-target="#expandable_{{form.vars.id}}" aria-expanded="true" aria-controls="collapseDanger">
+            {{ 'Read more'|trans({}, 'Admin.Actions') }}
+          </button>
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+{%- endblock form_alert -%}
+


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify Employee Options Form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Advanced Parameters -> Team -> Employees Options (below the grid). Everything must look the same aside for help now appearing under inputs instead as blue box, also some fields now will appear as required because they always were.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
