### PR TITLE
Disable access to the customer groups page when this feature is disabled

### DIFF
--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -695,7 +695,7 @@ class AdminGroupsControllerCore extends AdminController
     {
         if (!Group::isFeatureActive()) {
             $adminPerformanceUrl = $this->context->link->getAdminLink('AdminPerformance');
-            $url = '<a href="' . $adminPerformanceUrl . '#featuresDetachables">' . $this->trans('Performance', [], 'Admin.Global') . '</a>';
+            $url = '<a href="' . $adminPerformanceUrl . '">' . $this->trans('Performance', [], 'Admin.Global') . '</a>';
             $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %url%.', ['%url%' => $url], 'Admin.Catalog.Notification'));
 
             $this->context->smarty->assign([

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -691,7 +691,8 @@ class AdminGroupsControllerCore extends AdminController
      *
      * @see AdminController::initContent()
      */
-    public function initContent() {
+    public function initContent()
+    {
         if (!Group::isFeatureActive()) {
             $adminPerformanceUrl = $this->context->link->getAdminLink('AdminPerformance');
             $url = '<a href="' . $adminPerformanceUrl . '#featuresDetachables">' . $this->trans('Performance', [], 'Admin.Global') . '</a>';
@@ -700,6 +701,7 @@ class AdminGroupsControllerCore extends AdminController
             $this->context->smarty->assign([
                 'content' => $this->content,
             ]);
+
             return;
         }
 

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -161,7 +161,7 @@ class AdminGroupsControllerCore extends AdminController
 
     public function initPageHeaderToolbar()
     {
-        if (empty($this->display)) {
+        if (Group::isFeatureActive() && empty($this->display)) {
             $this->page_header_toolbar_btn['new_group'] = [
                 'href' => self::$currentIndex . '&addgroup&token=' . $this->token,
                 'desc' => $this->trans('Add new group', [], 'Admin.Shopparameters.Feature'),
@@ -199,6 +199,10 @@ class AdminGroupsControllerCore extends AdminController
 
     public function postProcess(): void
     {
+        if (!Group::isFeatureActive()) {
+            return;
+        }
+
         $tableCustomerGroup = 'customer_group';
         if (!empty($_POST[$tableCustomerGroup . 'Box'])
             && is_array($_POST[$tableCustomerGroup . 'Box'])
@@ -680,5 +684,25 @@ class AdminGroupsControllerCore extends AdminController
         ]);
 
         return $tpl->fetch();
+    }
+
+    /**
+     * AdminController::initContent() override.
+     *
+     * @see AdminController::initContent()
+     */
+    public function initContent() {
+        if (!Group::isFeatureActive()) {
+            $adminPerformanceUrl = $this->context->link->getAdminLink('AdminPerformance');
+            $url = '<a href="' . $adminPerformanceUrl . '#featuresDetachables">' . $this->trans('Performance', [], 'Admin.Global') . '</a>';
+            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %url%.', ['%url%' => $url], 'Admin.Catalog.Notification'));
+
+            $this->context->smarty->assign([
+                'content' => $this->content,
+            ]);
+            return;
+        }
+
+        parent::initContent();
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Disables access to the customer groups page if it has been disabled on the performance page and shows a warning message.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30062 (issue closed but still valid)
| Related PRs       |
| How to test?      | 1) Verify that everything on the customer groups page works. 2) Disable the customer groups feature. 3) Ensure that it is not possible to do anything on the customer groups page. 4) Enable the customer groups again. 5) Repeat step 1.
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
