### PR TITLE
Fix potential warning on getPosition method of Module class

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -2691,18 +2691,16 @@ abstract class ModuleCore implements ModuleInterface
      *
      * @param int $id_hook Hook ID
      *
-     * @return int position
+     * @return int position or 0 if hook not found
      */
     public function getPosition($id_hook)
     {
-        $result = Db::getInstance()->getRow('
+        return (int) Db::getInstance()->getValue('
             SELECT `position`
             FROM `' . _DB_PREFIX_ . 'hook_module`
             WHERE `id_hook` = ' . (int) $id_hook . '
             AND `id_module` = ' . (int) $this->id . '
             AND `id_shop` = ' . (int) Context::getContext()->shop->id);
-
-        return $result['position'];
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |  Fix potential warning on getPosition method of Module class - see details below
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | No ticket
| Related PRs       | N/A
| How to test?      | Use the method getPosition with an invalid & valid hooks
| Possible impacts? | I chose to return `false` in this case but we could also choose to return `-1` for example to keep the int return type.

Today, if we call the method getPosition with an unregistered hook, we get this warning:

```
Warning à la ligne 2704 du fichier /var/www/html/classes/module/Module.php
[2] Trying to access array offset on value of type bool
```

So this PR just check the result from DB.