### PR TITLE
Add SQL transactions support to Db

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -903,6 +903,9 @@ class HookCore extends ObjectModel
                 $hookRegistry->hookedByModule($moduleInstance);
             }
 
+            $db = Db::getInstance();
+            $transactionsDepth = $db->getTransactionsDepth();
+
             if (Hook::isHookCallableOn($moduleInstance, $registeredHookName)) {
                 $hook_args['altern'] = ++$altern;
 
@@ -946,6 +949,11 @@ class HookCore extends ObjectModel
                 if ($isRegistryEnabled) {
                     $hookRegistry->hookedByWidget($moduleInstance, $hook_args);
                 }
+            }
+
+            $diff = $db->getTransactionsDepth() - $transactionsDepth;
+            if ($diff) {
+                throw new PrestaShopException('Unbalanced database transaction in ' . $moduleInstance->name);
             }
         }
 

--- a/classes/db/Db.php
+++ b/classes/db/Db.php
@@ -58,6 +58,9 @@ abstract class DbCore
     /** @var PDO|mysqli|resource|null Resource link */
     protected $link;
 
+    /** @var int Transactions depth level */
+    protected $transactionsDepth = 0;
+
     /** @var PDOStatement|mysqli_result|resource|bool SQL cached result */
     protected $result;
 
@@ -201,6 +204,38 @@ abstract class DbCore
      * @return string
      */
     abstract public function getBestEngine();
