### PR TITLE
Move out legacy constants into parameters

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -10,8 +10,6 @@ imports:
 parameters:
   env(PS_THEME_NAME): "classic"
   AdapterSecurityAdminClass: PrestaShop\PrestaShop\Adapter\Security\Admin
-  translator.class: PrestaShopBundle\Translation\Translator
-  translator.data_collector: PrestaShopBundle\Translation\DataCollectorTranslator
   prestashop_views: "%kernel.root_dir%/../src/PrestaShopBundle/Resources/views"
   admin_page: "%prestashop_views%/Admin"
   env(PS_LOG_OUTPUT): "%kernel.logs_dir%/%kernel.environment%.log"
@@ -19,24 +17,27 @@ parameters:
   mail_themes_uri: "/mails/themes"
   mail_themes_dir: "%kernel.project_dir%%mail_themes_uri%"
   modules_translation_paths: [ ]
-
-  prestashop.mode_dev: !php/const _PS_MODE_DEV_
-  prestashop.employee_img_dir: !php/const _PS_EMPLOYEE_IMG_DIR_
-  prestashop.profile_img_dir: !php/const _PS_PROFILE_IMG_DIR_
-  prestashop.product_img_dir: !php/const _PS_PRODUCT_IMG_DIR_
-  prestashop.img_dir: !php/const _PS_IMG_DIR_
-  prestashop.tmp_img_dir: !php/const _PS_TMP_IMG_DIR_
-  prestashop.module_dir: !php/const _PS_MODULE_DIR_
-  prestashop.download_dir: !php/const _PS_DOWNLOAD_DIR_
-  prestashop.genders_dir: !php/const _PS_GENDERS_DIR_
-  prestashop.root_dir: !php/const _PS_ROOT_DIR_
-  prestashop.pdf_dir: !php/const _PS_PDF_DIR_
-  prestashop.cache_dir: !php/const _PS_CACHE_DIR_
-  prestashop.admin_profile: !php/const _PS_ADMIN_PROFILE_
-
   # legacy deprecated parameter
-  ps_cache_dir: !php/const _PS_CACHE_DIR_
   multishop.settings.share_orders: 'share_order'
+
+prestashop:
+  translator:
+    class: PrestaShopBundle\Translation\Translator
+    data_collector: PrestaShopBundle\Translation\DataCollectorTranslator
+  directories:
+    mode_dev: !php/const _PS_MODE_DEV_
+    employee_img_dir: !php/const _PS_EMPLOYEE_IMG_DIR_
+    profile_img_dir: !php/const _PS_PROFILE_IMG_DIR_
+    product_img_dir: !php/const _PS_PRODUCT_IMG_DIR_
+    img_dir: !php/const _PS_IMG_DIR_
+    tmp_img_dir: !php/const _PS_TMP_IMG_DIR_
+    module_dir: !php/const _PS_MODULE_DIR_
+    download_dir: !php/const _PS_DOWNLOAD_DIR_
+    genders_dir: !php/const _PS_GENDERS_DIR_
+    root_dir: !php/const _PS_ROOT_DIR_
+    pdf_dir: !php/const _PS_PDF_DIR_
+    cache_dir: !php/const _PS_CACHE_DIR_
+    admin_profile: !php/const _PS_ADMIN_PROFILE_
 
 # Autowires Core controllers
 services:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -20,15 +20,26 @@ parameters:
   mail_themes_dir: "%kernel.project_dir%%mail_themes_uri%"
   modules_translation_paths: [ ]
 
