### PR TITLE
Fix quick access new product

### DIFF
--- a/admin-dev/themes/default/package-lock.json
+++ b/admin-dev/themes/default/package-lock.json
@@ -12,6 +12,7 @@
         "@openfonts/ubuntu-condensed_latin": "^1.44.2",
         "open-sans-fonts": "^1.6.2",
         "perfect-scrollbar": "^1.4.0",
+        "prestakit": "^1.2.5",
         "vazirmatn": "32.102.0"
       },
       "devDependencies": {
@@ -2578,6 +2579,25 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+    },
+    "node_modules/bootstrap": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "peerDependencies": {
+        "jquery": "1.9.1 - 3",
+        "popper.js": "^1.16.1"
+      }
     },
     "node_modules/bourbon": {
       "version": "4.3.4",
@@ -6369,6 +6389,17 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
+      "peer": true
+    },
+    "node_modules/jquery.growl": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/jquery.growl/-/jquery.growl-1.3.5.tgz",
+      "integrity": "sha512-pK1RD8x3pXm1hEQ6KH0cu4QqzvI7R0EsUd5oneT5pavZ0cHwx/TV4qIdKeVfCWM0DVPyzI2GfXD6FwdDbRx1kw=="
+    },
     "node_modules/js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -6804,8 +6835,7 @@
     "node_modules/material-design-icons-iconfont": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-6.7.0.tgz",
-      "integrity": "sha512-lSj71DgVv20kO0kGbs42icDzbRot61gEDBLQACzkUuznRQBUYmbxzEkGU6dNBb5fRWHMaScYlAXX96HQ4/cJWA==",
-      "dev": true
+      "integrity": "sha512-lSj71DgVv20kO0kGbs42icDzbRot61gEDBLQACzkUuznRQBUYmbxzEkGU6dNBb5fRWHMaScYlAXX96HQ4/cJWA=="
     },
     "node_modules/math-expression-evaluator": {
       "version": "1.3.14",
@@ -8089,6 +8119,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.12",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
@@ -9355,6 +9396,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prestakit": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-1.2.5.tgz",
+      "integrity": "sha512-dLa1+teIRLLVtjk0F2pQL2Ya+HTGQUuJ6P6k+HZWJbT+1cwQkN7VAUiH7XGLHVSJchrI+hnarR43tI2B5XZDUA==",
+      "dependencies": {
+        "bootstrap": "^4.4.1",
+        "jquery.growl": "^1.3.5",
+        "material-design-icons-iconfont": "^6.1.0",
+        "open-sans-fonts": "^1.6.2",
+        "select2": "^4.0.5",
+        "select2-bootstrap-theme": "0.1.0-beta.10"
+      }
+    },
     "node_modules/pretty-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -10168,6 +10222,16 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/select2": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
+      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
+    },
+    "node_modules/select2-bootstrap-theme": {
+      "version": "0.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/select2-bootstrap-theme/-/select2-bootstrap-theme-0.1.0-beta.10.tgz",
+      "integrity": "sha512-gc9Y9yNjkGRqeFmI/pAKyL4maMKH9VKAn62E+uF/hxz8FTmfuKH0sDEGhFhk3f8Jp+emtsDdK1c1nb6S51BV0Q=="
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -14272,6 +14336,12 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
+    "bootstrap": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "requires": {}
+    },
     "bourbon": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/bourbon/-/bourbon-4.3.4.tgz",
@@ -17223,6 +17293,17 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
+      "peer": true
+    },
+    "jquery.growl": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/jquery.growl/-/jquery.growl-1.3.5.tgz",
+      "integrity": "sha512-pK1RD8x3pXm1hEQ6KH0cu4QqzvI7R0EsUd5oneT5pavZ0cHwx/TV4qIdKeVfCWM0DVPyzI2GfXD6FwdDbRx1kw=="
+    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -17585,8 +17666,7 @@
     "material-design-icons-iconfont": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-6.7.0.tgz",
