### PR TITLE
Allow themes to disable loading of core scripts

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -906,7 +906,9 @@ class FrontControllerCore extends Controller
             $this->registerStylesheet('theme-rtl', '/assets/css/rtl.css', ['media' => 'all', 'priority' => 900]);
         }
 
-        $this->registerJavascript('corejs', '/themes/core.js', ['position' => 'bottom', 'priority' => 0]);
+        if ($this->context->shop->theme->requiresCoreScripts()) {
+            $this->registerJavascript('corejs', '/themes/core.js', ['position' => 'bottom', 'priority' => 0]);
+        }
         $this->registerJavascript('theme-main', '/assets/js/theme.js', ['position' => 'bottom', 'priority' => 50]);
         $this->registerJavascript('theme-custom', '/assets/js/custom.js', ['position' => 'bottom', 'priority' => 1000]);
 

--- a/src/Core/Addon/Theme/Theme.php
+++ b/src/Core/Addon/Theme/Theme.php
@@ -271,4 +271,14 @@ class Theme implements AddonInterface
 
         return $js;
     }
+
+    /**
+     * Defines if the theme requires core.js scripts or it provides it's own implementation.
+     *
+     * @return bool
+     */
+    public function requiresCoreScripts(): bool
+    {
+        return $this->attributes->get('theme_settings.core_scripts', true);
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allows themes to disable loading core.js file and provide their own custom implementation of whole logic. They don't need to rely on anything in the core. This will be very useful for hummingbird.
| Type?             | new feature
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29994
| Related PRs       | no
| How to test?      | See below
| Possible impacts? | No, old themes will work just fine.

### How to test
- Have classic theme and some another theme installed.
- Add `core_scripts: false` into `themes/classic/config/theme.yml`, to `theme_settings` section. It should look like this:
![core_scripts](https://user-images.githubusercontent.com/6097524/195577123-3194d230-8b25-4681-8e67-9533ad9c455e.jpg)
- Switch to another theme and back to classic.
- Go to FO, show source code and see that core.js is no longer loaded.
- If you remove this again or set it to true, switch themes back and forth, it will be loaded again.