### PR TITLE
Add default config value for backorder status

### DIFF
--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -889,5 +889,8 @@ Country</value>
     <configuration id="PS_SECURITY_PASSWORD_POLICY_MINIMUM_SCORE" name="PS_SECURITY_PASSWORD_POLICY_MINIMUM_SCORE">
       <value>3</value>
     </configuration>
+    <configuration id="PS_ENABLE_BACKORDER_STATUS" name="PS_ENABLE_BACKORDER_STATUS">
+      <value>1</value>
+    </configuration>
   </entities>
 </entity_configuration>

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -890,7 +890,7 @@ Country</value>
       <value>3</value>
     </configuration>
     <configuration id="PS_ENABLE_BACKORDER_STATUS" name="PS_ENABLE_BACKORDER_STATUS">
-      <value>1</value>
+      <value>0</value>
     </configuration>
   </entities>
 </entity_configuration>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Default configuration value for https://github.com/PrestaShop/PrestaShop/pull/29753. Does not need QA.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | -
| Deprecations?     | -
| Fixed ticket?     | -
| Related PRs       | -
| How to test?      | To test : install a new shop and check the value in configuration table, also check if the switch button is to off in Shop Parameters > Order settings.
| Possible impacts? | -
