### PR TITLE
fix(Cart): fix notice saving customization when customer field is empty and not required

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4308,8 +4308,6 @@ class CartCore extends ObjectModel
      */
     public function deleteCustomizationToProduct($id_product, $index)
     {
-        $result = true;
-
         $cust_data = Db::getInstance()->getRow(
             'SELECT cu.`id_customization`, cd.`index`, cd.`value`, cd.`type` FROM `' . _DB_PREFIX_ . 'customization` cu
             LEFT JOIN `' . _DB_PREFIX_ . 'customized_data` cd
@@ -4320,8 +4318,14 @@ class CartCore extends ObjectModel
             AND `in_cart` = 0'
         );
 
+        if (!$cust_data) {
+            return true;
+        }
+
+        $result = true;
+
         // Delete customization picture if necessary
-        if (isset($cust_data['type']) && $cust_data['type'] == Product::CUSTOMIZE_FILE) {
+        if ($cust_data['type'] == Product::CUSTOMIZE_FILE) {
             $result = !file_exists(_PS_UPLOAD_DIR_ . $cust_data['value']) || @unlink(_PS_UPLOAD_DIR_ . $cust_data['value']);
             $result = !($result && file_exists(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small')) || @unlink(_PS_UPLOAD_DIR_ . $cust_data['value'] . '_small');
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0
| Description?      | I check that the query returns the customization.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30464.
| Related PRs       | no
| How to test?      | Follow issue video steps no notices are shown.
| Possible impacts? | no


