### PR TITLE
Optimize product assembler

### DIFF
--- a/classes/ProductAssembler.php
+++ b/classes/ProductAssembler.php
@@ -57,7 +57,7 @@ class ProductAssemblerCore
     {
         $sql = $this->getSqlQueryProductFields([(int) $rawProduct['id_product']]);
         $rows = Db::getInstance()->executeS($sql);
-        if ($rows === false) {
+        if (empty($rows)) {
             return $rawProduct;
         }
 
@@ -76,10 +76,7 @@ class ProductAssemblerCore
     private function addMissingProductFieldsForMultipleProducts(array $rawProducts): array
     {
         // Get product IDs we want to retrieve from database
-        $productIds = [];
-        foreach ($rawProducts as $rawProduct) {
-            $productIds[] = (int) $rawProduct['id_product'];
-        }
+        $productIds = array_column($rawProducts, 'id_product');
 
         // Retrieve data and reassign them to new array by their key
         $productData = [];

--- a/classes/ProductAssembler.php
+++ b/classes/ProductAssembler.php
@@ -55,6 +55,11 @@ class ProductAssemblerCore
      */
     private function addMissingProductFields(array $rawProduct): array
     {
+        // If there is no ID product provided, return the original data
+        if (empty($rawProduct['id_product'])) {
+            return $rawProduct;
+        }
+
         $sql = $this->getSqlQueryProductFields([(int) $rawProduct['id_product']]);
         $rows = Db::getInstance()->executeS($sql);
         if (empty($rows)) {
@@ -77,6 +82,12 @@ class ProductAssemblerCore
     {
         // Get product IDs we want to retrieve from database
         $productIds = array_column($rawProducts, 'id_product');
+
+        // If there were no product IDs provided or somebody passed an empty array,
+        // return the original data
+        if (empty($productIds)) {
+            return $rawProducts;
+        }
 
         // Retrieve data and reassign them to new array by their key
         $productData = [];

--- a/classes/ProductAssembler.php
+++ b/classes/ProductAssembler.php
@@ -101,9 +101,9 @@ class ProductAssemblerCore
 
     /**
      * Return the SQL query to get all product fields
-     * 
+     *
      * @param array $productIds
-     * 
+     *
      * @return string
      */
     private function getSqlQueryProductFields(array $productIds): string

--- a/classes/ProductAssembler.php
+++ b/classes/ProductAssembler.php
@@ -55,18 +55,70 @@ class ProductAssemblerCore
      */
     private function addMissingProductFields(array $rawProduct): array
     {
+        $sql = $this->getSqlQueryProductFields([(int) $rawProduct['id_product']]);
+        $rows = Db::getInstance()->executeS($sql);
+        if ($rows === false) {
+            return $rawProduct;
+        }
+
+        return array_merge($rows[0], $rawProduct);
+    }
+
+    /**
+     * Add missing product fields to multiple products
+     *
+     * @param array $rawProducts
+     *
+     * @return array
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    private function addMissingProductFieldsForMultipleProducts(array $rawProducts): array
+    {
+        // Get product IDs we want to retrieve from database
+        $productIds = [];
+        foreach ($rawProducts as $rawProduct) {
+            $productIds[] = (int) $rawProduct['id_product'];
+        }
+
+        // Retrieve data and reassign them to new array by their key
+        $productData = [];
+        $sql = $this->getSqlQueryProductFields($productIds);
+        $rows = Db::getInstance()->executeS($sql);
+        foreach ($rows as $row) {
+            $productData[(int) $row['id_product']] = $row;
+        }
+
+        // Use this data to enrich the products and return it
+        foreach ($rawProducts as &$rawProduct) {
+            if (isset($productData[$rawProduct['id_product']])) {
+                $rawProduct = array_merge($productData[$rawProduct['id_product']], $rawProduct);
+            }
+        }
+
+        return $rawProducts;
+    }
+
+    /**
+     * Return the SQL query to get all product fields
+     * 
+     * @param array $productIds
+     * 
+     * @return string
+     */
+    private function getSqlQueryProductFields(array $productIds): string
+    {
+        // Get basic configuration
         $idShop = $this->searchContext->getIdShop();
         $idShopGroup = $this->searchContext->getIdShopGroup();
         $isStockSharingBetweenShopGroupEnabled = $this->searchContext->isStockSharingBetweenShopGroupEnabled();
         $idLang = $this->searchContext->getIdLang();
-        $idProduct = (int) $rawProduct['id_product'];
         $prefix = _DB_PREFIX_;
 
         $nbDaysNewProduct = (int) Configuration::get('PS_NB_DAYS_NEW_PRODUCT');
         if (!Validate::isUnsignedInt($nbDaysNewProduct)) {
             $nbDaysNewProduct = 20;
         }
-
         $now = date('Y-m-d') . ' 00:00:00';
 
         $sql = "SELECT
@@ -92,27 +144,24 @@ class ProductAssemblerCore
         if ($isStockSharingBetweenShopGroupEnabled) {
             $sql .= "  ON sa.id_product = p.id_product
 			        AND sa.id_shop = 0
+                    AND sa.id_product_attribute = 0
 			        AND sa.id_shop_group = $idShopGroup ";
         } else {
             $sql .= "  ON sa.id_product = p.id_product
+                    AND sa.id_product_attribute = 0
 			        AND sa.id_shop = $idShop ";
         }
         $sql .= "LEFT JOIN {$prefix}product_shop ps
 			        ON ps.id_product = p.id_product
 			        AND ps.id_shop = $idShop
-			    WHERE p.id_product = $idProduct
-			    LIMIT 1";
+                WHERE p.id_product IN (" . implode(',', $productIds) . ')';
 
-        $rows = Db::getInstance()->executeS($sql);
-        if ($rows === false) {
-            return $rawProduct;
-        }
-
-        return array_merge($rows[0], $rawProduct);
+        return $sql;
     }
 
     /**
-     * Assemble Product.
+     * Get basic product data for single product.
+     * The only required property is id_product.
      *
      * @param array $rawProduct
      *
@@ -129,5 +178,30 @@ class ProductAssemblerCore
             $enrichedProduct,
             $this->context
         );
+    }
+
+    /**
+     * Get basic product data for multiple products.
+     * The only required property for each product is id_product.
+     *
+     * @param array $rawProducts Array with multiple products
+     *
+     * @return mixed
+     *
+     * @throws PrestaShopDatabaseException
+     */
+    public function assembleProducts(array $rawProducts)
+    {
+        $enrichedProducts = $this->addMissingProductFieldsForMultipleProducts($rawProducts);
+
+        foreach ($enrichedProducts as &$product) {
+            $product = Product::getProductProperties(
+                $this->searchContext->getIdLang(),
+                $product,
+                $this->context
+            );
+        }
+
+        return $enrichedProducts;
     }
 }

--- a/classes/controller/ProductListingFrontController.php
+++ b/classes/controller/ProductListingFrontController.php
@@ -74,14 +74,18 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
      *
      * @return array a product ready for templating
      */
+    // @phpstan-ignore-next-line
     private function prepareProductForTemplate(array $rawProduct)
     {
+        // Enrich data of product
         $product = (new ProductAssembler($this->context))
             ->assembleProduct($rawProduct);
 
+        // Prepare configuration
         $presenter = $this->getProductPresenter();
         $settings = $this->getProductPresentationSettings();
 
+        // Present and return product
         return $presenter->present(
             $settings,
             $product,
@@ -99,7 +103,24 @@ abstract class ProductListingFrontControllerCore extends ProductPresentingFrontC
      */
     protected function prepareMultipleProductsForTemplate(array $products)
     {
-        return array_map([$this, 'prepareProductForTemplate'], $products);
+        // Enrich data set of products
+        $products = (new ProductAssembler($this->context))
+            ->assembleProducts($products);
+
+        // Prepare configuration
+        $presenter = $this->getProductPresenter();
+        $settings = $this->getProductPresentationSettings();
+
+        // Present and return each product
+        foreach ($products as &$product) {
+            $product = $presenter->present(
+                $settings,
+                $product,
+                $this->context->language
+            );
+        }
+
+        return $products;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR optimizes product data enrichment a bit. Se more below.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Related PRs       | -
| How to test?      | We need to launch automatic tests on this PR
| Possible impacts? | -

### 
- This PR will speed up every product listing by few ms and save 23 database queries.
- It gets basic product data for all products at once, instead of calling it 24 times.
- No BC breaks. 
- `sa.id_product_attribute = 0` is added to the query to get proper quantity, this method does not work with combinations and it was producing duplicate entries. This was not visibile when getting single product because of LIMIT 1. Product quantity is recalculated later, but it could be wrong at that point.

### Data and timings
![loadtime](https://user-images.githubusercontent.com/6097524/200332726-6e27408a-3887-4cee-bc8d-8961e24edb5c.jpg)

### How to test / what to test
- The code that I changed does not select any products, it just gets some data for IDs provided. Faceted search says "I found these IDs" and gives a list. And this function gets the product name and other things for it.
- This code is used:
  - On all listing pages to get data for products listed - categories, price-drop page, manufacturer page etc.
  - On product page to list products in pack (the small ones above add to cart button).
  - To get data for products in cart.
- So, to test, install develop and install my PR with demo data and check that everything is the same when you click through some pages.
- You can also put `{dump($product)}` into `themes\classic\templates\catalog\_partials\miniatures\product.tpl`.
- If you want, you can also enable `_PS_DEBUG_PROFILING_` in `config\defines.inc.php` and see that the amount of DB queries dropped and there is some speed improvement. The more products per page you have set, the bigger the speed and query improvement.
