### PR TITLE
Fix generation of nightlies on develop branch

### DIFF
--- a/tools/build/Library/ReleaseCreator.php
+++ b/tools/build/Library/ReleaseCreator.php
@@ -370,17 +370,8 @@ class ReleaseCreator
      */
     protected function getCurrentVersion()
     {
-        $kernelFile = $this->projectPath.'/app/AppKernel.php';
-        $matches = [];
-
-        $kernelFileContent = file_get_contents($kernelFile);
-        $kernelFileContent = preg_match(
-            '~const VERSION = \'(.*)\';~',
-            $kernelFileContent,
-            $matches
-        );
-
-        return $matches[1];
+        require_once $this->projectPath.'/src/Core/Version.php';
+        return \PrestaShop\PrestaShop\Core\Version::VERSION;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Nightlies generation [appears to be broken](https://github.com/PrestaShop/PrestaShop/actions/workflows/cron_nightly_build.yml) since [Version class has been introduced](https://github.com/PrestaShop/PrestaShop/commit/8632cf0469e0c3056ab3b23d1a0e3c0abc2479e7). This PR changes the source file when it retrieves the Version constant.
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | Nope
| Deprecations?     | Nope
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30285
| Related PRs       | /
| How to test?      | Running `php tools/build/CreateRelease.php --destination-dir=/tmp/ps-release` must now succeed.
| Possible impacts? | /