### PR TITLE
Update last_passwd_gen when changing admin password from BackOffice

### DIFF
--- a/src/Adapter/Profile/Employee/CommandHandler/EditEmployeeHandler.php
+++ b/src/Adapter/Profile/Employee/CommandHandler/EditEmployeeHandler.php
@@ -143,6 +143,7 @@ final class EditEmployeeHandler extends AbstractEmployeeHandler implements EditE
 
         if (null !== $command->getPlainPassword()) {
             $employee->passwd = $this->hashing->hash($command->getPlainPassword()->getValue());
+            $employee->last_passwd_gen = $command->getLastPasswordGen()->format('Y-m-d H:i:s');
         }
 
         if (false === $employee->update()) {

--- a/src/Core/Domain/Employee/Command/EditEmployeeCommand.php
+++ b/src/Core/Domain/Employee/Command/EditEmployeeCommand.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Core\Domain\Employee\Command;
 
+use DateTime;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\EmployeeId;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\FirstName;
 use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\LastName;
@@ -86,6 +87,11 @@ class EditEmployeeCommand
      * @var Password
      */
     private $plainPassword;
+
+    /**
+     * @var DateTime
+     */
+    private $lastPasswordGen;
 
     /**
      * @var bool
@@ -299,8 +305,17 @@ class EditEmployeeCommand
     public function setPlainPassword($plainPassword, int $minLength, int $maxLength, int $minScore)
     {
         $this->plainPassword = new Password($plainPassword, $minLength, $maxLength, $minScore);
+        $this->lastPasswordGen = new DateTime('now');
 
         return $this;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getLastPasswordGen(): DateTime
+    {
+        return $this->lastPasswordGen;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Field `last_passwd_gen` in `ps_employee` was updated only when resetting the password  from the "password lost" fonction. For security reasons, we want the field to be updated as well when changing manually the password from the Employee page in the BO.
| Type?             | bug fix / improvement
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     | no
| Fixed ticket?     | #30597
| Related PRs       | -
| How to test?      | Before the PR : Go to Employee section in BO and change your password or the password of another employee. `last_passwd_gen` wasn't updated. After the PR : `last_passwd_gen` is updated
| Possible impacts? | `last_passwd_gen` is used to limit the delay between password reset with the password lost function. So updating the field will prevent the Admin to reset is password again before `PS_PASSWD_TIME_BACK`, which is expected. 
