### PR TITLE
UpdateProductCommand unification - Details related properties handling

### DIFF
--- a/src/Adapter/Product/Update/Filler/DetailsFiller.php
+++ b/src/Adapter/Product/Update/Filler/DetailsFiller.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Update\Filler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use Product;
+
+/**
+ * Fills product properties which can be considered as product details
+ */
+class DetailsFiller implements ProductFillerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function fillUpdatableProperties(Product $product, UpdateProductCommand $command): array
+    {
+        $updatableProperties = [];
+
+        if (null !== $command->getEan13()) {
+            $product->ean13 = $command->getEan13()->getValue();
+            $updatableProperties[] = 'ean13';
+        }
+
+        if (null !== $command->getIsbn()) {
+            $product->isbn = $command->getIsbn()->getValue();
+            $updatableProperties[] = 'isbn';
+        }
+
+        if (null !== $command->getMpn()) {
+            $product->mpn = $command->getMpn();
+            $updatableProperties[] = 'mpn';
+        }
+
+        if (null !== $command->getReference()) {
+            $product->reference = $command->getReference()->getValue();
+            $updatableProperties[] = 'reference';
+        }
+
+        if (null !== $command->getUpc()) {
+            $product->upc = $command->getUpc()->getValue();
+            $updatableProperties[] = 'upc';
+        }
+
+        return $updatableProperties;
+    }
+}

--- a/src/Core/Domain/Product/Command/UpdateProductCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductCommand.php
@@ -33,10 +33,14 @@ use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerConstra
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerIdInterface;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\NoManufacturerId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectOption;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Upc;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
@@ -163,6 +167,31 @@ class UpdateProductCommand
      * @var RedirectOption|null
      */
     private $redirectOption;
