### PR TITLE
Add getters for controller objects

### DIFF
--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -31,10 +31,21 @@ class CmsControllerCore extends FrontController
     /** @var string */
     public $php_self = 'cms';
     public $assignCase;
+
+    /**
+     * @deprecated Since 8.1, it will be protected on next major.
+     *
+     * @var CMS|null
+     */
     public $cms;
 
-    /** @var CMSCategory */
+    /**
+     * @deprecated Since 8.1, it will be protected on next major.
+     *
+     * @var CMSCategory|null
+     */
     public $cms_category;
+
     /** @var bool */
     public $ssl = false;
 
@@ -223,5 +234,21 @@ class CmsControllerCore extends FrontController
         }
 
         return $categoryCms;
+    }
+
+    /**
+     * @return CMS|null
+     */
+    public function getCms()
+    {
+        return $this->cms;
+    }
+
+    /**
+     * @return CMSCategory|null
+     */
+    public function getCmsCategory()
+    {
+        return $this->cms_category;
     }
 }

--- a/controllers/front/CmsController.php
+++ b/controllers/front/CmsController.php
@@ -33,14 +33,14 @@ class CmsControllerCore extends FrontController
     public $assignCase;
 
     /**
-     * @deprecated Since 8.1, it will be protected on next major.
+     * @deprecated Since 8.1, it will become protected in next major version. Use getCms() method instead.
      *
      * @var CMS|null
      */
     public $cms;
 
     /**
-     * @deprecated Since 8.1, it will be protected on next major.
+     * @deprecated Since 8.1, it will become protected in next major version. Use getCmsCategory() method instead.
      *
      * @var CMSCategory|null
      */

--- a/controllers/front/OrderConfirmationController.php
+++ b/controllers/front/OrderConfirmationController.php
@@ -39,8 +39,10 @@ class OrderConfirmationControllerCore extends FrontController
     public $id_module;
     public $id_order;
     public $secure_key;
+
     /** @var Order Order object we found by cart ID */
     protected $order;
+
     /** @var Customer Customer object related to the cart */
     protected $customer;
     public $reference; // Deprecated
@@ -297,5 +299,21 @@ class OrderConfirmationControllerCore extends FrontController
         ];
 
         return $breadcrumb;
+    }
+
+    /**
+     * @return Order
+     */
+    public function getOrder()
+    {
+        return $this->order;
+    }
+
+    /**
+     * @return Customer
+     */
+    public function getCustomer()
+    {
+        return $this->customer;
     }
 }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1016,11 +1016,17 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         return $specific_prices;
     }
 
+    /**
+     * @return Product
+     */
     public function getProduct()
     {
         return $this->product;
     }
 
+    /**
+     * @return Category|null
+     */
     public function getCategory()
     {
         return $this->category;

--- a/controllers/front/listing/CategoryController.php
+++ b/controllers/front/listing/CategoryController.php
@@ -256,6 +256,9 @@ class CategoryControllerCore extends ProductListingFrontController
         return $breadcrumb;
     }
 
+    /**
+     * @return Category
+     */
     public function getCategory()
     {
         return $this->category;

--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -32,6 +32,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
     /** @var string */
     public $php_self = 'manufacturer';
 
+    /** @var Manufacturer */
     protected $manufacturer;
     protected $label;
 
@@ -242,5 +243,13 @@ class ManufacturerControllerCore extends ProductListingFrontController
         $page['body_classes']['manufacturer-' . $this->manufacturer->name] = true;
 
         return $page;
+    }
+
+    /**
+     * @return Manufacturer
+     */
+    public function getManufacturer()
+    {
+        return $this->manufacturer;
     }
 }

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -247,4 +247,12 @@ class SupplierControllerCore extends ProductListingFrontController
 
         return $page;
     }
+
+    /**
+     * @return Supplier
+     */
+    public function getSupplier()
+    {
+        return $this->supplier;
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add getters for controller objects to get their content easier on action hooks. Also, you don't have to re-intiailize them again.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Related PRs       | -
| How to test?      | Hook to `displayHeader` with quality assurance module and try `dump($this->context->controller->getManufacturer());` on manufacturer detail page for example.
| Possible impacts? | No
| Sponsor company   | [TRENDO s.r.o.](https://www.trendo.cz)
