### PR TITLE
Remove multi statement SQL queries from integration tests

### DIFF
--- a/tests/Integration/bootstrap.php
+++ b/tests/Integration/bootstrap.php
@@ -26,7 +26,6 @@
 define('_PS_IN_TEST_', true);
 define('_PS_ROOT_DIR_', dirname(__DIR__, 2));
 define('_PS_MODULE_DIR_', _PS_ROOT_DIR_ . '/tests/Resources/modules/');
-define('_PS_ALLOW_MULTI_STATEMENTS_QUERIES_', true);
 require_once dirname(__DIR__, 2) . '/admin-dev/bootstrap.php';
 
 /*


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | We now strongly recommended not to rely on multi-statement queries as they are potentially insecure, yet in one of our tests we used it to initialize some fixtures data. Even if it's just in the tests and has no impact to prod we should enforce our own recommendations so this PR aims to fix this
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | No function QA needed this only impacts the tests so green CI is enough
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
