### PR TITLE
Load module autoloaders and service configurations before the core Symfony compiler passes are executed

### DIFF
--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -134,13 +134,13 @@ class ContainerBuilder
         $container = $this->loadDumpedContainer();
         if (null === $container) {
             $container = $this->compileContainer();
+        } else {
+            $this->loadModulesAutoloader($container);
         }
 
         // synthetic definitions can't be compiled
         $container->set('shop', $container->get('context')->shop);
         $container->set('employee', $container->get('context')->employee);
-
-        $this->loadModulesAutoloader($container);
 
         return $container;
     }
@@ -184,6 +184,7 @@ class ContainerBuilder
         }
 
         $this->loadServicesFromConfig($container);
+        $this->loadModulesAutoloader($container);
         $container->compile();
 
         //Dump the container file

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -170,7 +170,7 @@ class ContainerBuilder
         //If the container builder is modified the container logically should be rebuilt
         $container->addResource(new FileResource(__FILE__));
 
-        $container->addCompilerPass(new LoadServicesFromModulesPass($this->containerName), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new LoadServicesFromModulesPass($this->containerName), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
         $container->addCompilerPass(new LegacyCompilerPass());
 
         //Build extensions

--- a/src/Adapter/ContainerBuilder.php
+++ b/src/Adapter/ContainerBuilder.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Adapter\Container\LegacyContainerBuilder;
 use PrestaShop\PrestaShop\Core\EnvironmentInterface;
 use PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass;
 use PrestaShopBundle\Exception\ServiceContainerException;
+use PrestaShopBundle\PrestaShopBundle;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\Config\ConfigCache;
@@ -170,7 +171,7 @@ class ContainerBuilder
         //If the container builder is modified the container logically should be rebuilt
         $container->addResource(new FileResource(__FILE__));
 
-        $container->addCompilerPass(new LoadServicesFromModulesPass($this->containerName), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
+        $container->addCompilerPass(new LoadServicesFromModulesPass($this->containerName), PassConfig::TYPE_BEFORE_OPTIMIZATION, PrestaShopBundle::LOAD_MODULE_SERVICES_PASS_PRIORITY);
         $container->addCompilerPass(new LegacyCompilerPass());
 
         //Build extensions

--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -40,11 +40,23 @@ use PrestaShopBundle\DependencyInjection\Compiler\RemoveXmlCompiledContainerPass
 use PrestaShopBundle\DependencyInjection\Compiler\RouterPass;
 use PrestaShopBundle\DependencyInjection\PrestaShopExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
+use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class PrestaShopBundle extends Bundle
 {
+    /**
+     * The priority of @see LoadServicesFromModulesPass should be higher
+     * than the Symfony's @see ResolveClassPass
+     * and @see ResolveInstanceofConditionalsPass
+     *
+     * @see PassConfig::__construct
+     * @see https://github.com/PrestaShop/PrestaShop/pull/30588 for details
+     */
+    public const LOAD_MODULE_SERVICES_PASS_PRIORITY = 200;
+
     /**
      * {@inheritdoc}
      */
@@ -60,8 +72,8 @@ class PrestaShopBundle extends Bundle
     {
         $container->addCompilerPass(new DynamicRolePass());
         $container->addCompilerPass(new PopulateTranslationProvidersPass());
-        $container->addCompilerPass(new LoadServicesFromModulesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
-        $container->addCompilerPass(new LoadServicesFromModulesPass('admin'), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
+        $container->addCompilerPass(new LoadServicesFromModulesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, self::LOAD_MODULE_SERVICES_PASS_PRIORITY);
+        $container->addCompilerPass(new LoadServicesFromModulesPass('admin'), PassConfig::TYPE_BEFORE_OPTIMIZATION, self::LOAD_MODULE_SERVICES_PASS_PRIORITY);
         $container->addCompilerPass(new RemoveXmlCompiledContainerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RouterPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new OverrideTranslatorServiceCompilerPass());

--- a/src/PrestaShopBundle/PrestaShopBundle.php
+++ b/src/PrestaShopBundle/PrestaShopBundle.php
@@ -60,8 +60,8 @@ class PrestaShopBundle extends Bundle
     {
         $container->addCompilerPass(new DynamicRolePass());
         $container->addCompilerPass(new PopulateTranslationProvidersPass());
-        $container->addCompilerPass(new LoadServicesFromModulesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
-        $container->addCompilerPass(new LoadServicesFromModulesPass('admin'), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new LoadServicesFromModulesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
+        $container->addCompilerPass(new LoadServicesFromModulesPass('admin'), PassConfig::TYPE_BEFORE_OPTIMIZATION, 200);
         $container->addCompilerPass(new RemoveXmlCompiledContainerPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RouterPass(), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new OverrideTranslatorServiceCompilerPass());


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR modifies the order in which the service containers are compiled in a way that should allow module developers to use more of the configuration options provided by the Symfony framework when defining services. See below for details.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Related PRs       | -
| How to test?      | Example modules that try to demonstrate the mentioned topics are attached to this PR - details below.
| Possible impacts? | The changes should not impact the previously working service configurations, but it probably would not hurt to check a few example modules relying on Symfony services to verify that they are working as intended. Hopefully, the worst that happens is some left and forgotten `_instanceof` configurations suddenly starting to work and apply options that may not be desired anymore... ;)

### Description

Symfony 3.3 introduced several features that allow to simplify service configuration:
- [applying configuration based on the extended classes or implemented interfaces](https://symfony.com/blog/new-in-symfony-3-3-simpler-service-configuration#interface-based-service-configuration)
- [autoconfiguration](https://symfony.com/blog/new-in-symfony-3-3-simpler-service-configuration#interface-based-service-configuration)
- [an option to skip the `class` attribute](https://symfony.com/blog/new-in-symfony-3-3-optional-class-for-named-services)
- [automatically registering classes found in the specified directories as services](https://symfony.com/blog/new-in-symfony-3-3-psr-4-based-service-discovery)

Unfortunately, it is not currently possible to use any of the above-mentioned when configuring services for the PrestaShop modules. The reason for that is because the `PrestaShopBundle\DependencyInjection\Compiler\LoadServicesFromModulesPass`, which is responsible for loading the module service definitions, is executed after `Symfony\Component\DependencyInjection\Compiler\ResolveClassPass` and `Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass` that are responsible for setting the `class` attribute in the service definition if missing and applying configuration depending on `instanceof` conditionals. This PR addresses this issue by increasing the priority of the PrestaShop's compiler pass from 1 to 200 (it has to be greater than 100, which is the priority for both of the core Symfony passes).

Furthermore, because classes defined in module files might not exist during the service container compilation in the legacy environments (module autoloaders are not automatically included until after the container is compiled - in contrast to the BO, where it happens before container initialization in the `AppKernel`), some additional features that do work on the BO (e.g. autowiring) are not available on the FO (technically, it is possible to work around the issue by registering one of the hooks executed before controller initialization and including your classes/autoloader in the file declaring the module class...) and in the WebService context (not without overrides, which is an even uglier - and more unreliable at that - hack). This problem is fixed by adding the `loadModulesAutoloader` method call in `PrestaShop\PrestaShop\Adapter\ContainerBuilder` before calling `compile` on the core Symfony container builder (autloaders are still included separately if the cache is fresh). 

### How to test?

I have prepared 2 simple modules to help test the changes:

[classresolutiontest.zip](https://github.com/PrestaShop/PrestaShop/files/10240586/classresolutiontest.zip)
The module contains a few classes:
![classresolutiontest](https://user-images.githubusercontent.com/114291924/207995815-7b94feca-a005-4b7c-bf0f-f48d3970e710.png)
and a simple service configuration:
```yaml
# config/common.yml
services:
  _defaults:
    public: true
  TestModule\ClassResolution\:
    resource: ../src
    exclude:
      - ../src/ExcludedDirectory
      - ../src/**/index.php
  TestModule\ClassResolution\ExcludedDirectory\SkippedClassKeyInServiceDefinition: ~
```
3 messages saying whether or not a given class is present in the container as a service (2 out of 3 should be) are printed on the module's configuration page and on the home page. Without the changes from this PR, an exception with a somewhat misleading message is thrown during container compilation:
![no_class_attribute](https://user-images.githubusercontent.com/114291924/207997292-6ff43cb1-f92e-4a00-8712-b1e8441a0c06.png)

---

[instanceofconditionalstest.zip](https://github.com/PrestaShop/PrestaShop/files/10240587/instanceofconditionalstest.zip)
The module contains a controller, a collection class and an element class implementing an interface:
![instanceofconditionalstest](https://user-images.githubusercontent.com/114291924/207995811-8612947f-300c-4a34-850c-64fc873a4378.png)
Service configuration contains 2 definitions of collection services each autowiring all of the specifically tagged services (the collection constructor argument is [bound by name](https://symfony.com/doc/current/service_container.html#binding-arguments-by-name-or-type)):
```yaml
# config/common.yml
services:
  _defaults:
    autowire: true
    bind:
      $elements: !tagged test_module.instance_of.instance_of_tagged
  TestModule\InstanceofConditionals\Collection\Collection:
    class: TestModule\InstanceofConditionals\Collection\Collection
    public: true
  test_module.instance_of.manually_tagged_collection:
    class: TestModule\InstanceofConditionals\Collection\Collection
    public: true
    bind:
      $elements: !tagged test_module.instance_of.manually_tagged
```
as well as an element service that should have 2 tags (1 configured directly, 1 based on an `instanceof` conditional):
```yaml
  _instanceof:
    TestModule\InstanceofConditionals\Collection\ElementInterface:
      tags: [ test_module.instance_of.instance_of_tagged ]
  TestModule\InstanceofConditionals\Collection\Element:
    class: TestModule\InstanceofConditionals\Collection\Element
    tags: [ test_module.instance_of.manually_tagged ]
```
The controller service definition is both autowired and autoconfigured.
The module configuration page displays links to 2 controller actions:
* The first one displays the count of elements in each of the collection services. With the changes from this PR, both collections should contain a single element. Without them one is empty.
* The second takes an optional parameter and displays a different message depending if the argument was provided or not. It should be autowired thanks to the `controller.service_arguments` tag (because the controller class extends the Symfony's `AbstractController` it should come from the autoconfiguration), but without the changes from this PR it is not.

Messages similar to the ones from the first controller action are displayed on the home page. But if the `moduleRoutes` hook is not enabled for the module (its sole purpose is including the autoloader), an exception is thrown when trying to compile the container:
![unused_binding](https://user-images.githubusercontent.com/114291924/208006104-08166f37-5307-4b47-8ab8-ab4094ad913e.png)

---

You could also experiment with other options that you might find in [the Symfony documentation](https://symfony.com/doc/4.4/service_container.html#creating-configuring-services-in-the-container).