### PR TITLE
Fix undefined index precision

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -514,7 +514,7 @@ class ContextCore
     {
         if ($this->priceComputingPrecision === null) {
             $computingPrecision = new ComputingPrecision();
-            $this->priceComputingPrecision = $computingPrecision->getPrecision($this->currency->precision);
+            $this->priceComputingPrecision = $computingPrecision->getPrecision(isset($this->currency->precision)?$this->currency->precision:2);
         }
 
         return $this->priceComputingPrecision;


### PR DESCRIPTION
Fix this error
Argument 1 passed to PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision::getPrecision() must be of the type int, null given, called in /var/www/vhost/xxx.com/home/html/classes/Context.php on line 489


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | When you use this method with a currency without this variable, php throw this exception: <br>Argument 1 passed to PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision::getPrecision() must be of the type int, null given, called in /var/www/vhost/xxx.com/home/html/classes/Context.php on line 489
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | yes 
| Deprecations?     | no
| Fixed ticket?     | Fixes #{issue number here}. If your PR fixes multiple issues, use Resolves #{issue number here}, Resolves #{another issue number here}.
| Related PRs       | 
| How to test?      | Use a currency with no precision set
| Possible impacts? | Do not crash when no precition


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
