### PR TITLE
Remove getConfiguration usage in CommonAbstractType.php

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -79,3 +79,10 @@ parameters:
             message: 'use Symfony\Contracts\Translation\TranslatorInterface instead'
             disallowIn:
                 - src/*
+  disallowedMethodCalls:
+        -
+            method: 'PrestaShopBundle\Form\Admin\Type\CommonAbstractType::getConfiguration()'
+            message: 'Use dependency injection instead'
+            disallowIn:
+                - src/*
+

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/AbstractCategoryType.php
@@ -65,7 +65,7 @@ abstract class AbstractCategoryType extends TranslatorAwareType
     /**
      * @var ConfigurationInterface
      */
-    private $configuration;
+    protected $configuration;
 
     /**
      * @param TranslatorInterface $translator

--- a/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
+++ b/src/PrestaShopBundle/Form/Admin/Catalog/Category/CategoryType.php
@@ -45,7 +45,7 @@ class CategoryType extends AbstractCategoryType
         // Root category is always disabled
         $disabledCategories = array_merge(
             [
-                $this->getConfiguration()->getInt('PS_ROOT_CATEGORY'),
+                (int) $this->configuration->get('PS_ROOT_CATEGORY'),
             ],
             $options['subcategories']
         );

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/UploadQuotaType.php
@@ -26,12 +26,14 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class UploadQuotaType extends TranslatorAwareType
 {
@@ -40,11 +42,22 @@ class UploadQuotaType extends TranslatorAwareType
     public const FIELD_MAX_SIZE_PRODUCT_IMAGE = 'max_size_product_image';
 
     /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    public function __construct(TranslatorInterface $translator, array $locales, ConfigurationInterface $configuration)
+    {
+        parent::__construct($translator, $locales);
+        $this->configuration = $configuration;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $configuration = $this->getConfiguration();
+        $configuration = $this->configuration;
         $builder
             ->add(
                 self::FIELD_MAX_SIZE_ATTACHED_FILES,

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/General/PreferencesType.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\General;
 
 use PrestaShop\PrestaShop\Adapter\Entity\Order;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -56,8 +57,14 @@ class PreferencesType extends TranslatorAwareType
     private $isAllShopContext;
 
     /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
      * @param TranslatorInterface $translator
      * @param array $locales
+     * @param ConfigurationInterface $configuration
      * @param bool $isMultistoreUsed
      * @param bool $isSingleShopContext
      * @param bool $isAllShopContext
@@ -65,6 +72,7 @@ class PreferencesType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
+        ConfigurationInterface $configuration,
         $isMultistoreUsed,
         $isSingleShopContext,
         $isAllShopContext
@@ -74,6 +82,7 @@ class PreferencesType extends TranslatorAwareType
         $this->isMultistoreUsed = $isMultistoreUsed;
         $this->isSingleShopContext = $isSingleShopContext;
         $this->isAllShopContext = $isAllShopContext;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -86,8 +95,8 @@ class PreferencesType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $configuration = $this->getConfiguration();
-        $isSslEnabled = $configuration->getBoolean('PS_SSL_ENABLED');
+        $configuration = $this->configuration;
+        $isSslEnabled = (bool) $configuration->get('PS_SSL_ENABLED');
 
         if ($this->isSecure) {
             $builder->add('enable_ssl', SwitchType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GeneralType.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\OrderPreferences;
 
-use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
 use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -54,9 +54,15 @@ class GeneralType extends TranslatorAwareType
      */
     private $tosCmsChoices;
 
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
+        ConfigurationInterface $configuration,
         $defaultCurrencyIsoCode,
         array $tosCmsChoices
     ) {
@@ -64,13 +70,13 @@ class GeneralType extends TranslatorAwareType
 
         $this->defaultCurrencyIsoCode = $defaultCurrencyIsoCode;
         $this->tosCmsChoices = $tosCmsChoices;
+        $this->configuration = $configuration;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        /** @var Configuration $configuration */
-        $configuration = $this->getConfiguration();
-        $isMultishippingEnabled = $configuration->getBoolean('PS_ALLOW_MULTISHIPPING');
+        $configuration = $this->configuration;
+        $isMultishippingEnabled = (bool) $configuration->get('PS_ALLOW_MULTISHIPPING');
         $currencyIsoCode = $this->defaultCurrencyIsoCode;
 
         $builder

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderPreferences/GiftOptionsType.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\OrderPreferences;
 
-use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
 use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
@@ -59,8 +59,14 @@ class GiftOptionsType extends TranslatorAwareType
     private $router;
 
     /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
      * @param TranslatorInterface $translator
      * @param array $locales
+     * @param ConfigurationInterface $configuration
      * @param string $defaultCurrencyIsoCode
      * @param array $taxChoices
      * @param RouterInterface $router
@@ -68,6 +74,7 @@ class GiftOptionsType extends TranslatorAwareType
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
+        ConfigurationInterface $configuration,
         $defaultCurrencyIsoCode,
         array $taxChoices,
         RouterInterface $router
@@ -77,6 +84,7 @@ class GiftOptionsType extends TranslatorAwareType
         $this->defaultCurrencyIsoCode = $defaultCurrencyIsoCode;
         $this->taxChoices = $taxChoices;
         $this->router = $router;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -84,9 +92,7 @@ class GiftOptionsType extends TranslatorAwareType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        /** @var Configuration $configuration */
-        $configuration = $this->getConfiguration();
-        $atcpShipWrap = $configuration->getBoolean('PS_ATCP_SHIPWRAP');
+        $atcpShipWrap = (bool) $this->configuration->get('PS_ATCP_SHIPWRAP');
         $currencyIsoCode = $this->defaultCurrencyIsoCode;
 
         $builder

--- a/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/GenerateMailsType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Design/MailTheme/GenerateMailsType.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\Design\MailTheme;
 
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -44,20 +45,28 @@ class GenerateMailsType extends TranslatorAwareType
     private $themes;
 
     /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
+    /**
      * @param TranslatorInterface $translator
      * @param array $locales
+     * @param ConfigurationInterface $configuration
      * @param array $mailThemes
      * @param array $themes
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
+        ConfigurationInterface $configuration,
         array $mailThemes,
         array $themes
     ) {
         parent::__construct($translator, $locales);
         $this->mailThemes = $mailThemes;
         $this->themes = $themes;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -70,7 +79,7 @@ class GenerateMailsType extends TranslatorAwareType
         $builder
             ->add('mailTheme', ChoiceType::class, [
                 'choices' => $this->mailThemes,
-                'data' => $this->getConfiguration()->get('PS_MAIL_THEME'),
+                'data' => $this->configuration->get('PS_MAIL_THEME'),
             ])
             ->add('language', ChoiceType::class, [
                 'placeholder' => $this->trans('Language', 'Admin.Global'),

--- a/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
+++ b/src/PrestaShopBundle/Form/Admin/Improve/Shipping/Preferences/HandlingType.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShopBundle\Form\Admin\Improve\Shipping\Preferences;
 
-use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Currency\CurrencyDataProvider;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\MoneyWithSuffixType;
 use PrestaShopBundle\Form\Admin\Type\MultistoreConfigurationType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
@@ -50,23 +50,28 @@ class HandlingType extends TranslatorAwareType
      */
     private $currencyDataProvider;
 
+    /**
+     * @var ConfigurationInterface
+     */
+    private $configuration;
+
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
+        ConfigurationInterface $configuration,
         CurrencyDataProvider $currencyDataProvider
     ) {
         parent::__construct($translator, $locales);
 
         $this->currencyDataProvider = $currencyDataProvider;
+        $this->configuration = $configuration;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        /** @var Configuration $configuration */
-        $configuration = $this->getConfiguration();
-        $defaultCurrencyId = $configuration->getInt('PS_CURRENCY_DEFAULT');
+        $defaultCurrencyId = (int) $this->configuration->get('PS_CURRENCY_DEFAULT');
         $defaultCurrency = $this->currencyDataProvider->getCurrencyById($defaultCurrencyId);
-        $weightUnit = $configuration->get('PS_WEIGHT_UNIT');
+        $weightUnit = $this->configuration->get('PS_WEIGHT_UNIT');
 
         $builder
             ->add('shipping_handling_charges', MoneyWithSuffixType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductAttachement.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductAttachement.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Product;
 
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
@@ -34,6 +35,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * This form class is responsible to generate the product attachments.
@@ -43,15 +45,10 @@ class ProductAttachement extends CommonAbstractType
     private $translator;
     private $configuration;
 
-    /**
-     * Constructor.
-     *
-     * @param object $translator
-     */
-    public function __construct($translator)
+    public function __construct(TranslatorInterface $translator, ConfigurationInterface $configuration)
     {
         $this->translator = $translator;
-        $this->configuration = $this->getConfiguration();
+        $this->configuration = $configuration;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductCombination.php
@@ -26,10 +26,8 @@
 
 namespace PrestaShopBundle\Form\Admin\Product;
 
-use Context;
-use Currency;
-use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -50,34 +48,32 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ProductCombination extends CommonAbstractType
 {
     /**
-     * @var Configuration
+     * @var ConfigurationInterface
      */
     private $configuration;
-    /**
-     * @var Context
-     */
-    public $contextLegacy;
-    /**
-     * @var Currency
-     */
-    public $currency;
+
     /**
      * @var TranslatorInterface
      */
     public $translator;
 
     /**
+     * @var LegacyContext
+     */
+    private $legacyContext;
+
+    /**
      * Constructor.
      *
      * @param TranslatorInterface $translator
      * @param LegacyContext $legacyContext
+     * @param ConfigurationInterface $configuration
      */
-    public function __construct($translator, $legacyContext)
+    public function __construct(TranslatorInterface $translator, LegacyContext $legacyContext, ConfigurationInterface $configuration)
     {
         $this->translator = $translator;
-        $this->contextLegacy = $legacyContext->getContext();
-        $this->configuration = $this->getConfiguration();
-        $this->currency = $this->contextLegacy->currency;
+        $this->configuration = $configuration;
+        $this->legacyContext = $legacyContext;
     }
 
     /**
@@ -87,6 +83,7 @@ class ProductCombination extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $currencyIsoCode = $this->legacyContext->getContext()->currency->iso_code;
         $is_stock_management = $this->configuration->get('PS_STOCK_MANAGEMENT');
 
         $builder->add('id_product_attribute', HiddenType::class, [
@@ -133,26 +130,26 @@ class ProductCombination extends CommonAbstractType
             ->add('attribute_wholesale_price', MoneyType::class, [
                 'required' => false,
                 'label' => $this->translator->trans('Cost price', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
+                'currency' => $currencyIsoCode,
                 'attr' => ['class' => 'attribute_wholesale_price'],
             ])
             ->add('attribute_price', MoneyType::class, [
                 'required' => false,
                 'label' => $this->translator->trans('Impact on price (tax excl.)', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
+                'currency' => $currencyIsoCode,
                 'attr' => ['class' => 'attribute_priceTE'],
             ])
             ->add('attribute_priceTI', MoneyType::class, [
                 'required' => false,
                 'mapped' => false,
                 'label' => $this->translator->trans('Impact on price (tax incl.)', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
+                'currency' => $currencyIsoCode,
                 'attr' => ['class' => 'attribute_priceTI'],
             ])
             ->add('attribute_ecotax', MoneyType::class, [
                 'required' => false,
                 'label' => $this->translator->trans('Ecotax (tax incl.)', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
+                'currency' => $currencyIsoCode,
                 'constraints' => [
                     new Assert\NotBlank(),
                     new Assert\Type(['type' => 'float']),
@@ -172,7 +169,7 @@ class ProductCombination extends CommonAbstractType
             ->add('attribute_unity', MoneyType::class, [
                 'required' => false,
                 'label' => $this->translator->trans('Impact on price per unit (tax excl.)', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
+                'currency' => $currencyIsoCode,
                 'attr' => ['class' => 'attribute_unity'],
             ])
             ->add('attribute_minimal_quantity', NumberType::class, [
@@ -240,7 +237,7 @@ class ProductCombination extends CommonAbstractType
             ->add('final_price', MoneyType::class, [
                 'required' => false,
                 'label' => $this->translator->trans('Final price', [], 'Admin.Catalog.Feature'),
-                'currency' => $this->currency->iso_code,
+                'currency' => $currencyIsoCode,
             ]);
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductQuantity.php
@@ -28,8 +28,8 @@ namespace PrestaShopBundle\Form\Admin\Product;
 
 use Language;
 use Pack;
-use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\TranslateType;
@@ -48,7 +48,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class ProductQuantity extends CommonAbstractType
 {
     /**
-     * @var Configuration
+     * @var ConfigurationInterface
      */
     public $configuration;
     /**
@@ -74,14 +74,18 @@ class ProductQuantity extends CommonAbstractType
      * @param TranslatorInterface $translator
      * @param Router $router
      * @param LegacyContext $legacyContext
+     * @param ConfigurationInterface $configuration
      */
-    public function __construct($translator, $router, $legacyContext)
-    {
+    public function __construct(
+        TranslatorInterface $translator,
+        Router $router,
+        LegacyContext $legacyContext,
+        ConfigurationInterface $configuration
+    ) {
         $this->router = $router;
         $this->translator = $translator;
         $this->legacyContext = $legacyContext;
-        $this->locales = $this->legacyContext->getLanguages();
-        $this->configuration = $this->getConfiguration();
+        $this->configuration = $configuration;
     }
 
     /**
@@ -91,6 +95,7 @@ class ProductQuantity extends CommonAbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $this->locales = $this->legacyContext->getLanguages();
         $is_stock_management = $this->configuration->get('PS_STOCK_MANAGEMENT');
         $builder
             ->add(

--- a/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductVirtual.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Product;
 
-use PrestaShop\PrestaShop\Adapter\Configuration;
+use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShopBundle\Form\Admin\Type\CommonAbstractType;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use Symfony\Component\Form\Extension\Core\Type as FormType;
@@ -34,6 +34,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * This form class is responsible to generate the virtual product.
@@ -42,19 +43,20 @@ class ProductVirtual extends CommonAbstractType
 {
     private $translator;
     /**
-     * @var Configuration
+     * @var ConfigurationInterface
      */
     private $configuration;
 
     /**
      * Constructor.
      *
-     * @param object $translator
+     * @param TranslatorInterface $translator
+     * @param ConfigurationInterface $configuration
      */
-    public function __construct($translator)
+    public function __construct(TranslatorInterface $translator, ConfigurationInterface $configuration)
     {
         $this->translator = $translator;
-        $this->configuration = $this->getConfiguration();
+        $this->configuration = $configuration;
     }
 
     /**

--- a/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/CommonAbstractType.php
@@ -40,10 +40,20 @@ abstract class CommonAbstractType extends AbstractType
     /**
      * Get the configuration adapter.
      *
+     * @deprecated Since 8.1 Use dependency injection in your form type instead.
+     *
      * @return Configuration Configuration adapter
      */
     protected function getConfiguration()
     {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.1.0 and will be removed in the next major version.',
+                __FUNCTION__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return new Configuration();
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -78,6 +78,7 @@ services:
     class: PrestaShopBundle\Form\Admin\Product\ProductAttachement
     arguments:
       - "@translator"
+      - '@prestashop.adapter.legacy.configuration'
     parent: 'form.type.common_type'
     public: true
     tags:
@@ -88,6 +89,7 @@ services:
     arguments:
       - "@translator"
       - "@prestashop.adapter.legacy.context"
+      - '@prestashop.adapter.legacy.configuration'
     parent: 'form.type.common_type'
     public: true
     tags:
@@ -153,6 +155,7 @@ services:
       - "@translator"
       - "@router"
       - "@prestashop.adapter.legacy.context"
+      - '@prestashop.adapter.legacy.configuration'
     parent: 'form.type.common_type'
     public: true
     tags:
@@ -213,7 +216,7 @@ services:
     class: PrestaShopBundle\Form\Admin\Product\ProductVirtual
     arguments:
       - "@translator"
-      - "@prestashop.adapter.legacy.context"
+      - '@prestashop.adapter.legacy.configuration'
     parent: 'form.type.common_type'
     public: true
     tags:
@@ -356,6 +359,7 @@ services:
     class: 'PrestaShopBundle\Form\Admin\Configure\ShopParameters\General\PreferencesType'
     parent: 'form.type.translatable.aware'
     arguments:
+      - '@prestashop.adapter.legacy.configuration'
       - '@=service("prestashop.adapter.multistore_feature").isUsed()'
       - '@=service("prestashop.adapter.shop.context").isShopContext()'
       - '@=service("prestashop.adapter.shop.context").isAllContext()'
@@ -386,6 +390,8 @@ services:
   form.type.administration.upload_quota:
     class: 'PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\UploadQuotaType'
     parent: 'form.type.translatable.aware'
+    arguments:
+      - '@prestashop.adapter.legacy.configuration'
     public: true
     tags:
       - { name: form.type }
@@ -405,6 +411,7 @@ services:
     parent: 'form.type.translatable.aware'
     public: true
     arguments:
+      - '@prestashop.adapter.legacy.configuration'
       - '@prestashop.adapter.data_provider.currency'
     tags:
       - { name: form.type }
@@ -462,6 +469,7 @@ services:
     parent: 'form.type.translatable.aware'
     public: true
     arguments:
+      - '@prestashop.adapter.legacy.configuration'
       - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrencyIsoCode()'
       - '@=service("prestashop.adapter.data_provider.cms").getCmsChoices()'
     tags:
@@ -472,6 +480,7 @@ services:
     parent: 'form.type.translatable.aware'
     public: true
     arguments:
+      - '@prestashop.adapter.legacy.configuration'
       - '@=service("prestashop.adapter.data_provider.currency").getDefaultCurrencyIsoCode()'
       - '@=service("prestashop.adapter.data_provider.tax").getTaxRulesGroupChoices()'
       - "@router"
@@ -1048,6 +1057,7 @@ services:
     parent: 'form.type.translatable.aware'
     public: true
     arguments:
+      - "@=service('prestashop.adapter.legacy.configuration')"
       - '@=service("prestashop.core.form.choice_provider.mail_themes").getChoices()'
       - '@=service("prestashop.core.form.choice_provider.theme_by_name_with_emails").getChoices()'
     tags:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             |  refacto
| Category?         | CO
| BC breaks?        |  no
| Deprecations?     | yes
| How to test?      | Product edition form should be displayed correctly, Settings page also. Nothing should change as it is only refactoring.

This function breaks the Dependency Injection principle. We should remove it before it can mess our code.