+
+    /**
+     * @var Isbn|null
+     */
+    private $isbn;
+
+    /**
+     * @var Upc|null
+     */
+    private $upc;
+
+    /**
+     * @var Ean13|null
+     */
+    private $ean13;
+
+    /**
+     * @var string|null
+     */
+    private $mpn;
+
+    /**
+     * @var Reference|null
+     */
+    private $reference;
 
     /**
      * @param int $productId
@@ -612,6 +641,106 @@ class UpdateProductCommand
             new NoManufacturerId() :
             new ManufacturerId($manufacturerId)
         ;
+
+        return $this;
+    }
+
+    /**
+     * @return Isbn|null
+     */
+    public function getIsbn(): ?Isbn
+    {
+        return $this->isbn;
+    }
+
+    /**
+     * @param string $isbn
+     *
+     * @return self
+     */
+    public function setIsbn(string $isbn): self
+    {
+        $this->isbn = new Isbn($isbn);
+
+        return $this;
+    }
+
+    /**
+     * @return Upc|null
+     */
+    public function getUpc(): ?Upc
+    {
+        return $this->upc;
+    }
+
+    /**
+     * @param string $upc
+     *
+     * @return self
+     */
+    public function setUpc(string $upc): self
+    {
+        $this->upc = new Upc($upc);
+
+        return $this;
+    }
+
+    /**
+     * @return Ean13|null
+     */
+    public function getEan13(): ?Ean13
+    {
+        return $this->ean13;
+    }
+
+    /**
+     * @param string $ean13
+     *
+     * @return self
+     */
+    public function setEan13(string $ean13): self
+    {
+        $this->ean13 = new Ean13($ean13);
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMpn(): ?string
+    {
+        return $this->mpn;
+    }
+
+    /**
+     * @param string $mpn
+     *
+     * @return self
+     */
+    public function setMpn(string $mpn): self
+    {
+        $this->mpn = $mpn;
+
+        return $this;
+    }
+
+    /**
+     * @return Reference|null
+     */
+    public function getReference(): ?Reference
+    {
+        return $this->reference;
+    }
+
+    /**
+     * @param string $reference
+     *
+     * @return self
+     */
+    public function setReference(string $reference): self
+    {
+        $this->reference = new Reference($reference);
 
         return $this;
     }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
@@ -63,6 +63,7 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
             ->configureOptions($config, $formData)
             ->configurePrices($config)
             ->configureSeo($config)
+            ->configureDetails($config)
         ;
 
         $commandBuilder = new CommandBuilder($config);
@@ -75,7 +76,7 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
     /**
      * @param CommandBuilderConfig $config
      *
-     * @return $this
+     * @return self
      */
     private function configureBasicInformation(CommandBuilderConfig $config): self
     {
@@ -91,7 +92,7 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
     /**
      * @param CommandBuilderConfig $config
      *
-     * @return $this
+     * @return self
      */
     private function configureOptions(CommandBuilderConfig $config, array $formData): self
     {
@@ -136,7 +137,7 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
     /**
      * @param CommandBuilderConfig $config
      *
-     * @return $this
+     * @return self
      */
     private function configureSeo(CommandBuilderConfig $config): self
     {
@@ -151,6 +152,24 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
                     'default' => 0,
                 ],
             ])
+        ;
+
+        return $this;
+    }
+
+    /**
+     * @param CommandBuilderConfig $config
+     *
+     * @return self
+     */
+    private function configureDetails(CommandBuilderConfig $config): self
+    {
+        $config
+            ->addField('[specifications][references][reference]', 'setReference', DataField::TYPE_STRING)
+            ->addField('[specifications][references][mpn]', 'setMpn', DataField::TYPE_STRING)
+            ->addField('[specifications][references][upc]', 'setUpc', DataField::TYPE_STRING)
+            ->addField('[specifications][references][ean_13]', 'setEan13', DataField::TYPE_STRING)
+            ->addField('[specifications][references][isbn]', 'setIsbn', DataField::TYPE_STRING)
         ;
 
         return $this;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -557,3 +557,7 @@ services:
       - '@prestashop.adapter.product.repository.product_repository'
       - '@prestashop.adapter.category.repository.category_repository'
       - '@prestashop.adapter.tools'
+
+  prestashop.adapter.product.update.filler.details_filler:
+    class: PrestaShop\PrestaShop\Adapter\Product\Update\Filler\DetailsFiller
+    tags: [ 'core.product_filler' ]

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePricesFeatureContext.php
@@ -34,11 +34,10 @@ use PrestaShop\PrestaShop\Core\Domain\Exception\DomainException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
-use Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\AbstractUpdatePricesFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
-class UpdatePricesFeatureContext extends AbstractUpdatePricesFeatureContext
+class UpdatePricesFeatureContext extends AbstractProductFeatureContext
 {
     /**
      * @When I update product :productReference prices for shop :shopReference with following information:
@@ -94,29 +93,6 @@ class UpdatePricesFeatureContext extends AbstractUpdatePricesFeatureContext
         } catch (DomainException $e) {
             $this->setLastException($e);
         }
-    }
-
-    /**
-     * @Then product :productReference should have following prices information for shops :shopReference:
-     *
-     * @param string $productReference
-     * @param string $shopReferences
-     * @param TableNode $tableNode
-     */
-    public function assertPriceFieldsForShops(string $productReference, string $shopReferences, TableNode $tableNode): void
-    {
-        $this->performAssertPriceFieldsForShops($productReference, $shopReferences, $tableNode);
-    }
-
-    /**
-     * @Then product :productReference should have following prices information:
-     *
-     * @param string $productReference
-     * @param TableNode $tableNode
-     */
-    public function assertPriceFields(string $productReference, TableNode $tableNode): void
-    {
-        $this->performAssertPriceFields($productReference, $tableNode);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/DetailsAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/DetailsAssertionFeatureContext.php
@@ -33,6 +33,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductDetails;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 
+/**
+ * Context for asserting product Details related properties
+ */
 class DetailsAssertionFeatureContext extends AbstractProductFeatureContext
 {
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/DetailsAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/DetailsAssertionFeatureContext.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct;
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductDetails;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
+
+class DetailsAssertionFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @Transform table:product detail,value
+     *
+     * @param TableNode $tableNode
+     *
+     * @return ProductDetails
+     */
+    public function transformDetails(TableNode $tableNode): ProductDetails
+    {
+        $dataRows = $tableNode->getRowsHash();
+
+        return new ProductDetails(
+            $dataRows['isbn'],
+            $dataRows['upc'],
+            $dataRows['ean13'],
+            $dataRows['mpn'],
+            $dataRows['reference']
+        );
+    }
+
+    /**
+     * @Then product :productReference should have following details:
+     *
+     * @param string $productReference
+     * @param ProductDetails $expectedDetails
+     */
+    public function assertDetails(string $productReference, ProductDetails $expectedDetails): void
+    {
+        $properties = ['ean13', 'isbn', 'mpn', 'reference', 'upc'];
+        $actualDetails = $this->getProductForEditing($productReference)->getDetails();
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        foreach ($properties as $propertyName) {
+            Assert::assertSame(
+                $propertyAccessor->getValue($expectedDetails, $propertyName),
+                $propertyAccessor->getValue($actualDetails, $propertyName),
+                sprintf('Unexpected %s of "%s"', $propertyName, $productReference)
+            );
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/OptionsAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/OptionsAssertionFeatureContext.php
@@ -33,6 +33,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductOptions;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
+/**
+ * Context for product assertions related to Options related properties
+ */
 class OptionsAssertionFeatureContext extends AbstractUpdateOptionsFeatureContext
 {
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/PricesAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/PricesAssertionFeatureContext.php
@@ -31,11 +31,15 @@ use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductPricesInformation;
+use RuntimeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
+/**
+ * Context for product assertions related to Prices related properties
+ */
 class PricesAssertionFeatureContext extends AbstractProductFeatureContext
 {
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/PricesAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/PricesAssertionFeatureContext.php
@@ -31,31 +31,21 @@ use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductPricesInformation;
-use RuntimeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
-/**
- * This abstract class was introduced during UpdateProductCommand unification process,
- * and which idea is to remove multiple sub-commands and use single UpdateProductCommand instead.
- * This abstract context allows sharing assertions which and some other common methods for both implementations during the transition.
- *
- * @see UpdateProductCommand
- * @see UpdateProductHandlerInterface
- *
- * @todo: need to check if this abstract class is still needed when UpdateProductCommand is fully finished,
- *        because one of the contexts that uses it will be deleted, therefore leaving this abstract class useless.
- */
-abstract class AbstractUpdatePricesFeatureContext extends AbstractProductFeatureContext
+class PricesAssertionFeatureContext extends AbstractProductFeatureContext
 {
     /**
+     * @Then product :productReference should have following prices information for shops :shopReference:
+     *
      * @param string $productReference
      * @param string $shopReferences
      * @param TableNode $tableNode
      */
-    protected function performAssertPriceFieldsForShops(string $productReference, string $shopReferences, TableNode $tableNode): void
+    public function assertPriceFieldsForShops(string $productReference, string $shopReferences, TableNode $tableNode): void
     {
         $data = $tableNode->getRowsHash();
 
@@ -72,10 +62,12 @@ abstract class AbstractUpdatePricesFeatureContext extends AbstractProductFeature
     }
 
     /**
+     * @Then product :productReference should have following prices information:
+     *
      * @param string $productReference
      * @param TableNode $tableNode
      */
-    protected function performAssertPriceFields(string $productReference, TableNode $tableNode): void
+    public function assertPriceFields(string $productReference, TableNode $tableNode): void
     {
         $data = $tableNode->getRowsHash();
         $pricesInfo = $this->getProductForEditing($productReference)->getPricesInformation();

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/SeoAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/SeoAssertionFeatureContext.php
@@ -34,24 +34,18 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 
 /**
- * This abstract class was introduced during UpdateProductCommand unification process,
- * and which idea is to remove multiple sub-commands and use single UpdateProductCommand instead.
- * This abstract context allows sharing assertions which and some other common methods for both implementations during the transition.
- *
- * @see UpdateProductCommand
- * @see UpdateProductHandlerInterface
- *
- * @todo: need to check if this abstract class is still needed when UpdateProductCommand is fully finished,
- *        because one of the contexts that uses it will be deleted, therefore leaving this abstract class useless.
+ * Context for product assertions related to SEO properties
  */
-abstract class AbstractUpdateSeoFeatureContext extends AbstractProductFeatureContext
+class SeoAssertionFeatureContext extends AbstractProductFeatureContext
 {
     /**
+     * @Then product :productReference should have following seo options for shops :shopReferences:
+     *
      * @param string $productReference
      * @param string $shopReferences
      * @param TableNode $tableNode
      */
-    protected function performAssertSeoOptionsForShops(
+    public function assertSeoOptionsForShops(
         string $productReference,
         string $shopReferences,
         TableNode $tableNode
@@ -66,10 +60,12 @@ abstract class AbstractUpdateSeoFeatureContext extends AbstractProductFeatureCon
     }
 
     /**
+     * @Then product :productReference should have following seo options:
+     *
      * @param string $productReference
      * @param TableNode $tableNode
      */
-    protected function performAssertSeoOptionsForDefaultShop(string $productReference, TableNode $tableNode): void
+    public function assertSeoOptionsForDefaultShop(string $productReference, TableNode $tableNode): void
     {
         $this->assertSeoOptions(
             $productReference,
@@ -79,9 +75,11 @@ abstract class AbstractUpdateSeoFeatureContext extends AbstractProductFeatureCon
     }
 
     /**
+     * @Then product :productReference should not have a redirect target
+     *
      * @param string $productReference
      */
-    public function performAssertHasNoRedirectTargetId(string $productReference)
+    public function assertHasNoRedirectTargetId(string $productReference)
     {
         $productForEditing = $this->getProductForEditing($productReference);
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateBasicInformationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateBasicInformationFeatureContext.php
@@ -34,7 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
- * Context for updating product basic information properties using single UpdateProductCommand
+ * Context for updating product basic information properties using UpdateProductCommand
  *
  * @see UpdateProductCommand
  */

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateDetailsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateDetailsFeatureContext.php
@@ -23,15 +23,16 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
 declare(strict_types=1);
 
-namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct;
 
 use Behat\Gherkin\Node\TableNode;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductDetailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 
 class UpdateDetailsFeatureContext extends AbstractProductFeatureContext
 {
@@ -44,10 +45,12 @@ class UpdateDetailsFeatureContext extends AbstractProductFeatureContext
     public function updateProductDetails(string $productReference, TableNode $table): void
     {
         $data = $table->getRowsHash();
-        $productId = $this->getSharedStorage()->get($productReference);
 
         try {
-            $command = new UpdateProductDetailsCommand($productId);
+            $command = new UpdateProductCommand(
+                $this->getSharedStorage()->get($productReference),
+                ShopConstraint::shop($this->getDefaultShopId())
+            );
             $this->fillCommand($data, $command);
             $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
@@ -58,10 +61,10 @@ class UpdateDetailsFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @param array $data
-     * @param UpdateProductDetailsCommand $command
+     * @param array<string, mixed> $data
+     * @param UpdateProductCommand $command
      */
-    private function fillCommand(array $data, UpdateProductDetailsCommand $command): void
+    private function fillCommand(array $data, UpdateProductCommand $command): void
     {
         if (isset($data['isbn'])) {
             $command->setIsbn($data['isbn']);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateDetailsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateDetailsFeatureContext.php
@@ -34,6 +34,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 
+/**
+ * Context for product assertions related to Details related properties
+ */
 class UpdateDetailsFeatureContext extends AbstractProductFeatureContext
 {
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateOptionsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateOptionsFeatureContext.php
@@ -36,7 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 /**
- * Context for updating product options properties using single UpdateProductCommand
+ * Context for updating product options properties using UpdateProductCommand
  *
  * @see UpdateProductCommand
  */

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdatePricesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdatePricesFeatureContext.php
@@ -39,6 +39,11 @@ use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductF
 use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
+/**
+ * Context for updating product prices by using UpdateProductCommand
+ *
+ * @see UpdateProductCommand
+ */
 class UpdatePricesFeatureContext extends AbstractProductFeatureContext
 {
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdatePricesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdatePricesFeatureContext.php
@@ -35,10 +35,11 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductPricesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Domain\TaxRulesGroupFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
-class UpdatePricesFeatureContext extends AbstractUpdatePricesFeatureContext
+class UpdatePricesFeatureContext extends AbstractProductFeatureContext
 {
     /**
      * @When I update product :productReference prices for shop :shopReference with following information:
@@ -97,29 +98,6 @@ class UpdatePricesFeatureContext extends AbstractUpdatePricesFeatureContext
     }
 
     /**
-     * @Then product :productReference should have following prices information for shops :shopReference:
-     *
-     * @param string $productReference
-     * @param string $shopReferences
-     * @param TableNode $tableNode
-     */
-    public function assertPriceFieldsForShops(string $productReference, string $shopReferences, TableNode $tableNode): void
-    {
-        $this->performAssertPriceFieldsForShops($productReference, $shopReferences, $tableNode);
-    }
-
-    /**
-     * @Then product :productReference should have following prices information:
-     *
-     * @param string $productReference
-     * @param TableNode $tableNode
-     */
-    public function assertPriceFields(string $productReference, TableNode $tableNode): void
-    {
-        $this->performAssertPriceFields($productReference, $tableNode);
-    }
-
-    /**
      * @param string $productReference
      * @param TableNode $table
      * @param ShopConstraint $shopConstraint
@@ -157,7 +135,7 @@ class UpdatePricesFeatureContext extends AbstractUpdatePricesFeatureContext
         }
 
         try {
-            $this->getQueryBus()->handle($command);
+            $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
             $this->setLastException($e);
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateSeoFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateSeoFeatureContext.php
@@ -33,9 +33,15 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use RuntimeException;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
-class UpdateSeoFeatureContext extends AbstractUpdateSeoFeatureContext
+/**
+ * Context for updating product SEO properties by using UpdateProductCommand
+ *
+ * @see UpdateProductCommand
+ */
+class UpdateSeoFeatureContext extends AbstractProductFeatureContext
 {
     /**
      * @When I update product :productReference SEO information for shop :shopReference with following values:
@@ -88,32 +94,6 @@ class UpdateSeoFeatureContext extends AbstractUpdateSeoFeatureContext
             ),
             $tableNode
         );
-    }
-
-    /**
-     * @Then product :productReference should have following seo options for shops :shopReferences:
-     *
-     * @param string $productReference
-     * @param string $shopReferences
-     * @param TableNode $tableNode
-     */
-    public function assertSeoOptionsForShops(
-        string $productReference,
-        string $shopReferences,
-        TableNode $tableNode
-    ): void {
-        $this->performAssertSeoOptionsForShops($productReference, $shopReferences, $tableNode);
-    }
-
-    /**
-     * @Then product :productReference should have following seo options:
-     *
-     * @param string $productReference
-     * @param TableNode $tableNode
-     */
-    public function assertSeoOptionsForDefaultShop(string $productReference, TableNode $tableNode): void
-    {
-        $this->performAssertSeoOptionsForDefaultShop($productReference, $tableNode);
     }
 
     /**
@@ -202,16 +182,6 @@ class UpdateSeoFeatureContext extends AbstractUpdateSeoFeatureContext
         } catch (ProductException $e) {
             $this->setLastException($e);
         }
-    }
-
-    /**
-     * @Then product :productReference should not have a redirect target
-     *
-     * @param string $productReference
-     */
-    public function assertHasNoRedirectTargetId(string $productReference)
-    {
-        $this->performAssertHasNoRedirectTargetId($productReference);
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateSeoFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateSeoFeatureContext.php
@@ -34,10 +34,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductSeoCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use RuntimeException;
-use Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\AbstractUpdateSeoFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
-class UpdateSeoFeatureContext extends AbstractUpdateSeoFeatureContext
+class UpdateSeoFeatureContext extends AbstractProductFeatureContext
 {
     /**
      * @When I update product :productReference SEO information for shop :shopReference with following values:
@@ -90,42 +89,6 @@ class UpdateSeoFeatureContext extends AbstractUpdateSeoFeatureContext
             ),
             $tableNode
         );
-    }
-
-    /**
-     * @Then product :productReference should have following seo options for shops :shopReferences:
-     *
-     * @param string $productReference
-     * @param string $shopReferences
-     * @param TableNode $tableNode
-     */
-    public function assertSeoOptionsForShops(
-        string $productReference,
-        string $shopReferences,
-        TableNode $tableNode
-    ): void {
-        $this->performAssertSeoOptionsForShops($productReference, $shopReferences, $tableNode);
-    }
-
-    /**
-     * @Then product :productReference should have following seo options:
-     *
-     * @param string $productReference
-     * @param TableNode $tableNode
-     */
-    public function assertSeoOptionsForDefaultShop(string $productReference, TableNode $tableNode): void
-    {
-        $this->performAssertSeoOptionsForDefaultShop($productReference, $tableNode);
-    }
-
-    /**
-     * @Then product :productReference should not have a redirect target
-     *
-     * @param string $productReference
-     */
-    public function assertHasNoRedirectTargetId(string $productReference)
-    {
-        $this->performAssertHasNoRedirectTargetId($productReference);
     }
 
     /**

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -344,6 +344,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePackFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePositionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePricesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\PricesAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductFeatureValuesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateSeoFeatureContext
@@ -489,6 +490,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePackFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePositionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdatePricesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\PricesAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductFeatureValuesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdateSeoFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -150,6 +150,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateDetailsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\DetailsAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
         order_return_state:
           paths:
@@ -337,6 +338,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCategoriesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateDetailsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\DetailsAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateOptionsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\OptionsAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePackFeatureContext
@@ -480,7 +482,8 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdateBasicInformationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCategoriesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCustomizationFieldsFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateDetailsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdateDetailsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\DetailsAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdateOptionsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\OptionsAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdatePackFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -348,6 +348,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductFeatureValuesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateSeoFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\SeoAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateShippingFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
@@ -494,6 +495,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductFeatureValuesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdateSeoFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\SeoAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateShippingFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext

--- a/tests/Unit/Adapter/Product/Update/Filler/DetailsFillerTest.php
+++ b/tests/Unit/Adapter/Product/Update/Filler/DetailsFillerTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Product\Update\Filler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Update\Filler\DetailsFiller;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use Product;
+
+class DetailsFillerTest extends ProductFillerTestCase
+{
+    /**
+     * @dataProvider getDataToTestUpdatablePropertiesFilling
+     *
+     * @param Product $product
+     * @param UpdateProductCommand $command
+     * @param array $expectedUpdatableProperties
+     * @param Product $expectedProduct
+     */
+    public function testFillsUpdatableProperties(
+        Product $product,
+        UpdateProductCommand $command,
+        array $expectedUpdatableProperties,
+        Product $expectedProduct
+    ): void {
+        $this->fillUpdatableProperties(
+            $this->getFiller(),
+            $product,
+            $command,
+            $expectedUpdatableProperties,
+            $expectedProduct
+        );
+    }
+
+    /**
+     * @return iterable
+     */
+    public function getDataToTestUpdatablePropertiesFilling(): iterable
+    {
+        $command = $this->getEmptyCommand()
+            ->setUpc('3456789')
+            ->setIsbn('978-3-16-148410-1')
+        ;
+        $expectedProduct = $this->mockDefaultProduct();
+        $expectedProduct->upc = '3456789';
+        $expectedProduct->isbn = '978-3-16-148410-1';
+
+        yield [
+            $this->mockDefaultProduct(),
+            $command,
+            ['isbn', 'upc'],
+            $expectedProduct,
+        ];
+
+        $command = $this->getEmptyCommand()
+            ->setEan13('1234567890111')
+            ->setIsbn('978-3-16-148410-0')
+            ->setMpn('HUE222-7')
+            ->setReference('ref-HUE222-7')
+            ->setUpc('0123456789')
+        ;
+        $expectedProduct = $this->mockDefaultProduct();
+        $expectedProduct->ean13 = '1234567890111';
+        $expectedProduct->isbn = '978-3-16-148410-0';
+        $expectedProduct->mpn = 'HUE222-7';
+        $expectedProduct->reference = 'ref-HUE222-7';
+        $expectedProduct->upc = '0123456789';
+
+        yield [
+            $this->mockDefaultProduct(),
+            $command,
+            [
+                'ean13',
+                'isbn',
+                'mpn',
+                'reference',
+                'upc',
+            ],
+            $expectedProduct,
+        ];
+    }
+
+    /**
+     * @return DetailsFiller
+     */
+    private function getFiller(): DetailsFiller
+    {
+        return new DetailsFiller();
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -441,6 +441,71 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             [$command],
         ];
 
+        $command = $this->getSingleShopCommand();
+        $command->setReference('ref');
+        yield [
+            [
+                'specifications' => [
+                    'references' => [
+                        'reference' => 'ref',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setIsbn('0-8044-2957-X');
+        yield [
+            [
+                'specifications' => [
+                    'references' => [
+                        'isbn' => '0-8044-2957-X',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setEan13('13');
+        yield [
+            [
+                'specifications' => [
+                    'references' => [
+                        'ean_13' => '13',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setUpc('1345');
+        yield [
+            [
+                'specifications' => [
+                    'references' => [
+                        'upc' => '1345',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setMpn('mpn');
+        yield [
+            [
+                'specifications' => [
+                    'references' => [
+                        'mpn' => 'mpn',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
         $command = $this->getSingleShopCommand()
             ->setVisibility(ProductVisibility::INVISIBLE)
             ->setLocalizedShortDescriptions($localizedShortDescriptions)
@@ -455,6 +520,11 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             ->setLocalizedMetaDescriptions($localizedMetaDescriptions)
             ->setLocalizedLinkRewrites($localizedLinkRewrites)
             ->setRedirectOption(RedirectType::TYPE_PRODUCT_TEMPORARY, 42)
+            ->setIsbn('0-8044-2957-X')
+            ->setEan13('13')
+            ->setUpc('1345')
+            ->setMpn('mpn')
+            ->setReference('0123456789')
         ;
 
         yield [
@@ -494,6 +564,15 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                         'target' => [
                             'id' => 42,
                         ],
+                    ],
+                ],
+                'specifications' => [
+                    'references' => [
+                        'isbn' => '0-8044-2957-X',
+                        'ean_13' => '13',
+                        'upc' => '1345',
+                        'mpn' => 'mpn',
+                        'reference' => '0123456789',
                     ],
                 ],
             ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Following PR https://github.com/PrestaShop/PrestaShop/pull/30031. Introduces Details filler and properties into UpdateProductCommand. Covers with behat and unit tests.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | No QA yet. Build with all related tests should pass and should be enough. After this one we will still need to add Shipping properties and product status update and then the new approach will be integrated in v2 page it will be testable by QA.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
Related behats can be run by following commands:
- ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-details
- ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s update_product --tags update-details

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
