### PR TITLE
Test id_manufacturer index before accessing it

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5516,7 +5516,7 @@ class ProductCore extends ObjectModel
         $row['category'] = Category::getLinkRewrite((int) $row['id_category_default'], (int) $id_lang);
         $row['category_name'] = Db::getInstance()->getValue('SELECT name FROM ' . _DB_PREFIX_ . 'category_lang WHERE id_shop = ' . (int) $context->shop->id . ' AND id_lang = ' . (int) $id_lang . ' AND id_category = ' . (int) $row['id_category_default']);
         $row['link'] = $context->link->getProductLink((int) $row['id_product'], $row['link_rewrite'], $row['category'], $row['ean13']);
-        $row['manufacturer_name'] = (int) $row['id_manufacturer'] > 0 ? Manufacturer::getNameById((int) $row['id_manufacturer']) : null;
+        $row['manufacturer_name'] = !empty($row['id_manufacturer']) ? Manufacturer::getNameById((int) $row['id_manufacturer']) : null;
 
         $row['attribute_price'] = 0;
         if ($id_product_attribute) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Problem reported in this issue https://github.com/PrestaShop/PrestaShop/pull/30194 was a regression on develop and 8.0.x that was not caught. It fixed it on develop but the problem remained in 8.0.x. This PR is a backport of this change. Simple change and already tested, doesn't need QA.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30272
| Related PRs       | -
| How to test?      | See reproducible scenario on the issue.
| Possible impacts? | no