### PR TITLE
HelperList callback is not called when column data is null

### DIFF
--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -401,7 +401,7 @@ class HelperListCore extends Helper
                     }
                 } elseif (isset($params['type']) && $params['type'] == 'float') {
                     $this->_list[$index][$key] = rtrim(rtrim($tr[$key], '0'), '.');
-                } elseif (isset($tr[$key])) {
+                } elseif (array_key_exists($key, $tr)) {
                     $echo = $tr[$key];
                     if (isset($params['callback'])) {
                         $callback_obj = (isset($params['callback_object'])) ? $params['callback_object'] : $this->context->controller;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | `HelperList` `callback` is not called when column data is null.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30386
| Related PRs       | N/A
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/30386
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
