### PR TITLE
UpdateProductCommand unification - Shipping related properties handling

### DIFF
--- a/src/Adapter/Product/CommandHandler/UpdateProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductHandler.php
@@ -113,6 +113,14 @@ class UpdateProductHandler implements UpdateProductHandlerInterface
         if (null !== $command->getWholesalePrice()) {
             $this->updateDefaultSupplier($command->getProductId(), $command->getWholesalePrice());
         }
+
+        if (null !== $command->getCarrierReferenceIds()) {
+            $this->productRepository->setCarrierReferences(
+                new ProductId((int) $product->id),
+                $command->getCarrierReferenceIds(),
+                $shopConstraint
+            );
+        }
     }
 
     /**

--- a/src/Adapter/Product/CommandHandler/UpdateProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductHandler.php
@@ -113,14 +113,6 @@ class UpdateProductHandler implements UpdateProductHandlerInterface
         if (null !== $command->getWholesalePrice()) {
             $this->updateDefaultSupplier($command->getProductId(), $command->getWholesalePrice());
         }
-
-        if (null !== $command->getCarrierReferenceIds()) {
-            $this->productRepository->setCarrierReferences(
-                new ProductId((int) $product->id),
-                $command->getCarrierReferenceIds(),
-                $shopConstraint
-            );
-        }
     }
 
     /**

--- a/src/Adapter/Product/Update/Filler/ShippingFiller.php
+++ b/src/Adapter/Product/Update/Filler/ShippingFiller.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Update\Filler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use Product;
+
+/**
+ * Fills product properties which are related to product shipping
+ */
+class ShippingFiller implements ProductFillerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function fillUpdatableProperties(Product $product, UpdateProductCommand $command): array
+    {
+        $updatableProperties = [];
+
+        if (null !== $command->getWidth()) {
+            $product->width = (string) $command->getWidth();
+            $updatableProperties[] = 'width';
+        }
+
+        if (null !== $command->getHeight()) {
+            $product->height = (string) $command->getHeight();
+            $updatableProperties[] = 'height';
+        }
+
+        if (null !== $command->getDepth()) {
+            $product->depth = (string) $command->getDepth();
+            $updatableProperties[] = 'depth';
+        }
+
+        if (null !== $command->getWeight()) {
+            $product->weight = (string) $command->getWeight();
+            $updatableProperties[] = 'weight';
+        }
+
+        if (null !== $command->getAdditionalShippingCost()) {
+            $product->additional_shipping_cost = (float) (string) $command->getAdditionalShippingCost();
+            $updatableProperties[] = 'additional_shipping_cost';
+        }
+
+        if (null !== $command->getDeliveryTimeNoteType()) {
+            $product->additional_delivery_times = $command->getDeliveryTimeNoteType()->getValue();
+            $updatableProperties[] = 'additional_delivery_times';
+        }
+
+        if (null !== $command->getLocalizedDeliveryTimeInStockNotes()) {
+            $product->delivery_in_stock = $command->getLocalizedDeliveryTimeInStockNotes();
+            $updatableProperties['delivery_in_stock'] = array_keys($command->getLocalizedDeliveryTimeInStockNotes());
+        }
+
+        if (null !== $command->getLocalizedDeliveryTimeOutOfStockNotes()) {
+            $product->delivery_out_stock = $command->getLocalizedDeliveryTimeOutOfStockNotes();
+            $updatableProperties['delivery_out_stock'] = array_keys($command->getLocalizedDeliveryTimeOutOfStockNotes());
+        }
+
+        return $updatableProperties;
+    }
+}

--- a/src/Core/Domain/Product/Command/UpdateProductCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductCommand.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductHandler;
-use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierReferenceId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerIdInterface;
@@ -220,11 +219,6 @@ class UpdateProductCommand
      * @var DecimalNumber|null
      */
     private $additionalShippingCost;
-
-    /**
-     * @var CarrierReferenceId[]|null
-     */
-    private $carrierReferenceIds;
 
     /**
      * @var DeliveryTimeNoteType
@@ -897,28 +891,6 @@ class UpdateProductCommand
     public function setAdditionalShippingCost(string $additionalShippingCost): self
     {
         $this->additionalShippingCost = new DecimalNumber($additionalShippingCost);
-
-        return $this;
-    }
-
-    /**
-     * @return CarrierReferenceId[]|null
-     */
-    public function getCarrierReferenceIds(): ?array
-    {
-        return $this->carrierReferenceIds;
-    }
-
-    /**
-     * @param int[] $carrierReferenceIds
-     *
-     * @return self
-     */
-    public function setCarrierReferenceIds(array $carrierReferenceIds): self
-    {
-        foreach (array_unique($carrierReferenceIds) as $carrierReferenceId) {
-            $this->carrierReferenceIds[] = new CarrierReferenceId((int) $carrierReferenceId);
-        }
 
         return $this;
     }

--- a/src/Core/Domain/Product/Command/UpdateProductCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductCommand.php
@@ -29,10 +29,13 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductHandler;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierReferenceId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerIdInterface;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\NoManufacturerId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
@@ -192,6 +195,51 @@ class UpdateProductCommand
      * @var Reference|null
      */
     private $reference;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $width;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $height;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $depth;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $weight;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $additionalShippingCost;
