### PR TITLE
Add a modal window when the user clicks on 'Regenerate thumbnails' button

### DIFF
--- a/admin-dev/themes/default/template/controllers/images/content.tpl
+++ b/admin-dev/themes/default/template/controllers/images/content.tpl
@@ -56,7 +56,7 @@
 
 {if isset($display_regenerate)}
 
-	<form class="form-horizontal" action="{$current|escape:'html':'UTF-8'}&amp;token={$token|escape:'html':'UTF-8'}" method="post">
+	<form id="display_regenerate_form" class="form-horizontal" action="{$current|escape:'html':'UTF-8'}&amp;token={$token|escape:'html':'UTF-8'}" method="post">
 		<div class="panel">
 			<h3>
                 <i class="icon-picture"></i>
@@ -123,10 +123,23 @@
 				</div>
 			</div>
 			<div class="panel-footer">
-				<button type="submit" name="submitRegenerate{$table}" class="btn btn-default pull-right" onclick="return confirm('{l s='Are you sure?' d='Admin.Notifications.Warning'}');">
+        <input type="hidden" name="submitRegenerate{$table}" value="" />
+				<button id="submitRegenerate{$table}" class="btn btn-default pull-right">
 					<i class="process-icon-cogs"></i> {l s='Regenerate thumbnails' d='Admin.Design.Feature'}
 				</button>
 			</div>
 		</div>
 	</form>
+
+  <script type="text/javascript">
+    $(function() {
+      $('#submitRegenerate{$table}').on('click', function() {
+        $('#modalRegenerateThumbnails').modal('show');
+        return false;
+      });
+      $('.btn-regenerate-thumbnails').on('click', function () {
+        $('#display_regenerate_form').trigger('submit');
+      });
+    });
+  </script>
 {/if}

--- a/admin-dev/themes/default/template/controllers/images/content.tpl
+++ b/admin-dev/themes/default/template/controllers/images/content.tpl
@@ -124,7 +124,11 @@
 			</div>
 			<div class="panel-footer">
         <input type="hidden" name="submitRegenerate{$table}" value="" />
-				<button id="submitRegenerate{$table}" class="btn btn-default pull-right">
+				<button
+          type="submit"
+          value=""
+          class="btn btn-default pull-right"
+        >
 					<i class="process-icon-cogs"></i> {l s='Regenerate thumbnails' d='Admin.Design.Feature'}
 				</button>
 			</div>

