### PR TITLE
Create independent SetCarriersCommand

### DIFF
--- a/src/Adapter/Product/CommandHandler/SetCarriersHandler.php
+++ b/src/Adapter/Product/CommandHandler/SetCarriersHandler.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\SetCarriersHandlerInterface;
+
+/**
+ * Handles @var SetCarriersCommand using repository
+ */
+class SetCarriersHandler implements SetCarriersHandlerInterface
+{
+    /**
+     * @var ProductMultiShopRepository
+     */
+    private $productMultiShopRepository;
+
+    /**
+     * @param ProductMultiShopRepository $productMultiShopRepository
+     */
+    public function __construct(
+        ProductMultiShopRepository $productMultiShopRepository
+    ) {
+        $this->productMultiShopRepository = $productMultiShopRepository;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(SetCarriersCommand $command): void
+    {
+        $this->productMultiShopRepository->setCarrierReferences(
+            $command->getProductId(),
+            $command->getCarrierReferenceIds(),
+            $command->getShopConstraint()
+        );
+    }
+}

--- a/src/Adapter/Product/CommandHandler/UpdateProductShippingHandler.php
+++ b/src/Adapter/Product/CommandHandler/UpdateProductShippingHandler.php
@@ -32,7 +32,6 @@ use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductShippingCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductShippingHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use Product;
 
 /**
@@ -69,14 +68,6 @@ final class UpdateProductShippingHandler implements UpdateProductShippingHandler
             $shopConstraint,
             CannotUpdateProductException::FAILED_UPDATE_SHIPPING_OPTIONS
         );
-
-        if (null !== $command->getCarrierReferenceIds()) {
-            $this->productMultiShopRepository->setCarrierReferences(
-                new ProductId((int) $product->id),
-                $command->getCarrierReferenceIds(),
-                $shopConstraint
-            );
-        }
     }
 
     /**

--- a/src/Core/Domain/Product/Command/SetCarriersCommand.php
+++ b/src/Core/Domain/Product/Command/SetCarriersCommand.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierReferenceId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+/**
+ * Set the list of carriers for a product
+ */
+class SetCarriersCommand
+{
+    /**
+     * @var ProductId
+     */
+    private $productId;
+
+    /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
+     * @var CarrierReferenceId[]|null
+     */
+    private $carrierReferenceIds;
+
+    /**
+     * @param int $productId
+     * @param int[] $carrierReferenceIds List of carrier reference IDs (instead of usual primary id as most entities)
+     * @param ShopConstraint $shopConstraint
+     *
+     * @throws ProductConstraintException
+     */
+    public function __construct(
+        int $productId,
+        array $carrierReferenceIds,
+        ShopConstraint $shopConstraint
+    ) {
+        $this->productId = new ProductId($productId);
+        $this->shopConstraint = $shopConstraint;
+        $this->setCarrierReferenceIds($carrierReferenceIds);
+    }
+
+    /**
+     * @return ProductId
+     */
+    public function getProductId(): ProductId
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
+    }
+
+    /**
+     * @return CarrierReferenceId[]
+     */
+    public function getCarrierReferenceIds(): ?array
+    {
+        return $this->carrierReferenceIds;
+    }
+
+    /**
+     * @param int[] $carrierReferenceIds
+     */
+    private function setCarrierReferenceIds(array $carrierReferenceIds): void
+    {
+        $this->carrierReferenceIds = [];
+        foreach (array_unique($carrierReferenceIds) as $carrierReferenceId) {
+            $this->carrierReferenceIds[] = new CarrierReferenceId((int) $carrierReferenceId);
+        }
+    }
+}

--- a/src/Core/Domain/Product/Command/UpdateProductShippingCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductShippingCommand.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\Decimal\DecimalNumber;
-use PrestaShop\PrestaShop\Core\Domain\Carrier\ValueObject\CarrierReferenceId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
@@ -69,11 +68,6 @@ class UpdateProductShippingCommand
      * @var DecimalNumber|null
      */
     private $additionalShippingCost;
