### PR TITLE
Customization field multishop

### DIFF
--- a/src/Adapter/Product/Customization/CommandHandler/RemoveAllCustomizationFieldsFromProductHandler.php
+++ b/src/Adapter/Product/Customization/CommandHandler/RemoveAllCustomizationFieldsFromProductHandler.php
@@ -82,6 +82,6 @@ final class RemoveAllCustomizationFieldsFromProductHandler implements RemoveAllC
         }, $product->getCustomizationFieldIds());
 
         $this->customizationFieldDeleter->bulkDelete($customizationFieldIds);
-        $this->productCustomizationFieldUpdater->refreshProductCustomizability($product);
+        $this->productCustomizationFieldUpdater->refreshProductCustomizability($command->getProductId());
     }
 }

--- a/src/Adapter/Product/Customization/CommandHandler/SetProductCustomizationFieldsHandler.php
+++ b/src/Adapter/Product/Customization/CommandHandler/SetProductCustomizationFieldsHandler.php
@@ -29,13 +29,13 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Customization\CommandHandler;
 
 use CustomizationField;
+use PrestaShop\PrestaShop\Adapter\Product\Customization\Repository\CustomizationFieldRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Customization\Update\ProductCustomizationFieldUpdater;
-use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\SetProductCustomizationFieldsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CommandHandler\SetProductCustomizationFieldsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationField as CustomizationFieldDTO;
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 /**
  * Handles @see SetProductCustomizationFieldsCommand using legacy object model
@@ -43,9 +43,9 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 class SetProductCustomizationFieldsHandler implements SetProductCustomizationFieldsHandlerInterface
 {
     /**
-     * @var ProductRepository
+     * @var CustomizationFieldRepository
      */
-    private $productRepository;
+    private $customizationFieldRepository;
 
     /**
      * @var ProductCustomizationFieldUpdater
@@ -53,14 +53,14 @@ class SetProductCustomizationFieldsHandler implements SetProductCustomizationFie
     private $productCustomizationFieldUpdater;
 
     /**
-     * @param ProductRepository $productRepository
+     * @param CustomizationFieldRepository $customizationFieldRepository,
      * @param ProductCustomizationFieldUpdater $productCustomizationFieldUpdater
      */
     public function __construct(
-        ProductRepository $productRepository,
+        CustomizationFieldRepository $customizationFieldRepository,
         ProductCustomizationFieldUpdater $productCustomizationFieldUpdater
     ) {
-        $this->productRepository = $productRepository;
+        $this->customizationFieldRepository = $customizationFieldRepository;
         $this->productCustomizationFieldUpdater = $productCustomizationFieldUpdater;
     }
 
@@ -71,31 +71,34 @@ class SetProductCustomizationFieldsHandler implements SetProductCustomizationFie
      */
     public function handle(SetProductCustomizationFieldsCommand $command): array
     {
+        $shopId = $command->getShopConstraint()->getShopId();
         $productId = $command->getProductId();
-        $product = $this->productRepository->get($productId);
+
         $customizationFields = [];
-
         foreach ($command->getCustomizationFields() as $providedCustomizationField) {
-            $customizationFields[] = $this->buildEntityFromDTO($productId, $providedCustomizationField);
+            $customizationFields[] = $this->buildEntityFromDTO($productId, $providedCustomizationField, $shopId);
         }
+        $this->productCustomizationFieldUpdater->setProductCustomizationFields($productId, $customizationFields, $command->getShopConstraint());
 
-        $this->productCustomizationFieldUpdater->setProductCustomizationFields($productId, $customizationFields);
-
-        return array_map(function (int $customizationFieldId): CustomizationFieldId {
-            return new CustomizationFieldId($customizationFieldId);
-        }, $product->getNonDeletedCustomizationFieldIds());
+        return $this->customizationFieldRepository->getCustomizationFieldIds($productId);
     }
 
     /**
      * @param ProductId $productId
      * @param CustomizationFieldDTO $customizationFieldDTO
+     * @param ShopId $shopId
      *
      * @return CustomizationField
      */
