### PR TITLE
Skip admin IP check when maintenance mode is enabled 

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -236,18 +236,36 @@
       {/if}
 
       {if isset($maintenance_mode) && $maintenance_mode == true}
-      <div class="component hide-mobile-sm">
-        <a class="shop-state label-tooltip" id="maintenance-mode"
-           href="{$link->getAdminLink('AdminMaintenance')|escape:'html':'UTF-8'}"
-           data-toggle="tooltip"
-           data-placement="bottom"
-           data-html="true"
-           title="<p class=&quot;text-left text-nowrap&quot;><strong>{l|escape s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong></p><p class=&quot;text-left&quot;>{l|escape s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' sprintf=['<br />'] d='Admin.Navigation.Notification'}</p>"
-        >
-          <i class="material-icons">build</i>
-          <span>{l|escape s='Maintenance mode' d='Admin.Navigation.Header'}</span>
-        </a>
-      </div>
+        {capture name="title"}
+          <p class="text-left text-nowrap">
+            <strong>{l s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong>
+          </p>
+          <p class="text-left">
+              {l s='Your visitors and customers cannot access your shop while in maintenance mode.' d='Admin.Navigation.Notification'}
+          </p>
+          <p class="text-left">
+            {l s='To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' d='Admin.Navigation.Notification'}
+          </p>
+          {if isset($maintenance_skip_admin_ip_check) && $maintenance_skip_admin_ip_check}
+            <p class="text-left">
+                {l s='Admins can access the shop front-end without storing their IP.' d='Admin.Navigation.Notification'}
+            </p>
+          {/if}
+        {/capture}
+        <div class="component hide-mobile-sm">
+          <a class="shop-state label-tooltip" id="maintenance-mode"
+             href="{$link->getAdminLink('AdminMaintenance')|escape:'html':'UTF-8'}"
+             data-toggle="tooltip"
+             data-placement="bottom"
+             data-html="true"
+             title="{$smarty.capture.title|htmlspecialchars}"
+          >
+            <i class="material-icons"
+               style="{if isset($maintenance_skip_admin_ip_check)}color: #72c279;{/if}"
+            >build</i>
+            <span>{l|escape s='Maintenance mode' d='Admin.Navigation.Header'}</span>
+          </a>
+        </div>
       {/if}
 
       {* Shop name *}

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -246,7 +246,7 @@
           <p class="text-left">
             {l s='To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' d='Admin.Navigation.Notification'}
           </p>
-          {if isset($maintenance_skip_admin_ip_check) && $maintenance_skip_admin_ip_check}
+          {if isset($maintenance_allow_admins) && $maintenance_allow_admins}
             <p class="text-left">
                 {l s='Admins can access the shop front-end without storing their IP.' d='Admin.Navigation.Notification'}
             </p>
@@ -261,7 +261,7 @@
              title="{$smarty.capture.title|htmlspecialchars}"
           >
             <i class="material-icons"
-               style="{if isset($maintenance_skip_admin_ip_check)}color: #72c279;{/if}"
+               style="{if isset($maintenance_allow_admins)}color: #72c279;{/if}"
             >build</i>
             <span>{l|escape s='Maintenance mode' d='Admin.Navigation.Header'}</span>
           </a>

--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -238,17 +238,17 @@
       {if isset($maintenance_mode) && $maintenance_mode == true}
         {capture name="title"}
           <p class="text-left text-nowrap">
-            <strong>{l s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong>
+            <strong>{l s='Your store is in maintenance mode.' d='Admin.Navigation.Notification'}</strong>
           </p>
           <p class="text-left">
-              {l s='Your visitors and customers cannot access your shop while in maintenance mode.' d='Admin.Navigation.Notification'}
+              {l s='Your visitors and customers cannot access your store while in maintenance mode.' d='Admin.Navigation.Notification'}
           </p>
           <p class="text-left">
             {l s='To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' d='Admin.Navigation.Notification'}
           </p>
           {if isset($maintenance_allow_admins) && $maintenance_allow_admins}
             <p class="text-left">
-                {l s='Admins can access the shop front-end without storing their IP.' d='Admin.Navigation.Notification'}
+                {l s='Admins can access the store front office without storing their IP.' d='Admin.Navigation.Notification'}
             </p>
           {/if}
         {/capture}

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -54,15 +54,34 @@
       {/if}
 
       {if isset($maintenance_mode) && $maintenance_mode == true}
+        {capture name="title"}
+          <p class="text-left text-nowrap">
+            <strong>{l s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong>
+          </p>
+          <p class="text-left">
+              {l s='Your visitors and customers cannot access your shop while in maintenance mode.' d='Admin.Navigation.Notification'}
+          </p>
+          <p class="text-left">
+              {l s='To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' d='Admin.Navigation.Notification'}
+          </p>
+          {if isset($maintenance_skip_admin_ip_check) && $maintenance_skip_admin_ip_check}
+            <p class="text-left">
+              {l s='Admins can access the shop front-end without storing their IP.' d='Admin.Navigation.Notification'}
+            </p>
+          {/if}
+        {/capture}
         <div class="component hide-mobile-sm" id="header-maintenance-mode-container">
           <a class="link shop-state"
              id="maintenance-mode"
              data-toggle="pstooltip"
              data-placement="bottom"
              data-html="true"
-             title="<p class=&quot;text-left&quot;><strong>{l|escape s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong></p><p class=&quot;text-left&quot;>{l|escape s='Your visitors and customers cannot access your shop while in maintenance mode.%s To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' sprintf=['<br />'] d='Admin.Navigation.Notification'}</p>" href="{$link->getAdminLink('AdminMaintenance')|escape:'html':'UTF-8'}"
+             title="{$smarty.capture.title|htmlspecialchars}"
+             href="{$link->getAdminLink('AdminMaintenance')|escape:'html':'UTF-8'}"
           >
-            <i class="material-icons">build</i>
+            <i class="material-icons"
+              style="{if isset($maintenance_skip_admin_ip_check) && $maintenance_skip_admin_ip_check}color: var(--green);{/if}"
+            >build</i>
             <span>{l|escape s='Maintenance mode' d='Admin.Navigation.Header'}</span>
           </a>
         </div>

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -64,7 +64,7 @@
           <p class="text-left">
               {l s='To manage the maintenance settings, go to Shop Parameters > Maintenance tab.' d='Admin.Navigation.Notification'}
           </p>
-          {if isset($maintenance_skip_admin_ip_check) && $maintenance_skip_admin_ip_check}
+          {if isset($maintenance_allow_admins) && $maintenance_allow_admins}
             <p class="text-left">
               {l s='Admins can access the shop front-end without storing their IP.' d='Admin.Navigation.Notification'}
             </p>
@@ -80,7 +80,7 @@
              href="{$link->getAdminLink('AdminMaintenance')|escape:'html':'UTF-8'}"
           >
             <i class="material-icons"
-              style="{if isset($maintenance_skip_admin_ip_check) && $maintenance_skip_admin_ip_check}color: var(--green);{/if}"
+              style="{if isset($maintenance_allow_admins) && $maintenance_allow_admins}color: var(--green);{/if}"
             >build</i>
             <span>{l|escape s='Maintenance mode' d='Admin.Navigation.Header'}</span>
           </a>

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -56,7 +56,7 @@
       {if isset($maintenance_mode) && $maintenance_mode == true}
         {capture name="title"}
           <p class="text-left text-nowrap">
-            <strong>{l s='Your shop is in maintenance.' d='Admin.Navigation.Notification'}</strong>
+            <strong>{l s='Your store is in maintenance mode.' d='Admin.Navigation.Notification'}</strong>
           </p>
           <p class="text-left">
               {l s='Your visitors and customers cannot access your shop while in maintenance mode.' d='Admin.Navigation.Notification'}
@@ -66,7 +66,7 @@
           </p>
           {if isset($maintenance_allow_admins) && $maintenance_allow_admins}
             <p class="text-left">
-              {l s='Admins can access the shop front-end without storing their IP.' d='Admin.Navigation.Notification'}
+              {l s='Admins can access the store front office without storing their IP.' d='Admin.Navigation.Notification'}
             </p>
           {/if}
         {/capture}

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2244,7 +2244,7 @@ class AdminControllerCore extends Controller
 
         $this->context->smarty->assign([
             'maintenance_mode' => !(bool) Configuration::get('PS_SHOP_ENABLE'),
-            'maintenance_skip_admin_ip_check' => !(bool) Configuration::get('PS_SKIP_ADMIN_IP_CHECK'),
+            'maintenance_allow_admins' => !(bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS'),
             'debug_mode' => (bool) _PS_MODE_DEV_,
             'lite_display' => $this->lite_display,
             'url_post' => self::$currentIndex . '&token=' . $this->token,

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2244,6 +2244,7 @@ class AdminControllerCore extends Controller
 
         $this->context->smarty->assign([
             'maintenance_mode' => !(bool) Configuration::get('PS_SHOP_ENABLE'),
+            'maintenance_skip_admin_ip_check' => !(bool) Configuration::get('PS_SKIP_ADMIN_IP_CHECK'),
             'debug_mode' => (bool) _PS_MODE_DEV_,
             'lite_display' => $this->lite_display,
             'url_post' => self::$currentIndex . '&token=' . $this->token,

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2244,7 +2244,7 @@ class AdminControllerCore extends Controller
 
         $this->context->smarty->assign([
             'maintenance_mode' => !(bool) Configuration::get('PS_SHOP_ENABLE'),
-            'maintenance_allow_admins' => !(bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS'),
+            'maintenance_allow_admins' => (bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS'),
             'debug_mode' => (bool) _PS_MODE_DEV_,
             'lite_display' => $this->lite_display,
             'url_post' => self::$currentIndex . '&token=' . $this->token,

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -735,6 +735,13 @@ class FrontControllerCore extends Controller
     {
         if ($this->maintenance == true || !(int) Configuration::get('PS_SHOP_ENABLE')) {
             $this->maintenance = true;
+
+            $is_admin = (int)(new Cookie('psAdmin'))->id_employee;
+            $skip_admin_ip_check = (int) Configuration::get('PS_SKIP_ADMIN_IP_CHECK');
+            if ($is_admin && $skip_admin_ip_check) {
+                return;
+            }
+
             $allowed_ips = array_map('trim', explode(',', Configuration::get('PS_MAINTENANCE_IP')));
             if (!IpUtils::checkIp(Tools::getRemoteAddr(), $allowed_ips)) {
                 header('HTTP/1.1 503 Service Unavailable');

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -736,7 +736,7 @@ class FrontControllerCore extends Controller
         if ($this->maintenance == true || !(int) Configuration::get('PS_SHOP_ENABLE')) {
             $this->maintenance = true;
 
-            $is_admin = (int)(new Cookie('psAdmin'))->id_employee;
+            $is_admin = (int) (new Cookie('psAdmin'))->id_employee;
             $skip_admin_ip_check = (int) Configuration::get('PS_SKIP_ADMIN_IP_CHECK');
             if ($is_admin && $skip_admin_ip_check) {
                 return;

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -737,7 +737,7 @@ class FrontControllerCore extends Controller
             $this->maintenance = true;
 
             $is_admin = (int) (new Cookie('psAdmin'))->id_employee;
-            $maintenance_allow_admins = (int) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS');
+            $maintenance_allow_admins = (bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS');
             if ($is_admin && $maintenance_allow_admins) {
                 return;
             }

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -737,8 +737,8 @@ class FrontControllerCore extends Controller
             $this->maintenance = true;
 
             $is_admin = (int) (new Cookie('psAdmin'))->id_employee;
-            $skip_admin_ip_check = (int) Configuration::get('PS_SKIP_ADMIN_IP_CHECK');
-            if ($is_admin && $skip_admin_ip_check) {
+            $maintenance_allow_admins = (int) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS');
+            if ($is_admin && $maintenance_allow_admins) {
                 return;
             }
 

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -179,7 +179,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
 
         $vars = [
             'maintenance_mode' => !(bool) Configuration::get('PS_SHOP_ENABLE'),
-            'maintenance_skip_admin_ip_check' => !(bool) Configuration::get('PS_SKIP_ADMIN_IP_CHECK'),
+            'maintenance_allow_admins' => !(bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS'),
             'debug_mode' => (bool) _PS_MODE_DEV_,
             'headerTabContent' => $this->headerTabContent,
             'content' => '{$content}', //replace content by original smarty tag var

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -179,6 +179,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
 
         $vars = [
             'maintenance_mode' => !(bool) Configuration::get('PS_SHOP_ENABLE'),
+            'maintenance_skip_admin_ip_check' => !(bool) Configuration::get('PS_SKIP_ADMIN_IP_CHECK'),
             'debug_mode' => (bool) _PS_MODE_DEV_,
             'headerTabContent' => $this->headerTabContent,
             'content' => '{$content}', //replace content by original smarty tag var

--- a/controllers/admin/AdminLegacyLayoutController.php
+++ b/controllers/admin/AdminLegacyLayoutController.php
@@ -179,7 +179,7 @@ class AdminLegacyLayoutControllerCore extends AdminController
 
         $vars = [
             'maintenance_mode' => !(bool) Configuration::get('PS_SHOP_ENABLE'),
-            'maintenance_allow_admins' => !(bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS'),
+            'maintenance_allow_admins' => (bool) Configuration::get('PS_MAINTENANCE_ALLOW_ADMINS'),
             'debug_mode' => (bool) _PS_MODE_DEV_,
             'headerTabContent' => $this->headerTabContent,
             'content' => '{$content}', //replace content by original smarty tag var

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -77,7 +77,7 @@
   <configuration id="PS_SHOP_ENABLE" name="PS_SHOP_ENABLE">
     <value>1</value>
   </configuration>
-  <configuration id="PS_SKIP_ADMIN_IP_CHECK" name="PS_SKIP_ADMIN_IP_CHECK">
+  <configuration id="PS_MAINTENANCE_ALLOW_ADMINS" name="PS_MAINTENANCE_ALLOW_ADMINS">
     <value>1</value>
   </configuration>
   <configuration id="PS_NB_DAYS_NEW_PRODUCT" name="PS_NB_DAYS_NEW_PRODUCT">

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -77,6 +77,9 @@
   <configuration id="PS_SHOP_ENABLE" name="PS_SHOP_ENABLE">
     <value>1</value>
   </configuration>
+  <configuration id="PS_SKIP_ADMIN_IP_CHECK" name="PS_SKIP_ADMIN_IP_CHECK">
+    <value>1</value>
+  </configuration>
   <configuration id="PS_NB_DAYS_NEW_PRODUCT" name="PS_NB_DAYS_NEW_PRODUCT">
     <value>20</value>
   </configuration>

--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -37,7 +37,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
     /**
      * @var array<int, string>
      */
-    private const CONFIGURATION_FIELDS = ['enable_shop', 'maintenance_ip', 'maintenance_text'];
+    private const CONFIGURATION_FIELDS = ['enable_shop', 'skip_admin_ip_check', 'maintenance_ip', 'maintenance_text'];
 
     /**
      * {@inheritdoc}
@@ -48,6 +48,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
 
         return [
             'enable_shop' => (bool) $this->configuration->get('PS_SHOP_ENABLE', false, $shopConstraint),
+            'skip_admin_ip_check' => (bool) $this->configuration->get('PS_SKIP_ADMIN_IP_CHECK', false, $shopConstraint),
             'maintenance_ip' => $this->configuration->get('PS_MAINTENANCE_IP', null, $shopConstraint),
             'maintenance_text' => $this->configuration->get('PS_MAINTENANCE_TEXT', null, $shopConstraint),
         ];
@@ -62,6 +63,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
             $shopConstraint = $this->getShopConstraint();
 
             $this->updateConfigurationValue('PS_SHOP_ENABLE', 'enable_shop', $configurationInputValues, $shopConstraint);
+            $this->updateConfigurationValue('PS_SKIP_ADMIN_IP_CHECK', 'skip_admin_ip_check', $configurationInputValues, $shopConstraint);
             $this->updateConfigurationValue('PS_MAINTENANCE_IP', 'maintenance_ip', $configurationInputValues, $shopConstraint);
             $this->updateConfigurationValue('PS_MAINTENANCE_TEXT', 'maintenance_text', $configurationInputValues, $shopConstraint, ['html' => true]);
         }
@@ -77,6 +79,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
         $resolver = new OptionsResolver();
         $resolver->setDefined(self::CONFIGURATION_FIELDS);
         $resolver->setAllowedTypes('enable_shop', 'bool');
+        $resolver->setAllowedTypes('skip_admin_ip_check', 'bool');
         $resolver->setAllowedTypes('maintenance_ip', ['string', 'null']);
         $resolver->setAllowedTypes('maintenance_text', ['array', 'null']);
 

--- a/src/Adapter/Shop/MaintenanceConfiguration.php
+++ b/src/Adapter/Shop/MaintenanceConfiguration.php
@@ -37,7 +37,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
     /**
      * @var array<int, string>
      */
-    private const CONFIGURATION_FIELDS = ['enable_shop', 'skip_admin_ip_check', 'maintenance_ip', 'maintenance_text'];
+    private const CONFIGURATION_FIELDS = ['enable_shop', 'maintenance_allow_admins', 'maintenance_ip', 'maintenance_text'];
 
     /**
      * {@inheritdoc}
@@ -48,7 +48,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
 
         return [
             'enable_shop' => (bool) $this->configuration->get('PS_SHOP_ENABLE', false, $shopConstraint),
-            'skip_admin_ip_check' => (bool) $this->configuration->get('PS_SKIP_ADMIN_IP_CHECK', false, $shopConstraint),
+            'maintenance_allow_admins' => (bool) $this->configuration->get('PS_MAINTENANCE_ALLOW_ADMINS', false, $shopConstraint),
             'maintenance_ip' => $this->configuration->get('PS_MAINTENANCE_IP', null, $shopConstraint),
             'maintenance_text' => $this->configuration->get('PS_MAINTENANCE_TEXT', null, $shopConstraint),
         ];
@@ -63,7 +63,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
             $shopConstraint = $this->getShopConstraint();
 
             $this->updateConfigurationValue('PS_SHOP_ENABLE', 'enable_shop', $configurationInputValues, $shopConstraint);
-            $this->updateConfigurationValue('PS_SKIP_ADMIN_IP_CHECK', 'skip_admin_ip_check', $configurationInputValues, $shopConstraint);
+            $this->updateConfigurationValue('PS_MAINTENANCE_ALLOW_ADMINS', 'maintenance_allow_admins', $configurationInputValues, $shopConstraint);
             $this->updateConfigurationValue('PS_MAINTENANCE_IP', 'maintenance_ip', $configurationInputValues, $shopConstraint);
             $this->updateConfigurationValue('PS_MAINTENANCE_TEXT', 'maintenance_text', $configurationInputValues, $shopConstraint, ['html' => true]);
         }
@@ -79,7 +79,7 @@ class MaintenanceConfiguration extends AbstractMultistoreConfiguration
         $resolver = new OptionsResolver();
         $resolver->setDefined(self::CONFIGURATION_FIELDS);
         $resolver->setAllowedTypes('enable_shop', 'bool');
-        $resolver->setAllowedTypes('skip_admin_ip_check', 'bool');
+        $resolver->setAllowedTypes('maintenance_allow_admins', 'bool');
         $resolver->setAllowedTypes('maintenance_ip', ['string', 'null']);
         $resolver->setAllowedTypes('maintenance_text', ['array', 'null']);
 

--- a/src/PrestaShopBundle/Bridge/Smarty/ToolbarFlagsConfigurator.php
+++ b/src/PrestaShopBundle/Bridge/Smarty/ToolbarFlagsConfigurator.php
@@ -80,6 +80,7 @@ class ToolbarFlagsConfigurator implements ConfiguratorInterface
         $this->initPageHeaderToolbar($controllerConfiguration);
 
         $controllerConfiguration->templateVars['maintenance_mode'] = !(bool) $this->configuration->get('PS_SHOP_ENABLE');
+        $controllerConfiguration->templateVars['maintenance_skip_admin_ip_check'] = !(bool) $this->configuration->get('PS_SKIP_ADMIN_IP_CHECK');
         $controllerConfiguration->templateVars['debug_mode'] = $this->isDebugMode;
         $controllerConfiguration->templateVars['lite_display'] = $controllerConfiguration->liteDisplay;
         $controllerConfiguration->templateVars['show_page_header_toolbar'] = $controllerConfiguration->showPageHeaderToolbar;

--- a/src/PrestaShopBundle/Bridge/Smarty/ToolbarFlagsConfigurator.php
+++ b/src/PrestaShopBundle/Bridge/Smarty/ToolbarFlagsConfigurator.php
@@ -80,7 +80,7 @@ class ToolbarFlagsConfigurator implements ConfiguratorInterface
         $this->initPageHeaderToolbar($controllerConfiguration);
 
         $controllerConfiguration->templateVars['maintenance_mode'] = !(bool) $this->configuration->get('PS_SHOP_ENABLE');
-        $controllerConfiguration->templateVars['maintenance_skip_admin_ip_check'] = !(bool) $this->configuration->get('PS_SKIP_ADMIN_IP_CHECK');
+        $controllerConfiguration->templateVars['maintenance_allow_admins'] = !(bool) $this->configuration->get('PS_MAINTENANCE_ALLOW_ADMINS');
         $controllerConfiguration->templateVars['debug_mode'] = $this->isDebugMode;
         $controllerConfiguration->templateVars['lite_display'] = $controllerConfiguration->liteDisplay;
         $controllerConfiguration->templateVars['show_page_header_toolbar'] = $controllerConfiguration->showPageHeaderToolbar;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -90,7 +90,7 @@ class MaintenanceType extends TranslatorAwareType
                     'multistore_configuration_key' => 'PS_MAINTENANCE_ALLOW_ADMINS',
                     'label' => $this->trans('Enable store for logged-in employees', 'Admin.Shopparameters.Feature'),
                     'help' => $this->trans(
-                        'When enabled, admins will access the shop front-end without storing their IP.',
+                        'When enabled, admins will access the store front office without storing their IP.',
                         'Admin.Shopparameters.Help'
                     ),
                 ]

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -83,11 +83,11 @@ class MaintenanceType extends TranslatorAwareType
                 ]
             )
             ->add(
-                'skip_admin_ip_check',
+                'maintenance_allow_admins',
                 SwitchType::class,
                 [
                     'required' => false,
-                    'multistore_configuration_key' => 'PS_SKIP_ADMIN_IP_CHECK',
+                    'multistore_configuration_key' => 'PS_MAINTENANCE_ALLOW_ADMINS',
                     'label' => $this->trans('Allow admin access without IP check', 'Admin.Shopparameters.Feature'),
                     'help' => $this->trans(
                         'When enabled, admins will access the shop front-end without storing their IP.',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -83,6 +83,19 @@ class MaintenanceType extends TranslatorAwareType
                 ]
             )
             ->add(
+                'skip_admin_ip_check',
+                SwitchType::class,
+                [
+                    'required' => false,
+                    'multistore_configuration_key' => 'PS_SKIP_ADMIN_IP_CHECK',
+                    'label' => $this->trans('Allow admin access without IP check', 'Admin.Shopparameters.Feature'),
+                    'help' => $this->trans(
+                        'When enabled, admins will access the shop front-end without storing their IP.',
+                        'Admin.Shopparameters.Help'
+                    ),
+                ]
+            )
+            ->add(
                 'maintenance_ip',
                 IpAddressType::class,
                 [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/MaintenanceType.php
@@ -88,7 +88,7 @@ class MaintenanceType extends TranslatorAwareType
                 [
                     'required' => false,
                     'multistore_configuration_key' => 'PS_MAINTENANCE_ALLOW_ADMINS',
-                    'label' => $this->trans('Allow admin access without IP check', 'Admin.Shopparameters.Feature'),
+                    'label' => $this->trans('Enable store for logged-in employees', 'Admin.Shopparameters.Feature'),
                     'help' => $this->trans(
                         'When enabled, admins will access the shop front-end without storing their IP.',
                         'Admin.Shopparameters.Help'

--- a/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
+++ b/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
@@ -58,6 +58,7 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
                     ['PS_MAINTENANCE_IP', null, $shopConstraint, 'test'],
                     ['PS_MAINTENANCE_TEXT', null, $shopConstraint, 'test'],
                     ['PS_SHOP_ENABLE', false, $shopConstraint, true],
+                    ['PS_SKIP_ADMIN_IP_CHECK', false, $shopConstraint, false],
                 ]
             );
 
@@ -65,6 +66,7 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
         $this->assertSame(
             [
                 'enable_shop' => true,
+                'skip_admin_ip_check' => false,
                 'maintenance_ip' => 'test',
                 'maintenance_text' => 'test',
             ],
@@ -93,9 +95,10 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
     {
         return [
             [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
-            [InvalidOptionsException::class, ['enable_shop' => 'wrong_type', 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
-            [InvalidOptionsException::class, ['enable_shop' => true, 'maintenance_ip' => ['wrong_type'], 'maintenance_text' => ['fr' => 'test string']]],
-            [InvalidOptionsException::class, ['enable_shop' => true, 'maintenance_ip' => 'test', 'maintenance_text' => 'wrong_type']],
+            [InvalidOptionsException::class, ['enable_shop' => 'wrong_type', 'skip_admin_ip_check' => true, 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
+            [InvalidOptionsException::class, ['enable_shop' => true, 'skip_admin_ip_check' => 'wrong_type', 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
+            [InvalidOptionsException::class, ['enable_shop' => true, 'skip_admin_ip_check' => true, 'maintenance_ip' => ['wrong_type'], 'maintenance_text' => ['fr' => 'test string']]],
+            [InvalidOptionsException::class, ['enable_shop' => true, 'skip_admin_ip_check' => true, 'maintenance_ip' => 'test', 'maintenance_text' => 'wrong_type']],
         ];
     }
 
@@ -105,6 +108,7 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
 
         $res = $maintenanceConfiguration->updateConfiguration([
             'enable_shop' => true,
+            'skip_admin_ip_check' => false,
             'maintenance_ip' => 'test',
             'maintenance_text' => ['fr' => 'test string'],
         ]);

--- a/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
+++ b/tests/Unit/Adapter/Shop/MaintenanceConfigurationTest.php
@@ -58,7 +58,7 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
                     ['PS_MAINTENANCE_IP', null, $shopConstraint, 'test'],
                     ['PS_MAINTENANCE_TEXT', null, $shopConstraint, 'test'],
                     ['PS_SHOP_ENABLE', false, $shopConstraint, true],
-                    ['PS_SKIP_ADMIN_IP_CHECK', false, $shopConstraint, false],
+                    ['PS_MAINTENANCE_ALLOW_ADMINS', false, $shopConstraint, false],
                 ]
             );
 
@@ -66,7 +66,7 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
         $this->assertSame(
             [
                 'enable_shop' => true,
-                'skip_admin_ip_check' => false,
+                'maintenance_allow_admins' => false,
                 'maintenance_ip' => 'test',
                 'maintenance_text' => 'test',
             ],
@@ -95,10 +95,10 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
     {
         return [
             [UndefinedOptionsException::class, ['does_not_exist' => 'does_not_exist']],
-            [InvalidOptionsException::class, ['enable_shop' => 'wrong_type', 'skip_admin_ip_check' => true, 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
-            [InvalidOptionsException::class, ['enable_shop' => true, 'skip_admin_ip_check' => 'wrong_type', 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
-            [InvalidOptionsException::class, ['enable_shop' => true, 'skip_admin_ip_check' => true, 'maintenance_ip' => ['wrong_type'], 'maintenance_text' => ['fr' => 'test string']]],
-            [InvalidOptionsException::class, ['enable_shop' => true, 'skip_admin_ip_check' => true, 'maintenance_ip' => 'test', 'maintenance_text' => 'wrong_type']],
+            [InvalidOptionsException::class, ['enable_shop' => 'wrong_type', 'maintenance_allow_admins' => true, 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
+            [InvalidOptionsException::class, ['enable_shop' => true, 'maintenance_allow_admins' => 'wrong_type', 'maintenance_ip' => 'test', 'maintenance_text' => ['fr' => 'test string']]],
+            [InvalidOptionsException::class, ['enable_shop' => true, 'maintenance_allow_admins' => true, 'maintenance_ip' => ['wrong_type'], 'maintenance_text' => ['fr' => 'test string']]],
+            [InvalidOptionsException::class, ['enable_shop' => true, 'maintenance_allow_admins' => true, 'maintenance_ip' => 'test', 'maintenance_text' => 'wrong_type']],
         ];
     }
 
@@ -108,7 +108,7 @@ class MaintenanceConfigurationTest extends AbstractConfigurationTestCase
 
         $res = $maintenanceConfiguration->updateConfiguration([
             'enable_shop' => true,
-            'skip_admin_ip_check' => false,
+            'maintenance_allow_admins' => false,
             'maintenance_ip' => 'test',
             'maintenance_text' => ['fr' => 'test string'],
         ]);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add option to skip admin IP check 
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30161 
| How to test?      | Visit the maintenance page to see the new option
| Possible impacts? | 

Autoupgrade PR - https://github.com/PrestaShop/autoupgrade/pull/565

![screenshot-001391](https://user-images.githubusercontent.com/793712/199412633-90095171-16ab-4efb-9c1c-b89b31288869.png)


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
