### PR TITLE
Mail: add PS_MAIL_SUBJECT_PREFIX to control [Foo] subject prefix

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -494,7 +494,9 @@ class MailCore extends ObjectModel
             );
 
             /* Create mail and attach differents parts */
-            $subject = '[' . strip_tags($configuration['PS_SHOP_NAME']) . '] ' . $subject;
+            if (Configuration::get('PS_MAIL_SUBJECT_PREFIX')) {
+                $subject = '[' . strip_tags($configuration['PS_SHOP_NAME']) . '] ' . $subject;
+            }
             $message->setSubject($subject);
 
             $message->setCharset('utf-8');

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -712,6 +712,9 @@ Country</value>
   <configuration id="PS_MAIL_METHOD" name="PS_MAIL_METHOD">
     <value>1</value>
   </configuration>
+  <configuration id="PS_MAIL_SUBJECT_PREFIX" name="PS_MAIL_SUBJECT_PREFIX">
+    <value>1</value>
+  </configuration>
   <configuration id="PS_SHOP_ACTIVITY" name="PS_SHOP_ACTIVITY">
     <value>Animaux</value>
   </configuration>

--- a/src/Core/Email/EmailDataConfigurator.php
+++ b/src/Core/Email/EmailDataConfigurator.php
@@ -55,6 +55,7 @@ final class EmailDataConfigurator implements DataConfigurationInterface
         return [
             'send_emails_to' => $this->configuration->get('PS_MAIL_EMAIL_MESSAGE'),
             'mail_method' => (int) $this->configuration->get('PS_MAIL_METHOD'),
+            'subject_prefix' => (bool) $this->configuration->get('PS_MAIL_SUBJECT_PREFIX'),
             'mail_type' => (int) $this->configuration->get('PS_MAIL_TYPE'),
             'log_emails' => (bool) $this->configuration->get('PS_LOG_EMAILS'),
             'smtp_config' => [
@@ -82,6 +83,7 @@ final class EmailDataConfigurator implements DataConfigurationInterface
         if ($this->validateConfiguration($config)) {
             $this->configuration->set('PS_MAIL_EMAIL_MESSAGE', $config['send_emails_to']);
             $this->configuration->set('PS_MAIL_METHOD', $config['mail_method']);
+            $this->configuration->set('PS_MAIL_SUBJECT_PREFIX', $config['subject_prefix']);
             $this->configuration->set('PS_MAIL_TYPE', $config['mail_type']);
             $this->configuration->set('PS_LOG_EMAILS', $config['log_emails']);
             $this->configuration->set('PS_MAIL_DKIM_ENABLE', $config['dkim_enable']);
@@ -111,6 +113,7 @@ final class EmailDataConfigurator implements DataConfigurationInterface
         return isset(
             $config['send_emails_to'],
             $config['mail_method'],
+            $config['subject_prefix'],
             $config['mail_type'],
             $config['log_emails'],
             $config['dkim_enable'],

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
@@ -88,6 +88,9 @@ class EmailConfigurationType extends TranslatorAwareType
                 'multiple' => false,
                 'choices' => $this->mailMethodChoiceProvider->getChoices(),
             ])
+            ->add('subject_prefix', SwitchType::class, [
+                'label' => $this->trans('Prefix subject with shop name', 'Admin.Advparameters.Feature'),
+            ])
             ->add('mail_type', ChoiceType::class, [
                 'expanded' => true,
                 'multiple' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Email/EmailConfigurationType.php
@@ -89,7 +89,7 @@ class EmailConfigurationType extends TranslatorAwareType
                 'choices' => $this->mailMethodChoiceProvider->getChoices(),
             ])
             ->add('subject_prefix', SwitchType::class, [
-                'label' => $this->trans('Prefix subject with shop name', 'Admin.Advparameters.Feature'),
+                'label' => $this->trans('Enable the shop name as a prefix in the emails subject', 'Admin.Advparameters.Feature'),
             ])
             ->add('mail_type', ChoiceType::class, [
                 'expanded' => true,

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Email/Blocks/email_configuration.html.twig
@@ -38,6 +38,7 @@
         <div class="js-smtp-configuration{% if emailConfigurationForm.mail_method.vars.value != smtpMailMethod %} d-none{% endif %}">
           {{ form_widget(emailConfigurationForm.smtp_config) }}
         </div>
+        {{ form_row(emailConfigurationForm.subject_prefix) }}
         {{ form_row(emailConfigurationForm.mail_type) }}
         {{ form_row(emailConfigurationForm.log_emails) }}
         <div class="alert alert-info" role="alert">


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Mail::send() was prefixing every e-mail subject with a shop name in<br>square brackets. A lot of shop owners look for a way of disabling that<br>behaviour. Most of them probably find it redundant since there is<br>already a sender in the From field.<br><br>Add PS_MAIL_SUBJECT_PREFIX config option and allow changing it in the<br>Advanced Parameters → E-mail<br><br>Make it enabled by default to avoid changing a long-known behaviour.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #24492
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/544
| How to test?      | Disable "Prefix subject with shop name" and verify that outgoing e-mails don't have shop name as subject prefix
| Possible impacts? | Make sure that sending e-mails works