### PR TITLE
Fix CI for ubuntu-22.04

### DIFF
--- a/.github/workflows/sanity/setup-apache.sh
+++ b/.github/workflows/sanity/setup-apache.sh
@@ -21,4 +21,5 @@ sed -e "s?%BUILD_DIR%?$(echo $WORKSPACE)?g" --in-place /etc/apache2/sites-availa
 
 # Restart apache after giving permission
 chmod 777 -R $WORKSPACE
+chmod +x /home/runner/
 service apache2 restart


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When running the CI in ubuntu 22.04, the search permission (x) was missing on a folder, this PR adds it.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30389
| Related PRs       | 
| How to test?      | CI should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
