### PR TITLE
Allow legacy link feature flag

### DIFF
--- a/classes/lang/KeysReference/FeatureFlagLang.php
+++ b/classes/lang/KeysReference/FeatureFlagLang.php
@@ -41,4 +41,4 @@ trans('Access the new product page, even in a multistore context. This is a work
 
 // Legacy link feature flags
 trans('Attribute group', 'Admin.Advparameters.Feature');
-trans('Enable / Disable migrated attribute group page.', 'Admin.Advparameters.Help');
+trans('Enable or disable the migrated attribute groups page.', 'Admin.Advparameters.Help');

--- a/classes/lang/KeysReference/FeatureFlagLang.php
+++ b/classes/lang/KeysReference/FeatureFlagLang.php
@@ -40,5 +40,5 @@ trans('New product page - Multistore', 'Admin.Advparameters.Feature');
 trans('Access the new product page, even in a multistore context. This is a work in progress and some features are not available.', 'Admin.Advparameters.Help');
 
 // Legacy link feature flags
-trans('Attribute group', 'Admin.Advparameters.Feature');
+trans('Attribute groups', 'Admin.Advparameters.Feature');
 trans('Enable or disable the migrated attribute groups page.', 'Admin.Advparameters.Help');

--- a/install-dev/data/xml/feature_flag.xml
+++ b/install-dev/data/xml/feature_flag.xml
@@ -12,5 +12,6 @@
   <entities>
     <feature_flag id="product_page_v2" name="product_page_v2" label_wording="New product page - Single store" label_domain="Admin.Advparameters.Feature" description_wording="This page benefits from increased performance and includes new features such as a new combination management system." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
     <feature_flag id="product_page_v2_multi_shop" name="product_page_v2_multi_shop" label_wording="New product page - Multi store" label_domain="Admin.Advparameters.Feature" description_wording="Access the new product page, even in a multistore context. This is a work in progress and some features are not available." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
+    <feature_flag id="attribute_group" name="attribute_group" label_wording="Attribute group" label_domain="Admin.Advparameters.Feature" description_wording="Enable / Disable migrated attribute group page." description_domain="Admin.Advparameters.Help" state="0" stability="beta" />
   </entities>
 </entity_feature_flag>

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute_group.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/attribute_group.yml
@@ -5,7 +5,8 @@ admin_attribute_groups_index:
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\AttributeGroupController::indexAction'
     _legacy_controller: AdminAttributesGroups
-#  _legacy_link: AdminAttributesGroups
+    _legacy_link: AdminAttributesGroups
+    _legacy_feature_flag: attribute_group
 
 admin_attribute_groups_search:
   path: /
@@ -13,9 +14,10 @@ admin_attribute_groups_search:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\CommonController::searchGridAction
     _legacy_controller: AdminAttributesGroups
-    #  _legacy_link: AdminAttributeGroups:submitFilterattribute_group
+    _legacy_link: AdminAttributeGroups:submitFilterattribute_group
     gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.attribute_group
     redirectRoute: admin_attribute_groups_index
+    _legacy_feature_flag: attribute_group
 
 admin_attribute_groups_create:
   path: /new
@@ -24,7 +26,8 @@ admin_attribute_groups_create:
     # todo: implement create
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\AttributeGroupController::indexAction'
     _legacy_controller: AdminAttributesGroups
-#  _legacy_link: AdminAttributeGroups:addattribute_group
+    _legacy_link: AdminAttributeGroups:addattribute_group
+    _legacy_feature_flag: attribute_group
 
 admin_attribute_groups_view:
   path: /{attributeGroupId}/view
@@ -32,7 +35,8 @@ admin_attribute_groups_view:
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\AttributeController::indexAction'
     _legacy_controller: AdminAttributesGroups
-    #  _legacy_link: AdminAttributesGroups:viewattribute_group
+    _legacy_link: AdminAttributesGroups:viewattribute_group
+    _legacy_feature_flag: attribute_group
     _legacy_parameters:
       id_attribute_group: attributeGroupId
   requirements:
@@ -44,7 +48,8 @@ admin_attribute_groups_edit:
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\AttributeGroupController::editAction'
     _legacy_controller: AdminAttributesGroups
-    #  _legacy_link: AdminAttributesGroups:updateattribute_group
+    _legacy_link: AdminAttributesGroups:updateattribute_group
+    _legacy_feature_flag: attribute_group
     _legacy_parameters:
       id_attribute_group: attributeGroupId
   requirements:
@@ -56,7 +61,8 @@ admin_attribute_groups_delete:
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\AttributeGroupController::deleteAction'
     _legacy_controller: AdminAttributesGroups
-    #  _legacy_link: AdminAttributesGroups:deleteattribute_group
+    _legacy_feature_flag: attribute_group
+    _legacy_link: AdminAttributesGroups:deleteattribute_group
     _legacy_parameters:
       id_attribute_group: attributeGroupId
   requirements:
@@ -68,7 +74,8 @@ admin_attribute_groups_bulk_delete:
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\AttributeGroupController::bulkDeleteAction'
     _legacy_controller: AdminAttributesGroups
-#  _legacy_link: AdminAttributesGroups:submitBulkdeleteattribute_group
+    _legacy_link: AdminAttributesGroups:submitBulkdeleteattribute_group
+    _legacy_feature_flag: attribute_group
 
 admin_attribute_groups_export:
   path: /export
@@ -76,7 +83,8 @@ admin_attribute_groups_export:
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\AttributeGroupController::exportAction'
     _legacy_controller: AdminAttributesGroups
-#  _legacy_link: AdminAttributesGroups:exportattribute_group
+    _legacy_link: AdminAttributesGroups:exportattribute_group
+    _legacy_feature_flag: attribute_group
 
 admin_attribute_groups_update_position:
   path: /update-position
@@ -84,4 +92,5 @@ admin_attribute_groups_update_position:
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Sell\Catalog\AttributeGroupController::updatePositionAction'
     _legacy_controller: AdminAttributesGroups
-#  _legacy_link: AdminAttributesGroups:updateGroupsPositions
+    _legacy_link: AdminAttributesGroups:updateGroupsPositions
+    _legacy_feature_flag: attribute_group

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_data_provider.yml
@@ -274,6 +274,7 @@ services:
       - '@doctrine.orm.entity_manager'
       - 'stable'
       - '@=service("prestashop.adapter.multistore_feature").isActive()'
+      - '@prestashop.bundle.routing.converter.cache_provider'
 
   prestashop.admin.configure.advanced_parameters.beta_feature_flags_form_data_provider:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\FeatureFlag\FeatureFlagsFormDataProvider'
@@ -281,6 +282,7 @@ services:
       - '@doctrine.orm.entity_manager'
       - 'beta'
       - '@=service("prestashop.adapter.multistore_feature").isActive()'
+      - '@prestashop.bundle.routing.converter.cache_provider'
 
   prestashop.adapter.security.general.form_provider:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Security\FormDataProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/routing.yml
@@ -17,9 +17,16 @@ services:
     public: true
 
   prestashop.bundle.routing.converter.router_provider:
-    class: 'PrestaShopBundle\Routing\Converter\RouterProvider'
+    alias: PrestaShopBundle\Routing\Converter\RouterProvider
+    deprecated: ~
+
+  PrestaShopBundle\Routing\Converter\RouterProvider:
+    autowire: true
+
+  PrestaShopBundle\Routing\Converter\LegacyRouteFactory:
+    autowire: true
     arguments:
-      - '@router'
+      - '@prestashop.core.admin.feature_flag.repository'
 
   # We set this alias so that we can override it in test environment (to avoid memory limit crashes)
   prestashop.bundle.routing.converter.cache:

--- a/src/PrestaShopBundle/Routing/Converter/CacheCleanerInterface.php
+++ b/src/PrestaShopBundle/Routing/Converter/CacheCleanerInterface.php
@@ -24,21 +24,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-// Product feature flag in 1.7.8
-trans('Experimental product page', 'Admin.Advparameters.Feature');
-trans(
-    'This page benefits from increased performance and includes new features such as a new combination management system. Please note this is a work in progress and some features are not available yet.',
-    'Admin.Advparameters.Help'
-);
+namespace PrestaShopBundle\Routing\Converter;
 
-// Product feature flag in 8.0
-trans('New product page - Single store', 'Admin.Advparameters.Feature');
-trans('This page benefits from increased performance and includes new features such as a new combination management system.', 'Admin.Advparameters.Help');
-
-// Product multi store feature flag in 8.0
-trans('New product page - Multistore', 'Admin.Advparameters.Feature');
-trans('Access the new product page, even in a multistore context. This is a work in progress and some features are not available.', 'Admin.Advparameters.Help');
-
-// Legacy link feature flags
-trans('Attribute group', 'Admin.Advparameters.Feature');
-trans('Enable / Disable migrated attribute group page.', 'Admin.Advparameters.Help');
+interface CacheCleanerInterface
+{
+    public function clearCache(): void;
+}

--- a/src/PrestaShopBundle/Routing/Converter/CacheProvider.php
+++ b/src/PrestaShopBundle/Routing/Converter/CacheProvider.php
@@ -31,7 +31,7 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 /**
  * Class CacheProvider.
  */
-class CacheProvider extends AbstractLegacyRouteProvider
+class CacheProvider extends AbstractLegacyRouteProvider implements CacheCleanerInterface
 {
     /**
      * @var AdapterInterface
@@ -82,6 +82,32 @@ class CacheProvider extends AbstractLegacyRouteProvider
         return $this->legacyRoutes;
     }
 
+    public function clearCache(): void
+    {
+        $this->cache->deleteItem($this->cacheKeyGenerator->getCacheKey());
+    }
+
+    /**
+     * @param string $serializedLegacyRoutes
+     *
+     * @return LegacyRoute[]
+     */
+    private function unserializeLegacyRoutes($serializedLegacyRoutes)
+    {
+        $flattenRoutes = json_decode($serializedLegacyRoutes, true);
+
+        $legacyRoutes = [];
+        foreach ($flattenRoutes as $flattenRoute) {
+            $legacyRoutes[$flattenRoute['route_name']] = new LegacyRoute(
+                $flattenRoute['route_name'],
+                $flattenRoute['legacy_links'],
+                $flattenRoute['legacy_parameters']
+            );
+        }
+
+        return $legacyRoutes;
+    }
+
     /**
      * @param LegacyRoute[] $legacyRoutes
      *
@@ -108,26 +134,5 @@ class CacheProvider extends AbstractLegacyRouteProvider
         }
 
         return json_encode($flattenRoutes);
-    }
-
-    /**
-     * @param string $serializedLegacyRoutes
-     *
-     * @return LegacyRoute[]
-     */
-    private function unserializeLegacyRoutes($serializedLegacyRoutes)
-    {
-        $flattenRoutes = json_decode($serializedLegacyRoutes, true);
-
-        $legacyRoutes = [];
-        foreach ($flattenRoutes as $flattenRoute) {
-            $legacyRoutes[$flattenRoute['route_name']] = new LegacyRoute(
-                $flattenRoute['route_name'],
-                $flattenRoute['legacy_links'],
-                $flattenRoute['legacy_parameters']
-            );
-        }
-
-        return $legacyRoutes;
     }
 }

--- a/src/PrestaShopBundle/Routing/Converter/LegacyRouteFactory.php
+++ b/src/PrestaShopBundle/Routing/Converter/LegacyRouteFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PrestaShopBundle\Routing\Converter;
+
+use PrestaShopBundle\Entity\Repository\FeatureFlagRepository;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class LegacyRouteFactory
+{
+    /**
+     * @var FeatureFlagRepository
+     */
+    private $featureFlagRepository;
+
+    public function __construct(FeatureFlagRepository $featureFlagRepository)
+    {
+        $this->featureFlagRepository = $featureFlagRepository;
+    }
+
+    public function buildFromCollection(RouteCollection $routeCollection): array
+    {
+        $legacyRoutes = [];
+
+        foreach ($routeCollection as $routeName => $route) {
+            if ($this->isLegacyRoute($route)) {
+                $legacyRoutes[$routeName] = LegacyRoute::buildLegacyRoute($routeName, $route->getDefaults());
+            }
+        }
+
+        return $legacyRoutes;
+    }
+
+    private function isLegacyRoute(Route $route): bool
+    {
+        $routeDefaults = $route->getDefaults();
+
+        if (isset($routeDefaults[RouterProvider::LEGACY_LINK_ROUTE_ATTRIBUTE])) {
+            if (isset($routeDefaults[RouterProvider::FEATURE_FLAG_NAME])) {
+                return $this->featureFlagRepository->isEnabled($routeDefaults[RouterProvider::FEATURE_FLAG_NAME]);
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyRouteFactoryTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyRouteFactoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Entity\Repository\FeatureFlagRepository;
+use PrestaShopBundle\Routing\Converter\LegacyRoute;
+use PrestaShopBundle\Routing\Converter\LegacyRouteFactory;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+class LegacyRouteFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider getRouteDataProviderFeatureFlag
+     */
+    public function testRouteEnabledWithEnabledFeatureFlags(Route $route): void
+    {
+        $factory = new LegacyRouteFactory(
+            $featureFlagRepository = $this->createMock(FeatureFlagRepository::class)
+        );
+
+        $featureFlagRepository
+            ->method('isEnabled')
+            ->willReturn(true)
+        ;
+
+        $collection = new RouteCollection();
+        $collection->add('symfony_route', new Route('/', [
+            'route_name' => 'test',
+        ]));
+        $collection->add('feature_flag_route_name', $route);
+        $routes = $factory->buildFromCollection($collection);
+
+        self::assertIsArray($routes);
+        self::assertCount(1, $routes);
+        self::assertContainsOnlyInstancesOf(LegacyRoute::class, $routes);
+    }
+
+    public function getRouteDataProviderFeatureFlag(): iterable
+    {
+        yield [new Route('/', [
+            '_legacy_link' => 'AdminController',
+            '_legacy_feature_flag' => 'AdminControllerV2',
+        ])];
+    }
+
+    /**
+     * @dataProvider getRoutes
+     */
+    public function testRouteWithoutFeatureFlagShouldNeverCallRepository(
+        Route $route
+    ): void {
+        $factory = new LegacyRouteFactory(
+            $featureFlagRepo = $this->createMock(FeatureFlagRepository::class)
+        );
+
+        // assert no calls to repository
+        $featureFlagRepo
+            ->expects(self::never())
+            ->method('isEnabled')
+        ;
+
+        $collection = new RouteCollection();
+        $collection->add('test', $route);
+        $routes = $factory->buildFromCollection($collection);
+        self::assertIsArray($routes);
+        self::assertContainsOnlyInstancesOf(LegacyRoute::class, $routes);
+    }
+
+    public function getRoutes(): iterable
+    {
+        yield [new Route('/')];
+        yield [new Route('/', [
+            '_legacy_link' => 'AdminController',
+        ])];
+    }
+}

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/LegacyUrlConverterTest.php
@@ -28,8 +28,10 @@ namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Entity\Repository\FeatureFlagRepository;
 use PrestaShopBundle\Routing\Converter\Exception\ArgumentException;
 use PrestaShopBundle\Routing\Converter\Exception\RouteNotFoundException;
+use PrestaShopBundle\Routing\Converter\LegacyRouteFactory;
 use PrestaShopBundle\Routing\Converter\LegacyUrlConverter;
 use PrestaShopBundle\Routing\Converter\RouterProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -44,7 +46,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testBasic()
     {
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
         ]);
@@ -57,7 +59,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testMinifiedController()
     {
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'controller' => 'adminproducts',
         ]);
@@ -70,7 +72,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testBasicTab()
     {
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'tab' => 'AdminProducts',
         ]);
@@ -83,7 +85,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testIndexAlias()
     {
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
             'action' => 'index',
@@ -97,7 +99,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testTabIndexAlias()
     {
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'tab' => 'AdminProducts',
             'action' => 'index',
@@ -111,7 +113,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testInsensitiveListAlias()
     {
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
             'action' => 'LIST',
@@ -125,7 +127,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testAction()
     {
         $router = $this->buildRouterMock('admin_products_create', '/products/create', 'AdminProducts:create');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
             'action' => 'create',
@@ -139,7 +141,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testTabAction()
     {
         $router = $this->buildRouterMock('admin_products_create', '/products/create', 'AdminProducts:create');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'tab' => 'AdminProducts',
             'action' => 'create',
@@ -153,7 +155,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testActionWithTrue()
     {
         $router = $this->buildRouterMock('admin_products_create', '/products/create', 'AdminProducts:create');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
             'create' => true,
@@ -167,7 +169,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testActionWithEmptyString()
     {
         $router = $this->buildRouterMock('admin_products_create', '/products/create', 'AdminProducts:create');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
             'create' => '',
@@ -184,7 +186,7 @@ class LegacyUrlConverterTest extends TestCase
             'AdminModulesManage',
             'AdminModulesSf',
         ]);
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
 
         //First controller
         $url = $converter->convertByParameters([
@@ -212,7 +214,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testNonExistentAction()
     {
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
 
         $caughtException = null;
 
@@ -285,7 +287,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testIdEqualToOne()
     {
         $router = $this->buildRouterMock('admin_products_index', '/products', 'AdminProducts');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $convertedUrl = $converter->convertByUrl('?controller=AdminProducts&id_product=1');
         $this->assertEquals('/products', $convertedUrl);
 
@@ -303,7 +305,7 @@ class LegacyUrlConverterTest extends TestCase
             ['id' => 2]
         );
 
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
             'action' => 'edit',
@@ -331,7 +333,7 @@ class LegacyUrlConverterTest extends TestCase
             ['id' => 42]
         );
 
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByParameters([
             'controller' => 'AdminProducts',
             'action' => 'edit',
@@ -371,7 +373,7 @@ class LegacyUrlConverterTest extends TestCase
             ->method('getContext')
             ->willReturn($contextMock);
 
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $url = $converter->convertByRequest($request);
         $this->assertEquals('/products/create', $url);
     }
@@ -379,7 +381,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testMissingController()
     {
         $router = $this->buildRouterMock('admin_products_create', '/products/create', 'AdminProducts:create');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
         $this->expectException(ArgumentException::class);
         $this->expectExceptionMessage('Missing required controller argument');
         $converter->convertByParameters([
@@ -390,7 +392,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testControllerNotFound()
     {
         $router = $this->buildRouterMock('admin_products_create', '/products/create', 'AdminProducts:create');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
 
         /** @var RouteNotFoundException $caughtException */
         $caughtException = null;
@@ -411,7 +413,7 @@ class LegacyUrlConverterTest extends TestCase
     public function testActionNotFound()
     {
         $router = $this->buildRouterMock('admin_products_create', '/products/create', 'AdminProducts:create');
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
 
         /** @var RouteNotFoundException $caughtException */
         $caughtException = null;
@@ -450,7 +452,7 @@ class LegacyUrlConverterTest extends TestCase
                 '_legacy_link' => 'AdminProducts:add',
             ],
         ]);
-        $converter = new LegacyUrlConverter($router, new RouterProvider($router));
+        $converter = new LegacyUrlConverter($router, new RouterProvider($router, new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))));
 
         //Test index by parameter
         $url = $converter->convertByParameters([

--- a/tests/Unit/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
+++ b/tests/Unit/PrestaShopBundle/Routing/Converter/RouterProviderTest.php
@@ -28,8 +28,10 @@ namespace Tests\Unit\PrestaShopBundle\Routing\Converter;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use PrestaShopBundle\Entity\Repository\FeatureFlagRepository;
 use PrestaShopBundle\Routing\Converter\Exception\RouteNotFoundException;
 use PrestaShopBundle\Routing\Converter\LegacyRoute;
+use PrestaShopBundle\Routing\Converter\LegacyRouteFactory;
 use PrestaShopBundle\Routing\Converter\RouterProvider;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
@@ -54,7 +56,12 @@ class RouterProviderTest extends TestCase
                 ],
             ],
         ]);
-        $routerProvider = new RouterProvider($router);
+
+        $routerProvider = new RouterProvider(
+            $router,
+            new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))
+        );
+
         $legacyRoutes = $routerProvider->getLegacyRoutes();
         $this->assertCount(2, $legacyRoutes);
         $this->assertNotEmpty($legacyRoutes['admin_products']);
@@ -99,7 +106,10 @@ class RouterProviderTest extends TestCase
                 ],
             ],
         ]);
-        $routerProvider = new RouterProvider($router);
+        $routerProvider = new RouterProvider(
+            $router,
+            new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))
+        );
         $controllersActions = $routerProvider->getControllersActions();
         $this->assertCount(2, $controllersActions);
         $this->assertSame([
@@ -140,7 +150,12 @@ class RouterProviderTest extends TestCase
                 ],
             ],
         ]);
