### PR TITLE
Dynamic import for zxcvbn library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,8 @@ tests-legacy/.phpunit.result.cache
 themes/*/cache/*
 themes/core.js.map
 themes/core.js
+themes/*-chunk.js
+themes/*-chunk.js.map
 
 # Install folder
 /install-dev/theme/custom/*

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -490,6 +490,7 @@ class FrontControllerCore extends Controller
             'language' => $this->objectPresenter->present($this->context->language),
             'page' => $this->getTemplateVarPage(),
             'shop' => $this->getTemplateVarShop(),
+            'core_js_public_path' => $this->getCoreJsPublicPath(),
             'urls' => $this->getTemplateVarUrls(),
             'configuration' => $this->getTemplateVarConfiguration(),
             'field_required' => $this->context->customer->validateFieldsRequiredDatabase(),
@@ -1611,6 +1612,11 @@ class FrontControllerCore extends Controller
             'width' => $logoWidth,
             'height' => $logoHeight,
         ];
+    }
+
+    public function getCoreJsPublicPath()
+    {
+        return $this->context->shop->physical_uri . 'themes/';
     }
 
     public function getTemplateVarShop()

--- a/themes/_core/js/common.js
+++ b/themes/_core/js/common.js
@@ -24,7 +24,6 @@
  */
 import $ from 'jquery';
 import prestashop from 'prestashop';
-import zxcvbn from 'zxcvbn';
 
 export function psShowHide() {
   $('.ps-shown-by-js').show();
@@ -79,4 +78,8 @@ export function refreshCheckoutPage() {
  * Verify password score.
  * Estimate guesses needed to crack the password.
  */
-prestashop.checkPasswordScore = (password) => zxcvbn(password);
+prestashop.checkPasswordScore = async(password) => {
+  const zxcvbn = (await import('zxcvbn')).default;
+
+  return zxcvbn(password);
+};

--- a/themes/_core/js/theme.js
+++ b/themes/_core/js/theme.js
@@ -22,6 +22,8 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+__webpack_public_path__ = window.prestashop.core_js_public_path;
+
 import $ from 'jquery';
 
 import './migrate-mute';

--- a/themes/webpack.config.js
+++ b/themes/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = (env, argv) => {
     output: {
       path: path.resolve(__dirname),
       filename: 'core.js',
+      chunkFilename: '[chunkhash]-chunk.js',
     },
     module: {
       rules: [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x-rc 
| Description?      | `zxcvbn` library is rly huge and shouldn't be loaded in core.js. We are providing new filed to `prestashop` global variable `core_js_public_path`. It is being used for webpack `publicPath` on the fly to avoid problem when ruing prestashop inside catalog (`domain.com/directory/`). For now `prestashop.checkPasswordScore` is asynchronous and it's returning a promise. `zxcvbn` library is being loaded dynamically on calling `prestashop.checkPasswordScore` function. I will provide `PR` to classic and hummingbird.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | Yes and no. Since prestashop 8.0.0 isn't released yet but it will be if we don't implement it now.
| Deprecations?     | no
| Fixed ticket?     | Fixes #30088
| How to test?      | 1. Build core.js assets (there should new file with suffix `-chunk.js`. <br> 2. If testing with classic-theme https://github.com/PrestaShop/classic-theme/pull/67 apply changes from this PR.<br> 3. Go to FO register page. <br> 4. Type inside password field, (you can open network tab in browser, there should be js file loaded on password check). <br> 5. Password policy should be working as before.
| Possible impacts? | Check if it's working for prestashop installation with different `physicial_uri` 

Before:
core.js size: `940kB`

After:
core.js size: `144kB` 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
