### PR TITLE
Fix empty modules from Hook when first source is empty

### DIFF
--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -282,11 +282,7 @@ class ModuleRepository implements ModuleRepositoryInterface
         if ($this->modulesFromHook === null) {
             $modulesFromHook = $this->hookManager->exec('actionListModules', [], null, true);
             $modulesFromHook = array_values($modulesFromHook ?? []);
-
-            $this->modulesFromHook = [];
-            foreach ($modulesFromHook as $modulesFromSingleHook) {
-                $this->modulesFromHook += $modulesFromSingleHook;
-            }
+            $this->modulesFromHook = array_merge(...array_filter($modulesFromHook, function ($item) { return is_array($item); }));
         }
 
         return $this->modulesFromHook;

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -282,7 +282,7 @@ class ModuleRepository implements ModuleRepositoryInterface
         if ($this->modulesFromHook === null) {
             $modulesFromHook = $this->hookManager->exec('actionListModules', [], null, true);
             $modulesFromHook = array_values($modulesFromHook ?? []);
-            $this->modulesFromHook = empty(reset($modulesFromHook)) ? [] : array_merge(...$modulesFromHook);
+            $this->modulesFromHook = array_merge(...$modulesFromHook);
         }
 
         return $this->modulesFromHook;

--- a/src/Core/Module/ModuleRepository.php
+++ b/src/Core/Module/ModuleRepository.php
@@ -282,7 +282,11 @@ class ModuleRepository implements ModuleRepositoryInterface
         if ($this->modulesFromHook === null) {
             $modulesFromHook = $this->hookManager->exec('actionListModules', [], null, true);
             $modulesFromHook = array_values($modulesFromHook ?? []);
-            $this->modulesFromHook = array_merge(...$modulesFromHook);
+
+            $this->modulesFromHook = [];
+            foreach ($modulesFromHook as $modulesFromSingleHook) {
+                $this->modulesFromHook += $modulesFromSingleHook;
+            }
         }
 
         return $this->modulesFromHook;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When there is more than one external modules source, if the first one doesn't have upgradable modules, the list of upgrades is empty
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30462 
| Related PRs       | -
| How to test?      | See #30462 
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
