### PR TITLE
Lock sanity tests to use ubuntu 20.04 and not latest

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       actions: write   #   to cancel/stop running workflows (styfle/cancel-workflow-action)
       contents: read   #   to fetch code (actions/checkout)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Sanity
     strategy:
       matrix:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.0.x / 1.7.8.x
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | FO / BO / CO / IN / WS / TE / LO / ME / PM
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| Fixed ticket?     | Fixes #{issue number here}. If your PR fixes multiple issues, use Resolves #{issue number here}, Resolves #{another issue number here}.
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