-
-    /**
-     * @var CarrierReferenceId[]|null
-     */
-    private $carrierReferenceIds;
 
     /**
      * @var DeliveryTimeNoteType
@@ -221,28 +215,6 @@ class UpdateProductShippingCommand
     public function setAdditionalShippingCost(string $additionalShippingCost): UpdateProductShippingCommand
     {
         $this->additionalShippingCost = new DecimalNumber($additionalShippingCost);
-
-        return $this;
-    }
-
-    /**
-     * @return CarrierReferenceId[]|null
-     */
-    public function getCarrierReferenceIds(): ?array
-    {
-        return $this->carrierReferenceIds;
-    }
-
-    /**
-     * @param int[] $carrierReferenceIds
-     *
-     * @return UpdateProductShippingCommand
-     */
-    public function setCarrierReferenceIds(array $carrierReferenceIds): UpdateProductShippingCommand
-    {
-        foreach (array_unique($carrierReferenceIds) as $carrierReferenceId) {
-            $this->carrierReferenceIds[] = new CarrierReferenceId((int) $carrierReferenceId);
-        }
 
         return $this;
     }

--- a/src/Core/Domain/Product/CommandHandler/SetCarriersHandlerInterface.php
+++ b/src/Core/Domain/Product/CommandHandler/SetCarriersHandlerInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand;
+
+/**
+ * Defines contract for SetCarriersHandler
+ */
+interface SetCarriersHandlerInterface
+{
+    public function handle(SetCarriersCommand $command): void;
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/CarriersCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/CarriersCommandsBuilder.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+final class CarriersCommandsBuilder implements MultiShopProductCommandsBuilderInterface
+{
+    /**
+     * @var string
+     */
+    private $modifyAllNamePrefix;
+
+    /**
+     * @param string $modifyAllNamePrefix
+     */
+    public function __construct(
+        string $modifyAllNamePrefix
+    ) {
+        $this->modifyAllNamePrefix = $modifyAllNamePrefix;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildCommands(ProductId $productId, array $formData, ShopConstraint $singleShopConstraint): array
+    {
+        if (!isset($formData['shipping']['carriers'])) {
+            return [];
+        }
+
+        if (!empty($formData['shipping'][$this->modifyAllNamePrefix . 'carriers'])) {
+            $shopConstraint = ShopConstraint::allShops();
+        } else {
+            $shopConstraint = $singleShopConstraint;
+        }
+
+        return [
+            new SetCarriersCommand(
+                $productId->getValue(),
+                $formData['shipping']['carriers'],
+                $shopConstraint
+            ),
+        ];
+    }
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ShippingCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ShippingCommandsBuilder.php
@@ -71,7 +71,6 @@ final class ShippingCommandsBuilder implements MultiShopProductCommandsBuilderIn
             ->addMultiShopField('[additional_shipping_cost]', 'setAdditionalShippingCost', DataField::TYPE_STRING)
             ->addMultiShopField('[delivery_time_notes][in_stock]', 'setLocalizedDeliveryTimeInStockNotes', DataField::TYPE_ARRAY)
             ->addMultiShopField('[delivery_time_notes][out_of_stock]', 'setLocalizedDeliveryTimeOutOfStockNotes', DataField::TYPE_ARRAY)
-            ->addMultiShopField('[carriers]', 'setCarrierReferenceIds', DataField::TYPE_ARRAY)
         ;
 
         $commandBuilder = new CommandBuilder($config);

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -225,6 +225,14 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductShippingCommand
 
+  prestashop.adapter.product.command_handler.set_carriers_handler:
+    class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\SetCarriersHandler
+    arguments:
+      - '@prestashop.adapter.product.repository.product_multi_shop_repository'
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand
+
   prestashop.adapter.product.query_handler.get_product_supplier_options_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\QueryHandler\GetProductSupplierOptionsHandler
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -61,6 +61,12 @@ services:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
     tags: [ 'core.product_command_builder' ]
 
+  prestashop.core.form.command_builder.product.carriers:
+    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\CarriersCommandsBuilder
+    arguments:
+      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
+    tags: [ 'core.product_command_builder' ]
+
   prestashop.core.form.command_builder.product.stock_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\StockCommandsBuilder
     arguments:

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateShippingFeatureContext.php
@@ -361,7 +361,7 @@ class UpdateShippingFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @param string[] $carrierReferencesInput
+     * @param string[] $carrierReferences
      *
      * @return int[]
      */

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_shipping.feature
@@ -47,7 +47,9 @@ Feature: Update product shipping information from Back Office (BO) for multiple 
       | delivery time in stock notes[fr-FR]     | produit en stock            |
       | delivery time out of stock notes[en-US] | product out of stock        |
       | delivery time out of stock notes[fr-FR] | produit en rupture de stock |
-      | carriers                                | [carrier1,carrier2]         |
+    And I assign product product1 with following carriers:
+      | carrier1 |
+      | carrier2 |
     Then product product1 should have following shipping information:
       | width                                   | 10.5                        |
       | height                                  | 6                           |
@@ -88,7 +90,8 @@ Feature: Update product shipping information from Back Office (BO) for multiple 
       | delivery time in stock notes[fr-FR]     | valide      |
       | delivery time out of stock notes[en-US] | unavailable |
       | delivery time out of stock notes[fr-FR] | disparu     |
-      | carriers                                | [carrier1]  |
+    And I assign product product1 with following carriers for shop "shop2":
+      | carrier1 |
     Then product product1 should have following shipping information for shops "shop2":
       | width                                   | 5           |
       | height                                  | 5           |
@@ -129,7 +132,8 @@ Feature: Update product shipping information from Back Office (BO) for multiple 
       | delivery time in stock notes[fr-FR]     | ok            |
       | delivery time out of stock notes[en-US] | not-available |
       | delivery time out of stock notes[fr-FR] | no-ok         |
-      | carriers                                | [carrier2]    |
+    And I assign product product1 with following carriers for all shops:
+      | carrier2 |
     Then product product1 should have following shipping information for shops "shop1,shop2":
       | width                                   | 100           |
       | height                                  | 200           |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
@@ -91,7 +91,9 @@ Feature: Duplicate product from Back Office (BO).
       | delivery time in stock notes[fr-FR]     | en stock             |
       | delivery time out of stock notes[en-US] | product out of stock |
       | delivery time out of stock notes[fr-FR] | En rupture de stock  |
-      | carriers                                | [carrier1,carrier2]  |
+    And I assign product product1 with following carriers:
+      | carrier1 |
+      | carrier2 |
     When I associate suppliers to product "product1"
       | supplier  | product_supplier  |
       | supplier1 | product1supplier1 |
@@ -169,7 +171,9 @@ Feature: Duplicate product from Back Office (BO).
       | delivery time in stock notes[fr-FR]     | en stock             |
       | delivery time out of stock notes[en-US] | product out of stock |
       | delivery time out of stock notes[fr-FR] | En rupture de stock  |
-      | carriers                                | [carrier1,carrier2]  |
+    And I assign product product2 with following carriers:
+      | carrier1 |
+      | carrier2 |
     When I associate suppliers to product "product2"
       | supplier  | product_supplier  |
       | supplier1 | product2supplier1 |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -82,7 +82,9 @@ Feature: Duplicate product from Back Office (BO).
       | delivery time in stock notes[fr-FR]     | en stock             |
       | delivery time out of stock notes[en-US] | product out of stock |
       | delivery time out of stock notes[fr-FR] | En rupture de stock  |
-      | carriers                                | [carrier1,carrier2]  |
+    And I assign product product1 with following carriers:
+      | carrier1 |
+      | carrier2 |
     And I add new supplier supplier1 with following properties:
       | name                    | my supplier 1      |
       | address                 | Donelaicio st. 1   |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_shipping.feature
@@ -30,7 +30,9 @@ Feature: Update product shipping options from Back Office (BO)
       | delivery time notes type                | specific             |
       | delivery time in stock notes[en-US]     | product in stock     |
       | delivery time out of stock notes[en-US] | product out of stock |
-      | carriers                                | [carrier1,carrier2]  |
+    And I assign product product1 with following carriers:
+      | carrier1 |
+      | carrier2 |
     Then product product1 should have following shipping information:
       | width                                   | 10.5                 |
       | height                                  | 6                    |
@@ -122,7 +124,14 @@ Feature: Update product shipping options from Back Office (BO)
     When I update product product1 shipping information with following values:
       | delivery time in stock notes[en-US]     |  |
       | delivery time out of stock notes[en-US] |  |
-    Given product product1 should have following shipping information:
+    Then product product1 should have following shipping information:
       | delivery time notes type                | specific |
       | delivery time in stock notes[en-US]     |          |
       | delivery time out of stock notes[en-US] |          |
+
+  Scenario: Remove all product carriers
+    When I assign product product1 with following carriers:
+      | carrier1 |
+      | carrier2 |
+    Then product product1 should have following shipping information:
+      | carriers | [carrier1,carrier2] |

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/CarriersCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/CarriersCommandsBuilderTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\CarriersCommandsBuilder;
+
+class CarriersCommandsBuilderTest extends AbstractProductCommandBuilderTest
+{
+    /**
+     * @dataProvider getExpectedSingleShopCommands
+     *
+     * @param array $formData
+     * @param array $expectedCommands
+     */
+    public function testBuildSingleShopCommands(array $formData, array $expectedCommands): void
+    {
+        $builder = new CarriersCommandsBuilder(self::MODIFY_ALL_SHOPS_PREFIX);
+        $builtCommands = $builder->buildCommands($this->getProductId(), $formData, $this->getSingleShopConstraint());
+        $this->assertEquals($expectedCommands, $builtCommands);
+    }
+
+    /**
+     * @dataProvider getExpectedMultiShopCommands
+     *
+     * @param array $formData
+     * @param array $expectedCommands
+     */
+    public function testBuildMultiShopCommands(array $formData, array $expectedCommands): void
+    {
+        $builder = new CarriersCommandsBuilder(self::MODIFY_ALL_SHOPS_PREFIX);
+        $builtCommands = $builder->buildCommands($this->getProductId(), $formData, $this->getSingleShopConstraint());
+        $this->assertEquals($expectedCommands, $builtCommands);
+    }
+
+    public function getExpectedMultiShopCommands(): iterable
+    {
+        $command = $this->getAllShopsCommand([1, 2, 3]);
+        yield [
+            [
+                'shipping' => [
+                    'carriers' => ['1', '2', '3'],
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'carriers' => true,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand([1, 2, 3]);
+        yield [
+            [
+                'shipping' => [
+                    'carriers' => ['1', '2', '3'],
+                ],
+            ],
+            [$command],
+        ];
+    }
+
+    public function getExpectedSingleShopCommands(): iterable
+    {
+        yield [
+            [
+                'no data' => ['useless value'],
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'shipping' => [
+                    'not_handled' => 0,
+                ],
+            ],
+            [],
+        ];
+
+        $command = $this->getSingleShopCommand([1, 2, 3]);
+        yield [
+            [
+                'shipping' => [
+                    'carriers' => ['1', '2', '3'],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand([]);
+        yield [
+            [
+                'shipping' => [
+                    'carriers' => [],
+                ],
+            ],
+            [$command],
+        ];
+    }
+
+    private function getSingleShopCommand(array $carrierReferenceIds): SetCarriersCommand
+    {
+        return new SetCarriersCommand(
+            $this->getProductId()->getValue(),
+            $carrierReferenceIds,
+            $this->getSingleShopConstraint()
+        );
+    }
+
+    private function getAllShopsCommand(array $carrierReferenceIds): SetCarriersCommand
+    {
+        return new SetCarriersCommand(
+            $this->getProductId()->getValue(),
+            $carrierReferenceIds,
+            ShopConstraint::allShops()
+        );
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ShippingCommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ShippingCommandBuilderTest.php
@@ -68,18 +68,6 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
     public function getExpectedMultiShopCommands(): Generator
     {
         $command = $this->getAllShopsCommand();
-        $command->setCarrierReferenceIds([1, 2, 3]);
-        yield [
-            [
-                'shipping' => [
-                    'carriers' => ['1', '2', '3'],
-                    self::MODIFY_ALL_SHOPS_PREFIX . 'carriers' => true,
-                ],
-            ],
-            [$command],
-        ];
-
-        $command = $this->getAllShopsCommand();
         $localizedNotes = [
             '1' => 'test4',
             '3' => 'test5',
@@ -177,17 +165,6 @@ class ShippingCommandBuilderTest extends AbstractProductCommandBuilderTest
             [
                 'shipping' => [
                     'additional_shipping_cost' => '-0.55',
-                ],
-            ],
-            [$command],
-        ];
-
-        $command = $this->getSingleShopCommand();
-        $command->setCarrierReferenceIds([1, 2, 3]);
-        yield [
-            [
-                'shipping' => [
-                    'carriers' => ['1', '2', '3'],
                 ],
             ],
             [$command],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the process of uniting all the product commands into one (for its proper fields at least) we realized that `UpdateProductShippingCommand` also handles the carriers relationship The command will soon be removed so we need to handle this association in a dedicated command SetCarriersCommand
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | This PR is blocking this one https://github.com/PrestaShop/PrestaShop/pull/30228
| How to test?      | CI tests green should be enough, we'll wait for the PR that finalizes the unified command integration to check for potential regressions (a QA by dev has been done already)
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
