### PR TITLE
Do not force new translation system when no domain is provided

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -182,7 +182,7 @@ function smartyTranslate($params, $smarty)
     $basename = basename($filename, '.tpl');
 
     if (!isset($params['d'])) {
-        $params['d'] = $params['mod'] ? DomainHelper::buildModuleDomainFromLegacySource($params['mod'], $basename) : null;
+        $params['d'] = null;
     }
 
     if (!empty($params['d'])) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | This PR aims revert back the old behavior of when a module doesn't specify the `d`
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30076
| Related PRs       | #27422
| How to test?      | Please see #30076 & #27422
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
