### PR TITLE
Move Cache-Control header earlier

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1973,8 +1973,6 @@ class AdminControllerCore extends Controller
      */
     public function initHeader()
     {
-        header('Cache-Control: no-store, no-cache');
-
         $this->context->smarty->assign([
             'table' => $this->table,
             'current' => self::$currentIndex,
@@ -2731,6 +2729,8 @@ class AdminControllerCore extends Controller
      */
     public function init()
     {
+        header('Cache-Control: no-store, no-cache');
+
         Hook::exec(
             'actionAdminControllerInitBefore',
             [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The cache-Control header is sent too late: it should be set in init instead of initHeader. All ajaxProcess request return response before initHeader and can throw an error "Cannot modify header information - headers already sent by"
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/9602#issuecomment-1227104424
| How to test?      | Desactive output buffering, set the php/apache to don't remove cache-Control header, Call any ajaxProcessXXX in legacy backoffice controller like adding a product to a cart rule (linked in issue). hard to test because the cache-Control header can be removed by php/apache. 
| Possible impacts? | no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
