### PR TITLE
Unlink cart products from current address.

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -302,6 +302,7 @@ class AddressCore extends ObjectModel
         $sql->from('cart_product');
         $sql->where('id_address_delivery = ' . $this->id);
         $sql->orderBy('id_cart');
+
         return Db::getInstance()->executeS($sql);
     }
 

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -241,9 +241,9 @@ class AddressCore extends ObjectModel
             Customer::resetAddressCache($this->id_customer, $this->id);
         }
 
-        if (!$this->isUsed()) {
-            $this->deleteCartAddress();
+        $this->deleteCartAddress();
 
+        if (!$this->isUsed()) {
             // Update the cache
             if (isset(static::$addressExists[$this->id])) {
                 static::$addressExists[$this->id] = false;

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -271,6 +271,10 @@ class AddressCore extends ObjectModel
                     SET id_address_invoice = 0
                     WHERE id_address_invoice = ' . $this->id;
         Db::getInstance()->execute($sql);
+        $sql = 'UPDATE ' . _DB_PREFIX_ . 'cart_product
+                    SET id_address_delivery = 0
+                    WHERE id_address_delivery = ' . $this->id;
+        Db::getInstance()->execute($sql);
     }
 
     /**

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -300,7 +300,7 @@ class AddressCore extends ObjectModel
         $sql = new DbQuery();
         $sql->select('id_cart, id_product, id_product_attribute');
         $sql->from('cart_product');
-        $sql->where('id_address_delivery = ' . $this->id);
+        $sql->where('id_address_delivery = ' . (int) $this->id);
         $sql->orderBy('id_cart');
 
         return Db::getInstance()->executeS($sql);

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -281,15 +281,16 @@ class AddressCore extends ObjectModel
                 $cart = new Cart($prevIdCart);
             }
             if (
-                !Validate::isLoadedObject($cart) ||
-                $cart->orderExists()
+                !isset($cart) ||
+                (!Validate::isLoadedObject($cart) ||
+                $cart->orderExists())
             ) {
                 continue;
             }
             $cart->nullifyProductAddressDelivery(
                 $cartProduct['id_product'],
                 $cartProduct['id_product_attribute'],
-                $this->id
+                (int) $this->id
             );
         }
     }

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -282,8 +282,8 @@ class AddressCore extends ObjectModel
             }
             if (
                 !isset($cart) ||
-                (!Validate::isLoadedObject($cart) ||
-                $cart->orderExists())
+                !Validate::isLoadedObject($cart) ||
+                $cart->orderExists()
             ) {
                 continue;
             }

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -275,6 +275,10 @@ class AddressCore extends ObjectModel
                     SET id_address_delivery = 0
                     WHERE id_address_delivery = ' . $this->id;
         Db::getInstance()->execute($sql);
+        $sql = 'UPDATE ' . _DB_PREFIX_ . 'customization
+                    SET id_address_delivery = 0
+                    WHERE id_address_delivery = ' . $this->id;
+        Db::getInstance()->execute($sql);
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -326,17 +326,7 @@ class CartCore extends ObjectModel
             $this->update();
         }
 
-        $sql = 'UPDATE `' . _DB_PREFIX_ . 'cart_product`
-        SET `id_address_delivery` = ' . (int) $id_address_new . '
-        WHERE  `id_cart` = ' . (int) $this->id . '
-            AND `id_address_delivery` = ' . (int) $id_address;
-        Db::getInstance()->execute($sql);
-
-        $sql = 'UPDATE `' . _DB_PREFIX_ . 'customization`
-            SET `id_address_delivery` = ' . (int) $id_address_new . '
-            WHERE  `id_cart` = ' . (int) $this->id . '
-                AND `id_address_delivery` = ' . (int) $id_address;
-        Db::getInstance()->execute($sql);
+        $this->setAllProductsAddressDelivery($id_address, $id_address_new);
     }
 
     /**
@@ -352,17 +342,7 @@ class CartCore extends ObjectModel
             $this->update();
         }
 
-        $sql = 'UPDATE `' . _DB_PREFIX_ . 'cart_product`
-        SET `id_address_delivery` = ' . $newAddressId . '
-        WHERE  `id_cart` = ' . (int) $this->id . '
-            AND `id_address_delivery` = ' . $currentAddressId;
-        Db::getInstance()->execute($sql);
-
-        $sql = 'UPDATE `' . _DB_PREFIX_ . 'customization`
-            SET `id_address_delivery` = ' . $newAddressId . '
-            WHERE  `id_cart` = ' . (int) $this->id . '
-                AND `id_address_delivery` = ' . $currentAddressId;
-        Db::getInstance()->execute($sql);
+        $this->setAllProductsAddressDelivery($currentAddressId, $newAddressId);
     }
 
     /**
@@ -4606,6 +4586,30 @@ class CartCore extends ObjectModel
             $old_id_address_delivery,
             $new_id_address_delivery
         );
+    }
+
+    /**
+     * Set delivery Address of all Products corresponding to old address in the Cart.
+     *
+     * @param int $old_id_address_delivery Old delivery Address ID
+     * @param int $new_id_address_delivery New delivery Address ID, valid for the current customer
+     */
+    public function setAllProductsAddressDelivery($old_id_address_delivery, $new_id_address_delivery)
+    {
+        // Check address is linked with the customer
+        if (!Customer::customerHasAddress(Context::getContext()->customer->id, $new_id_address_delivery)) {
+            return;
+        }
+
+        $cartProducts = $this->getCartProducts($old_id_address_delivery);
+        foreach ($cartProducts as $cartProduct) {
+            $this->setProductAnyAddressDelivery(
+                $cartProduct['id_product'],
+                $cartProduct['id_product_attribute'],
+                $old_id_address_delivery,
+                $new_id_address_delivery
+            );
+        }
     }
 
     /**

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4607,6 +4607,7 @@ class CartCore extends ObjectModel
 
     /**
      * Set delivery Address of a Product in the Cart to 0.
+     * Works only for pending carts whithout existing order for them.
      *
      * @param int $id_product Product ID
      * @param int $id_product_attribute Product Attribute ID
@@ -4616,6 +4617,9 @@ class CartCore extends ObjectModel
      */
     public function nullifyProductAddressDelivery($id_product, $id_product_attribute, $old_id_address_delivery)
     {
+        if ($this->orderExists()) {
+            return false;
+        }
         return $this->setProductAnyAddressDelivery(
             $id_product,
             $id_product_attribute,

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4668,7 +4668,7 @@ class CartCore extends ObjectModel
         $sql->select('id_product, id_product_attribute');
         $sql->from('cart_product');
         $sql->where('id_cart = ' . (int) $this->id);
-        $sql->where('id_address_delivery = ' . $old_id_address_delivery);
+        $sql->where('id_address_delivery = ' . (int) $old_id_address_delivery);
         $sql->orderBy('id_cart');
 
         return Db::getInstance()->executeS($sql);

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1248,6 +1248,7 @@ class CartCore extends ObjectModel
         if ($needUpdate && $this->id) {
             return $this->update();
         }
+
         return true;
     }
 
@@ -4598,6 +4599,7 @@ class CartCore extends ObjectModel
         if (!Customer::customerHasAddress(Context::getContext()->customer->id, $new_id_address_delivery)) {
             return false;
         }
+
         return $this->setProductAnyAddressDelivery(
             $id_product,
             $id_product_attribute,
@@ -4621,6 +4623,7 @@ class CartCore extends ObjectModel
         if ($this->orderExists()) {
             return false;
         }
+
         return $this->setProductAnyAddressDelivery(
             $id_product,
             $id_product_attribute,
@@ -4663,6 +4666,7 @@ class CartCore extends ObjectModel
         $sql->where('id_cart = ' . $this->id);
         $sql->where('id_address_delivery = ' . $old_id_address_delivery);
         $sql->orderBy('id_cart');
+
         return Db::getInstance()->executeS($sql);
     }
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4667,7 +4667,7 @@ class CartCore extends ObjectModel
         $sql = new DbQuery();
         $sql->select('id_product, id_product_attribute');
         $sql->from('cart_product');
-        $sql->where('id_cart = ' . $this->id);
+        $sql->where('id_cart = ' . (int) $this->id);
         $sql->where('id_address_delivery = ' . $old_id_address_delivery);
         $sql->orderBy('id_cart');
 

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4606,6 +4606,25 @@ class CartCore extends ObjectModel
     }
 
     /**
+     * Set delivery Address of a Product in the Cart to 0.
+     *
+     * @param int $id_product Product ID
+     * @param int $id_product_attribute Product Attribute ID
+     * @param int $old_id_address_delivery Old delivery Address ID
+     *
+     * @return bool Whether the delivery Address of the product in the Cart has been successfully updated
+     */
+    public function nullifyProductAddressDelivery($id_product, $id_product_attribute, $old_id_address_delivery)
+    {
+        return $this->setProductAnyAddressDelivery(
+            $id_product,
+            $id_product_attribute,
+            $old_id_address_delivery,
+            0
+        );
+    }
+
+    /**
      * Set delivery Address of a Product in the Cart.
      *
      * @param int $id_product Product ID

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4587,7 +4587,7 @@ class CartCore extends ObjectModel
      * @param int $id_product Product ID
      * @param int $id_product_attribute Product Attribute ID
      * @param int $old_id_address_delivery Old delivery Address ID
-     * @param int $new_id_address_delivery New delivery Address ID
+     * @param int $new_id_address_delivery New delivery Address ID, valid for the current customer
      *
      * @return bool Whether the delivery Address of the product in the Cart has been successfully updated
      */
@@ -4597,7 +4597,26 @@ class CartCore extends ObjectModel
         if (!Customer::customerHasAddress(Context::getContext()->customer->id, $new_id_address_delivery)) {
             return false;
         }
+        return $this->setProductAnyAddressDelivery(
+            $id_product,
+            $id_product_attribute,
+            $old_id_address_delivery,
+            $new_id_address_delivery
+        );
+    }
 
+    /**
+     * Set delivery Address of a Product in the Cart.
+     *
+     * @param int $id_product Product ID
+     * @param int $id_product_attribute Product Attribute ID
+     * @param int $old_id_address_delivery Old delivery Address ID
+     * @param int $new_id_address_delivery New delivery Address ID, will not be validated
+     *
+     * @return bool Whether the delivery Address of the product in the Cart has been successfully updated
+     */
+    private function setProductAnyAddressDelivery($id_product, $id_product_attribute, $old_id_address_delivery, $new_id_address_delivery)
+    {
         if ($new_id_address_delivery == $old_id_address_delivery) {
             return false;
         }

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4576,7 +4576,7 @@ class CartCore extends ObjectModel
     public function setProductAddressDelivery($id_product, $id_product_attribute, $old_id_address_delivery, $new_id_address_delivery)
     {
         // Check address is linked with the customer
-        if (!Customer::customerHasAddress(Context::getContext()->customer->id, $new_id_address_delivery)) {
+        if (!Customer::customerHasAddress((int) $this->id_customer, $new_id_address_delivery)) {
             return false;
         }
 
@@ -4597,7 +4597,7 @@ class CartCore extends ObjectModel
     public function setAllProductsAddressDelivery($old_id_address_delivery, $new_id_address_delivery)
     {
         // Check address is linked with the customer
-        if (!Customer::customerHasAddress(Context::getContext()->customer->id, $new_id_address_delivery)) {
+        if (!Customer::customerHasAddress((int) $this->id_customer, $new_id_address_delivery)) {
             return;
         }
 

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -396,8 +396,7 @@ class FrontControllerCore extends Controller
                     !isset($cart->id_address_invoice) || $cart->id_address_invoice == 0) && $this->context->cookie->id_customer) {
                 $to_update = false;
                 if ($this->automaticallyAllocateDeliveryAddress && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0)) {
-                    $to_update = true;
-                    $cart->id_address_delivery = (int) Address::getFirstCustomerAddressId($cart->id_customer);
+                    $cart->updateDeliveryAddressId(0, (int) Address::getFirstCustomerAddressId($cart->id_customer));
                 }
                 if ($this->automaticallyAllocateInvoiceAddress && (!isset($cart->id_address_invoice) || $cart->id_address_invoice == 0)) {
                     $to_update = true;


### PR DESCRIPTION
Otherwise, if the address is deleted,
the system cannot find delivery options for the pending carts.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | PrestaShop v1.7.8.7. When products are added to a cart, the system sets ps_cart_product.id_address_delivery to current address of the cart. Later during the checkout process, function Carrier::getAvailableCarrierList uses this address to determine validity of carriers for this product (through function Address::isCountryActiveById). So if the address in question is deleted while the cart is still pending, then Carrier::getAvailableCarrierList returns empty list, therefore no carriers can be found for the cart, and the user has no other option than removing all his products from the cart and adding them again.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #30350.
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Reproduce the bug: Add a product to the cart from FO. Note: the current default address of the cart should be not used in previous orders (so it can be deleted after). Do not proceed to finish the order yet. Check the id_address_delivery field of the newly created ps_cart_product record. Delete this address from BO. Go back to FO and try to finish the order. At the step for choosing the carrier there will be an error that no carriers are available. When the fix in current pull request is applyed, there will be no such error and the system will correctly propose available carriers.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
