### PR TITLE
Force AbstractColumn::name to never be null

### DIFF
--- a/src/Core/Grid/Column/AbstractColumn.php
+++ b/src/Core/Grid/Column/AbstractColumn.php
@@ -55,6 +55,7 @@ abstract class AbstractColumn implements ColumnInterface
     public function __construct($id)
     {
         $this->id = $id;
+        $this->name = '';
     }
 
     /**

--- a/src/Core/Grid/Filter/GridFilterFormFactory.php
+++ b/src/Core/Grid/Filter/GridFilterFormFactory.php
@@ -104,7 +104,7 @@ final class GridFilterFormFactory implements GridFilterFormFactoryInterface
         try {
             if ($filter->getAssociatedColumn()) {
                 $column = $definition->getColumnById($filter->getAssociatedColumn());
-                $filterLabel = $column->getName();
+                $filterLabel = !empty($column->getName()) ? $column->getName() : $filterLabel;
             }
         } catch (ColumnNotFoundException $e) {
         }

--- a/tests/Unit/Core/Grid/Column/ActionColumnTest.php
+++ b/tests/Unit/Core/Grid/Column/ActionColumnTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Grid\Column;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
+
+class ActionColumnTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $column = new ActionColumn('actions');
+        $this->assertEquals('actions', $column->getId());
+        $this->assertEquals('', $column->getName());
+        // The resolver doesn't call the parent resolver method so only actions option is available by default, not sure
+        // if it's relevant maybe this should be improved one day, but it seems to work as is
+        $this->assertEquals([
+            'actions' => null,
+        ], $column->getOptions());
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | AbstractColumn can be instantiated with `$name` empty (null), which is against the `ColumnInterface` since `getName` must always return a string type. So we initialize it with the same value as ID, this way in case `setName` is not used on the column it will still have a value for name
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30302 and [#30358](https://github.com/PrestaShop/PrestaShop/issues/30358)
| Related PRs       | ~
| How to test?      | See issue, access to credit slip page you should have no exception anymore
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
