### PR TITLE
Improve cart recovery and show proper errors.

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -283,6 +283,7 @@ class FrontControllerCore extends Controller
             $useSSL = true;
         }
 
+        // Redirect to SSL variant of the page if required and visited in non-ssl mode
         $this->sslRedirection();
 
         if ($this->ajax) {
@@ -297,21 +298,23 @@ class FrontControllerCore extends Controller
 
         ob_start();
 
+        // Initialize URL provider in context, depending on SSL mode
         $protocol_link = (Configuration::get('PS_SSL_ENABLED') || Tools::usingSecureMode()) ? 'https://' : 'http://';
         $useSSL = ($this->ssl && Configuration::get('PS_SSL_ENABLED')) || Tools::usingSecureMode();
         $protocol_content = ($useSSL) ? 'https://' : 'http://';
         $link = new Link($protocol_link, $protocol_content);
         $this->context->link = $link;
 
-        if ($id_cart = (int) $this->recoverCart()) {
-            $this->context->cookie->id_cart = (int) $id_cart;
-        }
+        // Attempt to recover cart, if the user is using recovery link
+        // This is used by abandoned cart modules or when sending a prepared order to customer from backoffice
+        $this->recoverCart();
 
+        // Redirect user to login page, if the controller requires authentication
         if ($this->auth && !$this->context->customer->isLogged($this->guestAllowed)) {
             Tools::redirect('index.php?controller=authentication' . ($this->authRedirection ? '&back=' . $this->authRedirection : ''));
         }
 
-        /* Theme is missing */
+        // If the theme is missing, we need to die immediately
         if (!is_dir(_PS_THEME_DIR_)) {
             throw new PrestaShopException($this->trans('Current theme is unavailable. Please check your theme\'s directory name ("%s") and permissions.', [basename(rtrim(_PS_THEME_DIR_, '/\\'))], 'Admin.Design.Notification'));
         }
@@ -1229,29 +1232,57 @@ class FrontControllerCore extends Controller
      */
     protected function recoverCart()
     {
-        if (($id_cart = (int) Tools::getValue('recover_cart')) && Tools::getValue('token_cart') == md5(_COOKIE_KEY_ . 'recover_cart_' . $id_cart)) {
-            $cart = new Cart((int) $id_cart);
-            if (Validate::isLoadedObject($cart)) {
-                $customer = new Customer((int) $cart->id_customer);
-                if (Validate::isLoadedObject($customer)) {
-                    $customer->logged = true;
-                    $this->context->customer = $customer;
-                    $this->context->cookie->id_customer = (int) $customer->id;
-                    $this->context->cookie->customer_lastname = $customer->lastname;
-                    $this->context->cookie->customer_firstname = $customer->firstname;
-                    $this->context->cookie->logged = true;
-                    $this->context->cookie->check_cgv = 1;
-                    $this->context->cookie->is_guest = $customer->isGuest();
-                    $this->context->cookie->passwd = $customer->passwd;
-                    $this->context->cookie->email = $customer->email;
-                    $this->context->cookie->id_guest = (int) $cart->id_guest;
-
-                    return $id_cart;
-                }
-            }
+        if (!Tools::isSubmit('recover_cart')) {
+            return false;
         }
 
-        return false;
+        // Get ID cart from URL
+        $id_cart = (int) Tools::getValue('recover_cart');
+
+        // Check if token in URL matches, otherwise, ignore it, probably malicious intentions
+        if (Tools::getValue('token_cart') != md5(_COOKIE_KEY_ . 'recover_cart_' . $id_cart)) {
+            return false;
+        }
+
+        // Create cart object and check if it's still valid. It can be deleted by automated cleaners or manually.
+        $cart = new Cart($id_cart);
+        if (!Validate::isLoadedObject($cart)) {
+            $this->errors[] = $this->trans('This cart has expired.', [], 'Shop.Notifications.Error');
+
+            return false;
+        }
+
+        // Customer - same scenario. It can be deleted by automated cleaners or manually.
+        $customer = new Customer((int) $cart->id_customer);
+        if (!Validate::isLoadedObject($customer)) {
+            $this->errors[] = $this->trans('This cart has expired.', [], 'Shop.Notifications.Error');
+
+            return false;
+        }
+
+        // Check if there is already a finished order with this cart, we notify the customer nicely
+        if ($cart->orderExists()) {
+            $this->errors[] = $this->trans('This cart was already used in an order and has expired.', [], 'Shop.Notifications.Error');
+
+            return false;
+        }
+
+        // Initialize this data into cookie, FrontController will use it later
+        $customer->logged = true;
+        $this->context->customer = $customer;
+        $this->context->cookie->id_customer = (int) $customer->id;
+        $this->context->cookie->customer_lastname = $customer->lastname;
+        $this->context->cookie->customer_firstname = $customer->firstname;
+        $this->context->cookie->logged = true;
+        $this->context->cookie->check_cgv = 1;
+        $this->context->cookie->is_guest = $customer->isGuest();
+        $this->context->cookie->passwd = $customer->passwd;
+        $this->context->cookie->email = $customer->email;
+        $this->context->cookie->id_guest = (int) $cart->id_guest;
+        $this->context->cookie->id_cart = $id_cart;
+
+        // Return the value for backward compatibility
+        return $id_cart;
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -314,7 +314,7 @@ class FrontControllerCore extends Controller
             Tools::redirect('index.php?controller=authentication' . ($this->authRedirection ? '&back=' . $this->authRedirection : ''));
         }
 
-        // If the theme is missing, we need to die immediately
+        // If the theme is missing, we need to throw an Exception
         if (!is_dir(_PS_THEME_DIR_)) {
             throw new PrestaShopException($this->trans('Current theme is unavailable. Please check your theme\'s directory name ("%s") and permissions.', [basename(rtrim(_PS_THEME_DIR_, '/\\'))], 'Admin.Design.Notification'));
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR improves error messages when recovering a cart via an URL. It also better validates the cart before loading it, so there are less error messages in log.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30074 (partially, see https://github.com/PrestaShop/PrestaShop/issues/30074#issuecomment-1289178647)
| Related PRs       | -
| How to test?      | Use provided test module for easy testing, instructions below.
| Possible impacts? | -
| Sponsor company   | [TRENDO s.r.o.](https://www.trendo.cz)

### Description
- It improves the clarity of recoveryCart function.
- It adds further validation right in the function in order not to load the cart for it to be removed few lines after it.
- It shows error messages if customer or cart could not be loaded, it just failed silently before.
- It shows error message that the cart was already used in an order and can't be used, it failed silently before.
- There are some more issues with this that we found, but I don't want to dive deep into it in this PR. This is just a small refacto - https://github.com/PrestaShop/PrestaShop/issues/30074#issuecomment-1289178647

### How does it look
![error_deleted](https://user-images.githubusercontent.com/6097524/196809072-f646657f-e96c-46ff-9b34-5f1fb70094a8.jpg)
![error_used](https://user-images.githubusercontent.com/6097524/196809074-74c4fdad-d0c5-47f2-ae14-572fb4a3aaa2.jpg)

### How to test
I made a test module to easily reproduce this - [tox_cartrecoverytest.zip](https://github.com/PrestaShop/PrestaShop/files/9824473/tox_cartrecoverytest.zip)

1. Install my test module. Go configure this module.
![test_tool](https://user-images.githubusercontent.com/6097524/196807176-fb9aa895-dbc5-4677-abea-71f078520403.jpg)
2. I prepared an easy generator for these URLs. You can enter any cart ID and it will generate the URL for you.
3. Then just copy it and visit it in FO.

Try:
- A valid, non ordered cart with existing customer. Will work and show the cart to you. ✅ 
- An ID of cart that doesnt exist. Will show a nice error message. ✅ (before, it silently consumed the error)
- A cart that exists, but you deleted the customer that is related to the cart. Will show a nice error message. ✅ (before, it silently consumed the error)
- A cart that already has an order created. Will show a nice error message. ✅ (before, it silently consumed the error)