### PR TITLE
[POC] Unify product update commands to single UpdateProductCommand

### DIFF
--- a/src/Adapter/Product/CommandHandler/UpdateProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductHandler.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Update\ProductBasicInformationFiller;
+use PrestaShop\PrestaShop\Adapter\Product\Update\ProductOptionsFiller;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
+
+class UpdateProductHandler
+{
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+
+    /**
+     * @var ProductBasicInformationFiller
+     */
+    private $basicInformationFiller;
+
+    /**
+     * @var ProductOptionsFiller
+     */
+    private $productOptionsFiller;
+
+    public function __construct(
+        ProductMultiShopRepository $productRepository,
+        ProductBasicInformationFiller $basicInformationFiller,
+        ProductOptionsFiller $productOptionsFiller
+    ) {
+        $this->productRepository = $productRepository;
+        $this->basicInformationFiller = $basicInformationFiller;
+        $this->productOptionsFiller = $productOptionsFiller;
+    }
+
+    public function handle(UpdateProductCommand $command): void
+    {
+        $shopConstraint = $command->getShopConstraint();
+        $product = $this->productRepository->getByShopConstraint($command->getProductId(), $shopConstraint);
+
+        //@todo:  if we manage to tag/map the filler services with the dto's somehow it should be automatable
+        $updatableProperties = $this->basicInformationFiller->fillUpdatableProperties($product, $command->getBasicInformation());
+        $updatableProperties = array_merge(
+            $updatableProperties,
+            $this->productOptionsFiller->fillUpdatableProperties($product, $command->getOptions())
+        );
+
+        // @todo: other commands in dedicated PR's
+
+        $this->productRepository->partialUpdate(
+            $product,
+            $updatableProperties,
+            $shopConstraint,
+            CannotUpdateProductException::FAILED_UPDATE_OPTIONS
+        );
+    }
+}

--- a/src/Adapter/Product/Update/ProductBasicInformationFiller.php
+++ b/src/Adapter/Product/Update/ProductBasicInformationFiller.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Update;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
+use Product;
+
+//@todo: see maybe we can homogenize this and tag it as some filler interface (probably not doable because the dto's are different?)
+class ProductBasicInformationFiller
+{
+    /**
+     * @param Product $product
+     * @param UpdateProductBasicInformationCommand $command
+     *
+     * @return array<string, mixed>
+     */
+    public function fillUpdatableProperties(
+        Product $product,
+        UpdateProductBasicInformationCommand $command
+    ): array {
+        $updatableProperties = [];
+
+        $localizedNames = $command->getLocalizedNames();
+        if (null !== $localizedNames) {
+            $defaultName = $localizedNames[$this->defaultLanguageId];
+            // Go through all the product languages and make sure name is filled for each of them
+            $productLanguages = array_keys($product->name);
+            foreach ($productLanguages as $languageId) {
+                if (empty($localizedNames[$languageId])) {
+                    $localizedNames[$languageId] = $defaultName;
+                }
+            }
+            $product->name = $localizedNames;
+            $updatableProperties['name'] = array_keys($localizedNames);
+        }
+
+        foreach ($product->link_rewrite as $langId => $linkRewrite) {
+            if (!empty($linkRewrite) || empty($product->name[$langId])) {
+                continue;
+            }
+
+            $product->link_rewrite[$langId] = $this->tools->linkRewrite($product->name[$langId]);
+            $updatableProperties['link_rewrite'][] = $langId;
+        }
+
+        $localizedDescriptions = $command->getLocalizedDescriptions();
+        if (null !== $localizedDescriptions) {
+            $product->description = $localizedDescriptions;
+            $updatableProperties['description'] = array_keys($localizedDescriptions);
+        }
+
+        $localizedShortDescriptions = $command->getLocalizedShortDescriptions();
+        if (null !== $localizedShortDescriptions) {
+            $product->description_short = $localizedShortDescriptions;
+            $updatableProperties['description_short'] = array_keys($localizedShortDescriptions);
+        }
+
+        return $updatableProperties;
+    }
+}

--- a/src/Adapter/Product/Update/ProductBasicInformationFiller.php
+++ b/src/Adapter/Product/Update/ProductBasicInformationFiller.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Update;
 
 use PrestaShop\PrestaShop\Adapter\Tools;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductBasicInformationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\BasicInformationInput;
 use Product;
 

--- a/src/Adapter/Product/Update/ProductOptionsFiller.php
+++ b/src/Adapter/Product/Update/ProductOptionsFiller.php
@@ -27,56 +27,61 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Update;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\ProductOptionsInput;
 use Product;
 
