### PR TITLE
Enable unified UpdateProductCommand in product page v2

### DIFF
--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductStockCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductStockCommandsBuilder.php
@@ -40,7 +40,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\DataField;
  *
  * @see UpdateProductStockCommand
  */
-class ProductStockCommandsBuilder
+class ProductStockCommandsBuilder implements MultiShopProductCommandsBuilderInterface
 {
     /**
      * @var string
@@ -55,6 +55,13 @@ class ProductStockCommandsBuilder
         $this->modifyAllNamePrefix = $modifyAllNamePrefix;
     }
 
+    /**
+     * @param ProductId $productId
+     * @param array $formData
+     * @param ShopConstraint $singleShopConstraint
+     *
+     * @return UpdateProductStockCommand[]
+     */
     public function buildCommands(ProductId $productId, array $formData, ShopConstraint $singleShopConstraint): array
     {
         if (!isset($formData['stock']) && !isset($formData['combinations'])) {

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
@@ -65,6 +65,7 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
             ->configureSeo($config)
             ->configureDetails($config)
             ->configureShipping($config)
+            ->configureStockInformation($config, $formData)
         ;
 
         $config->addField('[header][active]', 'setActive', DataField::TYPE_BOOL);
@@ -194,6 +195,21 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
             ->addMultiShopField('[shipping][additional_shipping_cost]', 'setAdditionalShippingCost', DataField::TYPE_STRING)
             ->addMultiShopField('[shipping][delivery_time_notes][in_stock]', 'setLocalizedDeliveryTimeInStockNotes', DataField::TYPE_ARRAY)
             ->addMultiShopField('[shipping][delivery_time_notes][out_of_stock]', 'setLocalizedDeliveryTimeOutOfStockNotes', DataField::TYPE_ARRAY)
+        ;
+
+        return $this;
+    }
+
+    private function configureStockInformation(CommandBuilderConfig $config, array $formData): self
+    {
+        $config
+            ->addMultiShopField('[stock][quantities][minimal_quantity]', 'setMinimalQuantity', DataField::TYPE_INT)
+            ->addMultiShopField('[stock][options][disabling_switch_low_stock_threshold]', 'setLowStockAlert', DataField::TYPE_BOOL)
+            ->addMultiShopField('[stock][options][low_stock_threshold]', 'setLowStockThreshold', DataField::TYPE_INT)
+            ->addMultiShopField('[stock][pack_stock_type]', 'setPackStockType', DataField::TYPE_INT)
+            ->addMultiShopField('[stock][availability][available_now_label]', 'setLocalizedAvailableNowLabels', DataField::TYPE_ARRAY)
+            ->addMultiShopField('[stock][availability][available_later_label]', 'setLocalizedAvailableLaterLabels', DataField::TYPE_ARRAY)
+            ->addMultiShopField('[stock][availability][available_date]', 'setAvailableDate', DataField::TYPE_DATETIME)
         ;
 
         return $this;

--- a/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProvider.php
@@ -384,7 +384,7 @@ class ProductFormDataProvider implements FormDataProviderInterface
             'options' => [
                 'stock_location' => $stockInformation->getLocation(),
                 'low_stock_threshold' => $stockInformation->getLowStockThreshold(),
-                'low_stock_alert' => $stockInformation->isLowStockAlertEnabled(),
+                'disabling_switch_low_stock_threshold' => $stockInformation->isLowStockAlertEnabled(),
             ],
             'virtual_product_file' => $this->extractVirtualProductFileData($productForEditing),
             'pack_stock_type' => $stockInformation->getPackStockType(),

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -56,6 +56,12 @@ services:
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\PackedProductsCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
 
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductStockCommandsBuilder:
+    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductStockCommandsBuilder
+    arguments:
+      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
+    tags: [ 'core.product_command_builder' ]
+
   # Combination builders
   prestashop.core.form.command_builder.combination.combination_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilder

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -57,7 +57,6 @@ services:
     tags: [ 'core.product_command_builder' ]
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductStockCommandsBuilder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductStockCommandsBuilder
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
     tags: [ 'core.product_command_builder' ]

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -98,4 +98,3 @@ services:
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationStockAvailableCommandsBuilder: ~
   # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
   # tags: [ 'core.combination_command_builder' ]
-

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -2,13 +2,11 @@ services:
   _defaults:
     public: true
 
-  prestashop.core.form.command_builder.product_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductCommandsBuilder:
     arguments:
       - !tagged core.product_command_builder
 
-  prestashop.core.form.command_builder.product.update_product_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\UpdateProductCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\UpdateProductCommandsBuilder:
     tags:
       - { name: 'core.product_command_builder', priority: 10 }
     arguments:
@@ -16,57 +14,46 @@ services:
 
   # VERY IMPORTANT this builder must be the last one, it will avoid conflicts with previous commands
   # that may not be compatible with the updated type, its priority musk be kept lower than others
-  prestashop.core.form.command_builder.product.type:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\TypeCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\TypeCommandsBuilder:
     tags:
       - { name: 'core.product_command_builder', priority: -42 }
 
-  prestashop.core.form.command_builder.tags.seo:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\TagsCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\TagsCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
 
-  prestashop.core.form.command_builder.product.carriers:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\CarriersCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\CarriersCommandsBuilder:
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
     tags: [ 'core.product_command_builder' ]
 
-  prestashop.core.form.command_builder.product.product_suppliers_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductSuppliersCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductSuppliersCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
 
-  prestashop.core.form.command_builder.product.feature_values_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\FeatureValuesCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\FeatureValuesCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
 
-  prestashop.core.form.command_builder.product.customization_fields_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\CustomizationFieldsCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\CustomizationFieldsCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.product.virtual_product_file_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\VirtualProductFileCommandsBuilder
     tags: [ 'core.product_command_builder' ]
 
-  prestashop.core.form.command_builder.product.categories:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductCategoriesCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductCategoriesCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
 
-  prestashop.core.form.command_builder.product.attachments:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductAttachmentsCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductAttachmentsCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
 
-  prestashop.core.form.command_builder.product.related_products_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\RelatedProductsCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\RelatedProductsCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
 
-  prestashop_core_form_command_builder_product_specific_price_priority_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\SpecificPricePriorityCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\SpecificPricePriorityCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
 
-  prestashop.core.form.command_builder.product.packed_products_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\PackedProductsCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\PackedProductsCommandsBuilder:
     tags: [ 'core.product_command_builder' ]
 
   # Combination builders

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -14,24 +14,6 @@ services:
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
 
-  # IMPORTANT these two builders update the product indexation, since the indexes are based on other product data
-  # like names, references and so on they should be executed last for more up-to-date indexes, this can be done
-  # before the product type though as it doesn't influence the indexes
-  prestashop.core.form.command_builder.product.options_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\OptionsCommandsBuilder
-    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
-    # tags:
-      # - { name: 'core.product_command_builder', priority: -15 }
-    arguments:
-      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-
-  # Status update should be after the visibility as it is the final dependency on the product indexation
-  prestashop.core.form.command_builder.product.product_status_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductStatusCommandsBuilder
-      # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
-      # tags:
-      # - { name: 'core.product_command_builder', priority: -21 }
-
   # VERY IMPORTANT this builder must be the last one, it will avoid conflicts with previous commands
   # that may not be compatible with the updated type, its priority musk be kept lower than others
   prestashop.core.form.command_builder.product.type:
@@ -39,37 +21,9 @@ services:
     tags:
       - { name: 'core.product_command_builder', priority: -42 }
 
-  prestashop.core.form.command_builder.product.basic_information:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\BasicInformationCommandsBuilder
-    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
-    # tags: [ 'core.product_command_builder' ]
-    arguments:
-      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-
-  prestashop.core.form.command_builder.product.prices:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\PricesCommandsBuilder
-    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
-    # tags: [ 'core.product_command_builder' ]
-    arguments:
-      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-
-  prestashop.core.form.command_builder.product.seo:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\SEOCommandsBuilder
-    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
-    # tags: [ 'core.product_command_builder' ]
-    arguments:
-      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-
   prestashop.core.form.command_builder.tags.seo:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\TagsCommandsBuilder
     tags: [ 'core.product_command_builder' ]
-    arguments:
-      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-
-  prestashop.core.form.command_builder.product.shipping:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ShippingCommandsBuilder
-    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
-    # tags: [ 'core.product_command_builder' ]
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
 
@@ -78,13 +32,6 @@ services:
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
     tags: [ 'core.product_command_builder' ]
-
-  prestashop.core.form.command_builder.product.stock_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\StockCommandsBuilder
-    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
-    # tags: [ 'core.product_command_builder' ]
-    arguments:
-      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
 
   prestashop.core.form.command_builder.product.product_suppliers_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductSuppliersCommandsBuilder
@@ -105,11 +52,6 @@ services:
   prestashop.core.form.command_builder.product.categories:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductCategoriesCommandsBuilder
     tags: [ 'core.product_command_builder' ]
-
-  prestashop.core.form.command_builder.product.details_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\DetailsCommandsBuilder
-    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
-    # tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.product.attachments:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductAttachmentsCommandsBuilder

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -7,21 +7,30 @@ services:
     arguments:
       - !tagged core.product_command_builder
 
+  prestashop.core.form.command_builder.product.update_product_commands_builder:
+    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\UpdateProductCommandsBuilder
+    tags:
+      - { name: 'core.product_command_builder', priority: 10 }
+    arguments:
+      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
+
   # IMPORTANT these two builders update the product indexation, since the indexes are based on other product data
   # like names, references and so on they should be executed last for more up-to-date indexes, this can be done
   # before the product type though as it doesn't influence the indexes
   prestashop.core.form.command_builder.product.options_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\OptionsCommandsBuilder
+    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
+    # tags:
+      # - { name: 'core.product_command_builder', priority: -15 }
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-    tags:
-      - { name: 'core.product_command_builder', priority: -15 }
 
   # Status update should be after the visibility as it is the final dependency on the product indexation
   prestashop.core.form.command_builder.product.product_status_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductStatusCommandsBuilder
-    tags:
-      - { name: 'core.product_command_builder', priority: -21 }
+      # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
+      # tags:
+      # - { name: 'core.product_command_builder', priority: -21 }
 
   # VERY IMPORTANT this builder must be the last one, it will avoid conflicts with previous commands
   # that may not be compatible with the updated type, its priority musk be kept lower than others
@@ -32,34 +41,37 @@ services:
 
   prestashop.core.form.command_builder.product.basic_information:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\BasicInformationCommandsBuilder
+    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
+    # tags: [ 'core.product_command_builder' ]
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-    tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.product.prices:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\PricesCommandsBuilder
+    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
+    # tags: [ 'core.product_command_builder' ]
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-    tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.product.seo:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\SEOCommandsBuilder
+    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
+    # tags: [ 'core.product_command_builder' ]
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-    tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.tags.seo:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\TagsCommandsBuilder
-    # @todo: tag commented out until UpdateProductCommand is finished and the SeoCommandsBuilder is removed
-    # tags: [ 'core.product_command_builder' ]
+    tags: [ 'core.product_command_builder' ]
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
 
   prestashop.core.form.command_builder.product.shipping:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ShippingCommandsBuilder
+    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
+    # tags: [ 'core.product_command_builder' ]
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-    tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.product.carriers:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\CarriersCommandsBuilder
@@ -69,9 +81,10 @@ services:
 
   prestashop.core.form.command_builder.product.stock_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\StockCommandsBuilder
+    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
+    # tags: [ 'core.product_command_builder' ]
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-    tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.product.product_suppliers_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductSuppliersCommandsBuilder
@@ -95,7 +108,8 @@ services:
 
   prestashop.core.form.command_builder.product.details_commands_builder:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\DetailsCommandsBuilder
-    tags: [ 'core.product_command_builder' ]
+    # todo: this and related php classes can be deleted once UpdateProductCommandsBuilder is fully integrated and tested manually
+    # tags: [ 'core.product_command_builder' ]
 
   prestashop.core.form.command_builder.product.attachments:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductAttachmentsCommandsBuilder
@@ -143,13 +157,6 @@ services:
     class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\DefaultCombinationCommandsBuilder
     tags: [ 'core.combination_command_builder' ]
 
-  prestashop.core.form.command_builder.product.update_product_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\UpdateProductCommandsBuilder
-    # @todo: tags commented bellow, to avoid affecting product page until all the related commands are refactored.
-    # tags: [ 'core.product_command_builder' ]
-    arguments:
-      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
-
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder: ~
   # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
   # tags: [ 'core.combination_command_builder' ]
@@ -157,3 +164,4 @@ services:
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationStockAvailableCommandsBuilder: ~
   # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
   # tags: [ 'core.combination_command_builder' ]
+

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -189,7 +189,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\ProductFormDataHandler'
     arguments:
       - '@prestashop.core.command_bus'
-      - '@prestashop.core.form.command_builder.product_commands_builder'
+      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\ProductCommandsBuilder'
       - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
       - "@=service('prestashop.adapter.shop.context').getContextShopID()"
 

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -139,7 +139,7 @@ class ProductControllerTest extends FormGridControllerTestCase
         // @todo: also the fields with disabling input doesnt seem to work in tests. The data dissappears from request.
         //        need to handle that in a future too. (inputs like: low_stock_threshold, unit_price etc..)
         // @todo: handle options like $isEcoTaxEnabled, $isTaxEnabled depending on them there are some fields that may exist or not.
-        // @todo: handle relation checks like specific price priorities
+        // @todo: handle relation checks like specific price priorities, categories, related products, suppliers etc.
         // First update the product with a few data
         $formData = [
             'product[header][type]' => ProductType::TYPE_STANDARD,
@@ -147,6 +147,9 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[header][name][1]' => self::TEST_NAME,
             'product[header][cover_thumbnail]' => 'http://myshop.com/img/p/en-default-cart_default.jpg',
             'product[header][active]' => true,
+            'product[description][description][1]' => 'description 1',
+            'product[description][description_short][1]' => 'description short 1',
+            'product[description][manufacturer]' => 2,
             'product[stock][quantities][delta_quantity][delta]' => self::TEST_QUANTITY,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,
             'product[stock][options][stock_location]' => 'test stock location',
@@ -177,6 +180,9 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[header][name][1]' => self::TEST_NAME,
             'product[header][cover_thumbnail]' => 'http://myshop.com/img/p/en-default-cart_default.jpg',
             'product[header][active]' => true,
+            'product[description][description][1]' => 'description 1',
+            'product[description][description_short][1]' => 'description short 1',
+            'product[description][manufacturer]' => 2,
             'product[stock][quantities][delta_quantity][delta]' => 0,
             'product[stock][quantities][delta_quantity][quantity]' => 987,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -142,7 +142,11 @@ class ProductControllerTest extends FormGridControllerTestCase
         // @todo: handle relation checks like specific price priorities
         // First update the product with a few data
         $formData = [
+            'product[header][type]' => ProductType::TYPE_STANDARD,
+            'product[header][initial_type]' => ProductType::TYPE_STANDARD,
             'product[header][name][1]' => self::TEST_NAME,
+            'product[header][cover_thumbnail]' => 'http://myshop.com/img/p/en-default-cart_default.jpg',
+            'product[header][active]' => true,
             'product[stock][quantities][delta_quantity][delta]' => self::TEST_QUANTITY,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,
             'product[stock][options][stock_location]' => 'test stock location',
@@ -168,7 +172,11 @@ class ProductControllerTest extends FormGridControllerTestCase
         // Then check that it was correctly updated
         // Price is reformatted with 6 digits
         $expectedFormData = [
+            'product[header][type]' => ProductType::TYPE_STANDARD,
+            'product[header][initial_type]' => ProductType::TYPE_STANDARD,
             'product[header][name][1]' => self::TEST_NAME,
+            'product[header][cover_thumbnail]' => 'http://myshop.com/img/p/en-default-cart_default.jpg',
+            'product[header][active]' => true,
             'product[stock][quantities][delta_quantity][delta]' => 0,
             'product[stock][quantities][delta_quantity][quantity]' => 987,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Integration\PrestaShopBundle\Controller\Sell\Catalog;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
@@ -139,7 +140,7 @@ class ProductControllerTest extends FormGridControllerTestCase
         // @todo: also the fields with disabling input doesnt seem to work in tests. The data dissappears from request.
         //        need to handle that in a future too. (inputs like: low_stock_threshold, unit_price etc..)
         // @todo: handle options like $isEcoTaxEnabled, $isTaxEnabled depending on them there are some fields that may exist or not.
-        // @todo: handle relation checks like specific price priorities, categories, related products, suppliers etc.
+        // @todo: handle relation checks like priorities, categories, related products, suppliers, attachments, features etc.
         // First update the product with a few data
         $formData = [
             'product[header][type]' => ProductType::TYPE_STANDARD,
@@ -150,6 +151,13 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[description][description][1]' => 'description 1',
             'product[description][description_short][1]' => 'description short 1',
             'product[description][manufacturer]' => 2,
+            'product[specifications][references][mpn]' => 'mpn',
+            'product[specifications][references][upc]' => '72527273070',
+            'product[specifications][references][ean_13]' => '978020137962',
+            'product[specifications][references][isbn]' => '9781234567897',
+            'product[specifications][references][reference]' => 'reference1',
+            'product[specifications][show_condition]' => true,
+            'product[specifications][condition]' => ProductCondition::NEW,
             'product[stock][quantities][delta_quantity][delta]' => self::TEST_QUANTITY,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,
             'product[stock][options][stock_location]' => 'test stock location',
@@ -183,6 +191,13 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[description][description][1]' => 'description 1',
             'product[description][description_short][1]' => 'description short 1',
             'product[description][manufacturer]' => 2,
+            'product[specifications][references][mpn]' => 'mpn',
+            'product[specifications][references][upc]' => '72527273070',
+            'product[specifications][references][ean_13]' => '978020137962',
+            'product[specifications][references][isbn]' => '9781234567897',
+            'product[specifications][references][reference]' => 'reference1',
+            'product[specifications][show_condition]' => true,
+            'product[specifications][condition]' => ProductCondition::NEW,
             'product[stock][quantities][delta_quantity][delta]' => 0,
             'product[stock][quantities][delta_quantity][quantity]' => 987,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -30,6 +30,7 @@ namespace Tests\Integration\PrestaShopBundle\Controller\Sell\Catalog;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use Symfony\Component\DomCrawler\Crawler;
 use Tests\Integration\Core\Form\IdentifiableObject\Handler\FormHandlerChecker;
@@ -155,6 +156,11 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[pricing][retail_price][tax_rules_group_id]' => 1,
             'product[pricing][on_sale]' => false,
             'product[pricing][wholesale_price]' => 30.5,
+            'product[seo][meta_title][1]' => 'meta title 1',
+            'product[seo][meta_description][1]' => 'meta description 1',
+            'product[seo][link_rewrite][1]' => 'link-rewrite-1',
+            'product[seo][redirect_option][type]' => RedirectType::TYPE_NOT_FOUND,
+            'product[seo][tags][1]' => 'tag 1, tag 2',
         ];
 
         $this->editEntityFromPage(['productId' => $productId], $formData);
@@ -177,6 +183,11 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[pricing][retail_price][price_tax_included]' => 91.208,
             'product[pricing][on_sale]' => false,
             'product[pricing][wholesale_price]' => 30.5,
+            'product[seo][meta_title][1]' => 'meta title 1',
+            'product[seo][meta_description][1]' => 'meta description 1',
+            'product[seo][link_rewrite][1]' => 'link-rewrite-1',
+            'product[seo][redirect_option][type]' => RedirectType::TYPE_NOT_FOUND,
+            'product[seo][tags][1]' => 'tag 1,tag 2',
         ];
         $this->assertFormValuesFromPage(
             ['productId' => $productId],

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace Tests\Integration\PrestaShopBundle\Controller\Sell\Catalog;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
@@ -140,7 +141,7 @@ class ProductControllerTest extends FormGridControllerTestCase
         // @todo: also the fields with disabling input doesnt seem to work in tests. The data dissappears from request.
         //        need to handle that in a future too. (inputs like: low_stock_threshold, unit_price etc..)
         // @todo: handle options like $isEcoTaxEnabled, $isTaxEnabled depending on them there are some fields that may exist or not.
-        // @todo: handle relation checks like priorities, categories, related products, suppliers, attachments, features etc.
+        // @todo: handle relation checks like priorities, categories, related products, suppliers, attachments, features, carriers etc.
         // First update the product with a few data
         $formData = [
             'product[header][type]' => ProductType::TYPE_STANDARD,
@@ -158,6 +159,14 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[specifications][references][reference]' => 'reference1',
             'product[specifications][show_condition]' => true,
             'product[specifications][condition]' => ProductCondition::NEW,
+            'product[shipping][dimensions][width]' => 10.4,
+            'product[shipping][dimensions][height]' => 10.2,
+            'product[shipping][dimensions][depth]' => 5.5,
+            'product[shipping][dimensions][weight]' => 2,
+            'product[shipping][additional_shipping_cost]' => 20.4,
+            'product[shipping][delivery_time_note_type]' => DeliveryTimeNoteType::TYPE_SPECIFIC,
+            'product[shipping][delivery_time_notes][in_stock][1]' => 'in stock notes1',
+            'product[shipping][delivery_time_notes][out_of_stock][1]' => 'out of stock notes1',
             'product[stock][quantities][delta_quantity][delta]' => self::TEST_QUANTITY,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,
             'product[stock][options][stock_location]' => 'test stock location',
@@ -198,6 +207,14 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[specifications][references][reference]' => 'reference1',
             'product[specifications][show_condition]' => true,
             'product[specifications][condition]' => ProductCondition::NEW,
+            'product[shipping][dimensions][width]' => 10.4,
+            'product[shipping][dimensions][height]' => 10.2,
+            'product[shipping][dimensions][depth]' => 5.5,
+            'product[shipping][dimensions][weight]' => 2,
+            'product[shipping][additional_shipping_cost]' => 20.4,
+            'product[shipping][delivery_time_note_type]' => DeliveryTimeNoteType::TYPE_SPECIFIC,
+            'product[shipping][delivery_time_notes][in_stock][1]' => 'in stock notes1',
+            'product[shipping][delivery_time_notes][out_of_stock][1]' => 'out of stock notes1',
             'product[stock][quantities][delta_quantity][delta]' => 0,
             'product[stock][quantities][delta_quantity][quantity]' => 987,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,

--- a/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
+++ b/tests/Integration/PrestaShopBundle/Controller/Sell/Catalog/ProductControllerTest.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use Symfony\Component\DomCrawler\Crawler;
@@ -167,6 +168,10 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[shipping][delivery_time_note_type]' => DeliveryTimeNoteType::TYPE_SPECIFIC,
             'product[shipping][delivery_time_notes][in_stock][1]' => 'in stock notes1',
             'product[shipping][delivery_time_notes][out_of_stock][1]' => 'out of stock notes1',
+            'product[options][visibility][visibility]' => ProductVisibility::VISIBLE_IN_CATALOG,
+            'product[options][visibility][available_for_order]' => true,
+            'product[options][visibility][show_price]' => true,
+            'product[options][visibility][online_only]' => false,
             'product[stock][quantities][delta_quantity][delta]' => self::TEST_QUANTITY,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,
             'product[stock][options][stock_location]' => 'test stock location',
@@ -215,6 +220,10 @@ class ProductControllerTest extends FormGridControllerTestCase
             'product[shipping][delivery_time_note_type]' => DeliveryTimeNoteType::TYPE_SPECIFIC,
             'product[shipping][delivery_time_notes][in_stock][1]' => 'in stock notes1',
             'product[shipping][delivery_time_notes][out_of_stock][1]' => 'out of stock notes1',
+            'product[options][visibility][visibility]' => ProductVisibility::VISIBLE_IN_CATALOG,
+            'product[options][visibility][available_for_order]' => true,
+            'product[options][visibility][show_price]' => true,
+            'product[options][visibility][online_only]' => false,
             'product[stock][quantities][delta_quantity][delta]' => 0,
             'product[stock][quantities][delta_quantity][quantity]' => 987,
             'product[stock][quantities][minimal_quantity]' => self::TEST_MINIMAL_QUANTITY,

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -28,7 +28,9 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
 
+use DateTime;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
@@ -948,6 +950,15 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             [$command],
         ];
 
+        $localizedAvailableNowLabels = [
+            1 => 'Available now fr',
+            2 => 'Available now en',
+        ];
+        $localizedAvailableLaterLabels = [
+            1 => 'Available later fr',
+            2 => 'Available later en',
+        ];
+
         $singleShopCommand = $this->getSingleShopCommand();
         $singleShopCommand
             ->setVisibility(ProductVisibility::VISIBLE_EVERYWHERE)
@@ -964,6 +975,10 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                 2 => 'Isparduota',
             ])
             ->setActive(true)
+            ->setLowStockAlert(true)
+            ->setLowStockThreshold(10)
+            ->setLocalizedAvailableLaterLabels($localizedAvailableLaterLabels)
+            ->setAvailableDate(new DateTime('2022-10-11'))
         ;
 
         $allShopsCommand = $this->getAllShopsCommand();
@@ -978,6 +993,9 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                 1 => 'In stock',
                 2 => 'Yra sandelyje',
             ])
+            ->setMinimalQuantity(1)
+            ->setPackStockType(PackStockType::STOCK_TYPE_PRODUCTS_ONLY)
+            ->setLocalizedAvailableNowLabels($localizedAvailableNowLabels)
         ;
 
         yield [
@@ -1036,6 +1054,30 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                             1 => 'Out of stock',
                             2 => 'Isparduota',
                         ],
+                    ],
+                ],
+                'stock' => [
+                    'quantities' => [
+                        'minimal_quantity' => 1,
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'minimal_quantity' => true,
+                        // delta_quantity shouldn't affect anything in this command builder,
+                        // because it should be taken care of in a dedicated builder for StockAvailable
+                        'delta_quantity' => [
+                            'quantity' => 10,
+                            'delta' => 5,
+                        ],
+                    ],
+                    'options' => [
+                        'disabling_switch_low_stock_threshold' => true,
+                        'low_stock_threshold' => 10,
+                    ],
+                    'pack_stock_type' => PackStockType::STOCK_TYPE_PRODUCTS_ONLY,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'pack_stock_type' => true,
+                    'availability' => [
+                        'available_now_label' => $localizedAvailableNowLabels,
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'available_now_label' => true,
+                        'available_later_label' => $localizedAvailableLaterLabels,
+                        'available_date' => '2022-10-11',
                     ],
                 ],
             ],

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/ProductFormDataProviderTest.php
@@ -412,7 +412,7 @@ class ProductFormDataProviderTest extends TestCase
             'minimal_quantity' => 7,
             'location' => 'top shelf',
             'low_stock_threshold' => 5,
