### PR TITLE
Fixed Stats dashboard when AdminStats module is not enabled

### DIFF
--- a/controllers/admin/AdminStatsTabController.php
+++ b/controllers/admin/AdminStatsTabController.php
@@ -174,10 +174,16 @@ abstract class AdminStatsTabControllerCore extends AdminController
 
     protected function getModules()
     {
-        return array_map(
-            function ($moduleArray) {return ['name' => $moduleArray['module']]; },
-            Hook::getHookModuleExecList('displayAdminStatsModules')
-        );
+        if (true === is_array(Hook::getHookModuleExecList('displayAdminStatsModules'))) {
+            return array_map(
+                function ($moduleArray) {
+                    return ['name' => $moduleArray['module']];
+                },
+                Hook::getHookModuleExecList('displayAdminStatsModules')
+            );
+        }
+
+        return [];
     }
 
     public function displayStats()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If AdminStats module is not enabled, we can display the stats dashboard, where "no installed module" is displayed. 
| Type?             | bug fix
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixed #30173
| Related PRs       | ~
| How to test?      | See #30173
| Possible impacts? | ~


Now, we can display the stats dashboard without error. 

When module is enabled: 

<img width="1036" alt="Capture d’écran 2022-11-01 à 11 19 51" src="https://user-images.githubusercontent.com/121870/199212689-2bf2f653-f646-4ddc-8393-22c5ec71401c.png">

When module is disabled / uninstalled: 

<img width="1036" alt="Capture d’écran 2022-11-01 à 11 19 33" src="https://user-images.githubusercontent.com/121870/199212739-ca5ce5e1-3c9d-4d84-9c66-e0f71b30dd1e.png">

