### PR TITLE
Simplify default currency fetching for easier code understanding

### DIFF
--- a/admin-dev/init.php
+++ b/admin-dev/init.php
@@ -103,7 +103,7 @@ try {
         Tools::redirectAdmin($url['path'] . '?' . http_build_query($parseQuery, '', '&'));
     }
 
-    $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+    $context->currency = Currency::getDefaultCurrency();
 
     if ($context->employee->isLoggedBack()) {
         $shop_id = '';

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -175,7 +175,7 @@ class CartRuleCore extends ObjectModel
     public function add($autodate = true, $null_values = false)
     {
         if (!$this->reduction_currency) {
-            $this->reduction_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+            $this->reduction_currency = Currency::getDefaultCurrencyId();
         }
 
         if (!parent::add($autodate, $null_values)) {
@@ -202,7 +202,7 @@ class CartRuleCore extends ObjectModel
         Cache::clean('getContextualValue_' . $this->id . '_*');
 
         if (!$this->reduction_currency) {
-            $this->reduction_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+            $this->reduction_currency = Currency::getDefaultCurrencyId();
         }
 
         if (!parent::update($null_values)) {

--- a/classes/Currency.php
+++ b/classes/Currency.php
@@ -471,7 +471,7 @@ class CurrencyCore extends ObjectModel
      */
     public function delete()
     {
-        if ($this->id == Configuration::get('PS_CURRENCY_DEFAULT')) {
+        if ($this->id == Currency::getDefaultCurrencyId()) {
             $result = Db::getInstance()->getRow('SELECT `id_currency` FROM ' . _DB_PREFIX_ . 'currency WHERE `id_currency` != ' . (int) $this->id . ' AND `deleted` = 0');
             if (empty($result['id_currency'])) {
                 return false;
@@ -1030,12 +1030,22 @@ class CurrencyCore extends ObjectModel
      */
     public static function getDefaultCurrency()
     {
-        $idCurrency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $idCurrency = Currency::getDefaultCurrencyId();
         if ($idCurrency == 0) {
             return false;
         }
 
         return new Currency($idCurrency);
+    }
+
+    /**
+     * Get default currency Id.
+     *
+     * @return int
+     */
+    public static function getDefaultCurrencyId(): int
+    {
+        return (int) Configuration::get('PS_CURRENCY_DEFAULT');
     }
 
     /**
@@ -1105,7 +1115,7 @@ class CurrencyCore extends ObjectModel
      */
     public function getConversionRate()
     {
-        return ($this->id != (int) Configuration::get('PS_CURRENCY_DEFAULT')) ? $this->conversion_rate : 1;
+        return ($this->id != static::getDefaultCurrencyId()) ? $this->conversion_rate : 1;
     }
 
     /**

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -828,7 +828,7 @@ abstract class PaymentModuleCore extends Module
             if ($currency == -1) {
                 $id_currency = (int) $current_id_currency;
             } elseif ($currency == -2) {
-                $id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+                $id_currency = Currency::getDefaultCurrencyId();
             } else {
                 $id_currency = $currency;
             }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3668,7 +3668,7 @@ class ProductCore extends ObjectModel
             }
         }
 
-        $id_currency = Validate::isLoadedObject($context->currency) ? (int) $context->currency->id : (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $id_currency = Validate::isLoadedObject($context->currency) ? (int) $context->currency->id : Currency::getDefaultCurrencyId();
 
         if (!$id_address && Validate::isLoadedObject($cur_cart)) {
             $id_address = $cur_cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')};
@@ -4542,7 +4542,7 @@ class ProductCore extends ObjectModel
                 ' . Product::sqlStock('pa', 'pa') . '
                 LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_lang` pal
                     ON (
-                        pa.`id_product_attribute` = pal.`id_product_attribute` AND 
+                        pa.`id_product_attribute` = pal.`id_product_attribute` AND
                         pal.`id_lang` = ' . (int) Context::getContext()->language->id . ')
                 LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac ON (pac.`id_product_attribute` = pa.`id_product_attribute`)
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute` a ON (a.`id_attribute` = pac.`id_attribute`)
@@ -5835,7 +5835,7 @@ class ProductCore extends ObjectModel
         }
 
         // Finally, we apply the currency rate
-        $defaultCurrencyId = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $defaultCurrencyId = Currency::getDefaultCurrencyId();
         $currencyId = Validate::isLoadedObject($context->currency) ? (int) $context->currency->id : $defaultCurrencyId;
         if ($currencyId !== $defaultCurrencyId) {
             $baseUnitPrice = Tools::convertPrice($baseUnitPrice, $currencyId);
@@ -7424,7 +7424,7 @@ class ProductCore extends ObjectModel
 
         if (!Cache::isStored($cache_id)) {
             $result = Db::getInstance()->executeS('
-            SELECT a.`id_attribute`, a.`id_attribute_group`, al.`name`, agl.`name` as `group`, 
+            SELECT a.`id_attribute`, a.`id_attribute_group`, al.`name`, agl.`name` as `group`,
             pa.`reference`, pa.`ean13`, pa.`isbn`, pa.`upc`, pa.`mpn`,
             pal.`available_now`, pal.`available_later`
             FROM `' . _DB_PREFIX_ . 'attribute` a

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -705,7 +705,7 @@ class ToolsCore
             $currency = Currency::getCurrencyInstance((int) $cookie->id_currency);
         }
         if (!Validate::isLoadedObject($currency) || (bool) $currency->deleted || !(bool) $currency->active) {
-            $currency = Currency::getCurrencyInstance((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+            $currency = Currency::getCurrencyInstance(Currency::getDefaultCurrencyId());
         }
 
         $cookie->id_currency = (int) $currency->id;
@@ -850,7 +850,7 @@ class ToolsCore
      */
     public static function convertPrice($price, $currency = null, $to_currency = true, Context $context = null)
     {
-        $default_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $default_currency = Currency::getDefaultCurrencyId();
 
         if (!$context) {
             $context = Context::getContext();
@@ -896,7 +896,7 @@ class ToolsCore
             $currency_to = Currency::getDefaultCurrency();
         }
 
-        if ($currency_from->id == Configuration::get('PS_CURRENCY_DEFAULT')) {
+        if ($currency_from->id == Currency::getDefaultCurrencyId()) {
             $amount *= $currency_to->conversion_rate;
         } else {
             $conversion_rate = ($currency_from->conversion_rate == 0 ? 1 : $currency_from->conversion_rate);

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -889,11 +889,11 @@ class ToolsCore
         }
 
         if ($currency_from === null) {
-            $currency_from = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+            $currency_from = Currency::getDefaultCurrency();
         }
 
         if ($currency_to === null) {
-            $currency_to = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+            $currency_to = Currency::getDefaultCurrency();
         }
 
         if ($currency_from->id == Configuration::get('PS_CURRENCY_DEFAULT')) {

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2911,7 +2911,7 @@ class AdminControllerCore extends Controller
 
         // Replace current default country
         $this->context->country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'));
-        $this->context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $this->context->currency = Currency::getDefaultCurrency();
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -345,7 +345,7 @@ class FrontControllerCore extends Controller
 
                 if (!$has_currency && Validate::isLoadedObject($country) && $this->context->country->id !== $country->id) {
                     $this->context->country = $country;
-                    $this->context->cookie->id_currency = (int) Currency::getCurrencyInstance($country->id_currency ? (int) $country->id_currency : (int) Configuration::get('PS_CURRENCY_DEFAULT'))->id;
+                    $this->context->cookie->id_currency = (int) Currency::getCurrencyInstance($country->id_currency ? (int) $country->id_currency : Currency::getDefaultCurrencyId())->id;
                     $this->context->cookie->iso_code_country = strtoupper($country->iso_code);
                 }
             }
@@ -869,7 +869,7 @@ class FrontControllerCore extends Controller
                         $defaultCountry = new Country($idCountry);
                     }
                     if (isset($hasBeenSet) && $hasBeenSet) {
-                        $this->context->cookie->id_currency = (int) ($defaultCountry->id_currency ? (int) $defaultCountry->id_currency : (int) Configuration::get('PS_CURRENCY_DEFAULT'));
+                        $this->context->cookie->id_currency = (int) ($defaultCountry->id_currency ? (int) $defaultCountry->id_currency : Currency::getDefaultCurrencyId());
                     }
 
                     return $defaultCountry;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -1963,7 +1963,7 @@ class OrderCore extends ObjectModel
         if ($order_payment->id_currency == $this->id_currency) {
             $this->total_paid_real += $order_payment->amount;
         } else {
-            $default_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+            $default_currency = Currency::getDefaultCurrencyId();
             if ($order_payment->id_currency === $default_currency) {
                 $this->total_paid_real += Tools::ps_round(
                     Tools::convertPrice((float) $order_payment->amount, $this->id_currency, false),

--- a/classes/webservice/WebserviceRequest.php
+++ b/classes/webservice/WebserviceRequest.php
@@ -409,7 +409,7 @@ class WebserviceRequestCore
             $id_shop = (int) Context::getContext()->shop->id;
             $id_country = (int) (isset($value['country']) ? $value['country'] : (Configuration::get('PS_COUNTRY_DEFAULT')));
             $id_state = (int) (isset($value['state']) ? $value['state'] : 0);
-            $id_currency = (int) (isset($value['currency']) ? $value['currency'] : Configuration::get('PS_CURRENCY_DEFAULT'));
+            $id_currency = (int) (isset($value['currency']) ? $value['currency'] : Currency::getDefaultCurrencyId());
             $id_group = (int) (isset($value['group']) ? $value['group'] : (int) Configuration::get('PS_CUSTOMER_GROUP'));
             $quantity = (int) (isset($value['quantity']) ? $value['quantity'] : 1);
             $use_tax = (bool) (isset($value['use_tax']) ? $value['use_tax'] : Configuration::get('PS_TAX'));

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -983,7 +983,7 @@ class AdminCarrierWizardControllerCore extends AdminController
             Shop::setContext($this->type_context, $this->old_context->shop->id_shop_group);
         }
 
-        $currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $currency = Currency::getDefaultCurrency();
 
         Shop::setContext(Shop::CONTEXT_ALL);
 

--- a/controllers/admin/AdminCartRulesController.php
+++ b/controllers/admin/AdminCartRulesController.php
@@ -794,7 +794,7 @@ class AdminCartRulesControllerCore extends AdminController
                 'gift_product_select' => $gift_product_select,
                 'gift_product_attribute_select' => $gift_product_attribute_select,
                 'reductionProductFilter' => $reduction_product_filter,
-                'defaultCurrency' => Configuration::get('PS_CURRENCY_DEFAULT'),
+                'defaultCurrency' => Currency::getDefaultCurrencyId(),
                 'id_lang_default' => Configuration::get('PS_LANG_DEFAULT'),
                 'languages' => $languages,
                 'currencies' => $currencies,

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -357,7 +357,7 @@ class AdminCartsControllerCore extends AdminController
                 $this->context->cart->id_lang = (($id_lang = (int) Tools::getValue('id_lang')) ? $id_lang : Configuration::get('PS_LANG_DEFAULT'));
             }
             if (!$this->context->cart->id_currency) {
-                $this->context->cart->id_currency = (($id_currency = (int) Tools::getValue('id_currency')) ? $id_currency : Configuration::get('PS_CURRENCY_DEFAULT'));
+                $this->context->cart->id_currency = (($id_currency = (int) Tools::getValue('id_currency')) ? $id_currency : Currency::getDefaultCurrencyId());
             }
 
             $addresses = $customer->getAddresses((int) $this->context->cart->id_lang);

--- a/controllers/admin/AdminDashboardController.php
+++ b/controllers/admin/AdminDashboardController.php
@@ -67,7 +67,7 @@ class AdminDashboardControllerCore extends AdminController
 
     protected function getOptionFields()
     {
-        $currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $currency = Currency::getDefaultCurrency();
         $carriers = Carrier::getCarriers((int) $this->context->language->id, true, false, false, null, Carrier::ALL_CARRIERS);
         $modules = Module::getModulesOnDisk(true);
 

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2501,7 +2501,7 @@ class AdminProductsControllerCore extends AdminController
                     if ($this->context->currency->id) {
                         $product_supplier->id_currency = (int) $this->context->currency->id;
                     } else {
-                        $product_supplier->id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+                        $product_supplier->id_currency = Currency::getDefaultCurrencyId();
                     }
                     $product_supplier->save();
 

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -575,7 +575,7 @@ class AdminStatsControllerCore extends AdminStatsTabController
             return die(json_encode(['error' => 'You do not have the right permission']));
         }
 
-        $currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $currency = Currency::getDefaultCurrency();
         $tooltip = null;
         $value = false;
         switch (Tools::getValue('kpi')) {

--- a/controllers/admin/AdminStatsController.php
+++ b/controllers/admin/AdminStatsController.php
@@ -536,14 +536,14 @@ class AdminStatsControllerCore extends AdminStatsTabController
         foreach ($orders as $order) {
             // Add flat fees for this order
             $flat_fees = Configuration::get('CONF_ORDER_FIXED') + (
-                $order['id_currency'] == Configuration::get('PS_CURRENCY_DEFAULT')
+                $order['id_currency'] == Currency::getDefaultCurrencyId()
                     ? Configuration::get('CONF_' . strtoupper($order['module']) . '_FIXED')
                     : Configuration::get('CONF_' . strtoupper($order['module']) . '_FIXED_FOREIGN')
                 );
 
             // Add variable fees for this order
             $var_fees = $order['total_paid_tax_incl'] * (
-                $order['id_currency'] == Configuration::get('PS_CURRENCY_DEFAULT')
+                $order['id_currency'] == Currency::getDefaultCurrencyId()
                     ? Configuration::get('CONF_' . strtoupper($order['module']) . '_VAR')
                     : Configuration::get('CONF_' . strtoupper($order['module']) . '_VAR_FOREIGN')
                 ) / 100;

--- a/install-dev/controllers/console/process.php
+++ b/install-dev/controllers/console/process.php
@@ -94,7 +94,7 @@ class InstallControllerConsoleProcess extends InstallControllerConsole implement
             }
         }
         if (!isset(Context::getContext()->currency) || !Validate::isLoadedObject(Context::getContext()->currency)) {
-            if ($id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT')) {
+            if ($id_currency = Currency::getDefaultCurrencyId()) {
                 Context::getContext()->currency = new Currency((int) $id_currency);
             }
         }

--- a/install-dev/controllers/http/process.php
+++ b/install-dev/controllers/http/process.php
@@ -64,7 +64,7 @@ class InstallControllerHttpProcess extends InstallControllerHttp implements Http
         Configuration::loadConfiguration();
         Context::getContext()->language = new Language((int) Configuration::get('PS_LANG_DEFAULT'));
         Context::getContext()->country = new Country((int) Configuration::get('PS_COUNTRY_DEFAULT'));
-        Context::getContext()->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        Context::getContext()->currency = Currency::getDefaultCurrency();
         Context::getContext()->cart = new Cart();
         Context::getContext()->employee = new Employee(1);
         define('_PS_SMARTY_FAST_LOAD_', true);

--- a/src/Adapter/Cart/CommandHandler/CreateEmptyCustomerCartHandler.php
+++ b/src/Adapter/Cart/CommandHandler/CreateEmptyCustomerCartHandler.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter\Cart\CommandHandler;
 
 use Cart;
 use Configuration;
+use Currency;
 use Customer;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Command\CreateEmptyCustomerCartCommand;
 use PrestaShop\PrestaShop\Core\Domain\Cart\CommandHandler\CreateEmptyCustomerCartHandlerInterface;
@@ -75,7 +76,7 @@ final class CreateEmptyCustomerCartHandler implements CreateEmptyCustomerCartHan
 
         $cart->id_shop = $customer->id_shop;
         $cart->id_lang = (int) Configuration::get('PS_LANG_DEFAULT');
-        $cart->id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $cart->id_currency = Currency::getDefaultCurrencyId();
 
         $addresses = $customer->getAddresses($cart->id_lang);
         $addressId = !empty($addresses) ? (int) reset($addresses)['id_address'] : null;

--- a/src/Adapter/Product/AdminProductDataProvider.php
+++ b/src/Adapter/Product/AdminProductDataProvider.php
@@ -354,7 +354,7 @@ class AdminProductDataProvider extends AbstractAdminQueryBuilder implements Prod
         $total = $total[0]['FOUND_ROWS()'];
 
         // post treatment
-        $currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $currency = Currency::getDefaultCurrency();
         $localeCldr = Tools::getContextLocale(Context::getContext());
 
         /**

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -387,7 +387,7 @@ class Install extends AbstractInstall
             }
         }
         if (!isset($context->currency) || !Validate::isLoadedObject($context->currency)) {
-            if ($id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT')) {
+            if ($id_currency = Currency::getDefaultCurrencyId()) {
                 $context->currency = new Currency((int) $id_currency);
             }
         }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1640,7 +1640,7 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Sell\Product\Pricing\SpecificPriceImpactType'
     parent: 'form.type.translatable.aware'
     arguments:
-      - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrency().iso_code'
+      - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrencyIsoCode()'
     public: true
     tags:
       - { name: form.type }
@@ -1937,7 +1937,7 @@ services:
     parent: 'form.type.translatable.aware'
     public: true
     arguments:
-      - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrency().iso_code'
+      - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrencyIsoCode()'
       - "@=service('prestashop.adapter.legacy.configuration').get('PS_WEIGHT_UNIT')"
       - '@prestashop.adapter.product.repository.product_repository'
       - '@prestashop.adapter.tax.tax_computer'

--- a/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CurrencyFeatureContext.php
@@ -56,7 +56,7 @@ class CurrencyFeatureContext extends AbstractPrestaShopFeatureContext
      */
     public function storePreviousCurrencyId()
     {
-        $this->previousDefaultCurrencyId = Configuration::get('PS_CURRENCY_DEFAULT');
+        $this->previousDefaultCurrencyId = Currency::getDefaultCurrencyId();
         Cache::clean('Currency::*');
     }
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/AbstractDomainFeatureContext.php
@@ -309,7 +309,7 @@ abstract class AbstractDomainFeatureContext implements Context
 
     protected function getDefaultCurrencyId(): int
     {
-        return (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        return Currency::getDefaultCurrencyId();
     }
 
     protected function getDefaultCurrencyIsoCode(): string

--- a/tests/Integration/Classes/CartTest.php
+++ b/tests/Integration/Classes/CartTest.php
@@ -311,7 +311,7 @@ class CartTest extends TestCase
         parent::setUp();
 
         // Context needs a currency but doesn't set it by itself, use default one.
-        Context::getContext()->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        Context::getContext()->currency = Currency::getDefaultCurrency();
 
         Group::clearCachedValues();
         self::setRoundingType('line');

--- a/tests/Integration/Classes/CartTest.php
+++ b/tests/Integration/Classes/CartTest.php
@@ -202,7 +202,7 @@ class CartTest extends TestCase
     private static function makeCart(): Cart
     {
         $cart = new Cart(null, (int) Configuration::get('PS_LANG_DEFAULT'));
-        $cart->id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+        $cart->id_currency = Currency::getDefaultCurrencyId();
         $cart->id_address_invoice = self::$id_address;
         self::assertTrue($cart->save());
         Context::getContext()->cart = $cart;

--- a/tests/Integration/Utility/ContextMocker.php
+++ b/tests/Integration/Utility/ContextMocker.php
@@ -125,7 +125,7 @@ class ContextMocker
         // Use super admin employee by default
         $context->employee = new Employee(1);
         $context->employee->id_lang = $context->language->id;
-        $context->currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+        $context->currency = Currency::getDefaultCurrency();
         $protocol_link = (Tools::usingSecureMode() && Configuration::get('PS_SSL_ENABLED'))
             ? 'https://' : 'http://';
         $protocol_content = (Tools::usingSecureMode() && Configuration::get('PS_SSL_ENABLED'))

--- a/tests/Resources/modules_tests/override/AdminProductsController.php
+++ b/tests/Resources/modules_tests/override/AdminProductsController.php
@@ -2573,7 +2573,7 @@ class AdminProductsController extends AdminProductsControllerCore
                     if ($this->context->currency->id) {
                         $product_supplier->id_currency = (int) $this->context->currency->id;
                     } else {
-                        $product_supplier->id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+                        $product_supplier->id_currency = Currency::getDefaultCurrencyId();
                     }
                     $product_supplier->save();
                     $associated_suppliers[] = $product_supplier;
@@ -4119,7 +4119,7 @@ class AdminProductsController extends AdminProductsControllerCore
                     'product' => $obj,
                     'link' => $this->context->link,
                     'token' => $this->token,
-                    'id_default_currency' => Configuration::get('PS_CURRENCY_DEFAULT'),
+                    'id_default_currency' => Currency::getDefaultCurrencyId(),
                 ]);
             } else {
                 $this->displayWarning($this->l('You must save the product in this shop before managing suppliers.'));

--- a/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -2656,7 +2656,7 @@ class AdminProductsController extends AdminProductsControllerCore
                     if ($this->context->currency->id) {
                         $product_supplier->id_currency = (int) $this->context->currency->id;
                     } else {
-                        $product_supplier->id_currency = (int) Configuration::get('PS_CURRENCY_DEFAULT');
+                        $product_supplier->id_currency = Currency::getDefaultCurrencyId();
                     }
                     $product_supplier->save();
 
@@ -4335,7 +4335,7 @@ class AdminProductsController extends AdminProductsControllerCore
                     'product' => $obj,
                     'link' => $this->context->link,
                     'token' => $this->token,
-                    'id_default_currency' => Configuration::get('PS_CURRENCY_DEFAULT'),
+                    'id_default_currency' => Currency::getDefaultCurrencyId(),
                 ]);
             } else {
                 $this->displayWarning($this->l('You must save the product in this shop before managing suppliers.'));

--- a/webservice/dispatcher.php
+++ b/webservice/dispatcher.php
@@ -37,7 +37,7 @@ require_once dirname(__FILE__) . '/../config/config.inc.php';
 // Cart is needed for some requests
 Context::getContext()->cart = new Cart();
 Context::getContext()->container = ContainerBuilder::getContainer('webservice', _PS_MODE_DEV_);
-Context::getContext()->currency = Context::getContext()->currency ?? new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
+Context::getContext()->currency = Context::getContext()->currency ?? Currency::getDefaultCurrency();
 
 //set http auth headers for apache+php-cgi work around
 if (isset($_SERVER['HTTP_AUTHORIZATION']) && preg_match('/Basic\s+(.*)$/i', $_SERVER['HTTP_AUTHORIZATION'], $matches)) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      |Simplify default currency fetching for easier code understanding
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | This PR is basically replacing bad copy pasting by adding a unique method to handle getting default currency. QA can be done by a dev. But you can check some pages where you use the default currency to see if this is still working.
| Possible impacts? | Should have no impact.