-        $routerProvider = new RouterProvider($router);
+
+        $routerProvider = new RouterProvider(
+            $router,
+            new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))
+        );
+
         $controllerActions = $routerProvider->getActionsByController('AdminProducts');
         $this->assertCount(3, $controllerActions);
         $this->assertSame(['index', 'add', 'create'], $controllerActions);
@@ -171,7 +186,12 @@ class RouterProviderTest extends TestCase
                 ],
             ],
         ]);
-        $routerProvider = new RouterProvider($router);
+
+        $routerProvider = new RouterProvider(
+            $router,
+            new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))
+        );
+
         $controllerActions = $routerProvider->getActionsByController('adminproducts');
         $this->assertCount(3, $controllerActions);
         $this->assertSame(['index', 'add', 'create'], $controllerActions);
@@ -222,7 +242,12 @@ class RouterProviderTest extends TestCase
                 ],
             ],
         ]);
-        $routerProvider = new RouterProvider($router);
+
+        $routerProvider = new RouterProvider(
+            $router,
+            new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))
+        );
+
         $legacyRoute = $routerProvider->getLegacyRouteByAction('AdminProducts', 'index');
         $this->assertEquals('admin_products', $legacyRoute->getRouteName());
 
@@ -295,7 +320,12 @@ class RouterProviderTest extends TestCase
                 ],
             ],
         ]);
