### PR TITLE
Only show current and all shops for specific price type

### DIFF
--- a/src/Adapter/Form/ChoiceProvider/ShopNameByIdChoiceProvider.php
+++ b/src/Adapter/Form/ChoiceProvider/ShopNameByIdChoiceProvider.php
@@ -42,7 +42,7 @@ final class ShopNameByIdChoiceProvider implements FormChoiceProviderInterface
         $shopsById = [];
 
         foreach (Shop::getShops() as $shop) {
-            $shopsById[$shop['name']] = $shop['id_shop'];
+            $shopsById[$shop['name']] = (int) $shop['id_shop'];
         }
 
         return $shopsById;

--- a/src/Adapter/Product/SpecificPrice/Repository/SpecificPriceRepository.php
+++ b/src/Adapter/Product/SpecificPrice/Repository/SpecificPriceRepository.php
@@ -318,7 +318,7 @@ class SpecificPriceRepository extends AbstractObjectModelRepository
      */
     private function getSpecificPricesQueryBuilder(ProductId $productId, LanguageId $langId, array $filters): QueryBuilder
     {
-        //@todo: filters are not handled.
+        //@todo: filters are not fully handled.
         $qb = $this->connection->createQueryBuilder();
         $qb->from($this->dbPrefix . 'specific_price', 'sp')
             ->leftJoin(
@@ -360,6 +360,12 @@ class SpecificPriceRepository extends AbstractObjectModelRepository
             ->setParameter('productId', $productId->getValue())
             ->setParameter('langId', $langId->getValue())
         ;
+
+        if (!empty($filters['shopIds'])) {
+            $qb->andWhere($qb->expr()->in('sp.id_shop', ':shopIds'))
+                ->setParameter('shopIds', $filters['shopIds'], Connection::PARAM_INT_ARRAY)
+            ;
+        }
 
         return $qb;
     }

--- a/src/Core/Form/IdentifiableObject/DataProvider/SpecificPriceFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/SpecificPriceFormDataProvider.php
@@ -42,12 +42,20 @@ class SpecificPriceFormDataProvider implements FormDataProviderInterface
     private $queryBus;
 
     /**
+     * @var int
+     */
+    private $contextShopId;
+
+    /**
      * @param CommandBusInterface $queryBus
+     * @param int $contextShopId
      */
     public function __construct(
-        CommandBusInterface $queryBus
+        CommandBusInterface $queryBus,
+        int $contextShopId
     ) {
         $this->queryBus = $queryBus;
+        $this->contextShopId = $contextShopId;
     }
 
     /**
@@ -116,6 +124,9 @@ class SpecificPriceFormDataProvider implements FormDataProviderInterface
                     'include_tax' => true,
                 ],
                 'fixed_price_tax_excluded' => (float) InitialPrice::INITIAL_PRICE_VALUE,
+            ],
+            'groups' => [
+                'shop_id' => $this->contextShopId,
             ],
         ];
     }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/SpecificPriceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/SpecificPriceController.php
@@ -61,7 +61,9 @@ class SpecificPriceController extends FrameworkBundleAdminController
                 $productId,
                 $this->getContextLangId(),
                 $request->query->getInt('limit') ?: null,
-                $request->query->getInt('offset') ?: null
+                $request->query->getInt('offset') ?: null,
+                // Show only specific prices for current context shop or All shops
+                ['shopIds' => [0, $this->getContextShopId()]]
             )
         );
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Pricing/ApplicableGroupsType.php
@@ -146,7 +146,10 @@ class ApplicableGroupsType extends TranslatorAwareType
      */
     private function buildShopChoices(): array
     {
-        $choices = [];
+        $choices = [
+            $this->trans('All stores', 'Admin.Global') => 0,
+        ];
+
         $allShops = $this->shopByIdChoiceProvider->getChoices();
         foreach ($allShops as $name => $shopId) {
             if ($shopId === $this->contextShopId) {
@@ -154,7 +157,6 @@ class ApplicableGroupsType extends TranslatorAwareType
                 break;
             }
         }
-        $choices[$this->trans('All stores', 'Admin.Global')] = 0;
 
         return $choices;
     }

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1674,6 +1674,7 @@ services:
       - '@prestashop.adapter.form.choice_provider.shop_name_by_id'
       - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrency().symbol'
       - '@=service("prestashop.adapter.multistore_feature").isUsed()'
+      - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
     public: true
     tags:
       - { name: form.type }

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_provider.yml
@@ -205,6 +205,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\SpecificPriceFormDataProvider'
     arguments:
       - '@prestashop.core.query_bus'
+      - "@=service('prestashop.adapter.legacy.context').getContext().shop.id"
 
   prestashop.core.form.identifiable_object.data_provider.state_form_data_provider:
     class: 'PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\StateFormDataProvider'

--- a/tests/Unit/Core/Form/IdentifiableObject/DataProvider/SpecificPriceFormDataProviderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataProvider/SpecificPriceFormDataProviderTest.php
@@ -42,10 +42,12 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider\SpecificPric
 
 class SpecificPriceFormDataProviderTest extends TestCase
 {
+    private const CONTEXT_SHOP_ID = 2;
+
     public function testGetDefaultData(): void
     {
         $queryBusMock = $this->createMock(CommandBusInterface::class);
-        $provider = new SpecificPriceFormDataProvider($queryBusMock);
+        $provider = new SpecificPriceFormDataProvider($queryBusMock, self::CONTEXT_SHOP_ID);
 
         $expectedDefaultData = [
             'from_quantity' => 1,
@@ -56,6 +58,9 @@ class SpecificPriceFormDataProviderTest extends TestCase
                     'include_tax' => true,
                 ],
                 'fixed_price_tax_excluded' => (float) InitialPrice::INITIAL_PRICE_VALUE,
+            ],
+            'groups' => [
+                'shop_id' => self::CONTEXT_SHOP_ID,
             ],
         ];
 
@@ -71,7 +76,7 @@ class SpecificPriceFormDataProviderTest extends TestCase
     public function testGetData(SpecificPriceForEditing $specificPriceForEditing, array $expectedData): void
     {
         $queryBusMock = $this->createQueryBusMock($specificPriceForEditing);
-        $provider = new SpecificPriceFormDataProvider($queryBusMock);
+        $provider = new SpecificPriceFormDataProvider($queryBusMock, self::CONTEXT_SHOP_ID);
 
         $formData = $provider->getData($specificPriceForEditing->getSpecificPriceId());
         // assertSame is very important here We can't assume null and 0 are the same thing


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | https://github.com/PrestaShop/PrestaShop/issues/30120
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/30120
| Related PRs       | 
| How to test?      | refer to https://github.com/PrestaShop/PrestaShop/issues/30120. Also Check that the list of specific prices in new product page only shows specific prices for current shop OR for All shops.
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
