### PR TITLE
Better escape PR description for the Pull Request Validator Github action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,12 @@ jobs:
       - name: Check is merge PR
         id: check-is-merge
         run: |
-          if [[ ${{ toJSON(github.event.pull_request.body) }} =~ \|?[[:space:]]*Category\?[[:space:]]*\|[[:space:]]*ME([[:space:]]|(\\[rn]))+ ]]; then
+          description=$(
+          cat <<"EOF"
+          ${{ toJSON(github.event.pull_request.body) }}
+          EOF
+          )
+          if [[ $description =~ \|?[[:space:]]*Category\?[[:space:]]*\|[[:space:]]*ME([[:space:]]|(\\[rn]))+ ]]; then
               echo ::set-output name=isMerge::true
           fi
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When backticks `` ` `` were used in the PR description, this could prevent the `Pull Request Validator` github action to be well executed. This PR aims to solve this by use heredoc (`<<`)
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes N/A
| Related PRs       | 
| How to test?      | CI should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
