### PR TITLE
Add behat scenarios for combination generation and deletion in all shops

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/GenerateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/GenerateCombinationFeatureContext.php
@@ -46,7 +46,7 @@ class GenerateCombinationFeatureContext extends AbstractCombinationFeatureContex
      */
     public function generateCombinationsForDefaultShop(string $productReference, TableNode $table): void
     {
-        $this->generateCombinations($productReference, $table, $this->getDefaultShopId());
+        $this->generateCombinations($productReference, $table, ShopConstraint::shop($this->getDefaultShopId()));
     }
 
     /**
@@ -61,7 +61,22 @@ class GenerateCombinationFeatureContext extends AbstractCombinationFeatureContex
         $this->generateCombinations(
             $productReference,
             $table,
-            $this->getSharedStorage()->get($shopReference)
+            ShopConstraint::shop($this->getSharedStorage()->get($shopReference))
+        );
+    }
+
+    /**
+     * @When I generate combinations for product ":productReference" in all shops using following attributes:
+     *
+     * @param string $productReference
+     * @param TableNode $table
+     */
+    public function generateCombinationsForAllShops(string $productReference, TableNode $table): void
+    {
+        $this->generateCombinations(
+            $productReference,
+            $table,
+            ShopConstraint::allShops()
         );
     }
 
@@ -208,9 +223,9 @@ class GenerateCombinationFeatureContext extends AbstractCombinationFeatureContex
     /**
      * @param string $productReference
      * @param TableNode $table
-     * @param int $shopId
+     * @param ShopConstraint $shopConstraint
      */
