### PR TITLE
Fix issue on fresh installation with docker in branch 1.7.8.x

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,11 +1,14 @@
-FROM prestashop/prestashop-git:latest
+# To run files with the same group as your primary user
+ARG VERSION
+
+FROM prestashop/prestashop-git:$VERSION
 
 # To run files with the same group as your primary user
 RUN groupmod -g 1000 www-data \
   && usermod -u 1000 -g 1000 www-data
 
-COPY /wait-for-it.sh /tmp/
-COPY /docker_run_git.sh /tmp/
+COPY .docker/wait-for-it.sh /tmp/
+COPY .docker/docker_run_git.sh /tmp/
 
 RUN mkdir -p /var/www/.npm
 RUN chown -R www-data:www-data /var/www/.npm

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -17,7 +17,7 @@ RUN chown -R www-data:www-data /var/www/.npm
 RUN chown -R www-data:www-data /var/www/html/vendor
 RUN chown -R www-data:www-data /var/www/html/var
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
 RUN apt install -y nodejs
 
 CMD ["/tmp/docker_run_git.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       PS_LANGUAGE: ${PS_LANGUAGE:-fr}
       PS_DEV_MODE: ${PS_DEV_MODE:-0}
       ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}
-      ADMIN_PASSWD: ${ADMIN_PASSWD:-demodemo}
+      ADMIN_PASSWD: ${ADMIN_PASSWD:-prestashop_demo}
     command: ["/tmp/wait-for-it.sh", "--timeout=60", "--strict", "mysql:3306", "--", "/tmp/docker_run_git.sh"]
     ports:
       - "8001:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,11 @@ services:
       MYSQL_DATABASE: prestashop
     restart: always
   prestashop-git:
-    build: .docker
+    build:
+      dockerfile: .docker/Dockerfile
+      context: .
+      args:
+        - VERSION=${VERSION:-7.4}
     environment:
       DISABLE_MAKE: ${DISABLE_MAKE:-0}
       PS_INSTALL_AUTO: ${PS_INSTALL_AUTO:-1}
@@ -32,5 +36,3 @@ services:
       - "8001:80"
     volumes:
       - ./:/var/www/html/:delegated
-      - vendor:/var/www/html/vendor
-      - var:/var/www/html/var

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,15 @@ services:
       DB_PASSWD: ${DB_PASSWD:-prestashop}
       DB_NAME: ${DB_NAME:-prestashop}
       DB_SERVER: ${DB_SERVER:-mysql}
+      DB_PREFIX: ${DB_PREFIX:-ps_}
       PS_DOMAIN: ${PS_DOMAIN:-localhost:8001}
       PS_FOLDER_INSTALL: ${PS_FOLDER_INSTALL:-install-dev}
       PS_FOLDER_ADMIN: ${PS_FOLDER_ADMIN:-admin-dev}
+      PS_COUNTRY: ${PS_COUNTRY:-fr}
+      PS_LANGUAGE: ${PS_LANGUAGE:-fr}
+      PS_DEV_MODE: ${PS_DEV_MODE:-0}
+      ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}
+      ADMIN_PASSWD: ${ADMIN_PASSWD:-demodemo}
     command: ["/tmp/wait-for-it.sh", "--timeout=60", "--strict", "mysql:3306", "--", "/tmp/docker_run_git.sh"]
     ports:
       - "8001:80"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  1.7.8.x
| Description?      | By default is using latest version of docker "prestashop-git" the latest version is on 8.0 of PHP, and this version of branch doesn't support this version of PHP, for that I changed docker file to use environment variable, for default is 7.4 this version is stable <br> <br> Also I update node version because is deprecated, and it is not installing when run docker build, and for that also can't build the assets
| Type?             | bug fix
| Category?         | IN
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/30098
| Related PRs       | 
| How to test?      | Follow the steps of issue: https://github.com/PrestaShop/PrestaShop/issues/30098
| Possible impacts? | The installation and dependencies of node, although it should not give problems since all the steps have been based on the latest branch of 8.0 https://github.com/PrestaShop/PrestaShop/tree/8.0.x

