### PR TITLE
Add install fixtures for new registration page.

### DIFF
--- a/install-dev/data/xml/meta.xml
+++ b/install-dev/data/xml/meta.xml
@@ -56,6 +56,10 @@
 			<page>authentication</page>
 			<configurable>1</configurable>
 		</meta>
+		<meta id="registration">
+			<page>registration</page>
+			<configurable>1</configurable>
+		</meta>
 		<meta id="cart">
 			<page>cart</page>
 			<configurable>1</configurable>

--- a/install-dev/langs/en/data/meta.xml
+++ b/install-dev/langs/en/data/meta.xml
@@ -78,6 +78,12 @@
     <keywords/>
     <url_rewrite>login</url_rewrite>
   </meta>
+  <meta id="registration" id_shop="1">
+    <title>Registration</title>
+    <description/>
+    <keywords/>
+    <url_rewrite>registration</url_rewrite>
+  </meta>
   <meta id="cart" id_shop="1">
     <title>Cart</title>
     <description/>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Add missing install fixtures for new registration page. This is needed so a friendly URL route is registered on install.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/pull/27755#issuecomment-1279942207
| Related PRs       | -
| How to test?      | Install Prestashop and see that registration page now has friendly URL and it's present on SEO & URLs page in backoffice.
| Possible impacts? | -

cc @Caleydon 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