+
+    /**
+     * Initiate a new transaction.
+     *
+     * @return bool
+     */
+    abstract protected function _beginTransaction(): bool;
+
+    /**
+     * Set a named savepoint that transaction can be rolled back to.
+     *
+     * @param string $name Name of savepoint to set
+     *
+     * @return bool
+     */
+    abstract protected function _savepoint($name): bool;
+
+    /**
+     * Commit a transaction.
+     *
+     * @return bool
+     */
+    abstract protected function _commit(): bool;
+
+    /**
+     * Rollback a transaction.
+     *
+     * @param string $name Optional savepoint to rollback to
+     *
+     * @return bool
+     */
+    abstract protected function _rollback($name = null): bool;
 
     /**
      * Returns database object instance.
@@ -357,6 +392,87 @@ abstract class DbCore
         if ($this->link) {
             $this->disconnect();
         }
+    }
+
+    /**
+     * Initiate a new transaction.
+     *
+     * @return bool
+     */
+    public function beginTransaction(): bool
+    {
+        if ($this->transactionsDepth == 0) {
+            if ($this->_beginTransaction()) {
+                ++$this->transactionsDepth;
+
+                return true;
+            }
+        } elseif ($this->transactionsDepth > 0) {
+            if ($this->_savepoint('depth' . ($this->transactionsDepth + 1))) {
+                ++$this->transactionsDepth;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Commit a transaction.
+     *
+     * @return bool
+     */
+    public function commit(): bool
+    {
+        if ($this->transactionsDepth == 0) {
+            return false;
+        } elseif ($this->transactionsDepth > 1) {
+            --$this->transactionsDepth;
+
+            return true;
+        } elseif ($this->_commit()) {
+            --$this->transactionsDepth;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Rollback a transaction.
+     *
+     * @return bool
+     */
+    public function rollback(): bool
+    {
+        if ($this->transactionsDepth == 0) {
+            return false;
+        } elseif ($this->transactionsDepth > 1) {
+            if ($this->_rollback('depth' . $this->transactionsDepth)) {
+                --$this->transactionsDepth;
+
+                return true;
+            }
+        } elseif ($this->_rollback()) {
+            --$this->transactionsDepth;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get depth of transactions nesting. Value 0 means there is no ongoing
+     * transaction. Values higher than 1 mean being in a nested transaction.
+     *
+     * @return int
+     */
+    public function getTransactionsDepth(): int
+    {
+        return $this->transactionsDepth;
     }
 
     /**

--- a/classes/db/DbMySQLi.php
+++ b/classes/db/DbMySQLi.php
@@ -391,6 +391,50 @@ class DbMySQLiCore extends Db
     }
 
     /**
+     * Initiate a new transaction.
+     *
+     * @return bool
+     */
+    protected function _beginTransaction(): bool
+    {
+        return $this->link->begin_transaction();
+    }
+
+    /**
+     * Set a named savepoint that transaction can be rolled back to.
+     *
+     * @param string $name Name of savepoint to set
+     *
+     * @return bool
+     */
+    protected function _savepoint($name): bool
+    {
+        return $this->link->savepoint($name);
+    }
+
+    /**
+     * Commit a transaction.
+     *
+     * @return bool
+     */
+    protected function _commit(): bool
+    {
+        return $this->link->commit();
+    }
+
+    /**
+     * Rollback a transaction.
+     *
+     * @param string $name Optional savepoint to rollback to
+     *
+     * @return bool
+     */
+    protected function _rollback($name = null): bool
+    {
+        return $this->link->rollback(0, $name);
+    }
+
+    /**
      * Tries to connect to the database and create a table (checking creation privileges).
      *
      * @param string $server

--- a/classes/db/DbPDO.php
+++ b/classes/db/DbPDO.php
@@ -490,6 +490,58 @@ class DbPDOCore extends Db
     }
 
     /**
+     * Initiate a new transaction.
+     *
+     * @return bool
+     */
+    protected function _beginTransaction(): bool
+    {
+        return $this->link->beginTransaction();
+    }
+
+    /**
+     * Set a named savepoint that transaction can be rolled back to.
+     *
+     * @param string $name Name of savepoint to set
+     *
+     * @return bool
+     */
+    protected function _savepoint($name): bool
+    {
+        $result = $this->link->exec('SAVEPOINT `' . str_replace('`', '\\`', $name) . '`');
+
+        return $result !== false;
+    }
+
+    /**
+     * Commit a transaction.
+     *
+     * @return bool
+     */
+    protected function _commit(): bool
+    {
+        return $this->link->commit();
+    }
+
+    /**
+     * Rollback a transaction.
+     *
+     * @param string $name Optional savepoint to rollback to
+     *
+     * @return bool
+     */
+    protected function _rollback($name = null): bool
+    {
+        if ($name) {
+            $result = $this->link->exec('ROLLBACK TO SAVEPOINT `' . str_replace('`', '\\`', $name) . '`');
+
+            return $result !== false;
+        }
+
+        return $this->link->rollBack();
+    }
+
+    /**
      * Try a connection to the database and set names to UTF-8.
      *
      * @see Db::checkEncoding()

--- a/tests/Unit/Classes/RequestSqlTest.php
+++ b/tests/Unit/Classes/RequestSqlTest.php
@@ -112,6 +112,34 @@ namespace {
         public function getBestEngine()
         {
         }
+
+        /* @phpstan-ignore-next-line */
+        public function _beginTransaction(): bool
+        {
+            /* @phpstan-ignore-next-line */
+            return true;
+        }
+
+        /* @phpstan-ignore-next-line */
+        public function _savepoint($name): bool
+        {
+            /* @phpstan-ignore-next-line */
+            return true;
+        }
+
+        /* @phpstan-ignore-next-line */
+        public function _commit(): bool
+        {
+            /* @phpstan-ignore-next-line */
+            return true;
+        }
+
+        /* @phpstan-ignore-next-line */
+        public function _rollback($name = null): bool
+        {
+            /* @phpstan-ignore-next-line */
+            return true;
+        }
     }
 }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | All **related** database change queries should be executed in a single transaction. This way we make sure database won't get in inconsistent state if processing fails at some point.<br>This Pull Request adds transactions support to the `Db` API that allows improving core code & modules. Once this gets merged all *critical* code should get updated to run in transactions.
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | CO
| BC breaks?        | yes (limited to corner cases - custom DB classes)
| Deprecations?     | no
| Fixed ticket?     | Feature inspired by undebugged database inconsistency reported in the #17347
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/17360 https://github.com/PrestaShop/PrestaShop/pull/21740 https://github.com/PrestaShop/PrestaShop/pull/26966 (previous attempts - all closed)
| How to test?      | Try calling `beginTransaction()` and `commit()` or `rollback()`. See below for details.
| Possible impacts? | Just make sure PrestaShop can still access database. Open BO & FO.

---

For testing this pull request I used `dashactivity` module. I was adding testing code to the `hookDashboardZoneOne()` and I was opening BO dashboard page.

This code:
```
$db = Db::getInstance();
$db->beginTransaction();
```
results in "Unbalanced database transaction in dashactivity" (as expected ✓).

This code:
```
$db = Db::getInstance();
$db->beginTransaction();
$db->beginTransaction();
$db->delete('log');
$db->commit();
```
results in "Unbalanced database transaction in dashactivity" and doesn't affect database table (as expected ✓).

This code:
```
$db = Db::getInstance();
$db->beginTransaction();
$db->delete('log');
$db->rollback();
```
does nothing (as expected ✓).

This code (**use carefully** ❗):
```
$db = Db::getInstance();
$db->beginTransaction();
$db->delete('log');
$db->commit();
```
erases all logs (as expected ✓).

---

```
Hook: check for unbalanced transactions in modules

Unbalanced transactions can't be allowed as they can break saving
changes by other modules & core code.
```
```
Db: add support for SQL transactions

Transactions should be used when executing multiple related queries.
They are required to keep database in consistent state in case of any
errors.

MySQL doesn't support transactions when using MyISAM engine so this code
doesn't really help that case. When using MyISAM all transaction queries
are simply ignored (so it's still safe to call them though).

Those changes are designed for InnoDB (which is the default engine used
by PrestaShop).

Introduced design deals with nested transactions which helps a lot in
writing a clean controllers & modules code. Actual commit happens only
when called at the most outer level.

This code has to be used carefully:
1. Core code needs to keep transactions balanced (always commit or
    rollback after starting a transaction).
2. Modules shouldn't be fully trusted as unclosed transaction would
    prevent all core changes.

Ref: https://www.php.net/manual/en/pdo.transactions.php
```