### PR TITLE
Add method to clean active modules paths on ModuleRepository

### DIFF
--- a/src/Adapter/Module/Repository/ModuleRepository.php
+++ b/src/Adapter/Module/Repository/ModuleRepository.php
@@ -117,7 +117,7 @@ class ModuleRepository extends AbstractObjectModelRepository
      *
      * @return array<string, string> File paths indexed by module name
      */
-    public function getActiveModulesPaths(?bool $useCache = true): array
+    public function getActiveModulesPaths(bool $useCache = true): array
     {
         if (!$useCache || empty($this->activeModulesPaths)) {
             $this->activeModulesPaths = [];

--- a/src/Adapter/Module/Repository/ModuleRepository.php
+++ b/src/Adapter/Module/Repository/ModuleRepository.php
@@ -117,9 +117,9 @@ class ModuleRepository extends AbstractObjectModelRepository
      *
      * @return array<string, string> File paths indexed by module name
      */
-    public function getActiveModulesPaths(): array
+    public function getActiveModulesPaths(?bool $useCache = true): array
     {
-        if (empty($this->activeModulesPaths)) {
+        if (!$useCache || empty($this->activeModulesPaths)) {
             $this->activeModulesPaths = [];
             $activeModules = $this->getActiveModules();
 
@@ -131,11 +131,6 @@ class ModuleRepository extends AbstractObjectModelRepository
         }
 
         return $this->activeModulesPaths;
-    }
-
-    public function clearActiveModulesPaths(): void
-    {
-        $this->activeModulesPaths = [];
     }
 
     /**

--- a/src/Adapter/Module/Repository/ModuleRepository.php
+++ b/src/Adapter/Module/Repository/ModuleRepository.php
@@ -119,7 +119,7 @@ class ModuleRepository extends AbstractObjectModelRepository
      */
     public function getActiveModulesPaths(): array
     {
-        if (null === $this->activeModulesPaths) {
+        if (empty($this->activeModulesPaths)) {
             $this->activeModulesPaths = [];
             $activeModules = $this->getActiveModules();
 
@@ -131,6 +131,11 @@ class ModuleRepository extends AbstractObjectModelRepository
         }
 
         return $this->activeModulesPaths;
+    }
+
+    public function clearActiveModulesPaths(): void
+    {
+        $this->activeModulesPaths = [];
     }
 
     /**

--- a/src/Core/Translation/Util/Refresher.php
+++ b/src/Core/Translation/Util/Refresher.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Translation\Util;
 
+use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
 use PrestaShopBundle\Translation\TranslatorComponent;
 
@@ -42,12 +43,19 @@ class Refresher
      */
     private $moduleRepository;
 
+    /**
+     * @var LegacyContext
+     */
+    private $context;
+
     public function __construct(
         string $translationsCacheDir,
-        ModuleRepository $moduleRepository
+        ModuleRepository $moduleRepository,
+        LegacyContext $context
     ) {
         $this->translationsCacheDir = $translationsCacheDir;
         $this->moduleRepository = $moduleRepository;
+        $this->context = $context;
     }
 
     /**
@@ -74,7 +82,7 @@ class Refresher
 
         $translators = [];
         // Reload translations for each shop language
-        foreach (\Language::getLanguages() as $lang) {
+        foreach ($this->context->getLanguages() as $lang) {
             $translators[$lang['id_lang']] = \Context::getContext()->getTranslatorFromLocale($lang['locale']);
         }
 

--- a/src/Core/Translation/Util/Refresher.php
+++ b/src/Core/Translation/Util/Refresher.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Translation\Util;
+
+use PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository;
+use PrestaShopBundle\Translation\TranslatorComponent;
+
+class Refresher
+{
+    /**
+     * @var string
+     */
+    private $translationsCacheDir;
+
+    /**
+     * @var ModuleRepository
+     */
+    private $moduleRepository;
+
+    public function __construct(
+        string $translationsCacheDir,
+        ModuleRepository $moduleRepository
+    ) {
+        $this->translationsCacheDir = $translationsCacheDir;
+        $this->moduleRepository = $moduleRepository;
+    }
+
+    /**
+     * This method will clear the translations cache, reload the active modules and return fresh translators objects.
+     * The array of translators returned is indexed by languageId.
+     * This method can be useful to use translations of a newly enabled module.
+     *
+     * @return TranslatorComponent[]
+     */
+    public function getFreshTranslators(): array
+    {
+        // Clean translations cache
+        $cacheFiles = \Symfony\Component\Finder\Finder::create()
+            ->files()
+            ->in($this->translationsCacheDir)
+            ->depth('==0')
+            ->name('*');
+
+        (new \Symfony\Component\Filesystem\Filesystem())->remove($cacheFiles);
+
+        // Reload list of active modules
+        // This will allow to have the correct active modules when executing TranslatorLanguageLoaader::loadLanguage
+        $this->moduleRepository->getActiveModulesPaths(false);
+
+        $translators = [];
+        // Reload translations for each shop language
+        foreach (\Language::getLanguages() as $lang) {
+            $translators[$lang['id_lang']] = \Context::getContext()->getTranslatorFromLocale($lang['locale']);
+        }
+
+        return $translators;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/core/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/translation.yml
@@ -6,3 +6,9 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Translation\Locale\Converter'
     arguments:
       - '%kernel.project_dir%/app/Resources/legacy-to-standard-locales.json'
+
+  prestashop.core.translation.util.refresher:
+    class: 'PrestaShop\PrestaShop\Core\Translation\Util\Refresher'
+    arguments:
+      - '%kernel.cache_dir%/translations'
+      - '@prestashop.adapter.module.repository.module_repository'

--- a/src/PrestaShopBundle/Resources/config/services/core/translation.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/translation.yml
@@ -12,3 +12,4 @@ services:
     arguments:
       - '%kernel.cache_dir%/translations'
       - '@prestashop.adapter.module.repository.module_repository'
+      - '@prestashop.adapter.legacy.context'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add method to clear ModuleRepository attribute `activeModulesPaths`. Using this method will allow to use Module translations during installation 
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30241 
| Related PRs       | -
| How to test?      | Look at the issue description. <br>And now install [prestashopexamplemodule_with_fix.zip](https://github.com/PrestaShop/PrestaShop/files/9963565/prestashopexamplemodule_with_fix.zip)<br>You will have a translated menu added under `Modules` menu
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
