### PR TITLE
Customer/Customer Preferences : Display an alert message for partner offers

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/customer-preferences/customer-preferences-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-preferences/customer-preferences-map.ts
@@ -23,23 +23,11 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-import CustomerPreferencesMap from '@pages/customer-preferences/customer-preferences-map';
-
-$(() => {
-  window.prestashop.component.initComponents(
-    [
-      'MultistoreConfigField',
-    ],
-  );
-
-
-  // Required fields : Display alert for optin checkbox
-  $(CustomerPreferencesMap.switchPartnerOffers).on('click', () => handleFormCheckboxPartnerOffers());
-
-  function handleFormCheckboxPartnerOffers(): void {
-    $(CustomerPreferencesMap.checkboxPartnerOffersAlertOptin).toggleClass(
-      'd-none',
-      ($(CustomerPreferencesMap.checkboxPartnerOffers).val() === '1'),
-    );
-  }
-});
+/**
+ * Defines all selectors that are used in customer preferences form.
+ */
+export default {
+  checkboxPartnerOffersAlertOptin: '#configurationFormAlertMessageOptin',
+  switchPartnerOffers: '#form_enable_offers',
+  checkboxPartnerOffers: 'input[name="form[enable_offers]"]:checked',
+};

--- a/admin-dev/themes/new-theme/js/pages/customer-preferences/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer-preferences/index.ts
@@ -32,7 +32,6 @@ $(() => {
     ],
   );
 
-
   // Required fields : Display alert for optin checkbox
   $(CustomerPreferencesMap.switchPartnerOffers).on('click', () => handleFormCheckboxPartnerOffers());
 

--- a/admin-dev/themes/new-theme/js/pages/customer/customer-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/customer-form-map.ts
@@ -29,4 +29,6 @@
 export default {
   passwordInput: '#customer_password',
   passwordStrengthFeedbackContainer: '.password-strength-feedback',
+  requiredFieldsFormAlertOptin: '#customerRequiredFieldsAlertMessageOptin',
+  requiredFieldsFormCheckboxOptin: '#customerRequiredFieldsContainer input[type="checkbox"][value="optin"]',
 };

--- a/admin-dev/themes/new-theme/js/pages/customer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.ts
@@ -44,7 +44,7 @@ import FiltersSubmitButtonEnablerExtension
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
 import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
-import CustomerFormMap from "@pages/customer/customer-form-map";
+import CustomerFormMap from '@pages/customer/customer-form-map';
 
 const {$} = window;
 

--- a/admin-dev/themes/new-theme/js/pages/customer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.ts
@@ -44,6 +44,7 @@ import FiltersSubmitButtonEnablerExtension
 import ShowcaseCard from '@components/showcase-card/showcase-card';
 import ShowcaseCardCloseExtension from '@components/showcase-card/extension/showcase-card-close-extension';
 import AsyncToggleColumnExtension from '@components/grid/extension/column/common/async-toggle-column-extension';
+import CustomerFormMap from "@pages/customer/customer-form-map";
 
 const {$} = window;
 
