### PR TITLE
Define  `_PS_DO_NOT_LOAD_CONFIGURATION_` default state

### DIFF
--- a/classes/Configuration.php
+++ b/classes/Configuration.php
@@ -220,7 +220,7 @@ class ConfigurationCore extends ObjectModel
      */
     public static function get($key, $idLang = null, $idShopGroup = null, $idShop = null, $default = false)
     {
-        if (defined('_PS_DO_NOT_LOAD_CONFIGURATION_') && _PS_DO_NOT_LOAD_CONFIGURATION_) {
+        if (_PS_DO_NOT_LOAD_CONFIGURATION_) {
             return false;
         }
 

--- a/config/defines.inc.php
+++ b/config/defines.inc.php
@@ -58,6 +58,10 @@ if (!defined('_PS_ALLOW_MULTI_STATEMENTS_QUERIES_')) {
     define('_PS_ALLOW_MULTI_STATEMENTS_QUERIES_', false);
 }
 
+if (!defined('_PS_DO_NOT_LOAD_CONFIGURATION_')) {
+    define('_PS_DO_NOT_LOAD_CONFIGURATION_', false);
+}
+
 $currentDir = dirname(__FILE__);
 
 if (!defined('_PS_ROOT_DIR_') && (getenv('_PS_ROOT_DIR_') || getenv('REDIRECT__PS_ROOT_DIR_'))) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Define  `_PS_DO_NOT_LOAD_CONFIGURATION_` default state.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |  N/A.
| Related PRs       | N/A.
| How to test?      | set ` _PS_DO_NOT_LOAD_CONFIGURATION_` is `true` and make sure that `Configuration;;get ` return always false and the configuration is not loaded (it will probably break some pages). 
| Possible impacts? | N/A.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
