### PR TITLE
Replace deprecated usage of ::set-output in Github actions

### DIFF
--- a/.github/actions/setup-prestashop-env/action.yml
+++ b/.github/actions/setup-prestashop-env/action.yml
@@ -65,7 +65,7 @@ runs:
     - name: Get Composer Cache Directory
       shell: bash
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache Composer Directory
       uses: actions/cache@v3

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -27,11 +27,11 @@ jobs:
           mysql database: 'prestashop'
           mysql root password: 'password'
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: PrestaShop Configuration
         run: |

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Node Directory
         uses: actions/cache@v2

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -43,14 +43,14 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Node Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
 
       - name: Cache Composer Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/cron_docker_build.yml
+++ b/.github/workflows/cron_docker_build.yml
@@ -24,7 +24,7 @@ jobs:
           - fpm
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -20,12 +20,12 @@ jobs:
           mysql root password: 'password'
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: PrestaShop Configuration
         run: cp .github/workflows/phpunit/parameters.yml app/config/parameters.yml

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -32,8 +32,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Node Directory
         uses: actions/cache@v2

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Node Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Cache Composer Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -27,7 +27,7 @@ jobs:
       GC_SERVICE_KEY: ${{ secrets.GC_SERVICE_KEY }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ env.GH_BRANCH }}
@@ -39,7 +39,7 @@ jobs:
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/cron_nightly_gcp.yml
+++ b/.github/workflows/cron_nightly_gcp.yml
@@ -27,7 +27,7 @@ jobs:
       NIGHTLY_TOKEN: ${{ secrets.NIGHTLY_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ env.GH_BRANCH }}

--- a/.github/workflows/cron_nightly_tests.yml
+++ b/.github/workflows/cron_nightly_tests.yml
@@ -60,7 +60,7 @@ jobs:
       ADMIN_PASSWD: 'Correct Horse Battery Staple'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ env.GH_BRANCH }}
@@ -74,7 +74,7 @@ jobs:
           bash -c 'while [[ "$(curl -L -s -o /dev/null -w %{http_code} http://localhost:8001/en/)" != "200" ]]; do sleep 5; done'
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -100,7 +100,7 @@ jobs:
           FILENAME="$( echo -e '${{ env.TEST_CAMPAIGN }}' | tr  ':' '-'  )"
           mv ./mochawesome-report/mochawesome.json ${{ env.REPORTS_DIR_PATH }}/${FILENAME}.json
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         name: Upload report
         with:
           name: reports_${{ env.GH_BRANCH }}
@@ -126,19 +126,19 @@ jobs:
       COMBINED_REPORT_DIR: 'combined_reports'  # Where to store the combined report
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           ref: ${{ env.GH_BRANCH }}
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         name: Download reports
         with:
           name: reports_${{ env.GH_BRANCH }}
           path: ${{ env.REPORTS_DIR }}
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -15,7 +15,7 @@ jobs:
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Composer dependencies
         run: composer install --prefer-dist

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Node Directory
         uses: actions/cache@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,14 +27,14 @@ jobs:
           mysql database: 'prestashop'
           mysql root password: 'password'
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
 
       - name: Setup NPM
         run: npm install -g npm@7
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: PrestaShop Configuration
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,14 +46,14 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Node Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-node-
 
       - name: Cache Composer Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -15,7 +15,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.js }}
 
@@ -23,7 +23,7 @@ jobs:
         run: npm install -g npm@7
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Node Directory
         uses: actions/cache@v3

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache Node Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,7 +80,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -150,7 +150,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: BackOffice Theme `default`
         run: cd ./admin-dev/themes/default && npm install && npm run scss-lint
+
   eslint:
     name: ESLint
     runs-on: ubuntu-latest
@@ -57,6 +58,7 @@ jobs:
 
       - name: BackOffice Theme `new-theme`
         run: cd ./admin-dev/themes/new-theme && npm install && npm run lint
+
   yamllint_sf:
     name: YAML Lint (Symfony Check)
     runs-on: ubuntu-latest
