### PR TITLE
Fix applying special char on translations

### DIFF
--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -286,9 +286,17 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             }
         }
 
-        $parameters['legacy'] = 'htmlspecialchars';
+        if (isset($parameters['_raw'])) {
+            @trigger_error(
+                'The _raw parameter is deprecated and will be removed in the next major version.',
+                E_USER_DEPRECATED
+            );
+            unset($parameters['_raw']);
 
-        return $this->translator->trans($id, $parameters, $domain, $locale);
+            return $this->translator->trans($id, $parameters, $domain, $locale);
+        }
+
+        return htmlspecialchars($this->translator->trans($id, $parameters, $domain, $locale), ENT_NOQUOTES);
     }
 
     /**

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2718,12 +2718,11 @@ class AdminControllerCore extends Controller
     {
         @trigger_error(__FUNCTION__ . 'is deprecated. Use AdminController::trans instead.', E_USER_DEPRECATED);
 
-        $parameters = [];
-        if ($htmlentities) {
-            $parameters['legacy'] = 'htmlspecialchars';
+        if ($htmlentities === true) {
+            return htmlspecialchars($this->translator->trans($string, []), ENT_NOQUOTES);
         }
 
-        return $this->translator->trans($string, $parameters);
+        return $this->translator->trans($string, []);
     }
 
     /**

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -346,9 +346,17 @@ abstract class ControllerCore
 
     protected function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
-        $parameters['legacy'] = 'htmlspecialchars';
+        if (isset($parameters['_raw'])) {
+            @trigger_error(
+                'The _raw parameter is deprecated and will be removed in the next major version.',
+                E_USER_DEPRECATED
+            );
+            unset($parameters['_raw']);
 
-        return $this->translator->trans($id, $parameters, $domain, $locale);
+            return $this->translator->trans($id, $parameters, $domain, $locale);
+        }
+
+        return htmlspecialchars($this->translator->trans($id, $parameters, $domain, $locale), ENT_NOQUOTES);
     }
 
     /**

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3362,9 +3362,17 @@ abstract class ModuleCore implements ModuleInterface
 
     protected function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
-        $parameters['legacy'] = 'htmlspecialchars';
+        if (isset($parameters['_raw'])) {
+            @trigger_error(
+                'The _raw parameter is deprecated and will be removed in the next major version.',
+                E_USER_DEPRECATED
+            );
+            unset($parameters['_raw']);
 
-        return $this->getTranslator()->trans($id, $parameters, $domain, $locale);
+            return $this->getTranslator()->trans($id, $parameters, $domain, $locale);
+        }
+
+        return htmlspecialchars($this->getTranslator()->trans($id, $parameters, $domain, $locale), ENT_NOQUOTES);
     }
 
     /**

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -507,7 +507,7 @@ class AdminAttributesGroupsControllerCore extends AdminController
         } else {
             $adminPerformanceUrl = $this->context->link->getAdminLink('AdminPerformance');
             $url = '<a href="' . $adminPerformanceUrl . '#featuresDetachables">' . $this->trans('Performance', [], 'Admin.Global') . '</a>';
-            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %link%.', ['%link%' => $url], 'Admin.Catalog.Notification'));
+            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %link%.', ['_raw' => true, '%link%' => $url], 'Admin.Catalog.Notification'));
         }
 
         $this->context->smarty->assign([

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -447,7 +447,7 @@ class AdminFeaturesControllerCore extends AdminController
         } else {
             $adminPerformanceUrl = $this->context->link->getAdminLink('AdminPerformance');
             $url = '<a href="' . $adminPerformanceUrl . '#featuresDetachables">' . $this->trans('Performance', [], 'Admin.Global') . '</a>';
-            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %url%.', ['%url%' => $url], 'Admin.Catalog.Notification'));
+            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %url%.', ['_raw' => true, '%url%' => $url], 'Admin.Catalog.Notification'));
         }
 
         $this->context->smarty->assign([

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -644,9 +644,9 @@ class AdminGroupsControllerCore extends AdminController
         $guest = new Group((int) Configuration::get('PS_GUEST_GROUP'));
         $default = new Group((int) Configuration::get('PS_CUSTOMER_GROUP'));
 
-        $unidentified_group_information = $this->trans('%group_name% - All persons without a customer account or customers that are not logged in.', ['%group_name%' => '<b>' . $unidentified->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
-        $guest_group_information = $this->trans('%group_name% - All persons who placed an order through Guest Checkout.', ['%group_name%' => '<b>' . $guest->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
-        $default_group_information = $this->trans('%group_name% - All persons who created an account on this site.', ['%group_name%' => '<b>' . $default->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
+        $unidentified_group_information = $this->trans('%group_name% - All persons without a customer account or customers that are not logged in.', ['_raw' => true, '%group_name%' => '<b>' . $unidentified->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
+        $guest_group_information = $this->trans('%group_name% - All persons who placed an order through Guest Checkout.', ['_raw' => true, '%group_name%' => '<b>' . $guest->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
+        $default_group_information = $this->trans('%group_name% - All persons who created an account on this site.', ['_raw' => true, '%group_name%' => '<b>' . $default->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
 
         $this->displayInformation($this->trans('PrestaShop has three default customer groups:', [], 'Admin.Shopparameters.Help'));
         $this->displayInformation($unidentified_group_information);

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -91,7 +91,7 @@ class AdminLoginControllerCore extends AdminController
                 $url = 'https://' . Tools::safeOutput(Tools::getServerName()) . Tools::safeOutput($_SERVER['REQUEST_URI']);
                 $warningSslMessage = $this->trans(
                     'SSL is activated. Please connect using the following link to [1]log in to secure mode (https://)[/1]',
-                    ['[1]' => '<a href="' . $url . '">', '[/1]' => '</a>'],
+                    ['_raw' => true, '[1]' => '<a href="' . $url . '">', '[/1]' => '</a>'],
                     'Admin.Login.Notification'
                 );
             }

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -394,6 +394,7 @@ class AdminShopControllerCore extends AdminController
                     'desc' => [
                         $this->trans('This field does not refer to the shop name visible in the front office.', [], 'Admin.Shopparameters.Help'),
                         $this->trans('Follow [1]this link[/1] to edit the shop name used on the front office.', [
+                            '_raw' => true,
                             '[1]' => '<a href="' . $this->context->link->getAdminLink('AdminStores') . '#store_fieldset_general">',
                             '[/1]' => '</a>',
                         ], 'Admin.Shopparameters.Help'), ],
@@ -472,6 +473,7 @@ class AdminShopControllerCore extends AdminController
             'type' => 'select',
             'label' => $this->trans('Category root', [], 'Admin.Catalog.Feature'),
             'desc' => $this->trans('This is the root category of the store that you\'ve created. To define a new root category for your store, [1]please click here[/1].', [
+                '_raw' => true,
                 '[1]' => '<a href="' . $this->context->link->getAdminLink('AdminCategories') . '&addcategoryroot" target="_blank">',
                 '[/1]' => '</a>',
             ], 'Admin.Shopparameters.Help'),

--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -50,9 +50,13 @@ trait PrestaShopTranslatorTrait
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
         if (isset($parameters['legacy'])) {
-            $legacy = $parameters['legacy'];
+            @trigger_error(
+                'The legacy parameter is deprecated and will be removed in the next major version.',
+                E_USER_DEPRECATED
+            );
             unset($parameters['legacy']);
         }
+
         $isSprintf = !empty($parameters) && $this->isSprintfString($id);
 
         if (empty($locale)) {
@@ -68,8 +72,6 @@ trait PrestaShopTranslatorTrait
         if ($isSprintf) {
             $translated = vsprintf($translated, $parameters);
         }
-
-        $translated = isset($legacy) ? $this->replaceSpecialCharsWithLegacyFunctions($translated, $legacy) : $translated;
 
         return $translated;
     }
@@ -200,24 +202,5 @@ trait PrestaShopTranslatorTrait
             : null;
 
         return $normalizedDomain;
-    }
-
-    /**
-     * Replaces special characters on the message
-     *
-     * @param string $message the message
-     * @param callable-string $functionName Name of function to be called
-     *
-     * @return string
-     */
-    private function replaceSpecialCharsWithLegacyFunctions(string $message, string $functionName): string
-    {
-        if ('htmlspecialchars' === $functionName) {
-            $translated = htmlspecialchars($message, ENT_NOQUOTES);
-        } else {
-            $translated = call_user_func($functionName, $message);
-        }
-
-        return $translated;
     }
 }

