### PR TITLE
Add better logging in the create-test-db script

### DIFF
--- a/classes/log/AbstractLogger.php
+++ b/classes/log/AbstractLogger.php
@@ -23,7 +23,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-abstract class AbstractLoggerCore
+abstract class AbstractLoggerCore implements PrestaShopLoggerInterface
 {
     public $level;
     protected $level_value = [
@@ -32,11 +32,6 @@ abstract class AbstractLoggerCore
         2 => 'WARNING',
         3 => 'ERROR',
     ];
-
-    public const DEBUG = 0;
-    public const INFO = 1;
-    public const WARNING = 2;
-    public const ERROR = 3;
 
     public function __construct($level = self::INFO)
     {

--- a/classes/log/NullLogger.php
+++ b/classes/log/NullLogger.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+/**
+ * NullLogger is an implementation of the PrestaShop logger that logs nothing.
+ * It is convenient as a default value for logger instances, this way the code can be
+ * executed the same way even if it does nothing.
+ */
+class NullLogger extends AbstractLogger
+{
+    protected function logMessage($message, $level)
+    {
+        // Null logger doesn't log anything
+    }
+}

--- a/classes/log/PSRLoggerAdapter.php
+++ b/classes/log/PSRLoggerAdapter.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+/**
+ * This class is an adapter if can use PrestaShopLoggerInterface and decorate it into a PSR logger.
+ */
+class PSRLoggerAdapter implements LoggerInterface
+{
+    /**
+     * @var PrestaShopLoggerInterface
+     */
+    private $logger;
+
+    public function __construct(PrestaShopLoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function emergency($message, array $context = [])
+    {
+        $this->logger->logError($message);
+    }
+
+    public function alert($message, array $context = [])
+    {
+        $this->logger->logError($message);
+    }
+
+    public function critical($message, array $context = [])
+    {
+        $this->logger->logError($message);
+    }
+
+    public function error($message, array $context = [])
+    {
+        $this->logger->logError($message);
+    }
+
+    public function warning($message, array $context = [])
+    {
+        $this->logger->logWarning($message);
+    }
+
+    public function notice($message, array $context = [])
+    {
+        $this->logger->logInfo($message);
+    }
+
+    public function info($message, array $context = [])
+    {
+        $this->logger->logInfo($message);
+    }
+
+    public function debug($message, array $context = [])
+    {
+        $this->logger->logDebug($message);
+    }
+
+    public function log($level, $message, array $context = [])
+    {
+        switch ($level) {
+            case LogLevel::EMERGENCY:
+            case LogLevel::CRITICAL:
+            case LogLevel::ALERT:
+            case LogLevel::ERROR:
+                $legacyLevel = PrestaShopLoggerInterface::ERROR;
+                break;
+            case LogLevel::WARNING:
+                $legacyLevel = PrestaShopLoggerInterface::WARNING;
+                break;
+            case LogLevel::NOTICE:
+            case LogLevel::INFO:
+                $legacyLevel = PrestaShopLoggerInterface::INFO;
+                break;
+            case LogLevel::DEBUG:
+            default:
+                $legacyLevel = PrestaShopLoggerInterface::DEBUG;
+                break;
+        }
+        $this->logger->log($message, $legacyLevel);
+    }
+}

--- a/classes/log/PrestaShopLoggerInterface.php
+++ b/classes/log/PrestaShopLoggerInterface.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+interface PrestaShopLoggerInterface
+{
+    public const DEBUG = 0;
+    public const INFO = 1;
+    public const WARNING = 2;
+    public const ERROR = 3;
+
+    /**
+     * @param string $message
+     * @param int $level
+     *
+     * @return void
+     */
+    public function log($message, $level = self::DEBUG);
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public function logDebug($message);
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public function logInfo($message);
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public function logWarning($message);
+
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    public function logError($message);
+}

--- a/classes/log/SymfonyConsoleLogger.php
+++ b/classes/log/SymfonyConsoleLogger.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * This logger class respects the PrestaShopLoggerInterface but is based on the Symfony console
+ * component. It is used as a temporary solution in legacy code until we can replace the usage of
+ * the legacy interface.
+ */
+class SymfonyConsoleLogger extends AbstractLogger
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    public function __construct(OutputInterface $output, $level = self::INFO)
+    {
+        parent::__construct($level);
+        $this->output = $output;
+    }
+
+    protected function logMessage($message, $level)
+    {
+        $this->output->writeln($message);
+    }
+}

--- a/src/Core/Addon/Theme/ThemeManager.php
+++ b/src/Core/Addon/Theme/ThemeManager.php
@@ -43,6 +43,8 @@ use PrestaShop\PrestaShop\Core\Module\HookConfigurator;
 use PrestaShopBundle\Service\TranslationService;
 use PrestaShopBundle\Translation\Provider\TranslationFinder;
 use PrestaShopLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Shop;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -115,6 +117,11 @@ class ThemeManager implements AddonManagerInterface
     private $translationFinder;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @param Shop $shop
      * @param ConfigurationInterface $configuration
      * @param ThemeValidator $themeValidator
@@ -136,7 +143,8 @@ class ThemeManager implements AddonManagerInterface
         Finder $finder,
         HookConfigurator $hookConfigurator,
         ThemeRepository $themeRepository,
-        ImageTypeRepository $imageTypeRepository
+        ImageTypeRepository $imageTypeRepository,
+        LoggerInterface $logger = null
     ) {
         $this->translationFinder = new TranslationFinder();
         $this->shop = $shop;
@@ -149,6 +157,7 @@ class ThemeManager implements AddonManagerInterface
         $this->hookConfigurator = $hookConfigurator;
         $this->themeRepository = $themeRepository;
         $this->imageTypeRepository = $imageTypeRepository;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
@@ -239,20 +248,25 @@ class ThemeManager implements AddonManagerInterface
 
         $this->disable($this->shop->theme_name);
 
-        $this->doCreateCustomHooks($theme->get('global_settings.hooks.custom_hooks', []))
-            ->doApplyConfiguration($theme->get('global_settings.configuration', []))
-            ->doDisableModules($theme->get('global_settings.modules.to_disable', []))
-            ->doEnableModules($theme->getModulesToEnable())
-            ->doResetModules($theme->get('global_settings.modules.to_reset', []))
-            ->doApplyImageTypes($theme->get('global_settings.image_types', []))
-            ->doHookModules($theme->get('global_settings.hooks.modules_to_hook', []));
+        try {
+            $this->doCreateCustomHooks($theme->get('global_settings.hooks.custom_hooks', []))
+                ->doApplyConfiguration($theme->get('global_settings.configuration', []))
+                ->doDisableModules($theme->get('global_settings.modules.to_disable', []))
+                ->doEnableModules($theme->getModulesToEnable())
+                ->doResetModules($theme->get('global_settings.modules.to_reset', []))
+                ->doApplyImageTypes($theme->get('global_settings.image_types', []))
+                ->doHookModules($theme->get('global_settings.hooks.modules_to_hook', []));
 
-        $theme->onEnable();
+            $theme->onEnable();
 
-        $this->shop->theme_name = $theme->getName();
-        $this->shop->update();
+            $this->shop->theme_name = $theme->getName();
+            $this->shop->update();
 
-        $this->saveTheme($theme);
+            $this->saveTheme($theme);
+        } catch (Exception $e) {
+            $this->logger->error($e->getMessage());
+            throw $e;
+        }
 
         return true;
     }
@@ -454,6 +468,7 @@ class ThemeManager implements AddonManagerInterface
         $themeConfigurationFile = $sandboxPath . '/config/theme.yml';
 
         if (!file_exists($themeConfigurationFile)) {
+            $this->logger->error(sprintf('Configuration file not found %s', $themeConfigurationFile));
             throw new ThemeConstraintException('Missing theme configuration file which should be in located in /config/theme.yml', ThemeConstraintException::MISSING_CONFIGURATION_FILE);
         }
 
@@ -464,7 +479,9 @@ class ThemeManager implements AddonManagerInterface
         try {
             $theme = new Theme($theme_data);
         } catch (ErrorException $exception) {
-            throw new ThemeConstraintException(sprintf('Theme data %s is not valid', var_export($theme_data, true)), ThemeConstraintException::INVALID_DATA, $exception);
+            $errorMessage = sprintf('Theme data %s is not valid', var_export($theme_data, true));
+            $this->logger->error($errorMessage);
+            throw new ThemeConstraintException($errorMessage, ThemeConstraintException::INVALID_DATA, $exception);
         }
 
         if (!$this->themeValidator->isValid($theme)) {
@@ -472,7 +489,9 @@ class ThemeManager implements AddonManagerInterface
 
             $this->themeValidator->getErrors($theme->getName());
 
-            throw new ThemeConstraintException(sprintf('Theme configuration file is not valid - %s', var_export($this->themeValidator->getErrors($theme->getName()), true)), ThemeConstraintException::INVALID_CONFIGURATION);
+            $errorMessage = sprintf('Theme configuration file is not valid - %s', var_export($this->themeValidator->getErrors($theme->getName()), true));
+            $this->logger->error($errorMessage);
+            throw new ThemeConstraintException($errorMessage, ThemeConstraintException::INVALID_CONFIGURATION);
         }
 
         $module_root_dir = $this->appConfiguration->get('_PS_MODULE_DIR_');
@@ -494,7 +513,9 @@ class ThemeManager implements AddonManagerInterface
 
         $themePath = $this->appConfiguration->get('_PS_ALL_THEMES_DIR_') . $theme->getName();
         if ($this->filesystem->exists($themePath)) {
-            throw new ThemeAlreadyExistsException($theme->getName(), $this->translator->trans('There is already a theme named ' . $theme->getName() . ' in your themes/ folder. Remove it if you want to continue.', [], 'Admin.Design.Notification'));
+            $errorMessage = $this->translator->trans('There is already a theme named ' . $theme->getName() . ' in your themes/ folder. Remove it if you want to continue.', [], 'Admin.Design.Notification');
+            $this->logger->error($errorMessage);
+            throw new ThemeAlreadyExistsException($theme->getName(), $errorMessage);
         }
 
         $this->filesystem->mkdir($themePath);

--- a/src/Core/Addon/Theme/ThemeManagerBuilder.php
+++ b/src/Core/Addon/Theme/ThemeManagerBuilder.php
@@ -34,6 +34,8 @@ use PrestaShop\PrestaShop\Adapter\Hook\HookInformationProvider;
 use PrestaShop\PrestaShop\Core\Image\ImageTypeRepository;
 use PrestaShop\PrestaShop\Core\Module\HookConfigurator;
 use PrestaShop\PrestaShop\Core\Module\HookRepository;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Shop;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -43,12 +45,14 @@ class ThemeManagerBuilder
     private $context;
     private $db;
     private $themeValidator;
+    private $logger;
 
-    public function __construct(Context $context, Db $db, ThemeValidator $themeValidator = null)
+    public function __construct(Context $context, Db $db, ThemeValidator $themeValidator = null, LoggerInterface $logger = null)
     {
         $this->context = $context;
         $this->db = $db;
         $this->themeValidator = $themeValidator;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function build()
@@ -78,7 +82,8 @@ class ThemeManagerBuilder
                 )
             ),
             $this->buildRepository($this->context->shop),