+  prestashop.mode_dev: !php/const _PS_MODE_DEV_
+  prestashop.employee_img_dir: !php/const _PS_EMPLOYEE_IMG_DIR_
+  prestashop.profile_img_dir: !php/const _PS_PROFILE_IMG_DIR_
+  prestashop.product_img_dir: !php/const _PS_PRODUCT_IMG_DIR_
+  prestashop.img_dir: !php/const _PS_IMG_DIR_
+  prestashop.tmp_img_dir: !php/const _PS_TMP_IMG_DIR_
+  prestashop.module_dir: !php/const _PS_MODULE_DIR_
+  prestashop.download_dir: !php/const _PS_DOWNLOAD_DIR_
+  prestashop.genders_dir: !php/const _PS_GENDERS_DIR_
+  prestashop.root_dir: !php/const _PS_ROOT_DIR_
+  prestashop.pdf_dir: !php/const _PS_PDF_DIR_
+  prestashop.cache_dir: !php/const _PS_CACHE_DIR_
+  prestashop.admin_profile: !php/const _PS_ADMIN_PROFILE_
+
+  # legacy deprecated parameter
+  ps_cache_dir: !php/const _PS_CACHE_DIR_
+  multishop.settings.share_orders: 'share_order'
+
 # Autowires Core controllers
 services:
-  PrestaShopBundle\Controller\:
-    resource: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/*"
-    exclude: "%kernel.root_dir%/../src/PrestaShopBundle/Controller/Api"
-    public: true
-    tags:
-      - !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG
-
   logger:
     alias: monolog.logger
     public: true

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -46,11 +46,6 @@ monolog:
 # swiftmailer:
 #  delivery_address: me@example.com
 
-prestashop:
-  addons:
-    api_client:
-      ttl: 300  # 5min
-
 tactician:
   commandbus:
     default:

--- a/config/services/common.yml
+++ b/config/services/common.yml
@@ -1,5 +1,20 @@
 parameters:
     mail_themes_uri: "/mails/themes"
+    # compatibility layer for the front-end as there is no bundle nor config.
+    prestashop.mode_dev: !php/const _PS_MODE_DEV_
+    prestashop.employee_img_dir: !php/const _PS_EMPLOYEE_IMG_DIR_
+    prestashop.profile_img_dir: !php/const _PS_PROFILE_IMG_DIR_
+    prestashop.product_img_dir: !php/const _PS_PRODUCT_IMG_DIR_
+    prestashop.img_dir: !php/const _PS_IMG_DIR_
+    prestashop.tmp_img_dir: !php/const _PS_TMP_IMG_DIR_
+    prestashop.module_dir: !php/const _PS_MODULE_DIR_
+    prestashop.download_dir: !php/const _PS_DOWNLOAD_DIR_
+    prestashop.genders_dir: !php/const _PS_GENDERS_DIR_
+    prestashop.root_dir: !php/const _PS_ROOT_DIR_
+    prestashop.pdf_dir: !php/const _PS_PDF_DIR_
+    prestashop.cache_dir: !php/const _PS_CACHE_DIR_
+    prestashop.admin_profile: !php/const _PS_ADMIN_PROFILE_
+  # end compatibility layer for the front-end, will be removed once all kernels have been unified.
 
 imports:
     - { resource: ../../src/PrestaShopBundle/Resources/config/services/core/cldr.yml }

--- a/config/services/front/services_prod.yml
+++ b/config/services/front/services_prod.yml
@@ -50,8 +50,8 @@ services:
     prestashop.adapter.module.repository.module_repository:
       class: 'PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository'
       arguments:
-        - !php/const _PS_ROOT_DIR_
-        - !php/const _PS_MODULE_DIR_
+        - '%prestashop.root_dir%'
+        - '%prestashop.module_dir%'
 
     prestashop.translation.translator_language_loader:
       class: PrestaShopBundle\Translation\TranslatorLanguageLoader

--- a/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
+++ b/src/PrestaShopBundle/DependencyInjection/AddOnsConfiguration.php
@@ -30,6 +30,9 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Tools;
 
+/**
+ * @deprecated since 8.1, will be removed in 9.0
+ */
 class AddOnsConfiguration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()

