### PR TITLE
Allow negative number for attribute quantity

### DIFF
--- a/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
+++ b/src/PrestaShopBundle/Model/Product/AdminModelAdapter.php
@@ -337,9 +337,8 @@ class AdminModelAdapter extends \PrestaShopBundle\Model\AdminModelAdapter
             $form_data['combinations'][$k]['attribute_unity'] = abs(
                 $this->floatParser->fromString($combination['attribute_unity'])
             );
-            $form_data['combinations'][$k]['attribute_quantity'] = abs(
-                $this->floatParser->fromString($combination['attribute_quantity'])
-            );
+            $form_data['combinations'][$k]['attribute_quantity'] = $this->floatParser->fromString($combination['attribute_quantity']);
+
             $form_data['combinations'][$k]['attribute_wholesale_price'] = abs(
                 $this->floatParser->fromString($combination['attribute_wholesale_price'])
             );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | the quantity couldn't be negative as the function `abs` was used. This PR aims to allow negative values by removing the `abs` function.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25545
| Related PRs       | 
| How to test?      | Please see #25545
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