-      "integrity": "sha512-lSj71DgVv20kO0kGbs42icDzbRot61gEDBLQACzkUuznRQBUYmbxzEkGU6dNBb5fRWHMaScYlAXX96HQ4/cJWA==",
-      "dev": true
+      "integrity": "sha512-lSj71DgVv20kO0kGbs42icDzbRot61gEDBLQACzkUuznRQBUYmbxzEkGU6dNBb5fRWHMaScYlAXX96HQ4/cJWA=="
     },
     "math-expression-evaluator": {
       "version": "1.3.14",
@@ -18592,6 +18672,12 @@
           "dev": true
         }
       }
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "peer": true
     },
     "postcss": {
       "version": "8.4.12",
@@ -19665,6 +19751,19 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prestakit": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prestakit/-/prestakit-1.2.5.tgz",
+      "integrity": "sha512-dLa1+teIRLLVtjk0F2pQL2Ya+HTGQUuJ6P6k+HZWJbT+1cwQkN7VAUiH7XGLHVSJchrI+hnarR43tI2B5XZDUA==",
+      "requires": {
+        "bootstrap": "^4.4.1",
+        "jquery.growl": "^1.3.5",
+        "material-design-icons-iconfont": "^6.1.0",
+        "open-sans-fonts": "^1.6.2",
+        "select2": "^4.0.5",
+        "select2-bootstrap-theme": "0.1.0-beta.10"
+      }
+    },
     "pretty-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -20288,6 +20387,16 @@
           }
         }
       }
+    },
+    "select2": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
+      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
+    },
+    "select2-bootstrap-theme": {
+      "version": "0.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/select2-bootstrap-theme/-/select2-bootstrap-theme-0.1.0-beta.10.tgz",
+      "integrity": "sha512-gc9Y9yNjkGRqeFmI/pAKyL4maMKH9VKAn62E+uF/hxz8FTmfuKH0sDEGhFhk3f8Jp+emtsDdK1c1nb6S51BV0Q=="
     },
     "semver": {
       "version": "6.3.0",

--- a/admin-dev/themes/default/package.json
+++ b/admin-dev/themes/default/package.json
@@ -50,6 +50,7 @@
     "@openfonts/ubuntu-condensed_latin": "^1.44.2",
     "open-sans-fonts": "^1.6.2",
     "perfect-scrollbar": "^1.4.0",
-    "vazirmatn": "32.102.0"
+    "vazirmatn": "32.102.0",
+    "prestakit": "^1.2.5"
   }
 }

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -112,9 +112,9 @@
 </head>
 
 {if $display_header}
-<body class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} ps_back-office{if $employee->bo_menu} page-sidebar{if $collapse_menu} page-sidebar-closed{/if}{else} page-topbar{/if} {$controller_name|escape|strtolower}"
+< class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} ps_back-office{if $employee->bo_menu} page-sidebar{if $collapse_menu} page-sidebar-closed{/if}{else} page-topbar{/if} {$controller_name|escape|strtolower}"
       {if isset($js_router_metadata.base_url)}data-base-url="{$js_router_metadata.base_url}"{/if}
-      {if isset($js_router_metadata.token)}data-token="{$js_router_metadata.token}"{/if}
+      {if isset($js_router_metadata.token)}data-token="{$js_router_metadata.token}"{/if}>
   {* begin  HEADER *}
   <header id="header" class="bootstrap">
     <nav id="header_infos" role="navigation">

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -112,7 +112,9 @@
 </head>
 
 {if $display_header}
-  <body class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} ps_back-office{if $employee->bo_menu} page-sidebar{if $collapse_menu} page-sidebar-closed{/if}{else} page-topbar{/if} {$controller_name|escape|strtolower}">
+<body class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} ps_back-office{if $employee->bo_menu} page-sidebar{if $collapse_menu} page-sidebar-closed{/if}{else} page-topbar{/if} {$controller_name|escape|strtolower}"
+      {if isset($js_router_metadata.base_url)}data-base-url="{$js_router_metadata.base_url}"{/if}
+      {if isset($js_router_metadata.token)}data-token="{$js_router_metadata.token}"{/if}
   {* begin  HEADER *}
   <header id="header" class="bootstrap">
     <nav id="header_infos" role="navigation">
@@ -134,8 +136,8 @@
             {if !empty($quick_access)}
               {foreach $quick_access as $quick}
                 <li class="quick-row-link{if $link->matchQuickLink({$quick.link})}{assign "matchQuickLink" $quick.id_quick_access} active{/if}">
-                  <a href="{$quick.link|escape:'html':'UTF-8'}" {if $quick.new_window}target="_blank"{/if}>
-                    {$quick.name}
+                  <a {if isset($quick.class)}class="{$quick.class}"{/if} href="{$quick.link|escape:'html':'UTF-8'}" {if $quick.new_window}target="_blank"{/if}>
+                      {$quick.name}
                   </a>
                 </li>
               {/foreach}

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -112,7 +112,7 @@
 </head>
 
 {if $display_header}
