### PR TITLE
Speed up product deletion

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1306,10 +1306,7 @@ class ProductCore extends ObjectModel
         $result = parent::delete();
 
         // Removes the product from StockAvailable, for the current shop
-        $id_shop_list = Shop::getContextListShopID();
-        if (count($this->id_shop_list)) {
-            $id_shop_list = $this->id_shop_list;
-        }
+        $id_shop_list = count($this->id_shop_list) ? $this->id_shop_list : Shop::getContextListShopID();
         if (!empty($id_shop_list)) {
             foreach ($id_shop_list as $shopId) {
                 StockAvailable::removeProductFromStockAvailable($this->id, null, $shopId);
@@ -1330,7 +1327,7 @@ class ProductCore extends ObjectModel
             !$this->deleteProductAttributes() ||
             !$this->deleteImages() ||
             !GroupReduction::deleteProductReduction($this->id) ||
-            !$this->deleteCategories(true) ||
+            !$this->deleteCategories(false) ||
             !$this->deleteProductFeatures() ||
             !$this->deleteTags() ||
             !$this->deleteCartProducts() ||


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removes some useless computation and avoid recompute all products positions when deleting a product.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no, no?
| Deprecations?     | no
| Fixed ticket?     | Fixes #19605
| Related PRs       | #29804
| How to test?      | Delete a product of a category with a lot of products.
| Possible impacts? | The position is no longer continuous, although it is still valid for ordering.