-class ProductOptionsFiller
+class ProductOptionsFiller implements ProductPropertiesFillerInterface
 {
     /**
      * @param Product $product
-     * @param UpdateProductOptionsCommand $command
+     * @param ProductOptionsInput $input
      *
      * @return string[]|array<string, int[]> updatable properties
      */
-    public function fillUpdatableProperties(Product $product, UpdateProductOptionsCommand $command): array
+    public function fillUpdatableProperties(Product $product, $input): array
     {
+        if (!($input instanceof ProductOptionsInput)) {
+            //@todo; dedicated exception and better message
+            throw new \InvalidArgumentException(sprintf('Unsupported argument in %s', get_class($this)));
+        }
+
         $updatableProperties = [];
 
-        if (null !== $command->getVisibility()) {
-            $product->visibility = $command->getVisibility()->getValue();
+        if (null !== $input->getVisibility()) {
+            $product->visibility = $input->getVisibility()->getValue();
             $updatableProperties[] = 'visibility';
         }
 
-        if (null !== $command->isAvailableForOrder()) {
-            $product->available_for_order = $command->isAvailableForOrder();
+        if (null !== $input->isAvailableForOrder()) {
+            $product->available_for_order = $input->isAvailableForOrder();
             $updatableProperties[] = 'available_for_order';
         }
         $availableForOrder = $product->available_for_order;
 
-        if (null !== $command->showPrice() && !$availableForOrder) {
-            $product->show_price = $command->showPrice();
+        if (null !== $input->showPrice() && !$availableForOrder) {
+            $product->show_price = $input->showPrice();
             $updatableProperties[] = 'show_price';
         } elseif ($availableForOrder && !$product->show_price) {
             $product->show_price = true;
             $updatableProperties[] = 'show_price';
         }
 
-        if (null !== $command->isOnlineOnly()) {
-            $product->online_only = $command->isOnlineOnly();
+        if (null !== $input->isOnlineOnly()) {
+            $product->online_only = $input->isOnlineOnly();
             $updatableProperties[] = 'online_only';
         }
 
-        if (null !== $command->getCondition()) {
-            $product->condition = $command->getCondition()->getValue();
+        if (null !== $input->getCondition()) {
+            $product->condition = $input->getCondition()->getValue();
             $updatableProperties[] = 'condition';
         }
 
-        if (null !== $command->showCondition()) {
-            $product->show_condition = $command->showCondition();
+        if (null !== $input->showCondition()) {
+            $product->show_condition = $input->showCondition();
             $updatableProperties[] = 'show_condition';
         }
 
-        $manufacturerId = $command->getManufacturerId();
+        $manufacturerId = $input->getManufacturerId();
         if (null !== $manufacturerId) {
             $product->id_manufacturer = $manufacturerId->getValue();
             $updatableProperties[] = 'id_manufacturer';

--- a/src/Adapter/Product/Update/ProductOptionsFiller.php
+++ b/src/Adapter/Product/Update/ProductOptionsFiller.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Update;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand;
+use Product;
+
+class ProductOptionsFiller
+{
+    /**
+     * @param Product $product
+     * @param UpdateProductOptionsCommand $command
+     *
+     * @return string[]|array<string, int[]> updatable properties
+     */
+    public function fillUpdatableProperties(Product $product, UpdateProductOptionsCommand $command): array
+    {
+        $updatableProperties = [];
+
+        if (null !== $command->getVisibility()) {
+            $product->visibility = $command->getVisibility()->getValue();
+            $updatableProperties[] = 'visibility';
+        }
+
+        if (null !== $command->isAvailableForOrder()) {
+            $product->available_for_order = $command->isAvailableForOrder();
+            $updatableProperties[] = 'available_for_order';
+        }
+        $availableForOrder = $product->available_for_order;
+
+        if (null !== $command->showPrice() && !$availableForOrder) {
+            $product->show_price = $command->showPrice();
+            $updatableProperties[] = 'show_price';
+        } elseif ($availableForOrder && !$product->show_price) {
+            $product->show_price = true;
+            $updatableProperties[] = 'show_price';
+        }
+
+        if (null !== $command->isOnlineOnly()) {
+            $product->online_only = $command->isOnlineOnly();
+            $updatableProperties[] = 'online_only';
+        }
+
+        if (null !== $command->getCondition()) {
+            $product->condition = $command->getCondition()->getValue();
+            $updatableProperties[] = 'condition';
+        }
+
+        if (null !== $command->showCondition()) {
+            $product->show_condition = $command->showCondition();
+            $updatableProperties[] = 'show_condition';
+        }
+
+        $manufacturerId = $command->getManufacturerId();
+        if (null !== $manufacturerId) {
+            $product->id_manufacturer = $manufacturerId->getValue();
+            $updatableProperties[] = 'id_manufacturer';
+        }
+
+        return $updatableProperties;
+    }
+}

--- a/src/Adapter/Product/Update/ProductPropertiesFillerInterface.php
+++ b/src/Adapter/Product/Update/ProductPropertiesFillerInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Update;
+
+use Product;
+
+interface ProductPropertiesFillerInterface
+{
+    /**
+     * @param Product $product
+     * @param $input
+     *
+     * @return array<string, mixed> updatable properties
+     */
+    public function fillUpdatableProperties(Product $product, $input): array;
+}

--- a/src/Adapter/Product/Update/ProductPropertiesFillerProvider.php
+++ b/src/Adapter/Product/Update/ProductPropertiesFillerProvider.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Update;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\BasicInformationInput;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\ProductOptionsInput;
+
+class ProductPropertiesFillerProvider
+{
+    /**
+     * @var ProductPropertiesFillerInterface[]
+     */
+    private $fillers;
+
+    /**
+     * @param ProductPropertiesFillerInterface[] $fillers
+     */
+    public function __construct(
+        iterable $fillers
+    ) {
+        foreach ($fillers as $filler) {
+            if (!($filler instanceof ProductPropertiesFillerInterface)) {
+                throw new \InvalidArgumentException('Invalid filler provided');
+            }
+        }
+
+        $this->fillers = $fillers;
+    }
+
+    /**
+     * @param $dto
+     *
+     * @return ProductPropertiesFillerInterface
+     */
+    public function getFiller($dto): ProductPropertiesFillerInterface
+    {
+        $dtoClass = get_class($dto);
+
+        $map = [
+            BasicInformationInput::class => ProductBasicInformationFiller::class,
+            ProductOptionsInput::class => ProductOptionsFiller::class,
+        ];
+
+        if (!array_key_exists($dtoClass, $map)) {
+            //@todo: dedicated exception
+            throw new \Exception(sprintf('Invalid configuration. %s is not mapped', $dtoClass));
+        }
+
+        foreach ($this->fillers as $filler) {
+            if ($filler instanceof $map[$dtoClass]) {
+                return $filler;
+            }
+        }
+
+        throw new \Exception(sprintf('Invalid configuration. Missing filler for %s', $dtoClass));
+    }
+}

--- a/src/Core/Domain/Product/Command/UpdateProductCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductCommand.php
@@ -55,15 +55,15 @@ class UpdateProductCommand
     private $options;
 
     /**
-     * @param ProductId $productId
+     * @param int $productId
      * @param ShopConstraint $shopConstraint
      */
     public function __construct(
-        ProductId $productId,
+        int $productId,
         ShopConstraint $shopConstraint
     ) {
+        $this->productId = new ProductId($productId);
         $this->shopConstraint = $shopConstraint;
-        $this->productId = $productId;
     }
 
     /**

--- a/src/Core/Domain/Product/Command/UpdateProductCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductCommand.php
@@ -27,6 +27,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\BasicInformationInput;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\ProductOptionsInput;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
@@ -43,15 +45,12 @@ class UpdateProductCommand
     private $shopConstraint;
 
     /**
-     * @todo: the command is still a DTO, but we will have to rename it later (for POC its ok, as it has all the properties we need)
-     *        same for other commands used here
-     *
-     * @var UpdateProductBasicInformationCommand|null
+     * @var BasicInformationInput|null
      */
     private $basicInformation;
 
     /**
-     * @var UpdateProductOptionsCommand|null
+     * @var ProductOptionsInput|null
      */
     private $options;
 
@@ -84,19 +83,19 @@ class UpdateProductCommand
     }
 
     /**
-     * @return UpdateProductBasicInformationCommand|null
+     * @return BasicInformationInput|null
      */
-    public function getBasicInformation(): ?UpdateProductBasicInformationCommand
+    public function getBasicInformation(): ?BasicInformationInput
     {
         return $this->basicInformation;
     }
 
     /**
-     * @param UpdateProductBasicInformationCommand|null $basicInformation
+     * @param BasicInformationInput|null $basicInformation
      *
      * @return UpdateProductCommand
      */
-    public function setBasicInformation(?UpdateProductBasicInformationCommand $basicInformation): self
+    public function setBasicInformation(?BasicInformationInput $basicInformation): UpdateProductCommand
     {
         $this->basicInformation = $basicInformation;
 
@@ -104,19 +103,19 @@ class UpdateProductCommand
     }
 
     /**
-     * @return UpdateProductOptionsCommand|null
+     * @return ProductOptionsInput|null
      */
-    public function getOptions(): ?UpdateProductOptionsCommand
+    public function getOptions(): ?ProductOptionsInput
     {
         return $this->options;
     }
 
     /**
-     * @param UpdateProductOptionsCommand|null $options
+     * @param ProductOptionsInput|null $options
      *
      * @return UpdateProductCommand
      */
-    public function setOptions(?UpdateProductOptionsCommand $options): UpdateProductCommand
+    public function setOptions(?ProductOptionsInput $options): UpdateProductCommand
     {
         $this->options = $options;
 

--- a/src/Core/Domain/Product/Command/UpdateProductCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductCommand.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+class UpdateProductCommand
+{
+    /**
+     * @var ProductId
+     */
+    private $productId;
+
+    /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
+     * @todo: the command is still a DTO, but we will have to rename it later (for POC its ok, as it has all the properties we need)
+     *        same for other commands used here
+     *
+     * @var UpdateProductBasicInformationCommand|null
+     */
+    private $basicInformation;
+
+    /**
+     * @var UpdateProductOptionsCommand|null
+     */
+    private $options;
+
+    /**
+     * @param ProductId $productId
+     * @param ShopConstraint $shopConstraint
+     */
+    public function __construct(
+        ProductId $productId,
+        ShopConstraint $shopConstraint
+    ) {
+        $this->shopConstraint = $shopConstraint;
+        $this->productId = $productId;
+    }
+
+    /**
+     * @return ProductId
+     */
+    public function getProductId(): ProductId
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
+    }
+
+    /**
+     * @return UpdateProductBasicInformationCommand|null
+     */
+    public function getBasicInformation(): ?UpdateProductBasicInformationCommand
+    {
+        return $this->basicInformation;
+    }
+
+    /**
+     * @param UpdateProductBasicInformationCommand|null $basicInformation
+     *
+     * @return UpdateProductCommand
+     */
+    public function setBasicInformation(?UpdateProductBasicInformationCommand $basicInformation): self
+    {
+        $this->basicInformation = $basicInformation;
+
+        return $this;
+    }
+
+    /**
+     * @return UpdateProductOptionsCommand|null
+     */
+    public function getOptions(): ?UpdateProductOptionsCommand
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param UpdateProductOptionsCommand|null $options
+     *
+     * @return UpdateProductCommand
+     */
+    public function setOptions(?UpdateProductOptionsCommand $options): UpdateProductCommand
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+}

--- a/src/Core/Domain/Product/Command/UpdateProductInput/BasicInformationInput.php
+++ b/src/Core/Domain/Product/Command/UpdateProductInput/BasicInformationInput.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput;
+
+class BasicInformationInput
+{
+    /**
+     * @var string[]|null
+     */
+    private $localizedNames;
+
+    /**
+     * @var string[]|null key value pairs where key is the id of language
+     */
+    private $localizedDescriptions;
+
+    /**
+     * @var string[]|null key value pairs where key is the id of language
+     */
+    private $localizedShortDescriptions;
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedNames(): ?array
+    {
+        return $this->localizedNames;
+    }
+
+    /**
+     * @param string[] $localizedNames
+     *
+     * @return BasicInformationInput
+     */
+    public function setLocalizedNames(array $localizedNames): BasicInformationInput
+    {
+        $this->localizedNames = $localizedNames;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedDescriptions(): ?array
+    {
+        return $this->localizedDescriptions;
+    }
+
+    /**
+     * @param string[] $localizedDescriptions
+     *
+     * @return BasicInformationInput
+     */
+    public function setLocalizedDescriptions(array $localizedDescriptions): BasicInformationInput
+    {
+        $this->localizedDescriptions = $localizedDescriptions;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedShortDescriptions(): ?array
+    {
+        return $this->localizedShortDescriptions;
+    }
+
+    /**
+     * @param string[] $localizedShortDescriptions
+     *
+     * @return BasicInformationInput
+     */
+    public function setLocalizedShortDescriptions(array $localizedShortDescriptions): BasicInformationInput
+    {
+        $this->localizedShortDescriptions = $localizedShortDescriptions;
+
+        return $this;
+    }
+}

--- a/src/Core/Domain/Product/Command/UpdateProductInput/ProductOptionsInput.php
+++ b/src/Core/Domain/Product/Command/UpdateProductInput/ProductOptionsInput.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput;
+
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerIdInterface;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\NoManufacturerId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
+
+class ProductOptionsInput
+{
+    /**
+     * @var ProductVisibility|null
+     */
+    private $visibility;
+
+    /**
+     * @var bool|null
+     */
+    private $availableForOrder;
+
+    /**
+     * @var bool|null
+     */
+    private $onlineOnly;
+
+    /**
+     * @var bool|null
+     */
+    private $showPrice;
+
+    /**
+     * @var ProductCondition|null
+     */
+    private $condition;
+
+    /**
+     * @var bool|null
+     */
+    private $showCondition;
+
+    /**
+     * @var ManufacturerIdInterface|null
+     */
+    private $manufacturerId;
+
+    /**
+     * @return ProductVisibility|null
+     */
+    public function getVisibility(): ?ProductVisibility
+    {
+        return $this->visibility;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isAvailableForOrder(): ?bool
+    {
+        return $this->availableForOrder;
+    }
+
+    /**
+     * @param string $visibility
+     *
+     * @return ProductOptionsInput
+     */
+    public function setVisibility(string $visibility): ProductOptionsInput
+    {
+        $this->visibility = new ProductVisibility($visibility);
+
+        return $this;
+    }
+
+    /**
+     * @param bool $availableForOrder
+     *
+     * @return ProductOptionsInput
+     */
+    public function setAvailableForOrder(bool $availableForOrder): ProductOptionsInput
+    {
+        $this->availableForOrder = $availableForOrder;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isOnlineOnly(): ?bool
+    {
+        return $this->onlineOnly;
+    }
+
+    /**
+     * @param bool $onlineOnly
+     *
+     * @return ProductOptionsInput
+     */
+    public function setOnlineOnly(bool $onlineOnly): ProductOptionsInput
+    {
+        $this->onlineOnly = $onlineOnly;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function showPrice(): ?bool
+    {
+        return $this->showPrice;
+    }
+
+    /**
+     * @param bool $showPrice
+     *
+     * @return ProductOptionsInput
+     */
+    public function setShowPrice(bool $showPrice): ProductOptionsInput
+    {
+        $this->showPrice = $showPrice;
+
+        return $this;
+    }
+
+    /**
+     * @return ProductCondition|null
+     */
+    public function getCondition(): ?ProductCondition
+    {
+        return $this->condition;
+    }
+
+    /**
+     * @param string $condition
+     *
+     * @return ProductOptionsInput
+     */
+    public function setCondition(string $condition): ProductOptionsInput
+    {
+        $this->condition = new ProductCondition($condition);
+
+        return $this;
+    }
+
+    /**
+     * @param bool $showCondition
+     *
+     * @return ProductOptionsInput
+     */
+    public function setShowCondition(bool $showCondition): ProductOptionsInput
+    {
+        $this->showCondition = $showCondition;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function showCondition(): ?bool
+    {
+        return $this->showCondition;
+    }
+
+    /**
+     * @return ManufacturerIdInterface|null
+     */
+    public function getManufacturerId(): ?ManufacturerIdInterface
+    {
+        return $this->manufacturerId;
+    }
+
+    /**
+     * @param int $manufacturerId
+     *
+     * @throws ManufacturerConstraintException
+     *
+     * @return ProductOptionsInput
+     */
+    public function setManufacturerId(int $manufacturerId): ProductOptionsInput
+    {
+        $this->manufacturerId = NoManufacturerId::NO_MANUFACTURER_ID === $manufacturerId ?
+            new NoManufacturerId() :
+            new ManufacturerId($manufacturerId)
+        ;
+
+        return $this;
+    }
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/BasicInformationCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/BasicInformationCommandsBuilder.php
@@ -58,6 +58,8 @@ class BasicInformationCommandsBuilder implements MultiShopProductCommandsBuilder
      */
     public function buildCommands(ProductId $productId, array $formData, ShopConstraint $singleShopConstraint): array
     {
+        //@todo; does nothing for POC testing. UpdateProductCommandBuilder instead
+        return [];
         if (empty($formData['description']) && empty($formData['header']['name'])) {
             return [];
         }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/OptionsCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/OptionsCommandsBuilder.php
@@ -55,6 +55,9 @@ final class OptionsCommandsBuilder implements MultiShopProductCommandsBuilderInt
      */
     public function buildCommands(ProductId $productId, array $formData, ShopConstraint $singleShopConstraint): array
     {
+        //@todo; does nothing for POC testing. UpdateProductCommandBuilder instead
+        return [];
+
         if (empty($formData['options']) &&
             !isset($formData['description']['manufacturer']) &&
             !isset($formData['specifications'])) {

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
@@ -38,7 +38,7 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
 {
     public function buildCommands(ProductId $productId, array $formData, ShopConstraint $shopConstraint): array
     {
-        $updateProductCommand = new UpdateProductCommand($productId, $shopConstraint);
+        $updateProductCommand = new UpdateProductCommand($productId->getValue(), $shopConstraint);
 
         $updateProductCommand
             ->setBasicInformation($this->buildBasicInfo($formData))

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\BasicInformationInput;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\ProductOptionsInput;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+//@todo: abit confusing when it should always build only one command but is called plural and returns array. smth needs adjustments
+class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInterface
+{
+    public function buildCommands(ProductId $productId, array $formData, ShopConstraint $shopConstraint): array
+    {
+        $updateProductCommand = new UpdateProductCommand($productId, $shopConstraint);
+
+        $updateProductCommand
+            ->setBasicInformation($this->buildBasicInfo($formData))
+            ->setOptions($this->buildOptions($formData))
+        ;
+
+        return [$updateProductCommand];
+    }
+
+    private function buildBasicInfo(array $formData): ?BasicInformationInput
+    {
+        if (empty($formData['description']) && empty($formData['header']['name'])) {
+            return null;
+        }
+
+        //@todo: command builders is almost what we could use to build these dto's but not quite. Maybe its ok this simple way?
+        $basicInformationInput = new BasicInformationInput();
+        $basicInformationInput
+            ->setLocalizedNames($formData['header']['name'])
+            ->setLocalizedDescriptions($formData['description']['description'])
+            ->setLocalizedShortDescriptions($formData['description']['description_short'])
+        ;
+
+        return $basicInformationInput;
+    }
+
+    private function buildOptions(array $formData): ?ProductOptionsInput
+    {
+        if (empty($formData['options']) &&
+            !isset($formData['description']['manufacturer']) &&
+            !isset($formData['specifications'])) {
+            return null;
+        }
+
+        $productOptionsInput = new ProductOptionsInput();
+        $productOptionsInput
+            ->setManufacturerId((int) $formData['description']['manufacturer'])
+            ->setOnlineOnly((bool) $formData['options']['visibility']['online_only'])
+            ->setVisibility($formData['options']['visibility']['visibility'])
+            ->setAvailableForOrder((bool) $formData['options']['visibility']['available_for_order'])
+            ->setShowPrice((bool) $formData['options']['visibility']['show_price'])
+            ->setShowCondition((bool) $formData['specifications']['show_condition'])
+        ;
+
+        // based on show_condition value, the condition field can be disabled, in that case "condition" won't exist in request
+        if (!empty($formData['specifications']['condition'])) {
+            $productOptionsInput->setCondition((string) $formData['specifications']['condition']);
+        }
+
+        return $productOptionsInput;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -514,3 +514,28 @@ services:
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
       - '@prestashop.adapter.shop.repository.shop_repository'
+
+#@todo: POC services from here
+  prestashop.adapter.product.update.update_product_handler:
+    class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductHandler
+    arguments:
+      - '@prestashop.adapter.product.repository.product_multi_shop_repository'
+      - '@prestashop.adapter.product.update.product_properties_filler_provider'
+    tags:
+      - { name: tactician.handler, command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand }
+
+  prestashop.adapter.product.update.product_options_filler:
+    class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductOptionsFiller
+    tags: [ 'core.product_properties_filler' ]
+
+  prestashop.adapter.product.update.product_basic_information_filler:
+    class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductBasicInformationFiller
+    arguments:
+      - '@=service("prestashop.adapter.legacy.configuration").get("PS_LANG_DEFAULT")'
+      - '@prestashop.adapter.tools'
+    tags: [ 'core.product_properties_filler' ]
+
+  prestashop.adapter.product.update.product_properties_filler_provider:
+    class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductPropertiesFillerProvider
+    arguments:
+      - !tagged core.product_properties_filler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -521,6 +521,7 @@ services:
     arguments:
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@prestashop.adapter.product.update.product_properties_filler_provider'
+      - '@prestashop.adapter.product.update.product_indexation_updater'
     tags:
       - { name: tactician.handler, command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -129,3 +129,9 @@ services:
   prestashop.core.form.command_builder.product.combination.default_combination_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\DefaultCombinationCommandsBuilder
     tags: [ 'core.combination_command_builder' ]
+
+#@todo: POC services from here
+  prestashop.core.form.command_builder.product.update_product_commands_builder:
+    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\UpdateProductCommandsBuilder
+    tags:
+      - { name: 'core.product_command_builder' }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateBasicInformationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateBasicInformationFeatureContext.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct;
+
+use Behat\Gherkin\Node\TableNode;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\BasicInformationInput;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Product;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
+
+class UpdateBasicInformationFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I update product :productReference basic information for shop :shopReference with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductBasicInfoForShop(string $productReference, string $shopReference, TableNode $table): void
+    {
+        $shopId = $this->getSharedStorage()->get(trim($shopReference));
+        $shopConstraint = ShopConstraint::shop($shopId);
+        $this->updateProductBasicInfo($productReference, $table, $shopConstraint);
+    }
+
+    /**
+     * This method is created just for specific cases when product name needs to be updated
+     * using legacy object model, but not cqrs commands, to avoid some side effects while testing.
+     * For example when testing how cqrs command auto-fills link_rewrite in certain cases.
+     *
+     * @When /^I update product "([^"]*)" name \(not using commands\) with following localized values:$/
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     *
+     * @return void
+     */
+    public function updateProductName(string $productReference, TableNode $table): void
+    {
+        $productId = $this->getSharedStorage()->get($productReference);
+        $product = new Product($productId, true);
+        $product->name = $this->localizeByRows($table)['name'];
+
+        $product->update();
+    }
+
+    /**
+     * @When I update product :productReference basic information for all shops with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductBasicInfoForAllShops(string $productReference, TableNode $table): void
+    {
+        $this->updateProductBasicInfo($productReference, $table, ShopConstraint::allShops());
+    }
+
+    /**
+     * @When I update product :productReference basic information with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductBasicInfoWithDefaultShop(string $productReference, TableNode $table): void
+    {
+        $this->updateProductBasicInfo($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
+    }
+
+    /**
+     * @param string $productReference
+     * @param TableNode $table
+     * @param ShopConstraint $shopConstraint
+     */
+    private function updateProductBasicInfo(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
+    {
+        $data = $this->localizeByRows($table);
+        $productId = $this->getSharedStorage()->get($productReference);
+        $basicInformationInput = new BasicInformationInput();
+
+        if (isset($data['name'])) {
+            $basicInformationInput->setLocalizedNames($data['name']);
+        }
+
+        if (isset($data['description'])) {
+            $basicInformationInput->setLocalizedDescriptions($data['description']);
+        }
+
+        if (isset($data['description_short'])) {
+            $basicInformationInput->setLocalizedShortDescriptions($data['description_short']);
+        }
+
+        try {
+            $command = new UpdateProductCommand($productId, $shopConstraint);
+            $command->setBasicInformation($basicInformationInput);
+
+            $this->getCommandBus()->handle($command);
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateOptionsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateOptionsFeatureContext.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct;
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerException;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\NoManufacturerId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductInput\ProductOptionsInput;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductOptionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductOptions;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+class UpdateOptionsFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @When I update product :productReference options with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductOptionsForDefaultShop(string $productReference, TableNode $table): void
+    {
+        $this->updateProductOptions($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
+    }
+
+    /**
+     * @When I update product :productReference options for shop ":shopReference" with following values:
+     *
+     * @param string $productReference
+     * @param string $shopReference
+     * @param TableNode $table
+     */
+    public function updateProductOptionsForShop(string $productReference, string $shopReference, TableNode $table): void
+    {
+        $shopId = $this->getSharedStorage()->get(trim($shopReference));
+        $this->updateProductOptions($productReference, $table, ShopConstraint::shop($shopId));
+    }
+
+    /**
+     * @When I update product :productReference options for all shops with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductOptionsForAllShops(string $productReference, TableNode $table): void
+    {
+        $this->updateProductOptions($productReference, $table, ShopConstraint::allShops());
+    }
+
+    /**
+     * @When I assign non existing manufacturer to product :productReference
+     *
+     * @param string $productReference
+     */
+    public function updateOptionsWithNonExistingManufacturer(string $productReference): void
+    {
+        // intentional. Mimics id of non-existing manufacturer
+        $nonExistingId = 50000;
+
+        try {
+            $command = new UpdateProductOptionsCommand(
+                $this->getSharedStorage()->get($productReference),
+                ShopConstraint::shop($this->getDefaultShopId())
+            );
+            $command->setManufacturerId($nonExistingId);
+            $this->getCommandBus()->handle($command);
+        } catch (ManufacturerException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @Transform table:product option,value
+     *
+     * @param TableNode $tableNode
+     *
+     * @return ProductOptions
+     */
+    public function transformOptions(TableNode $tableNode): ProductOptions
+    {
+        $dataRows = $tableNode->getRowsHash();
+
+        return new ProductOptions(
+            $dataRows['visibility'],
+            PrimitiveUtils::castStringBooleanIntoBoolean($dataRows['available_for_order']),
+            PrimitiveUtils::castStringBooleanIntoBoolean($dataRows['online_only']),
+            PrimitiveUtils::castStringBooleanIntoBoolean($dataRows['show_price']),
+            $dataRows['condition'],
+            PrimitiveUtils::castStringBooleanIntoBoolean($dataRows['show_condition']),
+            $this->getManufacturerId($dataRows['manufacturer'])
+        );
+    }
+
+    /**
+     * @Then product :productReference should have following options:
+     *
+     * @param string $productReference
+     * @param ProductOptions $expectedOptions
+     */
+    public function assertOptionsForDefaultShop(string $productReference, ProductOptions $expectedOptions): void
+    {
+        $this->assertOptions($productReference, $expectedOptions, $this->getDefaultShopId());
+    }
+
+    /**
+     * @Then product :productReference should have following options for shops :shopReferences:
+     *
+     * @param string $productReference
+     * @param ProductOptions $expectedOptions
+     * @param string $shopReferences
+     */
+    public function assertOptionsForShops(string $productReference, ProductOptions $expectedOptions, string $shopReferences): void
+    {
+        $shopReferences = explode(',', $shopReferences);
+        foreach ($shopReferences as $shopReference) {
+            $shopId = $this->getSharedStorage()->get(trim($shopReference));
+            $this->assertOptions($productReference, $expectedOptions, $shopId);
+        }
+    }
+
+    /**
+     * @param string $productReference
+     * @param TableNode $table
+     * @param ShopConstraint $shopConstraint
+     */
+    private function updateProductOptions(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
+    {
+        $data = $table->getRowsHash();
+        $productId = $this->getSharedStorage()->get($productReference);
+
+        try {
+            $command = new UpdateProductCommand($productId, $shopConstraint);
+            $this->fillCommand($data, $command);
+            $this->getCommandBus()->handle($command);
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @param string $productReference
+     * @param ProductOptions $expectedOptions
+     * @param int $shopId
+     */
+    private function assertOptions(string $productReference, ProductOptions $expectedOptions, int $shopId): void
+    {
+        $properties = [
+            'availableForOrder',
+            'onlineOnly',
+            'showPrice',
+            'visibility',
+            'condition',
+            'showCondition',
+            'manufacturerId',
+        ];
+        $actualOptions = $this->getProductForEditing($productReference, $shopId)->getOptions();
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        foreach ($properties as $property) {
+            Assert::assertSame(
+                $propertyAccessor->getValue($expectedOptions, $property),
+                $propertyAccessor->getValue($actualOptions, $property),
+                sprintf('Unexpected %s of product "%s"', $property, $productReference)
+            );
+        }
+    }
+
+    /**
+     * @param array $data
+     * @param UpdateProductCommand $command
+     */
+    private function fillCommand(array $data, UpdateProductCommand $command): void
+    {
+        $input = new ProductOptionsInput();
+
+        if (isset($data['visibility'])) {
+            $input->setVisibility($data['visibility']);
+        }
+
+        if (isset($data['available_for_order'])) {
+            $input->setAvailableForOrder(PrimitiveUtils::castStringBooleanIntoBoolean($data['available_for_order']));
+        }
+
+        if (isset($data['online_only'])) {
+            $input->setOnlineOnly(PrimitiveUtils::castStringBooleanIntoBoolean($data['online_only']));
+        }
+
+        if (isset($data['show_price'])) {
+            $input->setShowPrice(PrimitiveUtils::castStringBooleanIntoBoolean($data['show_price']));
+        }
+
+        if (isset($data['condition'])) {
+            $input->setCondition($data['condition']);
+        }
+
+        if (isset($data['show_condition'])) {
+            $input->setShowCondition(PrimitiveUtils::castStringBooleanIntoBoolean($data['show_condition']));
+        }
+
+        if (isset($data['manufacturer'])) {
+            $input->setManufacturerId($this->getManufacturerId($data['manufacturer']));
+        }
+
+        $command->setOptions($input);
+    }
+
+    /**
+     * @param string $manufacturerReference
+     *
+     * @return int
+     */
+    private function getManufacturerId(string $manufacturerReference): int
+    {
+        if ('' === $manufacturerReference) {
+            return NoManufacturerId::NO_MANUFACTURER_ID;
+        }
+
+        return $this->getSharedStorage()->get($manufacturerReference);
+    }
+}

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -429,3 +429,72 @@ default:
             contexts:
                - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                - Tests\Integration\Behaviour\Features\Context\Domain\CountryFeatureContext
+        product_update:
+          paths:
+            - "%paths.base%/Features/Scenario/Product"
+          filters:
+            tags: "~@legacy-product-type"
+          contexts:
+            - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Configuration\CommonConfigurationFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\CountryFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\CurrencyFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\CustomerFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\AttachmentFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\AttributeFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\AttributeGroupFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\CarrierFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\CategoryFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\CountryFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\CurrencyFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\FeatureFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\FeatureValueFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\ManufacturerFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationListingFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\DeleteCombinationFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SearchCombinationFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationDetailsFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationPricesFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationStockFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationSuppliersFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SetDefaultCombinationFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\DuplicateProductFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductImageFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductShopFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\ProductTypeFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\RelatedProductsFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\SearchProductFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\SpecificPriceContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\SpecificPricePrioritiesFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateAttachmentFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdateBasicInformationFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCategoriesFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateDetailsFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdateOptionsFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePackFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePositionFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePricesFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductFeatureValuesFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductSuppliersFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateSeoFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateShippingFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateTagsFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\Product\VirtualProductFileFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\ShopFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\SupplierFeatureContext
+            - Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext
+            - Tests\Integration\Behaviour\Features\Transform\LocalizedArrayTransformContext
+            - Tests\Integration\Behaviour\Features\Transform\StringToArrayTransformContext
+            - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Current approach having multiple CQRS commands for product update (commands like `UpdateProductBasicInformationCommand, UpdateProductPricesCommand, UpdateProductOptionsCommand, UpdateProductDetailsCommand, UpdateProductSeoCommand`.) have some flaws - user saves product once but it is actually fetched and saved couple times  and the product update hooks fires multiple times too. This is POC to unify the commands into one (except for all the association commands like setting categories, suppliers, features etc.)
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | TBD
| Possible impacts? | Will impact the whole product page, as its quite a refacto for the CQRS layer of whole product domain.

In pr there is an example of joining UpdateBasicInformationCommand & UpdateProductOptionsCommand. Later we would add other missing commands into it them and leave only UpdateProductCommand. (and delete all the commands that are left unused)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
