### PR TITLE
Unified combination command - isDefault, prices and stock

### DIFF
--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandler.php
@@ -50,6 +50,7 @@ class UpdateCombinationStockAvailableHandler implements UpdateCombinationStockAv
      * @var MovementReasonRepository
      */
     private $movementReasonRepository;
+
     /**
      * @var StockAvailableRepository
      */

--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandler.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler;
+
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockProperties;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\UpdateCombinationStockAvailableHandlerInterface;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockModification;
+
+/**
+ * Updates combination stock available using legacy object model
+ */
+class UpdateCombinationStockAvailableHandler implements UpdateCombinationStockAvailableHandlerInterface
+{
+    /**
+     * @var CombinationStockUpdater
+     */
+    private $combinationStockUpdater;
+
+    /**
+     * @var MovementReasonRepository
+     */
+    private $movementReasonRepository;
+    /**
+     * @var StockAvailableRepository
+     */
+    private $stockAvailableRepository;
+
+    /**
+     * @param CombinationStockUpdater $combinationStockUpdater
+     * @param MovementReasonRepository $movementReasonRepository
+     * @param StockAvailableRepository $stockAvailableRepository
+     */
+    public function __construct(
+        CombinationStockUpdater $combinationStockUpdater,
+        MovementReasonRepository $movementReasonRepository,
+        StockAvailableRepository $stockAvailableRepository
+    ) {
+        $this->combinationStockUpdater = $combinationStockUpdater;
+        $this->movementReasonRepository = $movementReasonRepository;
+        $this->stockAvailableRepository = $stockAvailableRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(UpdateCombinationStockAvailableCommand $command): void
+    {
+        $stockModification = null;
+        if ($command->getDeltaQuantity()) {
+            $stockModification = new StockModification(
+                $command->getDeltaQuantity(),
+                $this->movementReasonRepository->getEmployeeEditionReasonId($command->getDeltaQuantity() > 0)
+            );
+        } elseif (null !== $command->getFixedQuantity()) {
+            $currentQuantity = (int) $this->stockAvailableRepository->getForCombination($command->getCombinationId())->quantity;
+            $deltaQuantity = $command->getFixedQuantity() - $currentQuantity;
+
+            $stockModification = new StockModification(
+                $deltaQuantity,
+                $this->movementReasonRepository->getEmployeeEditionReasonId($deltaQuantity > 0)
+            );
+        }
+
+        // Now we only fill the properties existing in StockAvailable object model.
+        // Other properties related to stock (which exists in Combination object model) should be taken care by a unified UpdateProductCommand.
+        // @todo: once the unification is done this should be refacto as the CombinationStockProperties contains too many fields now
+        $properties = new CombinationStockProperties(
+            $stockModification,
+            null,
+            $command->getLocation(),
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+
+        $this->combinationStockUpdater->update($command->getCombinationId(), $properties);
+    }
+}

--- a/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
@@ -142,11 +142,6 @@ class CombinationStockUpdater
             $updatableProperties[] = 'low_stock_alert';
         }
 
-        if (null !== $properties->getLocation()) {
-            $combination->location = $properties->getLocation();
-            $updatableProperties[] = 'location';
-        }
-
         return $updatableProperties;
     }
 

--- a/src/Adapter/Product/Combination/Update/Filler/DetailsFiller.php
+++ b/src/Adapter/Product/Combination/Update/Filler/DetailsFiller.php
@@ -68,8 +68,8 @@ class DetailsFiller implements CombinationFillerInterface
             $updatableProperties[] = 'upc';
         }
 
