### PR TITLE
Fix #29436 - The override directory is deleted when a module is uninstalled

### DIFF
--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3285,7 +3285,7 @@ abstract class ModuleCore implements ModuleInterface
 
             // Get Parent directory
             $splDir = $splDir->getPathInfo();
-        } while ($splDir->getPathname() !== $directoryOverride);
+        } while ($splDir->getRealPath() !== $directoryOverride);
     }
 
     private function getWidgetHooks()


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In Windows, getPathname might return a path with a mix of backslashes and forward slashes ('C:/some/path/to\a\file.txt'). Observed in PHP 5.2.9. By contrast, getRealPath will return a consistent result (all backslashes).
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29436


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
