### PR TITLE
Choose correct zone when looking up by address id

### DIFF
--- a/classes/Address.php
+++ b/classes/Address.php
@@ -316,7 +316,7 @@ class AddressCore extends ObjectModel
 			SELECT s.`id_zone` AS id_zone_state, c.`id_zone`
 			FROM `' . _DB_PREFIX_ . 'address` a
 			LEFT JOIN `' . _DB_PREFIX_ . 'country` c ON c.`id_country` = a.`id_country`
-			LEFT JOIN `' . _DB_PREFIX_ . 'state` s ON s.`id_state` = a.`id_state`
+			LEFT JOIN `' . _DB_PREFIX_ . 'state` s ON s.`id_state` = a.`id_state` AND s.`id_country` = c.`id_country`
 			WHERE a.`id_address` = ' . (int) $id_address);
 
         if (empty($result['id_zone_state']) && empty($result['id_zone'])) {


### PR DESCRIPTION
This fix constrains the zone lookup query by `id_country AND id_state` instead of only by `id_state`. By doing this the query will no longer find the incorrect zone for countries which have no states and the address record links to a state but not a country.

One place where the issue manifests itself is in the Prestashop Checkout module. When the PayPal Express checkout "shortcut" button (e.g., the one on the product page) is used to make a purchase, the created address has the correct `id_country`, but an `id_zone` of 1. This means that the zone that is returned is whatever country is associated with zone ID 1. In our specific case, this meant that UK customers were matched to the USA for carriage calculation purposes.

As far as I can make out, this issue is present in all current branches of the codebase.  We have identified it in 1.7.8.x

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.0.x / 1.7.8.x
| Description?      | This fix constrains the zone lookup query by `id_country AND id_state` instead of only by `id_state`. By doing this the query will no longer find the incorrect zone for countries which have no states and the address record links to a state but not a country.  One place where the issue manifests itself is in the Prestashop Checkout module. When the PayPal Express checkout "shortcut" button (e.g., the one on the product page) is used to make a purchase, the created address has the correct `id_country`, but an `id_zone` of 1. This means that the zone that is returned is whatever country is associated with zone ID 1. In our specific case, this meant that UK customers were matched to the USA for carriage calculation purposes.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30483
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | <ol><li>Add a zone for the United Kingdom.  Have different shipping costs for the default zone and the UK zone.  See the example below for test data:<br> ![(See this example)](https://user-images.githubusercontent.com/3032672/205509256-7b507f6c-e36f-4232-b206-8ab232424f56.png)</li><li>As a guest user (not logged in), purchase an item using paypal express checkout.  Define your address as in the UK.</li><li>Before this patch is applied, you will be offered a shipping cost for the default zone.</li><li>After the patch, you will be offered a shipping cost for the UK zone.</li></ol>
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->