### PR TITLE
Add a checkbox to generate combinations for all shops

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/generator/CombinationGenerator.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/generator/CombinationGenerator.vue
@@ -40,11 +40,13 @@
           @toggleAll="toggleAll"
           v-if="attributeGroups"
         />
+      </template>
 
+      <template #footer-confirmation>
         <div class="md-checkbox md-checkbox-inline">
           <label>
             <input
-              v-model=applyToAllShops
+              v-model="applyToAllShops"
               type="checkbox"
               id="generate_combinations_all_shop"
               name="generate_combinations_all_shop"

--- a/admin-dev/themes/new-theme/js/pages/product/components/generator/CombinationGenerator.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/components/generator/CombinationGenerator.vue
@@ -40,9 +40,21 @@
           @toggleAll="toggleAll"
           v-if="attributeGroups"
         />
-      </template>
 
-      <template #footer-confirmation>
+        <div class="md-checkbox md-checkbox-inline">
+          <label>
+            <input
+              v-model=applyToAllShops
+              type="checkbox"
+              id="generate_combinations_all_shop"
+              name="generate_combinations_all_shop"
+              class="form-check-input"
+            >
+            <i class="md-checkbox-control"/>
+            {{ $t('label.apply-to-all-shops') }}
+          </label>
+        </div>
+
         <button
           type="button"
           class="btn btn-outline-secondary"
@@ -99,6 +111,7 @@
     preLoading: boolean,
     loading: boolean,
     hasGeneratedCombinations: boolean,
+    applyToAllShops: boolean,
   }
 
   export default defineComponent({
@@ -112,6 +125,7 @@
         preLoading: true,
         loading: false,
         hasGeneratedCombinations: false,
+        applyToAllShops: false,
       };
     },
     props: {
@@ -198,6 +212,7 @@
         this.loading = true;
         const data: Record<string, any> = {
           attributes: {},
+          applyToAllShops: this.applyToAllShops ? 1 : 0,
         };
         Object.keys(this.selectedAttributeGroups).forEach((attributeGroupId) => {
           data.attributes[attributeGroupId] = [];

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -513,7 +513,7 @@ class CombinationController extends FrameworkBundleAdminController
             $combinationsIds = $this->getCommandBus()->handle(new GenerateProductCombinationsCommand(
                 $productId,
                 $attributes,
-                ShopConstraint::shop((int) $this->getContextShopId())
+                $request->request->get('applyToAllShops') ? ShopConstraint::allShops() : ShopConstraint::shop((int) $this->getContextShopId())
             ));
         } catch (Exception $e) {
             return $this->json([

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination.html.twig
@@ -56,6 +56,7 @@
            'search.placeholder': 'Search for attributes...'|trans({}, 'Admin.Catalog.Feature'),
            'modal.title': 'Generate combinations'|trans({}, 'Admin.Catalog.Feature'),
            'modal.close': 'Cancel'|trans({}, 'Admin.Actions'),
+           'label.apply-to-all-shops': 'Apply changes to all stores'|trans({}, 'Admin.Global'),
          }|json_encode }}"
     ></div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination.html.twig
@@ -56,7 +56,7 @@
            'search.placeholder': 'Search for attributes...'|trans({}, 'Admin.Catalog.Feature'),
            'modal.title': 'Generate combinations'|trans({}, 'Admin.Catalog.Feature'),
            'modal.close': 'Cancel'|trans({}, 'Admin.Actions'),
-           'label.apply-to-all-shops': 'Apply changes to all stores'|trans({}, 'Admin.Global'),
+           'label.apply-to-all-shops': 'Generate combinations for all stores'|trans({}, 'Admin.Global'),
          }|json_encode }}"
     ></div>
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a checkbox to generate combinations for all shops. Didn't pay attention to styling, apparently it needs some modifications :thinking: 
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | part of https://github.com/PrestaShop/PrestaShop/issues/30304
| Related PRs       | 
| How to test?      | When generating combinations you can select to generate them for all shops. Check that it works correctly (should generate the selected combinations for all the shops that product is associated to)
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
