### PR TITLE
Fix filemanager undefined translations

### DIFF
--- a/admin-dev/filemanager/lang/az.php
+++ b/admin-dev/filemanager/lang/az.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Seç');
 define('lang_Erase', 'Sil');
 define('lang_Open', 'Aç');

--- a/admin-dev/filemanager/lang/bg.php
+++ b/admin-dev/filemanager/lang/bg.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Избери');
 define('lang_Erase', 'Изтрий');
 define('lang_Open', 'Отвори');

--- a/admin-dev/filemanager/lang/br.php
+++ b/admin-dev/filemanager/lang/br.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Selecionar');
 define('lang_Erase', 'Apagar');
 define('lang_Open', 'Abrir');

--- a/admin-dev/filemanager/lang/cs.php
+++ b/admin-dev/filemanager/lang/cs.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Vybrat');
 define('lang_Erase', 'Smazat');
 define('lang_Open', 'Otevřít');
@@ -51,4 +53,8 @@ define('lang_Date_type', 'd.m.Y');
 define('lang_OK', 'OK');
 define('lang_Cancel', 'Zrušit');
 define('lang_Sorting', 'řazení');
-define('lang_Duplicate', 'Duplicate');
+define('lang_Show_url', 'zobrazit URL');
+define('lang_Extract', 'extrahovat zde');
+define('lang_File_info', 'informace o souboru');
+define('lang_Edit_image', 'upravit obrázek');
+define('lang_Duplicate', 'Duplikovat');

--- a/admin-dev/filemanager/lang/de.php
+++ b/admin-dev/filemanager/lang/de.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Ausw&auml;hlen');
 define('lang_Erase', 'L&ouml;schen');
 define('lang_Open', '&Ouml;ffnen');
@@ -45,8 +47,8 @@ define('lang_Type', 'Art');
 define('lang_Dimension', 'Dimensionen');
 define('lang_Size', 'Gr&ouml;&szlig;e');
 define('lang_Date', 'Datum');
-define('lang_Operations', 'Aktionen');
 define('lang_Filename', 'Dateiname');
+define('lang_Operations', 'Aktionen');
 define('lang_Date_type', 'd.m.Y');    //y-m-d
 define('lang_OK', 'OK');
 define('lang_Cancel', 'Abbrechen');

--- a/admin-dev/filemanager/lang/es.php
+++ b/admin-dev/filemanager/lang/es.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Seleccionar');
 define('lang_Erase', 'Eliminar');
 define('lang_Open', 'Abrir');

--- a/admin-dev/filemanager/lang/fa.php
+++ b/admin-dev/filemanager/lang/fa.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'انتخاب');
 define('lang_Erase', 'حذف');
 define('lang_Open', 'بازگشایی');

--- a/admin-dev/filemanager/lang/fr.php
+++ b/admin-dev/filemanager/lang/fr.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Sélectionner');
 define('lang_Erase', 'Effacer');
 define('lang_Open', 'Ouvrir');

--- a/admin-dev/filemanager/lang/hr.php
+++ b/admin-dev/filemanager/lang/hr.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Odaberi');
 define('lang_Erase', 'Obriši');
 define('lang_Open', 'Otvori');

--- a/admin-dev/filemanager/lang/hu.php
+++ b/admin-dev/filemanager/lang/hu.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Tallózás');
 define('lang_Erase', 'Törlés');
 define('lang_Open', 'Megnyitás');

--- a/admin-dev/filemanager/lang/id.php
+++ b/admin-dev/filemanager/lang/id.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Pilih');
 define('lang_Erase', 'Hapus');
 define('lang_Open', 'Buka');

--- a/admin-dev/filemanager/lang/it.php
+++ b/admin-dev/filemanager/lang/it.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Seleziona');
 define('lang_Erase', 'Cancella');
 define('lang_Open', 'Apri');

--- a/admin-dev/filemanager/lang/mn.php
+++ b/admin-dev/filemanager/lang/mn.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Сонгох');
 define('lang_Erase', 'Устгах');
 define('lang_Open', 'Нээх');

--- a/admin-dev/filemanager/lang/nb.php
+++ b/admin-dev/filemanager/lang/nb.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Velg');
 define('lang_Erase', 'Slett');
 define('lang_Open', 'Åpne');

--- a/admin-dev/filemanager/lang/nl.php
+++ b/admin-dev/filemanager/lang/nl.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Selecteren');
 define('lang_Erase', 'Verwijderen');
 define('lang_Open', 'Openen');

--- a/admin-dev/filemanager/lang/pl.php
+++ b/admin-dev/filemanager/lang/pl.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Wybierz');
 define('lang_Erase', 'Wyczyść');
 define('lang_Open', 'Otwórz');

--- a/admin-dev/filemanager/lang/pt.php
+++ b/admin-dev/filemanager/lang/pt.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Seleccionar');
 define('lang_Erase', 'Eliminar');
 define('lang_Open', 'Abrir');

--- a/admin-dev/filemanager/lang/ru.php
+++ b/admin-dev/filemanager/lang/ru.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Выбрать');
 define('lang_Erase', 'Удалить');
 define('lang_Open', 'Открыть');

--- a/admin-dev/filemanager/lang/se.php
+++ b/admin-dev/filemanager/lang/se.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Välj'); // Select
 define('lang_Erase', 'Radera'); // Erase
 define('lang_Open', 'Öppna'); // Open

--- a/admin-dev/filemanager/lang/sk.php
+++ b/admin-dev/filemanager/lang/sk.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Vybrať');
 define('lang_Erase', 'Odstrániť');
 define('lang_Open', 'Otvoriť');

--- a/admin-dev/filemanager/lang/tr.php
+++ b/admin-dev/filemanager/lang/tr.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Seç');
 define('lang_Erase', 'Sil');
 define('lang_Open', 'Aç');

--- a/admin-dev/filemanager/lang/uk.php
+++ b/admin-dev/filemanager/lang/uk.php
@@ -1,5 +1,7 @@
 <?php
-
+/*
+* Important - this file MUST implement all strings defined in base en.php file
+*/
 define('lang_Select', 'Вибрати');
 define('lang_Erase', 'Видалити');
 define('lang_Open', 'Відкрити');


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Read below
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30343
| Related PRs       | -
| How to test?      | Read below
| Possible impacts? | -

### Description
File manager in backoffice was throwing fatal errors in czech language ono PHP 8+, because of undefined constants. The undefined constants were translations in cs.php file of the file manager.

So I went and checked all languages to be sure

![strings1](https://user-images.githubusercontent.com/6097524/203043216-13b4d86d-7f12-4ce2-8995-ab9f270f050c.jpg)
![strings2](https://user-images.githubusercontent.com/6097524/203043224-90122bd9-0247-4c01-845f-276d87619786.jpg)

### How to test
- Install prestashop on PHP 8.1 in CZECH language - important.
- Go to edit a CMS page, add image, click on select an image, see empty window.
- With my PR, it works OK.