--- a/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideTranslatorServiceCompilerPass.php
+++ b/src/PrestaShopBundle/DependencyInjection/Compiler/OverrideTranslatorServiceCompilerPass.php
@@ -39,12 +39,12 @@ class OverrideTranslatorServiceCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $definition = $container->getDefinition('translator.default');
-        $definition->setClass($container->getParameter('translator.class'));
+        $definition->setClass($container->getParameter('prestashop.translator.class'));
 
         if (!in_array($container->getParameter('kernel.environment'), ['dev', 'test'])) {
             return;
         }
         $definition = $container->getDefinition('translator.data_collector');
-        $definition->setClass($container->getParameter('translator.data_collector'));
+        $definition->setClass($container->getParameter('prestashop.translator.data_collector'));
     }
 }

--- a/src/PrestaShopBundle/DependencyInjection/Configuration.php
+++ b/src/PrestaShopBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShopBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $tree = new TreeBuilder('prestashop');
+        $tree->getRootNode()
+            ->children()
+            ->arrayNode('translator')
+                ->children()
+                    ->scalarNode('class')->isRequired()->end()
+                    ->scalarNode('data_collector')->isRequired()->end()
+                ->end()
+            ->end()
+            ->arrayNode('directories')
+                ->children()
+                    ->scalarNode('cache_dir')->isRequired()->end()
+                    ->scalarNode('mode_dev')->isRequired()->end()
+                    ->scalarNode('employee_img_dir')->isRequired()->end()
+                    ->scalarNode('profile_img_dir')->isRequired()->end()
+                    ->scalarNode('product_img_dir')->isRequired()->end()
+                    ->scalarNode('img_dir')->isRequired()->end()
+                    ->scalarNode('tmp_img_dir')->isRequired()->end()
+                    ->scalarNode('module_dir')->isRequired()->end()
+                    ->scalarNode('download_dir')->isRequired()->end()
+                    ->scalarNode('genders_dir')->isRequired()->end()
+                    ->scalarNode('root_dir')->isRequired()->end()
+                    ->scalarNode('pdf_dir')->isRequired()->end()
+                    ->scalarNode('cache_dir')->isRequired()->end()
+                    ->scalarNode('admin_profile')->isRequired()->end()
+                ->end()
+            ->end()
+        ;
+
+        $this->appendCategories($tree);
+
+        return $tree;
+    }
+
+    private function appendCategories(TreeBuilder $builder) {
+
+        $builder
+            ->getRootNode()
+            ->children()
+            ->arrayNode('addons')
+            ->children()
+            ->arrayNode('categories')
+            ->arrayPrototype()
+            ->children()
+            ->scalarNode('id_category')->isRequired()->end()
+                ->scalarNode('name')->isRequired()->end()
+                ->scalarNode('order')->isRequired()->end()
+                ->scalarNode('link')->isRequired()->end()
+                ->scalarNode('id_parent')->isRequired()->end()
+                ->scalarNode('parent_link')->isRequired()->end()
+                ->scalarNode('tab')->isRequired()->end()
+            ->arrayNode('categories')
+            ->arrayPrototype()
+            ->children()
+                ->scalarNode('id_category')->isRequired()->end()
+                ->scalarNode('name')->isRequired()->end()
+                ->scalarNode('link')->isRequired()->end()
+                ->scalarNode('id_parent')->isRequired()->end()
+                ->scalarNode('link_rewrite')->isRequired()->end()
+                ->scalarNode('tab')->end()
+            ->end()
+            ->end()
+            ->end()
+            ->end()
+            ->end()
+            ->end()
+            ->arrayNode('api_client')
+            ->children()
+            ->integerNode('ttl')
+            ->defaultValue(0)
+            ->end()
+            ->scalarNode('verify_ssl')
+            ->defaultValue(_PS_CACHE_CA_CERT_FILE_)
+            ->end()
+            ->end()
+            ->end()
+            ->end()
+            ->end()
+            ->end();
+    }
+
+}