-    private function buildEntityFromDTO(ProductId $productId, CustomizationFieldDTO $customizationFieldDTO): CustomizationField
+    private function buildEntityFromDTO(ProductId $productId, CustomizationFieldDTO $customizationFieldDTO, ShopId $shopId): CustomizationField
     {
-        $customizationField = new CustomizationField();
-        $customizationField->id = $customizationFieldDTO->getCustomizationFieldId();
+        // Fetch existing customization field or create a new one
+        if ($customizationFieldDTO->getCustomizationFieldId()) {
+            $customizationField = new CustomizationField($customizationFieldDTO->getCustomizationFieldId(), null, $shopId->getValue());
+        } else {
+            $customizationField = new CustomizationField();
+        }
+
         $customizationField->id_product = $productId->getValue();
         $customizationField->type = $customizationFieldDTO->getType();
         $customizationField->required = $customizationFieldDTO->isRequired();

--- a/src/Adapter/Product/Customization/Repository/CustomizationFieldRepository.php
+++ b/src/Adapter/Product/Customization/Repository/CustomizationFieldRepository.php
@@ -29,35 +29,57 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Customization\Repository;
 
 use CustomizationField;
+use Doctrine\DBAL\Connection;
 use PrestaShop\PrestaShop\Adapter\Product\Customization\Validate\CustomizationFieldValidator;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CannotAddCustomizationFieldException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CannotDeleteCustomizationFieldException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CannotUpdateCustomizationFieldException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationFieldNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
-use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
+use PrestaShop\PrestaShop\Core\Repository\AbstractMultiShopObjectModelRepository;
 
 /**
  * Methods to access data storage for CustomizationField
  */
-class CustomizationFieldRepository extends AbstractObjectModelRepository
+class CustomizationFieldRepository extends AbstractMultiShopObjectModelRepository
 {
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var string
+     */
+    private $dbPrefix;
+
     /**
      * @var CustomizationFieldValidator
      */
     private $customizationFieldValidator;
 
     /**
+     * @param Connection $connection
+     * @param string $dbPrefix
      * @param CustomizationFieldValidator $customizationFieldValidator
      */
     public function __construct(
+        Connection $connection,
+        string $dbPrefix,
         CustomizationFieldValidator $customizationFieldValidator
     ) {
+        $this->connection = $connection;
+        $this->dbPrefix = $dbPrefix;
         $this->customizationFieldValidator = $customizationFieldValidator;
     }
 
     /**
+     * This getter without specified shop is useful when the product is only fetched for deletion.
+     * In which case the shopId doesn't matter we don't care about multishop content since the entity is about to be deleted.
+     *
      * @param CustomizationFieldId $fieldId
      *
      * @return CustomizationField
@@ -77,30 +99,53 @@ class CustomizationFieldRepository extends AbstractObjectModelRepository
     }
 
     /**
+     * @param CustomizationFieldId $fieldId
+     * @param ShopId $shopId
+     *
+     * @return CustomizationField
+     *
+     * @throws CoreException
+     */
+    public function getForShop(CustomizationFieldId $fieldId, ShopId $shopId): CustomizationField
+    {
+        /** @var CustomizationField $customizationField */
+        $customizationField = $this->getObjectModelForShop(
+            $fieldId->getValue(),
+            CustomizationField::class,
+            CustomizationFieldNotFoundException::class,
+            $shopId
+        );
+
+        return $customizationField;
+    }
+
+    /**
      * @param CustomizationField $customizationField
+     * @param ShopId[] $shopIds
      * @param int $errorCode
      *
      * @return CustomizationFieldId
      *
      * @throws CoreException
      */
-    public function add(CustomizationField $customizationField, int $errorCode = 0): CustomizationFieldId
+    public function add(CustomizationField $customizationField, array $shopIds, int $errorCode = 0): CustomizationFieldId
     {
         $this->customizationFieldValidator->validate($customizationField);
-        $this->addObjectModel($customizationField, CannotAddCustomizationFieldException::class, $errorCode);
+        $this->addObjectModelToShops($customizationField, $shopIds, CannotAddCustomizationFieldException::class, $errorCode);
 
         return new CustomizationFieldId((int) $customizationField->id);
     }
 
     /**
      * @param CustomizationField $customizationField
+     * @param ShopId[] $shopIds
      *
      * @throws CannotUpdateCustomizationFieldException
      */
-    public function update(CustomizationField $customizationField): void
+    public function update(CustomizationField $customizationField, array $shopIds): void
     {
         $this->customizationFieldValidator->validate($customizationField);
-        $this->updateObjectModel($customizationField, CannotUpdateCustomizationFieldException::class);
+        $this->updateObjectModelForShops($customizationField, $shopIds, CannotUpdateCustomizationFieldException::class);
     }
 
     /**
@@ -117,5 +162,32 @@ class CustomizationFieldRepository extends AbstractObjectModelRepository
     public function softDelete(CustomizationField $customizationField): void
     {
         $this->softDeleteObjectModel($customizationField, CannotDeleteCustomizationFieldException::class);
+    }
+
+    /**
+     * Returns the list of customization associated to a product (only their IDs), by default soft deleted entities
+     * are filtered.
+     *
+     * @param ProductId $productId
+     * @param bool $includeSoftDeleted
+     *
+     * @return CustomizationFieldId[]
+     */
+    public function getCustomizationFieldIds(ProductId $productId, bool $includeSoftDeleted = false): array
+    {
+        $qb = $this->connection->createQueryBuilder()
+            ->addSelect('cf.id_customization_field')
+            ->from($this->dbPrefix . 'customization_field', 'cf')
+            ->where('cf.id_product = :productId')
+            ->setParameter('productId', $productId->getValue())
+        ;
+
+        if (!$includeSoftDeleted) {
+            $qb->andWhere('cf.is_deleted = 0');
+        }
+
+        return array_map(static function (array $customizationFieldId) {
+            return new CustomizationFieldId((int) $customizationFieldId['id_customization_field']);
+        }, $qb->execute()->fetchAllAssociative());
     }
 }

--- a/src/Core/Domain/Product/Customization/Command/SetProductCustomizationFieldsCommand.php
+++ b/src/Core/Domain/Product/Customization/Command/SetProductCustomizationFieldsCommand.php
@@ -29,7 +29,9 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationField;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationShopConstraintTrait;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use RuntimeException;
 
 /**
@@ -37,6 +39,8 @@ use RuntimeException;
  */
 class SetProductCustomizationFieldsCommand
 {
+    use CustomizationShopConstraintTrait;
+
     /**
      * @var ProductId
      */
@@ -48,13 +52,23 @@ class SetProductCustomizationFieldsCommand
     private $customizationFields = [];
 
     /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
      * @param int $productId
      * @param array $customizationFields
      */
-    public function __construct(int $productId, array $customizationFields)
-    {
+    public function __construct(
+        int $productId,
+        array $customizationFields,
+        ShopConstraint $shopConstraint
+    ) {
         $this->productId = new ProductId($productId);
         $this->setCustomizationFields($customizationFields);
+        $this->checkShopConstraint($shopConstraint);
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -71,6 +85,14 @@ class SetProductCustomizationFieldsCommand
     public function getCustomizationFields(): array
     {
         return $this->customizationFields;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 
     /**

--- a/src/Core/Domain/Product/Customization/Command/SetProductCustomizationFieldsCommand.php
+++ b/src/Core/Domain/Product/Customization/Command/SetProductCustomizationFieldsCommand.php
@@ -58,7 +58,7 @@ class SetProductCustomizationFieldsCommand
 
     /**
      * @param int $productId
-     * @param array $customizationFields
+     * @param array{'type': int, "localized_names": array<int, string>, "is_required": bool, "added_by_module": bool, "id"?: int|null}[] $customizationFields
      */
     public function __construct(
         int $productId,
@@ -96,7 +96,7 @@ class SetProductCustomizationFieldsCommand
     }
 
     /**
-     * @param array $customizationFields
+     * @param array{'type': int, "localized_names": array<int, string>, "is_required": bool, "added_by_module": bool, "id"?: int|null}[] $customizationFields $customizationFields
      */
     private function setCustomizationFields(array $customizationFields): void
     {

--- a/src/Core/Domain/Product/Customization/CustomizationShopConstraintTrait.php
+++ b/src/Core/Domain/Product/Customization/CustomizationShopConstraintTrait.php
@@ -46,7 +46,7 @@ trait CustomizationShopConstraintTrait
      *
      * @throws InvalidShopConstraintException
      */
-    protected function checkShopConstraint(ShopCOnstraint $shopConstraint): void
+    protected function checkShopConstraint(ShopConstraint $shopConstraint): void
     {
         if ($shopConstraint->forAllShops() || $shopConstraint->getShopGroupId()) {
             throw new InvalidShopConstraintException(sprintf(

--- a/src/Core/Domain/Product/Customization/CustomizationShopConstraintTrait.php
+++ b/src/Core/Domain/Product/Customization/CustomizationShopConstraintTrait.php
@@ -26,55 +26,33 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query;
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Customization;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\Customization\CustomizationShopConstraintTrait;
-use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\InvalidShopConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
- * Gets product customization fields
+ * The customization field commands/queries only handles single shop use case, we didn't implement the allShops use case because
+ * it was considered too complex to handle compared to the benefit. The "apply to all shops" boolean can't be assigned on the
+ * command itself but on each contained CustomizationField in the command. Besides the association of customization fields is not
+ * dependent to a specific shop they are common to all shops, and it only allows update the name field for a specific shop.
+ *
+ * A POC had been started in case the feature needs to evolve someday https://github.com/PrestaShop/PrestaShop/pull/27944
  */
-class GetProductCustomizationFields
+trait CustomizationShopConstraintTrait
 {
-    use CustomizationShopConstraintTrait;
-
     /**
-     * @var ProductId
-     */
-    private $productId;
-
-    /**
-     * @var ShopConstraint
-     */
-    private $shopConstraint;
-
-    /**
-     * @param int $productId
      * @param ShopConstraint $shopConstraint
+     *
+     * @throws InvalidShopConstraintException
      */
-    public function __construct(
-        int $productId,
-        ShopConstraint $shopConstraint
-    ) {
-        $this->productId = new ProductId($productId);
-        $this->checkShopConstraint($shopConstraint);
-        $this->shopConstraint = $shopConstraint;
-    }
-
-    /**
-     * @return ProductId
-     */
-    public function getProductId(): ProductId
+    protected function checkShopConstraint(ShopCOnstraint $shopConstraint): void
     {
-        return $this->productId;
-    }
-
-    /**
-     * @return ShopConstraint
-     */
-    public function getShopConstraint(): ShopConstraint
-    {
-        return $this->shopConstraint;
+        if ($shopConstraint->forAllShops() || $shopConstraint->getShopGroupId()) {
+            throw new InvalidShopConstraintException(sprintf(
+                '%s only handles single shop constraint.',
+                self::class
+            ));
+        }
     }
 }

--- a/src/Core/Domain/Shop/Exception/ShopDefinitionNotFound.php
+++ b/src/Core/Domain/Shop/Exception/ShopDefinitionNotFound.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Shop\Exception;
+
+/**
+ * Thrown when trying to use a multishop feature on an entity that has no multishop feature
+ * (no association and no multilang_shop feature).
+ */
+class ShopDefinitionNotFound extends ShopException
+{
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/CustomizationFieldsCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/CustomizationFieldsCommandsBuilder.php
@@ -30,16 +30,17 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Prod
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\RemoveAllCustomizationFieldsFromProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\SetProductCustomizationFieldsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Builds commands from product customizations form
  */
-final class CustomizationFieldsCommandsBuilder implements ProductCommandsBuilderInterface
+final class CustomizationFieldsCommandsBuilder implements MultiShopProductCommandsBuilderInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function buildCommands(ProductId $productId, array $formData): array
+    public function buildCommands(ProductId $productId, array $formData, ShopConstraint $singleShopConstraint): array
     {
         if (!isset($formData['specifications']['customizations'])) {
             return [];
@@ -54,7 +55,8 @@ final class CustomizationFieldsCommandsBuilder implements ProductCommandsBuilder
         return [
             new SetProductCustomizationFieldsCommand(
                 $productId->getValue(),
-                $this->buildCustomizationFields($customizations['customization_fields'])
+                $this->buildCustomizationFields($customizations['customization_fields']),
+                $singleShopConstraint
             ),
         ];
     }

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -117,7 +117,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
             'id' => $productId,
             'header' => $this->extractHeaderData($productForEditing),
             'description' => $this->extractDescriptionData($productForEditing),
-            'specifications' => $this->extractSpecificationsData($productForEditing),
+            'specifications' => $this->extractSpecificationsData($productForEditing, $shopConstraint),
             'stock' => $this->extractStockData($productForEditing, $shopConstraint),
             'pricing' => $this->extractPricingData($productForEditing),
             'seo' => $this->extractSEOData($productForEditing),
@@ -302,10 +302,11 @@ class ProductFormDataProvider implements FormDataProviderInterface
 
     /**
      * @param ProductForEditing $productForEditing
+     * @param ShopConstraint $shopConstraint
      *
      * @return array<string, mixed>
      */
-    private function extractSpecificationsData(ProductForEditing $productForEditing): array
+    private function extractSpecificationsData(ProductForEditing $productForEditing, ShopConstraint $shopConstraint): array
     {
         $details = $productForEditing->getDetails();
         $options = $productForEditing->getOptions();
@@ -322,7 +323,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
             'attachments' => $this->extractAttachmentsData($productForEditing),
             'show_condition' => $options->showCondition(),
             'condition' => $options->getCondition(),
-            'customizations' => $this->extractCustomizationsData($productForEditing),
+            'customizations' => $this->extractCustomizationsData($productForEditing, $shopConstraint),
         ];
     }
 
@@ -592,14 +593,15 @@ class ProductFormDataProvider implements FormDataProviderInterface
 
     /**
      * @param ProductForEditing $productForEditing
+     * @param ShopConstraint $shopConstraint
      *
      * @return array<string, array<int, mixed>>
      */
-    private function extractCustomizationsData(ProductForEditing $productForEditing): array
+    private function extractCustomizationsData(ProductForEditing $productForEditing, ShopConstraint $shopConstraint): array
     {
         /** @var CustomizationField[] $customizationFields */
         $customizationFields = $this->queryBus->handle(
-            new GetProductCustomizationFields($productForEditing->getProductId())
+            new GetProductCustomizationFields($productForEditing->getProductId(), $shopConstraint)
         );
 
         if (empty($customizationFields)) {

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_customization.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_customization.yml
@@ -8,6 +8,8 @@ services:
   prestashop.adapter.product.customization.repository.customization_field_repository:
     class: PrestaShop\PrestaShop\Adapter\Product\Customization\Repository\CustomizationFieldRepository
     arguments:
+      - '@doctrine.dbal.default_connection'
+      - '%database_prefix%'
       - '@prestashop.adapter.product.customization.validate.customization_field_validator'
 
   prestashop.adapter.product.customization.update.customization_field_deleter:
@@ -21,13 +23,12 @@ services:
     arguments:
       - '@prestashop.adapter.product.customization.repository.customization_field_repository'
       - '@prestashop.adapter.product.customization.update.customization_field_deleter'
-      - '@prestashop.adapter.product.repository.product_repository'
+      - '@prestashop.adapter.product.repository.product_multi_shop_repository'
 
   prestashop.adapter.product.customization.query_handler.get_product_customization_fields_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Customization\QueryHandler\GetProductCustomizationFieldsHandler
     arguments:
       - '@prestashop.adapter.product.customization.repository.customization_field_repository'
-      - '@prestashop.adapter.product.repository.product_repository'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields
@@ -35,7 +36,7 @@ services:
   prestashop.adapter.product.customization.command_handler.set_product_customization_fields_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Customization\CommandHandler\SetProductCustomizationFieldsHandler
     arguments:
-      - '@prestashop.adapter.product.repository.product_repository'
+      - '@prestashop.adapter.product.customization.repository.customization_field_repository'
       - '@prestashop.adapter.product.customization.update.product_customization_field_updater'
     tags:
       - name: tactician.handler

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
@@ -146,14 +146,15 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
 
     /**
      * @param string $productReference
+     * @param ShopConstraint $shopConstraint
      *
      * @return CustomizationField[]
      */
-    protected function getProductCustomizationFields(string $productReference): array
+    protected function getProductCustomizationFields(string $productReference, ShopConstraint $shopConstraint): array
     {
         return $this->getQueryBus()->handle(new GetProductCustomizationFields(
             $this->getSharedStorage()->get($productReference),
-            ShopConstraint::shop($this->getDefaultShopId())
+            $shopConstraint
         ));
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/AbstractProductFeatureContext.php
@@ -152,7 +152,8 @@ abstract class AbstractProductFeatureContext extends AbstractDomainFeatureContex
     protected function getProductCustomizationFields(string $productReference): array
     {
         return $this->getQueryBus()->handle(new GetProductCustomizationFields(
-            $this->getSharedStorage()->get($productReference)
+            $this->getSharedStorage()->get($productReference),
+            ShopConstraint::shop($this->getDefaultShopId())
         ));
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\BulkDuplicateProductComman
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\DuplicateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 class DuplicateProductFeatureContext extends AbstractProductFeatureContext
 {
@@ -94,8 +95,8 @@ class DuplicateProductFeatureContext extends AbstractProductFeatureContext
      */
     public function assertDuplicatedCustomizationFields(string $newProductReference, string $oldProductReference): void
     {
-        $oldCustomizationFields = $this->getProductCustomizationFields($oldProductReference);
-        $newCustomizationFields = $this->getProductCustomizationFields($newProductReference);
+        $oldCustomizationFields = $this->getProductCustomizationFields($oldProductReference, ShopConstraint::shop($this->getDefaultShopId()));
+        $newCustomizationFields = $this->getProductCustomizationFields($newProductReference, ShopConstraint::shop($this->getDefaultShopId()));
 
         Assert::assertEquals(
             count($oldCustomizationFields),

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -50,7 +50,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param TableNode $table
      */
-    public function updateCustomizationFieldsForDefaultShop(string $productReference, TableNode $table)
+    public function updateCustomizationFieldsForDefaultShop(string $productReference, TableNode $table): void
     {
         $this->updateCustomizationFields($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
     }
@@ -61,7 +61,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param TableNode $table
      */
-    public function updateCustomizationFieldsForShop(string $productReference, TableNode $table, string $shopReference)
+    public function updateCustomizationFieldsForShop(string $productReference, TableNode $table, string $shopReference): void
     {
         $this->updateCustomizationFields($productReference, $table, ShopConstraint::shop((int) $this->getSharedStorage()->get($shopReference)));
     }
@@ -72,7 +72,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param int $nameLength
      */
-    public function addCustomizationFieldWithTooLongName(string $productReference, int $nameLength)
+    public function addCustomizationFieldWithTooLongName(string $productReference, int $nameLength): void
     {
         $fieldsForUpdate = [];
         foreach (Language::getIDs() as $langId) {
@@ -100,7 +100,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      *
      * @param string $productReference
      */
-    public function updateCustomizationFieldsWithEmptyArray(string $productReference)
+    public function updateCustomizationFieldsWithEmptyArray(string $productReference): void
     {
         try {
             $this->getCommandBus()->handle(new RemoveAllCustomizationFieldsFromProductCommand(
@@ -117,7 +117,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param string $customizability
      */
-    public function assertCustomizabilityForDefaultShop(string $productReference, string $customizability)
+    public function assertCustomizabilityForDefaultShop(string $productReference, string $customizability): void
     {
         $this->assertCustomizability($productReference, $customizability, $this->getDefaultShopId());
     }
@@ -128,7 +128,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param string $customizability
      */
-    public function assertCustomizabilityForShops(string $productReference, string $customizability, string $shopReferences)
+    public function assertCustomizabilityForShops(string $productReference, string $customizability, string $shopReferences): void
     {
         foreach (explode(',', $shopReferences) as $shopReference) {
             $this->assertCustomizability($productReference, $customizability, (int) $this->getSharedStorage()->get(trim($shopReference)));
@@ -141,7 +141,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param TableNode $table
      */
-    public function assertCustomizationFieldsForDefaultShop(string $productReference, TableNode $table)
+    public function assertCustomizationFieldsForDefaultShop(string $productReference, TableNode $table): void
     {
         $this->assertCustomizationFields($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
     }
@@ -152,7 +152,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param TableNode $table
      */
-    public function assertCustomizationFieldsForShops(string $productReference, TableNode $table, string $shopReferences)
+    public function assertCustomizationFieldsForShops(string $productReference, TableNode $table, string $shopReferences): void
     {
         foreach (explode(',', $shopReferences) as $shopReference) {
             $this->assertCustomizationFields($productReference, $table, ShopConstraint::shop((int) $this->getSharedStorage()->get(trim($shopReference))));
@@ -166,7 +166,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param int $expectedCount
      * @param string $customizationType
      */
-    public function assertCustomizationOptionsForDefaultShop(string $productReference, int $expectedCount, string $customizationType)
+    public function assertCustomizationOptionsForDefaultShop(string $productReference, int $expectedCount, string $customizationType): void
     {
         $this->assertCustomizationOptions($productReference, $expectedCount, $customizationType, $this->getDefaultShopId());
     }
@@ -178,7 +178,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param int $expectedCount
      * @param string $customizationType
      */
-    public function assertCustomizationOptionsForShops(string $productReference, int $expectedCount, string $customizationType, string $shopReferences)
+    public function assertCustomizationOptionsForShops(string $productReference, int $expectedCount, string $customizationType, string $shopReferences): void
     {
         foreach (explode(',', $shopReferences) as $shopReference) {
             $this->assertCustomizationOptions($productReference, $expectedCount, $customizationType, (int) $this->getSharedStorage()->get(trim($shopReference)));
@@ -328,7 +328,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
         }
     }
 
-    private function assertCustomizability(string $productReference, string $customizability, int $shopId)
+    private function assertCustomizability(string $productReference, string $customizability, int $shopId): void
     {
         $customizationOptions = $this->getProductForEditing($productReference, $shopId)->getCustomizationOptions();
 
@@ -359,7 +359,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
         }
     }
 
-    private function assertCustomizationOptions(string $productReference, int $expectedCount, string $customizationType, int $shopId)
+    private function assertCustomizationOptions(string $productReference, int $expectedCount, string $customizationType, int $shopId): void
     {
         if (!in_array($customizationType, array_keys(CustomizationFieldType::AVAILABLE_TYPES))) {
             throw new RuntimeException(sprintf('Invalid customization type "%s" provided in test scenario', $customizationType));

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Customization\QueryResult\Customiz
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\ValueObject\CustomizationFieldType;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use RuntimeException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
@@ -292,7 +293,8 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
         try {
             $newCustomizationFieldIds = $this->getCommandBus()->handle(new SetProductCustomizationFieldsCommand(
                 $this->getSharedStorage()->get($productReference),
-                $fieldsForUpdate
+                $fieldsForUpdate,
+                ShopConstraint::shop($this->getDefaultShopId())
             ));
 
             Assert::assertSameSize(

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -50,34 +50,20 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param TableNode $table
      */
-    public function updateCustomizationFields(string $productReference, TableNode $table)
+    public function updateCustomizationFieldsForDefaultShop(string $productReference, TableNode $table)
     {
-        $customizationFields = $this->localizeByColumns($table);
-        $fieldsForUpdate = [];
-        $fieldReferences = [];
+        $this->updateCustomizationFields($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
+    }
 
-        foreach ($customizationFields as $customizationField) {
-            $addedByModule = isset($customizationField['added by module']) ?
-                PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['added by module']) :
-                false;
-            $fieldReference = $customizationField['reference'];
-            $id = $this->getSharedStorage()->exists($fieldReference) ? $this->getSharedStorage()->get($fieldReference) : null;
-
-            $fieldReferences[] = $fieldReference;
-            $fieldsForUpdate[] = [
-                'id' => $id,
-                'type' => $customizationField['type'] === 'file' ? CustomizationFieldType::TYPE_FILE : CustomizationFieldType::TYPE_TEXT,
-                'localized_names' => $customizationField['name'],
-                'is_required' => PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['is required']),
-                'added_by_module' => $addedByModule,
-            ];
-        }
-
-        $this->updateProductCustomizationFields(
-            $productReference,
-            $fieldReferences,
-            $fieldsForUpdate
-        );
+    /**
+     * @When I update product :productReference with following customization fields for shop :shopReference:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function updateCustomizationFieldsForShop(string $productReference, TableNode $table, string $shopReference)
+    {
+        $this->updateCustomizationFields($productReference, $table, ShopConstraint::shop((int) $this->getSharedStorage()->get($shopReference)));
     }
 
     /**
@@ -103,7 +89,7 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
         }
 
         try {
-            $this->updateProductCustomizationFields($productReference, ['name'], $fieldsForUpdate);
+            $this->updateProductCustomizationFields($productReference, ['name'], $fieldsForUpdate, ShopConstraint::shop($this->getDefaultShopId()));
         } catch (ProductException $e) {
             $this->setLastException($e);
         }
@@ -131,34 +117,21 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param string $customizability
      */
-    public function assertCustomizability(string $productReference, string $customizability)
+    public function assertCustomizabilityForDefaultShop(string $productReference, string $customizability)
     {
-        $customizationOptions = $this->getProductForEditing($productReference)->getCustomizationOptions();
+        $this->assertCustomizability($productReference, $customizability, $this->getDefaultShopId());
+    }
 
-        switch ($customizability) {
-            case 'not be customizable':
-                Assert::assertTrue(
-                    $customizationOptions->isNotCustomizable(),
-                    sprintf('Expected product "%s" to be not customizable', $productReference)
-                );
-
-                break;
-            case 'allow customization':
-                Assert::assertTrue(
-                    $customizationOptions->allowsCustomization(),
-                    sprintf('Expected product "%s" to allow customization', $productReference)
-                );
-
-                break;
-            case 'require customization':
-                Assert::assertTrue(
-                    $customizationOptions->requiresCustomization(),
-                    sprintf('Expected product "%s" to require customization', $productReference)
-                );
-
-                break;
-            default:
-                throw new RuntimeException(sprintf('Invalid customizability "%s" provided in test scenario', $customizability));
+    /**
+     * @Then /^product "(.+)" should (not be customizable|allow customization|require customization) for shops "(.+)"$/
+     *
+     * @param string $productReference
+     * @param string $customizability
+     */
+    public function assertCustomizabilityForShops(string $productReference, string $customizability, string $shopReferences)
+    {
+        foreach (explode(',', $shopReferences) as $shopReference) {
+            $this->assertCustomizability($productReference, $customizability, (int) $this->getSharedStorage()->get(trim($shopReference)));
         }
     }
 
@@ -168,11 +141,124 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
      * @param string $productReference
      * @param TableNode $table
      */
-    public function assertCustomizationFields(string $productReference, TableNode $table)
+    public function assertCustomizationFieldsForDefaultShop(string $productReference, TableNode $table)
+    {
+        $this->assertCustomizationFields($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
+    }
+
+    /**
+     * @Then product :productReference should have following customization fields for shop(s) :shopReferences:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function assertCustomizationFieldsForShops(string $productReference, TableNode $table, string $shopReferences)
+    {
+        foreach (explode(',', $shopReferences) as $shopReference) {
+            $this->assertCustomizationFields($productReference, $table, ShopConstraint::shop((int) $this->getSharedStorage()->get(trim($shopReference))));
+        }
+    }
+
+    /**
+     * @Then product :productReference should have :expectedCount customizable :customizationType field(s)
+     *
+     * @param string $productReference
+     * @param int $expectedCount
+     * @param string $customizationType
+     */
+    public function assertCustomizationOptionsForDefaultShop(string $productReference, int $expectedCount, string $customizationType)
+    {
+        $this->assertCustomizationOptions($productReference, $expectedCount, $customizationType, $this->getDefaultShopId());
+    }
+
+    /**
+     * @Then product :productReference should have :expectedCount customizable :customizationType field(s) for shop(s) :shopReferences
+     *
+     * @param string $productReference
+     * @param int $expectedCount
+     * @param string $customizationType
+     */
+    public function assertCustomizationOptionsForShops(string $productReference, int $expectedCount, string $customizationType, string $shopReferences)
+    {
+        foreach (explode(',', $shopReferences) as $shopReference) {
+            $this->assertCustomizationOptions($productReference, $expectedCount, $customizationType, (int) $this->getSharedStorage()->get(trim($shopReference)));
+        }
+    }
+
+    /**
+     * @Then I should get error that product customization field name is invalid
+     */
+    public function assertCustomizationFieldNameError(): void
+    {
+        $this->assertLastErrorIs(
+            CustomizationFieldConstraintException::class,
+            CustomizationFieldConstraintException::INVALID_NAME
+        );
+    }
+
+    private function updateCustomizationFields(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
+    {
+        $customizationFields = $this->localizeByColumns($table);
+        $fieldsForUpdate = [];
+        $fieldReferences = [];
+
+        foreach ($customizationFields as $customizationField) {
+            $addedByModule = isset($customizationField['added by module']) && PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['added by module']);
+            $fieldReference = $customizationField['reference'];
+            $id = $this->getSharedStorage()->exists($fieldReference) ? $this->getSharedStorage()->get($fieldReference) : null;
+
+            $fieldReferences[] = $fieldReference;
+            $fieldsForUpdate[] = [
+                'id' => $id,
+                'type' => $customizationField['type'] === 'file' ? CustomizationFieldType::TYPE_FILE : CustomizationFieldType::TYPE_TEXT,
+                'localized_names' => $customizationField['name'],
+                'is_required' => PrimitiveUtils::castStringBooleanIntoBoolean($customizationField['is required']),
+                'added_by_module' => $addedByModule,
+            ];
+        }
+
+        $this->updateProductCustomizationFields(
+            $productReference,
+            $fieldReferences,
+            $fieldsForUpdate,
+            $shopConstraint
+        );
+    }
+
+    /**
+     * @param string $productReference
+     * @param array $fieldReferences
+     * @param array $fieldsForUpdate
+     */
+    private function updateProductCustomizationFields(string $productReference, array $fieldReferences, array $fieldsForUpdate, ShopConstraint $shopConstraint): void
+    {
+        try {
+            $newCustomizationFieldIds = $this->getCommandBus()->handle(new SetProductCustomizationFieldsCommand(
+                $this->getSharedStorage()->get($productReference),
+                $fieldsForUpdate,
+                $shopConstraint
+            ));
+
+            Assert::assertSameSize(
+                $fieldReferences,
+                $newCustomizationFieldIds,
+                'Cannot set references in shared storage. References and actual customization fields doesn\'t match.'
+            );
+
+            /** @var CustomizationFieldId $customizationFieldId */
+            foreach ($newCustomizationFieldIds as $key => $customizationFieldId) {
+                $this->getSharedStorage()->set($fieldReferences[$key], $customizationFieldId->getValue());
+            }
+        } catch (ProductException $e) {
+            $this->setLastException($e);
+        }
+    }
+
+    private function assertCustomizationFields(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
     {
         $data = $this->localizeByColumns($table);
         /** @var CustomizationField[] $actualFields */
-        $actualFields = $this->getProductCustomizationFields($productReference);
+        $actualFields = $this->getProductCustomizationFields($productReference, $shopConstraint);
         $notFoundExpectedFields = [];
 
         foreach ($data as $expectedField) {
@@ -242,20 +328,44 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
         }
     }
 
-    /**
-     * @Then product :productReference should have :expectedCount customizable :customizationType field(s)
-     *
-     * @param string $productReference
-     * @param int $expectedCount
-     * @param string $customizationType
-     */
-    public function assertCustomizationOptions(string $productReference, int $expectedCount, string $customizationType)
+    private function assertCustomizability(string $productReference, string $customizability, int $shopId)
+    {
+        $customizationOptions = $this->getProductForEditing($productReference, $shopId)->getCustomizationOptions();
+
+        switch ($customizability) {
+            case 'not be customizable':
+                Assert::assertTrue(
+                    $customizationOptions->isNotCustomizable(),
+                    sprintf('Expected product "%s" to be not customizable', $productReference)
+                );
+
+                break;
+            case 'allow customization':
+                Assert::assertTrue(
+                    $customizationOptions->allowsCustomization(),
+                    sprintf('Expected product "%s" to allow customization', $productReference)
+                );
+
+                break;
+            case 'require customization':
+                Assert::assertTrue(
+                    $customizationOptions->requiresCustomization(),
+                    sprintf('Expected product "%s" to require customization', $productReference)
+                );
+
+                break;
+            default:
+                throw new RuntimeException(sprintf('Invalid customizability "%s" provided in test scenario', $customizability));
+        }
+    }
+
+    private function assertCustomizationOptions(string $productReference, int $expectedCount, string $customizationType, int $shopId)
     {
         if (!in_array($customizationType, array_keys(CustomizationFieldType::AVAILABLE_TYPES))) {
             throw new RuntimeException(sprintf('Invalid customization type "%s" provided in test scenario', $customizationType));
         }
 
-        $productForEditing = $this->getProductForEditing($productReference);
+        $productForEditing = $this->getProductForEditing($productReference, $shopId);
 
         if ('file' === $customizationType) {
             Assert::assertEquals(
@@ -269,46 +379,6 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
                 $productForEditing->getCustomizationOptions()->getAvailableTextCustomizationsCount(),
                 'Unexpected customizable text fields count'
             );
-        }
-    }
-
-    /**
-     * @Then I should get error that product customization field name is invalid
-     */
-    public function assertCustomizationFieldNameError(): void
-    {
-        $this->assertLastErrorIs(
-            CustomizationFieldConstraintException::class,
-            CustomizationFieldConstraintException::INVALID_NAME
-        );
-    }
-
-    /**
-     * @param string $productReference
-     * @param array $fieldReferences
-     * @param array $fieldsForUpdate
-     */
-    private function updateProductCustomizationFields(string $productReference, array $fieldReferences, array $fieldsForUpdate): void
-    {
-        try {
-            $newCustomizationFieldIds = $this->getCommandBus()->handle(new SetProductCustomizationFieldsCommand(
-                $this->getSharedStorage()->get($productReference),
-                $fieldsForUpdate,
-                ShopConstraint::shop($this->getDefaultShopId())
-            ));
-
-            Assert::assertSameSize(
-                $fieldReferences,
-                $newCustomizationFieldIds,
-                'Cannot set references in shared storage. References and actual customization fields doesn\'t match.'
-            );
-
-            /** @var CustomizationFieldId $customizationFieldId */
-            foreach ($newCustomizationFieldIds as $key => $customizationFieldId) {
-                $this->getSharedStorage()->set($fieldReferences[$key], $customizationFieldId->getValue());
-            }
-        } catch (ProductException $e) {
-            $this->setLastException($e);
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/add_multishop_image.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/add_multishop_image.feature
@@ -2,6 +2,7 @@
 @restore-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
+@restore-shops-after-feature
 @product-image
 @add-multishop-image
 Feature: Add product image from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/set_product_images_for_all_shops.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/set_product_images_for_all_shops.feature
@@ -2,6 +2,7 @@
 @restore-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
+@restore-shops-after-feature
 @product-image
 @set-multishop-images-for-all-shops
 Feature: Set product images for all shops from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
@@ -2,6 +2,7 @@
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
+@restore-languages-after-feature
 @clear-cache-after-feature
 @product-multi-shop
 @update-multi-shop-management

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
@@ -338,24 +338,46 @@ Feature: Copy product from shop to shop.
       | en-US  | too slow... |
       | fr-FR  |             |
 
+  Scenario: I copy product to another shop that was not associated, customization fields are copied
+    When I add product "customizable_product" with following information:
+      | name[en-US] | nice customizable t-shirt |
+      | type        | standard                  |
+    And product "customizable_product" type should be standard
+    When I update product customizable_product with following customization fields:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField1 | text | front-text  | texte devant | true        |
+      | customField2 | text | bottom-text | texte du bas | true        |
+    Then product "customizable_product" should require customization
+    And product customizable_product should have 2 customizable text fields
+    And product customizable_product should have 0 customizable file fields
+    And product customizable_product should have following customization fields:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField1 | text | front-text  | texte devant | true        |
+      | customField2 | text | bottom-text | texte du bas | true        |
+    And I copy product customizable_product from shop shop1 to shop shop2
+    And product customizable_product should have following customization fields for shops shop1,shop2:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField1 | text | front-text  | texte devant | true        |
+      | customField2 | text | bottom-text | texte du bas | true        |
+
   Scenario: I copy product to another shop that was not associated, image associations are copied
-    Given I add product "product1" with following information:
+    Given I add product "graphicProduct" with following information:
       | name[en-US] | funny mug |
       | type        | standard  |
-    And I add new image "image1" named "app_icon.png" to product "product1" for shop "shop1"
-    And I add new image "image2" named "some_image.jpg" to product "product1" for shop "shop1"
-    And I copy product product1 from shop shop1 to shop shop2
-    Then product "product1" should have following images for shop "shop1":
+    And I add new image "image1" named "app_icon.png" to product "graphicProduct" for shop "shop1"
+    And I add new image "image2" named "some_image.jpg" to product "graphicProduct" for shop "shop1"
+    And I copy product graphicProduct from shop shop1 to shop shop2
+    Then product "graphicProduct" should have following images for shop "shop1":
       | image reference |  position | shops        |
       | image1          |  1        | shop1, shop2 |
       | image2          |  2        | shop1, shop2 |
-    And product "product1" should have following images for shop "shop2":
+    And product "graphicProduct" should have following images for shop "shop2":
       | image reference |  position | shops        |
       | image1          |  1        | shop1, shop2 |
       | image2          |  2        | shop1, shop2 |
-    And product "product1" should have following images for shop "shop3":
+    And product "graphicProduct" should have following images for shop "shop3":
       | image reference |  position | shops        |
-    And product "product1" should have following images for shop "shop4":
+    And product "graphicProduct" should have following images for shop "shop4":
       | image reference |  position | shops        |
     And following image types should be applicable to products:
       | reference     | name           | width | height |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_customization_fields.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_customization_fields.feature
@@ -1,0 +1,129 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-customization-fields-multishop
+@restore-products-before-feature
+@restore-languages-after-feature
+@clear-cache-before-feature
+@update-customization-fields-multishop
+Feature: Set product images for all shops from Back Office (BO)
+  As an employee I need to be able to edit customization fields for each shop
+
+  Background:
+    Given I enable multishop feature
+    And shop "shop1" with name "test_shop" exists
+    And shop group "default_shop_group" with name "Default" exists
+    # We don't init too many things in the background because the product and shops are used along all the scenarios
+    # so if we create them here there are new instances on each scenario
+
+  Scenario: I create a multishop product then I add customization fields (they are added to all shops)
+    Given I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And single shop context is loaded
+    And I add product "product1" to shop "shop1" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    And product "product1" type should be standard
+    And I copy product product1 from shop shop1 to shop shop2
+    Then product product1 is associated to shop shop1
+    And product product1 is associated to shop shop2
+    When I update product product1 with following customization fields for shop shop1:
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | true        |
+      | customField2 | text | back-text   | false       |
+    # The customizability is always the same for all shops since they share the same fields
+    Then product "product1" should require customization for shops "shop1,shop2"
+    And product product1 should have 2 customizable text fields for shops "shop1,shop2"
+    And product product1 should have 0 customizable file fields for shops "shop1,shop2"
+    And product product1 should have following customization fields for shops shop1,shop2:
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | true        |
+      | customField2 | text | back-text   | false       |
+
+  Scenario: I update some product customization fields and add additional one (name update only applies on one shop, new name is common to all)
+    Given product product1 should have following customization fields for shops shop1,shop2:
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | true        |
+      | customField2 | text | back-text   | false       |
+    When I update product product1 with following customization fields for shop shop2:
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | false       |
+      | customField2 | text | bottom-text | false       |
+      | customField3 | file | back image  | false       |
+    Then product "product1" should allow customization for shops "shop1,shop2"
+    And product product1 should have 2 customizable text fields for shops "shop1,shop2"
+    And product product1 should have 1 customizable file field for shops "shop1,shop2"
+    And product product1 should have following customization fields for shop shop2:
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | false       |
+      | customField2 | text | bottom-text | false       |
+      | customField3 | file | back image  | false       |
+    # List of fields is updated on all shops, but only shop2 had its name updated for customField2
+    And product product1 should have following customization fields for shop shop1:
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | false       |
+      | customField2 | text | back-text   | false       |
+      | customField3 | file | back image  | false       |
+
+  Scenario: I delete some product customization fields
+    Given product product1 should have following customization fields for shop shop2:
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | false       |
+      | customField2 | text | bottom-text | false       |
+      | customField3 | file | back image  | false       |
+    And product product1 should have following customization fields for shop shop1:
+      | reference    | type | name[en-US] | is required |
+      | customField1 | text | front-text  | false       |
+      | customField2 | text | back-text   | false       |
+      | customField3 | file | back image  | false       |
+    # Remove two fields and update the name for shop1 they now will be in sync
+    When I update product product1 with following customization fields for shop shop1:
+      | reference    | type | name[en-US] | is required |
+      | customField2 | text | bottom-text | true        |
+    Then product "product1" should require customization for shops "shop1,shop2"
+    And product product1 should have 1 customizable text field for shops "shop1,shop2"
+    And product product1 should have 0 customizable file fields for shops "shop1,shop2"
+    And product product1 should have following customization fields for shops shop1,shop2:
+      | reference    | type | name[en-US] | is required |
+      | customField2 | text | bottom-text | true        |
+
+  Scenario: Update customization field name in different languages
+    Given language "french" with locale "fr-FR" exists
+    And product "product1" should require customization
+    And product product1 should have 1 customizable text field
+    And product product1 should have 0 customizable file fields
+    # The previous name in english was kept for french
+    And product product1 should have following customization fields for shops shop1,shop2:
+      | reference    | type | name[en-US] | name[fr-FR] | is required |
+      | customField2 | text | bottom-text | bottom-text | true        |
+    When I update product product1 with following customization fields for shop shop1:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom-text | texte du bas | true        |
+    # Only shop1 will be updated
+    And product product1 should have following customization fields for shop shop1:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom-text | texte du bas | true        |
+    And product product1 should have following customization fields for shop shop2:
+      | reference    | type | name[en-US] | name[fr-FR] | is required |
+      | customField2 | text | bottom-text | bottom-text | true        |
+    # Only shop2 will be updated
+    When I update product product1 with following customization fields for shop shop2:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom      | texte du bas | true        |
+    Then product product1 should have following customization fields for shop shop1:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom-text | texte du bas | true        |
+    And product product1 should have following customization fields for shop shop2:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom      | texte du bas | true        |
+
+  Scenario: I delete all customization fields for product
+    Given product "product1" should require customization for shops "shop1,shop2"
+    And product product1 should have 1 customizable text field for shops shop1,shop2
+    And product product1 should have 0 customizable file fields for shops shop1,shop2
+    And product product1 should have following customization fields for shop shop1:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom-text | texte du bas | true        |
+    And product product1 should have following customization fields for shop shop2:
+      | reference    | type | name[en-US] | name[fr-FR]  | is required |
+      | customField2 | text | bottom      | texte du bas | true        |
+    When I remove all customization fields from product product1
+    Then product "product1" should not be customizable for shops "shop1,shop2"
+    Then product product1 should have 0 customizable text fields for shops shop1,shop2
+    And product product1 should have 0 customizable file fields for shops shop1,shop2

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_customization_fields.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_customization_fields.feature
@@ -1,6 +1,8 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-customization-fields-multishop
 @restore-products-before-feature
 @restore-languages-after-feature
+@restore-shops-after-feature
+@restore-languages-after-feature
 @clear-cache-before-feature
 @update-customization-fields-multishop
 Feature: Set product images for all shops from Back Office (BO)

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_shipping.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_shipping.feature
@@ -2,6 +2,7 @@
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
+@restore-languages-after-feature
 @clear-cache-after-feature
 @product-multi-shop
 @update-multi-shop-shipping

--- a/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
@@ -2,6 +2,7 @@
 @restore-products-before-feature
 @reset-downloads-after-feature
 @clear-cache-after-feature
+@restore-languages-after-feature
 @bulk-product
 @bulk-duplicate-product
 Feature: Duplicate product from Back Office (BO).

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_basic_information.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-basic-information
 @restore-products-before-feature
+@restore-languages-after-feature
 @update-basic-information
 Feature: Update product basic information from Back Office (BO)
   As a BO user

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/CustomizationFieldsCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/CustomizationFieldsCommandsBuilderTest.php
@@ -53,7 +53,7 @@ class CustomizationFieldsCommandsBuilderTest extends AbstractProductCommandBuild
      */
     public function testBuildCommand(array $formData, array $expectedCommands): void
     {
-        $builtCommands = $this->customizationFieldsCommandBuilder->buildCommands($this->getProductId(), $formData);
+        $builtCommands = $this->customizationFieldsCommandBuilder->buildCommands($this->getProductId(), $formData, $this->getSingleShopConstraint());
         $this->assertEquals($expectedCommands, $builtCommands);
     }
 
@@ -120,7 +120,8 @@ class CustomizationFieldsCommandsBuilderTest extends AbstractProductCommandBuild
                     'id' => null,
                     'added_by_module' => false,
                 ],
-            ]
+            ],
+            $this->getSingleShopConstraint()
         );
 
         yield [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle multishop for customization field in product V2, the name can be edited differently on each shop however we don't handle the `Apply to all shops` checkbox
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | This PR handles the multishop feature for customization fields in product page V2, so you should focus testing on these fields which have following rules in multishop:<br>- the creation and deletion of a customization field is common to ALL SHOPS, all the shops share the same number of fields<br>- the type and require values of fields are also common to ALL shops<br>- the only field that you can change depending on the shop is its name<br>- in product page V2 you can edit the name field differently by switching from a shop to another<br>- the `Modify for all shops` checkbox feature IS NOT implemented for this field
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