--- a/admin-dev/themes/default/template/controllers/images/content.tpl
+++ b/admin-dev/themes/default/template/controllers/images/content.tpl
@@ -137,7 +137,7 @@
 
   <script type="text/javascript">
     $(function() {
-      $('#submitRegenerate{$table}').on('click', function() {
+      $('#display_regenerate_form button[type="submit"]').on('click', function() {
         $('#modalRegenerateThumbnails').modal('show');
         return false;
       });

--- a/admin-dev/themes/default/template/controllers/images/modal_regenerate_thumbnails.tpl
+++ b/admin-dev/themes/default/template/controllers/images/modal_regenerate_thumbnails.tpl
@@ -24,7 +24,7 @@
  *}
 <div class="modal-body">
   {l
-    s="Are you sure you want to regenerate thumbnails for the selected images? With the erase option enabled, the previous thumbnails of your selection will be deleted."
+    s="Regenerate thumbnails for the selected images? With the erase option enabled, the previous thumbnails that you selected will be deleted."
     d="Admin.Design.Notification"
   }
 </div>

--- a/admin-dev/themes/default/template/controllers/images/modal_regenerate_thumbnails.tpl
+++ b/admin-dev/themes/default/template/controllers/images/modal_regenerate_thumbnails.tpl
@@ -22,34 +22,9 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
-<div class="modal fade" id="{$modal_id}" tabindex="-1">
-	<div class="modal-dialog {if isset($modal_class)}{$modal_class}{/if}">
-		<div class="modal-content">
-			{if isset($modal_title)}
-			<div class="modal-header">
-				<button type="button" class="close" data-dismiss="modal">&times;</button>
-				<h4 class="modal-title">{$modal_title}</h4>
-			</div>
-			{/if}
-
-			{$modal_content}
-
-			{if isset($modal_actions)}
-			<div class="modal-footer">
-				<button type="button" class="btn btn-default" data-dismiss="modal">
-          {if isset($modal_cancel_label)}{$modal_cancel_label}{else}{l s='Close' d='Admin.Actions'}{/if}
-        </button>
-				{foreach $modal_actions as $action}
-					{if $action.type == 'link'}
-						<a href="{$action.href}" class="btn {$action.class}">{$action.label}</a>
-					{elseif $action.type == 'button'}
-						<button type="button" value="{$action.value}" class="btn {$action.class}">
-							{$action.label}
-						</button>
-					{/if}
-				{/foreach}
-			</div>
-			{/if}
-		</div>
-	</div>
+<div class="modal-body">
+  {l
+    s="Are you sure you want to regenerate thumbnails for the selected images? With the erase option enabled, the previous thumbnails of your selection will be deleted."
+    d="Admin.Design.Notification"
+  }
 </div>

--- a/admin-dev/themes/new-theme/template/modal.tpl
+++ b/admin-dev/themes/new-theme/template/modal.tpl
@@ -36,7 +36,9 @@
 
 			{if isset($modal_actions)}
 			<div class="modal-footer">
-				<button type="button" class="btn btn-default" data-dismiss="modal">{l s='Close' d='Admin.Actions'}</button>
+				<button type="button" class="btn btn-default" data-dismiss="modal">
+          {if isset($modal_cancel_label)}{$modal_cancel_label}{else}{l s='Close' d='Admin.Actions'}{/if}
+        </button>
 				{foreach $modal_actions as $action}
 					{if $action.type == 'link'}
 						<a href="{$action.href}" class="btn {$action.class}">{$action.label}</a>

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -399,7 +399,7 @@ class AdminControllerCore extends Controller
     /** @var array */
     protected $list_partners_modules = [];
 
-    /** @var array */
+    /** @var array<string, string|array> */
     public $modals = [];
 
     /** @var bool if logged employee has access to AdminImport */

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -353,6 +353,7 @@ class AdminImagesControllerCore extends AdminController
 
     /**
      * @return void
+     *
      * @throws SmartyException
      */
     public function initModal(): void

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -351,6 +351,31 @@ class AdminImagesControllerCore extends AdminController
         ];
     }
 
+    /**
+     * @return void
+     * @throws SmartyException
+     */
+    public function initModal(): void
+    {
+        parent::initModal();
+
+        $this->modals[] = [
+            'modal_id' => 'modalRegenerateThumbnails',
+            'modal_class' => 'modal-md',
+            'modal_title' => $this->trans('Regenerate thumbnails', [], 'Admin.Actions'),
+            'modal_content' => $this->context->smarty->fetch('controllers/images/modal_regenerate_thumbnails.tpl'),
+            'modal_cancel_label' => $this->trans('Cancel', [], 'Admin.Actions'),
+            'modal_actions' => [
+                [
+                    'type' => 'button',
+                    'label' => $this->trans('Regenerate', [], 'Admin.Actions'),
+                    'class' => 'btn-default btn-regenerate-thumbnails',
+                    'value' => '',
+                ],
+            ],
+        ];
+    }
+
     public function postProcess()
     {
         // When moving images, if duplicate images were found they are moved to a folder named duplicates/

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -363,13 +363,13 @@ class AdminImagesControllerCore extends AdminController
         $this->modals[] = [
             'modal_id' => 'modalRegenerateThumbnails',
             'modal_class' => 'modal-md',
-            'modal_title' => $this->trans('Regenerate thumbnails', [], 'Admin.Actions'),
+            'modal_title' => $this->trans('Regenerate thumbnails', [], 'Admin.Design.Feature'),
             'modal_content' => $this->context->smarty->fetch('controllers/images/modal_regenerate_thumbnails.tpl'),
             'modal_cancel_label' => $this->trans('Cancel', [], 'Admin.Actions'),
             'modal_actions' => [
                 [
                     'type' => 'button',
-                    'label' => $this->trans('Regenerate', [], 'Admin.Actions'),
+                    'label' => $this->trans('Regenerate', [], 'Admin.Design.Feature'),
                     'class' => 'btn-default btn-regenerate-thumbnails',
                     'value' => '',
                 ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a modal window when the user clicks on 'Regenerate thumbnails' button
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #20962
| Related PRs       | N/A
| How to test?      | In Image Settings, a modal window has been added. The wording come from https://github.com/PrestaShop/PrestaShop/issues/20962#issue-699896621
| Possible impacts? | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
