### PR TITLE
Simplify Profile form

### DIFF
--- a/src/Adapter/Profile/QueryHandler/GetProfileForEditingHandler.php
+++ b/src/Adapter/Profile/QueryHandler/GetProfileForEditingHandler.php
@@ -42,6 +42,10 @@ use Profile;
 final class GetProfileForEditingHandler extends AbstractObjectModelHandler implements GetProfileForEditingHandlerInterface
 {
     /**
+     * @var string
+     */
+    private $defaultAvatarUrl;
+    /**
      * @var ImageTagSourceParserInterface
      */
     private $imageTagSourceParser;
@@ -53,8 +57,10 @@ final class GetProfileForEditingHandler extends AbstractObjectModelHandler imple
     /**
      * @param ImageTagSourceParserInterface|null $imageTagSourceParser
      * @param string $imgDir
+     * @param string $defaultAvatarUrl
      */
     public function __construct(
+        string $defaultAvatarUrl,
         ImageTagSourceParserInterface $imageTagSourceParser = null,
         string $imgDir = _PS_PROFILE_IMG_DIR_
     ) {
@@ -63,6 +69,7 @@ final class GetProfileForEditingHandler extends AbstractObjectModelHandler imple
             @trigger_error('The $imageTagSourceParser parameter should not be null, inject your main ImageTagSourceParserInterface service', E_USER_DEPRECATED);
         }
         $this->imageTagSourceParser = $imageTagSourceParser ?? new ImageTagSourceParser();
+        $this->defaultAvatarUrl = $defaultAvatarUrl;
     }
 
     /**
@@ -78,7 +85,7 @@ final class GetProfileForEditingHandler extends AbstractObjectModelHandler imple
         return new EditableProfile(
             $profileId,
             $profile->name,
-            $avatarUrl ? $avatarUrl['path'] : null
+            $avatarUrl ? $avatarUrl['path'] : $this->defaultAvatarUrl
         );
     }
 

--- a/src/Core/Domain/Profile/QueryResult/EditableProfile.php
+++ b/src/Core/Domain/Profile/QueryResult/EditableProfile.php
@@ -80,6 +80,8 @@ class EditableProfile
     }
 
     /**
+     * @deprecated Since PrestaShop 8.1, this method only returns string (and not null values)
+     *
      * @return string|null
      */
     public function getAvatarUrl(): ?string

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProfileFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProfileFormDataProvider.php
@@ -36,16 +36,24 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\QueryResult\EditableProfile;
 final class ProfileFormDataProvider implements FormDataProviderInterface
 {
     /**
+     * @var string
+     */
+    private $defaultAvatarUrl;
+    /**
      * @var CommandBusInterface
      */
     private $queryBus;
 
     /**
      * @param CommandBusInterface $queryBus
+     * @param string $defaultAvatarUrl
      */
-    public function __construct(CommandBusInterface $queryBus)
-    {
+    public function __construct(
+        CommandBusInterface $queryBus,
+        string $defaultAvatarUrl
+    ) {
         $this->queryBus = $queryBus;
+        $this->defaultAvatarUrl = $defaultAvatarUrl;
     }
 
     /**
@@ -58,6 +66,7 @@ final class ProfileFormDataProvider implements FormDataProviderInterface
 
         return [
             'name' => $editableProfile->getLocalizedNames(),
+            'avatar_url' => $editableProfile->getAvatarUrl(),
         ];
     }
 
@@ -66,6 +75,8 @@ final class ProfileFormDataProvider implements FormDataProviderInterface
      */
     public function getDefaultData()
     {
-        return [];
+        return [
+            'avatar_url' => $this->defaultAvatarUrl,
+        ];
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -218,7 +218,6 @@ class ProfileController extends FrameworkBundleAdminController
             ),
             'help_link' => $this->generateSidebarLink('AdminProfiles'),
             'enableSidebar' => true,
-            'editableProfile' => $editableProfile,
         ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Profile/ProfileType.php
@@ -30,11 +30,11 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Profile\ProfileSettings;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
+use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Constraints\Length;
 
 /**
@@ -42,15 +42,7 @@ use Symfony\Component\Validator\Constraints\Length;
  */
 class ProfileType extends AbstractType
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
+    use TranslatorAwareTrait;
 
     /**
      * {@inheritdoc}
@@ -59,6 +51,7 @@ class ProfileType extends AbstractType
     {
         $builder
             ->add('name', TranslatableType::class, [
+                'label' => $this->trans('Name', [], 'Admin.Global'),
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
@@ -70,7 +63,7 @@ class ProfileType extends AbstractType
                         ]),
                         new Length([
                             'max' => ProfileSettings::NAME_MAX_LENGTH,
-                            'maxMessage' => $this->translator->trans(
+                            'maxMessage' => $this->trans(
                                 'This field cannot be longer than %limit% characters',
                                 ['%limit%' => ProfileSettings::NAME_MAX_LENGTH],
                                 'Admin.Notifications.Error'
@@ -80,6 +73,8 @@ class ProfileType extends AbstractType
                 ],
             ])
             ->add('avatarUrl', FileType::class, [
+                'block_prefix' => 'avatar_url',
+                'label' => $this->trans('Avatar', [], 'Admin.Global'),
                 'required' => false,
                 'attr' => [
                     'accept' => 'gif,jpg,jpeg,jpe,png',

--- a/src/PrestaShopBundle/Resources/config/services/adapter/profile.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/profile.yml
@@ -36,6 +36,7 @@ services:
   prestashop.adapter.profile.query_handler.get_profile_for_editing_handler:
     class: 'PrestaShop\PrestaShop\Adapter\Profile\QueryHandler\GetProfileForEditingHandler'
     arguments:
+      - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
       - '@prestashop.core.image.parser.image_tag_source_parser'
       - !php/const _PS_PROFILE_IMG_DIR_
     tags:

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1324,8 +1324,8 @@ services:
   form.type.configure.advanced_parameters.profile:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Profile\ProfileType'
     public: true
-    arguments:
-      - '@translator'
+    calls:
+      - { method: setTranslator, arguments: [ '@translator' ] }
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -90,6 +90,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\ProfileFormDataProvider'
     arguments:
       - '@prestashop.core.query_bus'
+      - '@=service("prestashop.adapter.employee.avatar_provider").getDefaultAvatarUrl()'
 
   prestashop.core.form.identifiable_object.data_provider.cms_page_form_data_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\CmsPageFormDataProvider'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme profileForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {{ form_start(profileForm) }}
 <div class="card">
@@ -33,28 +33,7 @@
   </h3>
   <div class="card-body">
     <div class="form-wrapper">
-      {{ form_errors(profileForm) }}
-
-      {{ ps.form_group_row(profileForm.name, {}, {
-        'label': 'Name'|trans({}, 'Admin.Global')
-      }) }}
-
-      {{ ps.form_group_row(profileForm.avatarUrl, {}, {
-        'label': 'Avatar'|trans({}, 'Admin.Global')
-      }) }}
-
-      {% if avatarUrl|default('') is not empty %}
-      <div class="form-group row">
-        <label class="form-control-label"></label>
-        <div class="col-sm">
-          <img class="img-thumbnail clickable-avatar" src="{{ avatarUrl }}" alt="">
-        </div>
-      </div>
-      {% endif %}
-
-      {% block profile_form_rest %}
-        {{ form_rest(profileForm) }}
-      {% endblock %}
+      {{ form_widget(profileForm) }}
     </div>
   </div>
   <div class="card-footer">

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/Profiles/edit.html.twig
@@ -26,9 +26,7 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
 {% block content %}
-  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig' with {
-    avatarUrl: editableProfile.avatarUrl
-  } %}
+  {% include '@PrestaShop/Admin/Configure/AdvancedParameters/Profiles/Blocks/form.html.twig' %}
 {% endblock %}
 
 {% block javascripts %}

--- a/tests/Integration/Behaviour/Features/Context/Domain/ProfileFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/ProfileFeatureContext.php
@@ -118,6 +118,9 @@ class ProfileFeatureContext extends AbstractDomainFeatureContext
         if (isset($data['names'])) {
             Assert::assertEquals($editableProfile->getLocalizedNames(), $data['names']);
         }
+        if (isset($data['avatarUrl'])) {
+            Assert::assertEquals($editableProfile->getAvatarUrl(), $data['avatarUrl']);
+        }
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Profile/profile_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Profile/profile_management.feature
@@ -13,13 +13,15 @@ Feature: Manage profiles from BO
       | name[en-US] | Test Profile |
       | name[fr-FR] | Profil Test  |
     Then profile "test_profile" should have the following information:
-      | name[en-US] | Test Profile |
-      | name[fr-FR] | Profil Test  |
+      | name[en-US] | Test Profile                         |
+      | name[fr-FR] | Profil Test                          |
+      | avatarUrl   | http://localhost/img/pr/default.jpg  |
     When I edit a profile "test_profile" with following information:
       | name[en-US] | Test Profile edited |
       | name[fr-FR] | Profil Test édité   |
     Then profile "test_profile" should have the following information:
-      | name[en-US] | Test Profile edited |
-      | name[fr-FR] | Profil Test édité   |
+      | name[en-US] | Test Profile edited                  |
+      | name[fr-FR] | Profil Test édité                    |
+      | avatarUrl   | http://localhost/img/pr/default.jpg  |
     When I delete profile "test_profile"
     Then profile "test_profile" cannot be found


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | Simplify Profile Form
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Part of #16482
| How to test?  | Simplifying Advanced Parameters -> Team -> Profile. Everything must look the same aside for help now appearing under inputs instead as blue box, also some fields now will appear as required because they always were. The profile avatar is now displayed.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
