### PR TITLE
Unify brightness checks

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2234,12 +2234,22 @@ class ToolsCore
     }
 
     /**
+     * @deprecated since 8.1 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead
+     *
      * @param string $hex
      *
      * @return float|int|string
      */
     public static function getBrightness($hex)
     {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.1.0. use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         if (Tools::strtolower($hex) == 'transparent') {
             return '129';
         }
@@ -2257,8 +2267,19 @@ class ToolsCore
         return (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
     }
 
+    /**
+     * @deprecated since 8.1 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead
+     */
     public static function isBright($hex)
     {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.1.0. use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         if (null === self::$colorBrightnessCalculator) {
             self::$colorBrightnessCalculator = new ColorBrightnessCalculator();
         }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Number as NumberSpecification;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Price as PriceSpecification;
+use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class AdminControllerCore extends Controller
@@ -2031,7 +2032,7 @@ class AdminControllerCore extends Controller
             $this->context->smarty->assign([
                 'help_box' => Configuration::get('PS_HELPBOX'),
                 'round_mode' => Configuration::get('PS_PRICE_ROUND_MODE'),
-                'brightness' => Tools::getBrightness($bo_color) < 128 ? 'white' : '#383838',
+                'brightness' => (new ColorBrightnessCalculator())->isBright($bo_color) ? '#383838' : 'white',
                 'bo_width' => (int) $this->context->employee->bo_width,
                 'bo_color' => isset($this->context->employee->bo_color) ? Tools::htmlentitiesUTF8($this->context->employee->bo_color) : null,
                 'show_new_orders' => Configuration::get('PS_SHOW_NEW_ORDERS') && isset($accesses['AdminOrders']) && $accesses['AdminOrders']['view'],

--- a/src/Adapter/Presenter/Order/OrderLazyArray.php
+++ b/src/Adapter/Presenter/Order/OrderLazyArray.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Cart\CartPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Object\ObjectPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
+use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
 use PrestaShopBundle\Translation\TranslatorComponent;
 use PrestaShopException;
 use ProductDownload;
@@ -308,7 +309,7 @@ class OrderLazyArray extends AbstractLazyArray
             }
             $orderHistory[$historyId] = $history;
             $orderHistory[$historyId]['history_date'] = Tools::displayDate($history['date_add'], false);
-            $orderHistory[$historyId]['contrast'] = (Tools::getBrightness($history['color']) > 128) ? 'dark' : 'bright';
+            $orderHistory[$historyId]['contrast'] = (new ColorBrightnessCalculator())->isBright($history['color']) ? 'dark' : 'bright';
         }
 
         if (!isset($orderHistory['current'])) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes 
| Fixed ticket?     | None.
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      |QA by dev as too technical & complicated to create a reproducer
| Possible impacts? | n/a

We currently use `Tools::getBrightness()`only to check brightness in `AdminController` and to check if `$color` is bright or not. There is an inconsistency between the legacy method which returns `129` for 'transparent' hexadecimal code and the new method in the core that returns `130`, which can lead to weird behaviours.

This PR aims to remove `Tools::getBrightness()` usages and deprecate this function to fix this inconsistency.

```php
Tools::getBrightness('transparent'); // 129;
Tools::isBright('transparent'); // true
ColorBrightnessCalculator::calculate('transparent'):  // returns 130;
```

in adminController : 
`Tools::getBrightness($bo_color) < 128 ? 'white' : '#383838',` Should have been a `<=` but now refactored.

in OrderLazy..
`(Tools::getBrightness($history['color']) > 128) ? 'dark' : 'bright';` condition is wrong if `$history['color']` is `transparent`)



