### PR TITLE
Migrate `Tools::ps_round()` in non-legacy, introducing MathHelper

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
+use PrestaShop\PrestaShop\Core\Util\Number\Math;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -1784,22 +1785,12 @@ class ToolsCore
             $round_mode = Tools::$round_mode;
         }
 
-        switch ($round_mode) {
-            case PS_ROUND_UP:
-                return Tools::ceilf($value, $precision);
-            case PS_ROUND_DOWN:
-                return Tools::floorf($value, $precision);
-            case PS_ROUND_HALF_DOWN:
-            case PS_ROUND_HALF_EVEN:
-            case PS_ROUND_HALF_ODD:
-                return Tools::math_round($value, $precision, $round_mode);
-            case PS_ROUND_HALF_UP:
-            default:
-                return Tools::math_round($value, $precision, PS_ROUND_HALF_UP);
-        }
+        return Math::round($value, $precision, $round_mode);
     }
 
     /**
+     * @deprecated since 8.1 use PrestaShop\PrestaShop\Core\Util\Number\Math::math_round function instead
+     *
      * @param int|float $value
      * @param int|float $places
      * @param int<2,5> $mode (PS_ROUND_HALF_UP|PS_ROUND_HALF_DOWN|PS_ROUND_HALF_EVEN|PS_ROUND_HALF_ODD)
@@ -1808,63 +1799,12 @@ class ToolsCore
      */
     public static function math_round($value, $places, $mode = PS_ROUND_HALF_UP)
     {
-        //If PHP_ROUND_HALF_UP exist (PHP 5.3) use it and pass correct mode value (PrestaShop define - 1)
-        if (defined('PHP_ROUND_HALF_UP')) {
-            return round($value, $places, $mode - 1);
-        }
-
-        $precision_places = 14 - floor(log10(abs($value)));
-        $f1 = 10.0 ** (float) abs($places);
-
-        /* If the decimal precision guaranteed by FP arithmetic is higher than
-        * the requested places BUT is small enough to make sure a non-zero value
-        * is returned, pre-round the result to the precision */
-        if ($precision_places > $places && $precision_places - $places < 15) {
-            $f2 = 10.0 ** (float) abs($precision_places);
-
-            if ($precision_places >= 0) {
-                $tmp_value = $value * $f2;
-            } else {
-                $tmp_value = $value / $f2;
-            }
-
-            /* preround the result (tmp_value will always be something * 1e14,
-            * thus never larger than 1e15 here) */
-            $tmp_value = Tools::round_helper($tmp_value, $mode);
-            /* now correctly move the decimal point */
-            $f2 = 10.0 ** (float) abs($places - $precision_places);
-            /* because places < precision_places */
-            $tmp_value = $tmp_value / $f2;
-        } else {
-            /* adjust the value */
-            if ($places >= 0) {
-                $tmp_value = $value * $f1;
-            } else {
-                $tmp_value = $value / $f1;
-            }
-
-            /* This value is beyond our precision, so rounding it is pointless */
-            if (abs($tmp_value) >= 1e15) {
-                return $value;
-            }
-        }
-
-        /* round the temp value */
-        $tmp_value = Tools::round_helper($tmp_value, $mode);
-
-        /* see if it makes sense to use simple division to round the value */
-        if (abs($places) < 23) {
-            if ($places > 0) {
-                $tmp_value /= $f1;
-            } else {
-                $tmp_value *= $f1;
-            }
-        }
-
-        return $tmp_value;
+        return Math::math_round($value, $places, $mode);
     }
 
     /**
+     * @deprecated since 8.1. There is no replacement
+     *
      * @param float $value
      * @param int $mode
      *
@@ -1894,6 +1834,8 @@ class ToolsCore
     }
 
     /**
+     * @deprecated since 8.1 use PrestaShop\PrestaShop\Core\Util\Number\Math::ceilf function instead
+     *
      * Returns the rounded value up of $value to specified precision.
      *
      * @param float $value
@@ -1903,22 +1845,11 @@ class ToolsCore
      */
     public static function ceilf($value, $precision = 0)
     {
-        $precision_factor = $precision == 0 ? 1 : 10 ** $precision;
-        $tmp = $value * $precision_factor;
-        $tmp2 = (string) $tmp;
-        // If the current value has already the desired precision
-        if (strpos($tmp2, '.') === false) {
-            return $value;
-        }
-        if ($tmp2[strlen($tmp2) - 1] == 0) {
-            return $value;
-        }
-
-        return ceil($tmp) / $precision_factor;
+        return Math::ceilf($value, $precision);
     }
 
     /**
-     * Returns the rounded value down of $value to specified precision.
+     * @deprecated since 8.1 use PrestaShop\PrestaShop\Core\Util\Number\Math::floorf function instead
      *
      * @param float $value
      * @param int $precision
@@ -1927,18 +1858,7 @@ class ToolsCore
      */
     public static function floorf($value, $precision = 0)
     {
-        $precision_factor = $precision == 0 ? 1 : 10 ** $precision;
-        $tmp = $value * $precision_factor;
-        $tmp2 = (string) $tmp;
-        // If the current value has already the desired precision
-        if (strpos($tmp2, '.') === false) {
-            return $value;
-        }
-        if ($tmp2[strlen($tmp2) - 1] == 0) {
-            return $value;
-        }
-
-        return floor($tmp) / $precision_factor;
+        return Math::floorf($value, $precision);
     }
 
     /**

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -51,10 +51,10 @@ use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\Cust
 use PrestaShop\PrestaShop\Core\Domain\Cart\QueryResult\CartForOrderCreation\CustomizationFieldData;
 use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
+use PrestaShop\PrestaShop\Core\Util\Number\MathHelper;
 use PrestaShopException;
 use Product;
 use Shop;
-use Tools;
 
 /**
  * Handles GetCartForOrderCreation query using legacy object models
@@ -87,24 +87,32 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
     private $defaultCarrierId;
 
     /**
+     * @var MathHelper
+     */
+    private $mathHelper;
+
+    /**
      * @param LocaleInterface $locale
      * @param int $contextLangId
      * @param Link $contextLink
      * @param ContextStateManager $contextStateManager
      * @param int $defaultCarrierId
+     * @param MathHelper $mathHelper
      */
     public function __construct(
         LocaleInterface $locale,
         int $contextLangId,
         Link $contextLink,
         ContextStateManager $contextStateManager,
-        int $defaultCarrierId
+        int $defaultCarrierId,
+        MathHelper $mathHelper
     ) {
         $this->locale = $locale;
         $this->contextLangId = $contextLangId;
         $this->contextLink = $contextLink;
         $this->contextStateManager = $contextStateManager;
         $this->defaultCarrierId = $defaultCarrierId;
+        $this->mathHelper = $mathHelper;
     }
 
     /**
@@ -544,9 +552,9 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
             $product['name'],
             isset($product['attributes_small']) ? $product['attributes_small'] : '',
             $product['reference'],
-            (string) Tools::ps_round($product['price'], $currency->precision),
+            (string) $this->mathHelper->round($product['price'], $currency->precision),
             $product['quantity'],
-            (string) Tools::ps_round($product['total'], $currency->precision),
+            (string) $this->mathHelper->round($product['total'], $currency->precision),
             $this->contextLink->getImageLink($product['link_rewrite'], $product['id_image'], 'small_default'),
             $this->getProductCustomizedData($cart, $product),
             Product::getQuantity(

--- a/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
+++ b/src/Adapter/MailTemplate/MailPreviewVariablesBuilder.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Employee\ContextEmployeeProviderInterface;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\MailTemplate\Layout\LayoutInterface;
+use PrestaShop\PrestaShop\Core\Util\Number\MathHelper;
 use Product;
 use Symfony\Component\Translation\TranslatorInterface;
 use Tools;
@@ -80,6 +81,11 @@ final class MailPreviewVariablesBuilder
     private $translator;
 
     /**
+     * @var MathHelper
+     */
+    private $mathHelper;
+
+    /**
      * MailPreviewVariablesBuilder constructor.
      *
      * @param ConfigurationInterface $configuration
@@ -88,6 +94,7 @@ final class MailPreviewVariablesBuilder
      * @param MailPartialTemplateRenderer $mailPartialTemplateRenderer
      * @param Locale $locale
      * @param TranslatorInterface $translatorComponent
+     * @param MathHelper $mathHelper
      */
     public function __construct(
         ConfigurationInterface $configuration,
@@ -95,7 +102,8 @@ final class MailPreviewVariablesBuilder
         ContextEmployeeProviderInterface $employeeProvider,
         MailPartialTemplateRenderer $mailPartialTemplateRenderer,
         Locale $locale,
-        TranslatorInterface $translatorComponent
+        TranslatorInterface $translatorComponent,
+        MathHelper $mathHelper
     ) {
         $this->configuration = $configuration;
         $this->legacyContext = $legacyContext;
@@ -104,6 +112,7 @@ final class MailPreviewVariablesBuilder
         $this->mailPartialTemplateRenderer = $mailPartialTemplateRenderer;
         $this->locale = $locale;
         $this->translator = $translatorComponent;
+        $this->mathHelper = $mathHelper;
     }
 
     /**
@@ -358,7 +367,7 @@ final class MailPreviewVariablesBuilder
             $price = Product::getPriceStatic((int) $product['id_product'], false, ($product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null), 6, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{$this->configuration->get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
             $priceWithTax = Product::getPriceStatic((int) $product['id_product'], true, ($product['id_product_attribute'] ? (int) $product['id_product_attribute'] : null), 2, null, false, true, $product['cart_quantity'], false, (int) $order->id_customer, (int) $order->id_cart, (int) $order->{$this->configuration->get('PS_TAX_ADDRESS_TYPE')}, $specific_price, true, true, null, true, $product['id_customization']);
 
-            $productPrice = Product::getTaxCalculationMethod() == PS_TAX_EXC ? Tools::ps_round($price, 2) : $priceWithTax;
+            $productPrice = Product::getTaxCalculationMethod() == PS_TAX_EXC ? $this->mathHelper->round($price, 2) : $priceWithTax;
 
             $productTemplate = [
                 'id_product' => $product['id_product'],

--- a/src/Adapter/Order/OrderDetailUpdater.php
+++ b/src/Adapter/Order/OrderDetailUpdater.php
@@ -42,11 +42,11 @@ use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
+use PrestaShop\PrestaShop\Core\Util\Number\MathHelper;
 use Product;
 use Shop;
 use TaxCalculator;
 use TaxManagerFactory;
-use Tools;
 
 class OrderDetailUpdater
 {
@@ -63,15 +63,23 @@ class OrderDetailUpdater
     private $shopConfiguration;
 
     /**
+     * @var MathHelper
+     */
+    private $mathHelper;
+
+    /**
      * @param ContextStateManager $contextStateManager
      * @param ShopConfigurationInterface $shopConfiguration
+     * @param MathHelper $mathHelper
      */
     public function __construct(
         ContextStateManager $contextStateManager,
-        ShopConfigurationInterface $shopConfiguration
+        ShopConfigurationInterface $shopConfiguration,
+        MathHelper $mathHelper
     ) {
         $this->contextStateManager = $contextStateManager;
         $this->shopConfiguration = $shopConfiguration;
+        $this->mathHelper = $mathHelper;
     }
 
     /**
@@ -177,13 +185,13 @@ class OrderDetailUpdater
                     foreach ($taxesAmount as $taxId => $amount) {
                         switch ($roundType) {
                             case Order::ROUND_ITEM:
-                                $unitAmount = (float) Tools::ps_round($amount, $computingPrecision);
+                                $unitAmount = $this->mathHelper->round($amount, $computingPrecision);
                                 $totalAmount = $unitAmount * $orderDetail->product_quantity;
 
                                 break;
                             case Order::ROUND_LINE:
                                 $unitAmount = $amount;
-                                $totalAmount = Tools::ps_round($unitAmount * $orderDetail->product_quantity, $computingPrecision);
+                                $totalAmount = $this->mathHelper->round($unitAmount * $orderDetail->product_quantity, $computingPrecision);
 
                                 break;
                             case Order::ROUND_TOTAL:
@@ -274,15 +282,15 @@ class OrderDetailUpdater
 
                 break;
             case Order::ROUND_LINE:
-                $orderDetail->total_price_tax_excl = Tools::ps_round($floatPriceTaxExcluded * $orderDetail->product_quantity, $computingPrecision);
-                $orderDetail->total_price_tax_incl = Tools::ps_round($floatPriceTaxIncluded * $orderDetail->product_quantity, $computingPrecision);
+                $orderDetail->total_price_tax_excl = $this->mathHelper->round($floatPriceTaxExcluded * $orderDetail->product_quantity, $computingPrecision);
+                $orderDetail->total_price_tax_incl = $this->mathHelper->round($floatPriceTaxIncluded * $orderDetail->product_quantity, $computingPrecision);
 
                 break;
 
             case Order::ROUND_ITEM:
             default:
-                $orderDetail->product_price = $orderDetail->unit_price_tax_excl = Tools::ps_round($floatPriceTaxExcluded, $computingPrecision);
-                $orderDetail->unit_price_tax_incl = Tools::ps_round($floatPriceTaxIncluded, $computingPrecision);
+                $orderDetail->product_price = $orderDetail->unit_price_tax_excl = $this->mathHelper->round($floatPriceTaxExcluded, $computingPrecision);
+                $orderDetail->unit_price_tax_incl = $this->mathHelper->round($floatPriceTaxIncluded, $computingPrecision);
                 $orderDetail->total_price_tax_excl = $orderDetail->unit_price_tax_excl * $orderDetail->product_quantity;
                 $orderDetail->total_price_tax_incl = $orderDetail->unit_price_tax_incl * $orderDetail->product_quantity;
 

--- a/src/Adapter/Order/Refund/OrderRefundCalculator.php
+++ b/src/Adapter/Order/Refund/OrderRefundCalculator.php
@@ -38,9 +38,9 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidCancelProductExcept
 use PrestaShop\PrestaShop\Core\Domain\Order\ValueObject\OrderDetailRefund;
 use PrestaShop\PrestaShop\Core\Domain\Order\VoucherRefundType;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
+use PrestaShop\PrestaShop\Core\Util\Number\MathHelper;
 use PrestaShopDatabaseException;
 use PrestaShopException;
-use Tools;
 
 /**
  * Performs all computation for a refund on an Order, returns a OrderRefundDetail
@@ -48,6 +48,16 @@ use Tools;
  */
 class OrderRefundCalculator
 {
+    /**
+     * @var MathHelper
+     */
+    private $mathHelper;
+
+    public function __construct(MathHelper $mathHelper)
+    {
+        $this->mathHelper = $mathHelper;
+    }
+
     /**
      * @param Order $order
      * @param array $orderDetailRefunds
@@ -211,11 +221,11 @@ class OrderRefundCalculator
 
             // Add data for OrderDetail updates, it's important to round because too many decimals will fail in Validate::isPrice
             if ($isTaxIncluded) {
-                $productRefunds[$orderDetailId]['total_refunded_tax_incl'] = Tools::ps_round($productRefundAmount, $precision);
-                $productRefunds[$orderDetailId]['total_refunded_tax_excl'] = Tools::ps_round($taxCalculator->removeTaxes($productRefundAmount), $precision);
+                $productRefunds[$orderDetailId]['total_refunded_tax_incl'] = $this->mathHelper->round($productRefundAmount, $precision);
+                $productRefunds[$orderDetailId]['total_refunded_tax_excl'] = $this->mathHelper->round($taxCalculator->removeTaxes($productRefundAmount), $precision);
             } else {
-                $productRefunds[$orderDetailId]['total_refunded_tax_excl'] = Tools::ps_round($productRefundAmount, $precision);
-                $productRefunds[$orderDetailId]['total_refunded_tax_incl'] = Tools::ps_round($taxCalculator->addTaxes($productRefundAmount), $precision);
+                $productRefunds[$orderDetailId]['total_refunded_tax_excl'] = $this->mathHelper->round($productRefundAmount, $precision);
+                $productRefunds[$orderDetailId]['total_refunded_tax_incl'] = $this->mathHelper->round($taxCalculator->addTaxes($productRefundAmount), $precision);
             }
 
             // Add missing fields

--- a/src/Adapter/Product/AdminProductWrapper.php
+++ b/src/Adapter/Product/AdminProductWrapper.php
@@ -41,6 +41,7 @@ use ObjectModel;
 use PrestaShop\PrestaShop\Adapter\Entity\Customization;
 use PrestaShop\PrestaShop\Core\Foundation\Database\EntityNotFoundException;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
+use PrestaShop\PrestaShop\Core\Util\Number\MathHelper;
 use PrestaShopBundle\Form\Admin\Type\CustomMoneyType;
 use PrestaShopBundle\Utils\FloatParser;
 use Product;
@@ -84,6 +85,10 @@ class AdminProductWrapper
      * @var FloatParser
      */
     private $floatParser;
+    /**
+     * @var MathHelper
+     */
+    private $mathHelper;
 
     /**
      * Constructor : Inject Symfony\Component\Translation Translator.
@@ -93,12 +98,18 @@ class AdminProductWrapper
      * @param Locale $locale
      * @param FloatParser|null $floatParser
      */
-    public function __construct($translator, array $employeeAssociatedShops, Locale $locale, FloatParser $floatParser = null)
-    {
+    public function __construct(
+        $translator,
+        array $employeeAssociatedShops,
+        Locale $locale,
+        MathHelper $mathHelper,
+        FloatParser $floatParser = null
+    ) {
         $this->translator = $translator;
         $this->employeeAssociatedShops = $employeeAssociatedShops;
         $this->locale = $locale;
         $this->floatParser = $floatParser ?? new FloatParser();
+        $this->mathHelper = $mathHelper;
     }
 
     /**
@@ -148,7 +159,7 @@ class AdminProductWrapper
             $combinationValues['attribute_ecotax'] = 0;
         } else {
             // Value is displayed tax included but must be saved tax excluded
-            $combinationValues['attribute_ecotax'] = Tools::ps_round(
+            $combinationValues['attribute_ecotax'] = $this->mathHelper->round(
                 $combinationValues['attribute_ecotax'] / (1 + Tax::getProductEcotaxRate() / 100),
                 $computingPrecision
             );
@@ -503,8 +514,8 @@ class AdminProductWrapper
                         $can_delete_specific_prices = (count($this->employeeAssociatedShops) > 1 && !$specific_price['id_shop']) || $specific_price['id_shop'];
                     }
 
-                    $price = Tools::ps_round($specific_price['price'], 2);
-                    $fixed_price = (($price == Tools::ps_round($product->price, 2) && $current_specific_currency['id_currency'] == $defaultCurrency->id) || $specific_price['price'] == -1) ? '--' : $this->locale->formatPrice($price, $current_specific_currency['iso_code']);
+                    $price = $this->mathHelper->round($specific_price['price'], 2);
+                    $fixed_price = (($price == $this->mathHelper->round($product->price, 2) && $current_specific_currency['id_currency'] == $defaultCurrency->id) || $specific_price['price'] == -1) ? '--' : $this->locale->formatPrice($price, $current_specific_currency['iso_code']);
 
                     $content[] = [
                         'id_specific_price' => $specific_price['id_specific_price'],

--- a/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
+++ b/src/Adapter/Product/QueryHandler/SearchProductsHandler.php
@@ -35,7 +35,6 @@ use Order;
 use PrestaShop\PrestaShop\Adapter\ContextStateManager;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
 use PrestaShop\PrestaShop\Adapter\Order\AbstractOrderHandler;
-use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryHandler\SearchProductsHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\FoundProduct;
@@ -43,6 +42,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCombination;
 use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductCustomizationField;
 use PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision;
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
+use PrestaShop\PrestaShop\Core\Util\Number\MathHelper;
 use Product;
 use Shop;
 
@@ -72,29 +72,29 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
     private $currencyDataProvider;
 
     /**
-     * @var Tools
+     * @var MathHelper
      */
-    private $tools;
+    private $mathHelper;
 
     /**
      * @param int $contextLangId
      * @param LocaleInterface $contextLocale
-     * @param Tools $tools
      * @param CurrencyDataProvider $currencyDataProvider
      * @param ContextStateManager $contextStateManager
+     * @param MathHelper $mathHelper
      */
     public function __construct(
         int $contextLangId,
         LocaleInterface $contextLocale,
-        Tools $tools,
         CurrencyDataProvider $currencyDataProvider,
-        ContextStateManager $contextStateManager
+        ContextStateManager $contextStateManager,
+        MathHelper $mathHelper
     ) {
         $this->contextLangId = $contextLangId;
         $this->contextLocale = $contextLocale;
         $this->currencyDataProvider = $currencyDataProvider;
-        $this->tools = $tools;
         $this->contextStateManager = $contextStateManager;
+        $this->mathHelper = $mathHelper;
     }
 
     /**
@@ -193,8 +193,8 @@ final class SearchProductsHandler extends AbstractOrderHandler implements Search
             $product->id,
             $product->name[$this->contextLangId],
             $this->contextLocale->formatPrice($priceTaxExcluded, $isoCodeCurrency),
-            $this->tools->round($priceTaxIncluded, $computingPrecision),
-            $this->tools->round($priceTaxExcluded, $computingPrecision),
+            $this->mathHelper->round($priceTaxIncluded, $computingPrecision),
+            $this->mathHelper->round($priceTaxExcluded, $computingPrecision),
             $product->getTaxesRate($address),
             Product::getQuantity($product->id),
             $product->location,

--- a/src/Core/Util/Number/Math.php
+++ b/src/Core/Util/Number/Math.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Util\Number;
+
+class Math
+{
+    public const PS_ROUND_UP = 0;
+    public const PS_ROUND_DOWN = 1;
+    public const PS_ROUND_HALF_UP = 2;
+    public const PS_ROUND_HALF_DOWN = 3;
+    public const PS_ROUND_HALF_EVEN = 4;
+    public const PS_ROUND_HALF_ODD = 5;
+
+    /**
+     * returns the rounded value of $value to specified precision, according to your configuration;.
+     *
+     * @param float $value
+     * @param int $precision
+     * @param int $round_mode
+     *
+     * @return float
+     */
+    public static function round(float $value, int $precision, int $round_mode): float
+    {
+        switch ($round_mode) {
+            case self::PS_ROUND_UP:
+                return self::ceilf($value, $precision);
+            case self::PS_ROUND_DOWN:
+                return self::floorf($value, $precision);
+            case self::PS_ROUND_HALF_DOWN:
+            case self::PS_ROUND_HALF_EVEN:
+            case self::PS_ROUND_HALF_ODD:
+                return self::math_round($value, $precision, $round_mode);
+            case self::PS_ROUND_HALF_UP:
+            default:
+                return self::math_round($value, $precision);
+        }
+    }
+
+    /**
+     * @param int|float $value
+     * @param int|float $places
+     * @param int<2,5> $mode (PS_ROUND_HALF_UP|PS_ROUND_HALF_DOWN|PS_ROUND_HALF_EVEN|PS_ROUND_HALF_ODD)
+     *
+     * @return false|float
+     */
+    public static function math_round($value, $places, $mode = PS_ROUND_HALF_UP)
+    {
+        return round($value, $places, $mode - 1);
+    }
+
+    /**
+     * Returns the rounded value up of $value to specified precision.
+     *
+     * @param float $value
+     * @param int $precision
+     *
+     * @return float
+     */
+    public static function ceilf($value, $precision = 0)
+    {
+        $precision_factor = $precision == 0 ? 1 : 10 ** $precision;
+        $tmp = $value * $precision_factor;
+        $tmp2 = (string) $tmp;
+        // If the current value has already the desired precision
+        if (strpos($tmp2, '.') === false) {
+            return $value;
+        }
+        if ($tmp2[strlen($tmp2) - 1] == 0) {
+            return $value;
+        }
+
+        return ceil($tmp) / $precision_factor;
+    }
+
+    /**
+     * Returns the rounded value down of $value to specified precision.
+     *
+     * @param float $value
+     * @param int $precision
+     *
+     * @return float
+     */
+    public static function floorf($value, $precision = 0)
+    {
+        $precision_factor = $precision == 0 ? 1 : 10 ** $precision;
+        $tmp = $value * $precision_factor;
+        $tmp2 = (string) $tmp;
+        // If the current value has already the desired precision
+        if (strpos($tmp2, '.') === false) {
+            return $value;
+        }
+        if ($tmp2[strlen($tmp2) - 1] == 0) {
+            return $value;
+        }
+
+        return floor($tmp) / $precision_factor;
+    }
+}

--- a/src/Core/Util/Number/MathHelper.php
+++ b/src/Core/Util/Number/MathHelper.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Util\Number;
+
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+
+class MathHelper
+{
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
+     * @var int|null
+     */
+    private $defaultRoundMode = null;
+
+    public function __construct(ConfigurationInterface $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function round(float $value, int $precision = 0, ?int $roundMode = null): float
+    {
+        if (null === $roundMode) {
+            if (null === $this->defaultRoundMode) {
+                $this->defaultRoundMode = (int) $this->configuration->get('PS_PRICE_ROUND_MODE');
+            }
+
+            return Math::round($value, $precision, $this->defaultRoundMode);
+        }
+
+        return Math::round($value, $precision, $roundMode);
+    }
+}

--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Adapter\Tax\TaxRuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Adapter\Warehouse\WarehouseDataProvider;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
+use PrestaShop\PrestaShop\Core\Util\Number\MathHelper;
 use PrestaShopBundle\Utils\FloatParser;
 use Product;
 use ProductDownload;
@@ -168,6 +169,10 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
      * @var array
      */
     private $formData;
+    /**
+     * @var MathHelper|null
+     */
+    private $mathHelper;
 
     /**
      * Constructor
@@ -184,6 +189,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
      * @param ShopContext $shopContext
      * @param TaxRuleDataProvider $taxRuleDataProvider
      * @param Router $router
+     * @param MathHelper $mathHelper
      * @param FloatParser|null $floatParser
      */
     public function __construct(
@@ -198,6 +204,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         ShopContext $shopContext,
         TaxRuleDataProvider $taxRuleDataProvider,
         Router $router,
+        MathHelper $mathHelper,
         FloatParser $floatParser = null
     ) {
         $this->context = $legacyContext;
@@ -213,6 +220,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         $this->shopContext = $shopContext;
         $this->taxRuleDataProvider = $taxRuleDataProvider;
         $this->router = $router;
+        $this->mathHelper = $mathHelper;
         $this->floatParser = $floatParser ?? new FloatParser();
     }
 
@@ -572,7 +580,7 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
         // ecotax is stored with tax included but form uses the tax excluded value
         // using a precision of 6 digits as `AdminProductsController::_removeTaxFromEcotax()`
         // which does the opposite uses 6 digits too
-        $ecotax = $this->tools->round(
+        $ecotax = $this->mathHelper->round(
             $product->ecotax * (1 + $this->taxRuleDataProvider->getProductEcotaxRate() / 100),
             6
         );

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cart.yml
@@ -110,6 +110,7 @@ services:
       - '@=service("prestashop.adapter.legacy.context").getContext().link'
       - '@prestashop.adapter.context_state_manager'
       - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_CARRIER_DEFAULT")'
+      - '@PrestaShop\PrestaShop\Core\Util\Number\MathHelper'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForOrderCreation'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/mail_template.yml
@@ -31,3 +31,4 @@ services:
       - "@prestashop.adapter.mail_template.partial_template_renderer"
       - "@prestashop.core.localization.locale.context_locale"
       - "@translator"
+      - '@PrestaShop\PrestaShop\Core\Util\Number\MathHelper'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order.yml
@@ -26,6 +26,7 @@ services:
       - '@prestashop.adapter.order.amount.updater'
       - '@prestashop.adapter.order.product_quantity.updater'
       - '@prestashop.adapter.order.order_detail.updater'
+      - '@PrestaShop\PrestaShop\Core\Util\Number\MathHelper'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\AddProductToOrderCommand
@@ -159,12 +160,14 @@ services:
 
   prestashop.adapter.order.refund.order_refund_calculator:
     class: PrestaShop\PrestaShop\Adapter\Order\Refund\OrderRefundCalculator
+    autowire: true
 
   prestashop.adapter.order.refund.order_slip_creator:
     class: PrestaShop\PrestaShop\Adapter\Order\Refund\OrderSlipCreator
     arguments:
       - '@prestashop.adapter.legacy.configuration'
       - '@translator'
+      - '@PrestaShop\PrestaShop\Core\Util\Number\MathHelper'
 
   prestashop.adapter.order.refund.voucher_generator:
     class: PrestaShop\PrestaShop\Adapter\Order\Refund\VoucherGenerator
@@ -264,6 +267,7 @@ services:
       - '@prestashop.adapter.context_state_manager'
       - '@prestashop.adapter.order.order_detail.updater'
       - '@prestashop.adapter.order.product.remover'
+      - '@PrestaShop\PrestaShop\Core\Util\Number\MathHelper'
 
   prestashop.adapter.order.product_quantity.updater:
     class: PrestaShop\PrestaShop\Adapter\Order\OrderProductQuantityUpdater
@@ -277,6 +281,7 @@ services:
     arguments:
       - '@prestashop.adapter.context_state_manager'
       - '@prestashop.adapter.legacy.configuration'
+      - '@PrestaShop\PrestaShop\Core\Util\Number\MathHelper'
 
   prestashop.adapter.order.command_handler.set_internal_order_note_handler:
     class: PrestaShop\PrestaShop\Adapter\Order\CommandHandler\SetInternalOrderNoteHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -28,6 +28,7 @@ services:
       - "@translator"
       - "@=service('prestashop.adapter.legacy.context').getContext().employee.getAssociatedShops()"
       - "@prestashop.core.localization.locale.context_locale"
+      - '@PrestaShop\PrestaShop\Core\Util\Number\MathHelper'
       - "@prestashop.utils.float_parser"
 
   prestashop.adapter.admin.controller.attribute_generator:
@@ -58,9 +59,9 @@ services:
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext().language.id'
       - '@prestashop.core.localization.locale.context_locale'
-      - '@prestashop.adapter.tools'
       - '@prestashop.adapter.data_provider.currency'
       - '@prestashop.adapter.context_state_manager'
+      - '@PrestaShop\PrestaShop\Core\Util\Number\MathHelper'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProducts

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -99,6 +99,7 @@ services:
       - "@prestashop.adapter.data_provider.tax"
       - "@router"
       - "@prestashop.utils.float_parser"
+      - '@PrestaShop\PrestaShop\Core\Util\Number\MathHelper'
 
   prestashop.adapter.translation_route_finder:
     class: PrestaShop\PrestaShop\Adapter\Translations\TranslationRouteFinder

--- a/src/PrestaShopBundle/Resources/config/services/core/util/number.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/util/number.yml
@@ -6,3 +6,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Util\Number\NumberExtractor'
     arguments:
       - '@property_accessor'
+
+  PrestaShop\PrestaShop\Core\Util\Number\MathHelper:
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'

--- a/tests/Integration/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
+++ b/tests/Integration/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
@@ -26,6 +26,7 @@
 
 namespace Tests\Integration\PrestaShopBundle\Model\Product;
 
+use PrestaShop\PrestaShop\Core\Util\Number\MathHelper;
 use PrestaShopBundle\Model\Product\AdminModelAdapter;
 use Product;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -188,6 +189,7 @@ class AdminModelAdapterTest extends KernelTestCase
             self::$kernel->getContainer()->get('prestashop.adapter.shop.context'),
             self::$kernel->getContainer()->get('prestashop.adapter.data_provider.tax'),
             self::$kernel->getContainer()->get('router'),
+            self::$kernel->getContainer()->get(MathHelper::class),
             self::$kernel->getContainer()->get('prestashop.utils.float_parser')
         );
     }

--- a/tests/Unit/Core/Util/Number/MathHelperTest.php
+++ b/tests/Unit/Core/Util/Number/MathHelperTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Core\Util\Number;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Util\Number\Math;
+use PrestaShop\PrestaShop\Core\Util\Number\MathHelper;
+
+class MathHelperTest extends TestCase
+{
+    /**
+     * @dataProvider getRoundProvider
+     */
+    public function testRound(float $expectedResult, float $value, int $precision, int $mode): void
+    {
+        $mathHelper = new MathHelper(
+            $configurationMock = $this->createMock(ConfigurationInterface::class)
+        );
+
+        $configurationMock->expects($this->once())
+            ->method('get')
+            ->with('PS_PRICE_ROUND_MODE')
+            ->willReturn($mode)
+        ;
+
+        $this->assertSame($expectedResult, $mathHelper->round($value, $precision));
+    }
+
+    /**
+     * @dataProvider getRoundProvider
+     */
+    public function testRoundWithModeAsThirdArgument(float $expectedResult, float $value, int $precision, int $mode): void
+    {
+        $mathHelper = new MathHelper(
+            $configurationMock = $this->createMock(ConfigurationInterface::class)
+        );
+
+        // we should never call the configuration if the mode is set
+        $configurationMock->expects($this->never())
+            ->method('get')
+        ;
+
+        $this->assertSame($expectedResult, $mathHelper->round($value, $precision, $mode));
+    }
+
+    public function getRoundProvider(): array
+    {
+        return [
+            // 0 precision
+            [26, 25.32, 0, Math::PS_ROUND_UP],
+            [26, 25.52, 0, Math::PS_ROUND_UP],
+            [25, 25.32, 0, Math::PS_ROUND_HALF_DOWN],
+            [25, 25.50, 0, Math::PS_ROUND_HALF_DOWN],
+            [25, 25.32, 0, Math::PS_ROUND_HALF_EVEN],
+            [26, 25.50, 0, Math::PS_ROUND_HALF_EVEN],
+            [25, 25.32, 0, Math::PS_ROUND_HALF_ODD],
+            [25, 25.50, 0, Math::PS_ROUND_HALF_ODD],
+            [26, 25.51, 0, Math::PS_ROUND_HALF_ODD],
+            [25, 25.49, 0, Math::PS_ROUND_HALF_ODD],
+            // 2 precision
+            [25.33, 25.321, 2, Math::PS_ROUND_UP],
+            [25.53, 25.525, 2, Math::PS_ROUND_UP],
+            [25.32, 25.325, 2, Math::PS_ROUND_HALF_DOWN],
+            [25.5, 25.505, 2, Math::PS_ROUND_HALF_DOWN],
+            [25.32, 25.325, 2, Math::PS_ROUND_HALF_EVEN],
+            [25.5, 25.505, 2, Math::PS_ROUND_HALF_EVEN],
+            [25.33, 25.325, 2, Math::PS_ROUND_HALF_ODD],
+            [25.51, 25.505, 2, Math::PS_ROUND_HALF_ODD],
+            [25.51, 25.515, 2, Math::PS_ROUND_HALF_ODD],
+            [25.49, 25.495, 2, Math::PS_ROUND_HALF_ODD],
+
+            // floor
+            [25, 25.32, 0, Math::PS_ROUND_HALF_DOWN],
+            [25.3, 25.32, 1, Math::PS_ROUND_HALF_DOWN],
+            [25.32, 25.32, 2, Math::PS_ROUND_HALF_DOWN],
+
+            // up
+            [26, 25.32, 0, Math::PS_ROUND_UP],
+            [25.4, 25.32, 1, Math::PS_ROUND_UP],
+            [25.32, 25.32, 2, Math::PS_ROUND_UP],
+            [25.33, 25.325, 2, Math::PS_ROUND_UP],
+        ];
+    }
+}

--- a/tests/Unit/Core/Util/Number/MathTest.php
+++ b/tests/Unit/Core/Util/Number/MathTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Unit\Core\Util\Number;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Util\Number\Math;
+
+class MathTest extends TestCase
+{
+    /**
+     * @dataProvider providerPsRoundHelper
+     */
+    public function testRound(float $expectedResult, float $value, int $precision, int $mode): void
+    {
+        $this->assertSame($expectedResult, Math::round($value, $precision, $mode));
+    }
+
+    public function providerPsRoundHelper(): array
+    {
+        return [
+            // 0 precision
+            [26, 25.32, 0, Math::PS_ROUND_UP],
+            [26, 25.52, 0, Math::PS_ROUND_UP],
+            [25, 25.32, 0, Math::PS_ROUND_HALF_DOWN],
+            [25, 25.50, 0, Math::PS_ROUND_HALF_DOWN],
+            [25, 25.32, 0, Math::PS_ROUND_HALF_EVEN],
+            [26, 25.50, 0, Math::PS_ROUND_HALF_EVEN],
+            [25, 25.32, 0, Math::PS_ROUND_HALF_ODD],
+            [25, 25.50, 0, Math::PS_ROUND_HALF_ODD],
+            [26, 25.51, 0, Math::PS_ROUND_HALF_ODD],
+            [25, 25.49, 0, Math::PS_ROUND_HALF_ODD],
+            // 2 precision
+            [25.33, 25.321, 2, Math::PS_ROUND_UP],
+            [25.53, 25.525, 2, Math::PS_ROUND_UP],
+            [25.32, 25.325, 2, Math::PS_ROUND_HALF_DOWN],
+            [25.5, 25.505, 2, Math::PS_ROUND_HALF_DOWN],
+            [25.32, 25.325, 2, Math::PS_ROUND_HALF_EVEN],
+            [25.5, 25.505, 2, Math::PS_ROUND_HALF_EVEN],
+            [25.33, 25.325, 2, Math::PS_ROUND_HALF_ODD],
+            [25.51, 25.505, 2, Math::PS_ROUND_HALF_ODD],
+            [25.51, 25.515, 2, Math::PS_ROUND_HALF_ODD],
+            [25.49, 25.495, 2, Math::PS_ROUND_HALF_ODD],
+
+            // floor
+            [25, 25.32, 0, Math::PS_ROUND_HALF_DOWN],
+            [25.3, 25.32, 1, Math::PS_ROUND_HALF_DOWN],
+            [25.32, 25.32, 2, Math::PS_ROUND_HALF_DOWN],
+
+            // up
+            [26, 25.32, 0, Math::PS_ROUND_UP],
+            [25.4, 25.32, 1, Math::PS_ROUND_UP],
+            [25.32, 25.32, 2, Math::PS_ROUND_UP],
+            [25.33, 25.325, 2, Math::PS_ROUND_UP],
+        ];
+    }
+
+    public function providerMathRound(): array
+    {
+        return [
+            // 0 precision
+            [25, 25.32, 0, Math::PS_ROUND_UP],
+            [26, 25.52, 0, Math::PS_ROUND_UP],
+            [25, 25.32, 0, Math::PS_ROUND_HALF_DOWN],
+            [25, 25.50, 0, Math::PS_ROUND_HALF_DOWN],
+            [25, 25.32, 0, Math::PS_ROUND_HALF_EVEN],
+            [26, 25.50, 0, Math::PS_ROUND_HALF_EVEN],
+            [25, 25.32, 0, Math::PS_ROUND_HALF_ODD],
+            [25, 25.50, 0, Math::PS_ROUND_HALF_ODD],
+            [26, 25.51, 0, Math::PS_ROUND_HALF_ODD],
+            [25, 25.49, 0, Math::PS_ROUND_HALF_ODD],
+            // 2 precision
+            [25.32, 25.321, 2, Math::PS_ROUND_UP],
+            [25.53, 25.525, 2, Math::PS_ROUND_UP],
+            [25.32, 25.325, 2, Math::PS_ROUND_HALF_DOWN],
+            [25.5, 25.505, 2, Math::PS_ROUND_HALF_DOWN],
+            [25.32, 25.325, 2, Math::PS_ROUND_HALF_EVEN],
+            [25.5, 25.505, 2, Math::PS_ROUND_HALF_EVEN],
+            [25.33, 25.325, 2, Math::PS_ROUND_HALF_ODD],
+            [25.51, 25.505, 2, Math::PS_ROUND_HALF_ODD],
+            [25.51, 25.515, 2, Math::PS_ROUND_HALF_ODD],
+            [25.49, 25.495, 2, Math::PS_ROUND_HALF_ODD],
+        ];
+    }
+
+    /**
+     * @dataProvider providerMathRound
+     */
+    public function testMathRound(float $expectedResult, float $value, int $precision, int $mode): void
+    {
+        $this->assertSame($expectedResult, Math::math_round($value, $precision, $mode));
+    }
+
+    public function providerFloorF(): array
+    {
+        return [
+            [25, 25.32, 0],
+            [25.3, 25.32, 1],
+            [25.32, 25.32, 2],
+        ];
+    }
+
+    /**
+     * @dataProvider providerFloorF
+     */
+    public function testFloorf(float $expectedResult, float $value, int $precision): void
+    {
+        $this->assertSame($expectedResult, Math::floorf($value, $precision));
+    }
+
+    public function providerCeilF(): array
+    {
+        return [
+            [26, 25.32, 0],
+            [25.4, 25.32, 1],
+            [25.32, 25.32, 2],
+            [25.33, 25.325, 2],
+        ];
+    }
+
+    /**
+     * @dataProvider providerCeilF
+     */
+    public function testCeilf(float $expectedResult, float $value, int $precision): void
+    {
+        $this->assertSame($expectedResult, Math::ceilf($value, $precision));
+    }
+}


### PR DESCRIPTION


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             |  refacto
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | yes
| How to test?      | Check prices calculation, order, cart, products. 

- Created a `Math` core class that will migrate following methods and will have full unit tests.
  - Tools::ps_round()
  - Tools::ceilf()
  - Tools::floorf()

- Created a `MathHelper` service class that will fetch the default rounding mode from configuration so it can be injected into other services.

- Deprecate 
  - Tools::ceilf()
  - Tools::floorf()
  - Tools::round_helper() as unused
- Added 100 % unit tests on those methods

- Replacing Tools::ps_round() in src/Adapter and src/Core by MathHelper::round implementations

# Important

- Please note i'm not sure about the `MathHelper` classname and its location. 
- I chose to not deprecate ps_round as widely used in legacy, and cannot be migrated as is (SF Container for front end missing)
