### PR TITLE
Update product.id_category_default after deleting categories

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1311,6 +1311,10 @@ class CategoryCore extends ObjectModel
 			VALUES ' . implode(',', $row)
         );
 
+        if ($flag) {
+            Cache::clean('Product::getProductCategories_' . (int) $idNew);
+        }
+
         return $flag;
     }
 

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -1649,7 +1649,10 @@ class CategoryCore extends ObjectModel
      */
     public function cleanGroups()
     {
-        return Db::getInstance()->delete('category_group', 'id_category = ' . (int) $this->id);
+        $result = Db::getInstance()->delete('category_group', 'id_category = ' . (int) $this->id);
+        Cache::clean($this->getGroupsCacheId());
+
+        return $result;
     }
 
     /**
@@ -1674,6 +1677,8 @@ class CategoryCore extends ObjectModel
                 Db::getInstance()->insert('category_group', ['id_category' => (int) $this->id, 'id_group' => (int) $group]);
             }
         }
+
+        Cache::clean($this->getGroupsCacheId());
     }
 
     /**
@@ -1683,7 +1688,7 @@ class CategoryCore extends ObjectModel
      */
     public function getGroups()
     {
-        $cacheId = 'Category::getGroups_' . (int) $this->id;
+        $cacheId = $this->getGroupsCacheId();
         if (!Cache::isStored($cacheId)) {
             $sql = new DbQuery();
             $sql->select('cg.`id_group`');
@@ -1692,7 +1697,7 @@ class CategoryCore extends ObjectModel
             $result = Db::getInstance()->executeS($sql);
             $groups = [];
             foreach ($result as $group) {
-                $groups[] = $group['id_group'];
+                $groups[] = (int) $group['id_group'];
             }
             Cache::store($cacheId, $groups);
 
@@ -2447,5 +2452,13 @@ class CategoryCore extends ObjectModel
     public function isRootCategory(): bool
     {
         return 0 === (int) $this->id_parent;
+    }
+
+    /**
+     * @return string
+     */
+    private function getGroupsCacheId(): string
+    {
+        return 'Category::getGroups_' . (int) $this->id;
     }
 }

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1766,7 +1766,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         $list = [];
         $sql = 'SELECT id_shop FROM `' . _DB_PREFIX_ . $this->def['table'] . '_shop` WHERE `' . $this->def['primary'] . '` = ' . (int) $this->id;
         foreach (Db::getInstance()->executeS($sql) as $row) {
-            $list[] = $row['id_shop'];
+            $list[] = (int) $row['id_shop'];
         }
 
         return $list;

--- a/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
@@ -102,49 +102,6 @@ abstract class AbstractDeleteCategoryHandler
     }
 
     /**
-     * @todo: move to repository
-     *
-     * @return array
-     */
-    private function findProductsWithoutCategories(): array
-    {
-        $productsWithoutCategory = \Db::getInstance()->executeS('
-			SELECT p.`id_product`
-			FROM `' . _DB_PREFIX_ . 'product` p
-			' . Shop::addSqlAssociation('product', 'p') . '
-			WHERE NOT EXISTS (
-			    SELECT 1 FROM `' . _DB_PREFIX_ . 'category_product` cp WHERE cp.`id_product` = p.`id_product`
-			)
-		');
-
-        return $productsWithoutCategory ?? [];
-    }
-
-    /**
-     * @todo: move to repository sql part of the method - findProductsInDefaultCategories()?
-     *
-     * @param array<int, int[]> $deletedCategoryIdsByParent
-     *
-     * @return array
-     */
-    private function findProductsByDefaultCategories(array $deletedCategoryIdsByParent): array
-    {
-        $deletedCategoryIds = [];
-        foreach ($deletedCategoryIdsByParent as $deletedIds) {
-            $deletedCategoryIds = array_merge($deletedCategoryIds, array_map('intval', $deletedIds));
-        }
-
-        $affectedProducts = \Db::getInstance()->executeS('
-			SELECT p.`id_product`
-			FROM `' . _DB_PREFIX_ . 'product` p
-			' . Shop::addSqlAssociation('product', 'p') . '
-			WHERE p.id_category_default IN (' . implode(',', $deletedCategoryIds) . ')
-		');
-
-        return $affectedProducts ?? [];
-    }
-
-    /**
      * @param int $categoryId
      * @param array<int, int[]> $deletedCategoryIdsByParent
      *
@@ -231,5 +188,48 @@ abstract class AbstractDeleteCategoryHandler
 
             $this->addProductDefaultCategory($product, (int) $product->id_category_default, $deletedCategoryIdsByParent);
         }
+    }
+
+    /**
+     * @todo: move to repository
+     *
+     * @return array
+     */
+    private function findProductsWithoutCategories(): array
+    {
+        $productsWithoutCategory = \Db::getInstance()->executeS('
+			SELECT p.`id_product`
+			FROM `' . _DB_PREFIX_ . 'product` p
+			' . Shop::addSqlAssociation('product', 'p') . '
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM `' . _DB_PREFIX_ . 'category_product` cp WHERE cp.`id_product` = p.`id_product`
+			)
+		');
+
+        return $productsWithoutCategory ?? [];
+    }
+
+    /**
+     * @todo: move to repository sql part of the method - findProductsInDefaultCategories()?
+     *
+     * @param array<int, int[]> $deletedCategoryIdsByParent
+     *
+     * @return array
+     */
+    private function findProductsByDefaultCategories(array $deletedCategoryIdsByParent): array
+    {
+        $deletedCategoryIds = [];
+        foreach ($deletedCategoryIdsByParent as $deletedIds) {
+            $deletedCategoryIds = array_merge($deletedCategoryIds, array_map('intval', $deletedIds));
+        }
+
+        $affectedProducts = \Db::getInstance()->executeS('
+			SELECT p.`id_product`
+			FROM `' . _DB_PREFIX_ . 'product` p
+			' . Shop::addSqlAssociation('product', 'p') . '
+			WHERE p.id_category_default IN (' . implode(',', $deletedCategoryIds) . ')
+		');
+
+        return $affectedProducts ?? [];
     }
 }

--- a/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
@@ -169,10 +169,11 @@ abstract class AbstractDeleteCategoryHandler
         // @todo: inject rootCategoryId into constructor
         $rootCategoryId = (int) Configuration::get('PS_ROOT_CATEGORY');
 
-        $parentCategoryId = $this->findCategoryParentId($categoryId, $deletedCategoryIdsByParent);
-        $product->id_category_default = $parentCategoryId ?: $rootCategoryId;
-        $product->addToCategories($parentCategoryId);
+        $parentCategoryId = $this->findCategoryParentId($categoryId, $deletedCategoryIdsByParent) ?: $rootCategoryId;
+        $product->id_category_default = $parentCategoryId;
         $product->save();
+
+        $product->addToCategories($parentCategoryId);
     }
 
     /**

--- a/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
@@ -81,6 +81,11 @@ abstract class AbstractDeleteCategoryHandler
      */
     protected function handleProductsUpdate($parentCategoryId, CategoryDeleteMode $mode)
     {
+        @trigger_error(
+            __FUNCTION__ . 'is deprecated. Use AbstractDeleteCategoryHandler::updateProductCategories instead.',
+            E_USER_DEPRECATED
+        );
+
         $productsWithoutCategory = \Db::getInstance()->executeS('
 			SELECT p.`id_product`
 			FROM `' . _DB_PREFIX_ . 'product` p

--- a/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
@@ -27,7 +27,6 @@
 namespace PrestaShop\PrestaShop\Adapter\Category\CommandHandler;
 
 use Category;
-use Configuration;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryDeleteMode;
 use Product;
 use Shop;
@@ -37,6 +36,20 @@ use Shop;
  */
 abstract class AbstractDeleteCategoryHandler
 {
+    /**
+     * @var int
+     */
+    protected $homeCategoryId;
+
+    /**
+     * @param int $homeCategoryId
+     */
+    public function __construct(
+        int $homeCategoryId
+    ) {
+        $this->homeCategoryId = $homeCategoryId;
+    }
+
     /**
      * @deprecated
      * @todo: mark as deprecated properly
@@ -145,7 +158,7 @@ abstract class AbstractDeleteCategoryHandler
             }
 
             //@todo: use repository
-            if (!Category::existsInDatabase($categoryId)) {
+            if (!Category::existsInDatabase($parentId)) {
                 // if category doesn't exist, we could continue trying to find another parent
                 // but most of the time this command will be run from BO, which is constructed in a way that
                 // all the deleted category ids will have the same parent,
@@ -166,10 +179,7 @@ abstract class AbstractDeleteCategoryHandler
      */
     private function addProductDefaultCategory(Product $product, int $categoryId, array $deletedCategoryIdsByParent): void
     {
-        // @todo: inject rootCategoryId into constructor
-        $rootCategoryId = (int) Configuration::get('PS_ROOT_CATEGORY');
-
-        $parentCategoryId = $this->findCategoryParentId($categoryId, $deletedCategoryIdsByParent) ?: $rootCategoryId;
+        $parentCategoryId = $this->findCategoryParentId($categoryId, $deletedCategoryIdsByParent) ?: $this->homeCategoryId;
         $product->id_category_default = $parentCategoryId;
         $product->save();
 

--- a/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/AbstractDeleteCategoryHandler.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Category\CommandHandler;
 
+use Configuration;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryDeleteMode;
 use Product;
 use Shop;
@@ -36,6 +37,9 @@ use Shop;
 abstract class AbstractDeleteCategoryHandler
 {
     /**
+     * @deprecated
+     * @todo: mark as deprecated properly
+     *
      * Handle products category after its deletion.
      *
      * @param int $parentCategoryId
@@ -70,6 +74,142 @@ abstract class AbstractDeleteCategoryHandler
                 $product->addToCategories($parentCategoryId);
                 $product->save();
             }
+        }
+    }
+
+    /**
+     * @param array<int, int[]> $deletedCategoryIdsByParent
+     * @param CategoryDeleteMode $mode
+     */
+    protected function updateProductCategories(array $deletedCategoryIdsByParent, CategoryDeleteMode $mode): void
+    {
+        $this->updateProductsWithoutCategories($deletedCategoryIdsByParent, $mode);
+        $this->updateProductsByDefaultCategories($deletedCategoryIdsByParent);
+    }
+
+    /**
+     * @todo: move to repository
+     *
+     * @return array
+     */
+    private function findProductsWithoutCategories(): array
+    {
+        $productsWithoutCategory = \Db::getInstance()->executeS('
+			SELECT p.`id_product`
+			FROM `' . _DB_PREFIX_ . 'product` p
+			' . Shop::addSqlAssociation('product', 'p') . '
+			WHERE NOT EXISTS (
+			    SELECT 1 FROM `' . _DB_PREFIX_ . 'category_product` cp WHERE cp.`id_product` = p.`id_product`
+			)
+		');
+
+        return $productsWithoutCategory ?? [];
+    }
+
+    /**
+     * @todo: move to repository sql part of the method - findProductsInDefaultCategories()?
+     *
+     * @param array<int, int[]> $deletedCategoryIdsByParent
+     *
+     * @return array
+     */
+    private function findProductsByDefaultCategories(array $deletedCategoryIdsByParent): array
+    {
+        $deletedCategoryIds = [];
+        foreach ($deletedCategoryIdsByParent as $deletedIds) {
+            $deletedCategoryIds = array_merge($deletedCategoryIds, array_map('intval', $deletedIds));
+        }
+
+        $affectedProducts = \Db::getInstance()->executeS('
+			SELECT p.`id_product`
+			FROM `' . _DB_PREFIX_ . 'product` p
+			' . Shop::addSqlAssociation('product', 'p') . '
+			WHERE p.id_category_default IN (' . implode(',', $deletedCategoryIds) . ')
+		');
+
+        return $affectedProducts ?? [];
+    }
+
+    /**
+     * @param int $categoryId
+     * @param array<int, int[]> $deletedCategoryIdsByParent
+     *
+     * @return int|null
+     */
+    private function findCategoryParentId(int $categoryId, array $deletedCategoryIdsByParent): ?int
+    {
+        $parentCategoryId = null;
+        foreach ($deletedCategoryIdsByParent as $parentId => $deletedIds) {
+            // find parent id for deleted category
+            if (in_array($categoryId, $deletedIds, true)) {
+                $parentCategoryId = $parentId;
+                break;
+            }
+        }
+
+        return $parentCategoryId;
+    }
+
+    /**
+     * @param Product $product
+     * @param int $categoryId
+     * @param array<int, int[]> $deletedCategoryIdsByParent
+     */
+    private function addProductDefaultCategory(Product $product, int $categoryId, array $deletedCategoryIdsByParent): void
+    {
+        // @todo: inject rootCategoryId into constructor
+        $rootCategoryId = (int) Configuration::get('PS_ROOT_CATEGORY');
+
+        $parentCategoryId = $this->findCategoryParentId($categoryId, $deletedCategoryIdsByParent);
+        $product->id_category_default = $parentCategoryId ?: $rootCategoryId;
+        $product->addToCategories($parentCategoryId);
+        $product->save();
+    }
+
+    /**
+     * @param array<int, int[]> $deletedCategoryIdsByParent
+     * @param CategoryDeleteMode $mode
+     */
+    private function updateProductsWithoutCategories(array $deletedCategoryIdsByParent, CategoryDeleteMode $mode): void
+    {
+        $productsWithoutCategories = $this->findProductsWithoutCategories();
+
+        foreach ($productsWithoutCategories as $productWithoutCategory) {
+            //@todo: use ProductRepository->get()?
+            $product = new Product((int) $productWithoutCategory['id_product']);
+
+            if (!$product->id) {
+                continue;
+            }
+
+            if ($mode->shouldRemoveProducts()) {
+                $product->delete();
+
+                continue;
+            }
+
+            if ($mode->shouldDisableProducts()) {
+                $product->active = false;
+            }
+
+            $this->addProductDefaultCategory($product, (int) $product->id_category_default, $deletedCategoryIdsByParent);
+        }
+    }
+
+    /**
+     * @param array<int, int[]> $deletedCategoryIdsByParent
+     */
+    private function updateProductsByDefaultCategories(array $deletedCategoryIdsByParent): void
+    {
+        $affectedProductsByDefaultCategory = $this->findProductsByDefaultCategories($deletedCategoryIdsByParent);
+
+        foreach ($affectedProductsByDefaultCategory as $affectedProduct) {
+            $product = new Product((int) $affectedProduct['id_product']);
+            if (!$product->id) {
+                continue;
+            }
+
+            $this->addProductDefaultCategory($product, (int) $product->id_category_default, $deletedCategoryIdsByParent);
         }
     }
 }

--- a/src/Adapter/Category/CommandHandler/BulkDeleteCategoriesHandler.php
+++ b/src/Adapter/Category/CommandHandler/BulkDeleteCategoriesHandler.php
@@ -47,6 +47,7 @@ final class BulkDeleteCategoriesHandler extends AbstractDeleteCategoryHandler im
      */
     public function handle(BulkDeleteCategoriesCommand $command)
     {
+        $deletedCategoryIdsByParent = [];
         foreach ($command->getCategoryIds() as $categoryId) {
             $category = new Category($categoryId->getValue());
 
@@ -62,7 +63,13 @@ final class BulkDeleteCategoriesHandler extends AbstractDeleteCategoryHandler im
                 throw new FailedToDeleteCategoryException(sprintf('Failed to delete category with id %s', var_export($categoryId->getValue(), true)));
             }
 
-            $this->handleProductsUpdate((int) $category->id_parent, $command->getDeleteMode());
+            $deletedCategoryIdsByParent[(int) $category->id_parent] = [$categoryId->getValue()];
         }
+
+        if (empty($deletedCategoryIdsByParent)) {
+            return;
+        }
+
+        $this->updateProductCategories($deletedCategoryIdsByParent, $command->getDeleteMode());
     }
 }

--- a/src/Adapter/Category/CommandHandler/BulkDeleteCategoriesHandler.php
+++ b/src/Adapter/Category/CommandHandler/BulkDeleteCategoriesHandler.php
@@ -63,7 +63,7 @@ final class BulkDeleteCategoriesHandler extends AbstractDeleteCategoryHandler im
                 throw new FailedToDeleteCategoryException(sprintf('Failed to delete category with id %s', var_export($categoryId->getValue(), true)));
             }
 
-            $deletedCategoryIdsByParent[(int) $category->id_parent] = [$categoryId->getValue()];
+            $deletedCategoryIdsByParent[(int) $category->id_parent][] = $categoryId->getValue();
         }
 
         if (empty($deletedCategoryIdsByParent)) {

--- a/src/Adapter/Category/CommandHandler/DeleteCategoryHandler.php
+++ b/src/Adapter/Category/CommandHandler/DeleteCategoryHandler.php
@@ -62,6 +62,8 @@ final class DeleteCategoryHandler extends AbstractDeleteCategoryHandler implemen
             throw new FailedToDeleteCategoryException(sprintf('Failed to delete category with id %s', var_export($categoryIdValue, true)));
         }
 
-        $this->handleProductsUpdate((int) $category->id_parent, $command->getDeleteMode());
+        $this->updateProductCategories([
+            (int) $category->id_parent => [$categoryIdValue],
+        ], $command->getDeleteMode());
     }
 }

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Repository;
 
-use Db;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Exception;
 use Doctrine\DBAL\Exception as ExceptionAlias;
@@ -61,7 +60,6 @@ use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
 use PrestaShopException;
 use Product;
-use Shop;
 
 /**
  * Methods to access data storage for Product
@@ -561,55 +559,5 @@ class ProductRepository extends AbstractObjectModelRepository
         }
 
         return $product;
-    }
-
-    /**
-     * @return ProductId[]
-     */
-    public function findProductIdsWithoutCategories(): array
-    {
-        $results = Db::getInstance()->executeS('
-			SELECT p.`id_product`
-			FROM `' . _DB_PREFIX_ . 'product` p
-			' . Shop::addSqlAssociation('product', 'p') . '
-			WHERE NOT EXISTS (
-			    SELECT 1 FROM `' . _DB_PREFIX_ . 'category_product` cp WHERE cp.`id_product` = p.`id_product`
-			)
-		');
-
-        return $this->buildProductIdsFromResults($results);
-    }
-
-    /**
-     * @param int[] $defaultCategoryIds
-     *
-     * @return ProductId[]
-     */
-    public function findProductIdsByDefaultCategories(array $defaultCategoryIds): array
-    {
-        $results = Db::getInstance()->executeS('
-			SELECT p.`id_product`
-			FROM `' . _DB_PREFIX_ . 'product` p
-			' . Shop::addSqlAssociation('product', 'p') . '
-			WHERE p.id_category_default IN (' . implode(',', array_map('intval', $defaultCategoryIds)) . ')
-		');
-
-        return $this->buildProductIdsFromResults($results);
-    }
-
-    /**
-     * @param array<int, array<string, mixed>> $results
-     *
-     * @return ProductId[]
-     */
-    private function buildProductIdsFromResults(array $results): array
-    {
-        if (empty($results)) {
-            return [];
-        }
-
-        return array_map(static function (array $result): ProductId {
-            return new ProductId((int) $result['id_product']);
-        }, $results);
     }
 }

--- a/src/Core/Domain/Category/Command/EditRootCategoryCommand.php
+++ b/src/Core/Domain/Category/Command/EditRootCategoryCommand.php
@@ -31,6 +31,9 @@ use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 
 /**
  * Class EditRootCategoryCommand edits given root category.
+ *
+ * @todo: "root" keyword should be replaced by "home" to avoid confusion between the actual "root" category and "home" category.
+ *         This command is actually handling th Home category edition, as the actual "root" category doesn't exist from UX perspective
  */
 class EditRootCategoryCommand
 {

--- a/src/Core/Domain/Category/Command/EditRootCategoryCommand.php
+++ b/src/Core/Domain/Category/Command/EditRootCategoryCommand.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
  * Class EditRootCategoryCommand edits given root category.
  *
  * @todo: "root" keyword should be replaced by "home" to avoid confusion between the actual "root" category and "home" category.
- *         This command is actually handling th Home category edition, as the actual "root" category doesn't exist from UX perspective
+ *         This command is actually handling the Home category edition, as the actual "root" category doesn't exist from UX perspective
  */
 class EditRootCategoryCommand
 {

--- a/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
@@ -39,6 +39,8 @@ services:
     abstract: true
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id_category'
+      - '@prestashop.adapter.product.repository.product_repository'
+      - '@prestashop.adapter.category.repository.category_repository'
 
   prestashop.adapter.category.command_handler.delete_category_handler:
     class: PrestaShop\PrestaShop\Adapter\Category\CommandHandler\DeleteCategoryHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/category.yml
@@ -34,14 +34,24 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Category\Command\SetCategoryIsEnabledCommand
 
+  prestashop.adapter.category.command_handler.abstract_delete_category_handler:
+    class: PrestaShop\PrestaShop\Adapter\Category\CommandHandler\AbstractDeleteCategoryHandler
+    abstract: true
+    arguments:
+      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id_category'
+
   prestashop.adapter.category.command_handler.delete_category_handler:
     class: PrestaShop\PrestaShop\Adapter\Category\CommandHandler\DeleteCategoryHandler
+    parent: prestashop.adapter.category.command_handler.abstract_delete_category_handler
+    public: true
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Category\Command\DeleteCategoryCommand
 
   prestashop.adapter.category.command_handler.bulk_delete_categories_handler:
     class: PrestaShop\PrestaShop\Adapter\Category\CommandHandler\BulkDeleteCategoriesHandler
+    parent: prestashop.adapter.category.command_handler.abstract_delete_category_handler
+    public: true
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDeleteCategoriesCommand

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -252,6 +252,25 @@ abstract class AbstractDomainFeatureContext implements Context
     }
 
     /**
+     * @param string $references
+     *
+     * @return int[]
+     */
+    protected function referencesToIds(string $references): array
+    {
+        $ids = [];
+        foreach (explode(',', $references) as $reference) {
+            if ($this->getSharedStorage()->exists($reference)) {
+                $ids[] = $this->getSharedStorage()->get($reference);
+            }
+
+            throw new RuntimeException('Reference %s does not exist in shared storage');
+        }
+
+        return $ids;
+    }
+
+    /**
      * @param TableNode $tableNode
      *
      * @return array

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -260,11 +260,11 @@ abstract class AbstractDomainFeatureContext implements Context
     {
         $ids = [];
         foreach (explode(',', $references) as $reference) {
-            if ($this->getSharedStorage()->exists($reference)) {
-                $ids[] = $this->getSharedStorage()->get($reference);
+            if (!$this->getSharedStorage()->exists($reference)) {
+                throw new RuntimeException(sprintf('Reference %s does not exist in shared storage', $reference));
             }
 
-            throw new RuntimeException('Reference %s does not exist in shared storage');
+            $ids[] = $this->getSharedStorage()->get($reference);
         }
 
         return $ids;

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -374,8 +374,6 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
      * Technically both commands should be filled separately,
      * but it happens to match almost all properties except $parentId, so we can reuse them here.
      *
-     * Probably these commands are implemented wrong and instead should have extended each other if they supposed to share the properties and the logic,
-     * but that would require some more refactoring and BC breaks, so for now, lets just avoid duplicating the code at least here in test.
      * If in future these commands evolves differently (which probably won't happen),
      * then don't hesitate to extract this method into 2 dedicated ones.
      */

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -905,11 +905,11 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
      */
     private function getCategory(int $categoryId): Category
     {
-        // There is no position in EditableCategory class, so we ensure its correct by loading legacy ObjectModel
+        // There is no position in EditableCategory class, so we ensure it is correct by loading legacy ObjectModel
         $category = new Category($categoryId);
 
         if ((int) $category->id !== $categoryId) {
-            throw new RuntimeException(sprintf('Failed to load category with id %d', $categoryId, ));
+            throw new RuntimeException(sprintf('Failed to load category with id %d', $categoryId));
         }
 
         return $category;

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -52,7 +52,6 @@ use PrestaShop\PrestaShop\Core\Domain\Category\QueryResult\EditableCategory;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 use RuntimeException;
 use Shop;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 use Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext;
@@ -67,9 +66,6 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
         'up' => 0,
         'down' => 1,
     ];
-
-    /** @var ContainerInterface */
-    private $container;
 
     /** @var int */
     private $defaultLanguageId;
@@ -87,7 +83,6 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
      */
     public function __construct()
     {
-        $this->container = $this->getContainer();
         $this->defaultLanguageId = (int) Configuration::get('PS_LANG_DEFAULT');
         $this->psCatImgDir = _PS_CAT_IMG_DIR_;
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -329,7 +329,7 @@ class CategoryFeatureContext extends AbstractDomainFeatureContext
             $command = new AddRootCategoryCommand(
                 $data['name'],
                 $data['link rewrite'],
-                PrimitiveUtils::castStringBooleanIntoBoolean($data['active']),
+                PrimitiveUtils::castStringBooleanIntoBoolean($data['active'])
             );
         } else {
             $command = new AddCategoryCommand(

--- a/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CategoryFeatureContext.php
@@ -31,7 +31,6 @@ use Category;
 use Configuration;
 use Language;
 use PHPUnit\Framework\Assert as Assert;
-use PrestaShop\PrestaShop\Adapter\Form\ChoiceProvider\GroupByIdChoiceProvider;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\AddCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\AddRootCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDeleteCategoriesCommand;

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
@@ -75,7 +75,7 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
             $actualType = $imageTypes[$key];
             Assert::assertEquals($expectedType['name'], $actualType->name, 'Unexpected image type name');
             Assert::assertEquals($expectedType['width'], $actualType->width, 'Unexpected image type width');
-            Assert::assertEquals($expectedType['height'], $actualType->width, 'Unexpected image type height');
+            Assert::assertEquals($expectedType['height'], $actualType->height, 'Unexpected image type height');
 
             $this->getSharedStorage()->set($expectedType['reference'], (int) $actualType->id);
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
-use Cache;
 use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllAssociatedProductCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetAssociatedProductCategoriesCommand;

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCategoriesFeatureContext.php
@@ -83,7 +83,6 @@ class UpdateCategoriesFeatureContext extends AbstractProductFeatureContext
      */
     public function assertProductCategories(string $productReference, TableNode $table)
     {
-        Cache::clear();
         $productForEditing = $this->getProductForEditing($productReference);
         $expectedCategories = $table->getColumnsHash();
         $categoriesInfo = $productForEditing->getCategoriesInformation();

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -145,7 +145,7 @@ Feature: Category Management
     When I delete category "category5" choosing mode "remove_associated"
     Then category "category5" does not exist
 
-  Scenario: delete categories which are assigned to products
+  Scenario: Delete category which is assigned to product and it is the only one left by using different deletion modes
     Given I add new category "category6" with following details:
       | name[en-US]         | Mobile phones6    |
       | name[fr-FR]         | Mobile phones6 fr |
@@ -156,31 +156,149 @@ Feature: Category Management
     And I add product "product1" with following information:
       | name[en-US] | bottle of beer |
       | type        | standard       |
-    Then product "product1" should be disabled
-    And product "product1" type should be standard
+    And I enable product "product1"
+    And product "product1" should be enabled
     And product "product1" should be assigned to following categories:
       | id reference | name[en-US] | name[fr-FR] | is default |
       | home         | Home        | Home        | true       |
     And I assign product product1 to following categories:
-      | categories       | [home,category6] |
-      | default category | category6        |
+      | categories       | [category6] |
+      | default category | category6   |
     Then product "product1" should be assigned to following categories:
       | id reference | name[en-US]    | name[fr-FR]       | is default |
-      | home         | Home           | Home              | false      |
       | category6    | Mobile phones6 | Mobile phones6 fr | true       |
+    # associate_and_disable mode case
     When I delete category "category6" choosing mode "associate_and_disable"
     Then category "category6" does not exist
+    # product should be disabled and associated with the deleted category parent
     Then product "product1" should be assigned to following categories:
+      | id reference     | name[en-US]      | name[fr-FR]      | is default |
+      | home-accessories | Home Accessories | Home Accessories | true       |
+    And product "product1" should be disabled
+    Given I add new category "category7" with following details:
+      | name[en-US]         | Mobile phones7    |
+      | name[fr-FR]         | Mobile phones7 fr |
+      | active              | false             |
+      | parent category     | home-accessories  |
+      | link rewrite[en-US] | mobile-phones-en  |
+      | link rewrite[fr-FR] | mobile-phones-fr  |
+    And I enable product "product1"
+    And I assign product product1 to following categories:
+      | categories       | [category7] |
+      | default category | category7   |
+    And product "product1" should be assigned to following categories:
+      | id reference | name[en-US]    | name[fr-FR]       | is default |
+      | category7    | Mobile phones7 | Mobile phones7 fr | true       |
+    # associate_only mode case
+    When I delete category "category7" choosing mode "associate_only"
+    # product should be still be enabled and associated with the deleted category parent
+    Then product "product1" should be assigned to following categories:
+      | id reference     | name[en-US]      | name[fr-FR]      | is default |
+      | home-accessories | Home Accessories | Home Accessories | true       |
+    And product "product1" should be enabled
+    Given I add new category "category8" with following details:
+      | name[en-US]         | Mobile phones8    |
+      | name[fr-FR]         | Mobile phones8 fr |
+      | active              | false             |
+      | parent category     | home-accessories  |
+      | link rewrite[en-US] | mobile-phones-en  |
+      | link rewrite[fr-FR] | mobile-phones-fr  |
+    And I assign product product1 to following categories:
+      | categories       | [category8] |
+      | default category | category8   |
+    And product "product1" should be assigned to following categories:
+      | id reference | name[en-US]    | name[fr-FR]       | is default |
+      | category8    | Mobile phones8 | Mobile phones8 fr | true       |
+    # remove_associated mode case
+    When I delete category "category8" choosing mode "remove_associated"
+    # product should be removed
+    Then product "product1" should not exist anymore
+
+  Scenario: Delete category which is assigned as default for some product, but is not the last category of that product
+    Given I add new category "category9" with following details:
+      | name[en-US]         | Mobile phones9    |
+      | name[fr-FR]         | Mobile phones9 fr |
+      | active              | false             |
+      | parent category     | home-accessories  |
+      | link rewrite[en-US] | mobile-phones-en  |
+      | link rewrite[fr-FR] | mobile-phones-fr  |
+    And I add product "product2" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    And I enable product "product2"
+    And I assign product product2 to following categories:
+      | categories       | [home,category9] |
+      | default category | category9        |
+    Then product "product2" should be assigned to following categories:
+      | id reference | name[en-US]    | name[fr-FR]       | is default |
+      | home         | Home           | Home              | false      |
+      | category9    | Mobile phones9 | Mobile phones9 fr | true       |
+    When I delete category "category9" choosing mode "associate_and_disable"
+    Then category "category9" does not exist
+    # should assign the parent of the deleted category as the default one. Product status shouldn't be impacted.
+    Then product "product2" should be assigned to following categories:
       | id reference     | name[en-US]      | name[fr-FR]      | is default |
       | home             | Home             | Home             | false      |
       | home-accessories | Home Accessories | Home Accessories | true       |
+    And product "product2" should be enabled
+    # repeat the same with different modes to ensure that the modes doesn't have impact
+    Given I add new category "category10" with following details:
+      | name[en-US]         | Mobile phones10    |
+      | name[fr-FR]         | Mobile phones10 fr |
+      | active              | false              |
+      | parent category     | home-accessories   |
+      | link rewrite[en-US] | mobile-phones-en   |
+      | link rewrite[fr-FR] | mobile-phones-fr   |
+    And I assign product product2 to following categories:
+      | categories       | [home,category10] |
+      | default category | category10        |
+    # associate_only mode case
+    When I delete category "category10" choosing mode "associate_only"
+    Then category "category10" does not exist
+    Then product "product2" should be assigned to following categories:
+      | id reference     | name[en-US]      | name[fr-FR]      | is default |
+      | home             | Home             | Home             | false      |
+      | home-accessories | Home Accessories | Home Accessories | true       |
+    And product "product2" should be enabled
+    Given I add new category "category11" with following details:
+      | name[en-US]         | Mobile phones11    |
+      | name[fr-FR]         | Mobile phones11 fr |
+      | active              | false              |
+      | parent category     | home-accessories   |
+      | link rewrite[en-US] | mobile-phones-en   |
+      | link rewrite[fr-FR] | mobile-phones-fr   |
+    And I assign product product2 to following categories:
+      | categories       | [home,category11] |
+      | default category | category11        |
+    # remove_associated mode case
+    When I delete category "category11" choosing mode "remove_associated"
+    Then category "category11" does not exist
+    Then product "product2" should be assigned to following categories:
+      | id reference     | name[en-US]      | name[fr-FR]      | is default |
+      | home             | Home             | Home             | false      |
+      | home-accessories | Home Accessories | Home Accessories | true       |
+    And product "product2" should be enabled
 
-#  Scenario: Bulk delete categories
-#    And I bulk delete categories "category1,category2" choosing mode "associate_and_disable"
-#    Then category "category1" does not exist
-#    And category "category2" does not exist
+  Scenario: Bulk delete categories
+    Given I add new category "category12" with following details:
+      | name[en-US]         | Mobile phones12    |
+      | name[fr-FR]         | Mobile phones12 fr |
+      | active              | false              |
+      | parent category     | home-accessories   |
+      | link rewrite[en-US] | mobile-phones-en   |
+      | link rewrite[fr-FR] | mobile-phones-fr   |
+    Given I add new category "category13" with following details:
+      | name[en-US]         | Mobile phones12    |
+      | name[fr-FR]         | Mobile phones12 fr |
+      | active              | false              |
+      | parent category     | home-accessories   |
+      | link rewrite[en-US] | mobile-phones-en   |
+      | link rewrite[fr-FR] | mobile-phones-fr   |
+    And I bulk delete categories "category12,category13" choosing mode "associate_and_disable"
+    Then category "category12" does not exist
+    And category "category13" does not exist
 
-##    update category not available for multi shop context
+  # update category not available for multi shop context
 #  Scenario: Update category position
 #    When I add new category "category2" with following details:
 #      | Name            | PC parts 2       |

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -39,6 +39,8 @@ Feature: Category Management
       | meta description[fr-FR]       | meta description french        |
       | meta title[en-US]             | meta title english             |
       | meta title[fr-FR]             | meta title french              |
+      | meta keywords[en-US]          | meta,keyword,english           |
+      | meta keywords[fr-FR]          | meta,keyword,french            |
     Then category "category1" should have following details:
       | name[en-US]                   | PC parts                       |
       | name[fr-FR]                   | PC parts fr                    |
@@ -56,6 +58,8 @@ Feature: Category Management
       | meta description[fr-FR]       | meta description french        |
       | meta title[en-US]             | meta title english             |
       | meta title[fr-FR]             | meta title french              |
+      | meta keywords[en-US]          | meta,keyword,english           |
+      | meta keywords[fr-FR]          | meta,keyword,french            |
 
   Scenario: Edit category
     Given I add new category "category2" with following details:
@@ -82,6 +86,8 @@ Feature: Category Management
       | meta description[fr-FR]       |                                       |
       | meta title[en-US]             |                                       |
       | meta title[fr-FR]             |                                       |
+      | meta keywords[en-US]          |                                       |
+      | meta keywords[fr-FR]          |                                       |
     When I edit category "category2" with following details:
       | name[en-US]                   | Mobile phones super            |
       | name[fr-FR]                   | Mobile phones super fr         |
@@ -98,6 +104,8 @@ Feature: Category Management
       | meta description[fr-FR]       | meta description french        |
       | meta title[en-US]             | meta title english             |
       | meta title[fr-FR]             | meta title french              |
+      | meta keywords[en-US]          | meta,keyword,english           |
+      | meta keywords[fr-FR]          | meta,keyword,french            |
     Then category "category2" should have following details:
       | name[en-US]                   | Mobile phones super            |
       | name[fr-FR]                   | Mobile phones super fr         |
@@ -115,6 +123,8 @@ Feature: Category Management
       | meta description[fr-FR]       | meta description french        |
       | meta title[en-US]             | meta title english             |
       | meta title[fr-FR]             | meta title french              |
+      | meta keywords[en-US]          | meta,keyword,english           |
+      | meta keywords[fr-FR]          | meta,keyword,french            |
 
   Scenario: Delete category
     Given I add new category "category3" with following details:
@@ -344,27 +354,52 @@ Feature: Category Management
     Then category "category16" position should be "1"
     Then category "category14" position should be "2"
     Then category "category17" position should be "3"
-#
-#  Scenario: Edit home category
-#    When I edit home category "Home" with following details:
-#      | Name             | dummy root category name    |
-#      | Displayed        | false                       |
-#      | Description      | dummy root description      |
-#      | Meta title       | dummy root meta title       |
-#      | Meta description | dummy root meta description |
-#      | Friendly URL     | dummy-root                  |
-#      | Group access     | Visitor,Guest,Customer      |
-#    Then category "Home" should have following details:
-#      | Name             | dummy root category name    |
-#      | Displayed        | false                       |
-#      | Parent category  | Root                        |
-#      | Description      | dummy root description      |
-#      | Meta title       | dummy root meta title       |
-#      | Meta description | dummy root meta description |
-#      | Friendly URL     | dummy-root                  |
-#      | Group access     | Visitor,Guest,Customer      |
-#
-#  Scenario: Add root category
+    When I move category "category17" up to a position "1"
+    Then category "category15" position should be "0"
+    Then category "category17" position should be "1"
+    Then category "category16" position should be "2"
+    Then category "category14" position should be "3"
+
+  Scenario: Edit home category
+    When I edit home category "home" with following details:
+      | name[en-US]                   | PC parts                       |
+      | name[fr-FR]                   | PC parts fr                    |
+      | active                        | false                          |
+      | link rewrite[en-US]           | pc-parts                       |
+      | link rewrite[fr-FR]           | pc-parts-fr                    |
+      | group access                  | visitorGroup,guestGroup        |
+      | associated shops              | shop1                          |
+      | description[en-US]            | description english            |
+      | description[fr-FR]            | description french             |
+      | additional description[en-US] | additional description english |
+      | additional description[fr-FR] | additional description french  |
+      | meta description[en-US]       | meta description english       |
+      | meta description[fr-FR]       | meta description french        |
+      | meta title[en-US]             | meta title english             |
+      | meta title[fr-FR]             | meta title french              |
+      | meta keywords[en-US]          | meta,keyword,english           |
+      | meta keywords[fr-FR]          | meta,keyword,french            |
+    Then category "home" should have following details:
+      | name[en-US]                   | PC parts                       |
+      | name[fr-FR]                   | PC parts fr                    |
+      | active                        | false                          |
+      | parent category               | root                           |
+      | link rewrite[en-US]           | pc-parts                       |
+      | link rewrite[fr-FR]           | pc-parts-fr                    |
+      | group access                  | visitorGroup,guestGroup        |
+      | associated shops              | shop1                          |
+      | description[en-US]            | description english            |
+      | description[fr-FR]            | description french             |
+      | additional description[en-US] | additional description english |
+      | additional description[fr-FR] | additional description french  |
+      | meta description[en-US]       | meta description english       |
+      | meta description[fr-FR]       | meta description french        |
+      | meta title[en-US]             | meta title english             |
+      | meta title[fr-FR]             | meta title french              |
+      | meta keywords[en-US]          | meta,keyword,english           |
+      | meta keywords[fr-FR]          | meta,keyword,french            |
+##
+#  Scenario: Add home category
 #    When I add new root category "root1" with following details:
 #      | Name             | dummy root category name    |
 #      | Displayed        | false                       |
@@ -382,7 +417,7 @@ Feature: Category Management
 #      | Meta description | dummy root meta description |
 #      | Friendly URL     | dummy-root                  |
 #      | Group access     | Visitor,Guest,Customer      |
-#
+
 #  Scenario: delete category cover image
 #    Given I edit category "category1" with following details:
 #      | Name                 | dummy category name    |

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -6,21 +6,41 @@ Feature: Category Management
   As a BO user
   I must be able to create, edit and delete categories in my shop
 
-  Background: Adding new Category
-    Given category "home" in default language named "Home" exists
-    And category "home" is the default one
+  Background:
+    Given shop "shop1" with name "test_shop" exists
+    And language "en" with locale "en-US" exists
+    And language with iso code "en" is the default one
+    And language "fr" with locale "fr-FR" exists
+    And category "home" in default language named "Home" exists
+    And category "root" in default language named "Root" exists
+    And category "root" is the root category and it cannot be edited
+    And single shop context is loaded
+    And category "home" is set as the home category for shop "shop1"
     And category "home-accessories" in default language named "Home Accessories" exists
-    And I add new category "category1" with following details:
-      | Name            | PC parts         |
-      | Displayed       | false            |
-      | Parent category | Home Accessories |
-      | Friendly URL    | pc-parts         |
 
+  Scenario: Add category
+    When I add new category "category1" with following details:
+      | name[en-US]         | PC parts         |
+      | name[fr-FR]         | PC parts fr      |
+      | displayed           | false            |
+      | parent category     | home-accessories |
+      | link rewrite[en-US] | pc-parts         |
+      | link rewrite[fr-FR] | pc-parts-fr      |
+#    Then category "category1" should have following details:
+#      | Name                   | dummy category name      |
+#      | Displayed              | false                    |
+#      | Parent category        | home-accessories         |
+#      | Description            | dummy description        |
+#      | Additional description | dummy bottom description |
+#      | Meta title             | dummy meta title         |
+#      | Meta description       | dummy meta description   |
+#      | Friendly URL           | dummy                    |
+#      | Group access           | Visitor,Guest,Customer   |
 #  Scenario: Edit category
 #    When I edit category "category1" with following details:
 #      | Name                   | dummy category name      |
 #      | Displayed              | false                    |
-#      | Parent category        | Home Accessories         |
+#      | Parent category        | home-accessories         |
 #      | Description            | dummy description        |
 #      | Additional description | dummy bottom description |
 #      | Meta title             | dummy meta title         |
@@ -30,14 +50,14 @@ Feature: Category Management
 #    Then category "category1" should have following details:
 #      | Name                   | dummy category name      |
 #      | Displayed              | false                    |
-#      | Parent category        | Home Accessories         |
+#      | Parent category        | home-accessories         |
 #      | Description            | dummy description        |
 #      | Additional description | dummy bottom description |
 #      | Meta title             | dummy meta title         |
 #      | Meta description       | dummy meta description   |
 #      | Friendly URL           | dummy                    |
 #      | Group access           | Visitor,Guest,Customer   |
-#
+
 #  Scenario: Delete category
 #    When I delete category "category1" choosing mode "associate_and_disable"
 #    Then category "category1" does not exist
@@ -64,8 +84,8 @@ Feature: Category Management
 #      | Way             | Up               |
 #      | Found first     | false            |
 #
-#  Scenario: Edit root category
-#    When I edit root category "Home" with following details:
+#  Scenario: Edit home category
+#    When I edit home category "Home" with following details:
 #      | Name             | dummy root category name    |
 #      | Displayed        | false                       |
 #      | Description      | dummy root description      |
@@ -166,43 +186,40 @@ Feature: Category Management
 #    When I bulk disable categories "category1,category2"
 #    Then category "category1" is disabled
 #    And category "category2" is disabled
-
-  Scenario: delete categories which are assigned to products
-    When I add new root category "root1" with following details:
-      | Name             | dummy root category name    |
-      | Displayed        | false                       |
-      | Description      | dummy root description      |
-      | Meta title       | dummy root meta title       |
-      | Meta description | dummy root meta description |
-      | Friendly URL     | dummy-root                  |
-      | Group access     | Visitor,Guest,Customer      |
-    Given category "root1" in default language named "dummy root category name" exists
-    And I add product "product1" with following information:
-      | name[en-US] | bottle of beer |
-      | type        | standard       |
-    Then product "product1" should be disabled
-    And product "product1" type should be standard
-    And product "product1" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | true       |
-    And I add new category "category3" with following details:
-      | Name            | PC parts 3       |
-      | Displayed       | true             |
-      | Parent category | Home Accessories |
-      | Friendly URL    | pc-parts3        |
-    And I assign product product1 to following categories:
-      | categories       | [home,category3] |
-      | default category | category3        |
-    Then product "product1" should be assigned to following categories:
-      | id reference | name[en-US] | is default |
-      | home         | Home        | false      |
-      | category3    | PC parts 3  | true       |
-    When I bulk delete categories "category3" choosing mode "associate_and_disable"
-    Then category "category3" does not exist
-    Then product "product1" should be assigned to following categories:
-      | id reference     | name[en-US]      | is default |
-      | home             | Home             | false      |
-      #@todo: expecting home accessories, but its id is different than i would expect
-      #       probably cuz of retarded parent category assign by name instead of reference
-      #       on line 191
-      | home-accessories | Home Accessories | true       |
+#
+#  Scenario: delete categories which are assigned to products
+#    When I add new home category "root1" with following details:
+#      | Name             | dummy root category name    |
+#      | Displayed        | false                       |
+#      | Description      | dummy root description      |
+#      | Meta title       | dummy root meta title       |
+#      | Meta description | dummy root meta description |
+#      | Friendly URL     | dummy-root                  |
+#      | Group access     | Visitor,Guest,Customer      |
+#    Given category "root1" in default language named "dummy root category name" exists
+#    And I add product "product1" with following information:
+#      | name[en-US] | bottle of beer |
+#      | type        | standard       |
+#    Then product "product1" should be disabled
+#    And product "product1" type should be standard
+#    And product "product1" should be assigned to following categories:
+#      | id reference | name[en-US] | is default |
+#      | home         | Home        | true       |
+#    And I add new category "category3" with following details:
+#      | Name            | PC parts 3       |
+#      | Displayed       | true             |
+#      | Parent category | Home Accessories |
+#      | Friendly URL    | pc-parts3        |
+#    And I assign product product1 to following categories:
+#      | categories       | [home,category3] |
+#      | default category | category3        |
+#    Then product "product1" should be assigned to following categories:
+#      | id reference | name[en-US] | is default |
+#      | home         | Home        | false      |
+#      | category3    | PC parts 3  | true       |
+#    When I delete category "category3" choosing mode "associate_and_disable"
+#    Then category "category3" does not exist
+#    Then product "product1" should be assigned to following categories:
+#      | id reference     | name[en-US]      | is default |
+#      | home             | Home             | false      |
+#      | home-accessories | Home Accessories | true       |

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -226,8 +226,7 @@ Feature: Category Management
     # product should be removed
     Then product "product1" should not exist anymore
 
-  Scenario: Bulk delete categories which are the last remaining associated categories for some product
-  by using associate_only deletion mode
+  Scenario: Bulk delete categories which are the last remaining associated categories for some product by using associate_only deletion mode
     Given I add new category "category_b6" with following details:
       | name[en-US]         | not important    |
       | name[fr-FR]         | not important    |
@@ -288,8 +287,7 @@ Feature: Category Management
     And product "product_b1" should be enabled
     And product "product_b2" should be enabled
 
-  Scenario: Bulk delete categories which are the last remaining associated categories for some product
-  by using associate_and_disable deletion mode
+  Scenario: Bulk delete categories which are the last remaining associated categories for some product by using associate_and_disable deletion mode
     Given I add new category "category_b9" with following details:
       | name[en-US]         | not important |
       | name[fr-FR]         | not important |
@@ -340,8 +338,7 @@ Feature: Category Management
     And product "product_b1" should be disabled
     And product "product_b2" should be disabled
 
-  Scenario: Bulk delete categories which are the last remaining associated categories for some product
-  by using associate_and_remove deletion mode
+  Scenario: Bulk delete categories which are the last remaining associated categories for some product by using associate_and_remove deletion mode
     Given I add new category "category_b11" with following details:
       | name[en-US]         | not important |
       | name[fr-FR]         | not important |
@@ -383,8 +380,7 @@ Feature: Category Management
     And product "product_b1" should not exist anymore
     And product "product_b2" should not exist anymore
 
-  Scenario: Delete category which is assigned as default for some product, but is not the last category of that product
-  by using associate_and_disable deletion mode
+  Scenario: Delete category which is assigned as default for some product, but is not the last category of that product by using associate_and_disable deletion mode
     # deletion mode shouldn't have impact for this scenario
     Given I add new category "category9" with following details:
       | name[en-US]         | Mobile phones9    |
@@ -413,8 +409,7 @@ Feature: Category Management
     And product "product2" should be enabled
 
 
-  Scenario: Delete category which is assigned as default for some product, but is not the last category of that product
-  by using associate_only deletion mode
+  Scenario: Delete category which is assigned as default for some product, but is not the last category of that product by using associate_only deletion mode
     # deletion mode shouldn't have impact for this scenario
     Given I add new category "category10" with following details:
       | name[en-US]         | Mobile phones10    |
@@ -434,8 +429,7 @@ Feature: Category Management
       | home-accessories | Home Accessories | true       |
     And product "product2" should be enabled
 
-  Scenario: Delete category which is assigned as default for some product, but is not the last category of that product
-  by using remove_associated deletion mode
+  Scenario: Delete category which is assigned as default for some product, but is not the last category of that product by using remove_associated deletion mode
     # deletion mode shouldn't have impact for this scenario
     Given I add new category "category11" with following details:
       | name[en-US]         | Mobile phones11    |

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -18,6 +18,7 @@ Feature: Category Management
     And single shop context is loaded
     And category "home" is set as the home category for shop "shop1"
     And category "home-accessories" in default language named "Home Accessories" exists
+    And category "clothes" in default language named "Clothes" exists
     And group "visitorGroup" named "Visitor" exists
     And group "guestGroup" named "Guest" exists
     And group "customerGroup" named "Customer" exists
@@ -156,7 +157,7 @@ Feature: Category Management
     When I delete category "category5" choosing mode "remove_associated"
     Then category "category5" does not exist
 
-  Scenario: Delete category which is assigned to product and it is the only one left by using different deletion modes
+  Scenario: Delete a category which is the last category of that product
     Given I add new category "category6" with following details:
       | name[en-US]         | Mobile phones6    |
       | name[fr-FR]         | Mobile phones6 fr |
@@ -225,7 +226,166 @@ Feature: Category Management
     # product should be removed
     Then product "product1" should not exist anymore
 
+  Scenario: Bulk delete categories which are the last remaining associated categories for some product
+  by using associate_only deletion mode
+    Given I add new category "category_b6" with following details:
+      | name[en-US]         | not important    |
+      | name[fr-FR]         | not important    |
+      | active              | true             |
+      | parent category     | home-accessories |
+      | link rewrite[en-US] | not-important    |
+      | link rewrite[en-US] | not-important    |
+    And I add new category "category_b7" with following details:
+      | name[en-US]         | not important    |
+      | name[fr-FR]         | not important    |
+      | active              | true             |
+      | parent category     | home-accessories |
+      | link rewrite[en-US] | not-important    |
+      | link rewrite[en-US] | not-important    |
+    And I add new category "category_b8" with following details:
+      | name[en-US]         | not important    |
+      | name[fr-FR]         | not important    |
+      | active              | true             |
+      | parent category     | home-accessories |
+      | link rewrite[en-US] | not-important    |
+      | link rewrite[en-US] | not-important    |
+    And I add product "product_b1" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    And I add product "product_b2" with following information:
+      | name[en-US] | bottle of beer2 |
+      | type        | standard        |
+    And I enable product "product_b1"
+    And I enable product "product_b2"
+    And product "product_b1" should be enabled
+    And product "product_b2" should be enabled
+    And I assign product product_b1 to following categories:
+      | categories       | [category_b6,category_b7,category_b8] |
+      | default category | category_b7                           |
+    And I assign product product_b2 to following categories:
+      | categories       | [category_b6,category_b7,category_b8] |
+      | default category | category_b6                           |
+    Then product "product_b1" should be assigned to following categories:
+      | id reference | name[en-US]   | name[fr-FR]   | is default |
+      | category_b6  | not important | not important | false      |
+      | category_b7  | not important | not important | true       |
+      | category_b8  | not important | not important | false      |
+    Then product "product_b2" should be assigned to following categories:
+      | id reference | name[en-US]   | name[fr-FR]   | is default |
+      | category_b6  | not important | not important | true       |
+      | category_b7  | not important | not important | false      |
+      | category_b8  | not important | not important | false      |
+    When I bulk delete categories "category_b6,category_b7,category_b8" choosing mode "associate_only"
+    Then category "category_b6" does not exist
+    And category "category_b7" does not exist
+    And category "category_b8" does not exist
+    Then product "product_b1" should be assigned to following categories:
+      | id reference     | name[en-US]      | name[fr-FR]      | is default |
+      | home-accessories | Home Accessories | Home Accessories | true       |
+    Then product "product_b2" should be assigned to following categories:
+      | id reference     | name[en-US]      | name[fr-FR]      | is default |
+      | home-accessories | Home Accessories | Home Accessories | true       |
+    And product "product_b1" should be enabled
+    And product "product_b2" should be enabled
+
+  Scenario: Bulk delete categories which are the last remaining associated categories for some product
+  by using associate_and_disable deletion mode
+    Given I add new category "category_b9" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | false         |
+      | parent category     | clothes       |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    And I add new category "category_b10" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | true          |
+      | parent category     | clothes       |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    And I add product "product_b1" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    And I add product "product_b2" with following information:
+      | name[en-US] | bottle of beer2 |
+      | type        | standard        |
+    And I enable product "product_b1"
+    And I enable product "product_b2"
+    And product "product_b1" should be enabled
+    And product "product_b2" should be enabled
+    And I assign product product_b1 to following categories:
+      | categories       | [category_b9,category_b10] |
+      | default category | category_b9                |
+    And I assign product product_b2 to following categories:
+      | categories       | [category_b9,category_b10] |
+      | default category | category_b10               |
+    And product "product_b1" should be assigned to following categories:
+      | id reference | name[en-US]   | name[fr-FR]   | is default |
+      | category_b9  | not important | not important | true       |
+      | category_b10 | not important | not important | false      |
+    And product "product_b2" should be assigned to following categories:
+      | id reference | name[en-US]   | name[fr-FR]   | is default |
+      | category_b9  | not important | not important | false      |
+      | category_b10 | not important | not important | true       |
+    When I bulk delete categories "category_b9,category_b10" choosing mode "associate_and_disable"
+    Then category "category_b9" does not exist
+    And category "category_b10" does not exist
+    And product "product_b1" should be assigned to following categories:
+      | id reference | name[en-US] | name[fr-FR] | is default |
+      | clothes      | Clothes     | Clothes     | true       |
+    And product "product_b2" should be assigned to following categories:
+      | id reference | name[en-US] | name[fr-FR] | is default |
+      | clothes      | Clothes     | Clothes     | true       |
+    And product "product_b1" should be disabled
+    And product "product_b2" should be disabled
+
+  Scenario: Bulk delete categories which are the last remaining associated categories for some product
+  by using associate_and_remove deletion mode
+    Given I add new category "category_b11" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | false         |
+      | parent category     | clothes       |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    And I add new category "category_b12" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | false         |
+      | parent category     | clothes       |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    And I add product "product_b1" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    And I add product "product_b2" with following information:
+      | name[en-US] | bottle of beer2 |
+      | type        | standard        |
+    And I assign product product_b1 to following categories:
+      | categories       | [category_b11,category_b12] |
+      | default category | category_b12                |
+    And I assign product product_b2 to following categories:
+      | categories       | [category_b11,category_b12] |
+      | default category | category_b11                |
+    And product "product_b1" should be assigned to following categories:
+      | id reference | name[en-US]   | name[fr-FR]   | is default |
+      | category_b11 | not important | not important | false      |
+      | category_b12 | not important | not important | true       |
+    And product "product_b2" should be assigned to following categories:
+      | id reference | name[en-US]   | name[fr-FR]   | is default |
+      | category_b11 | not important | not important | true       |
+      | category_b12 | not important | not important | false      |
+    # remove_associated mode case
+    When I bulk delete categories "category_b11,category_b12" choosing mode "remove_associated"
+    Then category "category_b11" does not exist
+    And category "category_b12" does not exist
+    And product "product_b1" should not exist anymore
+    And product "product_b2" should not exist anymore
+
   Scenario: Delete category which is assigned as default for some product, but is not the last category of that product
+  by using associate_and_disable deletion mode
+    # deletion mode shouldn't have impact for this scenario
     Given I add new category "category9" with following details:
       | name[en-US]         | Mobile phones9    |
       | name[fr-FR]         | Mobile phones9 fr |
@@ -246,13 +406,16 @@ Feature: Category Management
       | category9    | Mobile phones9 | Mobile phones9 fr | true       |
     When I delete category "category9" choosing mode "associate_and_disable"
     Then category "category9" does not exist
-    # should assign the parent of the deleted category as the default one. Product status shouldn't be impacted.
     Then product "product2" should be assigned to following categories:
       | id reference     | name[en-US]      | name[fr-FR]      | is default |
       | home             | Home             | Home             | false      |
       | home-accessories | Home Accessories | Home Accessories | true       |
     And product "product2" should be enabled
-    # repeat the same with different modes to ensure that the modes doesn't have impact
+
+
+  Scenario: Delete category which is assigned as default for some product, but is not the last category of that product
+  by using associate_only deletion mode
+    # deletion mode shouldn't have impact for this scenario
     Given I add new category "category10" with following details:
       | name[en-US]         | Mobile phones10    |
       | name[fr-FR]         | Mobile phones10 fr |
@@ -263,7 +426,6 @@ Feature: Category Management
     And I assign product product2 to following categories:
       | categories       | [home,category10] |
       | default category | category10        |
-    # associate_only mode case
     When I delete category "category10" choosing mode "associate_only"
     Then category "category10" does not exist
     Then product "product2" should be assigned to following categories:
@@ -271,6 +433,10 @@ Feature: Category Management
       | home             | Home             | Home             | false      |
       | home-accessories | Home Accessories | Home Accessories | true       |
     And product "product2" should be enabled
+
+  Scenario: Delete category which is assigned as default for some product, but is not the last category of that product
+  by using remove_associated deletion mode
+    # deletion mode shouldn't have impact for this scenario
     Given I add new category "category11" with following details:
       | name[en-US]         | Mobile phones11    |
       | name[fr-FR]         | Mobile phones11 fr |
@@ -289,6 +455,60 @@ Feature: Category Management
       | home             | Home             | Home             | false      |
       | home-accessories | Home Accessories | Home Accessories | true       |
     And product "product2" should be enabled
+
+  Scenario: Bulk delete categories which are assigned as default for some product, but are not the last categories of that product
+    # deletion mode shouldn't have impact for this scenario
+    Given I add new category "category_b11" with following details:
+      | name[en-US]         | not important    |
+      | name[fr-FR]         | not important    |
+      | active              | false            |
+      | parent category     | home-accessories |
+      | link rewrite[en-US] | not-important    |
+      | link rewrite[en-US] | not-important    |
+    Given I add new category "category_b12" with following details:
+      | name[en-US]         | not important    |
+      | name[fr-FR]         | not important    |
+      | active              | false            |
+      | parent category     | home-accessories |
+      | link rewrite[en-US] | not-important    |
+      | link rewrite[en-US] | not-important    |
+    And I add product "product_b1" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    And I add product "product_b2" with following information:
+      | name[en-US] | bottle of beer2 |
+      | type        | standard        |
+    And I enable product "product_b1"
+    And I enable product "product_b2"
+    And product "product_b1" should be enabled
+    And product "product_b2" should be enabled
+    And I assign product product_b1 to following categories:
+      | categories       | [home,category_b11,category_b12] |
+      | default category | category_b11                     |
+    And product "product_b1" should be assigned to following categories:
+      | id reference | name[en-US]   | name[fr-FR]   | is default |
+      | home         | Home          | Home          | false      |
+      | category_b11 | not important | not important | true       |
+      | category_b12 | not important | not important | false      |
+    # product_b2 has "home" category as default, so it shouldn't be affected
+    And I assign product product_b2 to following categories:
+      | categories       | [home,category_b12] |
+      | default category | home              |
+    And product "product_b2" should be assigned to following categories:
+      | id reference | name[en-US]   | name[fr-FR]   | is default |
+      | home         | Home          | Home          | true       |
+      | category_b12 | not important | not important | false      |
+    When I bulk delete categories "category_b11,category_b12" choosing mode "remove_associated"
+    Then category "category_b11" does not exist
+    And category "category_b12" does not exist
+    And product "product_b1" should be assigned to following categories:
+      | id reference     | name[en-US]      | name[fr-FR]      | is default |
+      | home             | Home             | Home             | false      |
+      | home-accessories | Home Accessories | Home Accessories | true       |
+    And product "product_b1" should be assigned to following categories:
+      | id reference     | name[en-US]      | name[fr-FR]      | is default |
+      | home             | Home             | Home             | false      |
+      | home-accessories | Home Accessories | Home Accessories | true       |
 
   Scenario: Bulk delete categories
     Given I add new category "category12" with following details:

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -6,80 +6,167 @@ Feature: Category Management
   I must be able to create, edit and delete categories in my shop
 
   Background: Adding new Category
-    Given I add new category "category1" with following details:
-      | Name                 | PC parts         |
-      | Displayed            | false            |
-      | Parent category      | Home Accessories |
-      | Friendly URL         | pc-parts         |
+    Given category "home" in default language named "Home" exists
+    And category "home" is the default one
+    And category "home-accessories" in default language named "Home Accessories" exists
+    And I add new category "category1" with following details:
+      | Name            | PC parts         |
+      | Displayed       | false            |
+      | Parent category | Home Accessories |
+      | Friendly URL    | pc-parts         |
 
-  Scenario: Edit category
-    When I edit category "category1" with following details:
-      | Name               | dummy category name      |
-      | Displayed          | false                    |
-      | Parent category    | Home Accessories         |
-      | Description        | dummy description        |
-      | Additional description | dummy bottom description |
-      | Meta title         | dummy meta title         |
-      | Meta description   | dummy meta description   |
-      | Friendly URL       | dummy                    |
-      | Group access       | Visitor,Guest,Customer   |
-    Then category "category1" should have following details:
-      | Name               | dummy category name      |
-      | Displayed          | false                    |
-      | Parent category    | Home Accessories         |
-      | Description        | dummy description        |
-      | Additional description | dummy bottom description |
-      | Meta title         | dummy meta title         |
-      | Meta description   | dummy meta description   |
-      | Friendly URL       | dummy                    |
-      | Group access       | Visitor,Guest,Customer   |
+#  Scenario: Edit category
+#    When I edit category "category1" with following details:
+#      | Name                   | dummy category name      |
+#      | Displayed              | false                    |
+#      | Parent category        | Home Accessories         |
+#      | Description            | dummy description        |
+#      | Additional description | dummy bottom description |
+#      | Meta title             | dummy meta title         |
+#      | Meta description       | dummy meta description   |
+#      | Friendly URL           | dummy                    |
+#      | Group access           | Visitor,Guest,Customer   |
+#    Then category "category1" should have following details:
+#      | Name                   | dummy category name      |
+#      | Displayed              | false                    |
+#      | Parent category        | Home Accessories         |
+#      | Description            | dummy description        |
+#      | Additional description | dummy bottom description |
+#      | Meta title             | dummy meta title         |
+#      | Meta description       | dummy meta description   |
+#      | Friendly URL           | dummy                    |
+#      | Group access           | Visitor,Guest,Customer   |
+#
+#  Scenario: Delete category
+#    When I delete category "category1" choosing mode "associate_and_disable"
+#    Then category "category1" does not exist
+#
+#  Scenario: Bulk delete categories
+#    When I add new category "category2" with following details:
+#      | Name            | PC parts 2       |
+#      | Displayed       | true             |
+#      | Parent category | Home Accessories |
+#      | Friendly URL    | pc-parts2        |
+#    And I bulk delete categories "category1,category2" choosing mode "associate_and_disable"
+#    Then category "category1" does not exist
+#    And category "category2" does not exist
+#
+##    update category not available for multi shop context
+#  Scenario: Update category position
+#    When I add new category "category2" with following details:
+#      | Name            | PC parts 2       |
+#      | Displayed       | true             |
+#      | Parent category | Home Accessories |
+#      | Friendly URL    | pc-parts2        |
+#    And I update category "category2" with generated position and following details:
+#      | Parent category | Home Accessories |
+#      | Way             | Up               |
+#      | Found first     | false            |
+#
+#  Scenario: Edit root category
+#    When I edit root category "Home" with following details:
+#      | Name             | dummy root category name    |
+#      | Displayed        | false                       |
+#      | Description      | dummy root description      |
+#      | Meta title       | dummy root meta title       |
+#      | Meta description | dummy root meta description |
+#      | Friendly URL     | dummy-root                  |
+#      | Group access     | Visitor,Guest,Customer      |
+#    Then category "Home" should have following details:
+#      | Name             | dummy root category name    |
+#      | Displayed        | false                       |
+#      | Parent category  | Root                        |
+#      | Description      | dummy root description      |
+#      | Meta title       | dummy root meta title       |
+#      | Meta description | dummy root meta description |
+#      | Friendly URL     | dummy-root                  |
+#      | Group access     | Visitor,Guest,Customer      |
+#
+#  Scenario: Add root category
+#    When I add new root category "root1" with following details:
+#      | Name             | dummy root category name    |
+#      | Displayed        | false                       |
+#      | Description      | dummy root description      |
+#      | Meta title       | dummy root meta title       |
+#      | Meta description | dummy root meta description |
+#      | Friendly URL     | dummy-root                  |
+#      | Group access     | Visitor,Guest,Customer      |
+#    Then category "root1" should have following details:
+#      | Name             | dummy root category name    |
+#      | Displayed        | false                       |
+#      | Parent category  | Root                        |
+#      | Description      | dummy root description      |
+#      | Meta title       | dummy root meta title       |
+#      | Meta description | dummy root meta description |
+#      | Friendly URL     | dummy-root                  |
+#      | Group access     | Visitor,Guest,Customer      |
+#
+#  Scenario: delete category cover image
+#    Given I edit category "category1" with following details:
+#      | Name                 | dummy category name    |
+#      | Displayed            | false                  |
+#      | Parent category      | Home Accessories       |
+#      | Description          | dummy description      |
+#      | Meta title           | dummy meta title       |
+#      | Meta description     | dummy meta description |
+#      | Friendly URL         | dummy                  |
+#      | Group access         | Visitor,Guest,Customer |
+#      | Category cover image | logo.jpg               |
+#    And category "category1" has cover image
+#    When I delete category "category1" cover image
+#    Then category "category1" does not have cover image
+#
+#  Scenario: delete category menu thumbnail image
+#    Given I edit category "category1" with following details:
+#      | Name             | dummy category name    |
+#      | Displayed        | false                  |
+#      | Parent category  | Home Accessories       |
+#      | Description      | dummy description      |
+#      | Meta title       | dummy meta title       |
+#      | Meta description | dummy meta description |
+#      | Friendly URL     | dummy                  |
+#      | Group access     | Visitor,Guest,Customer |
+#      | Menu thumbnails  | logo.jpg               |
+#    And category "category1" has menu thumbnail image
+#    When I delete category "category1" menu thumbnail image
+#    Then category "category1" does not have menu thumbnail image
+#
+##    enabled seems to be the same as displayed
+#  Scenario: enable category
+#    Given category "category1" is disabled
+#    When I enable category "category1"
+#    Then category "category1" is enabled
+#
+#  Scenario: disable category
+#    Given I add new category "category2" with following details:
+#      | Name            | PC parts 2       |
+#      | Displayed       | true             |
+#      | Parent category | Home Accessories |
+#      | Friendly URL    | pc-parts2        |
+#    When I disable category "category2"
+#    Then category "category2" is disabled
+#
+#  Scenario: bulk enable selected categories
+#    Given I add new category "category2" with following details:
+#      | Name            | PC parts 2       |
+#      | Displayed       | false            |
+#      | Parent category | Home Accessories |
+#      | Friendly URL    | pc-parts2        |
+#    When I bulk enable categories "category1,category2"
+#    Then category "category1" is enabled
+#    And category "category2" is enabled
+#
+#  Scenario: bulk disable selected categories
+#    Given I add new category "category2" with following details:
+#      | Name            | PC parts 2       |
+#      | Displayed       | true             |
+#      | Parent category | Home Accessories |
+#      | Friendly URL    | pc-parts2        |
+#    When I bulk disable categories "category1,category2"
+#    Then category "category1" is disabled
+#    And category "category2" is disabled
 
-  Scenario: Delete category
-    When I delete category "category1" choosing mode "associate_and_disable"
-    Then category "category1" does not exist
-
-  Scenario: Bulk delete categories
-    When I add new category "category2" with following details:
-      | Name                 | PC parts 2       |
-      | Displayed            | true             |
-      | Parent category      | Home Accessories |
-      | Friendly URL         | pc-parts2        |
-    And I bulk delete categories "category1,category2" choosing mode "associate_and_disable"
-    Then category "category1" does not exist
-    And category "category2" does not exist
-
-#    update category not available for multi shop context
-  Scenario: Update category position
-    When I add new category "category2" with following details:
-      | Name                 | PC parts 2       |
-      | Displayed            | true             |
-      | Parent category      | Home Accessories |
-      | Friendly URL         | pc-parts2        |
-    And I update category "category2" with generated position and following details:
-      | Parent category | Home Accessories    |
-      | Way             | Up                  |
-      | Found first     | false               |
-
-  Scenario: Edit root category
-    When I edit root category "Home" with following details:
-      | Name             | dummy root category name    |
-      | Displayed        | false                       |
-      | Description      | dummy root description      |
-      | Meta title       | dummy root meta title       |
-      | Meta description | dummy root meta description |
-      | Friendly URL     | dummy-root                  |
-      | Group access     | Visitor,Guest,Customer      |
-    Then category "Home" should have following details:
-      | Name             | dummy root category name    |
-      | Displayed        | false                       |
-      | Parent category  | Root                        |
-      | Description      | dummy root description      |
-      | Meta title       | dummy root meta title       |
-      | Meta description | dummy root meta description |
-      | Friendly URL     | dummy-root                  |
-      | Group access     | Visitor,Guest,Customer      |
-
-  Scenario: Add root category
+  Scenario: delete categories which are assigned to products
     When I add new root category "root1" with following details:
       | Name             | dummy root category name    |
       | Displayed        | false                       |
@@ -88,78 +175,29 @@ Feature: Category Management
       | Meta description | dummy root meta description |
       | Friendly URL     | dummy-root                  |
       | Group access     | Visitor,Guest,Customer      |
-    Then category "root1" should have following details:
-      | Name             | dummy root category name    |
-      | Displayed        | false                       |
-      | Parent category  | Root                        |
-      | Description      | dummy root description      |
-      | Meta title       | dummy root meta title       |
-      | Meta description | dummy root meta description |
-      | Friendly URL     | dummy-root                  |
-      | Group access     | Visitor,Guest,Customer      |
-
-  Scenario: delete category cover image
-    Given I edit category "category1" with following details:
-      | Name                 | dummy category name    |
-      | Displayed            | false                  |
-      | Parent category      | Home Accessories       |
-      | Description          | dummy description      |
-      | Meta title           | dummy meta title       |
-      | Meta description     | dummy meta description |
-      | Friendly URL         | dummy                  |
-      | Group access         | Visitor,Guest,Customer |
-      | Category cover image | logo.jpg               |
-    And category "category1" has cover image
-    When I delete category "category1" cover image
-    Then category "category1" does not have cover image
-
-  Scenario: delete category menu thumbnail image
-    Given I edit category "category1" with following details:
-      | Name                 | dummy category name    |
-      | Displayed            | false                  |
-      | Parent category      | Home Accessories       |
-      | Description          | dummy description      |
-      | Meta title           | dummy meta title       |
-      | Meta description     | dummy meta description |
-      | Friendly URL         | dummy                  |
-      | Group access         | Visitor,Guest,Customer |
-      | Menu thumbnails      | logo.jpg               |
-    And category "category1" has menu thumbnail image
-    When I delete category "category1" menu thumbnail image
-    Then category "category1" does not have menu thumbnail image
-
-#    enabled seems to be the same as displayed
-  Scenario: enable category
-    Given category "category1" is disabled
-    When I enable category "category1"
-    Then category "category1" is enabled
-
-  Scenario: disable category
-    Given I add new category "category2" with following details:
-      | Name                 | PC parts 2       |
-      | Displayed            | true             |
-      | Parent category      | Home Accessories |
-      | Friendly URL         | pc-parts2        |
-    When I disable category "category2"
-    Then category "category2" is disabled
-
-  Scenario: bulk enable selected categories
-    Given I add new category "category2" with following details:
-      | Name                 | PC parts 2       |
-      | Displayed            | false            |
-      | Parent category      | Home Accessories |
-      | Friendly URL         | pc-parts2        |
-    When I bulk enable categories "category1,category2"
-    Then category "category1" is enabled
-    And category "category2" is enabled
-
-  Scenario: bulk disable selected categories
-    Given I add new category "category2" with following details:
-      | Name                 | PC parts 2       |
-      | Displayed            | true             |
-      | Parent category      | Home Accessories |
-      | Friendly URL         | pc-parts2        |
-    When I bulk disable categories "category1,category2"
-    Then category "category1" is disabled
-    And category "category2" is disabled
-
+    Given category "root1" in default language named "dummy root category name" exists
+    And I add product "product1" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    Then product "product1" should be disabled
+    And product "product1" type should be standard
+    And product "product1" should be assigned to following categories:
+      | id reference | name[en-US] | is default |
+      | home         | Home        | true       |
+    And I add new category "category3" with following details:
+      | Name            | PC parts 3       |
+      | Displayed       | true             |
+      | Parent category | Home Accessories |
+      | Friendly URL    | pc-parts3        |
+    And I assign product product1 to following categories:
+      | categories       | [home,category3] |
+      | default category | category3        |
+    When I delete category "category3" choosing mode "associate_and_disable"
+    Then product "product1" should be assigned to following categories:
+      | id reference     | name[en-US]      | is default |
+      | home-accessories | Home Accessories | true       |
+    Then product product1 should be assigned to following categories:
+      | id reference | name[en-US] | name[fr-FR] | is default |
+      | home         | Home        | Home        | false      |
+      | men          | Men         | Men         | false      |
+      | clothes      | Clothes     | Clothes     | true       |

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s category
 @restore-all-tables-before-feature
+@clear-cache-before-feature
 Feature: Category Management
   PrestaShop allows BO users to manage categories for products
   As a BO user
@@ -192,12 +193,16 @@ Feature: Category Management
     And I assign product product1 to following categories:
       | categories       | [home,category3] |
       | default category | category3        |
-    When I delete category "category3" choosing mode "associate_and_disable"
+    Then product "product1" should be assigned to following categories:
+      | id reference | name[en-US] | is default |
+      | home         | Home        | false      |
+      | category3    | PC parts 3  | true       |
+    When I bulk delete categories "category3" choosing mode "associate_and_disable"
+    Then category "category3" does not exist
     Then product "product1" should be assigned to following categories:
       | id reference     | name[en-US]      | is default |
+      | home             | Home             | false      |
+      #@todo: expecting home accessories, but its id is different than i would expect
+      #       probably cuz of retarded parent category assign by name instead of reference
+      #       on line 191
       | home-accessories | Home Accessories | true       |
-    Then product product1 should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | false      |
-      | men          | Men         | Men         | false      |
-      | clothes      | Clothes     | Clothes     | true       |

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -17,47 +17,104 @@ Feature: Category Management
     And single shop context is loaded
     And category "home" is set as the home category for shop "shop1"
     And category "home-accessories" in default language named "Home Accessories" exists
+    And group "visitorGroup" named "Visitor" exists
+    And group "guestGroup" named "Guest" exists
+    And group "customerGroup" named "Customer" exists
 
-  Scenario: Add category
-    When I add new category "category1" with following details:
-      | name[en-US]         | PC parts         |
-      | name[fr-FR]         | PC parts fr      |
-      | displayed           | false            |
-      | parent category     | home-accessories |
-      | link rewrite[en-US] | pc-parts         |
-      | link rewrite[fr-FR] | pc-parts-fr      |
+#  Scenario: Add category
+#    When I add new category "category1" with following details:
+#      | name[en-US]                   | PC parts                       |
+#      | name[fr-FR]                   | PC parts fr                    |
+#      | active                        | false                          |
+#      | parent category               | home-accessories               |
+#      | link rewrite[en-US]           | pc-parts                       |
+#      | link rewrite[fr-FR]           | pc-parts-fr                    |
+#      | group access                  | visitorGroup,guestGroup        |
+#      | associated shops              | shop1                          |
+#      | description[en-US]            | description english            |
+#      | description[fr-FR]            | description french             |
+#      | additional description[en-US] | additional description english |
+#      | additional description[fr-FR] | additional description french  |
+#      | meta description[en-US]       | meta description english       |
+#      | meta description[fr-FR]       | meta description french        |
+#      | meta title[en-US]             | meta title english             |
+#      | meta title[fr-FR]             | meta title french              |
 #    Then category "category1" should have following details:
-#      | Name                   | dummy category name      |
-#      | Displayed              | false                    |
-#      | Parent category        | home-accessories         |
-#      | Description            | dummy description        |
-#      | Additional description | dummy bottom description |
-#      | Meta title             | dummy meta title         |
-#      | Meta description       | dummy meta description   |
-#      | Friendly URL           | dummy                    |
-#      | Group access           | Visitor,Guest,Customer   |
-#  Scenario: Edit category
-#    When I edit category "category1" with following details:
-#      | Name                   | dummy category name      |
-#      | Displayed              | false                    |
-#      | Parent category        | home-accessories         |
-#      | Description            | dummy description        |
-#      | Additional description | dummy bottom description |
-#      | Meta title             | dummy meta title         |
-#      | Meta description       | dummy meta description   |
-#      | Friendly URL           | dummy                    |
-#      | Group access           | Visitor,Guest,Customer   |
-#    Then category "category1" should have following details:
-#      | Name                   | dummy category name      |
-#      | Displayed              | false                    |
-#      | Parent category        | home-accessories         |
-#      | Description            | dummy description        |
-#      | Additional description | dummy bottom description |
-#      | Meta title             | dummy meta title         |
-#      | Meta description       | dummy meta description   |
-#      | Friendly URL           | dummy                    |
-#      | Group access           | Visitor,Guest,Customer   |
+#      | name[en-US]                   | PC parts                       |
+#      | name[fr-FR]                   | PC parts fr                    |
+#      | active                        | false                          |
+#      | parent category               | home-accessories               |
+#      | link rewrite[en-US]           | pc-parts                       |
+#      | link rewrite[fr-FR]           | pc-parts-fr                    |
+#      | group access                  | visitorGroup,guestGroup        |
+#      | associated shops              | shop1                          |
+#      | description[en-US]            | description english            |
+#      | description[fr-FR]            | description french             |
+#      | additional description[en-US] | additional description english |
+#      | additional description[fr-FR] | additional description french  |
+#      | meta description[en-US]       | meta description english       |
+#      | meta description[fr-FR]       | meta description french        |
+#      | meta title[en-US]             | meta title english             |
+#      | meta title[fr-FR]             | meta title french              |
 
+  Scenario: Edit category
+    Given I add new category "category2" with following details:
+      | name[en-US]         | Mobile phones    |
+      | name[fr-FR]         | Mobile phones fr |
+      | active              | false            |
+      | parent category     | home             |
+      | link rewrite[en-US] | mobile-phones-en |
+      | link rewrite[fr-FR] | mobile-phones-fr |
+    And category "category2" should have following details:
+      | name[en-US]                   | Mobile phones                         |
+      | name[fr-FR]                   | Mobile phones fr                      |
+      | active                        | false                                 |
+      | parent category               | home                                  |
+      | link rewrite[en-US]           | mobile-phones-en                      |
+      | link rewrite[fr-FR]           | mobile-phones-fr                      |
+      | group access                  | visitorGroup,guestGroup,customerGroup |
+      | associated shops              | shop1                                 |
+      | description[en-US]            |                                       |
+      | description[fr-FR]            |                                       |
+      | additional description[en-US] |                                       |
+      | additional description[fr-FR] |                                       |
+      | meta description[en-US]       |                                       |
+      | meta description[fr-FR]       |                                       |
+      | meta title[en-US]             |                                       |
+      | meta title[fr-FR]             |                                       |
+    When I edit category "category2" with following details:
+      | name[en-US]                   | Mobile phones super            |
+      | name[fr-FR]                   | Mobile phones super fr         |
+      | active                        | true                           |
+      | parent category               | home-accessories               |
+      | link rewrite[en-US]           | mobile-phones-super-en         |
+      | link rewrite[fr-FR]           | mobile-phones-super-fr         |
+      | group access                  | guestGroup                     |
+      | description[en-US]            | description english            |
+      | description[fr-FR]            | description french             |
+      | additional description[en-US] | additional description english |
+      | additional description[fr-FR] | additional description french  |
+      | meta description[en-US]       | meta description english       |
+      | meta description[fr-FR]       | meta description french        |
+      | meta title[en-US]             | meta title english             |
+      | meta title[fr-FR]             | meta title french              |
+    Then category "category2" should have following details:
+      | name[en-US]                   | Mobile phones super            |
+      | name[fr-FR]                   | Mobile phones super fr         |
+      | active                        | true                           |
+      | parent category               | home-accessories               |
+      | link rewrite[en-US]           | mobile-phones-super-en         |
+      | link rewrite[fr-FR]           | mobile-phones-super-fr         |
+      | group access                  | guestGroup                     |
+      | associated shops              | shop1                          |
+      | description[en-US]            | description english            |
+      | description[fr-FR]            | description french             |
+      | additional description[en-US] | additional description english |
+      | additional description[fr-FR] | additional description french  |
+      | meta description[en-US]       | meta description english       |
+      | meta description[fr-FR]       | meta description french        |
+      | meta title[en-US]             | meta title english             |
+      | meta title[fr-FR]             | meta title french              |
 #  Scenario: Delete category
 #    When I delete category "category1" choosing mode "associate_and_disable"
 #    Then category "category1" does not exist

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -1,6 +1,7 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s category
 @restore-all-tables-before-feature
 @clear-cache-before-feature
+@reset-img-after-feature
 Feature: Category Management
   PrestaShop allows BO users to manage categories for products
   As a BO user
@@ -21,7 +22,7 @@ Feature: Category Management
     And group "guestGroup" named "Guest" exists
     And group "customerGroup" named "Customer" exists
 
-  Scenario: Add category
+  Scenario: Add new category
     When I add new category "category1" with following details:
       | name[en-US]                   | PC parts                       |
       | name[fr-FR]                   | PC parts fr                    |
@@ -398,88 +399,134 @@ Feature: Category Management
       | meta title[fr-FR]             | meta title french              |
       | meta keywords[en-US]          | meta,keyword,english           |
       | meta keywords[fr-FR]          | meta,keyword,french            |
-##
-#  Scenario: Add home category
-#    When I add new root category "root1" with following details:
-#      | Name             | dummy root category name    |
-#      | Displayed        | false                       |
-#      | Description      | dummy root description      |
-#      | Meta title       | dummy root meta title       |
-#      | Meta description | dummy root meta description |
-#      | Friendly URL     | dummy-root                  |
-#      | Group access     | Visitor,Guest,Customer      |
-#    Then category "root1" should have following details:
-#      | Name             | dummy root category name    |
-#      | Displayed        | false                       |
-#      | Parent category  | Root                        |
-#      | Description      | dummy root description      |
-#      | Meta title       | dummy root meta title       |
-#      | Meta description | dummy root meta description |
-#      | Friendly URL     | dummy-root                  |
-#      | Group access     | Visitor,Guest,Customer      |
 
-#  Scenario: delete category cover image
-#    Given I edit category "category1" with following details:
-#      | Name                 | dummy category name    |
-#      | Displayed            | false                  |
-#      | Parent category      | Home Accessories       |
-#      | Description          | dummy description      |
-#      | Meta title           | dummy meta title       |
-#      | Meta description     | dummy meta description |
-#      | Friendly URL         | dummy                  |
-#      | Group access         | Visitor,Guest,Customer |
-#      | Category cover image | logo.jpg               |
-#    And category "category1" has cover image
-#    When I delete category "category1" cover image
-#    Then category "category1" does not have cover image
-#
-#  Scenario: delete category menu thumbnail image
-#    Given I edit category "category1" with following details:
-#      | Name             | dummy category name    |
-#      | Displayed        | false                  |
-#      | Parent category  | Home Accessories       |
-#      | Description      | dummy description      |
-#      | Meta title       | dummy meta title       |
-#      | Meta description | dummy meta description |
-#      | Friendly URL     | dummy                  |
-#      | Group access     | Visitor,Guest,Customer |
-#      | Menu thumbnails  | logo.jpg               |
-#    And category "category1" has menu thumbnail image
-#    When I delete category "category1" menu thumbnail image
-#    Then category "category1" does not have menu thumbnail image
-#
-##    enabled seems to be the same as displayed
-#  Scenario: enable category
-#    Given category "category1" is disabled
-#    When I enable category "category1"
-#    Then category "category1" is enabled
-#
-#  Scenario: disable category
-#    Given I add new category "category2" with following details:
-#      | Name            | PC parts 2       |
-#      | Displayed       | true             |
-#      | Parent category | Home Accessories |
-#      | Friendly URL    | pc-parts2        |
-#    When I disable category "category2"
-#    Then category "category2" is disabled
-#
-#  Scenario: bulk enable selected categories
-#    Given I add new category "category2" with following details:
-#      | Name            | PC parts 2       |
-#      | Displayed       | false            |
-#      | Parent category | Home Accessories |
-#      | Friendly URL    | pc-parts2        |
-#    When I bulk enable categories "category1,category2"
-#    Then category "category1" is enabled
-#    And category "category2" is enabled
-#
-#  Scenario: bulk disable selected categories
-#    Given I add new category "category2" with following details:
-#      | Name            | PC parts 2       |
-#      | Displayed       | true             |
-#      | Parent category | Home Accessories |
-#      | Friendly URL    | pc-parts2        |
-#    When I bulk disable categories "category1,category2"
-#    Then category "category1" is disabled
-#    And category "category2" is disabled
-#
+  Scenario: Add new home category
+    When I add new home category "home2" with following details:
+      | name[en-US]                   | Home sweet home                |
+      | name[fr-FR]                   | Home sweet home fr             |
+      | active                        | true                           |
+      | link rewrite[en-US]           | home-sweet-home                |
+      | link rewrite[fr-FR]           | home-sweet-home-fr             |
+      | group access                  | customerGroup                  |
+      | associated shops              | shop1                          |
+      | description[en-US]            | description english            |
+      | description[fr-FR]            | description french             |
+      | additional description[en-US] | additional description english |
+      | additional description[fr-FR] | additional description french  |
+      | meta description[en-US]       | meta description english       |
+      | meta description[fr-FR]       | meta description french        |
+      | meta title[en-US]             | meta title english             |
+      | meta title[fr-FR]             | meta title french              |
+      | meta keywords[en-US]          | meta,english                   |
+      | meta keywords[fr-FR]          | meta,french                    |
+    Then category "home2" should have following details:
+      | name[en-US]                   | Home sweet home                |
+      | name[fr-FR]                   | Home sweet home fr             |
+      | active                        | true                           |
+      | parent category               | root                           |
+      | link rewrite[en-US]           | home-sweet-home                |
+      | link rewrite[fr-FR]           | home-sweet-home-fr             |
+      | group access                  | customerGroup                  |
+      | associated shops              | shop1                          |
+      | description[en-US]            | description english            |
+      | description[fr-FR]            | description french             |
+      | additional description[en-US] | additional description english |
+      | additional description[fr-FR] | additional description french  |
+      | meta description[en-US]       | meta description english       |
+      | meta description[fr-FR]       | meta description french        |
+      | meta title[en-US]             | meta title english             |
+      | meta title[fr-FR]             | meta title french              |
+      | meta keywords[en-US]          | meta,english                   |
+      | meta keywords[fr-FR]          | meta,french                    |
+
+  # We cannot test the actual image upload due to its dependency from real HTTP upload,
+  # but we can mimic the upload and test EditableCategory construct and images deletion
+  Scenario: Assert and delete category cover image
+    Given I add new category "category18" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | true          |
+      | parent category     | home          |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    And category "category18" should not have a cover image
+    When I upload cover image "cover1" named "app_icon.png" to category "category18"
+    # @todo: asserting image details is too much for current PR scope.
+    # each category image is actually a regenerated thumbnail with a timestamp (is that expected?).
+    # It is not so easy to test it, because it looks something like this:
+    # ['size' => '19.187kB', 'path' => '/img/tmp/category_29.jpg?time=1668089857']
+    Then category "category18" should have a cover image
+    When I delete cover image for category "category18"
+    Then category "category18" should not have a cover image
+    And image "cover1" should not exist
+
+  Scenario: Assert category thumbnail image
+    # @todo: there seems to be no command for thumbnail deletion (is it intentional or forgotten?)
+    Given I add new category "category19" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | true          |
+      | parent category     | home          |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    And category "category19" should not have a thumbnail image
+    When I upload thumbnail image "thumb1" named "app_icon.png" to category "category19"
+    Then category "category19" should have a thumbnail image
+
+  Scenario: Assert and delete category menu thumbnail images
+    Given I add new category "category20" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | true          |
+      | parent category     | home          |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    Then category "category20" does not have menu thumbnail image
+    When I upload menu thumbnail image "menu_thumb1" named "app_icon.png" to category "category20"
+    When I delete category "category20" menu thumbnail image
+    Then category "category20" does not have menu thumbnail image
+
+  # enabled seems to be the same as displayed
+  Scenario: Update category status
+    Given I add new category "category21" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | false         |
+      | parent category     | home          |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    And category "category21" is disabled
+    When I enable category "category21"
+    Then category "category21" is enabled
+    When I disable category "category21"
+    Then category "category21" is disabled
+
+  Scenario: Update category status using bulk action
+    Given I add new category "category22" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | false         |
+      | parent category     | home          |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    Given I add new category "category23" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | false         |
+      | parent category     | home          |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    When I bulk enable categories "category22,category23"
+    Then category "category22" is enabled
+    And category "category23" is enabled
+    When I bulk disable categories "category22,category23"
+    Then category "category22" is disabled
+    And category "category23" is disabled
+    When I enable category "category22"
+    And I bulk disable categories "category22,category23"
+    Then category "category22" is disabled
+    And category "category23" is disabled
+    When I enable category "category23"
+    And I bulk enable categories "category22,category23"
+    Then category "category22" is enabled
+    And category "category23" is enabled

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -171,21 +171,21 @@ Feature: Category Management
     And I enable product "product1"
     And product "product1" should be enabled
     And product "product1" should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | home         | Home        | Home        | true       |
+      | id reference | name | is default |
+      | home         | Home | true       |
     And I assign product product1 to following categories:
       | categories       | [category6] |
       | default category | category6   |
     Then product "product1" should be assigned to following categories:
-      | id reference | name[en-US]    | name[fr-FR]       | is default |
-      | category6    | Mobile phones6 | Mobile phones6 fr | true       |
+      | id reference | name           | is default |
+      | category6    | Mobile phones6 | true       |
     # associate_and_disable mode case
     When I delete category "category6" choosing mode "associate_and_disable"
     Then category "category6" does not exist
     # product should be disabled and associated with the deleted category parent
     Then product "product1" should be assigned to following categories:
-      | id reference     | name[en-US]      | name[fr-FR]      | is default |
-      | home-accessories | Home Accessories | Home Accessories | true       |
+      | id reference     | name             | is default |
+      | home-accessories | Home Accessories | true       |
     And product "product1" should be disabled
     Given I add new category "category7" with following details:
       | name[en-US]         | Mobile phones7    |
@@ -199,14 +199,14 @@ Feature: Category Management
       | categories       | [category7] |
       | default category | category7   |
     And product "product1" should be assigned to following categories:
-      | id reference | name[en-US]    | name[fr-FR]       | is default |
-      | category7    | Mobile phones7 | Mobile phones7 fr | true       |
+      | id reference | name           | is default |
+      | category7    | Mobile phones7 | true       |
     # associate_only mode case
     When I delete category "category7" choosing mode "associate_only"
     # product should be still be enabled and associated with the deleted category parent
     Then product "product1" should be assigned to following categories:
-      | id reference     | name[en-US]      | name[fr-FR]      | is default |
-      | home-accessories | Home Accessories | Home Accessories | true       |
+      | id reference     | name             | is default |
+      | home-accessories | Home Accessories | true       |
     And product "product1" should be enabled
     Given I add new category "category8" with following details:
       | name[en-US]         | Mobile phones8    |
@@ -219,8 +219,8 @@ Feature: Category Management
       | categories       | [category8] |
       | default category | category8   |
     And product "product1" should be assigned to following categories:
-      | id reference | name[en-US]    | name[fr-FR]       | is default |
-      | category8    | Mobile phones8 | Mobile phones8 fr | true       |
+      | id reference | name           | is default |
+      | category8    | Mobile phones8 | true       |
     # remove_associated mode case
     When I delete category "category8" choosing mode "remove_associated"
     # product should be removed
@@ -266,25 +266,25 @@ Feature: Category Management
       | categories       | [category_b6,category_b7,category_b8] |
       | default category | category_b6                           |
     Then product "product_b1" should be assigned to following categories:
-      | id reference | name[en-US]   | name[fr-FR]   | is default |
-      | category_b6  | not important | not important | false      |
-      | category_b7  | not important | not important | true       |
-      | category_b8  | not important | not important | false      |
+      | id reference | name          | is default |
+      | category_b6  | not important | false      |
+      | category_b7  | not important | true       |
+      | category_b8  | not important | false      |
     Then product "product_b2" should be assigned to following categories:
-      | id reference | name[en-US]   | name[fr-FR]   | is default |
-      | category_b6  | not important | not important | true       |
-      | category_b7  | not important | not important | false      |
-      | category_b8  | not important | not important | false      |
+      | id reference | name          | is default |
+      | category_b6  | not important | true       |
+      | category_b7  | not important | false      |
+      | category_b8  | not important | false      |
     When I bulk delete categories "category_b6,category_b7,category_b8" choosing mode "associate_only"
     Then category "category_b6" does not exist
     And category "category_b7" does not exist
     And category "category_b8" does not exist
     Then product "product_b1" should be assigned to following categories:
-      | id reference     | name[en-US]      | name[fr-FR]      | is default |
-      | home-accessories | Home Accessories | Home Accessories | true       |
+      | id reference     | name             | is default |
+      | home-accessories | Home Accessories | true       |
     Then product "product_b2" should be assigned to following categories:
-      | id reference     | name[en-US]      | name[fr-FR]      | is default |
-      | home-accessories | Home Accessories | Home Accessories | true       |
+      | id reference     | name             | is default |
+      | home-accessories | Home Accessories | true       |
     And product "product_b1" should be enabled
     And product "product_b2" should be enabled
 
@@ -321,22 +321,22 @@ Feature: Category Management
       | categories       | [category_b9,category_b10] |
       | default category | category_b10               |
     And product "product_b1" should be assigned to following categories:
-      | id reference | name[en-US]   | name[fr-FR]   | is default |
-      | category_b9  | not important | not important | true       |
-      | category_b10 | not important | not important | false      |
+      | id reference | name          | is default |
+      | category_b9  | not important | true       |
+      | category_b10 | not important | false      |
     And product "product_b2" should be assigned to following categories:
-      | id reference | name[en-US]   | name[fr-FR]   | is default |
-      | category_b9  | not important | not important | false      |
-      | category_b10 | not important | not important | true       |
+      | id reference | name          | is default |
+      | category_b9  | not important | false      |
+      | category_b10 | not important | true       |
     When I bulk delete categories "category_b9,category_b10" choosing mode "associate_and_disable"
     Then category "category_b9" does not exist
     And category "category_b10" does not exist
     And product "product_b1" should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | clothes      | Clothes     | Clothes     | true       |
+      | id reference | name    | is default |
+      | clothes      | Clothes | true       |
     And product "product_b2" should be assigned to following categories:
-      | id reference | name[en-US] | name[fr-FR] | is default |
-      | clothes      | Clothes     | Clothes     | true       |
+      | id reference | name    | is default |
+      | clothes      | Clothes | true       |
     And product "product_b1" should be disabled
     And product "product_b2" should be disabled
 
@@ -369,13 +369,13 @@ Feature: Category Management
       | categories       | [category_b11,category_b12] |
       | default category | category_b11                |
     And product "product_b1" should be assigned to following categories:
-      | id reference | name[en-US]   | name[fr-FR]   | is default |
-      | category_b11 | not important | not important | false      |
-      | category_b12 | not important | not important | true       |
+      | id reference | name          | is default |
+      | category_b11 | not important | false      |
+      | category_b12 | not important | true       |
     And product "product_b2" should be assigned to following categories:
-      | id reference | name[en-US]   | name[fr-FR]   | is default |
-      | category_b11 | not important | not important | true       |
-      | category_b12 | not important | not important | false      |
+      | id reference | name          | is default |
+      | category_b11 | not important | true       |
+      | category_b12 | not important | false      |
     # remove_associated mode case
     When I bulk delete categories "category_b11,category_b12" choosing mode "remove_associated"
     Then category "category_b11" does not exist
@@ -401,15 +401,15 @@ Feature: Category Management
       | categories       | [home,category9] |
       | default category | category9        |
     Then product "product2" should be assigned to following categories:
-      | id reference | name[en-US]    | name[fr-FR]       | is default |
-      | home         | Home           | Home              | false      |
-      | category9    | Mobile phones9 | Mobile phones9 fr | true       |
+      | id reference | name           | is default |
+      | home         | Home           | false      |
+      | category9    | Mobile phones9 | true       |
     When I delete category "category9" choosing mode "associate_and_disable"
     Then category "category9" does not exist
     Then product "product2" should be assigned to following categories:
-      | id reference     | name[en-US]      | name[fr-FR]      | is default |
-      | home             | Home             | Home             | false      |
-      | home-accessories | Home Accessories | Home Accessories | true       |
+      | id reference     | name             | is default |
+      | home             | Home             | false      |
+      | home-accessories | Home Accessories | true       |
     And product "product2" should be enabled
 
 
@@ -429,9 +429,9 @@ Feature: Category Management
     When I delete category "category10" choosing mode "associate_only"
     Then category "category10" does not exist
     Then product "product2" should be assigned to following categories:
-      | id reference     | name[en-US]      | name[fr-FR]      | is default |
-      | home             | Home             | Home             | false      |
-      | home-accessories | Home Accessories | Home Accessories | true       |
+      | id reference     | name             | is default |
+      | home             | Home             | false      |
+      | home-accessories | Home Accessories | true       |
     And product "product2" should be enabled
 
   Scenario: Delete category which is assigned as default for some product, but is not the last category of that product
@@ -451,9 +451,9 @@ Feature: Category Management
     When I delete category "category11" choosing mode "remove_associated"
     Then category "category11" does not exist
     Then product "product2" should be assigned to following categories:
-      | id reference     | name[en-US]      | name[fr-FR]      | is default |
-      | home             | Home             | Home             | false      |
-      | home-accessories | Home Accessories | Home Accessories | true       |
+      | id reference     | name             | is default |
+      | home             | Home             | false      |
+      | home-accessories | Home Accessories | true       |
     And product "product2" should be enabled
 
   Scenario: Bulk delete categories which are assigned as default for some product, but are not the last categories of that product
@@ -486,29 +486,29 @@ Feature: Category Management
       | categories       | [home,category_b11,category_b12] |
       | default category | category_b11                     |
     And product "product_b1" should be assigned to following categories:
-      | id reference | name[en-US]   | name[fr-FR]   | is default |
-      | home         | Home          | Home          | false      |
-      | category_b11 | not important | not important | true       |
-      | category_b12 | not important | not important | false      |
+      | id reference | name          | is default |
+      | home         | Home          | false      |
+      | category_b11 | not important | true       |
+      | category_b12 | not important | false      |
     # product_b2 has "home" category as default, so it shouldn't be affected
     And I assign product product_b2 to following categories:
       | categories       | [home,category_b12] |
-      | default category | home              |
+      | default category | home                |
     And product "product_b2" should be assigned to following categories:
-      | id reference | name[en-US]   | name[fr-FR]   | is default |
-      | home         | Home          | Home          | true       |
-      | category_b12 | not important | not important | false      |
+      | id reference | name          | is default |
+      | home         | Home          | true       |
+      | category_b12 | not important | false      |
     When I bulk delete categories "category_b11,category_b12" choosing mode "remove_associated"
     Then category "category_b11" does not exist
     And category "category_b12" does not exist
     And product "product_b1" should be assigned to following categories:
-      | id reference     | name[en-US]      | name[fr-FR]      | is default |
-      | home             | Home             | Home             | false      |
-      | home-accessories | Home Accessories | Home Accessories | true       |
+      | id reference     | name             | is default |
+      | home             | Home             | false      |
+      | home-accessories | Home Accessories | true       |
     And product "product_b1" should be assigned to following categories:
-      | id reference     | name[en-US]      | name[fr-FR]      | is default |
-      | home             | Home             | Home             | false      |
-      | home-accessories | Home Accessories | Home Accessories | true       |
+      | id reference     | name             | is default |
+      | home             | Home             | false      |
+      | home-accessories | Home Accessories | true       |
 
   Scenario: Bulk delete categories
     Given I add new category "category12" with following details:

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -298,17 +298,52 @@ Feature: Category Management
     Then category "category12" does not exist
     And category "category13" does not exist
 
-  # update category not available for multi shop context
-#  Scenario: Update category position
-#    When I add new category "category2" with following details:
-#      | Name            | PC parts 2       |
-#      | Displayed       | true             |
-#      | Parent category | Home Accessories |
-#      | Friendly URL    | pc-parts2        |
-#    And I update category "category2" with generated position and following details:
-#      | Parent category | Home Accessories |
-#      | Way             | Up               |
-#      | Found first     | false            |
+  Scenario: Update category position
+    Given I add new category "category-500" with following details:
+      | name[en-US]         | not important |
+      | name[fr-FR]         | not important |
+      | active              | true          |
+      | parent category     | home          |
+      | link rewrite[en-US] | not-important |
+      | link rewrite[en-US] | not-important |
+    Given I add new category "category14" with following details:
+      | name[en-US]         | PC parts 14    |
+      | name[fr-FR]         | PC parts 14 fr |
+      | active              | true           |
+      | parent category     | category-500   |
+      | link rewrite[en-US] | pc-parts14     |
+      | link rewrite[en-US] | pc-parts14-fr  |
+    And I add new category "category15" with following details:
+      | name[en-US]         | PC parts 15    |
+      | name[fr-FR]         | PC parts 15 fr |
+      | active              | true           |
+      | parent category     | category-500   |
+      | link rewrite[en-US] | pc-parts15     |
+      | link rewrite[en-US] | pc-parts15-fr  |
+    And I add new category "category16" with following details:
+      | name[en-US]         | PC parts 16    |
+      | name[fr-FR]         | PC parts 16 fr |
+      | active              | true           |
+      | parent category     | category-500   |
+      | link rewrite[en-US] | pc-parts16     |
+      | link rewrite[en-US] | pc-parts16-fr  |
+    And I add new category "category17" with following details:
+      | name[en-US]         | PC parts 17    |
+      | name[fr-FR]         | PC parts 17 fr |
+      | active              | true           |
+      | parent category     | category-500   |
+      | link rewrite[en-US] | pc-parts16     |
+      | link rewrite[en-US] | pc-parts17-fr  |
+    # "category14" is the first category in "category-500" parent, so I assume its position is 0
+    And category "category14" position should be "0"
+    And category "category15" position should be "1"
+    And category "category16" position should be "2"
+    And category "category17" position should be "3"
+    When I move category "category14" down to a position "2"
+    Then category "category15" position should be "0"
+    Then category "category16" position should be "1"
+    Then category "category14" position should be "2"
+    Then category "category17" position should be "3"
 #
 #  Scenario: Edit home category
 #    When I edit home category "Home" with following details:

--- a/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Category/category_management.feature
@@ -21,41 +21,41 @@ Feature: Category Management
     And group "guestGroup" named "Guest" exists
     And group "customerGroup" named "Customer" exists
 
-#  Scenario: Add category
-#    When I add new category "category1" with following details:
-#      | name[en-US]                   | PC parts                       |
-#      | name[fr-FR]                   | PC parts fr                    |
-#      | active                        | false                          |
-#      | parent category               | home-accessories               |
-#      | link rewrite[en-US]           | pc-parts                       |
-#      | link rewrite[fr-FR]           | pc-parts-fr                    |
-#      | group access                  | visitorGroup,guestGroup        |
-#      | associated shops              | shop1                          |
-#      | description[en-US]            | description english            |
-#      | description[fr-FR]            | description french             |
-#      | additional description[en-US] | additional description english |
-#      | additional description[fr-FR] | additional description french  |
-#      | meta description[en-US]       | meta description english       |
-#      | meta description[fr-FR]       | meta description french        |
-#      | meta title[en-US]             | meta title english             |
-#      | meta title[fr-FR]             | meta title french              |
-#    Then category "category1" should have following details:
-#      | name[en-US]                   | PC parts                       |
-#      | name[fr-FR]                   | PC parts fr                    |
-#      | active                        | false                          |
-#      | parent category               | home-accessories               |
-#      | link rewrite[en-US]           | pc-parts                       |
-#      | link rewrite[fr-FR]           | pc-parts-fr                    |
-#      | group access                  | visitorGroup,guestGroup        |
-#      | associated shops              | shop1                          |
-#      | description[en-US]            | description english            |
-#      | description[fr-FR]            | description french             |
-#      | additional description[en-US] | additional description english |
-#      | additional description[fr-FR] | additional description french  |
-#      | meta description[en-US]       | meta description english       |
-#      | meta description[fr-FR]       | meta description french        |
-#      | meta title[en-US]             | meta title english             |
-#      | meta title[fr-FR]             | meta title french              |
+  Scenario: Add category
+    When I add new category "category1" with following details:
+      | name[en-US]                   | PC parts                       |
+      | name[fr-FR]                   | PC parts fr                    |
+      | active                        | false                          |
+      | parent category               | home-accessories               |
+      | link rewrite[en-US]           | pc-parts                       |
+      | link rewrite[fr-FR]           | pc-parts-fr                    |
+      | group access                  | visitorGroup,guestGroup        |
+      | associated shops              | shop1                          |
+      | description[en-US]            | description english            |
+      | description[fr-FR]            | description french             |
+      | additional description[en-US] | additional description english |
+      | additional description[fr-FR] | additional description french  |
+      | meta description[en-US]       | meta description english       |
+      | meta description[fr-FR]       | meta description french        |
+      | meta title[en-US]             | meta title english             |
+      | meta title[fr-FR]             | meta title french              |
+    Then category "category1" should have following details:
+      | name[en-US]                   | PC parts                       |
+      | name[fr-FR]                   | PC parts fr                    |
+      | active                        | false                          |
+      | parent category               | home-accessories               |
+      | link rewrite[en-US]           | pc-parts                       |
+      | link rewrite[fr-FR]           | pc-parts-fr                    |
+      | group access                  | visitorGroup,guestGroup        |
+      | associated shops              | shop1                          |
+      | description[en-US]            | description english            |
+      | description[fr-FR]            | description french             |
+      | additional description[en-US] | additional description english |
+      | additional description[fr-FR] | additional description french  |
+      | meta description[en-US]       | meta description english       |
+      | meta description[fr-FR]       | meta description french        |
+      | meta title[en-US]             | meta title english             |
+      | meta title[fr-FR]             | meta title french              |
 
   Scenario: Edit category
     Given I add new category "category2" with following details:
@@ -115,20 +115,71 @@ Feature: Category Management
       | meta description[fr-FR]       | meta description french        |
       | meta title[en-US]             | meta title english             |
       | meta title[fr-FR]             | meta title french              |
-#  Scenario: Delete category
-#    When I delete category "category1" choosing mode "associate_and_disable"
-#    Then category "category1" does not exist
-#
+
+  Scenario: Delete category
+    Given I add new category "category3" with following details:
+      | name[en-US]         | Mobile phones3   |
+      | name[fr-FR]         | Mobile phones fr |
+      | active              | false            |
+      | parent category     | home             |
+      | link rewrite[en-US] | mobile-phones-en |
+      | link rewrite[fr-FR] | mobile-phones-fr |
+    And I add new category "category4" with following details:
+      | name[en-US]         | Mobile phones4   |
+      | name[fr-FR]         | Mobile phones fr |
+      | active              | false            |
+      | parent category     | home             |
+      | link rewrite[en-US] | mobile-phones-en |
+      | link rewrite[fr-FR] | mobile-phones-fr |
+    And I add new category "category5" with following details:
+      | name[en-US]         | Mobile phones5   |
+      | name[fr-FR]         | Mobile phones fr |
+      | active              | false            |
+      | parent category     | home             |
+      | link rewrite[en-US] | mobile-phones-en |
+      | link rewrite[fr-FR] | mobile-phones-fr |
+    When I delete category "category3" choosing mode "associate_and_disable"
+    Then category "category3" does not exist
+    When I delete category "category4" choosing mode "associate_only"
+    Then category "category4" does not exist
+    When I delete category "category5" choosing mode "remove_associated"
+    Then category "category5" does not exist
+
+  Scenario: delete categories which are assigned to products
+    Given I add new category "category6" with following details:
+      | name[en-US]         | Mobile phones6    |
+      | name[fr-FR]         | Mobile phones6 fr |
+      | active              | false             |
+      | parent category     | home-accessories  |
+      | link rewrite[en-US] | mobile-phones-en  |
+      | link rewrite[fr-FR] | mobile-phones-fr  |
+    And I add product "product1" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    Then product "product1" should be disabled
+    And product "product1" type should be standard
+    And product "product1" should be assigned to following categories:
+      | id reference | name[en-US] | name[fr-FR] | is default |
+      | home         | Home        | Home        | true       |
+    And I assign product product1 to following categories:
+      | categories       | [home,category6] |
+      | default category | category6        |
+    Then product "product1" should be assigned to following categories:
+      | id reference | name[en-US]    | name[fr-FR]       | is default |
+      | home         | Home           | Home              | false      |
+      | category6    | Mobile phones6 | Mobile phones6 fr | true       |
+    When I delete category "category6" choosing mode "associate_and_disable"
+    Then category "category6" does not exist
+    Then product "product1" should be assigned to following categories:
+      | id reference     | name[en-US]      | name[fr-FR]      | is default |
+      | home             | Home             | Home             | false      |
+      | home-accessories | Home Accessories | Home Accessories | true       |
+
 #  Scenario: Bulk delete categories
-#    When I add new category "category2" with following details:
-#      | Name            | PC parts 2       |
-#      | Displayed       | true             |
-#      | Parent category | Home Accessories |
-#      | Friendly URL    | pc-parts2        |
 #    And I bulk delete categories "category1,category2" choosing mode "associate_and_disable"
 #    Then category "category1" does not exist
 #    And category "category2" does not exist
-#
+
 ##    update category not available for multi shop context
 #  Scenario: Update category position
 #    When I add new category "category2" with following details:
@@ -244,39 +295,3 @@ Feature: Category Management
 #    Then category "category1" is disabled
 #    And category "category2" is disabled
 #
-#  Scenario: delete categories which are assigned to products
-#    When I add new home category "root1" with following details:
-#      | Name             | dummy root category name    |
-#      | Displayed        | false                       |
-#      | Description      | dummy root description      |
-#      | Meta title       | dummy root meta title       |
-#      | Meta description | dummy root meta description |
-#      | Friendly URL     | dummy-root                  |
-#      | Group access     | Visitor,Guest,Customer      |
-#    Given category "root1" in default language named "dummy root category name" exists
-#    And I add product "product1" with following information:
-#      | name[en-US] | bottle of beer |
-#      | type        | standard       |
-#    Then product "product1" should be disabled
-#    And product "product1" type should be standard
-#    And product "product1" should be assigned to following categories:
-#      | id reference | name[en-US] | is default |
-#      | home         | Home        | true       |
-#    And I add new category "category3" with following details:
-#      | Name            | PC parts 3       |
-#      | Displayed       | true             |
-#      | Parent category | Home Accessories |
-#      | Friendly URL    | pc-parts3        |
-#    And I assign product product1 to following categories:
-#      | categories       | [home,category3] |
-#      | default category | category3        |
-#    Then product "product1" should be assigned to following categories:
-#      | id reference | name[en-US] | is default |
-#      | home         | Home        | false      |
-#      | category3    | PC parts 3  | true       |
-#    When I delete category "category3" choosing mode "associate_and_disable"
-#    Then category "category3" does not exist
-#    Then product "product1" should be assigned to following categories:
-#      | id reference     | name[en-US]      | is default |
-#      | home             | Home             | false      |
-#      | home-accessories | Home Accessories | true       |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/category_tree.feature
@@ -43,10 +43,10 @@ Feature: Show category tree in product page (BO)
       | stationery       | Stationery       | Stationery       |                         |
       | home_accessories | Home Accessories | Home Accessories |                         |
     When I add new category "artWomen" with following details:
-      | Name            | Women     |
-      | Displayed       | true      |
-      | Parent category | Art       |
-      | Friendly URL    | art-women |
+      | name[en-US]         | Women     |
+      | active              | true      |
+      | parent category     | art       |
+      | link rewrite[en-US] | art-women |
     Then I should see following categories in "art" category in "en" language:
       | id reference | category name | display name | direct child categories |
       | artWomen     | Women         | Art > Women  |                         |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_position.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_position.feature
@@ -6,16 +6,23 @@ Feature: Update product position from BO (Back Office)
   As an employee I must be able to update product position
 
   Background: I add category and products
+    Given shop "shop1" with name "test_shop" exists
+    And single shop context is loaded
+    And language "en" with locale "en-US" exists
+    And language with iso code "en" is the default one
+    And category "home" in default language named "Home" exists
+    And category "home" is set as the home category for shop "shop1"
+    And category "home-accessories" in default language named "Home Accessories" exists
     Given I add new category "category_for_positions" with following details:
-      | Name            | Category for positions |
-      | Displayed       | true                   |
-      | Parent category | Home Accessories       |
-      | Friendly URL    | category-for-positions |
+      | name[en-US]         | Category for positions |
+      | active              | true                   |
+      | parent category     | home-accessories       |
+      | link rewrite[en-US] | category-for-positions |
     And I add new category "other_category_for_positions" with following details:
-      | Name            | Other category for positions |
-      | Displayed       | true                         |
-      | Parent category | Home Accessories             |
-      | Friendly URL    | category-for-positions       |
+      | name[en-US]         | Other category for positions |
+      | active              | true                         |
+      | parent category     | home-accessories             |
+      | link rewrite[en-US] | category-for-positions       |
     And category "home" in default language named "Home" exists
     And I add product "product1" with following information:
       | name[en-US] | Values list poster nr. 1 (paper) |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -63,6 +63,11 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CategoryFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCategoriesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
         cart:
             paths:
                 - "%paths.base%/Features/Scenario/Cart"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -70,6 +70,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
                 - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
         cart:
             paths:
                 - "%paths.base%/Features/Scenario/Cart"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -68,6 +68,8 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
+                - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
         cart:
             paths:
                 - "%paths.base%/Features/Scenario/Cart"

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -60,17 +60,17 @@ default:
             paths:
                 - "%paths.base%/Features/Scenario/Category"
             contexts:
-                - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\CategoryFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\CommonFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CategoryFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCategoriesFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
-                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
-                - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\CustomerFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateCategoriesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStatusFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\LanguageFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\ShopFeatureContext
+                - Tests\Integration\Behaviour\Features\Transform\StringToBoolTransformContext
         cart:
             paths:
                 - "%paths.base%/Features/Scenario/Cart"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Introduced new method in AbstractDeleteCategoryHandler which finds all products that has id_category_default amongst the recently deleted categories. For each of these products it finds parent category (parent of the one that was deleted, or fallbacks to a PS_HOME_CATEGORY) and assigns it, so that product doesn't end up being without default category. This method is called after handling the products which have no categories assigned at all (refactored a bit, but that ones logic doesn't change). Also it is moved out of a loop in bulk action, so it doesn't need to fetch the categories over and over again. Added behat tests (and refactored old tests which were really bad)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes (see bellow)
| Fixed ticket?     | Fixes #30219
| Related PRs       | 
| How to test?      | See bellow
| Possible impacts? | 

**deprecated** `PrestaShop\PrestaShop\Adapter\Category\CommandHandler\AbstractDeleteCategoryHandler::handleProductsUpdate`, Use `updateProductCategories` instead

**how to test**
Note - this scenario only applies if after category deletion there are other categories still left assigned with the product, but product ends up having no default category. In other case - If after category deletion the product is left without categories, then the "deletion mode" behavior applies as usually.

1. Create new categories "catA and catB".
2. Go to any product and assign those 2 categories and make catA default one. Make sure product now has only those 2 categories assigned.
3. Go to BO categories page and delete catA (no matter which deletion mode).
4. Go back to product page (v1 or v2 should both act same) and see that instead of the deleted "catA" the product default category is the parent category of the "catA" now

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