+
+    /**
+     * @var CarrierReferenceId[]|null
+     */
+    private $carrierReferenceIds;
+
+    /**
+     * @var DeliveryTimeNoteType
+     */
+    private $deliveryTimeNoteType;
+
+    /**
+     * @var string[]|null
+     */
+    private $localizedDeliveryTimeInStockNotes;
+
+    /**
+     * @var string[]|null
+     */
+    private $localizedDeliveryTimeOutOfStockNotes;
 
     /**
      * @param int $productId
@@ -743,5 +791,224 @@ class UpdateProductCommand
         $this->reference = new Reference($reference);
 
         return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getWidth(): ?DecimalNumber
+    {
+        return $this->width;
+    }
+
+    /**
+     * @param string $width
+     *
+     * @return self
+     */
+    public function setWidth(string $width): self
+    {
+        $width = new DecimalNumber($width);
+        $this->assertPackageDimensionIsPositiveOrZero($width, 'width');
+        $this->width = $width;
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getHeight(): ?DecimalNumber
+    {
+        return $this->height;
+    }
+
+    /**
+     * @param string $height
+     *
+     * @return self
+     */
+    public function setHeight(string $height): self
+    {
+        $height = new DecimalNumber($height);
+        $this->assertPackageDimensionIsPositiveOrZero($height, 'height');
+        $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getDepth(): ?DecimalNumber
+    {
+        return $this->depth;
+    }
+
+    /**
+     * @param string $depth
+     *
+     * @return self
+     */
+    public function setDepth(string $depth): self
+    {
+        $depth = new DecimalNumber($depth);
+        $this->assertPackageDimensionIsPositiveOrZero($depth, 'depth');
+        $this->depth = $depth;
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getWeight(): ?DecimalNumber
+    {
+        return $this->weight;
+    }
+
+    /**
+     * @param string $weight
+     *
+     * @return self
+     */
+    public function setWeight(string $weight): self
+    {
+        $weight = new DecimalNumber($weight);
+        $this->assertPackageDimensionIsPositiveOrZero($weight, 'weight');
+        $this->weight = $weight;
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getAdditionalShippingCost(): ?DecimalNumber
+    {
+        return $this->additionalShippingCost;
+    }
+
+    /**
+     * @param string $additionalShippingCost
+     *
+     * @return self
+     */
+    public function setAdditionalShippingCost(string $additionalShippingCost): self
+    {
+        $this->additionalShippingCost = new DecimalNumber($additionalShippingCost);
+
+        return $this;
+    }
+
+    /**
+     * @return CarrierReferenceId[]|null
+     */
+    public function getCarrierReferenceIds(): ?array
+    {
+        return $this->carrierReferenceIds;
+    }
+
+    /**
+     * @param int[] $carrierReferenceIds
+     *
+     * @return self
+     */
+    public function setCarrierReferenceIds(array $carrierReferenceIds): self
+    {
+        foreach (array_unique($carrierReferenceIds) as $carrierReferenceId) {
+            $this->carrierReferenceIds[] = new CarrierReferenceId((int) $carrierReferenceId);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return DeliveryTimeNoteType|null
+     */
+    public function getDeliveryTimeNoteType(): ?DeliveryTimeNoteType
+    {
+        return $this->deliveryTimeNoteType;
+    }
+
+    /**
+     * @param int $type
+     *
+     * @return self
+     */
+    public function setDeliveryTimeNoteType(int $type): self
+    {
+        $this->deliveryTimeNoteType = new DeliveryTimeNoteType($type);
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLocalizedDeliveryTimeInStockNotes(): ?array
+    {
+        return $this->localizedDeliveryTimeInStockNotes;
+    }
+
+    /**
+     * @param string[] $localizedDeliveryTimeInStockNotes
+     *
+     * @return self
+     */
+    public function setLocalizedDeliveryTimeInStockNotes(array $localizedDeliveryTimeInStockNotes): self
+    {
+        $this->localizedDeliveryTimeInStockNotes = $localizedDeliveryTimeInStockNotes;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedDeliveryTimeOutOfStockNotes(): ?array
+    {
+        return $this->localizedDeliveryTimeOutOfStockNotes;
+    }
+
+    /**
+     * @param string[] $localizedDeliveryTimeOutOfStockNotes
+     *
+     * @return self
+     */
+    public function setLocalizedDeliveryTimeOutOfStockNotes(array $localizedDeliveryTimeOutOfStockNotes): self
+    {
+        $this->localizedDeliveryTimeOutOfStockNotes = $localizedDeliveryTimeOutOfStockNotes;
+
+        return $this;
+    }
+
+    /**
+     * @todo: dimensions deserves dedicated VO and might be worth reusing in Carriers page.
+     *
+     * @todo Check https://github.com/PrestaShop/PrestaShop/issues/19666#issuecomment-756088706
+     *
+     * @param DecimalNumber $value
+     * @param string $dimensionName
+     *
+     * @throws ProductConstraintException
+     */
+    private function assertPackageDimensionIsPositiveOrZero(DecimalNumber $value, string $dimensionName): void
+    {
+        if ($value->isGreaterOrEqualThanZero()) {
+            return;
+        }
+
+        $codeByDimension = [
+            'width' => ProductConstraintException::INVALID_WIDTH,
+            'height' => ProductConstraintException::INVALID_HEIGHT,
+            'depth' => ProductConstraintException::INVALID_DEPTH,
+            'weight' => ProductConstraintException::INVALID_WEIGHT,
+        ];
+
+        throw new ProductConstraintException(
+            sprintf('Invalid product %s, it must be positive number or zero', $dimensionName),
+            $codeByDimension[$dimensionName]
+        );
     }
 }

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
@@ -192,7 +192,6 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
             ->addMultiShopField('[shipping][additional_shipping_cost]', 'setAdditionalShippingCost', DataField::TYPE_STRING)
             ->addMultiShopField('[shipping][delivery_time_notes][in_stock]', 'setLocalizedDeliveryTimeInStockNotes', DataField::TYPE_ARRAY)
             ->addMultiShopField('[shipping][delivery_time_notes][out_of_stock]', 'setLocalizedDeliveryTimeOutOfStockNotes', DataField::TYPE_ARRAY)
-            ->addMultiShopField('[shipping][carriers]', 'setCarrierReferenceIds', DataField::TYPE_ARRAY)
         ;
 
         return $this;

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
@@ -64,6 +64,7 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
             ->configurePrices($config)
             ->configureSeo($config)
             ->configureDetails($config)
+            ->configureShipping($config)
         ;
 
         $commandBuilder = new CommandBuilder($config);
@@ -170,6 +171,28 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
             ->addField('[specifications][references][upc]', 'setUpc', DataField::TYPE_STRING)
             ->addField('[specifications][references][ean_13]', 'setEan13', DataField::TYPE_STRING)
             ->addField('[specifications][references][isbn]', 'setIsbn', DataField::TYPE_STRING)
+        ;
+
+        return $this;
+    }
+
+    /**
+     * @param CommandBuilderConfig $config
+     *
+     * @return self
+     */
+    private function configureShipping(CommandBuilderConfig $config): self
+    {
+        $config
+            ->addField('[shipping][dimensions][width]', 'setWidth', DataField::TYPE_STRING)
+            ->addField('[shipping][dimensions][height]', 'setHeight', DataField::TYPE_STRING)
+            ->addField('[shipping][dimensions][depth]', 'setDepth', DataField::TYPE_STRING)
+            ->addField('[shipping][dimensions][weight]', 'setWeight', DataField::TYPE_STRING)
+            ->addField('[shipping][delivery_time_note_type]', 'setDeliveryTimeNoteType', DataField::TYPE_INT)
+            ->addMultiShopField('[shipping][additional_shipping_cost]', 'setAdditionalShippingCost', DataField::TYPE_STRING)
+            ->addMultiShopField('[shipping][delivery_time_notes][in_stock]', 'setLocalizedDeliveryTimeInStockNotes', DataField::TYPE_ARRAY)
+            ->addMultiShopField('[shipping][delivery_time_notes][out_of_stock]', 'setLocalizedDeliveryTimeOutOfStockNotes', DataField::TYPE_ARRAY)
+            ->addMultiShopField('[shipping][carriers]', 'setCarrierReferenceIds', DataField::TYPE_ARRAY)
         ;
 
         return $this;

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -569,3 +569,7 @@ services:
   prestashop.adapter.product.update.filler.details_filler:
     class: PrestaShop\PrestaShop\Adapter\Product\Update\Filler\DetailsFiller
     tags: [ 'core.product_filler' ]
+
+  prestashop.adapter.product.update.filler.shipping_filler:
+    class: PrestaShop\PrestaShop\Adapter\Product\Update\Filler\ShippingFiller
+    tags: [ 'core.product_filler' ]

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/AbstractShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/AbstractShippingFeatureContext.php
@@ -29,7 +29,6 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProd
 
 use Carrier;
 use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
-use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 /**
  * This abstract class was introduced during UpdateProductCommand unification process,

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/AbstractShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/AbstractShippingFeatureContext.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct;
+
+use Carrier;
+use Tests\Integration\Behaviour\Features\Context\Domain\Product\AbstractProductFeatureContext;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+
+/**
+ * This abstract class was introduced during UpdateProductCommand unification process,
+ * and which idea is to remove multiple sub-commands and use single UpdateProductCommand instead.
+ * This abstract context allows sharing assertions which and some other common methods for both implementations during the transition.
+ *
+ * @see UpdateProductCommand
+ * @see UpdateProductHandlerInterface
+ *
+ * @todo: need to check if this abstract class is still needed when UpdateProductCommand is fully finished,
+ *        because one of the contexts that uses it will be deleted, therefore leaving this abstract class useless.
+ */
+abstract class AbstractShippingFeatureContext extends AbstractProductFeatureContext
+{
+    /**
+     * @param string[] $carrierReferences
+     *
+     * @return int[]
+     */
+    protected function getCarrierReferenceIds(array $carrierReferences): array
+    {
+        $referenceIds = [];
+        foreach ($carrierReferences as $carrierReference) {
+            $carrier = new Carrier($this->getSharedStorage()->get($carrierReference));
+            $referenceIds[] = (int) $carrier->id_reference;
+        }
+
+        return $referenceIds;
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/ShippingAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/ShippingAssertionFeatureContext.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductShippingInforma
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use RuntimeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class ShippingAssertionFeatureContext extends AbstractShippingFeatureContext
 {
@@ -126,7 +127,7 @@ class ShippingAssertionFeatureContext extends AbstractShippingFeatureContext
         )->getShippingInformation();
 
         if (isset($data['carriers'])) {
-            $expectedReferenceIds = $this->getCarrierReferenceIds($data['carriers']);
+            $expectedReferenceIds = $this->getCarrierReferenceIds(PrimitiveUtils::castStringArrayIntoArray($data['carriers']));
             $actualReferenceIds = $productShippingInformation->getCarrierReferences();
 
             Assert::assertEquals(

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/ShippingAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/ShippingAssertionFeatureContext.php
@@ -23,112 +23,20 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
 declare(strict_types=1);
 
-namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct;
 
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductShippingCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductShippingInformation;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
-use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use RuntimeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\AbstractShippingFeatureContext;
-use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
-class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
+class ShippingAssertionFeatureContext extends AbstractShippingFeatureContext
 {
-    /**
-     * @When I update product :productReference shipping information with following values:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function updateProductShipping(string $productReference, TableNode $table): void
-    {
-        $this->updateShipping($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
-    }
-
-    /**
-     * @When I update product :productReference shipping information for shop :shopReference with following values:
-     *
-     * @param string $productReference
-     * @param string $shopReference
-     * @param TableNode $table
-     */
-    public function updateProductShippingForShop(string $productReference, string $shopReference, TableNode $table): void
-    {
-        $shopId = $this->getSharedStorage()->get(trim($shopReference));
-        $this->updateShipping($productReference, $table, ShopConstraint::shop($shopId));
-    }
-
-    /**
-     * @When I update product :productReference shipping information for all shops with following values:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function updateProductShippingForAllShops(string $productReference, TableNode $table): void
-    {
-        $this->updateShipping($productReference, $table, ShopConstraint::allShops());
-    }
-
-    /**
-     * @When I assign product :productReference with following carriers:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function setProductCarriersForDefaultShop(string $productReference, TableNode $table): void
-    {
-        $this->setCarriers($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
-    }
-
-    /**
-     * @When I assign product :productReference with following carriers for shop :shopReference:
-     *
-     * @param string $productReference
-     * @param string $shopReference
-     * @param TableNode $table
-     */
-    public function setProductCarriersForShop(string $productReference, string $shopReference, TableNode $table): void
-    {
-        $this->setCarriers($productReference, $table, ShopConstraint::shop((int) $this->getSharedStorage()->get($shopReference)));
-    }
-
-    /**
-     * @When I assign product :productReference with following carriers for all shops:
-     *
-     * @param string $productReference
-     * @param TableNode $table
-     */
-    public function setProductCarriersForAllShops(string $productReference, TableNode $table): void
-    {
-        $this->setCarriers($productReference, $table, ShopConstraint::allShops());
-    }
-
-    /**
-     * @param string $productReference
-     * @param TableNode $table
-     * @param ShopConstraint $shopConstraint
-     */
-    private function setCarriers(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
-    {
-        $carrierReferences = $this->getCarrierReferenceIds(array_keys($table->getRowsHash()));
-
-        $this->getCommandBus()->handle(new SetCarriersCommand(
-            (int) $this->getSharedStorage()->get($productReference),
-            $carrierReferences,
-            $shopConstraint
-        ));
-    }
-
     /**
      * @Then product :productReference should have no carriers assigned
      *
@@ -169,31 +77,6 @@ class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
         foreach ($shopReferences as $shopReference) {
             $shopId = $this->getSharedStorage()->get(trim($shopReference));
             $this->assertShippingInfo($productReference, $tableNode, $shopId);
-        }
-    }
-
-    /**
-     * @param string $productReference
-     * @param TableNode $table
-     * @param ShopConstraint $shopConstraint
-     */
-    private function updateShipping(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
-    {
-        $data = $this->localizeByRows($table);
-        $productId = $this->getSharedStorage()->get($productReference);
-
-        try {
-            $command = new UpdateProductShippingCommand($productId, $shopConstraint);
-            $unhandledData = $this->setUpdateShippingCommandData($data, $command);
-
-            Assert::assertEmpty(
-                $unhandledData,
-                sprintf('Not all provided values handled in scenario. %s', var_export($unhandledData, true))
-            );
-
-            $this->getCommandBus()->handle($command);
-        } catch (ProductException $e) {
-            $this->setLastException($e);
         }
     }
 
@@ -243,7 +126,7 @@ class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
         )->getShippingInformation();
 
         if (isset($data['carriers'])) {
-            $expectedReferenceIds = $this->getCarrierReferenceIds(PrimitiveUtils::castStringArrayIntoArray($data['carriers']));
+            $expectedReferenceIds = $this->getCarrierReferenceIds($data['carriers']);
             $actualReferenceIds = $productShippingInformation->getCarrierReferences();
 
             Assert::assertEquals(
@@ -305,58 +188,5 @@ class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
 
             unset($data['delivery time out of stock notes']);
         }
-    }
-
-    /**
-     * @param array $data
-     * @param UpdateProductShippingCommand $command
-     *
-     * @return array values that was provided, but wasn't handled
-     */
-    private function setUpdateShippingCommandData(array $data, UpdateProductShippingCommand $command): array
-    {
-        $unhandledValues = $data;
-
-        if (isset($data['width'])) {
-            $command->setWidth($data['width']);
-            unset($unhandledValues['width']);
-        }
-
-        if (isset($data['height'])) {
-            $command->setHeight($data['height']);
-            unset($unhandledValues['height']);
-        }
-
-        if (isset($data['depth'])) {
-            $command->setDepth($data['depth']);
-            unset($unhandledValues['depth']);
-        }
-
-        if (isset($data['weight'])) {
-            $command->setWeight($data['weight']);
-            unset($unhandledValues['weight']);
-        }
-
-        if (isset($data['additional_shipping_cost'])) {
-            $command->setAdditionalShippingCost($data['additional_shipping_cost']);
-            unset($unhandledValues['additional_shipping_cost']);
-        }
-
-        if (isset($data['delivery time notes type'])) {
-            $command->setDeliveryTimeNoteType(DeliveryTimeNoteType::ALLOWED_TYPES[$data['delivery time notes type']]);
-            unset($unhandledValues['delivery time notes type']);
-        }
-
-        if (isset($data['delivery time in stock notes'])) {
-            $command->setLocalizedDeliveryTimeInStockNotes($data['delivery time in stock notes']);
-            unset($unhandledValues['delivery time in stock notes']);
-        }
-
-        if (isset($data['delivery time out of stock notes'])) {
-            $command->setLocalizedDeliveryTimeOutOfStockNotes($data['delivery time out of stock notes']);
-            unset($unhandledValues['delivery time out of stock notes']);
-        }
-
-        return $unhandledValues;
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateShippingFeatureContext.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct;
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
+{
+    /**
+     * @When I update product :productReference shipping information with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductShipping(string $productReference, TableNode $table): void
+    {
+        $this->updateShipping($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
+    }
+
+    /**
+     * @When I update product :productReference shipping information for shop :shopReference with following values:
+     *
+     * @param string $productReference
+     * @param string $shopReference
+     * @param TableNode $table
+     */
+    public function updateProductShippingForShop(string $productReference, string $shopReference, TableNode $table): void
+    {
+        $shopId = $this->getSharedStorage()->get(trim($shopReference));
+        $this->updateShipping($productReference, $table, ShopConstraint::shop($shopId));
+    }
+
+    /**
+     * @When I update product :productReference shipping information for all shops with following values:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateProductShippingForAllShops(string $productReference, TableNode $table): void
+    {
+        $this->updateShipping($productReference, $table, ShopConstraint::allShops());
+    }
+
+    /**
+     * @param string $productReference
+     * @param TableNode $table
+     * @param ShopConstraint $shopConstraint
+     */
+    private function updateShipping(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
+    {
+        $data = $this->localizeByRows($table);
+        $productId = $this->getSharedStorage()->get($productReference);
+
+        try {
+            $command = new UpdateProductCommand($productId, $shopConstraint);
+            $unhandledData = $this->setUpdateShippingCommandData($data, $command);
+
+            Assert::assertEmpty(
+                $unhandledData,
+                sprintf('Not all provided values handled in scenario. %s', var_export($unhandledData, true))
+            );
+
+            $this->getCommandBus()->handle($command);
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    /**
+     * @param array $data
+     * @param UpdateProductCommand $command
+     *
+     * @return array values that was provided, but wasn't handled
+     */
+    private function setUpdateShippingCommandData(array $data, UpdateProductCommand $command): array
+    {
+        $unhandledValues = $data;
+
+        if (isset($data['width'])) {
+            $command->setWidth($data['width']);
+            unset($unhandledValues['width']);
+        }
+
+        if (isset($data['height'])) {
+            $command->setHeight($data['height']);
+            unset($unhandledValues['height']);
+        }
+
+        if (isset($data['depth'])) {
+            $command->setDepth($data['depth']);
+            unset($unhandledValues['depth']);
+        }
+
+        if (isset($data['weight'])) {
+            $command->setWeight($data['weight']);
+            unset($unhandledValues['weight']);
+        }
+
+        if (isset($data['additional_shipping_cost'])) {
+            $command->setAdditionalShippingCost($data['additional_shipping_cost']);
+            unset($unhandledValues['additional_shipping_cost']);
+        }
+
+        if (isset($data['delivery time notes type'])) {
+            $command->setDeliveryTimeNoteType(DeliveryTimeNoteType::ALLOWED_TYPES[$data['delivery time notes type']]);
+            unset($unhandledValues['delivery time notes type']);
+        }
+
+        if (isset($data['delivery time in stock notes'])) {
+            $command->setLocalizedDeliveryTimeInStockNotes($data['delivery time in stock notes']);
+            unset($unhandledValues['delivery time in stock notes']);
+        }
+
+        if (isset($data['delivery time out of stock notes'])) {
+            $command->setLocalizedDeliveryTimeOutOfStockNotes($data['delivery time out of stock notes']);
+            unset($unhandledValues['delivery time out of stock notes']);
+        }
+
+        if (isset($data['carriers'])) {
+            $command->setCarrierReferenceIds($this->getCarrierReferenceIds($data['carriers']));
+            unset($unhandledValues['carriers']);
+        }
+
+        return $unhandledValues;
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProduct/UpdateShippingFeatureContext.php
@@ -30,6 +30,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProd
 
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
@@ -73,6 +74,40 @@ class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
     }
 
     /**
+     * @When I assign product :productReference with following carriers:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function setProductCarriersForDefaultShop(string $productReference, TableNode $table): void
+    {
+        $this->setCarriers($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
+    }
+
+    /**
+     * @When I assign product :productReference with following carriers for shop :shopReference:
+     *
+     * @param string $productReference
+     * @param string $shopReference
+     * @param TableNode $table
+     */
+    public function setProductCarriersForShop(string $productReference, string $shopReference, TableNode $table): void
+    {
+        $this->setCarriers($productReference, $table, ShopConstraint::shop((int) $this->getSharedStorage()->get($shopReference)));
+    }
+
+    /**
+     * @When I assign product :productReference with following carriers for all shops:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function setProductCarriersForAllShops(string $productReference, TableNode $table): void
+    {
+        $this->setCarriers($productReference, $table, ShopConstraint::allShops());
+    }
+
+    /**
      * @param string $productReference
      * @param TableNode $table
      * @param ShopConstraint $shopConstraint
@@ -95,6 +130,22 @@ class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
         } catch (ProductException $e) {
             $this->setLastException($e);
         }
+    }
+
+    /**
+     * @param string $productReference
+     * @param TableNode $table
+     * @param ShopConstraint $shopConstraint
+     */
+    private function setCarriers(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
+    {
+        $carrierReferences = $this->getCarrierReferenceIds(array_keys($table->getRowsHash()));
+
+        $this->getCommandBus()->handle(new SetCarriersCommand(
+            (int) $this->getSharedStorage()->get($productReference),
+            $carrierReferences,
+            $shopConstraint
+        ));
     }
 
     /**
@@ -145,11 +196,6 @@ class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
         if (isset($data['delivery time out of stock notes'])) {
             $command->setLocalizedDeliveryTimeOutOfStockNotes($data['delivery time out of stock notes']);
             unset($unhandledValues['delivery time out of stock notes']);
-        }
-
-        if (isset($data['carriers'])) {
-            $command->setCarrierReferenceIds($this->getCarrierReferenceIds($data['carriers']));
-            unset($unhandledValues['carriers']);
         }
 
         return $unhandledValues;

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
@@ -30,17 +30,12 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
-use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductShippingCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductShippingInformation;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
-use RuntimeException;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 use Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\AbstractShippingFeatureContext;
-use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
 {
@@ -130,49 +125,6 @@ class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
     }
 
     /**
-     * @Then product :productReference should have no carriers assigned
-     *
-     * @param string $productReference
-     */
-    public function assertProductHasNoCarriers(string $productReference): void
-    {
-        $productForEditing = $this->getProductForEditing($productReference);
-
-        Assert::assertEmpty(
-            $productForEditing->getShippingInformation()->getCarrierReferences(),
-            sprintf('Expected product "%s" to have no carriers assigned', $productReference)
-        );
-    }
-
-    /**
-     * @Then product :productReference should have following shipping information:
-     *
-     * @param string $productReference
-     * @param TableNode $tableNode
-     */
-    public function assertShippingInformationForDefaultShop(string $productReference, TableNode $tableNode): void
-    {
-        $this->assertShippingInfo($productReference, $tableNode);
-    }
-
-    /**
-     * @Then product :productReference should have following shipping information for shops ":shopReferences":
-     *
-     * @param string $productReference
-     * @param TableNode $tableNode
-     * @param string $shopReferences
-     */
-    public function assertShippingInfoForShops(string $productReference, TableNode $tableNode, string $shopReferences): void
-    {
-        $shopReferences = explode(',', $shopReferences);
-
-        foreach ($shopReferences as $shopReference) {
-            $shopId = $this->getSharedStorage()->get(trim($shopReference));
-            $this->assertShippingInfo($productReference, $tableNode, $shopId);
-        }
-    }
-
-    /**
      * @param string $productReference
      * @param TableNode $table
      * @param ShopConstraint $shopConstraint
@@ -194,116 +146,6 @@ class UpdateShippingFeatureContext extends AbstractShippingFeatureContext
             $this->getCommandBus()->handle($command);
         } catch (ProductException $e) {
             $this->setLastException($e);
-        }
-    }
-
-    /**
-     * @param array $expectedValues
-     * @param ProductShippingInformation $actualValues
-     */
-    private function assertNumberShippingFields(array &$expectedValues, ProductShippingInformation $actualValues): void
-    {
-        $numberShippingFields = [
-            'width',
-            'height',
-            'depth',
-            'weight',
-            'additional_shipping_cost',
-        ];
-
-        $propertyAccessor = PropertyAccess::createPropertyAccessor();
-
-        foreach ($numberShippingFields as $field) {
-            if (isset($expectedValues[$field])) {
-                $expectedNumber = new DecimalNumber((string) $expectedValues[$field]);
-                $actualNumber = $propertyAccessor->getValue($actualValues, $field);
-
-                if (!$expectedNumber->equals($actualNumber)) {
-                    throw new RuntimeException(
-                        sprintf('Product %s expected to be "%s", but is "%s"', $field, $expectedNumber, $actualNumber)
-                    );
-                }
-
-                unset($expectedValues[$field]);
-            }
-        }
-    }
-
-    /**
-     * @param string $productReference
-     * @param TableNode $tableNode
-     * @param int|null $shopId
-     */
-    private function assertShippingInfo(string $productReference, TableNode $tableNode, ?int $shopId = null): void
-    {
-        $data = $this->localizeByRows($tableNode);
-        $productShippingInformation = $this->getProductForEditing(
-            $productReference,
-            $shopId
-        )->getShippingInformation();
-
-        if (isset($data['carriers'])) {
-            $expectedReferenceIds = $this->getCarrierReferenceIds(PrimitiveUtils::castStringArrayIntoArray($data['carriers']));
-            $actualReferenceIds = $productShippingInformation->getCarrierReferences();
-
-            Assert::assertEquals(
-                $expectedReferenceIds,
-                $actualReferenceIds,
-                'Unexpected carrier references in product shipping information'
-            );
-
-            unset($data['carriers']);
-        }
-
-        $this->assertNumberShippingFields($data, $productShippingInformation);
-        $this->assertDeliveryTimeNotes($data, $productShippingInformation);
-
-        // Assertions checking isset() can hide some errors if it doesn't find array key,
-        // to make sure all provided fields were checked we need to unset every asserted field
-        // and finally, if provided data is not empty, it means there are some unnasserted values left
-        Assert::assertEmpty($data, sprintf('Some provided product shipping fields haven\'t been asserted: %s', var_export($data, true)));
-    }
-
-    /**
-     * @param array $data
-     * @param ProductShippingInformation $productShippingInformation
-     */
-    private function assertDeliveryTimeNotes(array &$data, ProductShippingInformation $productShippingInformation): void
-    {
-        $notesTypeNamedValues = [
-            'none' => DeliveryTimeNoteType::TYPE_NONE,
-            'default' => DeliveryTimeNoteType::TYPE_DEFAULT,
-            'specific' => DeliveryTimeNoteType::TYPE_SPECIFIC,
-        ];
-
-        if (isset($data['delivery time notes type'])) {
-            $expectedType = $notesTypeNamedValues[$data['delivery time notes type']];
-            $actualType = $productShippingInformation->getDeliveryTimeNoteType();
-            Assert::assertEquals($expectedType, $actualType, 'Unexpected delivery time notes type value');
-
-            unset($data['delivery time notes type']);
-        }
-
-        if (isset($data['delivery time in stock notes'])) {
-            $actualLocalizedOutOfStockNotes = $productShippingInformation->getLocalizedDeliveryTimeInStockNotes();
-            Assert::assertEquals(
-                $data['delivery time in stock notes'],
-                $actualLocalizedOutOfStockNotes,
-                'Unexpected product delivery time in stock notes'
-            );
-
-            unset($data['delivery time in stock notes']);
-        }
-
-        if (isset($data['delivery time out of stock notes'])) {
-            $actualLocalizedOutOfStockNotes = $productShippingInformation->getLocalizedDeliveryTimeOutOfStockNotes();
-            Assert::assertEquals(
-                $data['delivery time out of stock notes'],
-                $actualLocalizedOutOfStockNotes,
-                'Unexpected product delivery time out of stock notes'
-            );
-
-            unset($data['delivery time out of stock notes']);
         }
     }
 

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -350,6 +350,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateSeoFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\SeoAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateShippingFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\ShippingAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateTagsFeatureContext
@@ -497,7 +498,8 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProductSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdateSeoFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\SeoAssertionFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateShippingFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\UpdateShippingFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateProduct\ShippingAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateTagsFeatureContext

--- a/tests/Unit/Adapter/Product/Update/Filler/ProductFillerTestCase.php
+++ b/tests/Unit/Adapter/Product/Update/Filler/ProductFillerTestCase.php
@@ -29,7 +29,6 @@ namespace Tests\Unit\Adapter\Product\Update\Filler;
 
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Product\Update\Filler\ProductFillerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\NoManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
@@ -87,7 +86,12 @@ abstract class ProductFillerTestCase extends TestCase
         $product->condition = ProductCondition::NEW;
         $product->show_condition = false;
         $product->online_only = false;
-        $product->id_manufacturer = NoManufacturerId::NO_MANUFACTURER_ID;
+        $product->width = 0;
+        $product->height = 0;
+        $product->depth = 0;
+        $product->weight = 0;
+        $product->additional_shipping_cost = 0;
+        $product->additional_delivery_times = 1;
 
         return $product;
     }

--- a/tests/Unit/Adapter/Product/Update/Filler/ShippingFillerTest.php
+++ b/tests/Unit/Adapter/Product/Update/Filler/ShippingFillerTest.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Product\Update\Filler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Update\Filler\ShippingFiller;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use Product;
+
+class ShippingFillerTest extends ProductFillerTestCase
+{
+    /**
+     * @dataProvider getDataToTestUpdatablePropertiesFilling
+     *
+     * @param Product $product
+     * @param UpdateProductCommand $command
+     * @param array $expectedUpdatableProperties
+     * @param Product $expectedProduct
+     */
+    public function testFillsUpdatableProperties(
+        Product $product,
+        UpdateProductCommand $command,
+        array $expectedUpdatableProperties,
+        Product $expectedProduct
+    ): void {
+        $this->fillUpdatableProperties(
+            $this->getFiller(),
+            $product,
+            $command,
+            $expectedUpdatableProperties,
+            $expectedProduct
+        );
+    }
+
+    /**
+     * @return iterable
+     */
+    public function getDataToTestUpdatablePropertiesFilling(): iterable
+    {
+        $command = $this->getEmptyCommand()
+            ->setWidth('10.5')
+            ->setHeight('8.5')
+            ->setDepth('4')
+            ->setWeight('3.2')
+        ;
+
+        $expectedProduct = $this->mockDefaultProduct();
+        $expectedProduct->width = 10.5;
+        $expectedProduct->height = 8.5;
+        $expectedProduct->depth = 4.0;
+        $expectedProduct->weight = 3.2;
+
+        yield [
+            $this->mockDefaultProduct(),
+            $command,
+            [
+                'width',
+                'height',
+                'depth',
+                'weight',
+            ],
+            $expectedProduct,
+        ];
+
+        $command = $this->getEmptyCommand()
+            ->setAdditionalShippingCost('15.5')
+            ->setDeliveryTimeNoteType(2)
+            ->setLocalizedDeliveryTimeInStockNotes([
+                1 => 'Available',
+                2 => 'Yra sandelyje',
+            ])
+            ->setLocalizedDeliveryTimeOutOfStockNotes([
+                1 => 'Currently out of stock',
+                2 => 'Isparduota',
+            ])
+        ;
+        $expectedProduct = $this->mockDefaultProduct();
+        $expectedProduct->additional_shipping_cost = 15.5;
+        $expectedProduct->additional_delivery_times = 2;
+        $expectedProduct->delivery_in_stock = [
+            1 => 'Available',
+            2 => 'Yra sandelyje',
+        ];
+        $expectedProduct->delivery_out_stock = [
+            1 => 'Currently out of stock',
+            2 => 'Isparduota',
+        ];
+
+        yield [
+            $this->mockDefaultProduct(),
+            $command,
+            [
+                'additional_shipping_cost',
+                'additional_delivery_times',
+                'delivery_in_stock' => [1, 2],
+                'delivery_out_stock' => [1, 2],
+            ],
+            $expectedProduct,
+        ];
+    }
+
+    /**
+     * @return ShippingFiller
+     */
+    private function getFiller(): ShippingFiller
+    {
+        return new ShippingFiller();
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -540,7 +540,6 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                 1 => 'Out of stock',
                 2 => 'Isparduota',
             ])
-            ->setCarrierReferenceIds([1, 3, 5])
         ;
 
         yield [
@@ -610,7 +609,6 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                             2 => 'Isparduota',
                         ],
                     ],
-                    'carriers' => [1, 3, 5],
                 ],
             ],
             [$command],
@@ -972,7 +970,6 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                 1 => 'In stock',
                 2 => 'Yra sandelyje',
             ])
-            ->setCarrierReferenceIds([1, 3, 5])
         ;
 
         yield [
@@ -1031,8 +1028,6 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                             2 => 'Isparduota',
                         ],
                     ],
-                    'carriers' => [1, 3, 5],
-                    self::MODIFY_ALL_SHOPS_PREFIX . 'carriers' => true,
                 ],
             ],
             [$singleShopCommand, $allShopsCommand],

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
@@ -525,6 +526,21 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             ->setUpc('1345')
             ->setMpn('mpn')
             ->setReference('0123456789')
+            ->setWidth('50.5')
+            ->setHeight('40.5')
+            ->setDepth('30.5')
+            ->setWeight('2.2')
+            ->setDeliveryTimeNoteType(DeliveryTimeNoteType::TYPE_SPECIFIC)
+            ->setAdditionalShippingCost('5.7')
+            ->setLocalizedDeliveryTimeInStockNotes([
+                1 => 'In stock',
+                2 => 'Yra sandelyje',
+            ])
+            ->setLocalizedDeliveryTimeOutOfStockNotes([
+                1 => 'Out of stock',
+                2 => 'Isparduota',
+            ])
+            ->setCarrierReferenceIds([1, 3, 5])
         ;
 
         yield [
@@ -574,6 +590,27 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                         'mpn' => 'mpn',
                         'reference' => '0123456789',
                     ],
+                ],
+                'shipping' => [
+                    'dimensions' => [
+                        'width' => '50.5',
+                        'height' => '40.5',
+                        'depth' => '30.5',
+                        'weight' => '2.2',
+                    ],
+                    'delivery_time_note_type' => DeliveryTimeNoteType::TYPE_SPECIFIC,
+                    'additional_shipping_cost' => '5.7',
+                    'delivery_time_notes' => [
+                        'in_stock' => [
+                            1 => 'In stock',
+                            2 => 'Yra sandelyje',
+                        ],
+                        'out_of_stock' => [
+                            1 => 'Out of stock',
+                            2 => 'Isparduota',
+                        ],
+                    ],
+                    'carriers' => [1, 3, 5],
                 ],
             ],
             [$command],
@@ -912,7 +949,17 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             ->setLocalizedShortDescriptions($localizedShortDescriptions)
             ->setLocalizedMetaTitles($localizedMetaTitles)
             ->setLocalizedLinkRewrites($localizedLinkRewrites)
+            ->setWidth('50.5')
+            ->setHeight('40.5')
+            ->setDepth('30.5')
+            ->setWeight('2.2')
+            ->setDeliveryTimeNoteType(DeliveryTimeNoteType::TYPE_SPECIFIC)
+            ->setLocalizedDeliveryTimeOutOfStockNotes([
+                1 => 'Out of stock',
+                2 => 'Isparduota',
+            ])
         ;
+
         $allShopsCommand = $this->getAllShopsCommand();
         $allShopsCommand
             ->setAvailableForOrder(true)
@@ -920,6 +967,12 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             ->setLocalizedDescriptions($localizedDescriptions)
             ->setLocalizedMetaDescriptions($localizedMetaDescriptions)
             ->setRedirectOption(RedirectType::TYPE_PRODUCT_TEMPORARY, 42)
+            ->setAdditionalShippingCost('5.7')
+            ->setLocalizedDeliveryTimeInStockNotes([
+                1 => 'In stock',
+                2 => 'Yra sandelyje',
+            ])
+            ->setCarrierReferenceIds([1, 3, 5])
         ;
 
         yield [
@@ -956,6 +1009,30 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                             self::MODIFY_ALL_SHOPS_PREFIX . 'id' => true,
                         ],
                     ],
+                ],
+                'shipping' => [
+                    'dimensions' => [
+                        'width' => '50.5',
+                        'height' => '40.5',
+                        'depth' => '30.5',
+                        'weight' => '2.2',
+                    ],
+                    'delivery_time_note_type' => DeliveryTimeNoteType::TYPE_SPECIFIC,
+                    'additional_shipping_cost' => '5.7',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'additional_shipping_cost' => true,
+                    'delivery_time_notes' => [
+                        'in_stock' => [
+                            1 => 'In stock',
+                            2 => 'Yra sandelyje',
+                        ],
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'in_stock' => true,
+                        'out_of_stock' => [
+                            1 => 'Out of stock',
+                            2 => 'Isparduota',
+                        ],
+                    ],
+                    'carriers' => [1, 3, 5],
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'carriers' => true,
                 ],
             ],
             [$singleShopCommand, $allShopsCommand],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Following PR https://github.com/PrestaShop/PrestaShop/pull/30031. Introduces Shipping filler and properties into UpdateProductCommand. Covers with behat and unit tests.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | No QA yet. Build with all related tests should pass and should be enough. After this one we will still need to add product status update and then the new approach will be integrated in v2 page it will be testable by QA.
| Possible impacts? | 

Related behats can be run by following commands:
- ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-shipping
- ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-shipping
- ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s update_product --tags update-shipping
- ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s update_product --tags update-multi-shop-shipping

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
