### PR TITLE
Remove 1 million cap limit in the max field for the product ID (1.7.8.x)

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Product/CatalogPage/Lists/products_table.html.twig
@@ -89,7 +89,6 @@
             {% include '@PrestaShop/Admin/Helpers/range_inputs.html.twig' with {
               'input_name': "filter_column_id_product",
               'min': '0',
-              'max': '1000000',
               'minLabel': "Min"|trans({}, 'Admin.Global'),
               'maxLabel': "Max"|trans({}, 'Admin.Global'),
               'value': filter_column_id_product,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | Remove the 1 million (front end) limitation to search IDs greater than 1 million
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | Open the product catalog list and type 1000001 in the max text field. Without the PR, you cannot do it. The PR allows it.
| Possible impacts? |  no


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
