### PR TITLE
Remove expired and disabled cart rules

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -542,6 +542,7 @@ class CartPresenter implements PresenterInterface
 
     private function getTemplateVarVouchers(Cart $cart)
     {
+        CartRule::autoRemoveFromCart();
         $cartVouchers = $cart->getCartRules();
         $vouchers = [];
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Upgrade cart rules which are deleted, expired or disabled when presenting the cart
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #19393
| How to test?      | Check ticket #19393


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
