### PR TITLE
Improve Product::getAttributesResume

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2725,10 +2725,9 @@ class ProductCore extends ObjectModel
             return false;
         }
 
-        $product_attributes = [];
-        foreach ($combinations as $combination) {
-            $product_attributes[] = (int) $combination['id_product_attribute'];
-        }
+        $combinations = array_column($combinations, null, 'id_product_attribute');
+
+        $product_attributes = array_keys($combinations);
 
         $lang = Db::getInstance()->executeS('SELECT pac.id_product_attribute, GROUP_CONCAT(agl.`name`, \'' . pSQL($attribute_value_separator) . '\',al.`name` ORDER BY agl.`id_attribute_group` SEPARATOR \'' . pSQL($attribute_separator) . '\') as attribute_designation
                 FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac
@@ -2740,8 +2739,8 @@ class ProductCore extends ObjectModel
                 GROUP BY pac.id_product_attribute
                 ORDER BY pac.id_product_attribute');
 
-        foreach ($lang as $k => $row) {
-            $combinations[$k]['attribute_designation'] = $row['attribute_designation'];
+        foreach ($lang as $row) {
+            $combinations[$row['id_product_attribute']]['attribute_designation'] = $row['attribute_designation'];
         }
 
         $computingPrecision = Context::getContext()->getComputingPrecision();

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2735,7 +2735,7 @@ class ProductCore extends ObjectModel
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag ON ag.`id_attribute_group` = a.`id_attribute_group`
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = ' . (int) $id_lang . ')
                 LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int) $id_lang . ')
-                WHERE pac.id_product_attribute IN (' . implode(',', $product_attributes) . ')
+                WHERE pac.id_product_attribute IN (' . implode(',', $combinationIds) . ')
                 GROUP BY pac.id_product_attribute
                 ORDER BY pac.id_product_attribute');
 

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -2727,7 +2727,7 @@ class ProductCore extends ObjectModel
 
         $combinations = array_column($combinations, null, 'id_product_attribute');
 
-        $product_attributes = array_keys($combinations);
+        $combinationIds = array_keys($combinations);
 
         $lang = Db::getInstance()->executeS('SELECT pac.id_product_attribute, GROUP_CONCAT(agl.`name`, \'' . pSQL($attribute_value_separator) . '\',al.`name` ORDER BY agl.`id_attribute_group` SEPARATOR \'' . pSQL($attribute_separator) . '\') as attribute_designation
                 FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | PrestaShop < 1.7.8.0 <br>Improve code to correctly apply attribute lang informations to the right combinations<br>Using id_product_attribute as index instead of an auto increment array index for a right match.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30533
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/24089
| How to test?      | It's a technical improvement than a real error we can reproducing easily.<br>It's an add to this PR: https://github.com/PrestaShop/PrestaShop/pull/24089
| Possible impacts? | Admin Product Controller tab combinations