### PR TITLE
Use shop constraint in UpdateCombinationCommand

### DIFF
--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationHandler.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler;
 
 use PrestaShop\Decimal\DecimalNumber;
-use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\DefaultCombinationUpdater;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\CombinationFillerInterface;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductSupplierRepository;
@@ -45,7 +45,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\ValueObject\ProductSuppli
 class UpdateCombinationHandler implements UpdateCombinationHandlerInterface
 {
     /**
-     * @var CombinationRepository
+     * @var CombinationMultiShopRepository
      */
     private $combinationRepository;
 
@@ -65,7 +65,7 @@ class UpdateCombinationHandler implements UpdateCombinationHandlerInterface
     private $defaultCombinationUpdater;
 
     public function __construct(
-        CombinationRepository $combinationRepository,
+        CombinationMultiShopRepository $combinationRepository,
         CombinationFillerInterface $combinationFiller,
         ProductSupplierRepository $productSupplierRepository,
         DefaultCombinationUpdater $defaultCombinationUpdater
@@ -81,12 +81,13 @@ class UpdateCombinationHandler implements UpdateCombinationHandlerInterface
      */
     public function handle(UpdateCombinationCommand $command): void
     {
-        $combination = $this->combinationRepository->get($command->getCombinationId());
+        $combination = $this->combinationRepository->getByShopConstraint($command->getCombinationId(), $command->getShopConstraint());
         $updatableProperties = $this->combinationFiller->fillUpdatableProperties($combination, $command);
 
         $this->combinationRepository->partialUpdate(
             $combination,
             $updatableProperties,
+            $command->getShopConstraint(),
             CannotUpdateCombinationException::FAILED_UPDATE_COMBINATION
         );
 

--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationHandler.php
@@ -38,7 +38,6 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\UpdateC
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CannotUpdateCombinationException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\ValueObject\ProductSupplierAssociation;
-use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Handles the @see UpdateCombinationCommand using legacy object model
@@ -95,8 +94,7 @@ class UpdateCombinationHandler implements UpdateCombinationHandlerInterface
         if (true === $command->isDefault()) {
             $this->defaultCombinationUpdater->setDefaultCombination(
                 $command->getCombinationId(),
-                // @todo: temporary hardcoded shop constraint. Needs to be required in command constructor.
-                ShopConstraint::shop((int) \Context::getContext()->shop->id)
+                $command->getShopConstraint()
             );
         }
 

--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandler.php
@@ -36,7 +36,6 @@ use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiSh
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\UpdateCombinationStockAvailableHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockModification;
-use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 
 /**
  * Updates combination stock available using legacy object model
@@ -88,22 +87,9 @@ class UpdateCombinationStockAvailableHandler implements UpdateCombinationStockAv
     {
         $stockModification = null;
         if ($command->getDeltaQuantity()) {
-            $stockModification = new StockModification(
-                $command->getDeltaQuantity(),
-                $this->movementReasonRepository->getEmployeeEditionReasonId($command->getDeltaQuantity() > 0)
-            );
+            $stockModification = StockModification::buildDeltaQuantity($command->getDeltaQuantity());
         } elseif (null !== $command->getFixedQuantity()) {
-            $combination = $this->combinationMultiShopRepository->getByShopConstraint($command->getCombinationId(), $command->getShopConstraint());
-            $currentQuantity = (int) $this->stockAvailableRepository->getForCombination(
-                $command->getCombinationId(),
-                new ShopId($combination->getShopId())
-            )->quantity;
-
-            $deltaQuantity = $command->getFixedQuantity() - $currentQuantity;
-            $stockModification = new StockModification(
-                $deltaQuantity,
-                $this->movementReasonRepository->getEmployeeEditionReasonId($deltaQuantity > 0)
-            );
+            $stockModification = StockModification::buildFixedQuantity($command->getFixedQuantity());
         }
 
         // Now we only fill the properties existing in StockAvailable object model.

--- a/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandler.php
+++ b/src/Adapter/Product/Combination/CommandHandler/UpdateCombinationStockAvailableHandler.php
@@ -28,11 +28,8 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Combination\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockProperties;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater;
-use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository;
-use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\CommandHandler\UpdateCombinationStockAvailableHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\StockModification;
@@ -48,36 +45,12 @@ class UpdateCombinationStockAvailableHandler implements UpdateCombinationStockAv
     private $combinationStockUpdater;
 
     /**
-     * @var MovementReasonRepository
-     */
-    private $movementReasonRepository;
-
-    /**
-     * @var StockAvailableMultiShopRepository
-     */
-    private $stockAvailableRepository;
-
-    /**
-     * @var CombinationMultiShopRepository
-     */
-    private $combinationMultiShopRepository;
-
-    /**
      * @param CombinationStockUpdater $combinationStockUpdater
-     * @param MovementReasonRepository $movementReasonRepository
-     * @param StockAvailableMultiShopRepository $stockAvailableRepository
-     * @param CombinationMultiShopRepository $combinationMultiShopRepository
      */
     public function __construct(
-        CombinationStockUpdater $combinationStockUpdater,
-        MovementReasonRepository $movementReasonRepository,
-        StockAvailableMultiShopRepository $stockAvailableRepository,
-        CombinationMultiShopRepository $combinationMultiShopRepository
+        CombinationStockUpdater $combinationStockUpdater
     ) {
         $this->combinationStockUpdater = $combinationStockUpdater;
-        $this->movementReasonRepository = $movementReasonRepository;
-        $this->stockAvailableRepository = $stockAvailableRepository;
-        $this->combinationMultiShopRepository = $combinationMultiShopRepository;
     }
 
     /**

--- a/src/Adapter/Product/Combination/Create/CombinationCreator.php
+++ b/src/Adapter/Product/Combination/Create/CombinationCreator.php
@@ -125,6 +125,24 @@ class CombinationCreator
         // apply all specific price rules at once after all the combinations are generated
         $this->applySpecificPriceRules($productId);
         $this->productRepository->updateCachedDefaultCombination($productId, $shopConstraint);
+        $this->syncOutOfStockType($product, $shopConstraint, $shopIdsByConstraint);
+
+        return $combinationIds;
+    }
+
+    /**
+     * Makes sure combinations out_of_stock type has the same value as the product out_of_stock type.
+     *
+     * @param Product $product
+     * @param ShopConstraint $shopConstraint
+     * @param ShopId[] $shopIdsByConstraint
+     */
+    private function syncOutOfStockType(
+        Product $product,
+        ShopConstraint $shopConstraint,
+        array $shopIdsByConstraint
+    ): void {
+        $productId = new ProductId((int) $product->id);
         $productStockAvailable = $this->stockAvailableMultiShopRepository->getForProduct($productId, new ShopId($product->getShopId()));
         $outOfStockType = new OutOfStockType((int) $productStockAvailable->out_of_stock);
 
@@ -135,8 +153,6 @@ class CombinationCreator
         } else {
             $this->combinationRepository->updateCombinationOutOfStockType($productId, $outOfStockType, $shopConstraint);
         }
-
-        return $combinationIds;
     }
 
     /**

--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -35,7 +35,7 @@ use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
-use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
 use PrestaShop\PrestaShop\Adapter\Tax\TaxComputer;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
@@ -82,7 +82,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
     private $attributeRepository;
 
     /**
-     * @var ProductRepository
+     * @var ProductMultiShopRepository
      */
     private $productRepository;
 
@@ -121,7 +121,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
      * @param CombinationNameBuilderInterface $combinationNameBuilder
      * @param StockAvailableRepository $stockAvailableRepository
      * @param AttributeRepository $attributeRepository
-     * @param ProductRepository $productRepository
+     * @param ProductMultiShopRepository $productRepository
      * @param ProductImageRepository $productImageRepository
      * @param NumberExtractor $numberExtractor
      * @param TaxComputer $taxComputer
@@ -134,7 +134,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
         CombinationNameBuilderInterface $combinationNameBuilder,
         StockAvailableRepository $stockAvailableRepository,
         AttributeRepository $attributeRepository,
-        ProductRepository $productRepository,
+        ProductMultiShopRepository $productRepository,
         ProductImageRepository $productImageRepository,
         NumberExtractor $numberExtractor,
         TaxComputer $taxComputer,
@@ -162,7 +162,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
     {
         $combination = $this->combinationRepository->getByShopConstraint($query->getCombinationId(), $query->getShopConstraint());
         $productId = new ProductId((int) $combination->id_product);
-        $product = $this->productRepository->get($productId);
+        $product = $this->productRepository->getByShopConstraint($productId, $query->getShopConstraint());
         $images = $this->getImages($combination);
 
         return new CombinationForEditing(

--- a/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
+++ b/src/Adapter/Product/Combination/QueryHandler/GetCombinationForEditingHandler.php
@@ -36,7 +36,7 @@ use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMult
 use PrestaShop\PrestaShop\Adapter\Product\Image\ProductImagePathFactory;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
-use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Tax\TaxComputer;
 use PrestaShop\PrestaShop\Core\Domain\Country\ValueObject\CountryId;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
@@ -50,6 +50,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\Combinatio
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\ValueObject\ImageId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\ValueObject\TaxRulesGroupId;
 use PrestaShop\PrestaShop\Core\Product\Combination\NameBuilder\CombinationNameBuilderInterface;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
@@ -72,7 +73,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
     private $combinationNameBuilder;
 
     /**
-     * @var StockAvailableRepository
+     * @var StockAvailableMultiShopRepository
      */
     private $stockAvailableRepository;
 
@@ -119,7 +120,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
     /**
      * @param CombinationMultiShopRepository $combinationRepository
      * @param CombinationNameBuilderInterface $combinationNameBuilder
-     * @param StockAvailableRepository $stockAvailableRepository
+     * @param StockAvailableMultiShopRepository $stockAvailableRepository
      * @param AttributeRepository $attributeRepository
      * @param ProductMultiShopRepository $productRepository
      * @param ProductImageRepository $productImageRepository
@@ -132,7 +133,7 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
     public function __construct(
         CombinationMultiShopRepository $combinationRepository,
         CombinationNameBuilderInterface $combinationNameBuilder,
-        StockAvailableRepository $stockAvailableRepository,
+        StockAvailableMultiShopRepository $stockAvailableRepository,
         AttributeRepository $attributeRepository,
         ProductMultiShopRepository $productRepository,
         ProductImageRepository $productImageRepository,
@@ -276,7 +277,10 @@ class GetCombinationForEditingHandler implements GetCombinationForEditingHandler
      */
     private function getStock(Combination $combination): CombinationStock
     {
-        $stockAvailable = $this->stockAvailableRepository->getForCombination(new Combinationid($combination->id));
+        $stockAvailable = $this->stockAvailableRepository->getForCombination(
+            new Combinationid($combination->id),
+            new ShopId($combination->getShopId())
+        );
 
         return new CombinationStock(
             (int) $stockAvailable->quantity,

--- a/src/Adapter/Product/Combination/Repository/CombinationMultiShopRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationMultiShopRepository.php
@@ -276,7 +276,7 @@ class CombinationMultiShopRepository extends AbstractMultiShopObjectModelReposit
             $shopId = $shopConstraint->getShopId();
         }
 
-        return $this->getCombinationByShopId($combinationId, $shopId);
+        return $this->get($combinationId, $shopId);
     }
 
     /**
@@ -680,23 +680,5 @@ class CombinationMultiShopRepository extends AbstractMultiShopObjectModelReposit
         }
 
         return [$shopConstraint->getShopId()];
-    }
-
-    /**
-     * @param CombinationId $combinationId
-     * @param ShopId $shopId
-     *
-     * @return Combination
-     */
-    private function getCombinationByShopId(CombinationId $combinationId, ShopId $shopId): Combination
-    {
-        $combination = $this->getObjectModelForShop(
-            $combinationId->getValue(),
-            Combination::class,
-            CombinationNotFoundException::class,
-            $shopId
-        );
-
-        return $this->get($combinationId, $shopId);
     }
 }

--- a/src/Adapter/Product/Combination/Repository/CombinationMultiShopRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationMultiShopRepository.php
@@ -272,7 +272,7 @@ class CombinationMultiShopRepository extends AbstractMultiShopObjectModelReposit
             $shopId = $shopConstraint->getShopId();
         }
 
-        return $this->get($combinationId, $shopId);
+        return $this->getCombinationByShopId($combinationId, $shopId);
     }
 
     /**
@@ -660,5 +660,23 @@ class CombinationMultiShopRepository extends AbstractMultiShopObjectModelReposit
         }
 
         return [$shopConstraint->getShopId()];
+    }
+
+    /**
+     * @param CombinationId $combinationId
+     * @param ShopId $shopId
+     *
+     * @return Combination
+     */
+    private function getCombinationByShopId(CombinationId $combinationId, ShopId $shopId): Combination
+    {
+        $combination = $this->getObjectModelForShop(
+            $combinationId->getValue(),
+            Combination::class,
+            CombinationNotFoundException::class,
+            $shopId
+        );
+
+        return $this->get($combinationId, $shopId);
     }
 }

--- a/src/Adapter/Product/Combination/Repository/CombinationRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationRepository.php
@@ -36,9 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CannotDelete
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CannotUpdateCombinationException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CombinationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
-use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\OutOfStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
-use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Grid\Query\ProductCombinationQueryBuilder;
 use PrestaShop\PrestaShop\Core\Repository\AbstractObjectModelRepository;
@@ -320,18 +318,5 @@ class CombinationRepository extends AbstractObjectModelRepository
         return array_map(function (array $combination) {
             return new CombinationId((int) $combination['id_product_attribute']);
         }, $result);
-    }
-
-    public function updateCombinationStock(ProductId $productId, OutOfStockType $outOfStockType, ShopConstraint $shopConstraint = null): void
-    {
-        $qb = $this->connection->createQueryBuilder();
-        $qb
-            ->update(sprintf('%sstock_available', $this->dbPrefix), 'ps')
-            ->set('ps.out_of_stock', (string) $outOfStockType->getValue())
-            ->where('ps.id_product = :productId')
-            ->setParameter('productId', $productId->getValue())
-        ;
-
-        $this->applyShopConstraint($qb, $shopConstraint)->execute();
     }
 }

--- a/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
+++ b/src/Adapter/Product/Combination/Update/CombinationStockUpdater.php
@@ -113,7 +113,7 @@ class CombinationStockUpdater
         );
 
         $this->updateStockByShopConstraint(
-            $this->stockAvailableRepository->getForCombination($combinationId, new ShopId($combination->getShopId())),
+            $combination,
             $properties,
             $shopConstraint
         );
@@ -232,22 +232,26 @@ class CombinationStockUpdater
     }
 
     private function updateStockByShopConstraint(
-        StockAvailable $stockAvailable,
+        Combination $combination,
         CombinationStockProperties $properties,
         ShopConstraint $shopConstraint
     ): void {
+        $combinationId = new CombinationId((int) $combination->id);
         if ($shopConstraint->forAllShops()) {
             // Since each stock has a distinct ID we can't use the ObjectModel multi shop feature based on id_shop_list,
             // so we manually loop to update each associated stocks
-            $shops = $this->stockAvailableRepository->getAssociatedShopIds(new StockId((int) $stockAvailable->id));
+            $shops = $this->combinationRepository->getAssociatedShopIds($combinationId);
             foreach ($shops as $shopId) {
                 $this->updateStockAvailable(
-                    $this->stockAvailableRepository->getForCombination(new CombinationId((int) $stockAvailable->id_product_attribute), $shopId),
+                    $this->stockAvailableRepository->getForCombination($combinationId, $shopId),
                     $properties
                 );
             }
         } else {
-            $this->updateStockAvailable($stockAvailable, $properties);
+            $this->updateStockAvailable(
+                $this->stockAvailableRepository->getForCombination($combinationId, new ShopId($combination->getShopId())),
+                $properties
+            );
         }
     }
 }

