### PR TITLE
Fix stock availability labels update when product is combination type

### DIFF
--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilder.php
@@ -29,6 +29,7 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Prod
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilder;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilderConfig;
@@ -207,10 +208,21 @@ class UpdateProductCommandsBuilder implements MultiShopProductCommandsBuilderInt
             ->addMultiShopField('[stock][options][disabling_switch_low_stock_threshold]', 'setLowStockAlert', DataField::TYPE_BOOL)
             ->addMultiShopField('[stock][options][low_stock_threshold]', 'setLowStockThreshold', DataField::TYPE_INT)
             ->addMultiShopField('[stock][pack_stock_type]', 'setPackStockType', DataField::TYPE_INT)
-            ->addMultiShopField('[stock][availability][available_now_label]', 'setLocalizedAvailableNowLabels', DataField::TYPE_ARRAY)
-            ->addMultiShopField('[stock][availability][available_later_label]', 'setLocalizedAvailableLaterLabels', DataField::TYPE_ARRAY)
             ->addMultiShopField('[stock][availability][available_date]', 'setAvailableDate', DataField::TYPE_DATETIME)
         ;
+
+        $productType = $formData['header']['type'] ?? ProductType::TYPE_STANDARD;
+        if ($productType === ProductType::TYPE_COMBINATIONS) {
+            $config
+                ->addMultiShopField('[combinations][availability][available_now_label]', 'setLocalizedAvailableNowLabels', DataField::TYPE_ARRAY)
+                ->addMultiShopField('[combinations][availability][available_later_label]', 'setLocalizedAvailableLaterLabels', DataField::TYPE_ARRAY)
+            ;
+        } else {
+            $config
+                ->addMultiShopField('[stock][availability][available_now_label]', 'setLocalizedAvailableNowLabels', DataField::TYPE_ARRAY)
+                ->addMultiShopField('[stock][availability][available_later_label]', 'setLocalizedAvailableLaterLabels', DataField::TYPE_ARRAY)
+            ;
+        }
 
         return $this;
     }

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
@@ -43,6 +44,7 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
     /**
      * @dataProvider getExpectedCommands
      * @dataProvider getExpectedCommandsMultiShop
+     * @dataProvider getExpectedCommandsForCombinationsTypeProduct
      *
      * @param array $formData
      * @param array $expectedCommands
@@ -515,6 +517,22 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             [$command],
         ];
 
+        $localizedTimeInStockNotes = [
+            1 => 'In stock',
+            2 => 'Yra sandelyje',
+        ];
+        $localizedTimeOutOfStockNotes = [
+            1 => 'Out of stock',
+            2 => 'Isparduota',
+        ];
+        $localizedAvailableNowLabels = [
+            1 => 'available now en',
+            2 => 'available now lt',
+        ];
+        $localizedAvailableLaterLabels = [
+            1 => 'available later en',
+            2 => 'available later lt',
+        ];
         $command = $this->getSingleShopCommand()
             ->setVisibility(ProductVisibility::INVISIBLE)
             ->setLocalizedShortDescriptions($localizedShortDescriptions)
@@ -540,14 +558,10 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             ->setWeight('2.2')
             ->setDeliveryTimeNoteType(DeliveryTimeNoteType::TYPE_SPECIFIC)
             ->setAdditionalShippingCost('5.7')
-            ->setLocalizedDeliveryTimeInStockNotes([
-                1 => 'In stock',
-                2 => 'Yra sandelyje',
-            ])
-            ->setLocalizedDeliveryTimeOutOfStockNotes([
-                1 => 'Out of stock',
-                2 => 'Isparduota',
-            ])
+            ->setLocalizedDeliveryTimeInStockNotes($localizedTimeInStockNotes)
+            ->setLocalizedDeliveryTimeOutOfStockNotes($localizedTimeOutOfStockNotes)
+            ->setLocalizedAvailableNowLabels($localizedAvailableNowLabels)
+            ->setLocalizedAvailableLaterLabels($localizedAvailableLaterLabels)
             ->setActive(false)
         ;
 
@@ -618,6 +632,56 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                             1 => 'Out of stock',
                             2 => 'Isparduota',
                         ],
+                    ],
+                ],
+                'stock' => [
+                    'availability' => [
+                        'available_now_label' => $localizedAvailableNowLabels,
+                        'available_later_label' => $localizedAvailableLaterLabels,
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+    }
+
+    public function getExpectedCommandsForCombinationsTypeProduct(): iterable
+    {
+        $localizedAvailableNowLabels = [
+            1 => 'available now en',
+            2 => 'available now lt',
+        ];
+        $localizedAvailableLaterLabels = [
+            1 => 'available later en',
+            2 => 'available later lt',
+        ];
+        // check labels for combinations type product
+        $command = $this->getSingleShopCommand()
+            ->setLocalizedAvailableNowLabels($localizedAvailableNowLabels)
+            ->setLocalizedAvailableLaterLabels($localizedAvailableLaterLabels)
+        ;
+        yield [
+            [
+                'header' => [
+                    'type' => ProductType::TYPE_COMBINATIONS,
+                ],
+                // for combinations product these should be ignored and the ones from combinations tab should be used instead.
+                'stock' => [
+                    'availability' => [
+                        'available_now_label' => [
+                            1 => 'Oh yes, we have it!',
+                            2 => 'Yra sandelyje',
+                        ],
+                        'available_later_label' => [
+                            1 => 'Sorry, unavailable.',
+                            2 => 'Greitai papildysime sandelį',
+                        ],
+                    ],
+                ],
+                'combinations' => [
+                    'availability' => [
+                        'available_now_label' => $localizedAvailableNowLabels,
+                        'available_later_label' => $localizedAvailableLaterLabels,
                     ],
                 ],
             ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Product available_now and available_later labels were ignored during update if product was combination type. Pr fixes it. Refer to issue for more details https://github.com/PrestaShop/PrestaShop/issues/30537
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30537
| Related PRs       | 
| How to test?      | refer to issue https://github.com/PrestaShop/PrestaShop/issues/30537
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