--- a/tests/Integration/Classes/ObjectModelTest.php
+++ b/tests/Integration/Classes/ObjectModelTest.php
@@ -96,7 +96,7 @@ class ObjectModelTest extends TestCase
     }
 
     /**
-     * Check if html in trans is escaped even if _raw parameter is used
+     * Check if html in trans is not escaped when the _raw parameter is used
      *
      * @return void
      *

--- a/tests/Integration/Classes/ObjectModelTest.php
+++ b/tests/Integration/Classes/ObjectModelTest.php
@@ -95,6 +95,25 @@ class ObjectModelTest extends TestCase
         $this->secondShopId = Shop::getIdByName('Shop 2');
     }
 
+    /**
+     * Check if html in trans is escaped even if _raw parameter is used
+     *
+     * @return void
+     *
+     * @throws \ReflectionException
+     */
+    public function testTrans(): void
+    {
+        $newObject = new TestableObjectModel();
+        $transMethod = new \ReflectionMethod($newObject, 'trans');
+        $transMethod->setAccessible(true);
+        $trans = $transMethod->invoke($newObject, '<a href="test">%d Succesful deletion "%s"</a>', ['_raw' => true, 10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
+        $this->assertEquals('<a href="test">10 Succesful deletion "<b>stringTest</b>"</a>', $trans);
+
+        $trans = $transMethod->invoke($newObject, '<a href="test">%d Succesful deletion "%s"</a>', [10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
+        $this->assertEquals('&lt;a href="test"&gt;10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"&lt;/a&gt;', $trans);
+    }
+
     public function testAdd(): void
     {
         $quantity = 42;

--- a/tests/Integration/Classes/controller/AdminControllerTest.php
+++ b/tests/Integration/Classes/controller/AdminControllerTest.php
@@ -88,6 +88,27 @@ class AdminControllerTest extends TestCase
     }
 
     /**
+     * Check if html in trans is escaped even if _raw parameter is used
+     *
+     * @dataProvider getControllersClasses
+     *
+     * @param string $controllerClass
+     *
+     * @return void
+     */
+    public function testTrans(string $controllerClass): void
+    {
+        $testedController = new $controllerClass();
+        $transMethod = new \ReflectionMethod($testedController, 'trans');
+        $transMethod->setAccessible(true);
+        $trans = $transMethod->invoke($testedController, '<a href="test">%d Succesful deletion "%s"</a>', ['_raw' => true, 10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
+        $this->assertEquals('<a href="test">10 Succesful deletion "<b>stringTest</b>"</a>', $trans);
+
+        $trans = $transMethod->invoke($testedController, '<a href="test">%d Succesful deletion "%s"</a>', [10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
+        $this->assertEquals('&lt;a href="test"&gt;10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"&lt;/a&gt;', $trans);
+    }
+
+    /**
      * @dataProvider getControllersClasses
      *
      * @param string $controllerClass

--- a/tests/Integration/Classes/controller/AdminControllerTest.php
+++ b/tests/Integration/Classes/controller/AdminControllerTest.php
@@ -88,7 +88,7 @@ class AdminControllerTest extends TestCase
     }
 
     /**
-     * Check if html in trans is escaped even if _raw parameter is used
+     * Check if html in trans is not escaped when the _raw parameter is used
      *
      * @dataProvider getControllersClasses
      *

--- a/tests/Integration/Classes/module/ModuleTest.php
+++ b/tests/Integration/Classes/module/ModuleTest.php
@@ -62,6 +62,25 @@ class ModuleTest extends TestCase
     }
 
     /**
+     * Check if html in trans is escaped even if _raw parameter is used
+     *
+     * @dataProvider providerModulesOnDisk
+     *
+     * @param string $moduleName the module name
+     */
+    public function testTrans(string $moduleName): void
+    {
+        $module = Module::getInstanceByName($moduleName);
+        $transMethod = new \ReflectionMethod($module, 'trans');
+        $transMethod->setAccessible(true);
+        $trans = $transMethod->invoke($module, '<a href="test">%d Succesful deletion "%s"</a>', ['_raw' => true, 10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
+        $this->assertEquals('<a href="test">10 Succesful deletion "<b>stringTest</b>"</a>', $trans);
+
+        $trans = $transMethod->invoke($module, '<a href="test">%d Succesful deletion "%s"</a>', [10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
+        $this->assertEquals('&lt;a href="test"&gt;10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"&lt;/a&gt;', $trans);
+    }
+
+    /**
      * @dataProvider providerModulesOnDisk
      * Note: improves module list fixtures in order to cancel any override.
      *

--- a/tests/Integration/Classes/module/ModuleTest.php
+++ b/tests/Integration/Classes/module/ModuleTest.php
@@ -62,7 +62,7 @@ class ModuleTest extends TestCase
     }
 
     /**
-     * Check if html in trans is escaped even if _raw parameter is used
+     * Check if html in trans is escaped when the _raw parameter is used
      *
      * @dataProvider providerModulesOnDisk
      *

--- a/tests/Integration/PrestaShopBundle/TranslationIntegrationTest.php
+++ b/tests/Integration/PrestaShopBundle/TranslationIntegrationTest.php
@@ -110,12 +110,6 @@ class TranslationIntegrationTest extends KernelTestCase
             'Modules.Mymodule.Foobar',
             ['%message%' => 'bad idea'],
         ];
-        yield 'translation with htmlspecialchars and sprintf' => [
-            '&lt;a href="test"&gt;10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"&lt;/a&gt;',
-            '<a href="test">%d Succesful deletion "%s"</a>',
-            'Admin.Notifications.Success',
-            ['legacy' => 'htmlspecialchars', 10, '<b>stringTest</b>'],
-        ];
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Move translation sanitize before applying SF translation to avoid sanitize on html in trans parameters
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Resolves #29959, resolves #29940 
| Related PRs       | [#29584](https://github.com/PrestaShop/PrestaShop/pull/29584)
| How to test?      | See #29959 #29940 
| Possible impacts? | Check also there is no regression on https://github.com/PrestaShop/PrestaShop/issues/28877

Escape html parameter in translator is not a good practice. This task must be done before to send it to the translator. To do not introduce a bc break with deletion of applying htmlspecialchars in trans method, we introduce the _raw parameter that can be sent to not apply htmlspecialchars on the translation. This parameter will be removed in the next major version.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