-            new ImageTypeRepository($this->db)
+            new ImageTypeRepository($this->db),
+            $this->logger
         );
     }
 

--- a/src/PrestaShopBundle/Install/AbstractInstall.php
+++ b/src/PrestaShopBundle/Install/AbstractInstall.php
@@ -26,6 +26,9 @@
 
 namespace PrestaShopBundle\Install;
 
+use NullLogger;
+use PrestaShopLoggerInterface;
+
 abstract class AbstractInstall
 {
     /**
@@ -42,6 +45,11 @@ abstract class AbstractInstall
      * @var array List of errors
      */
     protected $errors = [];
+
+    /**
+     * @var PrestaShopLoggerInterface
+     */
+    protected $logger;
 
     public function __construct()
     {
@@ -67,5 +75,25 @@ abstract class AbstractInstall
         $this->translator = $translator;
 
         return $this;
+    }
+
+    /**
+     * @return PrestaShopLoggerInterface;
+     */
+    public function getLogger(): PrestaShopLoggerInterface
+    {
+        if (null === $this->logger) {
+            $this->logger = new NullLogger();
+        }
+
+        return $this->logger;
+    }
+
+    /**
+     * @param PrestaShopLoggerInterface $logger
+     */
+    public function setLogger(PrestaShopLoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 }

--- a/src/PrestaShopBundle/Install/Install.php
+++ b/src/PrestaShopBundle/Install/Install.php
@@ -63,6 +63,7 @@ use PrestaShopBundle\Service\Database\Upgrade as UpgradeDatabase;
 use PrestaShopException;
 use PrestashopInstallerException;
 use PrestaShopLoggerInterface;
+use PSRLoggerAdapter;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
@@ -1159,12 +1160,16 @@ class Install extends AbstractInstall
         $themeName = $themeName ?: _THEME_NAME_;
         $builder = new ThemeManagerBuilder(
             Context::getContext(),
-            Db::getInstance()
+            Db::getInstance(),
+            null,
+            new PSRLoggerAdapter($this->getLogger())
         );
 
         $theme_manager = $builder->build();
 
         if (!($theme_manager->install($themeName) && $theme_manager->enable($themeName))) {
+            $this->getLogger()->log('Could not install theme');
+
             return false;
         }
 

--- a/src/PrestaShopBundle/Resources/config/services/core/addon.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/addon.yml
@@ -30,6 +30,7 @@ services:
       - '@=service("prestashop.adapter.legacy.context").getContext()'
       - '@prestashop.adapter.legacy_db'
       - '@prestashop.core.addon.theme.theme_validator'
+      - '@logger'
 
   prestashop.core.addon.theme.theme_manager:
     class: PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManager

--- a/tests/bin/create-test-db.php
+++ b/tests/bin/create-test-db.php
@@ -26,6 +26,8 @@
  */
 
 use PrestaShopBundle\Install\Install;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use SymfonyConsoleLogger;
 use Tests\Resources\DatabaseDump;
 use Tests\Resources\ResourceResetter;
 
@@ -36,7 +38,10 @@ const _PS_MODULE_DIR_ = _PS_ROOT_DIR_ . '/modules/';
 
 require_once _PS_ROOT_DIR_ . '/install-dev/init.php';
 
-$install = new Install();
+$output = new ConsoleOutput();
+$logger = new SymfonyConsoleLogger($output, PrestaShopLoggerInterface::DEBUG);
+
+$install = new Install(null, null, $logger);
 $install->setTranslator(Context::getContext()->getTranslatorFromLocale('en'));
 DbPDOCore::createDatabase(_DB_SERVER_, _DB_USER_, _DB_PASSWD_, _DB_NAME_);
 $install->clearDatabase(false);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The `composer create-test-db` command is often used locally by developers but really lacked some output about what it was doing, especially when it failed This PR adds some log in this process to help developers debugging their environment when this script fails
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | <br>- Run `composer install`<br>- Run `make assets`<br>- Run install CLI command for example `php install-dev/index_cli.php --language=en --country=fr --db_server=127.0.0.1 --db_user=root --db_name=prestashop-install-log --db_create=1 --name="PrestaShop Install log"` (you should have a `-- Installation successful! --` at the end)<br>- Finally run `composer create-test-db` you should now see some log info explaining the process
| Possible impacts? | ~
 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

**Failing script**
<img width="894" alt="Capture d’écran 2022-11-28 à 14 09 39" src="https://user-images.githubusercontent.com/13801017/204286916-9fe3435c-993f-4e9c-bfb7-8d1645144f96.png">

**Successful script**
<img width="891" alt="Capture d’écran 2022-11-28 à 14 15 10" src="https://user-images.githubusercontent.com/13801017/204286946-e23235bc-c83b-4418-86e3-a2c20844d404.png">