@@ -75,8 +77,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2
@@ -97,6 +98,7 @@ jobs:
 
       - name: Run Lint Yaml on `.t9n.yml`
         run: php bin/console lint:yaml .t9n.yml
+
   yamllint:
     name: YAML Lint (YamlLint Check)
     runs-on: ubuntu-latest
@@ -126,6 +128,7 @@ jobs:
 
       - name: yamllint on `.t9n.yml`
         run: yamllint -c .github/workflows/yamllint/.yamllint.yml .t9n.yml
+
   twiglint:
     name: Twig Lint
     runs-on: ubuntu-latest
@@ -144,8 +147,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
 
@@ -37,10 +37,10 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: '16.x'
 
@@ -73,7 +73,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -115,7 +115,7 @@ jobs:
       - name: Install YAMLLint
         run: |
           pip install --user yamllint
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: yamllint on `.github`
         run: yamllint -c .github/workflows/yamllint/.yamllint.yml .github
@@ -143,7 +143,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -68,7 +68,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -112,7 +112,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2
@@ -65,7 +65,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2
@@ -109,7 +109,7 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer Directory
         uses: actions/cache@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           php-version: 8.0
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -61,7 +61,7 @@ jobs:
           php-version: '8.0'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -102,7 +102,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: PrestaShop Configuration
         run: cp .github/workflows/phpunit/parameters.yml app/config/parameters.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
           EOF
           )
           if [[ $description =~ \|?[[:space:]]*Category\?[[:space:]]*\|[[:space:]]*ME([[:space:]]|(\\[rn]))+ ]]; then
-              echo ::set-output name=isMerge::true
+              echo "isMerge=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Block Merge Commits

--- a/.github/workflows/sanity-productV2.yml
+++ b/.github/workflows/sanity-productV2.yml
@@ -27,7 +27,7 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup environment
         uses: ./.github/actions/setup-prestashop-env
@@ -57,7 +57,7 @@ jobs:
           TAKE_SCREENSHOT_AFTER_FAIL: true
         working-directory: ./tests/UI
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: screenshots-${{ matrix.php }}

--- a/.github/workflows/sanity-productV2.yml
+++ b/.github/workflows/sanity-productV2.yml
@@ -42,7 +42,7 @@ jobs:
           ps-dev-mode: 'false'
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -17,7 +17,7 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup environment
         uses: ./.github/actions/setup-prestashop-env
@@ -43,7 +43,7 @@ jobs:
         run: npm install && npm run test:sanity:fast-fail
         working-directory: ./tests/UI
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
           name: screenshots-${{ matrix.php }}

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -30,7 +30,7 @@ jobs:
           npm-version: '7'
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers

--- a/.github/workflows/ui_tests_code_checks.yml
+++ b/.github/workflows/ui_tests_code_checks.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/ms-playwright/
           key: ${{ runner.os }}-browsers

--- a/.github/workflows/ui_tests_code_checks.yml
+++ b/.github/workflows/ui_tests_code_checks.yml
@@ -29,7 +29,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Playwright browsers
         uses: actions/cache@v3
@@ -38,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-browsers
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -63,7 +63,7 @@ jobs:
           access_token: ${{ github.token }}
 
       - name: Checkout the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Playwright browsers
         uses: actions/cache@v3
@@ -72,7 +72,7 @@ jobs:
           key: ${{ runner.os }}-browsers
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | As stated in this GitHub blog article https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ The usage of `::set-output` is deprecated and ill disappear so the usages are replaced in this PR<br />The `::save-state` command is also deprecated which is why some GH actions have been updated since they relied on its usage<br />Finally the usage of Node 12 is also deprecated https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ so some actions (`actions/setup-node` `actions/checkout` `actions/upload-artifact` `actions/download-artifact` have been updated to rely on Node 16
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | CI should be green, so should should automated tests (the deprecation messages regarding `set-output` should also disappear) The testing tool itself has been fixed in this PR https://github.com/PrestaShop/ga.tests.ui.pr/pull/4 so its branch should be used to validate the new workflow
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
