### PR TITLE
Upgrade cancel-workflow-action so that previous AND next same jobs are canceled except the last one

### DIFF
--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
 
       - name: Setup PHP

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
 
       - name: Setup PHP

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -8,6 +8,12 @@ jobs:
       matrix:
         js: [ '16' ]
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
       - name: Setup Node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,12 @@ jobs:
     name: SCSS Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
       - name: Setup Node
@@ -24,6 +30,12 @@ jobs:
     name: ESLint
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
       - uses: actions/checkout@v2
 
       - name: Setup Node
@@ -49,6 +61,12 @@ jobs:
     name: YAML Lint (Symfony Check)
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -83,6 +101,12 @@ jobs:
     name: YAML Lint (YamlLint Check)
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'
@@ -106,6 +130,12 @@ jobs:
     name: Twig Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,6 +8,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
 
       - name: Setup PHP
@@ -51,6 +52,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
 
       - name: Setup PHP
@@ -92,6 +94,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
 
       - name: Check is merge PR

--- a/.github/workflows/sanity-productV2.yml
+++ b/.github/workflows/sanity-productV2.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
 
       - uses: actions/checkout@v2

--- a/.github/workflows/ui_tests_code_checks.yml
+++ b/.github/workflows/ui_tests_code_checks.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
 
       - name: Checkout the repository
@@ -58,6 +59,7 @@ jobs:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0
         with:
+          all_but_latest: true
           access_token: ${{ github.token }}
 
       - name: Checkout the repository


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Adding all_but_latest in all "cancel previous action" and adding "cancel previous action" in every jobs except for actions based on cron. This way we will cancel every jobs which are not the last one for the concerned branch. This avoid to stack actions which are not useful anymore.
| Type?             | improvement
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30227
| Related PRs       | 
| How to test?      | Make a PR and push several commits. See if every jobs except for the last commit are canceled.
| Possible impacts? |


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