--- a/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
+++ b/src/PrestaShopBundle/DependencyInjection/PrestaShopExtension.php
@@ -41,28 +41,39 @@ class PrestaShopExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new AddOnsConfiguration();
+        $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new YamlFileLoader($container, new FileLocator(dirname(__DIR__) . '/Resources/config'));
         $env = $container->getParameter('kernel.environment');
         $loader->load('services_' . $env . '.yml');
 
+        $container->setParameter('prestashop.translator.class', $config['translator']['class']);
+        $container->setParameter('prestashop.translator.data_collector', $config['translator']['data_collector']);
+
+        $container->setParameter('prestashop.cache_dir', $config['directories']['cache_dir']);
+        $container->setParameter('prestashop.mode_dev', $config['directories']['mode_dev']);
+        $container->setParameter('prestashop.employee_img_dir', $config['directories']['employee_img_dir']);
+        $container->setParameter('prestashop.profile_img_dir', $config['directories']['profile_img_dir']);
+        $container->setParameter('prestashop.product_img_dir', $config['directories']['product_img_dir']);
+        $container->setParameter('prestashop.img_dir', $config['directories']['img_dir']);
+        $container->setParameter('prestashop.tmp_img_dir', $config['directories']['tmp_img_dir']);
+        $container->setParameter('prestashop.module_dir', $config['directories']['module_dir']);
+        $container->setParameter('prestashop.download_dir', $config['directories']['download_dir']);
+        $container->setParameter('prestashop.genders_dir', $config['directories']['genders_dir']);
+        $container->setParameter('prestashop.root_dir', $config['directories']['root_dir']);
+        $container->setParameter('prestashop.pdf_dir', $config['directories']['pdf_dir']);
+        $container->setParameter('prestashop.admin_profile', $config['directories']['admin_profile']);
+
+        // @deprecated since 8.1, will be removed in 9.0
+        $container->setParameter('ps_cache_dir', $config['directories']['cache_dir']);
         $container->setParameter('prestashop.addons.categories', $config['addons']['categories']);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
-    {
-        return new AddOnsConfiguration();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'prestashop';
     }

