### PR TITLE
Replace `Tools::link_rewrite` usages by `Tools::str2url`, deprecate `Tools::link_rewrite`

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -2022,9 +2022,9 @@ class CategoryCore extends ObjectModel
     {
         foreach ($this->name as $id_lang => $name) {
             if (empty($this->link_rewrite[$id_lang])) {
-                $this->link_rewrite[$id_lang] = Tools::link_rewrite($name);
+                $this->link_rewrite[$id_lang] = Tools::str2url($name);
             } elseif (!Validate::isLinkRewrite($this->link_rewrite[$id_lang])) {
-                $this->link_rewrite[$id_lang] = Tools::link_rewrite($this->link_rewrite[$id_lang]);
+                $this->link_rewrite[$id_lang] = Tools::str2url($this->link_rewrite[$id_lang]);
             }
         }
 

--- a/classes/Manufacturer.php
+++ b/classes/Manufacturer.php
@@ -254,7 +254,7 @@ class ManufacturerCore extends ObjectModel
         $totalManufacturers = count($manufacturers);
         $rewriteSettings = (int) Configuration::get('PS_REWRITING_SETTINGS');
         for ($i = 0; $i < $totalManufacturers; ++$i) {
-            $manufacturers[$i]['link_rewrite'] = ($rewriteSettings ? Tools::link_rewrite($manufacturers[$i]['name']) : 0);
+            $manufacturers[$i]['link_rewrite'] = ($rewriteSettings ? Tools::str2url($manufacturers[$i]['name']) : 0);
         }
 
         return $manufacturers;
@@ -351,7 +351,7 @@ class ManufacturerCore extends ObjectModel
      */
     public function getLink()
     {
-        return Tools::link_rewrite($this->name);
+        return Tools::str2url($this->name);
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7483,7 +7483,7 @@ class ProductCore extends ObjectModel
         $sep = Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR');
         foreach ($attributes as &$a) {
             foreach ($a as &$b) {
-                $b = str_replace($sep, '_', Tools::link_rewrite((string) $b));
+                $b = str_replace($sep, '_', Tools::str2url((string) $b));
             }
             $anchor .= '/' . ($with_id && isset($a['id_attribute']) && $a['id_attribute'] ? (int) $a['id_attribute'] . $sep : '') . $a['group'] . $sep . $a['name'];
         }
@@ -7908,9 +7908,9 @@ class ProductCore extends ObjectModel
 
         foreach ($this->name as $id_lang => $name) {
             if (empty($this->link_rewrite[$id_lang])) {
-                $this->link_rewrite[$id_lang] = Tools::link_rewrite($name);
+                $this->link_rewrite[$id_lang] = Tools::str2url($name);
             } elseif (!Validate::isLinkRewrite($this->link_rewrite[$id_lang])) {
-                $this->link_rewrite[$id_lang] = Tools::link_rewrite($this->link_rewrite[$id_lang]);
+                $this->link_rewrite[$id_lang] = Tools::str2url($this->link_rewrite[$id_lang]);
             }
         }
 

--- a/classes/Supplier.php
+++ b/classes/Supplier.php
@@ -104,7 +104,7 @@ class SupplierCore extends ObjectModel
 
     public function getLink()
     {
-        return Tools::link_rewrite($this->name);
+        return Tools::str2url($this->name);
     }
 
     /**
@@ -183,7 +183,7 @@ class SupplierCore extends ObjectModel
         $nbSuppliers = count($suppliers);
         $rewriteSettings = (int) Configuration::get('PS_REWRITING_SETTINGS');
         for ($i = 0; $i < $nbSuppliers; ++$i) {
-            $suppliers[$i]['link_rewrite'] = ($rewriteSettings ? Tools::link_rewrite($suppliers[$i]['name']) : 0);
+            $suppliers[$i]['link_rewrite'] = ($rewriteSettings ? Tools::str2url($suppliers[$i]['name']) : 0);
         }
 
         return $suppliers;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1370,6 +1370,8 @@ class ToolsCore
     /**
      * Return the friendly url from the provided string.
      *
+     * @deprecated since 8.1
+     *
      * @param string $str
      * @param bool $utf8_decode (deprecated)
      *
@@ -1377,6 +1379,11 @@ class ToolsCore
      */
     public static function link_rewrite($str, $utf8_decode = null)
     {
+        @trigger_error(
+            'This function is deprecated, use Tools::str2url($str) instead.',
+            E_USER_DEPRECATED
+        );
+
         if ($utf8_decode !== null) {
             Tools::displayParameterAsDeprecated('utf8_decode');
         }

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1423,7 +1423,7 @@ class AdminImportControllerCore extends AdminController
                 $category_to_create = new Category();
                 $category_to_create->name = AdminImportController::createMultiLangField($category->parent);
                 $category_to_create->active = true;
-                $category_link_rewrite = Tools::link_rewrite($category_to_create->name[$id_lang]);
+                $category_link_rewrite = Tools::str2url($category_to_create->name[$id_lang]);
                 $category_to_create->link_rewrite = AdminImportController::createMultiLangField($category_link_rewrite);
                 $category_to_create->id_parent = (int) Configuration::get('PS_HOME_CATEGORY'); // Default parent is home for unknown category to create
 
@@ -1464,7 +1464,7 @@ class AdminImportControllerCore extends AdminController
 
         $bak = $category->link_rewrite[$default_language_id];
         if ((isset($category->link_rewrite) && empty($category->link_rewrite[$default_language_id])) || !$valid_link) {
-            $category->link_rewrite = Tools::link_rewrite($category->name[$default_language_id]);
+            $category->link_rewrite = Tools::str2url($category->name[$default_language_id]);
             if ($category->link_rewrite == '') {
                 $category->link_rewrite = 'friendly-url-autogeneration-failed';
                 $this->warnings[] = $this->trans(
@@ -1893,7 +1893,7 @@ class AdminImportControllerCore extends AdminController
                         $category_to_create->name = AdminImportController::createMultiLangField($value);
                         $category_to_create->active = true;
                         $category_to_create->id_parent = (int) Configuration::get('PS_HOME_CATEGORY'); // Default parent is home for unknown category to create
-                        $category_link_rewrite = Tools::link_rewrite($category_to_create->name[$default_language_id]);
+                        $category_link_rewrite = Tools::str2url($category_to_create->name[$default_language_id]);
                         $category_to_create->link_rewrite = AdminImportController::createMultiLangField($category_link_rewrite);
                         if (($field_error = $category_to_create->validateFields(UNFRIENDLY_ERROR, true)) === true &&
                             ($lang_field_error = $category_to_create->validateFieldsLang(UNFRIENDLY_ERROR, true)) === true &&
@@ -1948,7 +1948,7 @@ class AdminImportControllerCore extends AdminController
         $link_rewrite = (is_array($product->link_rewrite) && isset($product->link_rewrite[$id_lang])) ? trim($product->link_rewrite[$id_lang]) : '';
         $valid_link = Validate::isLinkRewrite($link_rewrite);
         if ((isset($product->link_rewrite[$id_lang]) && empty($product->link_rewrite[$id_lang])) || !$valid_link) {
-            $link_rewrite = Tools::link_rewrite($product->name[$id_lang]);
+            $link_rewrite = Tools::str2url($product->name[$id_lang]);
             if ($link_rewrite == '') {
                 $link_rewrite = 'friendly-url-autogeneration-failed';
             }
@@ -2445,7 +2445,7 @@ class AdminImportControllerCore extends AdminController
         $category_to_create->name = AdminImportController::createMultiLangField(trim($category_name));
         $category_to_create->active = true;
         $category_to_create->id_parent = (int) $id_parent_category ? (int) $id_parent_category : (int) Configuration::get('PS_HOME_CATEGORY'); // Default parent is home for unknown category to create
-        $category_link_rewrite = Tools::link_rewrite($category_to_create->name[$default_language_id]);
+        $category_link_rewrite = Tools::str2url($category_to_create->name[$default_language_id]);
         $category_to_create->link_rewrite = AdminImportController::createMultiLangField($category_link_rewrite);
 
         if (($field_error = $category_to_create->validateFields(UNFRIENDLY_ERROR, true)) !== true ||

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -834,7 +834,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         if (is_array($attributes_combinations) && count($attributes_combinations)) {
             foreach ($attributes_combinations as &$ac) {
                 foreach ($ac as &$val) {
-                    $val = str_replace(Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'), '_', Tools::link_rewrite(str_replace([',', '.'], '-', $val)));
+                    $val = str_replace(Configuration::get('PS_ATTRIBUTE_ANCHOR_SEPARATOR'), '_', Tools::str2url(str_replace([',', '.'], '-', $val)));
                 }
             }
         } else {

--- a/tests/Integration/Behaviour/Features/Context/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CategoryFeatureContext.php
@@ -47,7 +47,7 @@ class CategoryFeatureContext extends AbstractPrestaShopFeatureContext
         $idLang = (int) Context::getContext()->language->id;
         $category = new Category();
         $category->name = [$idLang => $categoryName];
-        $category->link_rewrite = [$idLang => Tools::link_rewrite($categoryName)];
+        $category->link_rewrite = [$idLang => Tools::str2url($categoryName)];
         $category->add();
         $this->categories[$categoryName] = $category;
     }

--- a/tests/Integration/Classes/CartTest.php
+++ b/tests/Integration/Classes/CartTest.php
@@ -179,7 +179,7 @@ class CartTest extends TestCase
         $product->id_tax_rules_group = $id_tax_rules_group;
         $product->name = $name;
         $product->price = $price;
-        $product->link_rewrite = Tools::link_rewrite($name);
+        $product->link_rewrite = Tools::str2url($name);
         self::assertTrue($product->save());
 
         return $product;


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Duplicate function, one already calls the other one, this PR keeps only the used function and deprecates the old one
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | Tests should be sufficient as this is widely used function.
