### PR TITLE
Fix : Allow front product controller breadcrumb function override

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1031,7 +1031,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @return int
      */
-    private function getIdProductAttributeByRequest()
+    protected function getIdProductAttributeByRequest()
     {
         $requestedIdProductAttribute = (int) Tools::getValue('id_product_attribute');
 
@@ -1079,7 +1079,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      *
      * @return int
      */
-    private function tryToGetAvailableIdProductAttribute($checkedIdProductAttribute)
+    protected function tryToGetAvailableIdProductAttribute($checkedIdProductAttribute)
     {
         if (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
             $productCombinations = $this->product->getAttributeCombinations();


### PR DESCRIPTION
* switched all private function calls from breadcrumb function to protected visibility


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | I was trying to update the breadcrumb with the correct product category. So my goal was to replace the default product category with the ProductController category attribute. Product controller breacrumb is not available for a quick override, to add custom features to this function, we must override 3 functions because of private function declaration on ProductController.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Override `getBreadcrumbLinks` function of `controller/front/ProductController` class, replace $categoryDefault with `$this->category`, access a Product with multiple category assignation and see that the default category is no longer mentionned in the breadcrumb.