-< class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} ps_back-office{if $employee->bo_menu} page-sidebar{if $collapse_menu} page-sidebar-closed{/if}{else} page-topbar{/if} {$controller_name|escape|strtolower}"
+<body class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} ps_back-office{if $employee->bo_menu} page-sidebar{if $collapse_menu} page-sidebar-closed{/if}{else} page-topbar{/if} {$controller_name|escape|strtolower}"
       {if isset($js_router_metadata.base_url)}data-base-url="{$js_router_metadata.base_url}"{/if}
       {if isset($js_router_metadata.token)}data-token="{$js_router_metadata.token}"{/if}>
   {* begin  HEADER *}

--- a/admin-dev/themes/new-theme/.webpack/common.js
+++ b/admin-dev/themes/new-theme/.webpack/common.js
@@ -139,6 +139,8 @@ module.exports = {
     zone: './js/pages/zone',
     country: './js/pages/country',
     country_form: './js/pages/country/form',
+    create_product: './js/pages/product/create-product',
+    create_product_default_theme: './scss/pages/product/create_product_default_theme.scss',
   },
   output: {
     path: path.resolve(__dirname, '../public'),

--- a/admin-dev/themes/new-theme/js/pages/product/components/create-product-modal.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/create-product-modal.ts
@@ -42,7 +42,7 @@ export default class CreateProductModal {
 
       const iframeModal = new FormIframeModal({
         id: 'modal-create-product',
-        formSelector: 'form[name="product"]',
+        formSelector: ProductMap.create.form,
         formUrl: linkUrl,
         closable: true,
         // We override the body selector so that the modal keeps the size of the initial create form even after submit

--- a/admin-dev/themes/new-theme/js/pages/product/create-product.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/create-product.ts
@@ -1,4 +1,4 @@
-{#**
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,27 +21,10 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
-{% set legacyBaseLayout = lightDisplay|default(false) ? 'light_display_layout.tpl' : 'layout.tpl' %}
-{% extends '@PrestaShop/Admin/layout.html.twig' %}
+ */
 
-{% block stylesheets %}
-  <link rel="stylesheet" href="{{ asset('themes/new-theme/public/product.css') }}" type="text/css" media="all">
-{% endblock %}
+import CreateProductModal from '@pages/product/components/create-product-modal';
 
-{% block content %}
-  {{ form_start(productForm, {'attr': {'class': 'form-horizontal create-product-form justify-content-md-center product-form', 'novalidate': 'novalidate'}}) }}
-    {% block product_creation_form %}
-      {{ form_row(productForm) }}
-    {% endblock %}
-
-  {% block product_rest %}
-    {{ form_end(productForm) }}
-  {% endblock %}
-{% endblock %}
-
-{% block javascripts %}
-  {{ parent() }}
-
-  <script src="{{ asset('themes/new-theme/public/product_create.bundle.js') }}"></script>
-{% endblock %}
+$(() => {
+  new CreateProductModal();
+});

--- a/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/index.ts
@@ -41,7 +41,6 @@ import ProductTypeSwitcher from '@pages/product/edit/product-type-switcher';
 import VirtualProductManager from '@pages/product/edit/virtual-product-manager';
 import RelatedProductsManager from '@pages/product/edit/related-products-manager';
 import PackedProductsManager from '@pages/product/edit/packed-products-manager';
-import CreateProductModal from '@pages/product/components/create-product-modal';
 import SpecificPricesManager from '@pages/product/edit/specific-prices-manager';
 import initDropzone from '@pages/product/components/dropzone';
 import initTabs from '@pages/product/components/nav-tabs';
@@ -96,7 +95,6 @@ $(() => {
   if (productType === ProductConst.PRODUCT_TYPE.PACK) {
     new PackedProductsManager(eventEmitter);
   }
-  new CreateProductModal();
   new PriceSummary(productFormModel);
 
   const $productFormSubmitButton = $(ProductMap.productFormSubmitButton);

--- a/admin-dev/themes/new-theme/js/pages/product/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/index.ts
@@ -23,7 +23,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import CreateProductModal from '@pages/product/components/create-product-modal';
 import CategoryTreeFilter from '@pages/product/components/categories/category-tree-filter';
 
 const {$} = window;
@@ -42,7 +41,6 @@ $(() => {
   grid.addExtension(new window.prestashop.component.GridExtensions.FiltersSubmitButtonEnablerExtension());
   grid.addExtension(new window.prestashop.component.GridExtensions.AsyncToggleColumnExtension());
 
-  new CreateProductModal();
   grid.addExtension(new window.prestashop.component.GridExtensions.PositionExtension(grid));
 
   new CategoryTreeFilter();

--- a/admin-dev/themes/new-theme/js/pages/product/product-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/product-map.ts
@@ -54,6 +54,7 @@ export default {
   create: {
     newProductButton: '.new-product-button',
     createModalSelector: '#create_product_type',
+    form: 'form.product-form',
   },
   invalidField: '.is-invalid',
   productFormSubmitButton: '.product-form-save-button',

--- a/admin-dev/themes/new-theme/scss/components/_modal.scss
+++ b/admin-dev/themes/new-theme/scss/components/_modal.scss
@@ -57,11 +57,13 @@ $component-name: modal;
 
   &-loader {
     position: fixed;
+    left: 0;
     z-index: 1;
     display: flex;
     align-items: center;
     justify-content: center;
     width: 100%;
+    height: 100%;
     min-height: 80px;
     margin: 0 auto;
     background: rgba(255, 255, 255, 1);

--- a/admin-dev/themes/new-theme/scss/pages/product/create_product_default_theme.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/create_product_default_theme.scss
@@ -1,0 +1,48 @@
+#modal-create-product {
+  //modal loader
+  @import "~bootstrap/scss/mixins/border-radius";
+  @import "../../config/settings";
+  @import "~prestakit/scss/spinners";
+  @import "../../components/modal";
+  @import "create_product_modal";
+
+  .d-none {
+    /* stylelint-disable declaration-no-important */
+    display: none !important;
+    /* stylelint-enable declaration-no-important */
+  }
+
+  .modal-dialog {
+    top: 50%;
+    width: 90%;
+    max-width: 810px;
+    transform: translateY(-50%);
+  }
+
+  .modal-header {
+    display: flex;
+    justify-content: space-between;
+    border-bottom: none;
+  }
+
+  .modal-header .close {
+    float: right;
+    margin: -1rem 0 0 auto;
+  }
+
+  button.close {
+    padding: 0;
+    margin: initial;
+    font-size: 2rem;
+    background-color: transparent;
+    border: 0;
+  }
+
+  .modal-title {
+    font-size: 1rem;
+  }
+
+  .loader {
+    position: absolute;
+  }
+}

--- a/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/quick_access.tpl
@@ -29,7 +29,7 @@
   </button>
   <div class="dropdown-menu">
     {foreach $quick_access as $quick}
-      <a class="dropdown-item quick-row-link{if $link->matchQuickLink({$quick.link})}{assign "matchQuickLink" $quick.id_quick_access} active{/if}"
+      <a class="dropdown-item quick-row-link {if isset($quick.class)}{$quick.class}{/if}{if $link->matchQuickLink({$quick.link})}{assign "matchQuickLink" $quick.id_quick_access} active{/if}"
          href="{$quick.link|escape:'html':'UTF-8'}"
         {if $quick.new_window} target="_blank"{/if}
          data-item="{$quick.name}"

--- a/classes/QuickAccess.php
+++ b/classes/QuickAccess.php
@@ -42,6 +42,16 @@ class QuickAccessCore extends ObjectModel
     public $new_window;
 
     /**
+     * link to new product creation form
+     */
+    private const NEW_PRODUCT_LINK = 'index.php/sell/catalog/products/new';
+
+    /**
+     * link to new product creation form for product v2
+     */
+    private const NEW_PRODUCT_V2_LINK = 'index.php/sell/catalog/products-v2/create';
+
+    /**
      * @see ObjectModel::$definition
      */
     public static $definition = [
@@ -67,7 +77,7 @@ class QuickAccessCore extends ObjectModel
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 		SELECT *
 		FROM `' . _DB_PREFIX_ . 'quick_access` qa
-		LEFT JOIN `' . _DB_PREFIX_ . 'quick_access_lang` qal ON (qa.`id_quick_access` = qal.`id_quick_access` AND qal.`id_lang` = ' . (int) $idLang . ')
+		LEFT JOIN `' . _DB_PREFIX_ . 'quick_access_lang` qal ON (qa.`id_quick_access` = qal.`id_quick_access` AND qal.`id_lang` = ' . (int)$idLang . ')
 		ORDER BY `name` ASC');
     }
 
@@ -105,13 +115,13 @@ class QuickAccessCore extends ObjectModel
                     }
                     $quick_access[$index]['target'] = $admin_tab[1];
 
-                    $tokenString = $admin_tab[1] . (int) Tab::getIdFromClassName($admin_tab[1]) . $idEmployee;
+                    $tokenString = $admin_tab[1] . (int)Tab::getIdFromClassName($admin_tab[1]) . $idEmployee;
                 }
                 $quickAccess[$index]['link'] = Context::getContext()->link->getBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . $quick['link'];
-                if ($quick['link'] === 'index.php/sell/catalog/products/new' || $quick['link'] === 'index.php/sell/catalog/products-v2/create') {
+                if ($quick['link'] === self::NEW_PRODUCT_LINK || $quick['link'] === self::NEW_PRODUCT_V2_LINK) {
                     //if new product page feature is enabled we create new product v2 modal popup
                     if (self::productPageV2Enabled()) {
-                        $quickAccess[$index]['link'] = Context::getContext()->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . 'index.php/sell/catalog/products-v2/create';
+                        $quickAccess[$index]['link'] = Context::getContext()->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . self::NEW_PRODUCT_V2_LINK;
                         $quickAccess[$index]['class'] = 'new-product-button';
                     }
                 }
@@ -141,7 +151,7 @@ class QuickAccessCore extends ObjectModel
 
         $this->setFieldsToUpdate(['new_window' => true]);
 
-        $this->new_window = !(int) $this->new_window;
+        $this->new_window = !(int)$this->new_window;
 
         return $this->update(false);
     }
@@ -153,10 +163,10 @@ class QuickAccessCore extends ObjectModel
     {
         $multistoreFeature = SymfonyContainer::getInstance()->get('prestashop.adapter.multistore_feature');
 
-        if (!$multistoreFeature->isActive()) {
-            return SymfonyContainer::getInstance()->get('prestashop.core.admin.feature_flag.repository')->isEnabled(FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2);
-        }
-
-        return SymfonyContainer::getInstance()->get('prestashop.core.admin.feature_flag.repository')->isEnabled(FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2_MULTI_SHOP);
+        return SymfonyContainer::getInstance()->get('prestashop.core.admin.feature_flag.repository')->isEnabled(
+            $multistoreFeature->isActive()
+                ? FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2_MULTI_SHOP
+                : FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2
+        );
     }
 }

--- a/classes/QuickAccess.php
+++ b/classes/QuickAccess.php
@@ -77,7 +77,7 @@ class QuickAccessCore extends ObjectModel
         return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
 		SELECT *
 		FROM `' . _DB_PREFIX_ . 'quick_access` qa
-		LEFT JOIN `' . _DB_PREFIX_ . 'quick_access_lang` qal ON (qa.`id_quick_access` = qal.`id_quick_access` AND qal.`id_lang` = ' . (int)$idLang . ')
+		LEFT JOIN `' . _DB_PREFIX_ . 'quick_access_lang` qal ON (qa.`id_quick_access` = qal.`id_quick_access` AND qal.`id_lang` = ' . (int) $idLang . ')
 		ORDER BY `name` ASC');
     }
 
@@ -115,7 +115,7 @@ class QuickAccessCore extends ObjectModel
                     }
                     $quick_access[$index]['target'] = $admin_tab[1];
 
-                    $tokenString = $admin_tab[1] . (int)Tab::getIdFromClassName($admin_tab[1]) . $idEmployee;
+                    $tokenString = $admin_tab[1] . (int) Tab::getIdFromClassName($admin_tab[1]) . $idEmployee;
                 }
                 $quickAccess[$index]['link'] = Context::getContext()->link->getBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . $quick['link'];
                 if ($quick['link'] === self::NEW_PRODUCT_LINK || $quick['link'] === self::NEW_PRODUCT_V2_LINK) {
@@ -151,7 +151,7 @@ class QuickAccessCore extends ObjectModel
 
         $this->setFieldsToUpdate(['new_window' => true]);
 
-        $this->new_window = !(int)$this->new_window;
+        $this->new_window = !(int) $this->new_window;
 
         return $this->update(false);
     }

--- a/classes/QuickAccess.php
+++ b/classes/QuickAccess.php
@@ -24,6 +24,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+
 /**
  * Class QuickAccessCore.
  */
@@ -105,6 +108,13 @@ class QuickAccessCore extends ObjectModel
                     $tokenString = $admin_tab[1] . (int) Tab::getIdFromClassName($admin_tab[1]) . $idEmployee;
                 }
                 $quickAccess[$index]['link'] = Context::getContext()->link->getBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . $quick['link'];
+                if ($quick['link'] === 'index.php/sell/catalog/products/new' || $quick['link'] === 'index.php/sell/catalog/products-v2/create') {
+                    //if new product page feature is enabled we create new product v2 modal popup
+                    if (self::productPageV2Enabled()) {
+                        $quickAccess[$index]['link'] = Context::getContext()->link->getAdminBaseLink() . basename(_PS_ADMIN_DIR_) . '/' . 'index.php/sell/catalog/products-v2/create';
+                        $quickAccess[$index]['class'] = 'new-product-button';
+                    }
+                }
             }
 
             if (false === strpos($quickAccess[$index]['link'], 'token')) {
@@ -134,5 +144,19 @@ class QuickAccessCore extends ObjectModel
         $this->new_window = !(int) $this->new_window;
 
         return $this->update(false);
+    }
+
+    /**
+     * @return bool
+     */
+    private static function productPageV2Enabled(): bool
+    {
+        $multistoreFeature = SymfonyContainer::getInstance()->get('prestashop.adapter.multistore_feature');
+
+        if (!$multistoreFeature->isActive()) {
+            return SymfonyContainer::getInstance()->get('prestashop.core.admin.feature_flag.repository')->isEnabled(FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2);
+        }
+
+        return SymfonyContainer::getInstance()->get('prestashop.core.admin.feature_flag.repository')->isEnabled(FeatureFlagSettings::FEATURE_FLAG_PRODUCT_PAGE_V2_MULTI_SHOP);
     }
 }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2660,14 +2660,29 @@ class AdminControllerCore extends Controller
 
             // Specific Admin Theme
             $this->addCSS(__PS_BASE_URI__ . $this->admin_webpath . '/themes/' . $this->bo_theme . '/css/overrides.css', 'all', PHP_INT_MAX);
+            $username = $this->get('prestashop.user_provider')->getUsername();
+            $token = $this->get('security.csrf.token_manager')
+                ->getToken($username)
+                ->getValue();
+
+            $this->context->smarty->assign([
+                'js_router_metadata' => [
+                    'base_url' => __PS_BASE_URI__ . basename(_PS_ADMIN_DIR_),
+                    'token' => $token,
+                ],
+            ]);
         }
 
