### PR TITLE
Add PHPStan rule to disallow calling of deprecated Symfony Translation

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -73,3 +73,9 @@ parameters:
     - PaymentModuleCore::DEBUG_MODE
     - _PS_API_IN_USE_
     - _PS_ALLOW_MULTI_STATEMENTS_QUERIES_
+  disallowedNamespaces:
+        -
+            class: 'Symfony\Component\Translation\TranslatorInterface'
+            message: 'use Symfony\Contracts\Translation\TranslatorInterface instead'
+            disallowIn:
+                - src/*


### PR DESCRIPTION


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add PHPStan rule to disallow calling of deprecated Symfony Translation
| Type?             |  improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Nothing to test, dev env.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