-        $routerProvider = new RouterProvider($router);
+
+        $routerProvider = new RouterProvider(
+            $router,
+            new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))
+        );
+
         $legacyRoute = $routerProvider->getLegacyRouteByAction('adminproducts', 'index');
         $this->assertEquals('admin_products', $legacyRoute->getRouteName());
 
@@ -329,7 +359,11 @@ class RouterProviderTest extends TestCase
                 ],
             ],
         ]);
-        $routerProvider = new RouterProvider($router);
+
+        $routerProvider = new RouterProvider(
+            $router,
+            new LegacyRouteFactory($this->createMock(FeatureFlagRepository::class))
+        );
 
         $caughtException = null;
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | See #29998 .
| Type?             | new feature
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?     |  - Go to Catalog > Attributes and features you should see a legacy page with the URLs looking like this `/index.php?controller=AdminAttributesGroups` (you can check that the href of the menu link is also legacy)<br/>- Now go to Advanced parameters > New & Experimental Features and enable the feature flag for Attribute Groups page<br/>- Go back to Catalog > Attributes you should now be opening a Symfony page `/index.php/sell/catalog/attribute-groups` (you can check that the href of the menu link is also "Symfony style")<br><br>You should test this with debug mode enabled and without debug mode enabled, to make sure in both cases the routing cache is correctly updated and the feature flag new value is correctly taken into account.<br><br>NOTE: The purpose of this PR and tests IS **NOT TO TEST THE ATTRIBUTE GROUP PAGES** it is just to validate that the `_legacy_link` feature that allows redirecting from legacy to migrated page can now be configured via a feature flag
| Fixed ticket?     | Fixes #29998 .

