### PR TITLE
Make committers code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # See: https://help.github.com/en/articles/about-code-owners
 
-* @PrestaShop/prestashop-maintainers
+* @PrestaShop/committers
 tests/UI @PrestaShop/ui-tests-maintainers


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR is a change of the project organization. When this PR is merged, it will replace maintainers with committers in the code owners file. Maintainers will become a subteam from committers.<br/>For code review, this means that two committers can now fully approve a Core Pull Request. As committer might have less knowledge of PrestaShop inner structure, they must be aware of what PR they fill confident enough to approve and what PR they might request maintainer's review.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | 
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