@@ -86,6 +87,9 @@ $(() => {
   // Scroll to the block
   scrollToBlock();
 
+  // Required fields : Display alert for optin checkbox
+  $(CustomerFormMap.requiredFieldsFormCheckboxOptin).on('click', () => handleRequiredFieldsFormCheckboxOptin());
+
   function scrollToBlock(): void {
     const documentURL = new URL(document.URL);
     const documentHash = documentURL.hash.slice(1);
@@ -122,5 +126,12 @@ $(() => {
 
     // Scroll to the block
     window.scroll(0, positionTop);
+  }
+
+  function handleRequiredFieldsFormCheckboxOptin(): void {
+    $(CustomerFormMap.requiredFieldsFormAlertOptin).toggleClass(
+      'd-none',
+      !$(CustomerFormMap.requiredFieldsFormCheckboxOptin).is(':checked'),
+    );
   }
 });

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -35,6 +35,17 @@
     </h3>
     <div class="card-body">
       <div class="form-wrapper">
+        <div class="alert alert-danger d-none" role="alert" id="configurationFormAlertMessageOptin">
+          <div class="alert-text">
+            <p>{{ 'Before disabling partner offers, please [1]make[/1] sure they are not set as required in the [2]Customers[/2] section of the back office. Otherwise, new customers won\'t be able to create an account and [1]proceed[/1] to checkout.'|trans({
+                '[1]': '<strong>',
+                '[/1]': '</strong>',
+                '[2]': '<a href="' ~ path('admin_customers_index') ~ '">',
+                '[/2]': '</a>',
+              }, 'Admin.Shopparameters.Help')|raw }}</p>
+          </div>
+        </div>
+
         {{ form_widget(generalForm) }}
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/Blocks/customer_preferences_general.html.twig
@@ -37,7 +37,7 @@
       <div class="form-wrapper">
         <div class="alert alert-danger d-none" role="alert" id="configurationFormAlertMessageOptin">
           <div class="alert-text">
-            <p>{{ 'Before disabling partner offers, please [1]make[/1] sure they are not set as required in the [2]Customers[/2] section of the back office. Otherwise, new customers won\'t be able to create an account and [1]proceed[/1] to checkout.'|trans({
+            <p>{{ '[1]Make[/1] sure partner offers are not set as required in the [2]Customers[/2] section of the back office before disabling them. Otherwise, new customers won\'t be able to create an account and [1]proceed[/1] to checkout.'|trans({
                 '[1]': '<strong>',
                 '[/1]': '</strong>',
                 '[2]': '<a href="' ~ path('admin_customers_index') ~ '">',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
@@ -40,7 +40,7 @@
         </div>
         <div class="alert alert-danger d-none" role="alert" id="customerRequiredFieldsAlertMessageOptin">
           <div class="alert-text">
-            <p>{{ 'Before requiring partner offers, please [1]make[/1] sure you enabled them in the [2]Shop Parameters > Customer Settings[/2] section of the back office. Otherwise, new customers won\'t be able to create an account and [1]proceed[/1] to checkout.'|trans({
+            <p>{{ '[1]Make[/1] sure you enable partner offers in the [2]Shop Parameters > Customer Settings[/2] section of the back office before requiring them. Otherwise, new customers won\'t be able to create an account and [1]proceed[/1] to checkout.'|trans({
                 '[1]': '<strong>',
                 '[/1]': '</strong>',
                 '[2]': '<a href="' ~ path('admin_customer_preferences') ~ '">',

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/Index/required_fields.html.twig
@@ -38,6 +38,16 @@
             <p>{{ 'Please make sure you are complying with the opt-in legislation applicable in your country.'|trans({}, 'Admin.Orderscustomers.Help') }}</p>
           </div>
         </div>
+        <div class="alert alert-danger d-none" role="alert" id="customerRequiredFieldsAlertMessageOptin">
+          <div class="alert-text">
+            <p>{{ 'Before requiring partner offers, please [1]make[/1] sure you enabled them in the [2]Shop Parameters > Customer Settings[/2] section of the back office. Otherwise, new customers won\'t be able to create an account and [1]proceed[/1] to checkout.'|trans({
+                '[1]': '<strong>',
+                '[/1]': '</strong>',
+                '[2]': '<a href="' ~ path('admin_customer_preferences') ~ '">',
+                '[/2]': '</a>',
+              }, 'Admin.Orderscustomers.Help')|raw }}</p>
+          </div>
+        </div>
 
         {{ form_widget(customerRequiredFieldsForm.required_fields) }}
       </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Customer/Customer Preferences : Display an alert message for partner offers
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #20801
| Related PRs       | N/A
| How to test?      | In BO > Customers page, the alert message is displayed when the "Partner offers" required field is checked (only at the action)<br />In BO > Customers Preferences page, the alert message is displayed when the "Enable partner offers" option is disabled (only at the action)
| Possible impacts? | N/A


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
