### PR TITLE
Do not return customization values if cart is not set

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4362,6 +4362,11 @@ class CartCore extends ObjectModel
             return [];
         }
 
+        // if cart is not set, return nothing to prevent loading of other users data.
+        if (0 === (int) $this->id) {
+            return [];
+        }
+
         $result = Db::getInstance()->executeS(
             'SELECT cu.id_customization, cd.index, cd.value, cd.type, cu.in_cart, cu.quantity
             FROM `' . _DB_PREFIX_ . 'customization` cu


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fix for issue 29259 where customization values are shared between customers with disabled cookies.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #29259. 
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Follow instructions in issue.
| Possible impacts? | ront office with storing values for customizations on products.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