-            'low_stock_alert' => true,
+            'disabling_switch_low_stock_threshold' => true,
             'pack_stock_type' => PackStockType::STOCK_TYPE_PACK_ONLY,
             'out_of_stock_type' => OutOfStockType::OUT_OF_STOCK_AVAILABLE,
             'available_now' => $localizedValues,
@@ -475,7 +475,7 @@ class ProductFormDataProviderTest extends TestCase
         $expectedOutputData['stock']['quantities']['minimal_quantity'] = 7;
         $expectedOutputData['stock']['options']['stock_location'] = 'top shelf';
         $expectedOutputData['stock']['options']['low_stock_threshold'] = 5;
-        $expectedOutputData['stock']['options']['low_stock_alert'] = true;
+        $expectedOutputData['stock']['options']['disabling_switch_low_stock_threshold'] = true;
         $expectedOutputData['stock']['pack_stock_type'] = PackStockType::STOCK_TYPE_PACK_ONLY;
         $expectedOutputData['stock']['availability']['out_of_stock_type'] = OutOfStockType::OUT_OF_STOCK_AVAILABLE;
         $expectedOutputData['stock']['availability']['available_now_label'] = $localizedValues;
@@ -1317,7 +1317,7 @@ class ProductFormDataProviderTest extends TestCase
             $product['quantity'] ?? self::DEFAULT_QUANTITY,
             $product['minimal_quantity'] ?? 0,
             $product['low_stock_threshold'] ?? 0,
-            $product['low_stock_alert'] ?? false,
+            $product['disabling_switch_low_stock_threshold'] ?? false,
             $product['available_now'] ?? [],
             $product['available_later'] ?? [],
             $product['location'] ?? 'location',
@@ -1591,7 +1591,7 @@ class ProductFormDataProviderTest extends TestCase
                 'options' => [
                     'stock_location' => 'location',
                     'low_stock_threshold' => 0,
-                    'low_stock_alert' => false,
+                    'disabling_switch_low_stock_threshold' => false,
                 ],
                 'virtual_product_file' => [
                     'has_file' => false,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Enable new unified UpdateProductCommand in product v2 page. Behavior should not change, just behind the scenes instead of using multiple commands for Product entity update, now it should use main one UpdateProductCommand. (Note - all the relation commands are still there like - UpdateSuppliers, tags, features, attributes etc.. so commands builder builds 12 commands in total, one of which is the UpdateProductCommand handling all the general product fields which rests in ps_product table).
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | Will have to make sure product page v2 works as usually. All tabs must be tested. Following parts should not be affected - relations like combinations, packed items, features, customizations, files, suppliers. So the test should only focus on "simple fields" which are the Product's properties
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
