### PR TITLE
Changed the terminology `Best sales` to `Best sellers`

### DIFF
--- a/classes/lang/KeysReference/MetaLang.php
+++ b/classes/lang/KeysReference/MetaLang.php
@@ -66,7 +66,7 @@ trans('Lost ? Find what your are looking for', 'Shop.Navigation');
 
 trans('Suppliers list', 'Shop.Navigation');
 trans('page-not-found', 'Shop.Navigation');
-trans('best-sales', 'Shop.Navigation');
+trans('best-sellers', 'Shop.Navigation');
 trans('contact-us', 'Shop.Navigation');
 trans('brands', 'Shop.Navigation');
 trans('new-products', 'Shop.Navigation');

--- a/classes/lang/KeysReference/MetaLang.php
+++ b/classes/lang/KeysReference/MetaLang.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 trans('404 error', 'Shop.Navigation');
-trans('Best sellers', 'Shop.Theme.Catalog');
+trans('Best sellers', 'Shop.Navigation');
 trans('Contact us', 'Shop.Navigation');
 trans('Brands', 'Shop.Navigation');
 trans('New products', 'Shop.Navigation');

--- a/classes/lang/KeysReference/MetaLang.php
+++ b/classes/lang/KeysReference/MetaLang.php
@@ -24,7 +24,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 trans('404 error', 'Shop.Navigation');
-trans('Best sales', 'Shop.Navigation');
+trans('Best sellers', 'Shop.Theme.Catalog');
 trans('Contact us', 'Shop.Navigation');
 trans('Brands', 'Shop.Navigation');
 trans('New products', 'Shop.Navigation');

--- a/install-dev/langs/en/data/meta.xml
+++ b/install-dev/langs/en/data/meta.xml
@@ -10,7 +10,7 @@
     <title>Best sellers</title>
     <description>Our best sales</description>
     <keywords/>
-    <url_rewrite>best-sales</url_rewrite>
+    <url_rewrite>best-sellers</url_rewrite>
   </meta>
   <meta id="contact" id_shop="1">
     <title>Contact us</title>

--- a/install-dev/langs/en/data/meta.xml
+++ b/install-dev/langs/en/data/meta.xml
@@ -7,7 +7,7 @@
     <url_rewrite>page-not-found</url_rewrite>
   </meta>
   <meta id="best-sales" id_shop="1">
-    <title>Best sales</title>
+    <title>Best sellers</title>
     <description>Our best sales</description>
     <keywords/>
     <url_rewrite>best-sales</url_rewrite>

--- a/tests/UI/campaigns/functional/FO/02_headerAndFooter/02_checkLinksInFooter.js
+++ b/tests/UI/campaigns/functional/FO/02_headerAndFooter/02_checkLinksInFooter.js
@@ -97,7 +97,7 @@ describe('FO - Header and Footer : Check links in footer page', async () => {
     [
       {linkSelector: 'Prices drop', pageTitle: pricesDropPage.pageTitle},
       {linkSelector: 'New products', pageTitle: newProductsPage.pageTitle},
-      {linkSelector: 'Best sales', pageTitle: bestSalesPage.pageTitle},
+      {linkSelector: 'Best sellers', pageTitle: bestSalesPage.pageTitle},
     ].forEach((args, index) => {
       it(`should check '${args.linkSelector}' footer links`, async function () {
         await testContext.addContextItem(this, 'testIdentifier', `checkProductsFooterLinks${index}`, baseContext);

--- a/tests/UI/pages/FO/FObasePage.js
+++ b/tests/UI/pages/FO/FObasePage.js
@@ -436,7 +436,7 @@ class FOBasePage extends CommonPage {
         selector = this.newProductsLink;
         break;
 
-      case 'Best sales':
+      case 'Best sellers':
         selector = this.bestSalesLink;
         break;
 

--- a/tests/UI/pages/FO/bestSales/index.js
+++ b/tests/UI/pages/FO/bestSales/index.js
@@ -14,7 +14,7 @@ class BestSales extends FOBasePage {
   constructor() {
     super();
 
-    this.pageTitle = 'Best sales';
+    this.pageTitle = 'Best sellers';
   }
 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Changed the terminology 'Best sales' to 'Best sellers'
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19643
| Related PRs       | N/A
| How to test?      |  * Go to the FO<br>* Scroll down to 'Products' => see link 'Best sales' (now it's 'Best sellers')<br />Click on 'Best sales' (now it's 'Best sellers') => see 'Best sellers' in the header of new page
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