-    private function generateCombinations(string $productReference, TableNode $table, int $shopId): void
+    private function generateCombinations(string $productReference, TableNode $table, ShopConstraint $shopConstraint): void
     {
         $tableData = $table->getRowsHash();
         $groupedAttributeIds = $this->parseGroupedAttributeIds($tableData);
@@ -219,8 +234,7 @@ class GenerateCombinationFeatureContext extends AbstractCombinationFeatureContex
             $this->getCommandBus()->handle(new GenerateProductCombinationsCommand(
                 $this->getSharedStorage()->get($productReference),
                 $groupedAttributeIds,
-                //@todo: not yet handled for all shops
-                ShopConstraint::shop($shopId)
+                $shopConstraint
             ));
         } catch (InvalidProductTypeException $e) {
             $this->setLastException($e);

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_multishop_combination.feature
@@ -36,7 +36,7 @@ Feature: Delete combination from Back Office (BO) in multiple shops
     And I generate combinations in shop "shop1" for product product1 using following attributes:
       | Size  | [S,M]              |
       | Color | [White,Black,Blue] |
-    Then product "product1" should have the following combinations for shops "shop1":
+    And product "product1" should have the following combinations for shops "shop1":
       | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
       | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
       | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
@@ -46,10 +46,10 @@ Feature: Delete combination from Back Office (BO) in multiple shops
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop1" should be "product1SWhite"
     And product "product1" should have no combinations for shops "shop2"
-    When I generate combinations in shop "shop2" for product product1 using following attributes:
+    And I generate combinations in shop "shop2" for product product1 using following attributes:
       | Size  | [S,M]              |
       | Color | [White,Black,Blue] |
-    Then product "product1" should have the following combinations for shops "shop2":
+    And product "product1" should have the following combinations for shops "shop2":
       | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
       | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
       | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
@@ -176,7 +176,7 @@ Feature: Delete combination from Back Office (BO) in multiple shops
     And product "product1" should not have a default combination for shop "shop1"
     And product "product1" should not have a default combination for shop "shop2"
 
-  Scenario: Delete bulk delete combinations from specified shop
+  Scenario: Bulk delete combinations from specified shop
     When I delete following combinations of product product1 from shop "shop1":
       | id reference   |
       | product1SWhite |
@@ -229,7 +229,7 @@ Feature: Delete combination from Back Office (BO) in multiple shops
     Then product "product1" should have no combinations for shops "shop2"
     And product "product1" should not have a default combination for shop "shop2"
 
-  Scenario: Remove all the combinations for a specific shop and generate the same combinations again for the same shop
+  Scenario: Delete all the combinations for a specific shop and generate the same combinations again for the same shop
     When I delete following combinations of product product1 from shop "shop1":
       | id reference   |
       | product1SWhite |
@@ -261,3 +261,29 @@ Feature: Delete combination from Back Office (BO) in multiple shops
       | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop2" should be "product1SWhite"
+
+  Scenario: Delete combination for all shops
+    When I delete combination "product1SBlack" from all shops
+    Then product "product1" should have the following combinations for shops "shop1,shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SWhite"
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"
+
+  Scenario: Bulk delete combinations for all shops
+    When I delete following combinations of product "product1" from all shops:
+      | id reference   |
+      | product1SWhite |
+      | product1MBlue  |
+    Then product "product1" should have the following combinations for shops "shop1,shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | true       |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SBlack"
+    And product "product1" default combination for shop "shop2" should be "product1SBlack"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/generate_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/generate_multishop_combination.feature
@@ -182,3 +182,41 @@ Feature: Generate combination from Back Office (BO) when using multi-shop featur
     And product "product1" should have the following combinations for shops "shop2":
       | combination id | combination name | reference | attributes | impact on price | quantity | is default |
       | product1S      | Size - S         |           | [Size:S]   | 0               | 0        | true       |
+
+  Scenario: Generate combinations in all shops
+    When I generate combinations for product "product1" in all shops using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    Then product "product1" should have the following combinations for shops "shop1,shop2":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SWhite"
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"
+
+  Scenario: Generate combinations in all shops when there is already existing combinations in one of shops
+    Given I generate combinations in shop "shop1" for product product1 using following attributes:
+      | Size | [S] |
+    And product "product1" should have the following combinations for shops "shop1":
+      | id reference | combination name | reference | attributes | impact on price | quantity | is default |
+      | product1S    | Size - S         |           | [Size:S]   | 0               | 0        | true       |
+    When I generate combinations for product "product1" in all shops using following attributes:
+      | Size  | [M]                |
+      | Color | [White,Black,Blue] |
+    Then product "product1" should have the following combinations for shops "shop1":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1S      | Size - S                |           | [Size:S]             | 0               | 0        | true       |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    Then product "product1" should have the following combinations for shops "shop2":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | true       |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1S"
+    And product "product1" default combination for shop "shop2" should be "product1MWhite"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/generate_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/generate_multishop_combination.feature
@@ -198,7 +198,7 @@ Feature: Generate combination from Back Office (BO) when using multi-shop featur
     And product "product1" default combination for shop "shop1" should be "product1SWhite"
     And product "product1" default combination for shop "shop2" should be "product1SWhite"
 
-  Scenario: Generate combinations in all shops when there is already existing combinations in one of shops
+  Scenario: Generate combinations in all shops when there is already existing different combinations in one of shops
     Given I generate combinations in shop "shop1" for product product1 using following attributes:
       | Size | [S] |
     And product "product1" should have the following combinations for shops "shop1":
@@ -214,9 +214,37 @@ Feature: Generate combination from Back Office (BO) when using multi-shop featur
       | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     Then product "product1" should have the following combinations for shops "shop2":
-      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
       | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | true       |
       | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop1" should be "product1S"
     And product "product1" default combination for shop "shop2" should be "product1MWhite"
+
+  Scenario: Generate combinations in all shops when there is already existing identical combinations in one of shops
+    Given I generate combinations in shop "shop1" for product "product1" using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    Then product "product1" should have the following combinations for shops "shop1":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" should have no combinations for shops "shop2"
+    And product "product1" should not have a default combination for shop "shop2"
+    When I generate combinations for product "product1" in all shops using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    Then product "product1" should have the following combinations for shops "shop1,shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SWhite"
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add couple behat test scenarios to support combination generation for all shops.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | part of https://github.com/PrestaShop/PrestaShop/issues/30304
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Only tests affected, so green build should be enough. :heavy_check_mark: 
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
