### PR TITLE
Remove unused "override" property in class index

### DIFF
--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -329,18 +329,6 @@ class PrestaShopAutoload
     {
         return (isset($this->index[$classname]['path'])) ? $this->index[$classname]['path'] : null;
     }
-
-    /**
-     * Normalize directory.
-     *
-     * @param string $directory
-     *
-     * @return string
-     */
-    private function normalizeDirectory($directory)
-    {
-        return rtrim($directory, '/\\') . DIRECTORY_SEPARATOR;
-    }
 }
 
 spl_autoload_register([PrestaShopAutoload::getInstance(), 'load']);

--- a/classes/PrestaShopAutoload.php
+++ b/classes/PrestaShopAutoload.php
@@ -132,12 +132,9 @@ class PrestaShopAutoload
 
         // If $classname has not core suffix (E.g. Shop, Product)
         if (substr($className, -4) != 'Core' && !class_exists($className, false)) {
-            $classDir = (isset($this->index[$className]['override'])
-                && $this->index[$className]['override'] === true) ? $this->normalizeDirectory(_PS_ROOT_DIR_) : $this->root_dir;
-
             // If requested class does not exist, load associated core class
             if (isset($this->index[$className]) && !$this->index[$className]['path']) {
-                require_once $classDir . $this->index[$className . 'Core']['path'];
+                require_once $this->root_dir . $this->index[$className . 'Core']['path'];
 
                 if ($this->index[$className . 'Core']['type'] != 'interface') {
                     eval($this->index[$className . 'Core']['type'] . ' ' . $className . ' extends ' . $className . 'Core {}');
@@ -149,7 +146,7 @@ class PrestaShopAutoload
                 }
 
                 if (isset($this->index[$className])) {
-                    require_once $classDir . $this->index[$className]['path'];
+                    require_once $this->root_dir . $this->index[$className]['path'];
                 }
             }
         } elseif (isset($this->index[$className]['path']) && $this->index[$className]['path']) {
@@ -307,14 +304,12 @@ class PrestaShopAutoload
                         $classes[$m['classname']] = [
                             'path' => $path . $file,
                             'type' => trim($m[1]),
-                            'override' => false,
                         ];
 
                         if (substr($m['classname'], -4) == 'Core') {
                             $classes[substr($m['classname'], 0, -4)] = [
                                 'path' => '',
                                 'type' => $classes[$m['classname']]['type'],
-                                'override' => false,
                             ];
                         }
                     }

--- a/tests/Integration/Classes/PrestaShopAutoloadTest.php
+++ b/tests/Integration/Classes/PrestaShopAutoloadTest.php
@@ -83,11 +83,11 @@ class PrestaShopAutoloadTest extends TestCase
         $this->assertFileExists($this->file_index);
         $data = include $this->file_index;
         $this->assertEquals($data['OrderControllerCore']['path'], 'controllers/front/OrderController.php');
-        $this->assertEquals($data['Connection']['override'], false);
+        $this->assertEquals($data['Connection']['path'], '');
         Configuration::updateGlobalValue('PS_DISABLE_OVERRIDES', 0);
         PrestaShopAutoload::getInstance()->generateIndex();
         $data = include $this->file_index;
-        $this->assertEquals($data['Connection']['override'], false);
+        $this->assertEquals($data['Connection']['path'], 'override/classes/Connection.php');
     }
 
     public function testClassFromCoreDirShouldntBeLoaded(): void


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed useless "override" property which was always set to false. It was only read [here](https://github.com/PrestaShop/PrestaShop/blob/1.7.8.0/classes/PrestaShopAutoload.php#L135-L136), and it was clearly related to the obsolete `_PS_HOST_MODE` [removed in 8.0](https://github.com/PrestaShop/PrestaShop/commit/5aa6204f29aa3e4ca586e32d7623f6fed82cdc1a#diff-1623042d578cba742c76ebf0f8a3931c76932f9cc394247bdcfb71a4bca63af2)
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Related PRs       | N/A
| How to test?      | Verified by automated tests
| Possible impacts? | Nothing that I can see


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