+        $this->addCSS(__PS_BASE_URI__ . $this->admin_webpath . '/themes/new-theme/public/create_product_default_theme.css', 'all', 0);
         $this->addJS([
             _PS_JS_DIR_ . 'admin.js?v=' . _PS_VERSION_, // TODO: SEE IF REMOVABLE
             __PS_BASE_URI__ . $this->admin_webpath . '/themes/new-theme/public/cldr.bundle.js',
             _PS_JS_DIR_ . 'tools.js?v=' . _PS_VERSION_,
             __PS_BASE_URI__ . $this->admin_webpath . '/public/bundle.js',
         ]);
+
+        // This is handled as an external common dependency for both themes, but once new-theme is the only one it should be integrated directly into the main.bundle.js file
+        $this->addJS(__PS_BASE_URI__ . $this->admin_webpath . '/themes/new-theme/public/create_product.bundle.js');
 
         Media::addJsDef([
             'changeFormLanguageUrl' => $this->context->link->getAdminLink(

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/edit.html.twig
@@ -42,7 +42,7 @@
   </div>
 
   {{ form_start(productForm, {'attr': {
-    'class': 'form-horizontal product-page justify-content-md-center', 'novalidate': 'novalidate',
+    'class': 'form-horizontal product-page justify-content-md-center product-form', 'novalidate': 'novalidate',
     'data-product-id': productId,
     'data-product-type': productType
   }}) }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Quick access fix with new product v2 page. Need to check new and old controllers.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | Fixes #28673 .
| How to test?      | First you need to upgrade default and new theme. Then enable new product page feature and try to create new product using quick access. Same cases should be tested when multi-shop is enabled.
| Possible impacts? | Updated BO JS and CSS so it might have some impact.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

#### Screenshots

Old controller: 
![image](https://user-images.githubusercontent.com/51944825/185335563-ff1d16e2-5230-49ed-b0e0-39a2d91c62a7.png)
New controller: 
![image](https://user-images.githubusercontent.com/51944825/185335651-01e7a110-c259-419c-88d4-1e100c8b7dd6.png)
