### PR TITLE
Send the Error message into errors when XHR failed

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -595,14 +595,14 @@ class ProductController extends FrameworkBundleAdminController
             // this controller can be called as an AJAX JSON route or a HTML page
             // so we need to return the right type of response if an exception it thrown
             if ($request->isXmlHttpRequest()) {
-                $errors = [];
+                $error = [];
 
                 if ($this->get('prestashop.adapter.environment')->isDebug()) {
-                    $errors[] = $e->getMessage();
+                    $error['error'] = $e->getMessage();
                 }
-                
+
                 return $this->returnErrorJsonResponse(
-                    $errors,
+                    $error,
                     Response::HTTP_INTERNAL_SERVER_ERROR
                 );
             }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -595,8 +595,14 @@ class ProductController extends FrameworkBundleAdminController
             // this controller can be called as an AJAX JSON route or a HTML page
             // so we need to return the right type of response if an exception it thrown
             if ($request->isXmlHttpRequest()) {
+                $errors = [];
+
+                if ($this->get('prestashop.adapter.environment')->isDebug()) {
+                    $errors[] = $e->getMessage();
+                }
+                
                 return $this->returnErrorJsonResponse(
-                    [],
+                    $errors,
                     Response::HTTP_INTERNAL_SERVER_ERROR
                 );
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When an error 500 is throw on the save of a product, there is an error but there is nothing to see this error.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You will need to enable the debug mode in order to see the error into the JSON returns.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