--- a/src/PrestaShopBundle/Resources/config/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services.yml
@@ -1,9 +1,14 @@
-parameters:
-  multishop.settings.share_orders: !php/const Shop::SHARE_ORDER
-
 imports:
   - { resource: services/bundle/*.yml }
   - { resource: services/core/*.yml }
   - { resource: services/adapter/*.yml }
   - { resource: services/legacy.yml }
   - { resource: services/alias.yml }
+
+services:
+  PrestaShopBundle\Controller\:
+    resource: "../../Controller/*"
+    exclude: "../../Controller/Api"
+    public: true
+    tags:
+      - !php/const PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController::PRESTASHOP_CORE_CONTROLLERS_TAG

--- a/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/admin.yml
@@ -6,7 +6,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Admin\PagePreference
     arguments:
       - "@session"
-      - !php/const _PS_MODE_DEV_
+      - '%prestashop.mode_dev%'
     decorates: prestashop.core.admin.page_preference_interface
     public: false
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/attachment.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/attachment.yml
@@ -19,7 +19,7 @@ services:
   prestashop.adapter.attachment.query_handler.get_attachment_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Attachment\QueryHandler\GetAttachmentHandler'
     arguments:
-      - !php/const _PS_DOWNLOAD_DIR_
+      - '%prestashop.download_dir%'
     tags:
       - { name: 'tactician.handler', command: 'PrestaShop\PrestaShop\Core\Domain\Attachment\Query\GetAttachment' }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/common.yml
@@ -17,7 +17,7 @@ services:
   prestashop.adapter.environment:
     class: PrestaShop\PrestaShop\Adapter\Environment
     arguments:
-      - !php/const _PS_MODE_DEV_
+      - '%prestashop.mode_dev%'
 
   prestashop.adapter.validate:
     class: PrestaShop\PrestaShop\Adapter\Validate

--- a/src/PrestaShopBundle/Resources/config/services/adapter/context.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/context.yml
@@ -5,7 +5,7 @@ services:
   # SECURITY
   # @todo: is this service used?
   prestashop.adapter.security.admin:
-    class: "%AdapterSecurityAdminClass%"
+    class: PrestaShop\PrestaShop\Adapter\Security\Admin
     arguments:
       - "@prestashop.adapter.legacy.context"
       - "@security.token_storage"

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_provider.yml
@@ -78,13 +78,13 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Tab\TabDataProvider
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().employee.id_profile'
-      - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
+      - '%prestashop.admin_profile%'
 
   prestashop.adapter.data_provider.profile:
     class: PrestaShop\PrestaShop\Adapter\Profile\ProfileDataProvider
     arguments:
       - '@prestashop.adapter.data_provider.employee'
-      - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
+      - '%prestashop.admin_profile%'
 
   prestashop.adapter.data_provider.module:
     class: PrestaShop\PrestaShop\Adapter\Module\ModuleDataProvider

--- a/src/PrestaShopBundle/Resources/config/services/adapter/image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/image.yml
@@ -16,14 +16,14 @@ services:
   prestashop.adapter.image.uploader.employee_image_uploader:
     class: 'PrestaShop\PrestaShop\Adapter\Image\Uploader\EmployeeImageUploader'
     arguments:
-      - !php/const _PS_EMPLOYEE_IMG_DIR_
-      - !php/const _PS_TMP_IMG_DIR_
+      - '%prestashop.employee_img_dir%'
+      - '%prestashop.tmp_img_dir%'
 
   prestashop.adapter.image.uploader.profile_image_uploader:
     class: 'PrestaShop\PrestaShop\Adapter\Image\Uploader\ProfileImageUploader'
     arguments:
-      - !php/const _PS_PROFILE_IMG_DIR_
-      - !php/const _PS_TMP_IMG_DIR_
+      - '%prestashop.profile_img_dir%'
+      - '%prestashop.tmp_img_dir%'
 
   prestashop.adapter.image.uploader.manufacturer_image_uploader:
     class: 'PrestaShop\PrestaShop\Adapter\Image\Uploader\ManufacturerImageUploader'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/module.yml
@@ -75,5 +75,5 @@ services:
   prestashop.adapter.module.repository.module_repository:
     class: 'PrestaShop\PrestaShop\Adapter\Module\Repository\ModuleRepository'
     arguments:
-      - !php/const _PS_ROOT_DIR_
-      - !php/const _PS_MODULE_DIR_
+      - '%prestashop.root_dir%'
+      - '%prestashop.module_dir%'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -91,15 +91,15 @@ services:
   prestashop.adapter.product.image.product_image_filesystem_path_factory:
     class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
     arguments:
-      - !php/const _PS_PRODUCT_IMG_DIR_
-      - !php/const _PS_TMP_IMG_DIR_
+      - '%prestashop.product_img_dir%'
+      - '%prestashop.tmp_img_dir%'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
 
   prestashop.adapter.product.image.product_image_url_factory:
     class: PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory
     arguments:
       - '@=service("prestashop.adapter.shop.url.product_image_folder_provider").getUrl()'
-      - !php/const _PS_TMP_IMG_DIR_
+      - '%prestashop.tmp_img_dir%'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.iso_code'
 
   prestashop.adapter.product.image.uploader.product_image_uploader:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_virtual_product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_virtual_product.yml
@@ -43,7 +43,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\File\Uploader\VirtualProductFileUploader
     arguments:
       - '@prestashop.adapter.file.validator.virtual_product_file_validator'
-      - !php/const _PS_DOWNLOAD_DIR_
+      - '%prestashop.download_dir%'
 
   prestashop.adapter.product.virtual_product.command_handler.delete_virtual_product_file_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\VirtualProduct\CommandHandler\DeleteVirtualProductFileHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/profile.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/profile.yml
@@ -6,7 +6,7 @@ services:
   prestashop.adapter.profile.command_handler.delete_profile:
     class: 'PrestaShop\PrestaShop\Adapter\Profile\CommandHandler\DeleteProfileHandler'
     arguments:
-      - '@=service("prestashop.adapter.legacy.configuration").get("_PS_ADMIN_PROFILE_")'
+      - '%prestashop.admin_profile%'
       - '@prestashop.adapter.data_provider.employee'
     tags:
       - name: 'tactician.handler'
@@ -15,7 +15,7 @@ services:
   prestashop.adapter.profile.command_handler.bulk_delete_profile:
     class: 'PrestaShop\PrestaShop\Adapter\Profile\CommandHandler\BulkDeleteProfileHandler'
     arguments:
-      - '@=service("prestashop.adapter.legacy.configuration").get("_PS_ADMIN_PROFILE_")'
+      - '%prestashop.admin_profile%'
       - '@prestashop.adapter.data_provider.employee'
     tags:
       - name: 'tactician.handler'
@@ -37,7 +37,7 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Profile\QueryHandler\GetProfileForEditingHandler'
     arguments:
       - '@prestashop.core.image.parser.image_tag_source_parser'
-      - !php/const _PS_PROFILE_IMG_DIR_
+      - '%prestashop.profile_img_dir%'
     tags:
       - name: 'tactician.handler'
         command: 'PrestaShop\PrestaShop\Core\Domain\Profile\Query\GetProfileForEditing'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
@@ -50,7 +50,7 @@ services:
     class: 'PrestaShop\PrestaShop\Adapter\Shop\QueryHandler\GetLogosPathsHandler'
     arguments:
       - '@=service("prestashop.adapter.legacy.configuration").get("_PS_IMG_")'
-      - '@=service("prestashop.adapter.legacy.configuration").get("_PS_IMG_DIR_")'
+      - '%prestashop.img_dir%'
     tags:
       - name: 'tactician.handler'
         command: PrestaShop\PrestaShop\Core\Domain\Shop\Query\GetLogosPaths

--- a/src/PrestaShopBundle/Resources/config/services/adapter/title.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/title.yml
@@ -7,7 +7,7 @@ services:
     arguments:
       - '@prestashop.core.image.parser.image_tag_source_parser'
       - '@prestashop.adapter.image_manager'
-      - !php/const _PS_GENDERS_DIR_
+      - '%prestashop.genders_dir%'
 
   prestashop.adapter.title.command_handler.delete_title_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Title\CommandHandler\DeleteTitleHandler'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -996,7 +996,7 @@ services:
       - '@=service("prestashop.core.form.choice_provider.profile").getChoices()'
       - '@=service("prestashop.adapter.multistore_feature").isActive()'
       - "@=service('prestashop.adapter.legacy.configuration')"
-      - !php/const _PS_ADMIN_PROFILE_
+      - '%prestashop.admin_profile%'
       - '@prestashop.router'
     calls:
       - { method: setTranslator, arguments: [ '@translator' ] }

--- a/src/PrestaShopBundle/Resources/config/services/core/cldr.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/cldr.yml
@@ -1,6 +1,3 @@
-parameters:
-  ps_cache_dir: !php/const _PS_CACHE_DIR_
-
 services:
   _defaults:
     public: true
@@ -13,7 +10,7 @@ services:
     arguments:
       - 'CLDR'
       - 0
-      - '%ps_cache_dir%/localization'
+      - '%prestashop.cache_dir%/localization'
 
   prestashop.core.localization.locale.repository:
     class: PrestaShop\PrestaShop\Core\Localization\Locale\Repository

--- a/src/PrestaShopBundle/Resources/config/services/core/employee.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/employee.yml
@@ -12,4 +12,4 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Employee\Access\ProfileAccessChecker'
     arguments:
       - '@prestashop.adapter.employee.data_provider'
-      - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
+      - '%prestashop.admin_profile%'

--- a/src/PrestaShopBundle/Resources/config/services/core/file.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/file.yml
@@ -6,8 +6,8 @@ services:
     class: 'PrestaShop\PrestaShop\Core\File\InvoiceModelFinder'
     arguments:
       - [
-        "@=service('prestashop.adapter.legacy.configuration').get('_PS_THEME_DIR_')~'pdf/'",
-        "@=service('prestashop.adapter.legacy.configuration').get('_PS_PDF_DIR_')"
+        "@=parameter('prestashop.theme_dir')~'pdf/'",
+        '%prestashop.pdf_dir%'
       ]
 
   prestashop.core.file.cached_finder.invoice_model:

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -79,7 +79,7 @@ services:
     arguments:
       - '@prestashop.core.command_bus'
       - '@=service("prestashop.adapter.shop.context").getShops(true, true)'
-      - '@=service("prestashop.adapter.legacy.configuration").getInt("_PS_ADMIN_PROFILE_")'
+      - '%prestashop.admin_profile%'
       - '@prestashop.adapter.employee.form_access_checker'
       - '@prestashop.adapter.employee.data_provider'
       - '@prestashop.core.crypto.hashing'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/accessibility_checker.yml
@@ -5,7 +5,7 @@ services:
   prestashop.core.grid.action.row.accessibility_checker.delete_profile:
     class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\DeleteProfileAccessibilityChecker'
     arguments:
-      - '@=service("prestashop.adapter.legacy.configuration").get("_PS_ADMIN_PROFILE_")'
+      - '%prestashop.admin_profile%'
 
   prestashop.core.grid.action.row.accessibility_checker.print_invoice:
     class: 'PrestaShop\PrestaShop\Core\Grid\Action\Row\AccessibilityChecker\PrintInvoiceAccessibilityChecker'

--- a/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/mail_template.yml
@@ -41,7 +41,7 @@ services:
       - '@prestashop.core.mail_template.theme_catalog'
       - '@prestashop.core.mail_template.generator'
       - '%kernel.project_dir%/mails'
-      - "@=service('prestashop.adapter.legacy.configuration').get('_PS_MODULE_DIR_')"
+      - '%prestashop.module_dir%'
     public: true
     tags:
       - name: tactician.handler

--- a/src/PrestaShopBundle/Resources/config/services/core/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/module.yml
@@ -17,7 +17,7 @@ services:
       - '@prestashop.adapter.admin.data_provider.module'
       - '@doctrine.cache.provider'
       - '@prestashop.adapter.hook.manager'
-      - "@=service('prestashop.adapter.legacy.configuration').get('_PS_MODULE_DIR_')"
+      - '%prestashop.module_dir%'
 
   prestashop.core.admin.module.repository.eventsubscriber:
     class: PrestaShop\PrestaShop\Core\Module\EventSubscriber

--- a/src/PrestaShopBundle/Resources/config/services/core/util.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util.yml
@@ -8,7 +8,7 @@ services:
   prestashop.core.util.url.url_file_checker:
     class: 'PrestaShop\PrestaShop\Core\Util\Url\UrlFileChecker'
     arguments:
-      - '@=service("prestashop.adapter.legacy.configuration").get("_PS_ROOT_DIR_")'
+      - '%prestashop.root_dir%'
 
   prestashop.core.uti.back_url_provider:
     class: PrestaShop\PrestaShop\Core\Util\Url\BackUrlProvider


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | First step of DI optimizations, first extract constants from the code, the we'll be able to use bundle configuration. <br> - Move out legacy constants into parameters <br> - Remove constant call from ModuleManagerBuilder.php<br> - Update constants DI for _PS_PDF_DIR_ and _PS_ADMIN_PROFILE_<br> - Move share order definition into root config file<br> - Update configuration remove adapter call for constants 
| Type?             | improvement
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Can be done by a dev, check parameters values are the same as constants.
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
