### PR TITLE
Unification combination command details

### DIFF
--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationHandler.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\CombinationFillerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\UpdateCommandHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CannotUpdateCombinationException;
+
+/**
+ * Handles the @see UpdateCombinationCommand using legacy object model
+ */
+class UpdateCombinationHandler implements UpdateCommandHandlerInterface
+{
+    /**
+     * @var CombinationRepository
+     */
+    private $combinationRepository;
+
+    /**
+     * @var CombinationFillerInterface
+     */
+    private $combinationFiller;
+
+    public function __construct(
+        CombinationRepository $combinationRepository,
+        CombinationFillerInterface $combinationFiller
+    ) {
+        $this->combinationRepository = $combinationRepository;
+        $this->combinationFiller = $combinationFiller;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(UpdateCombinationCommand $command): void
+    {
+        $combination = $this->combinationRepository->get($command->getCombinationId());
+        $updatableProperties = $this->combinationFiller->fillUpdatableProperties($combination, $command);
+
+        $this->combinationRepository->partialUpdate(
+            $combination,
+            $updatableProperties,
+            CannotUpdateCombinationException::FAILED_UPDATE_COMBINATION
+        );
+    }
+}

--- a/src/Adapter/Product/Combination/Update/Filler/CombinationFiller.php
+++ b/src/Adapter/Product/Combination/Update/Filler/CombinationFiller.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler;
+
+use Combination;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+
+/**
+ * This class wraps up all the product property fillers and merges the updatable properties into a single array.
+ * It is intentional that this class doesn't have the same tag as all the internal property fillers.
+ *
+ * All the internal property fillers are split just to contain less code and be more readable (because the Product contains many of properties).
+ */
+class CombinationFiller implements CombinationFillerInterface
+{
+    /**
+     * @var CombinationFillerInterface[]
+     */
+    private $updatablePropertyFillers;
+
+    /**
+     * @param CombinationFillerInterface[] $updatablePropertyFillers
+     */
+    public function __construct(
+        iterable $updatablePropertyFillers
+    ) {
+        $this->updatablePropertyFillers = $updatablePropertyFillers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function fillUpdatableProperties(Combination $combination, UpdateCombinationCommand $command): array
+    {
+        $updatableProperties = [];
+
+        foreach ($this->updatablePropertyFillers as $filler) {
+            $properties = $filler->fillUpdatableProperties($combination, $command);
+
+            if (empty($properties)) {
+                continue;
+            }
+
+            $updatableProperties = array_merge($updatableProperties, $properties);
+        }
+
+        return $updatableProperties;
+    }
+}

--- a/src/Adapter/Product/Combination/Update/Filler/CombinationFillerInterface.php
+++ b/src/Adapter/Product/Combination/Update/Filler/CombinationFillerInterface.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler;
+
+use Combination;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+
+/**
+ * Responsible for filling up the Combination with the properties which have to be updated
+ */
+interface CombinationFillerInterface
+{
+    /**
+     * Fill combination properties from the command and return an array of the properties to update.
+     *
+     * Returns a list of properties that were filled.
+     * Simple (not multilingual) fields will be provided in a simple array as a values, while for
+     * multilingual ones the array key will be the field name and the value will be an array of language ids.
+     *
+     * @return array<int, string|array<string, int>>
+     *
+     * e.g.:
+     * [
+     *     'reference',
+     *     'visibility',
+     *     'name' => [1, 2],
+     * ]
+     */
+    public function fillUpdatableProperties(Combination $combination, UpdateCombinationCommand $command): array;
+}

--- a/src/Adapter/Product/Combination/Update/Filler/DetailsFiller.php
+++ b/src/Adapter/Product/Combination/Update/Filler/DetailsFiller.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler;
+
+use Combination;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+
+/**
+ * Fills combination properties which can be considered as product details
+ */
+class DetailsFiller implements CombinationFillerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function fillUpdatableProperties(Combination $combination, UpdateCombinationCommand $command): array
+    {
+        $updatableProperties = [];
+
+        if (null !== $command->getEan13()) {
+            $combination->ean13 = $command->getEan13()->getValue();
+            $updatableProperties[] = 'ean13';
+        }
+
+        if (null !== $command->getIsbn()) {
+            $combination->isbn = $command->getIsbn()->getValue();
+            $updatableProperties[] = 'isbn';
+        }
+
+        if (null !== $command->getMpn()) {
+            $combination->mpn = $command->getMpn();
+            $updatableProperties[] = 'mpn';
+        }
+
+        if (null !== $command->getReference()) {
+            $combination->reference = $command->getReference()->getValue();
+            $updatableProperties[] = 'reference';
+        }
+
+        if (null !== $command->getUpc()) {
+            $combination->upc = $command->getUpc()->getValue();
+            $updatableProperties[] = 'upc';
+        }
+
+        if (null !== $command->getWeight()) {
+            $combination->weight = (float) (string) $command->getWeight();
+            $updatableProperties[] = 'weight';
+        }
+
+        return $updatableProperties;
+    }
+}

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
+
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Upc;
+
+/**
+ * Contains all the data needed to handle the command update.
+ *
+ * @see UpdateCommandHandlerInterface
+ *
+ * This command is only designed for the general data of combination which can be persisted in one call.
+ * It was not designed to handle the combination relations.
+ */
+class UpdateCombinationCommand
+{
+    /**
+     * @var CombinationId
+     */
+    private $combinationId;
+
+    /**
+     * @var Ean13|null
+     */
+    private $ean13;
+
+    /**
+     * @var Isbn|null
+     */
+    private $isbn;
+
+    /**
+     * @var string|null
+     */
+    private $mpn;
+
+    /**
+     * @var Reference|null
+     */
+    private $reference;
+
+    /**
+     * @var Upc|null
+     */
+    private $upc;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $weight;
+
+    /**
+     * @param int $combinationId
+     *
+     * @throws ProductConstraintException
+     */
+    public function __construct(
+        int $combinationId
+    ) {
+        $this->combinationId = new CombinationId($combinationId);
+    }
+
+    /**
+     * @return CombinationId
+     */
+    public function getCombinationId(): CombinationId
+    {
+        return $this->combinationId;
+    }
+
+    /**
+     * @return Ean13|null
+     */
+    public function getEan13(): ?Ean13
+    {
+        return $this->ean13;
+    }
+
+    /**
+     * @param string $ean13
+     *
+     * @return $this
+     */
+    public function setEan13(string $ean13): self
+    {
+        $this->ean13 = new Ean13($ean13);
+
+        return $this;
+    }
+
+    /**
+     * @return Isbn|null
+     */
+    public function getIsbn(): ?Isbn
+    {
+        return $this->isbn;
+    }
+
+    /**
+     * @param string $isbn
+     *
+     * @return $this
+     */
+    public function setIsbn(string $isbn): self
+    {
+        $this->isbn = new Isbn($isbn);
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMpn(): ?string
+    {
+        return $this->mpn;
+    }
+
+    /**
+     * @param string $mpn
+     *
+     * @return $this
+     */
+    public function setMpn(string $mpn): self
+    {
+        $this->mpn = $mpn;
+
+        return $this;
+    }
+
+    /**
+     * @return Reference|null
+     */
+    public function getReference(): ?Reference
+    {
+        return $this->reference;
+    }
+
+    /**
+     * @param string $reference
+     *
+     * @return $this
+     */
+    public function setReference(string $reference): self
+    {
+        $this->reference = new Reference($reference);
+
+        return $this;
+    }
+
+    /**
+     * @return Upc|null
+     */
+    public function getUpc(): ?Upc
+    {
+        return $this->upc;
+    }
+
+    /**
+     * @param string $upc
+     *
+     * @return $this
+     */
+    public function setUpc(string $upc): self
+    {
+        $this->upc = new Upc($upc);
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getWeight(): ?DecimalNumber
+    {
+        return $this->weight;
+    }
+
+    /**
+     * @param string $weight
+     *
+     * @return $this
+     */
+    public function setWeight(string $weight): self
+    {
+        $this->weight = new DecimalNumber($weight);
+
+        return $this;
+    }
+}

--- a/src/Core/Domain/Product/Combination/CommandHandler/UpdateCommandHandlerInterface.php
+++ b/src/Core/Domain/Product/Combination/CommandHandler/UpdateCommandHandlerInterface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+
+/**
+ * Defines contract to handle @see UpdateCombinationCommand
+ */
+interface UpdateCommandHandlerInterface
+{
+    public function handle(UpdateCombinationCommand $command): void;
+}

--- a/src/Core/Domain/Product/Combination/Exception/CannotUpdateCombinationException.php
+++ b/src/Core/Domain/Product/Combination/Exception/CannotUpdateCombinationException.php
@@ -34,6 +34,11 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception;
 class CannotUpdateCombinationException extends CombinationException
 {
     /**
+     * When generic product update fails
+     */
+    public const FAILED_UPDATE_COMBINATION = 1;
+
+    /**
      * When fails to update options of single combination
      */
     public const FAILED_UPDATE_DETAILS = 10;

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilder;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilderConfig;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\DataField;
+
+/**
+ * This command builder builds the unified UpdateCombinationCommand which includes many sub scopes of the combination
+ * edition, to clarify the configuration each sub-domain is configured separately but in the end we use one config, one
+ * builder and one command for the whole Combination fields updates.
+ */
+class UpdateCombinationCommandsBuilder implements CombinationCommandsBuilderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function buildCommands(CombinationId $combinationId, array $formData): array
+    {
+        $config = new CommandBuilderConfig();
+        $this
+            ->configurePriceImpact($config)
+            ->configureDetails($config)
+        ;
+
+        $commandBuilder = new CommandBuilder($config);
+        $shopCommand = new UpdateCombinationCommand($combinationId->getValue());
+
+        return $commandBuilder->buildCommands($formData, $shopCommand);
+    }
+
+    private function configurePriceImpact(CommandBuilderConfig $config): self
+    {
+        $config
+            ->addField('[price_impact][weight]', 'setWeight', DataField::TYPE_STRING)
+        ;
+
+        return $this;
+    }
+
+    private function configureDetails(CommandBuilderConfig $config): self
+    {
+        $config
+            ->addField('[references][reference]', 'setReference', DataField::TYPE_STRING)
+            ->addField('[references][mpn]', 'setMpn', DataField::TYPE_STRING)
+            ->addField('[references][upc]', 'setUpc', DataField::TYPE_STRING)
+            ->addField('[references][ean_13]', 'setEan13', DataField::TYPE_STRING)
+            ->addField('[references][isbn]', 'setIsbn', DataField::TYPE_STRING)
+        ;
+
+        return $this;
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -11,6 +11,15 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\GenerateProductCombinationsCommand
 
+  prestashop.adapter.product.command.update_combination_handler:
+    class: PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\UpdateCombinationHandler
+    arguments:
+      - '@prestashop.adapter.product.combination.repository.combination_repository'
+      - '@prestashop.adapter.product.combination.update.filler.combination_filler'
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand
+
   prestashop.adapter.product.command.update_combination_details_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\UpdateCombinationDetailsHandler
     arguments:
@@ -193,3 +202,12 @@ services:
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\SetDefaultCombinationCommand
+
+  prestashop.adapter.product.combination.update.filler.combination_filler:
+    class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\CombinationFiller
+    arguments:
+      - !tagged core.combination_filler
+
+  prestashop.adapter.product.combination.update.filler.details_filler:
+    class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\DetailsFiller
+    tags: [ 'core.combination_filler' ]

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -149,3 +149,8 @@ services:
     # tags: [ 'core.product_command_builder' ]
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
+
+  prestashop.core.form.command_builder.product.combination.update_combination_commands_builder:
+    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder
+    # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
+    # tags: [ 'core.combination_command_builder' ]

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination;
+
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit\Framework\Assert;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationDetails;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class CombinationAssertionFeatureContext extends AbstractCombinationFeatureContext
+{
+    /**
+     * @Then combination :combinationReference should have following details:
+     *
+     * @param string $combinationReference
+     * @param CombinationDetails $expectedDetails
+     */
+    public function assertDetails(string $combinationReference, CombinationDetails $expectedDetails): void
+    {
+        $scalarDetailNames = ['ean13', 'isbn', 'mpn', 'reference', 'upc'];
+        $actualDetails = $this->getCombinationForEditing($combinationReference, $this->getDefaultShopId())->getDetails();
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
+
+        foreach ($scalarDetailNames as $propertyName) {
+            Assert::assertSame(
+                $propertyAccessor->getValue($expectedDetails, $propertyName),
+                $propertyAccessor->getValue($actualDetails, $propertyName),
+                sprintf('Unexpected %s of "%s"', $propertyName, $combinationReference)
+            );
+        }
+
+        Assert::assertTrue(
+            $expectedDetails->getImpactOnWeight()->equals($actualDetails->getImpactOnWeight()),
+            sprintf(
+                'Unexpected combination impact on weight. Expected "%s" got "%s"',
+                var_export($expectedDetails->getImpactOnWeight(), true),
+                var_export($actualDetails->getImpactOnWeight(), true)
+            )
+        );
+    }
+
+    /**
+     * @Transform table:combination detail,value
+     *
+     * @param TableNode $tableNode
+     *
+     * @return CombinationDetails
+     */
+    public function transformDetails(TableNode $tableNode): CombinationDetails
+    {
+        $details = $tableNode->getRowsHash();
+
+        return new CombinationDetails(
+            $details['ean13'],
+            $details['isbn'],
+            $details['mpn'],
+            $details['reference'],
+            $details['upc'],
+            new DecimalNumber($details['impact on weight'] ?? '0')
+        );
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
@@ -29,9 +29,14 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination;
 
 use Behat\Gherkin\Node\TableNode;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationDetailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
 
-class UpdateCombinationDetailsFeatureContext extends AbstractCombinationFeatureContext
+/**
+ * This feature context is based on the unified command UpdateCombinationCommand, it will include all the other steps
+ * implemented in other contexts based on specified command until everything is unified. Once it's done the steps should
+ * be simplified into a single unified step usable in all the behat scenarios.
+ */
+class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
 {
     /**
      * @When I update combination :combinationReference details with following values:
@@ -41,17 +46,17 @@ class UpdateCombinationDetailsFeatureContext extends AbstractCombinationFeatureC
      */
     public function updateDetails(string $combinationReference, TableNode $tableNode): void
     {
-        $command = new UpdateCombinationDetailsCommand($this->getSharedStorage()->get($combinationReference));
+        $command = new UpdateCombinationCommand($this->getSharedStorage()->get($combinationReference));
 
         $this->fillCommand($command, $tableNode->getRowsHash());
         $this->getCommandBus()->handle($command);
     }
 
     /**
-     * @param UpdateCombinationDetailsCommand $command
+     * @param UpdateCombinationCommand $command
      * @param array $dataRows
      */
-    private function fillCommand(UpdateCombinationDetailsCommand $command, array $dataRows): void
+    private function fillCommand(UpdateCombinationCommand $command, array $dataRows): void
     {
         if (isset($dataRows['ean13'])) {
             $command->setEan13($dataRows['ean13']);

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -313,6 +313,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\ManufacturerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationListingFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\DeleteCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext
@@ -493,11 +494,12 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\ManufacturerFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\ProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationListingFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\DeleteCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SearchCombinationFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationDetailsFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationPricesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationStockFeatureContext

--- a/tests/Unit/Adapter/Product/Combination/Update/Filler/CombinationFillerTestCase.php
+++ b/tests/Unit/Adapter/Product/Combination/Update/Filler/CombinationFillerTestCase.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Product\Combination\Update\Filler;
+
+use Combination;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\CombinationFillerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+
+abstract class CombinationFillerTestCase extends TestCase
+{
+    protected const DEFAULT_LANG_ID = 1;
+    protected const DEFAULT_SHOP_ID = 2;
+    protected const COMBINATION_ID = 3;
+
+    /**
+     * @param CombinationFillerInterface $filler
+     * @param Combination $combination
+     * @param UpdateCombinationCommand $command
+     * @param array $expectedUpdatableProperties
+     * @param Combination $expectedCombination
+     */
+    protected function fillUpdatableProperties(
+        CombinationFillerInterface $filler,
+        Combination $combination,
+        UpdateCombinationCommand $command,
+        array $expectedUpdatableProperties,
+        Combination $expectedCombination
+    ) {
+        $this->assertSame(
+            $expectedUpdatableProperties,
+            $filler->fillUpdatableProperties($combination, $command)
+        );
+
+        // make sure the combination properties were filled as expected.
+        $this->assertEquals($expectedCombination, $combination);
+    }
+
+    /**
+     * This method mocks combination into its default state.
+     * Feel free to override it if needed for specific test cases.
+     *
+     * @return Combination
+     */
+    protected function mockDefaultCombination(): Combination
+    {
+        $combination = $this->createMock(Combination::class);
+        $combination->id = self::COMBINATION_ID;
+        $combination->weight = 0;
+
+        return $combination;
+    }
+
+    /**
+     * @return UpdateCombinationCommand
+     */
+    protected function getEmptyCommand(): UpdateCombinationCommand
+    {
+        return new UpdateCombinationCommand(self::COMBINATION_ID);
+    }
+}

--- a/tests/Unit/Adapter/Product/Combination/Update/Filler/DetailsFillerTest.php
+++ b/tests/Unit/Adapter/Product/Combination/Update/Filler/DetailsFillerTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Product\Combination\Update\Filler;
+
+use Combination;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\DetailsFiller;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+
+class DetailsFillerTest extends CombinationFillerTestCase
+{
+    /**
+     * @dataProvider getDataToTestUpdatablePropertiesFilling
+     *
+     * @param Combination $combination
+     * @param UpdateCombinationCommand $command
+     * @param array $expectedUpdatableProperties
+     * @param Combination $expectedProduct
+     */
+    public function testFillsUpdatableProperties(
+        Combination $combination,
+        UpdateCombinationCommand $command,
+        array $expectedUpdatableProperties,
+        Combination $expectedProduct
+    ): void {
+        $this->fillUpdatableProperties(
+            $this->getFiller(),
+            $combination,
+            $command,
+            $expectedUpdatableProperties,
+            $expectedProduct
+        );
+    }
+
+    /**
+     * @return iterable
+     */
+    public function getDataToTestUpdatablePropertiesFilling(): iterable
+    {
+        $command = $this->getEmptyCommand()
+            ->setUpc('3456789')
+            ->setIsbn('978-3-16-148410-1')
+        ;
+        $expectedCombination = $this->mockDefaultCombination();
+        $expectedCombination->upc = '3456789';
+        $expectedCombination->isbn = '978-3-16-148410-1';
+
+        yield [
+            $this->mockDefaultCombination(),
+            $command,
+            ['isbn', 'upc'],
+            $expectedCombination,
+        ];
+
+        $command = $this->getEmptyCommand()
+            ->setEan13('1234567890111')
+            ->setIsbn('978-3-16-148410-0')
+            ->setMpn('HUE222-7')
+            ->setReference('ref-HUE222-7')
+            ->setUpc('0123456789')
+            ->setWeight('3')
+        ;
+        $expectedCombination = $this->mockDefaultCombination();
+        $expectedCombination->ean13 = '1234567890111';
+        $expectedCombination->isbn = '978-3-16-148410-0';
+        $expectedCombination->mpn = 'HUE222-7';
+        $expectedCombination->reference = 'ref-HUE222-7';
+        $expectedCombination->upc = '0123456789';
+        $expectedCombination->weight = '3';
+
+        yield [
+            $this->mockDefaultCombination(),
+            $command,
+            [
+                'ean13',
+                'isbn',
+                'mpn',
+                'reference',
+                'upc',
+                'weight',
+            ],
+            $expectedCombination,
+        ];
+    }
+
+    /**
+     * @return DetailsFiller
+     */
+    private function getFiller(): DetailsFiller
+    {
+        return new DetailsFiller();
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder;
+
+class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBuilderTest
+{
+    /**
+     * @dataProvider getExpectedCommands
+     *
+     * @param array $formData
+     * @param array $expectedCommands
+     */
+    public function testBuildCommand(array $formData, array $expectedCommands)
+    {
+        $builder = new UpdateCombinationCommandsBuilder();
+        $builtCommands = $builder->buildCommands($this->getCombinationId(), $formData);
+        $this->assertEquals($expectedCommands, $builtCommands);
+    }
+
+    public function getExpectedCommands(): iterable
+    {
+        yield [
+            [
+                'no data' => ['useless value'],
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'price_impact' => [
+                    'not_handled' => 0,
+                ],
+                'references' => [
+                    'not_handled' => 0,
+                ],
+            ],
+            [],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setWeight('12.00');
+        $command->setReference('toto');
+        yield [
+            [
+                'price_impact' => [
+                    'not_handled' => 0,
+                    'weight' => 12.0,
+                ],
+                'references' => [
+                    'reference' => 'toto',
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setWeight('12.00');
+        yield [
+            [
+                'price_impact' => [
+                    'not_handled' => 0,
+                    'weight' => 12.0,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setUpc('123456');
+        $command->setMpn('mpn');
+        yield [
+            [
+                'references' => [
+                    'upc' => '123456',
+                    'mpn' => 'mpn',
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setIsbn('0-8044-2957-X');
+        $command->setEan13('12345678910');
+        yield [
+            [
+                'references' => [
+                    'isbn' => '0-8044-2957-X',
+                    'ean_13' => '12345678910',
+                ],
+            ],
+            [$command],
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We start the same refacto work for combination commands as we did for the product ones, the idea is to fuse all the small sub domain commands into one unified to decrease the number of DB fetches and updates and simplify the code. We use the same alternative `update_product` behat suite this way only one will have to be cleaned.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | Refacto PR validated by automatic tests, no new component is integrated in the form for now. The final PR will be functionally tested.
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