--- a/src/Adapter/Product/Stock/CommandHandler/UpdateProductStockAvailableHandler.php
+++ b/src/Adapter/Product/Stock/CommandHandler/UpdateProductStockAvailableHandler.php
@@ -77,7 +77,7 @@ class UpdateProductStockAvailableHandler implements UpdateProductStockHandlerInt
     {
         $stockModification = null;
         if ($command->getDeltaQuantity()) {
-            $stockModification = new StockModification(
+            $stockModification = StockModification::buildDeltaQuantity(
                 $command->getDeltaQuantity(),
                 $this->movementReasonRepository->getEmployeeEditionReasonId($command->getDeltaQuantity() > 0)
             );

--- a/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
+++ b/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
@@ -282,6 +282,7 @@ class ProductStockUpdater
     private function updateStockAvailable(StockAvailable $stockAvailable, ProductStockProperties $properties)
     {
         $stockUpdateRequired = false;
+        $previousQuantity = $stockAvailable->quantity;
 
         if (null !== $properties->getOutOfStockType()) {
             $stockAvailable->out_of_stock = $properties->getOutOfStockType()->getValue();
@@ -293,7 +294,6 @@ class ProductStockUpdater
         }
 
         if ($properties->getStockModification()) {
-            $previousQuantity = $stockAvailable->quantity;
             $stockAvailable->quantity += $properties->getStockModification()->getDeltaQuantity();
             $stockUpdateRequired = true;
         }

--- a/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
+++ b/src/Adapter/Product/Stock/Update/ProductStockUpdater.php
@@ -282,7 +282,7 @@ class ProductStockUpdater
     private function updateStockAvailable(StockAvailable $stockAvailable, ProductStockProperties $properties)
     {
         $stockUpdateRequired = false;
-        $previousQuantity = $stockAvailable->quantity;
+        $previousQuantity = (int) $stockAvailable->quantity;
 
         if (null !== $properties->getOutOfStockType()) {
             $stockAvailable->out_of_stock = $properties->getOutOfStockType()->getValue();

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Upc;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Contains all the data needed to handle the command update.
@@ -138,14 +139,21 @@ class UpdateCombinationCommand
     private $localizedAvailableLaterLabels;
 
     /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
      * @param int $combinationId
      *
      * @throws ProductConstraintException
      */
     public function __construct(
-        int $combinationId
+        int $combinationId,
+        ShopConstraint $shopConstraint
     ) {
         $this->combinationId = new CombinationId($combinationId);
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -502,5 +510,13 @@ class UpdateCombinationCommand
         $this->localizedAvailableLaterLabels = $localizedAvailableLaterLabels;
 
         return $this;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 }

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockAvailableCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationStockAvailableCommand.php
@@ -30,15 +30,8 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
-/**
- * This class should actually be called UpdateCombinationStockCommand but the name is already take,
- * although the current command should be cleaned once the unification is done. When that is done this
- * command should be correctly renamed.
- *
- * Either that or UpdateProductStockCommand could be renamed into UpdateProductStockAvailableCommand,the
- * idea is to keep the consistency.
- */
 class UpdateCombinationStockAvailableCommand
 {
     /**
@@ -62,12 +55,19 @@ class UpdateCombinationStockAvailableCommand
     private $location;
 
     /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
      * @param int $combinationId
      */
     public function __construct(
-        int $combinationId
+        int $combinationId,
+        ShopConstraint $shopConstraint
     ) {
         $this->combinationId = new CombinationId($combinationId);
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -148,5 +148,13 @@ class UpdateCombinationStockAvailableCommand
         $this->location = $location;
 
         return $this;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 }

--- a/src/Core/Domain/Product/Stock/ValueObject/StockModification.php
+++ b/src/Core/Domain/Product/Stock/ValueObject/StockModification.php
@@ -35,48 +35,80 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstr
 class StockModification
 {
     /**
-     * @var int
+     * @var int|null
      */
     private $deltaQuantity;
 
     /**
-     * @var MovementReasonId
+     * @var int|null
      */
-    private $movementReasonId;
+    private $fixedQuantity;
 
     /**
+     * Builds class using delta quantity (delta means the quantity will be added up to the previous quantity)
+     *
      * @param int $deltaQuantity
-     * @param MovementReasonId $movementReasonId
+     *
+     * @return self
      */
-    public function __construct(
-        int $deltaQuantity,
-        MovementReasonId $movementReasonId
-    ) {
-        $this->assertDeltaQuantityIsNotZero($deltaQuantity);
-        $this->deltaQuantity = $deltaQuantity;
-        $this->movementReasonId = $movementReasonId;
+    public static function buildDeltaQuantity(int $deltaQuantity): self
+    {
+        return new self($deltaQuantity, null);
     }
 
     /**
-     * @return int
+     * Builds class using fixed quantity (fixed means the new quantity will replace the previous quantity)
+     *
+     * @param int $fixedQuantity
+     *
+     * @return self
      */
-    public function getDeltaQuantity(): int
+    public static function buildFixedQuantity(int $fixedQuantity): self
+    {
+        return new self(null, $fixedQuantity);
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getDeltaQuantity(): ?int
     {
         return $this->deltaQuantity;
     }
 
     /**
-     * @return MovementReasonId
+     * @return int|null
      */
-    public function getMovementReasonId(): MovementReasonId
+    public function getFixedQuantity(): ?int
     {
-        return $this->movementReasonId;
+        return $this->fixedQuantity;
     }
 
     /**
-     * @param int $quantity
+     * Constructor is private on purpose. This Value object can either have delta OR fixed quantity set,
+     * so we need to use static factory methods to make sure we always build it correctly.
+     *
+     * @see buildDeltaQuantity
+     * @see buildFixedQuantity
+     *
+     * @param int|null $deltaQuantity
+     * @param int|null $fixedQuantity
+     *
+     * @throws ProductStockConstraintException
      */
-    private function assertDeltaQuantityIsNotZero(int $quantity): void
+    private function __construct(
+        ?int $deltaQuantity,
+        ?int $fixedQuantity
+    ) {
+        $this->assertDeltaQuantityIsNotZero($deltaQuantity);
+        $this->deltaQuantity = $deltaQuantity;
+        $this->fixedQuantity = $fixedQuantity;
+    }
+
+    /**
+     * @param int|null $quantity
+     */
+    private function assertDeltaQuantityIsNotZero(?int $quantity): void
     {
         if (0 === $quantity) {
             throw new ProductStockConstraintException(

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/MultiShopCombinationCommandsBuilderInterface.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/MultiShopCombinationCommandsBuilderInterface.php
@@ -24,46 +24,29 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-declare(strict_types=1);
-
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination;
 
+use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
-class CombinationCommandsBuilder implements MultiShopCombinationCommandsBuilderInterface
+/**
+ * This interface is similar to CombinationCommandsBuilderInterface except it handles the product commands
+ * which are related to multishop fields, so it has an extra $singleShopConstraint parameter.
+ *
+ * @todo: since not all builders are migrated yet we need two interfaces but in the this is the only
+ *        one that should remain, so it will be merged back or renamed as the initial one ProductCommandsBuilderInterface
+ *        and the shop constraint parameter will always be mandatory (there might a few builders which won't need it
+ *        though, but it doesn't matter) So this interface is a temporary one just like @see CombinationMultiShopRepository
+ */
+interface MultiShopCombinationCommandsBuilderInterface
 {
     /**
-     * @var iterable<CombinationCommandsBuilderInterface|MultiShopCombinationCommandsBuilderInterface>
+     * @param CombinationId $combinationId
+     * @param array $formData
+     * @param ShopConstraint $singleShopConstraint
+     *
+     * @return array Returns empty array if the required data for the command is absent
      */
-    private $commandBuilders;
-
-    /**
-     * @param iterable<CombinationCommandsBuilderInterface|MultiShopCombinationCommandsBuilderInterface> $commandBuilders
-     */
-    public function __construct(iterable $commandBuilders)
-    {
-        $this->commandBuilders = $commandBuilders;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function buildCommands(CombinationId $combinationId, array $formData, ShopConstraint $singleShopConstraint): array
-    {
-        $commandCollection = [];
-        foreach ($this->commandBuilders as $commandBuilder) {
-            if ($commandBuilder instanceof MultiShopCombinationCommandsBuilderInterface) {
-                $commands = $commandBuilder->buildCommands($combinationId, $formData, $singleShopConstraint);
-            } else {
-                $commands = $commandBuilder->buildCommands($combinationId, $formData);
-            }
-
-            if (!empty($commands)) {
-                $commandCollection = array_merge($commandCollection, $commands);
-            }
-        }
-
-        return $commandCollection;
-    }
+    public function buildCommands(CombinationId $combinationId, array $formData, ShopConstraint $singleShopConstraint): array;
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/CombinationFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CombinationFormDataHandler.php
@@ -31,7 +31,7 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
-use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilder;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\MultiShopCombinationCommandsBuilderInterface;
 
 /**
  * Handles data posted from combination form
@@ -44,7 +44,7 @@ class CombinationFormDataHandler implements FormDataHandlerInterface
     private $bus;
 
     /**
-     * @var CombinationCommandsBuilder
+     * @var MultiShopCombinationCommandsBuilderInterface
      */
     private $commandsBuilder;
 
@@ -60,11 +60,11 @@ class CombinationFormDataHandler implements FormDataHandlerInterface
 
     /**
      * @param CommandBusInterface $bus
-     * @param CombinationCommandsBuilder $commandsBuilder
+     * @param MultiShopCombinationCommandsBuilderInterface $commandsBuilder
      */
     public function __construct(
         CommandBusInterface $bus,
-        CombinationCommandsBuilder $commandsBuilder,
+        MultiShopCombinationCommandsBuilderInterface $commandsBuilder,
         int $contextShopId,
         int $defaultShopId
     ) {

--- a/src/Core/Form/IdentifiableObject/DataHandler/CombinationFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/CombinationFormDataHandler.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilder;
 
 /**
@@ -48,15 +49,29 @@ class CombinationFormDataHandler implements FormDataHandlerInterface
     private $commandsBuilder;
 
     /**
+     * @var int
+     */
+    private $contextShopId;
+
+    /**
+     * @var int
+     */
+    private $defaultShopId;
+
+    /**
      * @param CommandBusInterface $bus
      * @param CombinationCommandsBuilder $commandsBuilder
      */
     public function __construct(
         CommandBusInterface $bus,
-        CombinationCommandsBuilder $commandsBuilder
+        CombinationCommandsBuilder $commandsBuilder,
+        int $contextShopId,
+        int $defaultShopId
     ) {
         $this->bus = $bus;
         $this->commandsBuilder = $commandsBuilder;
+        $this->contextShopId = $contextShopId;
+        $this->defaultShopId = $defaultShopId;
     }
 
     /**
@@ -73,7 +88,9 @@ class CombinationFormDataHandler implements FormDataHandlerInterface
      */
     public function update($id, array $data)
     {
-        $commands = $this->commandsBuilder->buildCommands(new CombinationId($id), $data);
+        $singleShopConstraint = $this->contextShopId ? ShopConstraint::shop($this->contextShopId) : ShopConstraint::shop($this->defaultShopId);
+
+        $commands = $this->commandsBuilder->buildCommands(new CombinationId($id), $data, $singleShopConstraint);
 
         foreach ($commands as $command) {
             $this->bus->handle($command);

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -484,8 +484,8 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\CommandHandler\UpdateProductStockAvailableHandler
     arguments:
       - '@prestashop.adapter.product.stock.update.product_stock_updater'
-      - '@prestashop.adapter.product.stock.repository.movement_reason_repository'
-      - '@prestashop.adapter.product.combination.repository.combination_repository'
+      - '@prestashop.adapter.product.repository.product_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\UpdateProductStockAvailableCommand

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -110,7 +110,7 @@ services:
       - '@prestashop.core.util.number.number_extractor'
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@prestashop.adapter.category.repository.category_repository'
-      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
       - '@prestashop.adapter.product.virtual_product.repository.virtual_product_file_repository'
       - '@prestashop.adapter.product.image.repository.product_image_repository'
       - '@prestashop.adapter.attachment.attachment_repository'
@@ -465,7 +465,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\Update\ProductShopUpdater
     arguments:
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
-      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
       - '@prestashop.adapter.shop.repository.shop_repository'
       - '@prestashop.adapter.product.image.repository.product_image_multishop_repository'
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -26,7 +26,7 @@ services:
   prestashop.adapter.product.combination.query_handler.get_combination_for_editing_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\QueryHandler\GetCombinationForEditingHandler
     arguments:
-      - '@prestashop.adapter.product.combination.repository.combination_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
       - '@prestashop.core.product.combination.name_builder.combination_name_builder'
       - '@prestashop.adapter.product.stock.repository.stock_available_repository'
       - '@prestashop.adapter.attribute.repository.attribute_repository'
@@ -78,8 +78,7 @@ services:
     alias: PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository
     deprecated: ~
 
-  prestashop.adapter.product.combination.repository.combination_multi_shop_repository:
-    class: PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository
+  PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
@@ -102,14 +101,14 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Create\CombinationCreator
     arguments:
       - '@prestashop.core.product.combination.generator.combination_generator'
-      - '@prestashop.adapter.product.combination.repository.combination_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
       - '@prestashop.adapter.product.combination.update.default_combination_updater'
 
   PrestaShop\PrestaShop\Adapter\Product\Combination\Update\DefaultCombinationUpdater:
     arguments:
-      - '@prestashop.adapter.product.combination.repository.combination_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
 
   prestashop.adapter.product.combination.update.default_combination_updater:
@@ -120,7 +119,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationDeleter
     arguments:
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
-      - '@prestashop.adapter.product.combination.repository.combination_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
       - '@prestashop.adapter.product.combination.update.default_combination_updater'
 
   prestashop.adapter.product.combination.update.combination_images_updater:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -90,6 +90,7 @@ services:
     arguments:
       - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
       - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\MovementReasonRepository'
       - '@prestashop.core.stock.stock_manager'
       - '@prestashop.adapter.legacy.configuration'
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -30,7 +30,7 @@ services:
       - '@prestashop.core.product.combination.name_builder.combination_name_builder'
       - '@prestashop.adapter.product.stock.repository.stock_available_repository'
       - '@prestashop.adapter.attribute.repository.attribute_repository'
-      - '@prestashop.adapter.product.repository.product_repository'
+      - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@prestashop.adapter.product.image.repository.product_image_repository'
       - '@prestashop.core.util.number.number_extractor'
       - '@prestashop.adapter.tax.tax_computer'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_combination.yml
@@ -28,7 +28,7 @@ services:
     arguments:
       - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
       - '@prestashop.core.product.combination.name_builder.combination_name_builder'
-      - '@prestashop.adapter.product.stock.repository.stock_available_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
       - '@prestashop.adapter.attribute.repository.attribute_repository'
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
       - '@prestashop.adapter.product.image.repository.product_image_repository'
@@ -88,8 +88,8 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater:
     arguments:
-      - '@prestashop.adapter.product.stock.repository.stock_available_repository'
-      - '@prestashop.adapter.product.combination.repository.combination_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
       - '@prestashop.core.stock.stock_manager'
       - '@prestashop.adapter.legacy.configuration'
 
@@ -103,7 +103,7 @@ services:
       - '@prestashop.core.product.combination.generator.combination_generator'
       - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
-      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
       - '@prestashop.adapter.product.combination.update.default_combination_updater'
 
   PrestaShop\PrestaShop\Adapter\Product\Combination\Update\DefaultCombinationUpdater:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
@@ -15,8 +15,7 @@ services:
     alias: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableRepository
     deprecated: ~
 
-  prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository:
-    class: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository
+  PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository:
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
@@ -39,7 +38,7 @@ services:
   prestashop.adapter.product.stock.query_handler.get_product_stock_movements_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\QueryHandler\GetProductStockMovementsHandler
     arguments:
-      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
       - '@prestashop.adapter.product.stock.repository.stock_movement_repository'
       - '@translator'
     tags:
@@ -49,7 +48,7 @@ services:
   prestashop.adapter.product.stock.query_handler.get_combination_stock_movements_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\QueryHandler\GetCombinationStockMovementsHandler
     arguments:
-      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
       - '@prestashop.adapter.product.stock.repository.stock_movement_repository'
       - '@translator'
     tags:
@@ -61,7 +60,7 @@ services:
     arguments:
       - '@prestashop.core.stock.stock_manager'
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
-      - '@prestashop.adapter.product.stock.repository.stock_available_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
       - '@prestashop.adapter.product.stock.repository.movement_reason_repository'
       - '@prestashop.adapter.legacy.configuration'
       - '@prestashop.adapter.hook.manager'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -76,6 +76,10 @@ services:
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder:
     tags: [ 'core.combination_command_builder' ]
+    arguments:
+      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationStockAvailableCommandsBuilder:
     tags: [ 'core.combination_command_builder' ]
+    arguments:
+      - !php/const PrestaShopBundle\Form\Admin\Extension\ModifyAllShopsExtension::MODIFY_ALL_SHOPS_PREFIX

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -200,8 +200,9 @@ services:
       - '@prestashop.core.admin.shop.repository'
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CombinationFormDataHandler:
-    autowire: true
     arguments:
+      - '@prestashop.core.command_bus'
+      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilder'
       - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
       - "@=service('prestashop.adapter.shop.context').getContextShopID()"
 
@@ -209,7 +210,11 @@ services:
     autowire: true
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CombinationListFormDataHandler:
-    autowire: true
+    - '@prestashop.core.command_bus'
+    - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataFormatter\CombinationListFormDataFormatter'
+    - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilder'
+    - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
+    - "@=service('prestashop.adapter.shop.context').getContextShopID()"
 
   prestashop.core.form.identifiable_object.data_handler.product_image_form_data_handler:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\ProductImageFormDataHandler'

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -201,6 +201,9 @@ services:
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CombinationFormDataHandler:
     autowire: true
+    arguments:
+      - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
+      - "@=service('prestashop.adapter.shop.context').getContextShopID()"
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\BulkCombinationFormDataHandler:
     autowire: true

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
@@ -165,66 +165,25 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
     }
 
     /**
-     * @Then combination :combinationReference should have following stock details:
+     * @Then combination ":combinationReference" should have following stock details:
      *
      * @param string $combinationReference
      * @param CombinationStock $expectedStock
      */
-    public function assertStockDetails(string $combinationReference, CombinationStock $expectedStock): void
+    public function assertStockForDefaultShop(string $combinationReference, CombinationStock $expectedStock): void
     {
-        $actualStock = $this->getCombinationForEditing($combinationReference, $this->getDefaultShopId())->getStock();
+        $this->assertStockDetails($combinationReference, $expectedStock, [$this->getDefaultShopId()]);
+    }
 
-        Assert::assertSame(
-            $expectedStock->getQuantity(),
-            $actualStock->getQuantity(),
-            sprintf('Unexpected combination "%s" quantity', $combinationReference)
-        );
-        Assert::assertSame(
-            $expectedStock->getMinimalQuantity(),
-            $actualStock->getMinimalQuantity(),
-            sprintf('Unexpected combination "%s" minimal quantity', $combinationReference)
-        );
-        Assert::assertSame(
-            $expectedStock->getLowStockThreshold(),
-            $actualStock->getLowStockThreshold(),
-            sprintf('Unexpected combination "%s" low stock threshold', $combinationReference)
-        );
-        Assert::assertSame(
-            $expectedStock->isLowStockAlertEnabled(),
-            $actualStock->isLowStockAlertEnabled(),
-            sprintf('Unexpected combination "%s" low stock alert', $combinationReference)
-        );
-        Assert::assertSame(
-            $expectedStock->getLocation(),
-            $actualStock->getLocation(),
-            sprintf('Unexpected combination "%s" location', $combinationReference)
-        );
-        if (null === $expectedStock->getAvailableDate()) {
-            Assert::assertSame(
-                $expectedStock->getAvailableDate(),
-                $actualStock->getAvailableDate(),
-                sprintf('Unexpected combination "%s" availability date. Expected NULL, got "%s"',
-                    $combinationReference,
-                    var_export($actualStock->getAvailableDate(), true)
-                )
-            );
-        } else {
-            Assert::assertEquals(
-                $expectedStock->getAvailableDate()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
-                $actualStock->getAvailableDate()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
-                sprintf('Unexpected combination "%s" availability date', $combinationReference)
-            );
-        }
-        $this->assertLocalizedProperty(
-            $expectedStock->getLocalizedAvailableNowLabels(),
-            $actualStock->getLocalizedAvailableNowLabels(),
-            'available now label'
-        );
-        $this->assertLocalizedProperty(
-            $expectedStock->getLocalizedAvailableLaterLabels(),
-            $actualStock->getLocalizedAvailableLaterLabels(),
-            'available later label'
-        );
+    /**
+     * @Then combination ":combinationReference" should have following stock details for shops ":shopReferences":
+     *
+     * @param string $combinationReference
+     * @param CombinationStock $expectedStock
+     */
+    public function assertStockForShops(string $combinationReference, CombinationStock $expectedStock, string $shopReferences): void
+    {
+        $this->assertStockDetails($combinationReference, $expectedStock, $this->referencesToIds($shopReferences));
     }
 
     /**
@@ -253,28 +212,43 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
     /**
      * @Then /^all combinations of product "([^"]*)" should have the stock policy to "([^"]*)"$/
      */
-    public function allCombinationsOfProductShouldHaveTheStockPolicyTo(string $reference, string $outOfStock)
+    public function assertCombinationStockPolicyForDefaultShop(string $productReference, string $outOfStock)
     {
-        $product = $this->getProductForEditing($reference);
+        $this->assertStockPolicyForShops($productReference, $outOfStock, [$this->getDefaultShopId()]);
+    }
 
-        $outOfStockInt = $this->convertOutOfStockToInt($outOfStock);
-        Assert::assertSame(
-            $product->getStockInformation()->getOutOfStockType(),
-            $outOfStockInt
-        );
+    /**
+     * @Then /^all combinations of product "([^"]*)" for shops "([^"]*)" should have the stock policy to "([^"]*)"$/
+     */
+    public function assertCombinationStockPolicyForShops(string $productReference, string $shopReferences, string $outOfStock)
+    {
+        $this->assertStockPolicyForShops($productReference, $outOfStock, $this->referencesToIds($shopReferences));
+    }
 
-        $combinations = $this->getCombinationsList($reference, $this->getDefaultShopId());
+    private function assertStockPolicyForShops(string $productReference, string $outOfStock, array $shopIds): void
+    {
+        foreach ($shopIds as $shopId) {
+            $product = $this->getProductForEditing($productReference, $shopId);
 
-        foreach ($combinations->getCombinations() as $combination) {
-            $id = StockAvailable::getStockAvailableIdByProductId(
-                $this->getSharedStorage()->get($reference),
-                $combination->getCombinationId()
-            );
-
+            $outOfStockInt = $this->convertOutOfStockToInt($outOfStock);
             Assert::assertSame(
-                (int) (new StockAvailable($id))->out_of_stock,
+                $product->getStockInformation()->getOutOfStockType(),
                 $outOfStockInt
             );
+
+            $combinations = $this->getCombinationsList($productReference, $this->getDefaultShopId());
+
+            foreach ($combinations->getCombinations() as $combination) {
+                $id = StockAvailable::getStockAvailableIdByProductId(
+                    $this->getSharedStorage()->get($productReference),
+                    $combination->getCombinationId()
+                );
+
+                Assert::assertSame(
+                    (int) (new StockAvailable($id))->out_of_stock,
+                    $outOfStockInt
+                );
+            }
         }
     }
 
@@ -432,6 +406,72 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
                     (string) $expectedPrices->getProductEcotax(),
                     (string) $actualPrices->getProductEcotax()
                 )
+            );
+        }
+    }
+
+    /**
+     * @param string $combinationReference
+     * @param CombinationStock $expectedStock
+     * @param int[] $shopIds
+     */
+    private function assertStockDetails(string $combinationReference, CombinationStock $expectedStock, array $shopIds): void
+    {
+        foreach ($shopIds as $shopId) {
+            $actualStock = $this->getCombinationForEditing($combinationReference, $shopId)->getStock();
+
+            Assert::assertSame(
+                $expectedStock->getQuantity(),
+                $actualStock->getQuantity(),
+                sprintf('Unexpected combination "%s" quantity for shop %d', $combinationReference, $shopId)
+            );
+            Assert::assertSame(
+                $expectedStock->getMinimalQuantity(),
+                $actualStock->getMinimalQuantity(),
+                sprintf('Unexpected combination "%s" minimal quantity for shop %d', $combinationReference, $shopId)
+            );
+            Assert::assertSame(
+                $expectedStock->getLowStockThreshold(),
+                $actualStock->getLowStockThreshold(),
+                sprintf('Unexpected combination "%s" low stock threshold for shop %d', $combinationReference, $shopId)
+            );
+            Assert::assertSame(
+                $expectedStock->isLowStockAlertEnabled(),
+                $actualStock->isLowStockAlertEnabled(),
+                sprintf('Unexpected combination "%s" low stock alert for shop %d', $combinationReference, $shopId)
+            );
+            Assert::assertSame(
+                $expectedStock->getLocation(),
+                $actualStock->getLocation(),
+                sprintf('Unexpected combination "%s" location for shop %d', $combinationReference, $shopId)
+            );
+            if (null === $expectedStock->getAvailableDate()) {
+                Assert::assertSame(
+                    $expectedStock->getAvailableDate(),
+                    $actualStock->getAvailableDate(),
+                    sprintf('Unexpected combination "%s" availability date for shop %d. Expected NULL, got "%s"',
+                        $combinationReference,
+                        $shopId,
+                        var_export($actualStock->getAvailableDate(), true)
+                    )
+                );
+            } else {
+                Assert::assertEquals(
+                    $expectedStock->getAvailableDate()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
+                    $actualStock->getAvailableDate()->format(DateTimeUtil::DEFAULT_DATETIME_FORMAT),
+                    sprintf('Unexpected combination "%s" availability date for shop %d', $combinationReference, $shopId)
+                );
+            }
+
+            $this->assertLocalizedProperty(
+                $expectedStock->getLocalizedAvailableNowLabels(),
+                $actualStock->getLocalizedAvailableNowLabels(),
+                sprintf('available now label for shop %d', $shopId)
+            );
+            $this->assertLocalizedProperty(
+                $expectedStock->getLocalizedAvailableLaterLabels(),
+                $actualStock->getLocalizedAvailableLaterLabels(),
+                sprintf('available later label for shop %d', $shopId)
             );
         }
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
@@ -236,12 +236,13 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
                 $outOfStockInt
             );
 
-            $combinations = $this->getCombinationsList($productReference, $this->getDefaultShopId());
+            $combinations = $this->getCombinationsList($productReference, $shopId);
 
             foreach ($combinations->getCombinations() as $combination) {
                 $id = StockAvailable::getStockAvailableIdByProductId(
                     $this->getSharedStorage()->get($productReference),
-                    $combination->getCombinationId()
+                    $combination->getCombinationId(),
+                    $shopId
                 );
 
                 Assert::assertSame(

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
@@ -94,96 +94,20 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
      * @param string $combinationReference
      * @param CombinationPrices $expectedPrices
      */
-    public function assertCombinationPrices(string $combinationReference, CombinationPrices $expectedPrices): void
+    public function assertPricesForDefaultShop(string $combinationReference, CombinationPrices $expectedPrices): void
     {
-        $actualPrices = $this->getCombinationForEditing($combinationReference, $this->getDefaultShopId())->getPrices();
+        $this->assertPrices($combinationReference, $expectedPrices, [$this->getDefaultShopId()]);
+    }
 
-        Assert::assertTrue(
-            $expectedPrices->getImpactOnPrice()->equals($actualPrices->getImpactOnPrice()),
-            sprintf(
-                'Unexpected combination impact on price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getImpactOnPrice(),
-                (string) $actualPrices->getImpactOnPrice()
-            )
-        );
-        Assert::assertTrue(
-            $expectedPrices->getImpactOnPriceTaxIncluded()->equals($actualPrices->getImpactOnPriceTaxIncluded()),
-            sprintf(
-                'Unexpected combination impact on price with taxes. Expected "%s", got "%s"',
-                (string) $expectedPrices->getImpactOnPriceTaxIncluded(),
-                (string) $actualPrices->getImpactOnPriceTaxIncluded()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getEcotax()->equals($actualPrices->getEcotax()),
-            sprintf(
-                'Unexpected combination eco tax. Expected "%s", got "%s"',
-                (string) $expectedPrices->getEcotax(),
-                (string) $actualPrices->getEcotax()
-            )
-        );
-        Assert::assertTrue(
-            $expectedPrices->getEcotaxTaxIncluded()->equals($actualPrices->getEcotaxTaxIncluded()),
-            sprintf(
-                'Unexpected combination eco tax with taxes. Expected "%s", got "%s"',
-                (string) $expectedPrices->getEcotaxTaxIncluded(),
-                (string) $actualPrices->getEcotaxTaxIncluded()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getImpactOnUnitPrice()->equals($actualPrices->getImpactOnUnitPrice()),
-            sprintf(
-                'Unexpected combination impact on unit price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getImpactOnUnitPrice(),
-                (string) $actualPrices->getImpactOnUnitPrice()
-            )
-        );
-        Assert::assertTrue(
-            $expectedPrices->getImpactOnPriceTaxIncluded()->equals($actualPrices->getImpactOnPriceTaxIncluded()),
-            sprintf(
-                'Unexpected combination impact on unit price with taxes. Expected "%s", got "%s"',
-                (string) $expectedPrices->getImpactOnPriceTaxIncluded(),
-                (string) $actualPrices->getImpactOnPriceTaxIncluded()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getWholesalePrice()->equals($actualPrices->getWholesalePrice()),
-            sprintf(
-                'Unexpected combination wholesale price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getWholesalePrice(),
-                (string) $actualPrices->getWholesalePrice()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getProductTaxRate()->equals($actualPrices->getProductTaxRate()),
-            sprintf(
-                'Unexpected combination product tax rate. Expected "%s", got "%s"',
-                (string) $expectedPrices->getProductTaxRate(),
-                (string) $actualPrices->getProductTaxRate()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getProductPrice()->equals($actualPrices->getProductPrice()),
-            sprintf(
-                'Unexpected combination product price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getProductPrice(),
-                (string) $actualPrices->getProductPrice()
-            )
-        );
-
-        Assert::assertTrue(
-            $expectedPrices->getProductEcotax()->equals($actualPrices->getProductEcotax()),
-            sprintf(
-                'Unexpected combination wholesale price. Expected "%s", got "%s"',
-                (string) $expectedPrices->getProductEcotax(),
-                (string) $actualPrices->getProductEcotax()
-            )
-        );
+    /**
+     * @Then combination ":combinationReference" should have following prices for shops ":shopReferences":
+     *
+     * @param string $combinationReference
+     * @param CombinationPrices $expectedPrices
+     */
+    public function assertPricesForShops(string $combinationReference, CombinationPrices $expectedPrices, string $shopReferences): void
+    {
+        $this->assertPrices($combinationReference, $expectedPrices, $this->referencesToIds($shopReferences));
     }
 
     /**
@@ -403,6 +327,110 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
                     var_export($expectedDetails->getImpactOnWeight(), true),
                     var_export($actualDetails->getImpactOnWeight(), true),
                     $shopId
+                )
+            );
+        }
+    }
+
+    private function assertPrices(string $combinationReference, CombinationPrices $expectedPrices, array $shopIds): void
+    {
+        foreach ($shopIds as $shopId) {
+            $actualPrices = $this->getCombinationForEditing($combinationReference, $shopId)->getPrices();
+
+            Assert::assertTrue(
+                $expectedPrices->getImpactOnPrice()->equals($actualPrices->getImpactOnPrice()),
+                sprintf(
+                    'Unexpected combination impact on price for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getImpactOnPrice(),
+                    (string) $actualPrices->getImpactOnPrice()
+                )
+            );
+            Assert::assertTrue(
+                $expectedPrices->getImpactOnPriceTaxIncluded()->equals($actualPrices->getImpactOnPriceTaxIncluded()),
+                sprintf(
+                    'Unexpected combination impact on price with taxes for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getImpactOnPriceTaxIncluded(),
+                    (string) $actualPrices->getImpactOnPriceTaxIncluded()
+                )
+            );
+
+            Assert::assertTrue(
+                $expectedPrices->getEcotax()->equals($actualPrices->getEcotax()),
+                sprintf(
+                    'Unexpected combination eco tax for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getEcotax(),
+                    (string) $actualPrices->getEcotax()
+                )
+            );
+            Assert::assertTrue(
+                $expectedPrices->getEcotaxTaxIncluded()->equals($actualPrices->getEcotaxTaxIncluded()),
+                sprintf(
+                    'Unexpected combination eco tax with taxes for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getEcotaxTaxIncluded(),
+                    (string) $actualPrices->getEcotaxTaxIncluded()
+                )
+            );
+
+            Assert::assertTrue(
+                $expectedPrices->getImpactOnUnitPrice()->equals($actualPrices->getImpactOnUnitPrice()),
+                sprintf(
+                    'Unexpected combination impact on unit price for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getImpactOnUnitPrice(),
+                    (string) $actualPrices->getImpactOnUnitPrice()
+                )
+            );
+            Assert::assertTrue(
+                $expectedPrices->getImpactOnPriceTaxIncluded()->equals($actualPrices->getImpactOnPriceTaxIncluded()),
+                sprintf(
+                    'Unexpected combination impact on unit price with taxes for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getImpactOnPriceTaxIncluded(),
+                    (string) $actualPrices->getImpactOnPriceTaxIncluded()
+                )
+            );
+
+            Assert::assertTrue(
+                $expectedPrices->getWholesalePrice()->equals($actualPrices->getWholesalePrice()),
+                sprintf(
+                    'Unexpected combination wholesale price for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getWholesalePrice(),
+                    (string) $actualPrices->getWholesalePrice()
+                )
+            );
+
+            Assert::assertTrue(
+                $expectedPrices->getProductTaxRate()->equals($actualPrices->getProductTaxRate()),
+                sprintf(
+                    'Unexpected combination product tax rate for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getProductTaxRate(),
+                    (string) $actualPrices->getProductTaxRate()
+                )
+            );
+
+            Assert::assertTrue(
+                $expectedPrices->getProductPrice()->equals($actualPrices->getProductPrice()),
+                sprintf(
+                    'Unexpected combination product price for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getProductPrice(),
+                    (string) $actualPrices->getProductPrice()
+                )
+            );
+
+            Assert::assertTrue(
+                $expectedPrices->getProductEcotax()->equals($actualPrices->getProductEcotax()),
+                sprintf(
+                    'Unexpected combination wholesale price for shop %d. Expected "%s", got "%s"',
+                    $shopId,
+                    (string) $expectedPrices->getProductEcotax(),
+                    (string) $actualPrices->getProductEcotax()
                 )
             );
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationShopFeatureContext.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination;
+
+use PHPUnit\Framework\Assert;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
+
+class CombinationShopFeatureContext extends AbstractCombinationFeatureContext
+{
+    /**
+     * @Then /^combinations "(.*)" are not associated to shop "(.*)"$/
+     *
+     * @param string $combinationReferences
+     * @param string $shopReference
+     */
+    public function checkNoShopAssociation(string $combinationReferences, string $shopReference): void
+    {
+        $shopId = $this->getSharedStorage()->get($shopReference);
+
+        foreach (explode(',', $combinationReferences) as $combinationReference) {
+            $caughtException = null;
+            try {
+                $this->getCombinationForEditing($combinationReference, $shopId);
+            } catch (ShopAssociationNotFound $e) {
+                $caughtException = $e;
+            }
+
+            Assert::assertNotNull($caughtException);
+        }
+    }
+
+    /**
+     * @Then /^combinations "(.*)" are associated to shop "(.*)"$/
+     *
+     * @param string $combinationReferences
+     * @param string $shopReference
+     */
+    public function checkShopAssociation(string $combinationReferences, string $shopReference): void
+    {
+        $shopId = $this->getSharedStorage()->get($shopReference);
+
+        foreach (explode(',', $combinationReferences) as $combinationReference) {
+            $caughtException = null;
+            try {
+                $this->getCombinationForEditing($combinationReference, $shopId);
+            } catch (ShopAssociationNotFound $e) {
+                $caughtException = $e;
+            }
+
+            Assert::assertNull($caughtException);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
@@ -33,6 +33,7 @@ use DateTime;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
 /**
@@ -63,9 +64,41 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
      *
      * @param string $combinationReference
      */
-    public function setDefaultCombination(string $combinationReference): void
+    public function setDefaultCombinationForDefaultShop(string $combinationReference): void
     {
-        $command = new UpdateCombinationCommand((int) $this->getSharedStorage()->get($combinationReference));
+        $this->setDefaultCombination($combinationReference, ShopConstraint::shop($this->getDefaultShopId()));
+    }
+
+    /**
+     * @When I set combination ":combinationReference" as default for shop ":shopReference"
+     *
+     * @param string $combinationReference
+     * @param string $shopReference
+     */
+    public function setDefaultCombinationForShop(string $combinationReference, string $shopReference): void
+    {
+        $this->setDefaultCombination(
+            $combinationReference,
+            ShopConstraint::shop($this->getSharedStorage()->get($shopReference))
+        );
+    }
+
+    /**
+     * @When I set combination ":combinationReference" as default for all shops
+     *
+     * @param string $combinationReference
+     */
+    public function setDefaultCombinationForAllShops(string $combinationReference): void
+    {
+        $this->setDefaultCombination($combinationReference, ShopConstraint::allShops());
+    }
+
+    private function setDefaultCombination(string $combinationReference, ShopConstraint $shopConstraint): void
+    {
+        $command = new UpdateCombinationCommand(
+            (int) $this->getSharedStorage()->get($combinationReference),
+            $shopConstraint
+        );
         $command->setIsDefault(true);
         $this->getCommandBus()->handle($command);
     }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
@@ -128,7 +128,7 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
         $this->getCommandBus()->handle($command);
     }
 
-    private function updateCombinationStockAvailable(string $combinationReference, array $dataRows): void
+    private function updateCombinationStockAvailable(string $combinationReference, array $dataRows, ShopConstraint $shopConstraint): void
     {
         if (!isset($dataRows['delta quantity'])
             && !isset($dataRows['fixed quantity'])
@@ -137,7 +137,10 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
         }
 
         try {
-            $command = new UpdateCombinationStockAvailableCommand((int) $this->getSharedStorage()->get($combinationReference));
+            $command = new UpdateCombinationStockAvailableCommand(
+                (int) $this->getSharedStorage()->get($combinationReference),
+                $shopConstraint
+            );
             if (isset($dataRows['delta quantity'])) {
                 $command->setDeltaQuantity((int) $dataRows['delta quantity']);
             }
@@ -229,6 +232,6 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
         $this->fillCommand($command, $tableNode->getRowsHash());
         $this->getCommandBus()->handle($command);
 
-        $this->updateCombinationStockAvailable($combinationReference, $tableNode->getRowsHash());
+        $this->updateCombinationStockAvailable($combinationReference, $tableNode->getRowsHash(), $shopConstraint);
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
@@ -31,8 +31,6 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combinatio
 use Behat\Gherkin\Node\TableNode;
 use DateTime;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
-use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
 
@@ -128,35 +126,6 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
         $this->getCommandBus()->handle($command);
     }
 
-    private function updateCombinationStockAvailable(string $combinationReference, array $dataRows, ShopConstraint $shopConstraint): void
-    {
-        if (!isset($dataRows['delta quantity'])
-            && !isset($dataRows['fixed quantity'])
-            && !isset($dataRows['location'])) {
-            return;
-        }
-
-        try {
-            $command = new UpdateCombinationStockAvailableCommand(
-                (int) $this->getSharedStorage()->get($combinationReference),
-                $shopConstraint
-            );
-            if (isset($dataRows['delta quantity'])) {
-                $command->setDeltaQuantity((int) $dataRows['delta quantity']);
-            }
-            if (isset($dataRows['fixed quantity'])) {
-                $command->setFixedQuantity((int) $dataRows['fixed quantity']);
-            }
-            if (isset($dataRows['location'])) {
-                $command->setLocation($dataRows['location']);
-            }
-
-            $this->getCommandBus()->handle($command);
-        } catch (ProductStockConstraintException $e) {
-            $this->setLastException($e);
-        }
-    }
-
     /**
      * @param UpdateCombinationCommand $command
      * @param array $dataRows
@@ -231,7 +200,5 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
 
         $this->fillCommand($command, $tableNode->getRowsHash());
         $this->getCommandBus()->handle($command);
-
-        $this->updateCombinationStockAvailable($combinationReference, $tableNode->getRowsHash(), $shopConstraint);
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
@@ -49,14 +49,39 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
      * @param string $combinationReference
      * @param TableNode $tableNode
      */
-    public function updateCombination(string $combinationReference, TableNode $tableNode): void
+    public function updateCombinationForDefaultShop(string $combinationReference, TableNode $tableNode): void
     {
-        $command = new UpdateCombinationCommand((int) $this->getSharedStorage()->get($combinationReference));
+        $this->updateCombination($combinationReference, $tableNode, ShopConstraint::shop($this->getDefaultShopId()));
+    }
 
-        $this->fillCommand($command, $tableNode->getRowsHash());
-        $this->getCommandBus()->handle($command);
+    /**
+     * @When I update combination ":combinationReference" with following values for shop ":shopReference":
+     *
+     * @param string $combinationReference
+     * @param TableNode $tableNode
+     */
+    public function updateCombinationForShop(string $combinationReference, TableNode $tableNode, string $shopReference): void
+    {
+        $this->updateCombination(
+            $combinationReference,
+            $tableNode,
+            ShopConstraint::shop($this->getSharedStorage()->get($shopReference))
+        );
+    }
 
-        $this->updateCombinationStockAvailable($combinationReference, $tableNode->getRowsHash());
+    /**
+     * @When I update combination ":combinationReference" with following values for all shops:
+     *
+     * @param string $combinationReference
+     * @param TableNode $tableNode
+     */
+    public function updateCombinationForAllShops(string $combinationReference, TableNode $tableNode): void
+    {
+        $this->updateCombination(
+            $combinationReference,
+            $tableNode,
+            ShopConstraint::allShops()
+        );
     }
 
     /**
@@ -192,5 +217,18 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
             $command->setLocalizedAvailableLaterLabels($dataRows['available later labels']);
             unset($dataRows['available later labels']);
         }
+    }
+
+    private function updateCombination(string $combinationReference, TableNode $tableNode, ShopConstraint $shopConstraint): void
+    {
+        $command = new UpdateCombinationCommand(
+            (int) $this->getSharedStorage()->get($combinationReference),
+            $shopConstraint
+        );
+
+        $this->fillCommand($command, $tableNode->getRowsHash());
+        $this->getCommandBus()->handle($command);
+
+        $this->updateCombinationStockAvailable($combinationReference, $tableNode->getRowsHash());
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination;
+
+use Behat\Gherkin\Node\TableNode;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureContext
+{
+    /**
+     * @When I update combination ":combinationReference" stock with following details:
+     */
+    public function updateStockForDefaultShop(
+        string $combinationReference,
+        TableNode $tableNode
+    ): void {
+        $this->updateStockAvailable(
+            $combinationReference,
+            $tableNode->getRowsHash(),
+            ShopConstraint::shop($this->getDefaultShopId())
+        );
+    }
+
+    /**
+     * @When I update combination ":combinationReference" stock for shop ":shopReference" with following details:
+     */
+    public function updateStockForShop(
+        string $combinationReference,
+        string $shopReference,
+        TableNode $tableNode
+    ): void {
+        $this->updateStockAvailable(
+            $combinationReference,
+            $tableNode->getRowsHash(),
+            ShopConstraint::shop($this->getSharedStorage()->get($shopReference))
+        );
+    }
+
+    /**
+     * @When I update combination ":combinationReference" stock for all shops with following details:
+     */
+    public function updateStockForAllShops(
+        string $combinationReference,
+        TableNode $tableNode
+    ): void {
+        $this->updateStockAvailable(
+            $combinationReference,
+            $tableNode->getRowsHash(),
+            ShopConstraint::allShops()
+        );
+    }
+
+    private function updateStockAvailable(string $combinationReference, array $dataRows, ShopConstraint $shopConstraint): void
+    {
+        if (!isset($dataRows['delta quantity'])
+            && !isset($dataRows['fixed quantity'])
+            && !isset($dataRows['location'])) {
+            return;
+        }
+
+        try {
+            $command = new UpdateCombinationStockAvailableCommand(
+                (int) $this->getSharedStorage()->get($combinationReference),
+                $shopConstraint
+            );
+            if (isset($dataRows['delta quantity'])) {
+                $command->setDeltaQuantity((int) $dataRows['delta quantity']);
+            }
+            if (isset($dataRows['fixed quantity'])) {
+                $command->setFixedQuantity((int) $dataRows['fixed quantity']);
+            }
+            if (isset($dataRows['location'])) {
+                $command->setLocation($dataRows['location']);
+            }
+
+            $this->getCommandBus()->handle($command);
+        } catch (ProductStockConstraintException $e) {
+            $this->setLastException($e);
+        }
+    }
+}

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/StockAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/StockAssertionFeatureContext.php
@@ -160,6 +160,19 @@ class StockAssertionFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
+     * @Then combination ":combinationReference" should have no stock movements for shop ":shopReference"
+     *
+     * @param string $combinationReference
+     * @param string $shopReference
+     */
+    public function assertCombinationNoLastStockMovementsForShop(
+        string $combinationReference,
+        string $shopReference
+    ): void {
+        $this->assertNoStockMovementForCombination($combinationReference, $this->getSharedStorage()->get($shopReference));
+    }
+
+    /**
      * @Then /^product "(.*)" last stock movement (increased|decreased) by (\d+)$/
      */
     public function assertProductLastStockMovementForDefaultShop(
@@ -410,6 +423,16 @@ class StockAssertionFeatureContext extends AbstractProductFeatureContext
 
         $stockMovementHistories = $this->getQueryBus()->handle(
             new GetProductStockMovements($productId, $shopId)
+        );
+        Assert::assertEmpty($stockMovementHistories, 'Expected to find no stock movements');
+    }
+
+    private function assertNoStockMovementForCombination(string $combinationReference, int $shopId): void
+    {
+        $combinationId = $this->getSharedStorage()->get($combinationReference);
+
+        $stockMovementHistories = $this->getQueryBus()->handle(
+            new GetCombinationStockMovements($combinationId, $shopId)
         );
         Assert::assertEmpty($stockMovementHistories, 'Expected to find no stock movements');
     }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_multishop_combination.feature
@@ -36,7 +36,11 @@ Feature: Delete combination from Back Office (BO) in multiple shops
     And I generate combinations in shop "shop1" for product product1 using following attributes:
       | Size  | [S,M]              |
       | Color | [White,Black,Blue] |
-    And product "product1" should have the following combinations for shops "shop1":
+    And product "product1" should have no combinations for shops "shop2"
+    And I generate combinations in shop "shop2" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop1,shop2":
       | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
       | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
       | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
@@ -45,18 +49,6 @@ Feature: Delete combination from Back Office (BO) in multiple shops
       | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop1" should be "product1SWhite"
-    And product "product1" should have no combinations for shops "shop2"
-    And I generate combinations in shop "shop2" for product product1 using following attributes:
-      | Size  | [S,M]              |
-      | Color | [White,Black,Blue] |
-    And product "product1" should have the following combinations for shops "shop2":
-      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
-      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
-      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
-      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
-      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
-      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
-      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop2" should be "product1SWhite"
 
   Scenario: Delete one non-default combination from the default shop

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_multishop_combination.feature
@@ -28,7 +28,7 @@ Feature: Delete combination from Back Office (BO) in multiple shops
     And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
     And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
     And single shop context is loaded
-    Given I add product "product1" with following information:
+    And I add product "product1" with following information:
       | name[en-US] | universal T-shirt |
       | type        | combinations      |
     And product product1 type should be combinations

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/generate_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/generate_multishop_combination.feature
@@ -248,3 +248,42 @@ Feature: Generate combination from Back Office (BO) when using multi-shop featur
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop1" should be "product1SWhite"
     And product "product1" default combination for shop "shop2" should be "product1SWhite"
+
+  Scenario: Generated combination out of stock type matches with product when generating for specific shop
+    Given product "product1" should have following stock information for shops "shop1,shop2":
+      | out_of_stock_type | default |
+    When I generate combinations in shop "shop1" for product "product1" using following attributes:
+      | Size  | [S]           |
+      | Color | [White,Black] |
+    Then product "product1" should have the following combinations for shops "shop1":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+    And product "product1" should have no combinations for shops "shop2"
+    And all combinations of product "product1" for shops "shop1" should have the stock policy to "default"
+    When I update product "product1" stock for shop "shop2" with following information:
+      | out_of_stock_type | available |
+    And I generate combinations in shop "shop2" for product "product1" using following attributes:
+      | Size  | [S]           |
+      | Color | [White,Black] |
+    Then product "product1" should have the following combinations for shops "shop1,shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+    And all combinations of product "product1" for shops "shop2" should have the stock policy to "available"
+    But all combinations of product "product1" for shops "shop1" should have the stock policy to "default"
+
+  Scenario: Generated combination out of stock type matches with product when generating for all shops
+    Given product "product1" should have following stock information for shops "shop1,shop2":
+      | out_of_stock_type | default |
+    When I generate combinations for product "product1" in all shops using following attributes:
+      | Size  | [S]           |
+      | Color | [White,Black] |
+    And all combinations of product "product1" for shops "shop1" should have the stock policy to "default"
+    When I update product "product1" stock for all shops with following information:
+      | out_of_stock_type | not_available |
+    And I generate combinations for product "product1" in all shops using following attributes:
+      | Size  | [S]           |
+      | Color | [White,Black] |
+    And all combinations of product "product1" for shops "shop2" should have the stock policy to "not_available"
+    And all combinations of product "product1" for shops "shop1" should have the stock policy to "not_available"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/set_default_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/set_default_multishop_combination.feature
@@ -34,7 +34,11 @@ Feature: Set default combination for product in Back Office (BO) in multi shop c
     And I generate combinations in shop "shop1" for product product1 using following attributes:
       | Size  | [S,M]              |
       | Color | [White,Black,Blue] |
-    And product "product1" should have the following combinations for shops "shop1":
+    And product "product1" should have no combinations for shops "shop2"
+    And I generate combinations in shop "shop2" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop1,shop2":
       | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
       | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
       | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
@@ -43,18 +47,6 @@ Feature: Set default combination for product in Back Office (BO) in multi shop c
       | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop1" should be "product1SWhite"
-    And product "product1" should have no combinations for shops "shop2"
-    And I generate combinations in shop "shop2" for product product1 using following attributes:
-      | Size  | [S,M]              |
-      | Color | [White,Black,Blue] |
-    And product "product1" should have the following combinations for shops "shop2":
-      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
-      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
-      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
-      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
-      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
-      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
-      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop2" should be "product1SWhite"
     And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop1"
     And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop2"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/set_default_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/set_default_multishop_combination.feature
@@ -3,7 +3,7 @@
 @clear-cache-before-feature
 @product-combination
 @set-default-multi-shop-combination
-Feature: Set default combination for product in Back Office (BO) in multiShop context
+Feature: Set default combination for product in Back Office (BO) in multi shop context
   As an employee
   I need to be able to set default combination from BO in multiple shops
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/set_default_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/set_default_multishop_combination.feature
@@ -1,0 +1,134 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags set-default-multi-shop-combination
+@restore-products-before-feature
+@clear-cache-before-feature
+@product-combination
+@set-default-multi-shop-combination
+Feature: Set default combination for product in Back Office (BO) in multiShop context
+  As an employee
+  I need to be able to set default combination from BO in multiple shops
+
+  Background:
+    Given language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
+    And attribute "Red" named "Red" in en language exists
+    And shop "shop1" with name "test_shop" exists
+    And I enable multishop feature
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And single shop context is loaded
+    And I add product "product1" with following information:
+      | name[en-US] | universal T-shirt |
+      | type        | combinations      |
+    And product product1 type should be combinations
+    And I copy product product1 from shop shop1 to shop shop2
+    And I generate combinations in shop "shop1" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop1":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SWhite"
+    And product "product1" should have no combinations for shops "shop2"
+    And I generate combinations in shop "shop2" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop1"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop2"
+
+  Scenario: Change default combination for product in specific shop
+    When I set combination "product1SBlack" as default for shop "shop1"
+    Then product "product1" should have the following combinations for shops "shop1":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | false      |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | true       |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SBlack"
+    And product "product1" should have the following combinations for shops "shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"
+    When I set combination "product1SBlack" as default for shop "shop2"
+    Then product "product1" should have the following combinations for shops "shop1":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | false      |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | true       |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SBlack"
+    And product "product1" should have the following combinations for shops "shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | false      |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | true       |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop2" should be "product1SBlack"
+    When I set combination "product1MBlue" as default for shop "shop2"
+    Then product "product1" should have the following combinations for shops "shop1":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | false      |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | true       |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SBlack"
+    And product "product1" should have the following combinations for shops "shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | false      |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | true       |
+    And product "product1" default combination for shop "shop2" should be "product1MBlue"
+
+  Scenario: Change default combination for product in all shops
+    When I set combination "product1MBlue" as default for all shops
+    Then product "product1" should have the following combinations for shops "shop1,shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | false      |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | true       |
+    And product "product1" default combination for shop "shop1" should be "product1MBlue"
+    And product "product1" default combination for shop "shop2" should be "product1MBlue"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are not associated to shop "shop3"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are not associated to shop "shop4"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_details.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_details.feature
@@ -34,7 +34,11 @@ Feature: Update product combination details in Back Office (BO) in multi shop co
     And I generate combinations in shop "shop1" for product product1 using following attributes:
       | Size  | [S,M]              |
       | Color | [White,Black,Blue] |
-    And product "product1" should have the following combinations for shops "shop1":
+    And product "product1" should have no combinations for shops "shop2"
+    And I generate combinations in shop "shop2" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop1,shop2":
       | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
       | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
       | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
@@ -43,18 +47,6 @@ Feature: Update product combination details in Back Office (BO) in multi shop co
       | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop1" should be "product1SWhite"
-    And product "product1" should have no combinations for shops "shop2"
-    And I generate combinations in shop "shop2" for product product1 using following attributes:
-      | Size  | [S,M]              |
-      | Color | [White,Black,Blue] |
-    And product "product1" should have the following combinations for shops "shop2":
-      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
-      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
-      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
-      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
-      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
-      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
-      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
     And product "product1" default combination for shop "shop2" should be "product1SWhite"
     And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop1"
     And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop2"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_details.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_details.feature
@@ -1,0 +1,119 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-multi-shop-details
+@restore-products-before-feature
+@clear-cache-before-feature
+@product-combination
+@update-combination-multi-shop-details
+Feature: Update product combination details in Back Office (BO) in multi shop context
+  As an employee
+  I need to be able to update product combination details from BO in multiple shops
+
+  Background:
+    Given language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
+    And attribute "Red" named "Red" in en language exists
+    And shop "shop1" with name "test_shop" exists
+    And I enable multishop feature
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And single shop context is loaded
+    And I add product "product1" with following information:
+      | name[en-US] | universal T-shirt |
+      | type        | combinations      |
+    And product product1 type should be combinations
+    And I copy product product1 from shop shop1 to shop shop2
+    And I generate combinations in shop "shop1" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop1":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SWhite"
+    And product "product1" should have no combinations for shops "shop2"
+    And I generate combinations in shop "shop2" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop1"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop2"
+
+  Scenario: I update combination details for specific shop:
+    And combination "product1SWhite" should have following details for shops "shop1,shop2":
+      | combination detail | value |
+      | ean13              |       |
+      | isbn               |       |
+      | mpn                |       |
+      | reference          |       |
+      | upc                |       |
+      | impact on weight   | 0     |
+      # details are shared between shops.
+      # doesn't matter which shop we provide, they are updated in general product_attribute table
+      # except the impact_on_weight
+    When I update combination "product1SWhite" with following values for shop "shop1":
+      | ean13            | 978020137962      |
+      | isbn             | 978-3-16-148410-0 |
+      | mpn              | mpn1              |
+      | reference        | ref1              |
+      | upc              | 72527273070       |
+      | impact on weight | 17.25             |
+    Then combination "product1SWhite" should have following details for shops "shop1":
+      | combination detail | value             |
+      | ean13              | 978020137962      |
+      | isbn               | 978-3-16-148410-0 |
+      | mpn                | mpn1              |
+      | reference          | ref1              |
+      | upc                | 72527273070       |
+      | impact on weight   | 17.25             |
+    And combination "product1SWhite" should have following details for shops "shop2":
+      | combination detail | value             |
+      | ean13              | 978020137962      |
+      | isbn               | 978-3-16-148410-0 |
+      | mpn                | mpn1              |
+      | reference          | ref1              |
+      | upc                | 72527273070       |
+      | impact on weight   | 0                 |
+    When I update combination "product1SWhite" with following values for shop "shop2":
+      | ean13            |      |
+      | isbn             |      |
+      | mpn              |      |
+      | reference        | ref2 |
+      | upc              |      |
+      | impact on weight | 7    |
+    Then combination "product1SWhite" should have following details for shops "shop2":
+      | combination detail | value |
+      | ean13              |       |
+      | isbn               |       |
+      | mpn                |       |
+      | reference          | ref2  |
+      | upc                |       |
+      | impact on weight   | 7     |
+    Then combination "product1SWhite" should have following details for shops "shop1":
+      | combination detail | value |
+      | ean13              |       |
+      | isbn               |       |
+      | mpn                |       |
+      | reference          | ref2  |
+      | upc                |       |
+      | impact on weight   | 17.25 |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_details.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_details.feature
@@ -117,3 +117,35 @@ Feature: Update product combination details in Back Office (BO) in multi shop co
       | reference          | ref2  |
       | upc                |       |
       | impact on weight   | 17.25 |
+    And combinations "product1SWhite" are not associated to shop "shop3"
+    And combinations "product1SWhite" are not associated to shop "shop4"
+
+  Scenario: I update combination details for all shops:
+    And combination "product1SBlack" should have following details for shops "shop1,shop2":
+      | combination detail | value |
+      | ean13              |       |
+      | isbn               |       |
+      | mpn                |       |
+      | reference          |       |
+      | upc                |       |
+      | impact on weight   | 0     |
+      # details are shared between shops.
+      # doesn't matter which shop we provide, they are updated in general product_attribute table
+      # except the impact_on_weight
+    When I update combination "product1SBlack" with following values for all shops:
+      | ean13            | 978020137962      |
+      | isbn             | 978-3-16-148410-0 |
+      | mpn              | mpn1              |
+      | reference        | ref1              |
+      | upc              | 72527273070       |
+      | impact on weight | 17.25             |
+    Then combination "product1SBlack" should have following details for shops "shop1,shop2":
+      | combination detail | value             |
+      | ean13              | 978020137962      |
+      | isbn               | 978-3-16-148410-0 |
+      | mpn                | mpn1              |
+      | reference          | ref1              |
+      | upc                | 72527273070       |
+      | impact on weight   | 17.25             |
+    And combinations "product1SBlack" are not associated to shop "shop3"
+    And combinations "product1SBlack" are not associated to shop "shop4"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_prices.feature
@@ -1,0 +1,246 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-multi-shop-prices
+@restore-products-before-feature
+@clear-cache-before-feature
+@product-combination
+@update-product-prices
+@update-combination-multi-shop-prices
+Feature: Update product combination prices in Back Office (BO) in multi shop context
+  As an employee
+  I need to be able to update product combination prices from BO for multiple shops
+
+  Background:
+    Given language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
+    And attribute "Red" named "Red" in en language exists
+    And I identify tax rules group named "US-AL Rate (4%)" as "us-al-tax-rate"
+    And I identify tax rules group named "US-KS Rate (5.3%)" as "us-ks-tax-rate"
+    And shop "shop1" with name "test_shop" exists
+    And I enable multishop feature
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And single shop context is loaded
+    And I add product "product1" with following information:
+      | name[en-US] | universal T-shirt |
+      | type        | combinations      |
+    And product product1 type should be combinations
+    And I copy product product1 from shop shop1 to shop shop2
+    And I generate combinations in shop "shop1" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have no combinations for shops "shop2"
+    And I generate combinations in shop "shop2" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop1,shop2":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SWhite"
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop1"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop2"
+
+  Scenario: I update combination prices for specific shop:
+    Given I update product "product1" for shop "shop1" with following values:
+      | price           | 51.49           |
+      | ecotax          | 17.78           |
+      | tax rules group | US-AL Rate (4%) |
+    And I update product "product1" for shop "shop2" with following values:
+      | price           | 21.99             |
+      | ecotax          | 5.5               |
+      | tax rules group | US-KS Rate (5.3%) |
+    And combination "product1SWhite" should have following prices for shops "shop1":
+      | combination price detail        | value |
+      | impact on price                 | 0     |
+      | impact on price with taxes      | 0     |
+      | impact on unit price            | 0     |
+      | impact on unit price with taxes | 0     |
+      | eco tax                         | 0     |
+      | eco tax with taxes              | 0     |
+      | wholesale price                 | 0     |
+      | product tax rate                | 4.00  |
+      | product price                   | 51.49 |
+      | product ecotax                  | 17.78 |
+    And combination "product1SWhite" should have following prices for shops "shop2":
+      | combination price detail        | value |
+      | impact on price                 | 0     |
+      | impact on price with taxes      | 0     |
+      | impact on unit price            | 0     |
+      | impact on unit price with taxes | 0     |
+      | eco tax                         | 0     |
+      | eco tax with taxes              | 0     |
+      | wholesale price                 | 0     |
+      | product tax rate                | 5.3   |
+      | product price                   | 21.99 |
+      | product ecotax                  | 5.5   |
+    When I update combination "product1SWhite" with following values for shop "shop1":
+      | eco tax              | 0.5 |
+      | impact on price      | -5  |
+      | impact on unit price | -1  |
+      | wholesale price      | 20  |
+    And I update combination "product1SWhite" with following values for shop "shop2":
+      | eco tax              | 0.2 |
+      | impact on price      | -10 |
+      | impact on unit price | -2  |
+      | wholesale price      | 30  |
+    Then combination "product1SWhite" should have following prices for shops "shop1":
+      | combination price detail        | value |
+      | impact on price                 | -5    |
+      | impact on price with taxes      | -5.20 |
+      | impact on unit price            | -1    |
+      | impact on unit price with taxes | -1.04 |
+      | eco tax                         | 0.5   |
+      | eco tax with taxes              | 0.5   |
+      | wholesale price                 | 20    |
+      | product tax rate                | 4.00  |
+      | product price                   | 51.49 |
+      | product ecotax                  | 17.78 |
+    Then combination "product1SWhite" should have following prices for shops "shop2":
+      | combination price detail        | value  |
+      | impact on price                 | -10    |
+      | impact on price with taxes      | -10.53 |
+      | impact on unit price            | -2     |
+      | impact on unit price with taxes | -2.106 |
+      | eco tax                         | 0.2    |
+      | eco tax with taxes              | 0.2    |
+      | wholesale price                 | 30     |
+      | product tax rate                | 5.3    |
+      | product price                   | 21.99  |
+      | product ecotax                  | 5.5    |
+    # Enable ecotax
+    And shop configuration for "PS_USE_ECOTAX" is set to 1
+    And shop configuration for "PS_ECOTAX_TAX_RULES_GROUP_ID" is set to us-ks-tax-rate
+    Then combination "product1SWhite" should have following prices for shops "shop1":
+      | combination price detail        | value  |
+      | impact on price                 | -5     |
+      | impact on price with taxes      | -5.20  |
+      | impact on unit price            | -1     |
+      | impact on unit price with taxes | -1.04  |
+      | eco tax                         | 0.5    |
+      | eco tax with taxes              | 0.5265 |
+      | wholesale price                 | 20     |
+      | product tax rate                | 4.00   |
+      | product price                   | 51.49  |
+      | product ecotax                  | 17.78  |
+    Then combination "product1SWhite" should have following prices for shops "shop2":
+      | combination price detail        | value  |
+      | impact on price                 | -10    |
+      | impact on price with taxes      | -10.53 |
+      | impact on unit price            | -2     |
+      | impact on unit price with taxes | -2.106 |
+      | eco tax                         | 0.2    |
+      | eco tax with taxes              | 0.2106 |
+      | wholesale price                 | 30     |
+      | product tax rate                | 5.3    |
+      | product price                   | 21.99  |
+      | product ecotax                  | 5.5    |
+    # Reset price
+    When I update combination "product1SWhite" with following values for shop "shop1":
+      | impact on price | 0 |
+    Then combination "product1SWhite" should have following prices for shops "shop1":
+      | combination price detail        | value  |
+      | impact on price                 | 0      |
+      | impact on price with taxes      | 0      |
+      | impact on unit price            | -1     |
+      | impact on unit price with taxes | -1.04  |
+      | eco tax                         | 0.5    |
+      | eco tax with taxes              | 0.5265 |
+      | wholesale price                 | 20     |
+      | product tax rate                | 4.00   |
+      | product price                   | 51.49  |
+      | product ecotax                  | 17.78  |
+    And combination "product1SWhite" should have following prices for shops "shop2":
+      | combination price detail        | value  |
+      | impact on price                 | -10    |
+      | impact on price with taxes      | -10.53 |
+      | impact on unit price            | -2     |
+      | impact on unit price with taxes | -2.106 |
+      | eco tax                         | 0.2    |
+      | eco tax with taxes              | 0.2106 |
+      | wholesale price                 | 30     |
+      | product tax rate                | 5.3    |
+      | product price                   | 21.99  |
+      | product ecotax                  | 5.5    |
+    When I update combination "product1SWhite" with following values for shop "shop2":
+      | impact on price | 0 |
+    Then combination "product1SWhite" should have following prices for shops "shop2":
+      | combination price detail        | value  |
+      | impact on price                 | 0      |
+      | impact on price with taxes      | 0      |
+      | impact on unit price            | -2     |
+      | impact on unit price with taxes | -2.106 |
+      | eco tax                         | 0.2    |
+      | eco tax with taxes              | 0.2106 |
+      | wholesale price                 | 30     |
+      | product tax rate                | 5.3    |
+      | product price                   | 21.99  |
+      | product ecotax                  | 5.5    |
+    # Reset all
+    When I update combination "product1SWhite" with following values for shop "shop1":
+      | eco tax              | 0 |
+      | impact on price      | 0 |
+      | impact on unit price | 0 |
+      | wholesale price      | 0 |
+    And I update product "product1" for shop "shop1" with following values:
+      | price           | 0 |
+      | ecotax          | 0 |
+      | tax rules group |   |
+    Then combination "product1SWhite" should have following prices for shops "shop1":
+      | combination price detail        | value |
+      | impact on price                 | 0     |
+      | impact on price with taxes      | 0     |
+      | impact on unit price            | 0     |
+      | impact on unit price with taxes | 0     |
+      | eco tax                         | 0     |
+      | eco tax with taxes              | 0     |
+      | wholesale price                 | 0     |
+      | product tax rate                | 0     |
+      | product price                   | 0     |
+      | product ecotax                  | 0     |
+    And combination "product1SWhite" should have following prices for shops "shop2":
+      | combination price detail        | value  |
+      | impact on price                 | 0      |
+      | impact on price with taxes      | 0      |
+      | impact on unit price            | -2     |
+      | impact on unit price with taxes | -2.106 |
+      | eco tax                         | 0.2    |
+      | eco tax with taxes              | 0.2106 |
+      | wholesale price                 | 30     |
+      | product tax rate                | 5.3    |
+      | product price                   | 21.99  |
+      | product ecotax                  | 5.5    |
+    When I update combination "product1SWhite" with following values for shop "shop2":
+      | eco tax              | 0 |
+      | impact on price      | 0 |
+      | impact on unit price | 0 |
+      | wholesale price      | 0 |
+    And I update product "product1" for shop "shop2" with following values:
+      | price           | 0 |
+      | ecotax          | 0 |
+      | tax rules group |   |
+    Then combination "product1SWhite" should have following prices for shops "shop1,shop2":
+      | combination price detail        | value |
+      | impact on price                 | 0     |
+      | impact on price with taxes      | 0     |
+      | impact on unit price            | 0     |
+      | impact on unit price with taxes | 0     |
+      | eco tax                         | 0     |
+      | eco tax with taxes              | 0     |
+      | wholesale price                 | 0     |
+      | product tax rate                | 0     |
+      | product price                   | 0     |
+      | product ecotax                  | 0     |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_prices.feature
@@ -122,7 +122,7 @@ Feature: Update product combination prices in Back Office (BO) in multi shop con
       | product price                   | 21.99  |
       | product ecotax                  | 5.5    |
     # Enable ecotax
-    And shop configuration for "PS_USE_ECOTAX" is set to 1
+    When shop configuration for "PS_USE_ECOTAX" is set to 1
     And shop configuration for "PS_ECOTAX_TAX_RULES_GROUP_ID" is set to us-ks-tax-rate
     Then combination "product1SWhite" should have following prices for shops "shop1":
       | combination price detail        | value  |
@@ -233,6 +233,145 @@ Feature: Update product combination prices in Back Office (BO) in multi shop con
       | ecotax          | 0 |
       | tax rules group |   |
     Then combination "product1SWhite" should have following prices for shops "shop1,shop2":
+      | combination price detail        | value |
+      | impact on price                 | 0     |
+      | impact on price with taxes      | 0     |
+      | impact on unit price            | 0     |
+      | impact on unit price with taxes | 0     |
+      | eco tax                         | 0     |
+      | eco tax with taxes              | 0     |
+      | wholesale price                 | 0     |
+      | product tax rate                | 0     |
+      | product price                   | 0     |
+      | product ecotax                  | 0     |
+
+  Scenario: I update combination prices for all shops:
+    Given I update product "product1" for shop "shop1" with following values:
+      | price           | 51.49           |
+      | ecotax          | 17.78           |
+      | tax rules group | US-AL Rate (4%) |
+    And I update product "product1" for shop "shop2" with following values:
+      | price           | 21.99             |
+      | ecotax          | 5.5               |
+      | tax rules group | US-KS Rate (5.3%) |
+    And combination "product1SBlack" should have following prices for shops "shop1":
+      | combination price detail        | value |
+      | impact on price                 | 0     |
+      | impact on price with taxes      | 0     |
+      | impact on unit price            | 0     |
+      | impact on unit price with taxes | 0     |
+      | eco tax                         | 0     |
+      | eco tax with taxes              | 0     |
+      | wholesale price                 | 0     |
+      | product tax rate                | 4.00  |
+      | product price                   | 51.49 |
+      | product ecotax                  | 17.78 |
+    And combination "product1SBlack" should have following prices for shops "shop2":
+      | combination price detail        | value |
+      | impact on price                 | 0     |
+      | impact on price with taxes      | 0     |
+      | impact on unit price            | 0     |
+      | impact on unit price with taxes | 0     |
+      | eco tax                         | 0     |
+      | eco tax with taxes              | 0     |
+      | wholesale price                 | 0     |
+      | product tax rate                | 5.3   |
+      | product price                   | 21.99 |
+      | product ecotax                  | 5.5   |
+    When I update combination "product1SBlack" with following values for all shops:
+      | eco tax              | 0.5 |
+      | impact on price      | -5  |
+      | impact on unit price | -1  |
+      | wholesale price      | 20  |
+    Then combination "product1SBlack" should have following prices for shops "shop1":
+      | combination price detail        | value |
+      | impact on price                 | -5    |
+      | impact on price with taxes      | -5.20 |
+      | impact on unit price            | -1    |
+      | impact on unit price with taxes | -1.04 |
+      | eco tax                         | 0.5   |
+      | eco tax with taxes              | 0.5   |
+      | wholesale price                 | 20    |
+      | product tax rate                | 4.00  |
+      | product price                   | 51.49 |
+      | product ecotax                  | 17.78 |
+    And combination "product1SBlack" should have following prices for shops "shop2":
+      | combination price detail        | value  |
+      | impact on price                 | -5     |
+      | impact on price with taxes      | -5.265 |
+      | impact on unit price            | -1     |
+      | impact on unit price with taxes | -1.053 |
+      | eco tax                         | 0.5    |
+      | eco tax with taxes              | 0.5    |
+      | wholesale price                 | 20     |
+      | product tax rate                | 5.3    |
+      | product price                   | 21.99  |
+      | product ecotax                  | 5.5    |
+    # Enable ecotax
+    When shop configuration for "PS_USE_ECOTAX" is set to 1
+    And shop configuration for "PS_ECOTAX_TAX_RULES_GROUP_ID" is set to us-ks-tax-rate
+    Then combination "product1SBlack" should have following prices for shops "shop1":
+      | combination price detail        | value  |
+      | impact on price                 | -5     |
+      | impact on price with taxes      | -5.20  |
+      | impact on unit price            | -1     |
+      | impact on unit price with taxes | -1.04  |
+      | eco tax                         | 0.5    |
+      | eco tax with taxes              | 0.5265 |
+      | wholesale price                 | 20     |
+      | product tax rate                | 4.00   |
+      | product price                   | 51.49  |
+      | product ecotax                  | 17.78  |
+    And combination "product1SBlack" should have following prices for shops "shop2":
+      | combination price detail        | value  |
+      | impact on price                 | -5     |
+      | impact on price with taxes      | -5.265 |
+      | impact on unit price            | -1     |
+      | impact on unit price with taxes | -1.053 |
+      | eco tax                         | 0.5    |
+      | eco tax with taxes              | 0.5265 |
+      | wholesale price                 | 20     |
+      | product tax rate                | 5.3    |
+      | product price                   | 21.99  |
+      | product ecotax                  | 5.5    |
+    # Reset price
+    When I update combination "product1SBlack" with following values for all shops:
+      | impact on price | 0 |
+    Then combination "product1SBlack" should have following prices for shops "shop1":
+      | combination price detail        | value  |
+      | impact on price                 | 0      |
+      | impact on price with taxes      | 0      |
+      | impact on unit price            | -1     |
+      | impact on unit price with taxes | -1.04  |
+      | eco tax                         | 0.5    |
+      | eco tax with taxes              | 0.5265 |
+      | wholesale price                 | 20     |
+      | product tax rate                | 4.00   |
+      | product price                   | 51.49  |
+      | product ecotax                  | 17.78  |
+    And combination "product1SBlack" should have following prices for shops "shop2":
+      | combination price detail        | value  |
+      | impact on price                 | 0      |
+      | impact on price with taxes      | 0      |
+      | impact on unit price            | -1     |
+      | impact on unit price with taxes | -1.053 |
+      | eco tax                         | 0.5    |
+      | eco tax with taxes              | 0.5265 |
+      | wholesale price                 | 20     |
+      | product tax rate                | 5.3    |
+      | product price                   | 21.99  |
+      | product ecotax                  | 5.5    |
+    # Reset all
+    When I update combination "product1SBlack" with following values for all shops:
+      | eco tax              | 0 |
+      | impact on price      | 0 |
+      | impact on unit price | 0 |
+      | wholesale price      | 0 |
+    And I update product "product1" for all shops with following values:
+      | price           | 0 |
+      | ecotax          | 0 |
+      | tax rules group |   |
+    Then combination "product1SBlack" should have following prices for shops "shop1,shop2":
       | combination price detail        | value |
       | impact on price                 | 0     |
       | impact on price with taxes      | 0     |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
@@ -287,17 +287,19 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | available date             | 2021-10-10  |
     And combination "product1SBlack" last stock movements for shop "shop1" should be:
       | employee   | delta_quantity |
-      | Puff Daddy | 100            |
+      | Puff Daddy | 120            |
     And combination "product1SBlack" last stock movement for shop "shop1" increased by 120
     And combination "product1SBlack" last stock movements for shop "shop2" should be:
       | employee   | delta_quantity |
-      | Puff Daddy | 100            |
+      | Puff Daddy | 120            |
     And combination "product1SBlack" last stock movement for shop "shop2" increased by 120
     And combinations "product1SBlack" are not associated to shop "shop3"
     And combinations "product1SBlack" are not associated to shop "shop4"
 
   Scenario: I update combination stock for all shops using fixed quantity
-    Given combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+    Given I update combination "product1SBlack" with following values for shop "shop2":
+      | delta quantity | 10 |
+    And combination "product1SBlack" should have following stock details for shops "shop1":
       | combination stock detail   | value |
       | quantity                   | 0     |
       | minimal quantity           | 1     |
@@ -305,8 +307,19 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | low stock alert is enabled | false |
       | location                   |       |
       | available date             |       |
+    And combination "product1SBlack" should have following stock details for shops "shop2":
+      | combination stock detail   | value |
+      | quantity                   | 10    |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
     And product "product1" should have no stock movements for shop "shop1"
-    And product "product1" should have no stock movements for shop "shop2"
+    And combination "product1SBlack" last stock movement for shop "shop2" increased by 10
+    And combination "product1SBlack" last stock movements for shop "shop2" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 10             |
     When I update combination "product1SBlack" with following values for all shops:
       | fixed quantity | 12 |
     Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
@@ -317,6 +330,15 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | low stock alert is enabled | false |
       | location                   |       |
       | available date             |       |
+    And combination "product1SBlack" last stock movement for shop "shop1" increased by 12
+    And combination "product1SBlack" last stock movements for shop "shop1" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 12             |
+    And combination "product1SBlack" last stock movement for shop "shop2" increased by 2
+    And combination "product1SBlack" last stock movements for shop "shop2" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 2              |
+      | Puff Daddy | 10             |
     When I update combination "product1SBlack" with following values for all shops:
       | fixed quantity | 5 |
     Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
@@ -336,7 +358,8 @@ Feature: Update product combination stock information in Back Office (BO) in mul
     And combination "product1SBlack" last stock movements for shop "shop2" should be:
       | employee   | delta_quantity |
       | Puff Daddy | -7             |
-      | Puff Daddy | 12             |
+      | Puff Daddy | 2              |
+      | Puff Daddy | 10             |
     And combinations "product1SBlack" are not associated to shop "shop3"
     And combinations "product1SBlack" are not associated to shop "shop4"
 
@@ -402,7 +425,7 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | available now labels[en-US]   |       |
       | available later labels[en-US] |       |
 
-  Scenario: I update product out of stock type to see how combinations stock policy depends on it
+  Scenario: I update product out of stock type to see how the combinations stock policy depends on it
     And product "product1" should have following stock information for shops "shop1,shop2":
       | out_of_stock_type | default |
     And all combinations of product "product1" for shops "shop1,shop2" should have the stock policy to "available"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
@@ -70,12 +70,13 @@ Feature: Update product combination stock information in Back Office (BO) in mul
 
   Scenario: I update combination stock for specific shop using delta quantity:
     When I update combination "product1SBlack" with following values for shop "shop1":
-      | delta quantity             | 100         |
-      | minimal quantity           | 10          |
-      | location                   | Storage nr1 |
-      | low stock threshold        | 10          |
-      | low stock alert is enabled | true        |
-      | available date             | 2021-10-10  |
+      | minimal quantity           | 10         |
+      | low stock threshold        | 10         |
+      | low stock alert is enabled | true       |
+      | available date             | 2021-10-10 |
+    And I update combination "product1SBlack" stock for shop "shop1" with following details:
+      | delta quantity | 100         |
+      | location       | Storage nr1 |
     Then combination "product1SBlack" should have following stock details for shops "shop1":
       | combination stock detail   | value       |
       | quantity                   | 100         |
@@ -98,12 +99,13 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | available date             |       |
     And combination "product1SBlack" should have no stock movements for shop "shop2"
     When I update combination "product1SBlack" with following values for shop "shop2":
-      | delta quantity             | 101         |
-      | minimal quantity           | 1           |
-      | location                   | Storage nr2 |
-      | low stock threshold        | 5           |
-      | low stock alert is enabled | true        |
-      | available date             | 2022-10-10  |
+      | minimal quantity           | 1          |
+      | low stock threshold        | 5          |
+      | low stock alert is enabled | true       |
+      | available date             | 2022-10-10 |
+    And I update combination "product1SBlack" stock for shop "shop2" with following details:
+      | delta quantity | 101         |
+      | location       | Storage nr2 |
     Then combination "product1SBlack" should have following stock details for shops "shop2":
       | combination stock detail   | value       |
       | quantity                   | 101         |
@@ -129,19 +131,21 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | Puff Daddy | 100            |
     And combination "product1SBlack" last stock movement for shop "shop1" increased by 100
     When I update combination "product1SWhite" with following values for shop "shop1":
-      | delta quantity             | 50          |
-      | minimal quantity           | 10          |
-      | location                   | Storage nr1 |
-      | low stock threshold        | 10          |
-      | low stock alert is enabled | true        |
-      | available date             | 2021-10-10  |
+      | minimal quantity           | 10         |
+      | low stock threshold        | 10         |
+      | low stock alert is enabled | true       |
+      | available date             | 2021-10-10 |
+    And I update combination "product1SWhite" stock for shop "shop1" with following details:
+      | delta quantity | 50          |
+      | location       | Storage nr1 |
     When I update combination "product1SWhite" with following values for shop "shop2":
-      | delta quantity             | 30          |
-      | minimal quantity           | 10          |
-      | location                   | Storage nr2 |
-      | low stock threshold        | 10          |
-      | low stock alert is enabled | true        |
-      | available date             | 2021-10-10  |
+      | minimal quantity           | 10         |
+      | low stock threshold        | 10         |
+      | low stock alert is enabled | true       |
+      | available date             | 2021-10-10 |
+    And I update combination "product1SWhite" stock for shop "shop2" with following details:
+      | delta quantity | 30          |
+      | location       | Storage nr2 |
     Then combination "product1SWhite" should have following stock details for shops "shop1":
       | combination stock detail   | value       |
       | quantity                   | 50          |
@@ -192,7 +196,7 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | location                   |       |
       | available date             |       |
     And product "product1" should have no stock movements for shop "shop1"
-    When I update combination "product1SBlack" with following values for shop "shop1":
+    When I update combination "product1SBlack" stock for shop "shop1" with following details:
       | fixed quantity | 10 |
     Then combination "product1SBlack" should have following stock details for shops "shop1":
       | combination stock detail   | value |
@@ -202,7 +206,7 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | low stock alert is enabled | false |
       | location                   |       |
       | available date             |       |
-    When I update combination "product1SBlack" with following values for shop "shop1":
+    When I update combination "product1SBlack" stock for shop "shop1" with following details:
       | fixed quantity | -3 |
     Then combination "product1SBlack" should have following stock details for shops "shop1":
       | combination stock detail   | value |
@@ -226,7 +230,7 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | location                   |       |
       | available date             |       |
     And combination "product1SBlack" should have no stock movements for shop "shop2"
-    When I update combination "product1SBlack" with following values for shop "shop2":
+    When I update combination "product1SBlack" stock for shop "shop2" with following details:
       | fixed quantity | 34 |
     Then combination "product1SBlack" should have following stock details for shops "shop2":
       | combination stock detail   | value |
@@ -240,7 +244,7 @@ Feature: Update product combination stock information in Back Office (BO) in mul
     And combination "product1SBlack" last stock movements for shop "shop2" should be:
       | employee   | delta_quantity |
       | Puff Daddy | 34             |
-    When I update combination "product1SBlack" with following values for shop "shop2":
+    When I update combination "product1SBlack" stock for shop "shop2" with following details:
       | fixed quantity | 4 |
     Then combination "product1SBlack" should have following stock details for shops "shop2":
       | combination stock detail   | value |
@@ -271,12 +275,13 @@ Feature: Update product combination stock information in Back Office (BO) in mul
 
   Scenario: I update combination stock for all shops using delta quantity:
     When I update combination "product1SBlack" with following values for all shops:
-      | delta quantity             | 120         |
-      | minimal quantity           | 10          |
-      | location                   | Storage nr1 |
-      | low stock threshold        | 10          |
-      | low stock alert is enabled | true        |
-      | available date             | 2021-10-10  |
+      | minimal quantity           | 10         |
+      | low stock threshold        | 10         |
+      | low stock alert is enabled | true       |
+      | available date             | 2021-10-10 |
+    And I update combination "product1SBlack" stock for all shops with following details:
+      | delta quantity | 120         |
+      | location       | Storage nr1 |
     Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
       | combination stock detail   | value       |
       | quantity                   | 120         |
@@ -297,7 +302,7 @@ Feature: Update product combination stock information in Back Office (BO) in mul
     And combinations "product1SBlack" are not associated to shop "shop4"
 
   Scenario: I update combination stock for all shops using fixed quantity
-    Given I update combination "product1SBlack" with following values for shop "shop2":
+    Given I update combination "product1SBlack" stock for shop "shop2" with following details:
       | delta quantity | 10 |
     And combination "product1SBlack" should have following stock details for shops "shop1":
       | combination stock detail   | value |
@@ -320,7 +325,7 @@ Feature: Update product combination stock information in Back Office (BO) in mul
     And combination "product1SBlack" last stock movements for shop "shop2" should be:
       | employee   | delta_quantity |
       | Puff Daddy | 10             |
-    When I update combination "product1SBlack" with following values for all shops:
+    When I update combination "product1SBlack" stock for all shops with following details:
       | fixed quantity | 12 |
     Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
       | combination stock detail   | value |
@@ -339,7 +344,7 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | employee   | delta_quantity |
       | Puff Daddy | 2              |
       | Puff Daddy | 10             |
-    When I update combination "product1SBlack" with following values for all shops:
+    When I update combination "product1SBlack" stock for all shops with following details:
       | fixed quantity | 5 |
     Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
       | combination stock detail   | value |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
@@ -428,9 +428,11 @@ Feature: Update product combination stock information in Back Office (BO) in mul
   Scenario: I update product out of stock type to see how the combinations stock policy depends on it
     And product "product1" should have following stock information for shops "shop1,shop2":
       | out_of_stock_type | default |
-    And all combinations of product "product1" for shops "shop1,shop2" should have the stock policy to "available"
+    And all combinations of product "product1" for shops "shop1,shop2" should have the stock policy to "default"
     When I update product "product1" stock for shop "shop1" with following information:
       | out_of_stock_type | available |
+    And I update product "product1" stock for shop "shop2" with following information:
+      | out_of_stock_type | default |
     Then all combinations of product "product1" for shops "shop1" should have the stock policy to "available"
     Then all combinations of product "product1" for shops "shop2" should have the stock policy to "default"
     When I update product "product1" stock for shop "shop2" with following information:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
@@ -1,0 +1,419 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-combination-stock
+@restore-products-before-feature
+@clear-cache-before-feature
+@product-combination
+@update-multi-shop-combination-stock
+Feature: Update product combination stock information in Back Office (BO) in multi shop context
+  As an employee
+  I need to be able to update product combination stock information from BO for multiple shops
+
+  Background:
+    Given language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
+    And attribute "Red" named "Red" in en language exists
+    And shop "shop1" with name "test_shop" exists
+    And I enable multishop feature
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And single shop context is loaded
+    And I add product "product1" with following information:
+      | name[en-US] | universal T-shirt |
+      | type        | combinations      |
+    And product product1 type should be combinations
+    And I copy product product1 from shop shop1 to shop shop2
+    And I generate combinations in shop "shop1" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have no combinations for shops "shop2"
+    And I generate combinations in shop "shop2" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop1,shop2":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SWhite"
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop1"
+    And combinations "product1SWhite,product1SBlack,product1SBlue,product1MWhite,product1MBlack,product1MBlue" are associated to shop "shop2"
+    And product "product1" should have following stock information for shops "shop1,shop2":
+      | pack_stock_type     | default |
+      | out_of_stock_type   | default |
+      | quantity            | 0       |
+      | minimal_quantity    | 1       |
+      | location            |         |
+      | low_stock_threshold | 0       |
+      | low_stock_alert     | false   |
+      | available_date      |         |
+    And combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+
+  Scenario: I update combination stock for specific shop using delta quantity:
+    When I update combination "product1SBlack" with following values for shop "shop1":
+      | delta quantity             | 100         |
+      | minimal quantity           | 10          |
+      | location                   | Storage nr1 |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | available date             | 2021-10-10  |
+    Then combination "product1SBlack" should have following stock details for shops "shop1":
+      | combination stock detail   | value       |
+      | quantity                   | 100         |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr1 |
+      | available date             | 2021-10-10  |
+    And combination "product1SBlack" last stock movements for shop "shop1" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 100            |
+    And combination "product1SBlack" last stock movement for shop "shop1" increased by 100
+    And combination "product1SBlack" should have following stock details for shops "shop2":
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    And combination "product1SBlack" should have no stock movements for shop "shop2"
+    When I update combination "product1SBlack" with following values for shop "shop2":
+      | delta quantity             | 101         |
+      | minimal quantity           | 1           |
+      | location                   | Storage nr2 |
+      | low stock threshold        | 5           |
+      | low stock alert is enabled | true        |
+      | available date             | 2022-10-10  |
+    Then combination "product1SBlack" should have following stock details for shops "shop2":
+      | combination stock detail   | value       |
+      | quantity                   | 101         |
+      | minimal quantity           | 1           |
+      | low stock threshold        | 5           |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr2 |
+      | available date             | 2022-10-10  |
+    And combination "product1SBlack" last stock movements for shop "shop2" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 101            |
+    And combination "product1SBlack" last stock movement for shop "shop2" increased by 101
+    And combination "product1SBlack" should have following stock details for shops "shop1":
+      | combination stock detail   | value       |
+      | quantity                   | 100         |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr1 |
+      | available date             | 2021-10-10  |
+    And combination "product1SBlack" last stock movements for shop "shop1" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 100            |
+    And combination "product1SBlack" last stock movement for shop "shop1" increased by 100
+    When I update combination "product1SWhite" with following values for shop "shop1":
+      | delta quantity             | 50          |
+      | minimal quantity           | 10          |
+      | location                   | Storage nr1 |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | available date             | 2021-10-10  |
+    When I update combination "product1SWhite" with following values for shop "shop2":
+      | delta quantity             | 30          |
+      | minimal quantity           | 10          |
+      | location                   | Storage nr2 |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | available date             | 2021-10-10  |
+    Then combination "product1SWhite" should have following stock details for shops "shop1":
+      | combination stock detail   | value       |
+      | quantity                   | 50          |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr1 |
+      | available date             | 2021-10-10  |
+    And combination "product1SWhite" should have following stock details for shops "shop2":
+      | combination stock detail   | value       |
+      | quantity                   | 30          |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr2 |
+      | available date             | 2021-10-10  |
+    And combination "product1SWhite" last stock movement for shop "shop1" increased by 50
+    And combination "product1SWhite" last stock movement for shop "shop2" increased by 30
+    And product "product1" should have the following combinations for shops "shop1":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 50       | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 100      | false      |
+      | product1Blue   | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" should have the following combinations for shops "shop2":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 30       | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 101      | false      |
+      | product1Blue   | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    # Product quantity is the sum of all combinations' quantity
+    And product "product1" should have following stock information for shops "shop1":
+      | quantity | 150 |
+    And product "product1" should have following stock information for shops "shop2":
+      | quantity | 131 |
+
+  Scenario: I update combination stock for specific shop using fixed quantity
+    Given combination "product1SBlack" should have following stock details for shops "shop1":
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    And product "product1" should have no stock movements for shop "shop1"
+    When I update combination "product1SBlack" with following values for shop "shop1":
+      | fixed quantity | 10 |
+    Then combination "product1SBlack" should have following stock details for shops "shop1":
+      | combination stock detail   | value |
+      | quantity                   | 10    |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    When I update combination "product1SBlack" with following values for shop "shop1":
+      | fixed quantity | -3 |
+    Then combination "product1SBlack" should have following stock details for shops "shop1":
+      | combination stock detail   | value |
+      | quantity                   | -3    |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    And combination "product1SBlack" last stock movement for shop "shop1" decreased by 13
+    And combination "product1SBlack" last stock movements for shop "shop1" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | -13            |
+      | Puff Daddy | 10             |
+    And combination "product1SBlack" should have following stock details for shops "shop2":
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    And combination "product1SBlack" should have no stock movements for shop "shop2"
+    When I update combination "product1SBlack" with following values for shop "shop2":
+      | fixed quantity | 34 |
+    Then combination "product1SBlack" should have following stock details for shops "shop2":
+      | combination stock detail   | value |
+      | quantity                   | 34    |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    And combination "product1SBlack" last stock movement for shop "shop2" increased by 34
+    And combination "product1SBlack" last stock movements for shop "shop2" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 34             |
+    When I update combination "product1SBlack" with following values for shop "shop2":
+      | fixed quantity | 4 |
+    Then combination "product1SBlack" should have following stock details for shops "shop2":
+      | combination stock detail   | value |
+      | quantity                   | 4     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    And combination "product1SBlack" last stock movement for shop "shop2" decreased by 30
+    And combination "product1SBlack" last stock movements for shop "shop2" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | -30            |
+      | Puff Daddy | 34             |
+    And combination "product1SBlack" should have following stock details for shops "shop1":
+      | combination stock detail   | value |
+      | quantity                   | -3    |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    And combination "product1SBlack" last stock movement for shop "shop1" decreased by 13
+    And combination "product1SBlack" last stock movements for shop "shop1" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | -13            |
+      | Puff Daddy | 10             |
+
+  Scenario: I update combination stock for all shops using delta quantity:
+    When I update combination "product1SBlack" with following values for all shops:
+      | delta quantity             | 120         |
+      | minimal quantity           | 10          |
+      | location                   | Storage nr1 |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | available date             | 2021-10-10  |
+    Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+      | combination stock detail   | value       |
+      | quantity                   | 120         |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr1 |
+      | available date             | 2021-10-10  |
+    And combination "product1SBlack" last stock movements for shop "shop1" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 100            |
+    And combination "product1SBlack" last stock movement for shop "shop1" increased by 120
+    And combination "product1SBlack" last stock movements for shop "shop2" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 100            |
+    And combination "product1SBlack" last stock movement for shop "shop2" increased by 120
+    And combinations "product1SBlack" are not associated to shop "shop3"
+    And combinations "product1SBlack" are not associated to shop "shop4"
+
+  Scenario: I update combination stock for all shops using fixed quantity
+    Given combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    And product "product1" should have no stock movements for shop "shop1"
+    And product "product1" should have no stock movements for shop "shop2"
+    When I update combination "product1SBlack" with following values for all shops:
+      | fixed quantity | 12 |
+    Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+      | combination stock detail   | value |
+      | quantity                   | 12    |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    When I update combination "product1SBlack" with following values for all shops:
+      | fixed quantity | 5 |
+    Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+      | combination stock detail   | value |
+      | quantity                   | 5     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    And combination "product1SBlack" last stock movement for shop "shop1" decreased by 7
+    And combination "product1SBlack" last stock movements for shop "shop1" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | -7             |
+      | Puff Daddy | 12             |
+    And combination "product1SBlack" last stock movement for shop "shop2" decreased by 7
+    And combination "product1SBlack" last stock movements for shop "shop2" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | -7             |
+      | Puff Daddy | 12             |
+    And combinations "product1SBlack" are not associated to shop "shop3"
+    And combinations "product1SBlack" are not associated to shop "shop4"
+
+  Scenario: I update product availability labels and expect them to always change in all shops, no matter which shop is being updated
+    Given combination "product1SBlack" should have following stock details:
+      | combination stock detail   | value |
+      | quantity                   | 0     |
+      | minimal quantity           | 1     |
+      | low stock threshold        | 0     |
+      | low stock alert is enabled | false |
+      | location                   |       |
+      | available date             |       |
+    When I update combination "product1SBlack" with following values for shop "shop1":
+      | available now labels[en-US]   | Get it now    |
+      | available later labels[en-US] | Too late dude |
+    Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+      | combination stock detail      | value         |
+      | quantity                      | 0             |
+      | minimal quantity              | 1             |
+      | low stock threshold           | 0             |
+      | low stock alert is enabled    | false         |
+      | location                      |               |
+      | available date                |               |
+      | available now labels[en-US]   | Get it now    |
+      | available later labels[en-US] | Too late dude |
+    When I update combination "product1SBlack" with following values for shop "shop2":
+      | available now labels[en-US]   | Get it now2    |
+      | available later labels[en-US] | Too late dude2 |
+    Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+      | combination stock detail      | value          |
+      | quantity                      | 0              |
+      | minimal quantity              | 1              |
+      | low stock threshold           | 0              |
+      | low stock alert is enabled    | false          |
+      | location                      |                |
+      | available date                |                |
+      | available now labels[en-US]   | Get it now2    |
+      | available later labels[en-US] | Too late dude2 |
+    When I update combination "product1SBlack" with following values for all shops:
+      | available now labels[en-US]   | Get it now all shops    |
+      | available later labels[en-US] | Too late dude all shops |
+    Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+      | combination stock detail      | value                   |
+      | quantity                      | 0                       |
+      | minimal quantity              | 1                       |
+      | low stock threshold           | 0                       |
+      | low stock alert is enabled    | false                   |
+      | location                      |                         |
+      | available date                |                         |
+      | available now labels[en-US]   | Get it now all shops    |
+      | available later labels[en-US] | Too late dude all shops |
+    When I update combination "product1SBlack" with following values for all shops:
+      | available now labels[en-US]   |  |
+      | available later labels[en-US] |  |
+    Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+      | combination stock detail      | value |
+      | quantity                      | 0     |
+      | minimal quantity              | 1     |
+      | low stock threshold           | 0     |
+      | low stock alert is enabled    | false |
+      | location                      |       |
+      | available date                |       |
+      | available now labels[en-US]   |       |
+      | available later labels[en-US] |       |
+
+  Scenario: I update product out of stock type to see how combinations stock policy depends on it
+    And product "product1" should have following stock information for shops "shop1,shop2":
+      | out_of_stock_type | default |
+    And all combinations of product "product1" for shops "shop1,shop2" should have the stock policy to "available"
+    When I update product "product1" stock for shop "shop1" with following information:
+      | out_of_stock_type | available |
+    Then all combinations of product "product1" for shops "shop1" should have the stock policy to "available"
+    Then all combinations of product "product1" for shops "shop2" should have the stock policy to "default"
+    When I update product "product1" stock for shop "shop2" with following information:
+      | out_of_stock_type | available |
+    Then all combinations of product "product1" for shops "shop1,shop2" should have the stock policy to "available"
+    When I update product "product1" stock for all shops with following information:
+      | out_of_stock_type | not_available |
+    Then all combinations of product "product1" for shops "shop1,shop2" should have the stock policy to "not_available"
+

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_multishop_combination_stock.feature
@@ -138,7 +138,7 @@ Feature: Update product combination stock information in Back Office (BO) in mul
     And I update combination "product1SWhite" stock for shop "shop1" with following details:
       | delta quantity | 50          |
       | location       | Storage nr1 |
-    When I update combination "product1SWhite" with following values for shop "shop2":
+    And I update combination "product1SWhite" with following values for shop "shop2":
       | minimal quantity           | 10         |
       | low stock threshold        | 10         |
       | low stock alert is enabled | true       |
@@ -163,7 +163,14 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | location                   | Storage nr2 |
       | available date             | 2021-10-10  |
     And combination "product1SWhite" last stock movement for shop "shop1" increased by 50
+    And combination "product1SWhite" last stock movements for shop "shop1" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 50             |
     And combination "product1SWhite" last stock movement for shop "shop2" increased by 30
+    And combination "product1SWhite" last stock movements for shop "shop2" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 30             |
+
     And product "product1" should have the following combinations for shops "shop1":
       | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
       | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 50       | true       |
@@ -274,29 +281,61 @@ Feature: Update product combination stock information in Back Office (BO) in mul
       | Puff Daddy | 10             |
 
   Scenario: I update combination stock for all shops using delta quantity:
-    When I update combination "product1SBlack" with following values for all shops:
+    Given I update combination "product1SBlack" with following values for all shops:
       | minimal quantity           | 10         |
       | low stock threshold        | 10         |
       | low stock alert is enabled | true       |
       | available date             | 2021-10-10 |
-    And I update combination "product1SBlack" stock for all shops with following details:
-      | delta quantity | 120         |
+    And I update combination "product1SBlack" stock for shop "shop1" with following details:
+      | delta quantity | 10          |
       | location       | Storage nr1 |
-    Then combination "product1SBlack" should have following stock details for shops "shop1,shop2":
+    And I update combination "product1SBlack" stock for shop "shop2" with following details:
+      | delta quantity | 100         |
+      | location       | Storage nr2 |
+    And combination "product1SBlack" should have following stock details for shops "shop1":
       | combination stock detail   | value       |
-      | quantity                   | 120         |
+      | quantity                   | 10          |
       | minimal quantity           | 10          |
       | low stock threshold        | 10          |
       | low stock alert is enabled | true        |
       | location                   | Storage nr1 |
       | available date             | 2021-10-10  |
+    And combination "product1SBlack" should have following stock details for shops "shop2":
+      | combination stock detail   | value       |
+      | quantity                   | 100         |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr2 |
+      | available date             | 2021-10-10  |
+    When I update combination "product1SBlack" stock for all shops with following details:
+      | delta quantity | 120         |
+      | location       | Storage nr3 |
+    Then combination "product1SBlack" should have following stock details for shops "shop1":
+      | combination stock detail   | value       |
+      | quantity                   | 130         |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr3 |
+      | available date             | 2021-10-10  |
+    Then combination "product1SBlack" should have following stock details for shops "shop2":
+      | combination stock detail   | value       |
+      | quantity                   | 220         |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr3 |
+      | available date             | 2021-10-10  |
     And combination "product1SBlack" last stock movements for shop "shop1" should be:
       | employee   | delta_quantity |
       | Puff Daddy | 120            |
+      | Puff Daddy | 10             |
     And combination "product1SBlack" last stock movement for shop "shop1" increased by 120
     And combination "product1SBlack" last stock movements for shop "shop2" should be:
       | employee   | delta_quantity |
       | Puff Daddy | 120            |
+      | Puff Daddy | 100            |
     And combination "product1SBlack" last stock movement for shop "shop2" increased by 120
     And combinations "product1SBlack" are not associated to shop "shop3"
     And combinations "product1SBlack" are not associated to shop "shop4"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/combinations_listing.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/combinations_listing.feature
@@ -136,19 +136,19 @@ Feature: Generate attribute combinations for product in Back Office (BO)
     Given product "product1" combinations list search criteria is set to defaults
     And I update combination "product1SWhite" with following values:
       | impact on price | -1  |
-    And I update combination "product1SWhite" with following values:
+    And I update combination "product1SWhite" stock with following details:
       | delta quantity  | 10  |
     And I update combination "product1SWhite" with following values:
       | reference       | AAA |
     And I update combination "product1SBlue" with following values:
       | impact on price | 1   |
-    And I update combination "product1SBlue" with following values:
+    And I update combination "product1SBlue" stock with following details:
       | delta quantity  | 100 |
     And I update combination "product1SBlue" with following values:
       | reference       | BBB |
     And I update combination "product1SBlack" with following values:
       | impact on price | 10   |
-    And I update combination "product1SBlack" with following values:
+    And I update combination "product1SBlack" stock with following details:
       | delta quantity  | 50 |
     And I update combination "product1SBlack" with following values:
       | reference       | CCC |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_prices.feature
@@ -22,7 +22,7 @@ Feature: Update product combination prices in Back Office (BO)
     And I identify tax rules group named "US-AL Rate (4%)" as "us-al-tax-rate"
     And I identify tax rules group named "US-KS Rate (5.3%)" as "us-ks-tax-rate"
 
-  Scenario: I update combination options:
+  Scenario: I update combination prices:
     Given I add product "product1" with following information:
       | name[en-US] | universal T-shirt |
       | type        | combinations      |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -53,7 +53,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | location                   |       |
       | available date             |       |
 
-  Scenario: I update combination options:
+  Scenario: I update combination stock:
     When I update combination "product1SBlack" with following values:
       | delta quantity             | 100         |
       | minimal quantity           | 10          |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -55,12 +55,13 @@ Feature: Update product combination stock information in Back Office (BO)
 
   Scenario: I update combination stock:
     When I update combination "product1SBlack" with following values:
-      | delta quantity             | 100         |
       | minimal quantity           | 10          |
-      | location                   | Storage nr1 |
       | low stock threshold        | 10          |
       | low stock alert is enabled | true        |
       | available date             | 2021-10-10  |
+    And I update combination "product1SBlack" stock with following details:
+      | delta quantity             | 100         |
+      | location                   | Storage nr1 |
     Then combination "product1SBlack" should have following stock details:
       | combination stock detail   | value       |
       | quantity                   | 100         |
@@ -74,12 +75,13 @@ Feature: Update product combination stock information in Back Office (BO)
       | Puff Daddy | 100            |
     And combination "product1SBlack" last stock movement increased by 100
     When I update combination "product1SWhite" with following values:
-      | delta quantity             | 50          |
       | minimal quantity           | 10          |
-      | location                   | Storage nr1 |
       | low stock threshold        | 10          |
       | low stock alert is enabled | true        |
       | available date             | 2021-10-10  |
+    And I update combination "product1SWhite" stock with following details:
+      | delta quantity             | 50          |
+      | location                   | Storage nr1 |
     Then combination "product1SWhite" should have following stock details:
       | combination stock detail   | value       |
       | quantity                   | 50          |
@@ -101,10 +103,11 @@ Feature: Update product combination stock information in Back Office (BO)
     And product "product1" should have following stock information:
       | quantity | 150 |
     When I update combination "product1SBlack" with following values:
-      | delta quantity      | -101        |
       | minimal quantity    | 1           |
-      | location            | Storage nr2 |
       | low stock threshold | 10          |
+    And I update combination "product1SBlack" stock with following details:
+      | delta quantity      | -101        |
+      | location            | Storage nr2 |
     Then combination "product1SBlack" should have following stock details:
       | combination stock detail   | value       |
       | quantity                   | -1          |
@@ -121,12 +124,13 @@ Feature: Update product combination stock information in Back Office (BO)
     And product "product1" should have following stock information:
       | quantity | 49 |
     When I update combination "product1SBlack" with following values:
-      | delta quantity             | 1          |
       | minimal quantity           | 0          |
-      | location                   |            |
       | low stock threshold        | 0          |
       | low stock alert is enabled | false      |
       | available date             | 2020-01-01 |
+    And I update combination "product1SBlack" stock with following details:
+      | delta quantity             | 1          |
+      | location                   |            |
     Then combination "product1SBlack" should have following stock details:
       | combination stock detail   | value      |
       | quantity                   | 0          |
@@ -152,7 +156,7 @@ Feature: Update product combination stock information in Back Office (BO)
     And product "product1" should have following stock information:
       | quantity | 50 |
     # Following assert makes sure that 0 delta quantity is valid input for command but is skipped and stock does not move
-    When I update combination "product1SBlack" with following values:
+    When I update combination "product1SBlack" stock with following details:
       | delta quantity | 0 |
     Then combination "product1SBlack" should have following stock details:
       | combination stock detail   | value      |
@@ -181,7 +185,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | location                   |       |
       | available date             |       |
     And product "product1" should have no stock movements
-    When I update combination "product1SBlack" with following values:
+    When I update combination "product1SBlack" stock with following details:
       | fixed quantity | 10 |
     Then combination "product1SBlack" should have following stock details:
       | combination stock detail   | value |
@@ -195,7 +199,7 @@ Feature: Update product combination stock information in Back Office (BO)
     And combination "product1SBlack" last stock movements should be:
       | employee   | delta_quantity |
       | Puff Daddy | 10             |
-    When I update combination "product1SBlack" with following values:
+    When I update combination "product1SBlack" stock with following details:
       | fixed quantity | -3 |
     Then combination "product1SBlack" should have following stock details:
       | combination stock detail   | value |
@@ -221,7 +225,7 @@ Feature: Update product combination stock information in Back Office (BO)
       | location                   |       |
       | available date             |       |
     And product "product1" should have no stock movements
-    When I update combination "product1SBlack" with following values:
+    When I update combination "product1SBlack" stock with following details:
       | fixed quantity | -7 |
       | delta quantity | -5 |
     Then I should get error that it is not allowed to perform update using both - delta and fixed quantity

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/update_combination_stock.feature
@@ -286,6 +286,7 @@ Feature: Update product combination stock information in Back Office (BO)
   Scenario: I update product out of stock
     And product "product1" should have following stock information:
       | out_of_stock_type | default |
+    And all combinations of product "product1" should have the stock policy to "default"
     When I update product "product1" stock with following information:
       | out_of_stock_type | available |
     Then all combinations of product "product1" should have the stock policy to "available"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/StockMovement/combination_stock_movement_history.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/StockMovement/combination_stock_movement_history.feature
@@ -43,7 +43,7 @@ Feature: Search stock movements from Back Office (BO)
       | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
 
   Scenario: I can get the last 5 rows of stock movements by default and I can paginate
-    When I update combination "product1SBlack" with following values:
+    When I update combination "product1SBlack" stock with following details:
       | delta quantity | 100 |
     When I create an empty cart "dummy_cart1" for customer "testCustomer"
     And I select "US" address as delivery and invoice address for customer "testCustomer" in cart "dummy_cart1"
@@ -67,7 +67,7 @@ Feature: Search stock movements from Back Office (BO)
     # Even though the quantity is reserved and no stock movement was generated the available quantity is correctly updated
     And combination "product1SBlack" should have 95 available items
     # Then update the product stock from BO by adding 10 more combinations
-    When I update combination "product1SBlack" with following values:
+    When I update combination "product1SBlack" stock with following details:
       | delta quantity | 10 |
     Then combination "product1SBlack" should have 105 available items
     # Then order 4 product1SBlack (status delivered)
@@ -91,7 +91,7 @@ Feature: Search stock movements from Back Office (BO)
       | status              | Delivered                  |
     And combination "product1SBlack" should have 96 available items
     # Now update product quantity of product1SBlack by 5
-    When I update combination "product1SBlack" with following values:
+    When I update combination "product1SBlack" stock with following details:
       | delta quantity | 5 |
     Then combination "product1SBlack" should have 101 available items
     # Order 5 product1SBlack (status delivered)
@@ -157,11 +157,11 @@ Feature: Search stock movements from Back Office (BO)
 
   Scenario: I can search the last stock movements also if the first one is an edition (and can have multiple editions one after another)
     # First edit product quantity
-    When I update combination "product1MWhite" with following values:
+    When I update combination "product1MWhite" stock with following details:
       | delta quantity | 15 |
     Then combination "product1MWhite" should have 15 available items
     # Edit a second time to have two edition rows one after another
-    When I update combination "product1MWhite" with following values:
+    When I update combination "product1MWhite" stock with following details:
       | delta quantity | -5 |
     Then combination "product1MWhite" should have 10 available items
     # Then create a cart with 2 product1MWhite and order it
@@ -174,7 +174,7 @@ Feature: Search stock movements from Back Office (BO)
       | payment module name | dummy_payment              |
       | status              | Delivered                  |
     Then combination "product1MWhite" should have 8 available items
-    When I update combination "product1MWhite" with following values:
+    When I update combination "product1MWhite" stock with following details:
       | delta quantity | -3 |
     Then combination "product1MWhite" should have 5 available items
     When I search stock movements of combination "product1MWhite" I should get following results:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_product_type.feature
@@ -181,7 +181,7 @@ Feature: Add basic product from Back Office (BO)
       | productCombinations3MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |                       |
       | productCombinations3MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |                       |
       | productCombinations3MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |                       |
-    When I update combination "productCombinations3SWhite" with following values:
+    When I update combination "productCombinations3SWhite" stock with following details:
       | delta quantity | 100 |
     Then combination "productCombinations3SWhite" should have following stock details:
       | combination stock detail   | value |
@@ -195,7 +195,7 @@ Feature: Add basic product from Back Office (BO)
       | employee   | delta_quantity |
       | Puff Daddy | 100            |
     And combination "productCombinations3SWhite" last stock movement increased by 100
-    When I update combination "productCombinations3SBlack" with following values:
+    When I update combination "productCombinations3SBlack" stock with following details:
       | delta quantity | 50 |
     Then combination "productCombinations3SBlack" should have following stock details:
       | combination stock detail   | value |

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -340,6 +340,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationStockMovementsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationStockFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\StockMovementsFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\UpdateStockFeatureContext
         shop:
@@ -429,12 +430,13 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\AddProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationAssertionFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationListingFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationShopFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\DeleteCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\GenerateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SearchCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
-                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationShopFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationStockFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext

--- a/tests/Integration/Behaviour/behat.yml
+++ b/tests/Integration/Behaviour/behat.yml
@@ -434,6 +434,7 @@ default:
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\SearchCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationImagesFeatureContext
+                - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\CombinationShopFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\Combination\UpdateCombinationSuppliersFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\CommonProductFeatureContext
                 - Tests\Integration\Behaviour\Features\Context\Domain\Product\DeleteProductFeatureContext

--- a/tests/Unit/Adapter/Product/Combination/Update/Filler/CombinationFillerTestCase.php
+++ b/tests/Unit/Adapter/Product/Combination/Update/Filler/CombinationFillerTestCase.php
@@ -31,6 +31,7 @@ use Combination;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\Filler\CombinationFillerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 abstract class CombinationFillerTestCase extends TestCase
 {
@@ -81,6 +82,6 @@ abstract class CombinationFillerTestCase extends TestCase
      */
     protected function getEmptyCommand(): UpdateCombinationCommand
     {
-        return new UpdateCombinationCommand(self::COMBINATION_ID);
+        return new UpdateCombinationCommand(self::COMBINATION_ID, ShopConstraint::shop(self::DEFAULT_SHOP_ID));
     }
 }

--- a/tests/Unit/Core/Domain/Product/Combination/Command/UpdateCombinationStockAvailableCommandTest.php
+++ b/tests/Unit/Core/Domain/Product/Combination/Command/UpdateCombinationStockAvailableCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Domain\Product\Combination\Command;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+
+class UpdateCombinationStockAvailableCommandTest extends TestCase
+{
+    public function testItThrowsExceptionWhenTryingToSetFixedQuantityWhenDeltaQuantityIsAlreadySet(): void
+    {
+        $command = new UpdateCombinationStockAvailableCommand(1, ShopConstraint::allShops());
+        $this->expectException(ProductStockConstraintException::class);
+        $this->expectExceptionCode(ProductStockConstraintException::FIXED_AND_DELTA_QUANTITY_PROVIDED);
+
+        $command->setDeltaQuantity(10);
+        $command->setFixedQuantity(1);
+    }
+
+    public function testItThrowsExceptionWhenTryingToSetDeltaQuantityWhenFixedQuantityIsAlreadySet(): void
+    {
+        $command = new UpdateCombinationStockAvailableCommand(1, ShopConstraint::allShops());
+        $this->expectException(ProductStockConstraintException::class);
+        $this->expectExceptionCode(ProductStockConstraintException::FIXED_AND_DELTA_QUANTITY_PROVIDED);
+
+        $command->setFixedQuantity(1);
+        $command->setDeltaQuantity(10);
+    }
+}

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/AbstractMultiShopCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/AbstractMultiShopCommandsBuilderTest.php
@@ -23,33 +23,21 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
 declare(strict_types=1);
 
-namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination;
+namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
 
-use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
-use Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product\AbstractMultiShopCommandsBuilderTest;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
-/**
- * Base class to test a combination command builder
- */
-abstract class AbstractCombinationCommandBuilderTest extends AbstractMultiShopCommandsBuilderTest
+abstract class AbstractMultiShopCommandsBuilderTest extends TestCase
 {
-    /**
-     * @var CombinationId
-     */
-    private $combinationId;
+    protected const SHOP_ID = 1;
 
-    /**
-     * @return CombinationId
-     */
-    protected function getCombinationId(): CombinationId
+    protected const MODIFY_ALL_SHOPS_PREFIX = 'modify_all_shops_';
+
+    protected function getSingleShopConstraint(): ShopConstraint
     {
-        if (null === $this->combinationId) {
-            $this->combinationId = new CombinationId(43);
-        }
-
-        return $this->combinationId;
+        return ShopConstraint::shop(self::SHOP_ID);
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/AbstractProductCommandBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/AbstractProductCommandBuilderTest.php
@@ -28,19 +28,13 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
 
-use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
-use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Base class to test a product command builder
  */
-abstract class AbstractProductCommandBuilderTest extends TestCase
+abstract class AbstractProductCommandBuilderTest extends AbstractMultiShopCommandsBuilderTest
 {
-    public const SHOP_ID = 1;
-
-    protected const MODIFY_ALL_SHOPS_PREFIX = 'modify_all_shops_';
-
     /**
      * @var ProductId
      */
@@ -56,10 +50,5 @@ abstract class AbstractProductCommandBuilderTest extends TestCase
         }
 
         return $this->productId;
-    }
-
-    protected function getSingleShopConstraint(): ShopConstraint
-    {
-        return ShopConstraint::shop(self::SHOP_ID);
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/CombinationCommandsBuilderTest.php
@@ -44,11 +44,11 @@ class CombinationCommandsBuilderTest extends AbstractCombinationCommandBuilderTe
     public function testBuildCommands(array $formData, array $commandBuilders, array $expectedCommands)
     {
         $builder = new CombinationCommandsBuilder($commandBuilders);
-        $builtCommands = $builder->buildCommands($this->getCombinationId(), $formData);
+        $builtCommands = $builder->buildCommands($this->getCombinationId(), $formData, $this->getSingleShopConstraint());
         $this->assertEquals($expectedCommands, $builtCommands);
     }
 
-    public function getExpectedCommands()
+    public function getExpectedCommands(): iterable
     {
         $collection = [];
         yield [

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
@@ -30,6 +30,7 @@ namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product\Combina
 
 use DateTime;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder;
 use PrestaShop\PrestaShop\Core\Util\DateTime\NullDateTime;
 
@@ -37,14 +38,15 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
 {
     /**
      * @dataProvider getExpectedCommands
+     * @dataProvider getExpectedCommandsMultiShop
      *
      * @param array $formData
      * @param array $expectedCommands
      */
-    public function testBuildCommand(array $formData, array $expectedCommands)
+    public function testBuildCommands(array $formData, array $expectedCommands)
     {
-        $builder = new UpdateCombinationCommandsBuilder();
-        $builtCommands = $builder->buildCommands($this->getCombinationId(), $formData);
+        $builder = new UpdateCombinationCommandsBuilder(self::MODIFY_ALL_SHOPS_PREFIX);
+        $builtCommands = $builder->buildCommands($this->getCombinationId(), $formData, $this->getSingleShopConstraint());
         $this->assertEquals($expectedCommands, $builtCommands);
     }
 
@@ -70,7 +72,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
         ];
 
         // References
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setReference('toto');
         yield [
             [
@@ -81,7 +83,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setUpc('123456');
         $command->setMpn('mpn');
         yield [
@@ -94,7 +96,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setIsbn('0-8044-2957-X');
         $command->setEan13('12345678910');
         yield [
@@ -108,7 +110,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
         ];
 
         // Price impact
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setImpactOnWeight('12');
         yield [
             [
@@ -120,7 +122,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setImpactOnUnitPrice('51.00');
         $command->setWholesalePrice('12.00');
         yield [
@@ -133,7 +135,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setEcoTax('42.00');
         $command->setImpactOnPrice('49.00');
         yield [
@@ -147,7 +149,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
         ];
 
         // Stock information
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setMinimalQuantity(1);
         yield [
             [
@@ -160,7 +162,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setLowStockThreshold(5);
         yield [
             [
@@ -173,7 +175,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setLowStockAlert(false);
         yield [
             [
@@ -186,7 +188,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setAvailableDate(new DateTime('2022-10-10'));
         yield [
             [
@@ -197,7 +199,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setAvailableDate(new NullDateTime());
         yield [
             [
@@ -208,7 +210,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setIsDefault(true);
         yield [
             [
@@ -219,7 +221,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setIsDefault(false);
         yield [
             [
@@ -230,7 +232,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [$command],
         ];
 
-        $command = new UpdateCombinationCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setIsDefault(false);
         yield [
             [
@@ -240,5 +242,240 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             ],
             [$command],
         ];
+    }
+
+    public function getExpectedCommandsMultiShop(): iterable
+    {
+        // check that references are always updated only as a single shop,
+        // even if for some reason there would be all shops prefix in form,
+        // because these fields are not multiShop shops
+        $singleShopCommand = $this
+            ->getSingleShopCommand()
+            ->setReference('toto')
+            ->setUpc('123456')
+            ->setMpn('mpn')
+            ->setIsbn('0-8044-2957-X')
+            ->setEan13('12345678910')
+        ;
+        yield [
+            [
+                'references' => [
+                    'reference' => 'toto',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'reference' => true,
+                    'upc' => '123456',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'upc' => true,
+                    'mpn' => 'mpn',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'mpn' => true,
+                    'isbn' => '0-8044-2957-X',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'isbn' => true,
+                    'ean_13' => '12345678910',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'ean_13' => true,
+                ],
+            ],
+            [$singleShopCommand],
+        ];
+
+        $allShopsCommand = $this
+            ->getAllShopsCommand()
+            ->setImpactOnWeight('12')
+            ->setImpactOnUnitPrice('51.00')
+            ->setWholesalePrice('12.00')
+            ->setEcoTax('42.00')
+            ->setImpactOnPrice('49.00')
+        ;
+
+        yield [
+            [
+                'price_impact' => [
+                    'not_handled' => 0,
+                    'weight' => 12.0,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'weight' => true,
+                    'unit_price_tax_excluded' => 51.00,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'unit_price_tax_excluded' => true,
+                    'wholesale_price' => '12.00',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'wholesale_price' => true,
+                    'ecotax_tax_excluded' => 42.00,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'ecotax_tax_excluded' => true,
+                    'price_tax_excluded' => '49.00',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'price_tax_excluded' => true,
+                ],
+            ],
+            [$allShopsCommand],
+        ];
+
+        $singleShopCommand = $this
+            ->getSingleShopCommand()
+            ->setImpactOnWeight('12')
+            ->setImpactOnUnitPrice('51.00')
+            ->setWholesalePrice('12.00')
+
+        ;
+        $allShopsCommand = $this
+            ->getAllShopsCommand()
+            ->setEcoTax('42.00')
+            ->setImpactOnPrice('49.00')
+        ;
+
+        yield [
+            [
+                'price_impact' => [
+                    'not_handled' => 0,
+                    'weight' => 12.0,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'weight' => false,
+                    'unit_price_tax_excluded' => 51.00,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'unit_price_tax_excluded' => false,
+                    'wholesale_price' => '12.00',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'wholesale_price' => false,
+                    'ecotax_tax_excluded' => 42.00,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'ecotax_tax_excluded' => true,
+                    'price_tax_excluded' => '49.00',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'price_tax_excluded' => true,
+                ],
+            ],
+            [$singleShopCommand, $allShopsCommand],
+        ];
+
+        $localizedAvailableNow = [
+            1 => 'available',
+            2 => 'disponible',
+        ];
+        $localizedAvailableLater = [
+            1 => 'available1',
+            2 => 'disponible2',
+        ];
+
+        $singleShopCommand = $this
+            ->getSingleShopCommand()
+            ->setLocalizedAvailableNowLabels($localizedAvailableNow)
+            ->setLocalizedAvailableLaterLabels($localizedAvailableLater)
+        ;
+        $allShopsCommand = $this
+            ->getAllShopsCommand()
+            ->setMinimalQuantity(1)
+            ->setLowStockThreshold(5)
+            ->setLowStockAlert(false)
+            ->setAvailableDate(new DateTime('2022-10-10'))
+        ;
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'minimal_quantity' => 1,
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'minimal_quantity' => true,
+                    ],
+                    'options' => [
+                        'low_stock_threshold' => '5',
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'low_stock_threshold' => true,
+                        'disabling_switch_low_stock_threshold' => '0',
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'disabling_switch_low_stock_threshold' => true,
+                    ],
+                    'available_date' => '2022-10-10',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'available_date' => true,
+                    'available_now_label' => $localizedAvailableNow,
+                    // even if all shops field is present for some reason,
+                    // it still should generate single shop command for this field,
+                    // because it is not multiShop field
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'available_now_label' => true,
+                    'available_later_label' => $localizedAvailableLater,
+                ],
+            ],
+            [$singleShopCommand, $allShopsCommand],
+        ];
+
+        $singleShopCommand = $this
+            ->getSingleShopCommand()
+            ->setMinimalQuantity(1)
+            ->setLowStockThreshold(5)
+        ;
+        $allShopsCommand = $this
+            ->getAllShopsCommand()
+            ->setLowStockAlert(false)
+            ->setAvailableDate(new NullDateTime())
+        ;
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'minimal_quantity' => 1,
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'minimal_quantity' => false,
+                    ],
+                    'options' => [
+                        'low_stock_threshold' => '5',
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'low_stock_threshold' => false,
+                        'disabling_switch_low_stock_threshold' => '0',
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'disabling_switch_low_stock_threshold' => true,
+                    ],
+                    'available_date' => '',
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'available_date' => true,
+                ],
+            ],
+            [$singleShopCommand, $allShopsCommand],
+        ];
+
+        $allShopsCommand = $this
+            ->getAllShopsCommand()
+            ->setIsDefault(true)
+        ;
+        yield [
+            [
+                'header' => [
+                    'is_default' => true,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'is_default' => true,
+                ],
+            ],
+            [$allShopsCommand],
+        ];
+
+        $allShopsCommand = $this
+            ->getAllShopsCommand()
+            ->setIsDefault(false)
+        ;
+        yield [
+            [
+                'header' => [
+                    'is_default' => false,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'is_default' => true,
+                ],
+            ],
+            [$allShopsCommand],
+        ];
+
+        $singleShopCommand = $this
+            ->getSingleShopCommand()
+            ->setIsDefault(true)
+        ;
+        yield [
+            [
+                'header' => [
+                    'is_default' => true,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'is_default' => false,
+                ],
+            ],
+            [$singleShopCommand],
+        ];
+
+        $singleShopCommand = $this
+            ->getSingleShopCommand()
+            ->setIsDefault(false)
+        ;
+        yield [
+            [
+                'header' => [
+                    'is_default' => false,
+                    self::MODIFY_ALL_SHOPS_PREFIX . 'is_default' => false,
+                ],
+            ],
+            [$singleShopCommand],
+        ];
+    }
+
+    private function getSingleShopCommand(): UpdateCombinationCommand
+    {
+        return new UpdateCombinationCommand($this->getCombinationId()->getValue(), $this->getSingleShopConstraint());
+    }
+
+    private function getAllShopsCommand(): UpdateCombinationCommand
+    {
+        return new UpdateCombinationCommand($this->getCombinationId()->getValue(), ShopConstraint::allShops());
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationStockAvailableCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationStockAvailableCommandsBuilderTest.php
@@ -29,20 +29,22 @@ declare(strict_types=1);
 namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationStockAvailableCommand;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationStockAvailableCommandsBuilder;
 
 class UpdateCombinationStockAvailableCommandsBuilderTest extends AbstractCombinationCommandBuilderTest
 {
     /**
      * @dataProvider getExpectedCommands
+     * @dataProvider getExpectedCommandsMultiShop
      *
      * @param array $formData
      * @param array $expectedCommands
      */
-    public function testBuildCommand(array $formData, array $expectedCommands): void
+    public function testBuildCommands(array $formData, array $expectedCommands): void
     {
-        $builder = new UpdateCombinationStockAvailableCommandsBuilder();
-        $builtCommands = $builder->buildCommands($this->getCombinationId(), $formData);
+        $builder = new UpdateCombinationStockAvailableCommandsBuilder(self::MODIFY_ALL_SHOPS_PREFIX);
+        $builtCommands = $builder->buildCommands($this->getCombinationId(), $formData, $this->getSingleShopConstraint());
         $this->assertEquals($expectedCommands, $builtCommands);
     }
 
@@ -64,7 +66,7 @@ class UpdateCombinationStockAvailableCommandsBuilderTest extends AbstractCombina
             [],
         ];
 
-        $command = new UpdateCombinationStockAvailableCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setDeltaQuantity(100);
         yield [
             [
@@ -81,7 +83,7 @@ class UpdateCombinationStockAvailableCommandsBuilderTest extends AbstractCombina
             [$command],
         ];
 
-        $command = new UpdateCombinationStockAvailableCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setFixedQuantity(134);
         yield [
             [
@@ -94,7 +96,7 @@ class UpdateCombinationStockAvailableCommandsBuilderTest extends AbstractCombina
             [$command],
         ];
 
-        $command = new UpdateCombinationStockAvailableCommand($this->getCombinationId()->getValue());
+        $command = $this->getSingleShopCommand();
         $command->setLocation('Im in miami...');
         yield [
             [
@@ -106,5 +108,103 @@ class UpdateCombinationStockAvailableCommandsBuilderTest extends AbstractCombina
             ],
             [$command],
         ];
+    }
+
+    public function getExpectedCommandsMultiShop(): iterable
+    {
+        $allShopsCommand = $this
+            ->getAllShopsCommand()
+            ->setDeltaQuantity(100)
+            ->setLocation('Im in miami...')
+        ;
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'delta_quantity' => [
+                            // quantity is used for view only, the real value that is used now is delta
+                            'quantity' => 1000000,
+                            'delta' => 100,
+                            self::MODIFY_ALL_SHOPS_PREFIX . 'delta' => true,
+                        ],
+                    ],
+                    'options' => [
+                        'stock_location' => 'Im in miami...',
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'stock_location' => true,
+                    ],
+                ],
+            ],
+            [$allShopsCommand],
+        ];
+
+        $singleShopCommand = $this
+            ->getSingleShopCommand()
+            ->setDeltaQuantity(100)
+        ;
+        $allShopsCommand = $this
+            ->getAllShopsCommand()
+            ->setLocation('Im in miami...')
+        ;
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'delta_quantity' => [
+                            // quantity is used for view only, the real value that is used now is delta
+                            'quantity' => 1000000,
+                            'delta' => 100,
+                            self::MODIFY_ALL_SHOPS_PREFIX . 'delta' => false,
+                        ],
+                    ],
+                    'options' => [
+                        'stock_location' => 'Im in miami...',
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'stock_location' => true,
+                    ],
+                ],
+            ],
+            [$singleShopCommand, $allShopsCommand],
+        ];
+
+        $allShopsCommand = $this
+            ->getAllShopsCommand()
+            ->setFixedQuantity(134)
+        ;
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'fixed_quantity' => 134,
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'fixed_quantity' => true,
+                    ],
+                ],
+            ],
+            [$allShopsCommand],
+        ];
+
+        $singleShopCommand = $this
+            ->getSingleShopCommand()
+            ->setFixedQuantity(134)
+        ;
+        yield [
+            [
+                'stock' => [
+                    'quantities' => [
+                        'fixed_quantity' => 134,
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'fixed_quantity' => false,
+                    ],
+                ],
+            ],
+            [$singleShopCommand],
+        ];
+    }
+
+    private function getSingleShopCommand(): UpdateCombinationStockAvailableCommand
+    {
+        return new UpdateCombinationStockAvailableCommand($this->getCombinationId()->getValue(), $this->getSingleShopConstraint());
+    }
+
+    private function getAllShopsCommand(): UpdateCombinationStockAvailableCommand
+    {
+        return new UpdateCombinationStockAvailableCommand($this->getCombinationId()->getValue(), ShopConstraint::allShops());
     }
 }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -42,11 +42,12 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
 {
     /**
      * @dataProvider getExpectedCommands
+     * @dataProvider getExpectedCommandsMultiShop
      *
      * @param array $formData
      * @param array $expectedCommands
      */
-    public function testBuildCommand(array $formData, array $expectedCommands)
+    public function testBuildCommands(array $formData, array $expectedCommands)
     {
         $builder = new UpdateProductCommandsBuilder(self::MODIFY_ALL_SHOPS_PREFIX);
         $builtCommands = $builder->buildCommands($this->getProductId(), $formData, $this->getSingleShopConstraint());
@@ -622,19 +623,6 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             ],
             [$command],
         ];
-    }
-
-    /**
-     * @dataProvider getExpectedCommandsMultiShop
-     *
-     * @param array $formData
-     * @param array $expectedCommands
-     */
-    public function testBuildCommandMultiShop(array $formData, array $expectedCommands): void
-    {
-        $builder = new UpdateProductCommandsBuilder(self::MODIFY_ALL_SHOPS_PREFIX);
-        $builtCommands = $builder->buildCommands($this->getProductId(), $formData, $this->getSingleShopConstraint());
-        $this->assertEquals($expectedCommands, $builtCommands);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handles multishop behavior for UpdateCombinationCommand and UpdateCombinationStockAvailableCommand by using ShopConstraint. Also adds related behat scenarios.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | Automated tests should be enough for now. The frontend (form) part is not yet adapted to support "allshops" update, so manual testing could be done after that.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
