### PR TITLE
Fix exception throwing in CategoryRepository

### DIFF
--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -73,12 +73,16 @@ class CategoryRepository extends AbstractObjectModelRepository
      */
     public function get(CategoryId $categoryId): Category
     {
-        /** @var Category $category */
-        $category = $this->getObjectModel(
-            $categoryId->getValue(),
-            Category::class,
-            CategoryNotFoundException::class
-        );
+        try {
+            /** @var Category $category */
+            $category = $this->getObjectModel(
+                $categoryId->getValue(),
+                Category::class,
+                CategoryException::class
+            );
+        } catch (CategoryException $e) {
+            throw new CategoryNotFoundException($categoryId, $e->getMessage());
+        }
 
         return $category;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | AbstractObjectModel repository doesn't support exceptions with custom constructs like CategoryNotFoundException which requires CategoryId in construct. This PR fixes CategoryRepository::get() method so it correctly throws CategoryNotFoundException.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | It should be reproducible by getting non existing category, but I think its not worth to waste QA time on this and developers should be enough.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
