### PR TITLE
Generate product categories breadcrumb accordingly to accessed category

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1350,13 +1350,25 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         return $requiredQuantity;
     }
 
-    public function getBreadcrumbLinks()
+    /**
+     * Generates breadcrumb according to product categories and his category subtree.
+     * If the product is accessed from another category than product default category, it will generate the breadcrumb according to current category.
+     *
+     * @return array
+     * @throws PrestaShopException
+     */
+    public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
 
-        $categoryDefault = new Category($this->product->id_category_default, $this->context->language->id);
+        if (!is_null($this->category) && in_array($this->category->id_category, $this->product->getCategories(), true)) {
+            $currentCategory = $this->category;
+        } else {
+            $currentCategory = new Category($this->product->id_category_default, $this->context->language->id);
+        }
 
-        foreach ($categoryDefault->getAllParents() as $category) {
+
+        foreach ($currentCategory->getAllParents() as $category) {
             /** @var Category $category */
             if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
                 $breadcrumb['links'][] = [
@@ -1366,10 +1378,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             }
         }
 
-        if ($categoryDefault->id_parent != 0 && !$categoryDefault->is_root_category && $categoryDefault->active) {
+        if ($currentCategory->id_parent != 0 && !$currentCategory->is_root_category && $currentCategory->active) {
             $breadcrumb['links'][] = [
-                'title' => $categoryDefault->name,
-                'url' => $this->context->link->getCategoryLink($categoryDefault),
+                'title' => $currentCategory->name,
+                'url' => $this->context->link->getCategoryLink($currentCategory),
             ];
         }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1360,8 +1360,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
-
-        if (!is_null($this->category) && in_array($this->category->id_category, $this->product->getCategories(), true)) {
+        $shouldForceDefaultCat = Configuration::get('PS_FORCE_DEFAULT_CAT_BREADCRUMB');
+        if (!$shouldForceDefaultCat &&
+            !is_null($this->category) &&
+            in_array($this->category->id_category, $this->product->getCategories(), true)) {
             $currentCategory = $this->category;
         } else {
             $currentCategory = new Category($this->product->id_category_default, $this->context->language->id);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1360,17 +1360,21 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
-        $shouldForceDefaultCat = Configuration::get('PS_FORCE_DEFAULT_CAT_BREADCRUMB');
-        if (!$shouldForceDefaultCat &&
+        $productBreadcrumbCategoryMode = Configuration::get('PS_PRODUCT_BREADCRUMB_CATEGORY');
+        // $productBreadcrumbCategory can have two possible values
+        // - current : Category the product was accessed from
+        // - default : Product default category
+
+        if (('current' === $productBreadcrumbCategoryMode) &&
             !is_null($this->category) &&
             in_array($this->category->id_category, $this->product->getCategories(), true)) {
-            $currentCategory = $this->category;
+            $productBreadcrumbCategory = $this->category;
         } else {
-            $currentCategory = new Category($this->product->id_category_default, $this->context->language->id);
+            $productBreadcrumbCategory = new Category($this->product->id_category_default, $this->context->language->id);
         }
 
 
-        foreach ($currentCategory->getAllParents() as $category) {
+        foreach ($productBreadcrumbCategory->getAllParents() as $category) {
             /** @var Category $category */
             if ($category->id_parent != 0 && !$category->is_root_category && $category->active) {
                 $breadcrumb['links'][] = [
@@ -1380,10 +1384,10 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
             }
         }
 
-        if ($currentCategory->id_parent != 0 && !$currentCategory->is_root_category && $currentCategory->active) {
+        if ($productBreadcrumbCategory->id_parent != 0 && !$productBreadcrumbCategory->is_root_category && $productBreadcrumbCategory->active) {
             $breadcrumb['links'][] = [
-                'title' => $currentCategory->name,
-                'url' => $this->context->link->getCategoryLink($currentCategory),
+                'title' => $productBreadcrumbCategory->name,
+                'url' => $this->context->link->getCategoryLink($productBreadcrumbCategory),
             ];
         }
 

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1351,7 +1351,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     }
 
     /**
-     * Generates breadcrumb according to product categories and his category subtree.
+     * Generates breadcrumb according to product category tree.
      * If the product is accessed from another category than product default category, it will generate the breadcrumb according to current category.
      *
      * @return array

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1366,7 +1366,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         // - current : Category the product was accessed from
         // - default : Product default category
         if (('current' === Configuration::get('PS_PRODUCT_BREADCRUMB_CATEGORY')) &&
-            !is_null($this->category)) {
+            !empty($this->category)) {
             $productBreadcrumbCategory = $this->category;
         } else {
             $productBreadcrumbCategory = new Category($this->product->id_category_default, $this->context->language->id);

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1355,24 +1355,22 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
      * If the product is accessed from another category than product default category, it will generate the breadcrumb according to current category.
      *
      * @return array
+     *
      * @throws PrestaShopException
      */
     public function getBreadcrumbLinks(): array
     {
         $breadcrumb = parent::getBreadcrumbLinks();
-        $productBreadcrumbCategoryMode = Configuration::get('PS_PRODUCT_BREADCRUMB_CATEGORY');
+
         // $productBreadcrumbCategory can have two possible values
         // - current : Category the product was accessed from
         // - default : Product default category
-
-        if (('current' === $productBreadcrumbCategoryMode) &&
-            !is_null($this->category) &&
-            in_array($this->category->id_category, $this->product->getCategories(), true)) {
+        if (('current' === Configuration::get('PS_PRODUCT_BREADCRUMB_CATEGORY')) &&
+            !is_null($this->category)) {
             $productBreadcrumbCategory = $this->category;
         } else {
             $productBreadcrumbCategory = new Category($this->product->id_category_default, $this->context->language->id);
         }
-
 
         foreach ($productBreadcrumbCategory->getAllParents() as $category) {
             /** @var Category $category */

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -888,5 +888,8 @@ Country</value>
     <configuration id="PS_DEBUG_COOKIE_VALUE" name="PS_DEBUG_COOKIE_VALUE">
       <value/>
     </configuration>
+    <configuration id="PS_PRODUCT_BREADCRUMB_CATEGORY" name="PS_PRODUCT_BREADCRUMB_CATEGORY">
+      <value>default</value>
+    </configuration>
   </entities>
 </entity_configuration>

--- a/src/Adapter/Product/GeneralConfiguration.php
+++ b/src/Adapter/Product/GeneralConfiguration.php
@@ -72,6 +72,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             'short_description_limit' => $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT'),
             'quantity_discount' => $this->configuration->get('PS_QTY_DISCOUNT_ON_COMBINATION'),
             'force_friendly_url' => $this->configuration->getBoolean('PS_FORCE_FRIENDLY_PRODUCT'),
+            'force_default_category_breadcrumb' => $this->configuration->getBoolean('PS_FORCE_DEFAULT_CAT_BREADCRUMB'),
             'default_status' => $this->configuration->getBoolean('PS_PRODUCT_ACTIVATION_DEFAULT'),
             'specific_price_priorities' => $this->getPrioritiesData(),
             'disabled_products_behavior' => $this->configuration->get('PS_PRODUCT_REDIRECTION_DEFAULT'),
@@ -93,6 +94,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             $this->configuration->set('PS_PRODUCT_SHORT_DESC_LIMIT', (int) $config['short_description_limit']);
             $this->configuration->set('PS_QTY_DISCOUNT_ON_COMBINATION', (int) $config['quantity_discount']);
             $this->configuration->set('PS_FORCE_FRIENDLY_PRODUCT', (int) $config['force_friendly_url']);
+            $this->configuration->set('PS_FORCE_DEFAULT_CAT_BREADCRUMB', (int) $config['force_default_category_breadcrumb']);
             $this->configuration->set('PS_PRODUCT_ACTIVATION_DEFAULT', (int) $config['default_status']);
             $this->configuration->set('PS_PRODUCT_REDIRECTION_DEFAULT', (string) $config['disabled_products_behavior']);
             try {
@@ -126,6 +128,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             'short_description_limit',
             'quantity_discount',
             'force_friendly_url',
+            'force_default_category_breadcrumb',
             'default_status',
             'specific_price_priorities',
             'disabled_products_behavior',

--- a/src/Adapter/Product/GeneralConfiguration.php
+++ b/src/Adapter/Product/GeneralConfiguration.php
@@ -72,7 +72,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             'short_description_limit' => $this->configuration->get('PS_PRODUCT_SHORT_DESC_LIMIT'),
             'quantity_discount' => $this->configuration->get('PS_QTY_DISCOUNT_ON_COMBINATION'),
             'force_friendly_url' => $this->configuration->getBoolean('PS_FORCE_FRIENDLY_PRODUCT'),
-            'force_default_category_breadcrumb' => $this->configuration->getBoolean('PS_FORCE_DEFAULT_CAT_BREADCRUMB'),
+            'product_breadcrumb_category' => $this->configuration->get('PS_PRODUCT_BREADCRUMB_CATEGORY'),
             'default_status' => $this->configuration->getBoolean('PS_PRODUCT_ACTIVATION_DEFAULT'),
             'specific_price_priorities' => $this->getPrioritiesData(),
             'disabled_products_behavior' => $this->configuration->get('PS_PRODUCT_REDIRECTION_DEFAULT'),
@@ -94,7 +94,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             $this->configuration->set('PS_PRODUCT_SHORT_DESC_LIMIT', (int) $config['short_description_limit']);
             $this->configuration->set('PS_QTY_DISCOUNT_ON_COMBINATION', (int) $config['quantity_discount']);
             $this->configuration->set('PS_FORCE_FRIENDLY_PRODUCT', (int) $config['force_friendly_url']);
-            $this->configuration->set('PS_FORCE_DEFAULT_CAT_BREADCRUMB', (int) $config['force_default_category_breadcrumb']);
+            $this->configuration->set('PS_PRODUCT_BREADCRUMB_CATEGORY', (string) $config['product_breadcrumb_category']);
             $this->configuration->set('PS_PRODUCT_ACTIVATION_DEFAULT', (int) $config['default_status']);
             $this->configuration->set('PS_PRODUCT_REDIRECTION_DEFAULT', (string) $config['disabled_products_behavior']);
             try {
@@ -128,7 +128,7 @@ class GeneralConfiguration implements DataConfigurationInterface
             'short_description_limit',
             'quantity_discount',
             'force_friendly_url',
-            'force_default_category_breadcrumb',
+            'product_breadcrumb_category',
             'default_status',
             'specific_price_priorities',
             'disabled_products_behavior',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -152,7 +152,7 @@ class GeneralType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Global',
                 'placeholder' => false,
                 'help' => $this->trans(
-                    'Select what category you want to display in breadcrumbs on product page. It could be always the default category of the product, or the category the customer came from.',
+                    'Select which category to display on the product page breadcrumbs. It can be the default category of the product or the category the customer came from.',
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -152,7 +152,7 @@ class GeneralType extends TranslatorAwareType
                 'choice_translation_domain' => 'Admin.Global',
                 'placeholder' => false,
                 'help' => $this->trans(
-                    'Select which category to display on the product page breadcrumbs. It can be the default category of the product or the category the customer came from.',
+                    'Select which category to display on the product page breadcrumbs. It can be the product\'s default category or the category the customer came from.',
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -140,6 +140,17 @@ class GeneralType extends TranslatorAwareType
                 ),
                 'required' => false,
             ])
+            ->add('force_default_category_breadcrumb', SwitchType::class, [
+                'label' => $this->trans(
+                    'Force default category use for breadcrumb generation',
+                    'Admin.Shopparameters.Feature'
+                ),
+                'help' => $this->trans(
+                    'When active, if a product is assigned to multiple category, the product breadcrumb will always refer to default category path.',
+                    'Admin.Shopparameters.Help'
+                ),
+                'required' => false,
+            ])
             ->add('default_status', SwitchType::class, [
                 'label' => $this->trans(
                     'Activate new products by default',

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -146,8 +146,8 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'choices' => [
-                    $this->trans('Product default category','Admin.Shopparameters.Feature') => 'default',
-                    $this->trans('Category the product was accessed from','Admin.Shopparameters.Feature') => 'current',
+                    $this->trans('Product default category', 'Admin.Shopparameters.Feature') => 'default',
+                    $this->trans('Category the product was accessed from', 'Admin.Shopparameters.Feature') => 'current',
                 ],
                 'choice_translation_domain' => 'Admin.Global',
                 'placeholder' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -146,8 +146,8 @@ class GeneralType extends TranslatorAwareType
                     'Admin.Shopparameters.Feature'
                 ),
                 'choices' => [
-                    'Product default category' => 'default',
-                    'Category the product was accessed from' => 'current',
+                    $this->trans('Product default category','Admin.Shopparameters.Feature') => 'default',
+                    $this->trans('Category the product was accessed from','Admin.Shopparameters.Feature') => 'current',
                 ],
                 'choice_translation_domain' => 'Admin.Global',
                 'placeholder' => false,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/ProductPreferences/GeneralType.php
@@ -140,13 +140,19 @@ class GeneralType extends TranslatorAwareType
                 ),
                 'required' => false,
             ])
-            ->add('force_default_category_breadcrumb', SwitchType::class, [
+            ->add('product_breadcrumb_category', ChoiceType::class, [
                 'label' => $this->trans(
-                    'Force default category use for breadcrumb generation',
+                    'Category used in breadcrumbs',
                     'Admin.Shopparameters.Feature'
                 ),
+                'choices' => [
+                    'Product default category' => 'default',
+                    'Category the product was accessed from' => 'current',
+                ],
+                'choice_translation_domain' => 'Admin.Global',
+                'placeholder' => false,
                 'help' => $this->trans(
-                    'When active, if a product is assigned to multiple category, the product breadcrumb will always refer to default category path.',
+                    'Select what category you want to display in breadcrumbs on product page. It could be always the default category of the product, or the category the customer came from.',
                     'Admin.Shopparameters.Help'
                 ),
                 'required' => false,


### PR DESCRIPTION
If the product is accessed from another category than product default category, it will generate the breadcrumb according to current category.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | By default, product breadcrumb is generated by using product default category. With this feature, if a category is stored on the product controller and assigned to the viewed product, the breadcrumb will be generated accordingly. 
| Type?             | improvement 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?       | Fix https://github.com/PrestaShop/PrestaShop/issues/30547
| UI Test       | https://github.com/florine2623/testing_pr/actions/runs/8247064149
| Related PRs       | [30522](https://github.com/PrestaShop/PrestaShop/pull/30522)
| How to test?      | Assign a product to two categories, and access on both categories to this product. Expect the breadcrumb to be generated accordingly to accessed category.