-        if (null !== $command->getWeight()) {
-            $combination->weight = (float) (string) $command->getWeight();
+        if (null !== $command->getImpactOnWeight()) {
+            $combination->weight = (float) (string) $command->getImpactOnWeight();
             $updatableProperties[] = 'weight';
         }
 

--- a/src/Adapter/Product/Combination/Update/Filler/PricesFiller.php
+++ b/src/Adapter/Product/Combination/Update/Filler/PricesFiller.php
@@ -34,7 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinat
 /**
  * Fills combination properties which can be considered as combination details
  */
-class DetailsFiller implements CombinationFillerInterface
+class PricesFiller implements CombinationFillerInterface
 {
     /**
      * {@inheritDoc}
@@ -43,34 +43,24 @@ class DetailsFiller implements CombinationFillerInterface
     {
         $updatableProperties = [];
 
-        if (null !== $command->getEan13()) {
-            $combination->ean13 = $command->getEan13()->getValue();
-            $updatableProperties[] = 'ean13';
+        if (null !== $command->getImpactOnPrice()) {
+            $combination->price = (float) (string) $command->getImpactOnPrice();
+            $updatableProperties[] = 'price';
         }
 
-        if (null !== $command->getIsbn()) {
-            $combination->isbn = $command->getIsbn()->getValue();
-            $updatableProperties[] = 'isbn';
+        if (null !== $command->getEcoTax()) {
+            $combination->ecotax = (float) (string) $command->getEcoTax();
+            $updatableProperties[] = 'ecotax';
         }
 
-        if (null !== $command->getMpn()) {
-            $combination->mpn = $command->getMpn();
-            $updatableProperties[] = 'mpn';
+        if (null !== $command->getImpactOnUnitPrice()) {
+            $combination->unit_price_impact = (float) (string) $command->getImpactOnUnitPrice();
+            $updatableProperties[] = 'unit_price_impact';
         }
 
-        if (null !== $command->getReference()) {
-            $combination->reference = $command->getReference()->getValue();
-            $updatableProperties[] = 'reference';
-        }
-
-        if (null !== $command->getUpc()) {
-            $combination->upc = $command->getUpc()->getValue();
-            $updatableProperties[] = 'upc';
-        }
-
-        if (null !== $command->getWeight()) {
-            $combination->weight = (float) (string) $command->getWeight();
-            $updatableProperties[] = 'weight';
+        if (null !== $command->getWholesalePrice()) {
+            $combination->wholesale_price = (float) (string) $command->getWholesalePrice();
+            $updatableProperties[] = 'wholesale_price';
         }
 
         return $updatableProperties;

--- a/src/Adapter/Product/Combination/Update/Filler/StockInformationFiller.php
+++ b/src/Adapter/Product/Combination/Update/Filler/StockInformationFiller.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler;
+
+use Combination;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
+
+/**
+ * Fills combination properties related to stock. But just the ones in Combination entity and not the ones in StockAvailable.
+ * For properties like quantity, out_of_stock and location @see UpdateCombinationStockAvailableCommand
+ */
+class StockInformationFiller implements CombinationFillerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function fillUpdatableProperties(Combination $combination, UpdateCombinationCommand $command): array
+    {
+        $updatableProperties = [];
+
+        $localizedLaterLabels = $command->getLocalizedAvailableLaterLabels();
+        if (null !== $localizedLaterLabels) {
+            $combination->available_later = $localizedLaterLabels;
+            $updatableProperties['available_later'] = array_keys($localizedLaterLabels);
+        }
+
+        $localizedNowLabels = $command->getLocalizedAvailableNowLabels();
+        if (null !== $localizedNowLabels) {
+            $combination->available_now = $localizedNowLabels;
+            $updatableProperties['available_now'] = array_keys($localizedNowLabels);
+        }
+
+        if (null !== $command->getAvailableDate()) {
+            $combination->available_date = $command->getAvailableDate()->format(DateTime::DEFAULT_DATE_FORMAT);
+            $updatableProperties[] = 'available_date';
+        }
+
+        if (null !== $command->getLowStockThreshold()) {
+            $combination->low_stock_threshold = $command->getLowStockThreshold();
+            $updatableProperties[] = 'low_stock_threshold';
+        }
+
+        if (null !== $command->getMinimalQuantity()) {
+            $combination->minimal_quantity = $command->getMinimalQuantity();
+            $updatableProperties[] = 'minimal_quantity';
+        }
+
+        if (null !== $command->isLowStockAlertEnabled()) {
+            $combination->low_stock_alert = $command->isLowStockAlertEnabled();
+            $updatableProperties[] = 'low_stock_alert';
+        }
+
+        return $updatableProperties;
+    }
+}

--- a/src/Adapter/Product/Stock/CommandHandler/UpdateProductStockHandler.php
+++ b/src/Adapter/Product/Stock/CommandHandler/UpdateProductStockHandler.php
@@ -88,6 +88,7 @@ class UpdateProductStockHandler implements UpdateProductStockHandlerInterface
         // For now this will also fill some of deprecated properties in product (quantity, location, out_of_stock),
         // but in future we will remove those fields from Product,
         // and then this handler will only persist StockAvailable related fields as it is designed for.
+        // @todo: once the unification is done this should be refacto as the ProductStockProperties contains too many fields now
         $this->productStockUpdater->update(
             $command->getProductId(),
             new ProductStockProperties(

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
@@ -53,6 +53,11 @@ class UpdateCombinationCommand
     private $combinationId;
 
     /**
+     * @var bool|null
+     */
+    private $isDefault;
+
+    /**
      * @var Ean13|null
      */
     private $ean13;
@@ -149,6 +154,26 @@ class UpdateCombinationCommand
     public function getCombinationId(): CombinationId
     {
         return $this->combinationId;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isDefault(): ?bool
+    {
+        return $this->isDefault;
+    }
+
+    /**
+     * @param bool|null $isDefault
+     *
+     * @return static
+     */
+    public function setIsDefault(?bool $isDefault): self
+    {
+        $this->isDefault = $isDefault;
+
+        return $this;
     }
 
     /**

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 
+use DateTimeInterface;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
@@ -100,6 +101,36 @@ class UpdateCombinationCommand
      * @var DecimalNumber|null
      */
     private $wholesalePrice;
+
+    /**
+     * @var int|null
+     */
+    private $minimalQuantity;
+
+    /**
+     * @var int|null
+     */
+    private $lowStockThreshold;
+
+    /**
+     * @var bool|null
+     */
+    private $lowStockAlertEnabled;
+
+    /**
+     * @var DateTimeInterface|null
+     */
+    private $availableDate;
+
+    /**
+     * @var string[]|null key value pairs where key is the id of language
+     */
+    private $localizedAvailableNowLabels;
+
+    /**
+     * @var string[]|null key value pairs where key is the id of language
+     */
+    private $localizedAvailableLaterLabels;
 
     /**
      * @param int $combinationId
@@ -316,6 +347,134 @@ class UpdateCombinationCommand
     public function setWholesalePrice(string $wholesalePrice): self
     {
         $this->wholesalePrice = new DecimalNumber($wholesalePrice);
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMinimalQuantity(): ?int
+    {
+        return $this->minimalQuantity;
+    }
+
+    /**
+     * @param int $minimalQuantity
+     *
+     * @return $this
+     */
+    public function setMinimalQuantity(int $minimalQuantity): self
+    {
+        $this->minimalQuantity = $minimalQuantity;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getLowStockThreshold(): ?int
+    {
+        return $this->lowStockThreshold;
+    }
+
+    /**
+     * @param int $lowStockThreshold
+     *
+     * @return $this
+     */
+    public function setLowStockThreshold(int $lowStockThreshold): self
+    {
+        $this->lowStockThreshold = $lowStockThreshold;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function isLowStockAlertEnabled(): ?bool
+    {
+        return $this->lowStockAlertEnabled;
+    }
+
+    /**
+     * @param bool $enabled
+     *
+     * @return $this
+     */
+    public function setLowStockAlert(bool $enabled): self
+    {
+        $this->lowStockAlertEnabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * @return DateTimeInterface|null
+     */
+    public function getAvailableDate(): ?DateTimeInterface
+    {
+        return $this->availableDate;
+    }
+
+    /**
+     * @param DateTimeInterface $availableDate
+     *
+     * @return $this
+     */
+    public function setAvailableDate(DateTimeInterface $availableDate): self
+    {
+        $this->availableDate = $availableDate;
+
+        return $this;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getLowStockAlertEnabled(): ?bool
+    {
+        return $this->lowStockAlertEnabled;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedAvailableNowLabels(): ?array
+    {
+        return $this->localizedAvailableNowLabels;
+    }
+
+    /**
+     * @param string[] $localizedAvailableNowLabels
+     *
+     * @return $this
+     */
+    public function setLocalizedAvailableNowLabels(array $localizedAvailableNowLabels): self
+    {
+        $this->localizedAvailableNowLabels = $localizedAvailableNowLabels;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getLocalizedAvailableLaterLabels(): ?array
+    {
+        return $this->localizedAvailableLaterLabels;
+    }
+
+    /**
+     * @param string[] $localizedAvailableLaterLabels
+     *
+     * @return $this
+     */
+    public function setLocalizedAvailableLaterLabels(array $localizedAvailableLaterLabels): self
+    {
+        $this->localizedAvailableLaterLabels = $localizedAvailableLaterLabels;
 
         return $this;
     }

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
@@ -79,7 +79,7 @@ class UpdateCombinationCommand
     /**
      * @var DecimalNumber|null
      */
-    private $weight;
+    private $impactOnWeight;
 
     /**
      * @var DecimalNumber|null
@@ -223,19 +223,19 @@ class UpdateCombinationCommand
     /**
      * @return DecimalNumber|null
      */
-    public function getWeight(): ?DecimalNumber
+    public function getImpactOnWeight(): ?DecimalNumber
     {
-        return $this->weight;
+        return $this->impactOnWeight;
     }
 
     /**
-     * @param string $weight
+     * @param string $impactOnWeight
      *
      * @return $this
      */
-    public function setWeight(string $weight): self
+    public function setImpactOnWeight(string $impactOnWeight): self
     {
-        $this->weight = new DecimalNumber($weight);
+        $this->impactOnWeight = new DecimalNumber($impactOnWeight);
 
         return $this;
     }

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
@@ -82,6 +82,26 @@ class UpdateCombinationCommand
     private $weight;
 
     /**
+     * @var DecimalNumber|null
+     */
+    private $impactOnPrice;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $ecoTax;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $impactOnUnitPrice;
+
+    /**
+     * @var DecimalNumber|null
+     */
+    private $wholesalePrice;
+
+    /**
      * @param int $combinationId
      *
      * @throws ProductConstraintException
@@ -216,6 +236,86 @@ class UpdateCombinationCommand
     public function setWeight(string $weight): self
     {
         $this->weight = new DecimalNumber($weight);
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getImpactOnPrice(): ?DecimalNumber
+    {
+        return $this->impactOnPrice;
+    }
+
+    /**
+     * @param string $impactOnPrice
+     *
+     * @return $this
+     */
+    public function setImpactOnPrice(string $impactOnPrice): self
+    {
+        $this->impactOnPrice = new DecimalNumber($impactOnPrice);
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getEcoTax(): ?DecimalNumber
+    {
+        return $this->ecoTax;
+    }
+
+    /**
+     * @param string $ecoTax
+     *
+     * @return $this
+     */
+    public function setEcoTax(string $ecoTax): self
+    {
+        $this->ecoTax = new DecimalNumber($ecoTax);
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getImpactOnUnitPrice(): ?DecimalNumber
+    {
+        return $this->impactOnUnitPrice;
+    }
+
+    /**
+     * @param string $impactOnUnitPrice
+     *
+     * @return $this
+     */
+    public function setImpactOnUnitPrice(string $impactOnUnitPrice): self
+    {
+        $this->impactOnUnitPrice = new DecimalNumber($impactOnUnitPrice);
+
+        return $this;
+    }
+
+    /**
+     * @return DecimalNumber|null
+     */
+    public function getWholesalePrice(): ?DecimalNumber
+    {
+        return $this->wholesalePrice;
+    }
+
+    /**
+     * @param string $wholesalePrice
+     *
+     * @return $this
+     */
+    public function setWholesalePrice(string $wholesalePrice): self
+    {
+        $this->wholesalePrice = new DecimalNumber($wholesalePrice);
 
         return $this;
     }

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockAvailableCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockAvailableCommand.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
+
+/**
+ * This class should actually be called UpdateCombinationStockCommand but the name is already take,
+ * although the current command should be cleaned once the unification is done. When that is done this
+ * command should be correctly renamed.
+ *
+ * Either that or UpdateProductStockCommand could be renamed into UpdateProductStockAvailableCommand,the
+ * idea is to keep the consistency.
+ */
+class UpdateCombinationStockAvailableCommand
+{
+    /**
+     * @var CombinationId
+     */
+    private $combinationId;
+
+    /**
+     * @var int|null
+     */
+    private $deltaQuantity;
+
+    /**
+     * @var int|null
+     */
+    private $fixedQuantity;
+
+    /**
+     * @var string|null
+     */
+    private $location;
+
+    /**
+     * @param int $combinationId
+     */
+    public function __construct(
+        int $combinationId
+    ) {
+        $this->combinationId = new CombinationId($combinationId);
+    }
+
+    /**
+     * @return CombinationId
+     */
+    public function getCombinationId(): CombinationId
+    {
+        return $this->combinationId;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getDeltaQuantity(): ?int
+    {
+        return $this->deltaQuantity;
+    }
+
+    /**
+     * @param int $deltaQuantity
+     *
+     * @return $this
+     */
+    public function setDeltaQuantity(int $deltaQuantity): self
+    {
+        if (null !== $this->fixedQuantity) {
+            throw new ProductStockConstraintException(
+                'Cannot set $deltaQuantity, because $fixedQuantity is already set',
+                ProductStockConstraintException::FIXED_AND_DELTA_QUANTITY_PROVIDED
+            );
+        }
+        $this->deltaQuantity = $deltaQuantity;
+
+        return $this;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getFixedQuantity(): ?int
+    {
+        return $this->fixedQuantity;
+    }
+
+    /**
+     * @param int $fixedQuantity
+     *
+     * @return $this
+     */
+    public function setFixedQuantity(int $fixedQuantity): self
+    {
+        if ($this->deltaQuantity) {
+            throw new ProductStockConstraintException(
+                'Cannot set $fixedQuantity, because $deltaQuantity is already set',
+                ProductStockConstraintException::FIXED_AND_DELTA_QUANTITY_PROVIDED
+            );
+        }
+        $this->fixedQuantity = $fixedQuantity;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLocation(): ?string
+    {
+        return $this->location;
+    }
+
+    /**
+     * @param string $location
+     *
+     * @return $this
+     */
+    public function setLocation(string $location): self
+    {
+        $this->location = $location;
+
+        return $this;
+    }
+}

--- a/src/Core/Domain/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandlerInterface.php
+++ b/src/Core/Domain/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandlerInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
+
+/**
+ * Defines contract to handle @see UpdateCombinationStockAvailableCommand
+ */
+interface UpdateCombinationStockAvailableHandlerInterface
+{
+    public function handle(UpdateCombinationStockAvailableCommand $command): void;
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
@@ -47,6 +47,10 @@ class UpdateCombinationCommandsBuilder implements CombinationCommandsBuilderInte
     public function buildCommands(CombinationId $combinationId, array $formData): array
     {
         $config = new CommandBuilderConfig();
+        $config
+            ->addField('[header][is_default]', 'setIsDefault', DataField::TYPE_BOOL)
+        ;
+
         $this
             ->configurePriceImpact($config)
             ->configureDetails($config)

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
@@ -50,6 +50,7 @@ class UpdateCombinationCommandsBuilder implements CombinationCommandsBuilderInte
         $this
             ->configurePriceImpact($config)
             ->configureDetails($config)
+            ->configureStock($config)
         ;
 
         $commandBuilder = new CommandBuilder($config);
@@ -61,6 +62,10 @@ class UpdateCombinationCommandsBuilder implements CombinationCommandsBuilderInte
     private function configurePriceImpact(CommandBuilderConfig $config): self
     {
         $config
+            ->addField('[price_impact][price_tax_excluded]', 'setImpactOnPrice', DataField::TYPE_STRING)
+            ->addField('[price_impact][ecotax_tax_excluded]', 'setEcoTax', DataField::TYPE_STRING)
+            ->addField('[price_impact][unit_price_tax_excluded]', 'setImpactOnUnitPrice', DataField::TYPE_STRING)
+            ->addField('[price_impact][wholesale_price]', 'setWholesalePrice', DataField::TYPE_STRING)
             ->addField('[price_impact][weight]', 'setImpactOnWeight', DataField::TYPE_STRING)
         ;
 
@@ -75,6 +80,21 @@ class UpdateCombinationCommandsBuilder implements CombinationCommandsBuilderInte
             ->addField('[references][upc]', 'setUpc', DataField::TYPE_STRING)
             ->addField('[references][ean_13]', 'setEan13', DataField::TYPE_STRING)
             ->addField('[references][isbn]', 'setIsbn', DataField::TYPE_STRING)
+        ;
+
+        return $this;
+    }
+
+    private function configureStock(CommandBuilderConfig $config): self
+    {
+        $config
+            ->addField('[stock][quantities][minimal_quantity]', 'setMinimalQuantity', DataField::TYPE_INT)
+            ->addField('[stock][options][low_stock_threshold]', 'setLowStockThreshold', DataField::TYPE_INT)
+            ->addField('[stock][options][disabling_switch_low_stock_threshold]', 'setLowStockAlert', DataField::TYPE_BOOL)
+            ->addField('[stock][pack_stock_type]', 'setPackStockType', DataField::TYPE_INT)
+            ->addField('[stock][available_date]', 'setAvailableDate', DataField::TYPE_DATETIME)
+            ->addField('[stock][available_now_label]', 'setLocalizedAvailableNowLabels', DataField::TYPE_ARRAY)
+            ->addField('[stock][available_later_label]', 'setLocalizedAvailableLaterLabels', DataField::TYPE_ARRAY)
         ;
 
         return $this;

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
@@ -61,7 +61,7 @@ class UpdateCombinationCommandsBuilder implements CombinationCommandsBuilderInte
     private function configurePriceImpact(CommandBuilderConfig $config): self
     {
         $config
-            ->addField('[price_impact][weight]', 'setWeight', DataField::TYPE_STRING)
+            ->addField('[price_impact][weight]', 'setImpactOnWeight', DataField::TYPE_STRING)
         ;
 
         return $this;

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationStockAvailableCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationStockAvailableCommandsBuilder.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilder;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilderConfig;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\DataField;
+
+/**
+ * Builds commands from command stock form type only fields related to StockAvailable
+ */
+class UpdateCombinationStockAvailableCommandsBuilder implements CombinationCommandsBuilderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildCommands(CombinationId $combinationId, array $formData): array
+    {
+        $config = new CommandBuilderConfig();
+        $config
+            ->addField('[stock][quantities][delta_quantity][delta]', 'setDeltaQuantity', DataField::TYPE_INT)
+            ->addField('[stock][quantities][fixed_quantity]', 'setFixedQuantity', DataField::TYPE_INT)
+            ->addField('[stock][options][stock_location]', 'setLocation', DataField::TYPE_STRING)
+        ;
+
+        $commandBuilder = new CommandBuilder($config);
+        $command = new UpdateCombinationStockAvailableCommand($combinationId->getValue());
+
+        return $commandBuilder->buildCommands($formData, $command);
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -402,12 +402,15 @@ services:
       - '@prestashop.adapter.supplier.repository.supplier_repository'
       - '@prestashop.adapter.currency.repository.currency_repository'
 
-  prestashop.adapter.product.repository.product_supplier_repository:
-    class: PrestaShop\PrestaShop\Adapter\Product\Repository\ProductSupplierRepository
+  PrestaShop\PrestaShop\Adapter\Product\Repository\ProductSupplierRepository:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
       - '@prestashop.adapter.product.validate.product_supplier_validator'
+
+  prestashop.adapter.product.repository.product_supplier_repository:
+    alias: PrestaShop\PrestaShop\Adapter\Product\Repository\ProductSupplierRepository
+    deprecated: ~
 
   prestashop.adapter.product.update.product_supplier_updater:
     class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductSupplierUpdater

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -135,11 +135,14 @@ services:
       - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
       - '@prestashop.adapter.product.combination.update.default_combination_updater'
 
-  prestashop.adapter.product.combination.update.default_combination_updater:
-    class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\DefaultCombinationUpdater
+  PrestaShop\PrestaShop\Adapter\Product\Combination\Update\DefaultCombinationUpdater:
     arguments:
       - '@prestashop.adapter.product.combination.repository.combination_multi_shop_repository'
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
+
+  prestashop.adapter.product.combination.update.default_combination_updater:
+    alias: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\DefaultCombinationUpdater
+    deprecated: ~
 
   prestashop.adapter.product.combination.update.combination_deleter:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationDeleter

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -95,7 +95,6 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Validate\CombinationValidator
 
   PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository:
-    class: PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -44,6 +44,12 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockCommand
 
+  PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\UpdateCombinationStockAvailableHandler:
+    autowire: true
+    tags:
+      - name: tactician.handler
+        command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand
+
   prestashop.adapter.product.combination.query_handler.get_combination_for_editing_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler\GetCombinationForEditingHandler
     arguments:
@@ -109,13 +115,16 @@ services:
       - '@prestashop.adapter.attribute.repository.attribute_repository'
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
 
-  prestashop.adapter.product.combination.update.combination_stock_updater:
-    class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater
+  PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater:
     arguments:
       - '@prestashop.adapter.product.stock.repository.stock_available_repository'
       - '@prestashop.adapter.product.combination.repository.combination_repository'
       - '@prestashop.core.stock.stock_manager'
       - '@prestashop.adapter.legacy.configuration'
+
+  prestashop.adapter.product.combination.update.combination_stock_updater:
+    alias: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater
+    deprecated: ~
 
   prestashop.adapter.product.combination.create.combination_creator:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Create\CombinationCreator

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -224,3 +224,6 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\PricesFiller:
     tags: [ 'core.combination_filler' ]
+
+  PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\StockInformationFiller:
+    tags: [ 'core.combination_filler' ]

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -11,11 +11,8 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\GenerateProductCombinationsCommand
 
-  prestashop.adapter.product.command.update_combination_handler:
-    class: PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\UpdateCombinationHandler
-    arguments:
-      - '@prestashop.adapter.product.combination.repository.combination_repository'
-      - '@prestashop.adapter.product.combination.update.filler.combination_filler'
+  PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler\UpdateCombinationHandler:
+    autowire: true
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand
@@ -91,13 +88,17 @@ services:
   prestashop.adapter.product.combination.validate.combination_validator:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Validate\CombinationValidator
 
-  prestashop.adapter.product.combination.repository.combination_repository:
+  PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
       - '@prestashop.adapter.product.combination.validate.combination_validator'
       - '@prestashop.core.grid.query_builder.product_combination'
+
+  prestashop.adapter.product.combination.repository.combination_repository:
+    alias: PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository
+    deprecated: ~
 
   prestashop.adapter.product.combination.repository.combination_multi_shop_repository:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository
@@ -203,11 +204,14 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\SetDefaultCombinationCommand
 
-  prestashop.adapter.product.combination.update.filler.combination_filler:
-    class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\CombinationFiller
+  PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\CombinationFiller:
     arguments:
       - !tagged core.combination_filler
 
-  prestashop.adapter.product.combination.update.filler.details_filler:
-    class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\DetailsFiller
+  PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\CombinationFillerInterface: '@PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\CombinationFiller'
+
+  PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\DetailsFiller:
+    tags: [ 'core.combination_filler' ]
+
+  PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\PricesFiller:
     tags: [ 'core.combination_filler' ]

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
@@ -5,12 +5,15 @@ services:
   prestashop.adapter.product.stock.validate.stock_available_validator:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\Validate\StockAvailableValidator
 
-  prestashop.adapter.product.stock.repository.stock_available_repository:
-    class: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository
+  PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
       - '@prestashop.adapter.product.stock.validate.stock_available_validator'
+
+  prestashop.adapter.product.stock.repository.stock_available_repository:
+    alias: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository
+    deprecated: ~
 
   prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository
@@ -25,10 +28,13 @@ services:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
 
-  prestashop.adapter.product.stock.repository.movement_reason_repository:
-    class: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository
+  PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository:
     arguments:
       - '@prestashop.adapter.legacy.configuration'
+
+  prestashop.adapter.product.stock.repository.movement_reason_repository:
+    alias: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository
+    deprecated: ~
 
   prestashop.adapter.product.stock.command_handler.update_product_stock_information_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\CommandHandler\UpdateProductStockInformationHandler

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -151,9 +151,9 @@ services:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder: ~
-    # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
-    # tags: [ 'core.combination_command_builder' ]
+  # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
+  # tags: [ 'core.combination_command_builder' ]
 
-  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationStockAvailableCommandsBuilder: ~
-    # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
-    # tags: [ 'core.combination_command_builder' ]
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationStockAvailableCommandsBuilder: ~
+  # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
+  # tags: [ 'core.combination_command_builder' ]

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -150,7 +150,10 @@ services:
     arguments:
       - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
 
-  prestashop.core.form.command_builder.product.combination.update_combination_commands_builder:
-    class: PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder: ~
+    # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
+    # tags: [ 'core.combination_command_builder' ]
+
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationStockAvailableCommandsBuilder: ~
     # @todo: tags commented bellow, to avoid affecting combination page until all the related commands are refactored.
     # tags: [ 'core.combination_command_builder' ]

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
@@ -29,11 +29,19 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination;
 
 use Behat\Gherkin\Node\TableNode;
+use DateTime;
+use Language;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationDetails;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationPrices;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationStock;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
+use RuntimeException;
+use StockAvailable;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class CombinationAssertionFeatureContext extends AbstractCombinationFeatureContext
 {
@@ -209,5 +217,175 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
             new DecimalNUmber($dataRows['product price']),
             new DecimalNUmber($dataRows['product ecotax'])
         );
+    }
+
+    /**
+     * @Then combination :combinationReference should have :availableQuantity available items
+     *
+     * @param string $combinationReference
+     * @param int $availableQuantity
+     */
+    public function assertCombinationAvailableQuantity(string $combinationReference, int $availableQuantity): void
+    {
+        $actualStock = $this->getCombinationForEditing($combinationReference, $this->getDefaultShopId())->getStock();
+        Assert::assertSame(
+            $availableQuantity,
+            $actualStock->getQuantity(),
+            sprintf('Unexpected combination "%s" quantity', $combinationReference)
+        );
+    }
+
+    /**
+     * @Then I should get error that it is not allowed to perform update using both - delta and fixed quantity
+     *
+     * @return void
+     */
+    public function assertLastErrorIsDuplicateQuantityUpdate(): void
+    {
+        $this->assertLastErrorIs(
+            ProductStockConstraintException::class,
+            ProductStockConstraintException::FIXED_AND_DELTA_QUANTITY_PROVIDED
+        );
+    }
+
+    /**
+     * @Then combination :combinationReference should have following stock details:
+     *
+     * @param string $combinationReference
+     * @param CombinationStock $expectedStock
+     */
+    public function assertStockDetails(string $combinationReference, CombinationStock $expectedStock): void
+    {
+        $actualStock = $this->getCombinationForEditing($combinationReference, $this->getDefaultShopId())->getStock();
+
+        Assert::assertSame(
+            $expectedStock->getQuantity(),
+            $actualStock->getQuantity(),
+            sprintf('Unexpected combination "%s" quantity', $combinationReference)
+        );
+        Assert::assertSame(
+            $expectedStock->getMinimalQuantity(),
+            $actualStock->getMinimalQuantity(),
+            sprintf('Unexpected combination "%s" minimal quantity', $combinationReference)
+        );
+        Assert::assertSame(
+            $expectedStock->getLowStockThreshold(),
+            $actualStock->getLowStockThreshold(),
+            sprintf('Unexpected combination "%s" low stock threshold', $combinationReference)
+        );
+        Assert::assertSame(
+            $expectedStock->isLowStockAlertEnabled(),
+            $actualStock->isLowStockAlertEnabled(),
+            sprintf('Unexpected combination "%s" low stock alert', $combinationReference)
+        );
+        Assert::assertSame(
+            $expectedStock->getLocation(),
+            $actualStock->getLocation(),
+            sprintf('Unexpected combination "%s" location', $combinationReference)
+        );
+        if (null === $expectedStock->getAvailableDate()) {
+            Assert::assertSame(
+                $expectedStock->getAvailableDate(),
+                $actualStock->getAvailableDate(),
+                sprintf('Unexpected combination "%s" availability date. Expected NULL, got "%s"',
+                    $combinationReference,
+                    var_export($actualStock->getAvailableDate(), true)
+                )
+            );
+        } else {
+            Assert::assertEquals(
+                $expectedStock->getAvailableDate()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
+                $actualStock->getAvailableDate()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
+                sprintf('Unexpected combination "%s" availability date', $combinationReference)
+            );
+        }
+        $this->assertLocalizedProperty(
+            $expectedStock->getLocalizedAvailableNowLabels(),
+            $actualStock->getLocalizedAvailableNowLabels(),
+            'available now label'
+        );
+        $this->assertLocalizedProperty(
+            $expectedStock->getLocalizedAvailableLaterLabels(),
+            $actualStock->getLocalizedAvailableLaterLabels(),
+            'available later label'
+        );
+    }
+
+    /**
+     * @Transform table:combination stock detail,value
+     *
+     * @param TableNode $tableNode
+     *
+     * @return CombinationStock
+     */
+    public function transformCombinationStock(TableNode $tableNode): CombinationStock
+    {
+        $dataRows = $tableNode->getRowsHash();
+
+        return new CombinationStock(
+            (int) $dataRows['quantity'],
+            (int) $dataRows['minimal quantity'],
+            (int) $dataRows['low stock threshold'],
+            PrimitiveUtils::castStringBooleanIntoBoolean($dataRows['low stock alert is enabled']),
+            $dataRows['location'],
+            '' === $dataRows['available date'] ? null : new DateTime($dataRows['available date']),
+            !empty($dataRows['available now labels']) ? $dataRows['available now labels'] : [],
+            !empty($dataRows['available later labels']) ? $dataRows['available later labels'] : []
+        );
+    }
+
+    /**
+     * @Then /^all combinations of product "([^"]*)" should have the stock policy to "([^"]*)"$/
+     */
+    public function allCombinationsOfProductShouldHaveTheStockPolicyTo(string $reference, string $outOfStock)
+    {
+        $product = $this->getProductForEditing($reference);
+
+        $outOfStockInt = $this->convertOutOfStockToInt($outOfStock);
+        Assert::assertSame(
+            $product->getStockInformation()->getOutOfStockType(),
+            $outOfStockInt
+        );
+
+        $combinations = $this->getCombinationsList($reference, $this->getDefaultShopId());
+
+        foreach ($combinations->getCombinations() as $combination) {
+            $id = StockAvailable::getStockAvailableIdByProductId(
+                $this->getSharedStorage()->get($reference),
+                $combination->getCombinationId()
+            );
+
+            Assert::assertSame(
+                (int) (new StockAvailable($id))->out_of_stock,
+                $outOfStockInt
+            );
+        }
+    }
+
+    private function assertLocalizedProperty(array $expectedValues, array $actualValues, string $fieldName): void
+    {
+        foreach ($expectedValues as $langId => $expectedValue) {
+            $langIso = Language::getIsoById($langId);
+
+            if (!isset($actualValues[$langId])) {
+                throw new RuntimeException(sprintf(
+                    'Expected localized %s value is not set in %s language',
+                    $fieldName,
+                    $langIso
+                ));
+            }
+
+            if ($expectedValue !== $actualValues[$langId]) {
+                throw new RuntimeException(
+                    sprintf(
+                        'Expected %s in "%s" language was "%s", but got "%s"',
+                        $fieldName,
+                        $langIso,
+                        var_export($expectedValue, true),
+                        var_export($actualValues[$langId], true)
+                    )
+                );
+            }
+        }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
@@ -32,6 +32,7 @@ use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationDetails;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationPrices;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class CombinationAssertionFeatureContext extends AbstractCombinationFeatureContext
@@ -84,6 +85,129 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
             $details['reference'],
             $details['upc'],
             new DecimalNumber($details['impact on weight'] ?? '0')
+        );
+    }
+
+    /**
+     * @Then combination :combinationReference should have following prices:
+     *
+     * @param string $combinationReference
+     * @param CombinationPrices $expectedPrices
+     */
+    public function assertCombinationPrices(string $combinationReference, CombinationPrices $expectedPrices): void
+    {
+        $actualPrices = $this->getCombinationForEditing($combinationReference, $this->getDefaultShopId())->getPrices();
+
+        Assert::assertTrue(
+            $expectedPrices->getImpactOnPrice()->equals($actualPrices->getImpactOnPrice()),
+            sprintf(
+                'Unexpected combination impact on price. Expected "%s", got "%s"',
+                (string) $expectedPrices->getImpactOnPrice(),
+                (string) $actualPrices->getImpactOnPrice()
+            )
+        );
+        Assert::assertTrue(
+            $expectedPrices->getImpactOnPriceTaxIncluded()->equals($actualPrices->getImpactOnPriceTaxIncluded()),
+            sprintf(
+                'Unexpected combination impact on price with taxes. Expected "%s", got "%s"',
+                (string) $expectedPrices->getImpactOnPriceTaxIncluded(),
+                (string) $actualPrices->getImpactOnPriceTaxIncluded()
+            )
+        );
+
+        Assert::assertTrue(
+            $expectedPrices->getEcotax()->equals($actualPrices->getEcotax()),
+            sprintf(
+                'Unexpected combination eco tax. Expected "%s", got "%s"',
+                (string) $expectedPrices->getEcotax(),
+                (string) $actualPrices->getEcotax()
+            )
+        );
+        Assert::assertTrue(
+            $expectedPrices->getEcotaxTaxIncluded()->equals($actualPrices->getEcotaxTaxIncluded()),
+            sprintf(
+                'Unexpected combination eco tax with taxes. Expected "%s", got "%s"',
+                (string) $expectedPrices->getEcotaxTaxIncluded(),
+                (string) $actualPrices->getEcotaxTaxIncluded()
+            )
+        );
+
+        Assert::assertTrue(
+            $expectedPrices->getImpactOnUnitPrice()->equals($actualPrices->getImpactOnUnitPrice()),
+            sprintf(
+                'Unexpected combination impact on unit price. Expected "%s", got "%s"',
+                (string) $expectedPrices->getImpactOnUnitPrice(),
+                (string) $actualPrices->getImpactOnUnitPrice()
+            )
+        );
+        Assert::assertTrue(
+            $expectedPrices->getImpactOnPriceTaxIncluded()->equals($actualPrices->getImpactOnPriceTaxIncluded()),
+            sprintf(
+                'Unexpected combination impact on unit price with taxes. Expected "%s", got "%s"',
+                (string) $expectedPrices->getImpactOnPriceTaxIncluded(),
+                (string) $actualPrices->getImpactOnPriceTaxIncluded()
+            )
+        );
+
+        Assert::assertTrue(
+            $expectedPrices->getWholesalePrice()->equals($actualPrices->getWholesalePrice()),
+            sprintf(
+                'Unexpected combination wholesale price. Expected "%s", got "%s"',
+                (string) $expectedPrices->getWholesalePrice(),
+                (string) $actualPrices->getWholesalePrice()
+            )
+        );
+
+        Assert::assertTrue(
+            $expectedPrices->getProductTaxRate()->equals($actualPrices->getProductTaxRate()),
+            sprintf(
+                'Unexpected combination product tax rate. Expected "%s", got "%s"',
+                (string) $expectedPrices->getProductTaxRate(),
+                (string) $actualPrices->getProductTaxRate()
+            )
+        );
+
+        Assert::assertTrue(
+            $expectedPrices->getProductPrice()->equals($actualPrices->getProductPrice()),
+            sprintf(
+                'Unexpected combination product price. Expected "%s", got "%s"',
+                (string) $expectedPrices->getProductPrice(),
+                (string) $actualPrices->getProductPrice()
+            )
+        );
+
+        Assert::assertTrue(
+            $expectedPrices->getProductEcotax()->equals($actualPrices->getProductEcotax()),
+            sprintf(
+                'Unexpected combination wholesale price. Expected "%s", got "%s"',
+                (string) $expectedPrices->getProductEcotax(),
+                (string) $actualPrices->getProductEcotax()
+            )
+        );
+    }
+
+    /**
+     * @Transform table:combination price detail,value
+     *
+     * @param TableNode $tableNode
+     *
+     * @return CombinationPrices
+     */
+    public function transformCombinationPrices(TableNode $tableNode): CombinationPrices
+    {
+        $dataRows = $tableNode->getRowsHash();
+
+        return new CombinationPrices(
+            new DecimalNumber($dataRows['impact on price']),
+            new DecimalNumber($dataRows['impact on price with taxes']),
+            new DecimalNUmber($dataRows['impact on unit price']),
+            new DecimalNUmber($dataRows['impact on unit price with taxes']),
+            new DecimalNumber($dataRows['eco tax']),
+            new DecimalNumber($dataRows['eco tax with taxes']),
+            new DecimalNUmber($dataRows['wholesale price']),
+            new DecimalNUmber($dataRows['product tax rate']),
+            new DecimalNUmber($dataRows['product price']),
+            new DecimalNUmber($dataRows['product ecotax'])
         );
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
@@ -40,11 +40,12 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
 {
     /**
      * @When I update combination :combinationReference details with following values:
+     * @When I update combination :combinationReference prices with following details:
      *
      * @param string $combinationReference
      * @param TableNode $tableNode
      */
-    public function updateDetails(string $combinationReference, TableNode $tableNode): void
+    public function updateCombination(string $combinationReference, TableNode $tableNode): void
     {
         $command = new UpdateCombinationCommand($this->getSharedStorage()->get($combinationReference));
 
@@ -75,6 +76,18 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
         }
         if (isset($dataRows['impact on weight'])) {
             $command->setWeight($dataRows['impact on weight']);
+        }
+        if (isset($dataRows['eco tax'])) {
+            $command->setEcoTax($dataRows['eco tax']);
+        }
+        if (isset($dataRows['impact on price'])) {
+            $command->setImpactOnPrice($dataRows['impact on price']);
+        }
+        if (isset($dataRows['impact on unit price'])) {
+            $command->setImpactOnUnitPrice($dataRows['impact on unit price']);
+        }
+        if (isset($dataRows['wholesale price'])) {
+            $command->setWholesalePrice($dataRows['wholesale price']);
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
@@ -75,7 +75,7 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
             $command->setUpc($dataRows['upc']);
         }
         if (isset($dataRows['impact on weight'])) {
-            $command->setWeight($dataRows['impact on weight']);
+            $command->setImpactOnWeight($dataRows['impact on weight']);
         }
         if (isset($dataRows['eco tax'])) {
             $command->setEcoTax($dataRows['eco tax']);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
@@ -60,6 +60,18 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
         $this->updateCombinationStockAvailable($combinationReference, $tableNode->getRowsHash());
     }
 
+    /**
+     * @When I set combination ":combinationReference" as default
+     *
+     * @param string $combinationReference
+     */
+    public function setDefaultCombination(string $combinationReference): void
+    {
+        $command = new UpdateCombinationCommand((int) $this->getSharedStorage()->get($combinationReference));
+        $command->setIsDefault(true);
+        $this->getCommandBus()->handle($command);
+    }
+
     private function updateCombinationStockAvailable(string $combinationReference, array $dataRows): void
     {
         if (!isset($dataRows['delta quantity'])
@@ -92,6 +104,10 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
      */
     private function fillCommand(UpdateCombinationCommand $command, array $dataRows): void
     {
+        // Is default
+        if (isset($dataRows['is default'])) {
+            $command->setIsDefault(PrimitiveUtils::castStringBooleanIntoBoolean($dataRows['is default']));
+        }
         // References
         if (isset($dataRows['ean13'])) {
             $command->setEan13($dataRows['ean13']);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationPricesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationPricesFeatureContext.php
@@ -29,38 +29,10 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination;
 
 use Behat\Gherkin\Node\TableNode;
-use PHPUnit\Framework\Assert;
-use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationPricesCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationPrices;
 
 class UpdateCombinationPricesFeatureContext extends AbstractCombinationFeatureContext
 {
-    /**
-     * @Transform table:combination price detail,value
-     *
-     * @param TableNode $tableNode
-     *
-     * @return CombinationPrices
-     */
-    public function transformCombinationPrices(TableNode $tableNode): CombinationPrices
-    {
-        $dataRows = $tableNode->getRowsHash();
-
-        return new CombinationPrices(
-            new DecimalNumber($dataRows['impact on price']),
-            new DecimalNumber($dataRows['impact on price with taxes']),
-            new DecimalNUmber($dataRows['impact on unit price']),
-            new DecimalNUmber($dataRows['impact on unit price with taxes']),
-            new DecimalNumber($dataRows['eco tax']),
-            new DecimalNumber($dataRows['eco tax with taxes']),
-            new DecimalNUmber($dataRows['wholesale price']),
-            new DecimalNUmber($dataRows['product tax rate']),
-            new DecimalNUmber($dataRows['product price']),
-            new DecimalNUmber($dataRows['product ecotax'])
-        );
-    }
-
     /**
      * @When I update combination :combinationReference prices with following details:
      *
@@ -73,104 +45,6 @@ class UpdateCombinationPricesFeatureContext extends AbstractCombinationFeatureCo
         $this->fillCommand($command, $tableNode->getRowsHash());
 
         $this->getCommandBus()->handle($command);
-    }
-
-    /**
-     * @Then combination :combinationReference should have following prices:
-     *
-     * @param string $combinationReference
-     * @param CombinationPrices $expectedPrices
-     */
-    public function assertCombinationPrices(string $combinationReference, CombinationPrices $expectedPrices): void
-    {
-        $actualPrices = $this->getCombinationForEditing($combinationReference, $this->getDefaultShopId())->getPrices();
-
-        Assert::assertTrue(
-            $expectedPrices->getImpactOnPrice()->equals($actualPrices->getImpactOnPrice()),
-            sprintf(
-                'Unexpected combination impact on price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getImpactOnPrice(),
-                (string) $actualPrices->getImpactOnPrice()
-            )
-        );
-        Assert::assertTrue(
-            $expectedPrices->getImpactOnPriceTaxIncluded()->equals($actualPrices->getImpactOnPriceTaxIncluded()),
-            sprintf(
-                'Unexpected combination impact on price with taxes. Expected "%s", got "%s"',
-                (string) $expectedPrices->getImpactOnPriceTaxIncluded(),
-                (string) $actualPrices->getImpactOnPriceTaxIncluded()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getEcotax()->equals($actualPrices->getEcotax()),
-            sprintf(
-                'Unexpected combination eco tax. Expected "%s", got "%s"',
-                (string) $expectedPrices->getEcotax(),
-                (string) $actualPrices->getEcotax()
-            )
-        );
-        Assert::assertTrue(
-            $expectedPrices->getEcotaxTaxIncluded()->equals($actualPrices->getEcotaxTaxIncluded()),
-            sprintf(
-                'Unexpected combination eco tax with taxes. Expected "%s", got "%s"',
-                (string) $expectedPrices->getEcotaxTaxIncluded(),
-                (string) $actualPrices->getEcotaxTaxIncluded()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getImpactOnUnitPrice()->equals($actualPrices->getImpactOnUnitPrice()),
-            sprintf(
-                'Unexpected combination impact on unit price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getImpactOnUnitPrice(),
-                (string) $actualPrices->getImpactOnUnitPrice()
-            )
-        );
-        Assert::assertTrue(
-            $expectedPrices->getImpactOnPriceTaxIncluded()->equals($actualPrices->getImpactOnPriceTaxIncluded()),
-            sprintf(
-                'Unexpected combination impact on unit price with taxes. Expected "%s", got "%s"',
-                (string) $expectedPrices->getImpactOnPriceTaxIncluded(),
-                (string) $actualPrices->getImpactOnPriceTaxIncluded()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getWholesalePrice()->equals($actualPrices->getWholesalePrice()),
-            sprintf(
-                'Unexpected combination wholesale price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getWholesalePrice(),
-                (string) $actualPrices->getWholesalePrice()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getProductTaxRate()->equals($actualPrices->getProductTaxRate()),
-            sprintf(
-                'Unexpected combination product tax rate. Expected "%s", got "%s"',
-                (string) $expectedPrices->getProductTaxRate(),
-                (string) $actualPrices->getProductTaxRate()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getProductPrice()->equals($actualPrices->getProductPrice()),
-            sprintf(
-                'Unexpected combination product price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getProductPrice(),
-                (string) $actualPrices->getProductPrice()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getProductEcotax()->equals($actualPrices->getProductEcotax()),
-            sprintf(
-                'Unexpected combination wholesale price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getProductEcotax(),
-                (string) $actualPrices->getProductEcotax()
-            )
-        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
@@ -30,14 +30,8 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combinatio
 
 use Behat\Gherkin\Node\TableNode;
 use DateTime;
-use Language;
-use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\QueryResult\CombinationStock;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
-use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
-use RuntimeException;
-use StockAvailable;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureContext
@@ -58,148 +52,6 @@ class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureCon
         } catch (ProductStockConstraintException $e) {
             $this->setLastException($e);
         }
-    }
-
-    /**
-     * @Transform table:combination stock detail,value
-     *
-     * @param TableNode $tableNode
-     *
-     * @return CombinationStock
-     */
-    public function transformCombinationStock(TableNode $tableNode): CombinationStock
-    {
-        $dataRows = $tableNode->getRowsHash();
-
-        return new CombinationStock(
-            (int) $dataRows['quantity'],
-            (int) $dataRows['minimal quantity'],
-            (int) $dataRows['low stock threshold'],
-            PrimitiveUtils::castStringBooleanIntoBoolean($dataRows['low stock alert is enabled']),
-            $dataRows['location'],
-            '' === $dataRows['available date'] ? null : new DateTime($dataRows['available date']),
-            !empty($dataRows['available now labels']) ? $dataRows['available now labels'] : [],
-            !empty($dataRows['available later labels']) ? $dataRows['available later labels'] : []
-        );
-    }
-
-    /**
-     * @Then combination :combinationReference should have :availableQuantity available items
-     *
-     * @param string $combinationReference
-     * @param int $availableQuantity
-     */
-    public function assertCombinationAvailableQuantity(string $combinationReference, int $availableQuantity): void
-    {
-        $actualStock = $this->getCombinationForEditing($combinationReference, $this->getDefaultShopId())->getStock();
-        Assert::assertSame(
-            $availableQuantity,
-            $actualStock->getQuantity(),
-            sprintf('Unexpected combination "%s" quantity', $combinationReference)
-        );
-    }
-
-    /**
-     * @Then combination :combinationReference should have following stock details:
-     *
-     * @param string $combinationReference
-     * @param CombinationStock $expectedStock
-     */
-    public function assertStockDetails(string $combinationReference, CombinationStock $expectedStock): void
-    {
-        $actualStock = $this->getCombinationForEditing($combinationReference, $this->getDefaultShopId())->getStock();
-
-        Assert::assertSame(
-            $expectedStock->getQuantity(),
-            $actualStock->getQuantity(),
-            sprintf('Unexpected combination "%s" quantity', $combinationReference)
-        );
-        Assert::assertSame(
-            $expectedStock->getMinimalQuantity(),
-            $actualStock->getMinimalQuantity(),
-            sprintf('Unexpected combination "%s" minimal quantity', $combinationReference)
-        );
-        Assert::assertSame(
-            $expectedStock->getLowStockThreshold(),
-            $actualStock->getLowStockThreshold(),
-            sprintf('Unexpected combination "%s" low stock threshold', $combinationReference)
-        );
-        Assert::assertSame(
-            $expectedStock->isLowStockAlertEnabled(),
-            $actualStock->isLowStockAlertEnabled(),
-            sprintf('Unexpected combination "%s" low stock alert', $combinationReference)
-        );
-        Assert::assertSame(
-            $expectedStock->getLocation(),
-            $actualStock->getLocation(),
-            sprintf('Unexpected combination "%s" location', $combinationReference)
-        );
-        if (null === $expectedStock->getAvailableDate()) {
-            Assert::assertSame(
-                $expectedStock->getAvailableDate(),
-                $actualStock->getAvailableDate(),
-                sprintf('Unexpected combination "%s" availability date. Expected NULL, got "%s"',
-                    $combinationReference,
-                    var_export($actualStock->getAvailableDate(), true)
-                )
-            );
-        } else {
-            Assert::assertEquals(
-                $expectedStock->getAvailableDate()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
-                $actualStock->getAvailableDate()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
-                sprintf('Unexpected combination "%s" availability date', $combinationReference)
-            );
-        }
-        $this->assertLocalizedProperty(
-            $expectedStock->getLocalizedAvailableNowLabels(),
-            $actualStock->getLocalizedAvailableNowLabels(),
-            'available now label'
-        );
-        $this->assertLocalizedProperty(
-            $expectedStock->getLocalizedAvailableLaterLabels(),
-            $actualStock->getLocalizedAvailableLaterLabels(),
-            'available later label'
-        );
-    }
-
-    private function assertLocalizedProperty(array $expectedValues, array $actualValues, string $fieldName): void
-    {
-        foreach ($expectedValues as $langId => $expectedValue) {
-            $langIso = Language::getIsoById($langId);
-
-            if (!isset($actualValues[$langId])) {
-                throw new RuntimeException(sprintf(
-                    'Expected localized %s value is not set in %s language',
-                    $fieldName,
-                    $langIso
-                ));
-            }
-
-            if ($expectedValue !== $actualValues[$langId]) {
-                throw new RuntimeException(
-                    sprintf(
-                        'Expected %s in "%s" language was "%s", but got "%s"',
-                        $fieldName,
-                        $langIso,
-                        var_export($expectedValue, true),
-                        var_export($actualValues[$langId], true)
-                    )
-                );
-            }
-        }
-    }
-
-    /**
-     * @Then I should get error that it is not allowed to perform update using both - delta and fixed quantity
-     *
-     * @return void
-     */
-    public function assertLastErrorIsDuplicateQuantityUpdate(): void
-    {
-        $this->assertLastErrorIs(
-            ProductStockConstraintException::class,
-            ProductStockConstraintException::FIXED_AND_DELTA_QUANTITY_PROVIDED
-        );
     }
 
     /**
@@ -236,34 +88,6 @@ class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureCon
         if (isset($dataRows['available later labels'])) {
             $command->setLocalizedAvailableLaterLabels($dataRows['available later labels']);
             unset($dataRows['available later labels']);
-        }
-    }
-
-    /**
-     * @Then /^all combinations of product "([^"]*)" should have the stock policy to "([^"]*)"$/
-     */
-    public function allCombinationsOfProductShouldHaveTheStockPolicyTo(string $reference, string $outOfStock)
-    {
-        $product = $this->getProductForEditing($reference);
-
-        $outOfStockInt = $this->convertOutOfStockToInt($outOfStock);
-        Assert::assertSame(
-            $product->getStockInformation()->getOutOfStockType(),
-            $outOfStockInt
-        );
-
-        $combinations = $this->getCombinationsList($reference, $this->getDefaultShopId());
-
-        foreach ($combinations->getCombinations() as $combination) {
-            $id = StockAvailable::getStockAvailableIdByProductId(
-                $this->getSharedStorage()->get($reference),
-                $combination->getCombinationId()
-            );
-
-            Assert::assertSame(
-                (int) (new StockAvailable($id))->out_of_stock,
-                $outOfStockInt
-            );
         }
     }
 }

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -504,7 +504,6 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SearchCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationStockFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SetDefaultCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -504,7 +504,6 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SearchCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationPricesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationStockFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SetDefaultCombinationFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -506,7 +506,6 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationSuppliersFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SetDefaultCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\DuplicateProductFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -405,6 +405,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\CartFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\OrderFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationListingFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationStockMovementsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext

--- a/tests/Unit/Adapter/Product/Combination/Update/Filler/DetailsFillerTest.php
+++ b/tests/Unit/Adapter/Product/Combination/Update/Filler/DetailsFillerTest.php
@@ -83,7 +83,7 @@ class DetailsFillerTest extends CombinationFillerTestCase
             ->setMpn('HUE222-7')
             ->setReference('ref-HUE222-7')
             ->setUpc('0123456789')
-            ->setWeight('3')
+            ->setImpactOnWeight('3')
         ;
         $expectedCombination = $this->mockDefaultCombination();
         $expectedCombination->ean13 = '1234567890111';

--- a/tests/Unit/Adapter/Product/Combination/Update/Filler/PricesFillerTest.php
+++ b/tests/Unit/Adapter/Product/Combination/Update/Filler/PricesFillerTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Product\Combination\Update\Filler;
+
+use Combination;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\PricesFiller;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+
+class PricesFillerTest extends CombinationFillerTestCase
+{
+    /**
+     * @dataProvider getDataToTestUpdatablePropertiesFilling
+     *
+     * @param Combination $combination
+     * @param UpdateCombinationCommand $command
+     * @param array $expectedUpdatableProperties
+     * @param Combination $expectedProduct
+     */
+    public function testFillsUpdatableProperties(
+        Combination $combination,
+        UpdateCombinationCommand $command,
+        array $expectedUpdatableProperties,
+        Combination $expectedProduct
+    ): void {
+        $this->fillUpdatableProperties(
+            $this->getFiller(),
+            $combination,
+            $command,
+            $expectedUpdatableProperties,
+            $expectedProduct
+        );
+    }
+
+    /**
+     * @return iterable
+     */
+    public function getDataToTestUpdatablePropertiesFilling(): iterable
+    {
+        $command = $this->getEmptyCommand()
+            ->setWholesalePrice('4.99')
+            ->setImpactOnPrice('45.99')
+        ;
+        $expectedCombination = $this->mockDefaultCombination();
+        $expectedCombination->wholesale_price = 4.99;
+        $expectedCombination->price = 45.99;
+
+        yield [
+            $this->mockDefaultCombination(),
+            $command,
+            [
+                'price',
+                'wholesale_price',
+            ],
+            $expectedCombination,
+        ];
+
+        $command = $this->getEmptyCommand()
+            ->setEcotax('0.3')
+            ->setImpactOnUnitPrice('10')
+        ;
+        $expectedCombination = $this->mockDefaultCombination();
+        $expectedCombination->ecotax = 0.3;
+        $expectedCombination->unit_price_impact = 10.0;
+        yield [
+            $this->mockDefaultCombination(),
+            $command,
+            [
+                'ecotax',
+                'unit_price_impact',
+            ],
+            $expectedCombination,
+        ];
+    }
+
+    /**
+     * @return PricesFiller
+     */
+    private function getFiller(): PricesFiller
+    {
+        return new PricesFiller();
+    }
+}

--- a/tests/Unit/Adapter/Product/Combination/Update/Filler/StockInformationFillerTest.php
+++ b/tests/Unit/Adapter/Product/Combination/Update/Filler/StockInformationFillerTest.php
@@ -23,35 +23,35 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 declare(strict_types=1);
 
-namespace Tests\Unit\Adapter\Product\Update\Filler;
+namespace Tests\Unit\Adapter\Product\Combination\Update\Filler;
 
+use Combination;
 use DateTime;
-use PrestaShop\PrestaShop\Adapter\Product\Update\Filler\StockInformationFiller;
-use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
-use Product;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\StockInformationFiller;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
 
-class StockInformationFillerTest extends ProductFillerTestCase
+class StockInformationFillerTest extends CombinationFillerTestCase
 {
     /**
      * @dataProvider getDataToTestUpdatablePropertiesFilling
      *
-     * @param Product $product
-     * @param UpdateProductCommand $command
+     * @param Combination $combination
+     * @param UpdateCombinationCommand $command
      * @param array $expectedUpdatableProperties
-     * @param Product $expectedProduct
+     * @param Combination $expectedProduct
      */
     public function testFillsUpdatableProperties(
-        Product $product,
-        UpdateProductCommand $command,
+        Combination $combination,
+        UpdateCombinationCommand $command,
         array $expectedUpdatableProperties,
-        Product $expectedProduct
+        Combination $expectedProduct
     ): void {
         $this->fillUpdatableProperties(
-            new StockInformationFiller(),
-            $product,
+            $this->getFiller(),
+            $combination,
             $command,
             $expectedUpdatableProperties,
             $expectedProduct
@@ -63,23 +63,20 @@ class StockInformationFillerTest extends ProductFillerTestCase
      */
     public function getDataToTestUpdatablePropertiesFilling(): iterable
     {
-        $product = $this->mockDefaultProduct();
+        $combination = $this->mockDefaultCombination();
         $command = $this->getEmptyCommand()
             ->setMinimalQuantity(11)
-            ->setPackStockType(PackStockType::STOCK_TYPE_PRODUCTS_ONLY)
         ;
-        $expectedProduct = $this->mockDefaultProduct();
-        $expectedProduct->minimal_quantity = 11;
-        $expectedProduct->pack_stock_type = PackStockType::STOCK_TYPE_PRODUCTS_ONLY;
+        $expectedCombination = $this->mockDefaultCombination();
+        $expectedCombination->minimal_quantity = 11;
 
         yield [
-            $product,
+            $combination,
             $command,
             [
                 'minimal_quantity',
-                'pack_stock_type',
             ],
-            $expectedProduct,
+            $expectedCombination,
         ];
 
         $localizedAvailableNow = [
@@ -91,38 +88,43 @@ class StockInformationFillerTest extends ProductFillerTestCase
             2 => 'english available later',
         ];
 
-        $product = $this->mockDefaultProduct();
+        $combination = $this->mockDefaultCombination();
         $command = $this->getEmptyCommand()
             ->setLocalizedAvailableNowLabels($localizedAvailableNow)
             ->setLocalizedAvailableLaterLabels($localizedAvailableLater)
             ->setLowStockAlert(true)
             ->setLowStockThreshold(42)
             ->setMinimalQuantity(10)
-            ->setPackStockType(PackStockType::STOCK_TYPE_BOTH)
             ->setAvailableDate(new DateTime('2022-10-10'))
         ;
-        $expectedProduct = $this->mockDefaultProduct();
-        $expectedProduct->available_now = $localizedAvailableNow;
-        $expectedProduct->available_later = $localizedAvailableLater;
-        $expectedProduct->low_stock_alert = true;
-        $expectedProduct->low_stock_threshold = 42;
-        $expectedProduct->minimal_quantity = 10;
-        $expectedProduct->pack_stock_type = PackStockType::STOCK_TYPE_BOTH;
-        $expectedProduct->available_date = '2022-10-10';
+        $expectedCombination = $this->mockDefaultCombination();
+        $expectedCombination->available_now = $localizedAvailableNow;
+        $expectedCombination->available_later = $localizedAvailableLater;
+        $expectedCombination->low_stock_alert = true;
+        $expectedCombination->low_stock_threshold = 42;
+        $expectedCombination->minimal_quantity = 10;
+        $expectedCombination->available_date = '2022-10-10';
 
         yield [
-            $product,
+            $combination,
             $command,
             [
                 'available_later' => [1, 2],
                 'available_now' => [1, 2],
-                'low_stock_alert',
+                'available_date',
                 'low_stock_threshold',
                 'minimal_quantity',
-                'pack_stock_type',
-                'available_date',
+                'low_stock_alert',
             ],
-            $expectedProduct,
+            $expectedCombination,
         ];
+    }
+
+    /**
+     * @return StockInformationFiller
+     */
+    private function getFiller(): StockInformationFiller
+    {
+        return new StockInformationFiller();
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
@@ -207,5 +207,38 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             ],
             [$command],
         ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setIsDefault(true);
+        yield [
+            [
+                'header' => [
+                    'is_default' => true,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setIsDefault(false);
+        yield [
+            [
+                'header' => [
+                    'is_default' => '0',
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setIsDefault(false);
+        yield [
+            [
+                'header' => [
+                    'is_default' => null,
+                ],
+            ],
+            [$command],
+        ];
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
@@ -68,7 +68,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
         ];
 
         $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
-        $command->setWeight('12.00');
+        $command->setImpactOnWeight('12.00');
         $command->setReference('toto');
         yield [
             [
@@ -84,7 +84,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
         ];
 
         $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
-        $command->setWeight('12.00');
+        $command->setImpactOnWeight('12.00');
         yield [
             [
                 'price_impact' => [

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
@@ -28,8 +28,10 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination;
 
+use DateTime;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder;
+use PrestaShop\PrestaShop\Core\Util\DateTime\NullDateTime;
 
 class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBuilderTest
 {
@@ -67,29 +69,13 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [],
         ];
 
+        // References
         $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
-        $command->setImpactOnWeight('12.00');
         $command->setReference('toto');
         yield [
             [
-                'price_impact' => [
-                    'not_handled' => 0,
-                    'weight' => 12.0,
-                ],
                 'references' => [
                     'reference' => 'toto',
-                ],
-            ],
-            [$command],
-        ];
-
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
-        $command->setImpactOnWeight('12.00');
-        yield [
-            [
-                'price_impact' => [
-                    'not_handled' => 0,
-                    'weight' => 12.0,
                 ],
             ],
             [$command],
@@ -116,6 +102,107 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
                 'references' => [
                     'isbn' => '0-8044-2957-X',
                     'ean_13' => '12345678910',
+                ],
+            ],
+            [$command],
+        ];
+
+        // Price impact
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setImpactOnWeight('12');
+        yield [
+            [
+                'price_impact' => [
+                    'not_handled' => 0,
+                    'weight' => 12.0,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setImpactOnUnitPrice('51.00');
+        $command->setWholesalePrice('12.00');
+        yield [
+            [
+                'price_impact' => [
+                    'unit_price_tax_excluded' => 51.00,
+                    'wholesale_price' => '12.00',
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setEcoTax('42.00');
+        $command->setImpactOnPrice('49.00');
+        yield [
+            [
+                'price_impact' => [
+                    'ecotax_tax_excluded' => 42.00,
+                    'price_tax_excluded' => '49.00',
+                ],
+            ],
+            [$command],
+        ];
+
+        // Stock information
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setMinimalQuantity(1);
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'minimal_quantity' => 1,
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setLowStockThreshold(5);
+        yield [
+            [
+                'stock' => [
+                    'options' => [
+                        'low_stock_threshold' => '5',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setLowStockAlert(false);
+        yield [
+            [
+                'stock' => [
+                    'options' => [
+                        'disabling_switch_low_stock_threshold' => '0',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setAvailableDate(new DateTime('2022-10-10'));
+        yield [
+            [
+                'stock' => [
+                    'available_date' => '2022-10-10',
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command->setAvailableDate(new NullDateTime());
+        yield [
+            [
+                'stock' => [
+                    'available_date' => '',
                 ],
             ],
             [$command],

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationStockAvailableCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationStockAvailableCommandsBuilderTest.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationStockAvailableCommandsBuilder;
+
+class UpdateCombinationStockAvailableCommandsBuilderTest extends AbstractCombinationCommandBuilderTest
+{
+    /**
+     * @dataProvider getExpectedCommands
+     *
+     * @param array $formData
+     * @param array $expectedCommands
+     */
+    public function testBuildCommand(array $formData, array $expectedCommands): void
+    {
+        $builder = new UpdateCombinationStockAvailableCommandsBuilder();
+        $builtCommands = $builder->buildCommands($this->getCombinationId(), $formData);
+        $this->assertEquals($expectedCommands, $builtCommands);
+    }
+
+    public function getExpectedCommands(): iterable
+    {
+        yield [
+            [
+                'no data' => ['useless value'],
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'stock' => [
+                    'not_handled' => 0,
+                ],
+            ],
+            [],
+        ];
+
+        $command = new UpdateCombinationStockAvailableCommand($this->getCombinationId()->getValue());
+        $command->setDeltaQuantity(100);
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'delta_quantity' => [
+                            // quantity is used for view only, the real value that is used now is delta
+                            'quantity' => 1000000,
+                            'delta' => 100,
+                        ],
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationStockAvailableCommand($this->getCombinationId()->getValue());
+        $command->setFixedQuantity(134);
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'fixed_quantity' => 134,
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = new UpdateCombinationStockAvailableCommand($this->getCombinationId()->getValue());
+        $command->setLocation('Im in miami...');
+        yield [
+            [
+                'stock' => [
+                    'options' => [
+                        'stock_location' => 'Im in miami...',
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This follow the unification process of Combination command, this PR handles the prices and stock sub-domains along with the isDefault field
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | CI tests green, only behat modifications in this PR
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
