### PR TITLE
Fix recording last connection of a user

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -367,7 +367,10 @@ class ContextCore
             $this->cart->secure_key = $customer->secure_key;
             $this->cookie->id_guest = (int) $this->cart->id_guest;
         } else {
-            Guest::setNewGuest($this->cookie);
+            if (!$this->cookie->id_guest) {
+                Guest::setNewGuest($this->cookie);
+            }
+
             if (Validate::isLoadedObject($this->cart)) {
                 $idCarrier = (int) $this->cart->id_carrier;
                 $this->cart->secure_key = $customer->secure_key;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When a user create an account or login, the column "Last visit" in customer grid in BO was always empty
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30155 
| Related PRs       | #29104 
| How to test?      | See #30155 and #28336 <br> Don't forget to test these automation tests : ![image](https://user-images.githubusercontent.com/1533248/201897664-13d9009b-6155-4d7b-a51a-ebe5d63c0dab.png)
| Possible impacts? | Regression on #28336 

The bug was introduce during the PR #29104, so maybe It's a good idea to verify if #28336 still ok with this update


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
