### PR TITLE
Fix phpstan error "Right side of && is always true"

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -71,3 +71,4 @@ parameters:
     - PHP_VERSION_ID
     - Memcached::HAVE_IGBINARY
     - PaymentModuleCore::DEBUG_MODE
+    - _PS_API_IN_USE_


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There is an error in develop branch git actions of phpstan complaning about Shop.php::L400 "Right side of && is always true"
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Didn't create a ticket for this little issue.
| Related PRs       | 
| How to test?      | the phpstan should pass in this PR git actions checks (nothing to test manually)
| Possible impacts? |
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
