### PR TITLE
Fix total total_price_tax_excl

### DIFF
--- a/install-dev/fixtures/fashion/data/order_detail.xml
+++ b/install-dev/fixtures/fashion/data/order_detail.xml
@@ -86,7 +86,7 @@
                       product_weight="0.000000" tax_computation_method="0" tax_name="" tax_rate="0.000"
                       ecotax="0.000000" ecotax_tax_rate="0.000" discount_quantity_applied="0" download_nb="0"
                       download_deadline="0000-00-00 00:00:00" total_price_tax_incl="158.000000"
-                      total_price_tax_excl="79.000000" unit_price_tax_incl="79.000000" unit_price_tax_excl="79.000000"
+                      total_price_tax_excl="158.000000" unit_price_tax_incl="79.000000" unit_price_tax_excl="79.000000"
                       total_shipping_price_tax_incl="0.000000" total_shipping_price_tax_excl="0.000000"
                       purchase_supplier_price="0.000000" original_product_price="79.000000">
             <product_name>The adventure begins Framed poster - Size : 80x120cm</product_name>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | "total_price_tax_excl"value is wrong for "The_adventure_begins_Framed_poster" in "order_detail_3" should be 158 and not 79 because quantity of this product is set to 2
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     |no
| Fixed ticket?     | -
| Related PRs       | -
| How to test?      | -
| Possible impacts? | -


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
