### PR TITLE
Add `id_feature_value` in `Product::getFrontFeaturesStatic`

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5933,7 +5933,7 @@ class ProductCore extends ObjectModel
         if (!array_key_exists($id_product . '-' . $id_lang, self::$_frontFeaturesCache)) {
             self::$_frontFeaturesCache[$id_product . '-' . $id_lang] = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
                 '
-                SELECT name, value, pf.id_feature, f.position
+                SELECT name, value, pf.id_feature, f.position, fvl.id_feature_value
                 FROM ' . _DB_PREFIX_ . 'feature_product pf
                 LEFT JOIN ' . _DB_PREFIX_ . 'feature_lang fl ON (fl.id_feature = pf.id_feature AND fl.id_lang = ' . (int) $id_lang . ')
                 LEFT JOIN ' . _DB_PREFIX_ . 'feature_value_lang fvl ON (fvl.id_feature_value = pf.id_feature_value AND fvl.id_lang = ' . (int) $id_lang . ')


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add `id_feature_value` in `Product::getFrontFeaturesStatic`.
| Type?             | improvement
| Category?         | FO 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Related PRs       | N/A
| How to test?      |  Try this code in product.tpl `{var_dump($product.features)}` and make make you have `id_feature_value` for each feature value.
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
