### PR TITLE
Improve syntax of information page

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/LogsPage/Blocks/severity_levels.html.twig
@@ -29,30 +29,28 @@
     {{ 'Severity levels'|trans({}, 'Admin.Advparameters.Help') }}
   </h3>
   <div class="card-body">
-    <div class="card-text">
-      <p>{{ 'Meaning of severity levels:'|trans }}</p>
-      <ol>
-        <li>
-          <span class="badge badge-pill badge-success">
-            {{ 'Informative only'|trans({}, 'Admin.Advparameters.Help') }}
-          </span>
-        </li>
-        <li>
-          <span class="badge badge-pill badge-warning">
-            {{ 'Warning'|trans({}, 'Admin.Advparameters.Help') }}
-          </span>
-        </li>
-        <li>
-          <span class="badge badge-pill badge-danger">
-            {{ 'Error'|trans({}, 'Admin.Advparameters.Help') }}
-          </span>
-        </li>
-        <li>
-          <span class="badge badge-pill badge-dark">
-            {{ 'Major issue (crash)!'|trans({}, 'Admin.Advparameters.Help') }}
-          </span>
-        </li>
-      </ol>
-    </div>
+    <p>{{ 'Meaning of severity levels:'|trans }}</p>
+    <ol>
+      <li>
+        <span class="badge badge-pill badge-success">
+          {{ 'Informative only'|trans({}, 'Admin.Advparameters.Help') }}
+        </span>
+      </li>
+      <li>
+        <span class="badge badge-pill badge-warning">
+          {{ 'Warning'|trans({}, 'Admin.Advparameters.Help') }}
+        </span>
+      </li>
+      <li>
+        <span class="badge badge-pill badge-danger">
+          {{ 'Error'|trans({}, 'Admin.Advparameters.Help') }}
+        </span>
+      </li>
+      <li>
+        <span class="badge badge-pill badge-dark">
+          {{ 'Major issue (crash)!'|trans({}, 'Admin.Advparameters.Help') }}
+        </span>
+      </li>
+    </ol>
   </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -33,9 +33,7 @@
         <i class="material-icons">info_outline</i> {{ 'Configuration information'|trans }}
       </h3>
       <div class="card-body">
-        <div class="card-text">
-          <p>{{ 'This information must be provided when you report an issue on GitHub or on the forum.'|trans }}</p>
-        </div>
+        <p class="mb-0">{{ 'This information must be provided when you report an issue on GitHub or on the forum.'|trans }}</p>
       </div>
     </div>
 
@@ -44,31 +42,29 @@
         <i class="material-icons">info_outline</i> {{ 'Server information'|trans }}
       </h3>
       <div class="card-body">
-        <div class="card-text">
-          {% if system.uname is not empty %}
-            <p>
-              <strong>{{ 'Server information:'|trans }}</strong> {{ system.uname }}
-            </p>
-          {% endif %}
-          <p>
-            <strong>{{ 'Server software version:'|trans }}</strong> {{ system.server.version }}
+        {% if system.uname is not empty %}
+          <p class="mb-0">
+            <strong>{{ 'Server information:'|trans }}</strong> {{ system.uname }}
           </p>
-          <p>
-            <strong>{{ 'PHP version:'|trans }}</strong> {{ system.server.php.version }}
-          </p>
-          <p>
-            <strong>{{ 'Memory limit:'|trans }}</strong> {{ system.server.php.memoryLimit }}
-          </p>
-          <p>
-            <strong>{{ 'Max execution time:'|trans }}</strong> {{ system.server.php.maxExecutionTime }}
-          </p>
-          <p>
-            <strong>{{ 'Upload Max File size:'|trans }}</strong> {{ system.server.php.maxFileSizeUpload }}
-          </p>
-          {% if system.instaWebInstalled %}
-            <p>{{ 'PageSpeed module for Apache installed (mod_instaweb)'|trans }}</p>
-          {% endif %}
-        </div>
+        {% endif %}
+        <p class="mb-0">
+          <strong>{{ 'Server software version:'|trans }}</strong> {{ system.server.version }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'PHP version:'|trans }}</strong> {{ system.server.php.version }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'Memory limit:'|trans }}</strong> {{ system.server.php.memoryLimit }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'Max execution time:'|trans }}</strong> {{ system.server.php.maxExecutionTime }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'Upload Max File size:'|trans }}</strong> {{ system.server.php.maxFileSizeUpload }}
+        </p>
+        {% if system.instaWebInstalled %}
+          <p class="mb-0">{{ 'PageSpeed module for Apache installed (mod_instaweb)'|trans }}</p>
+        {% endif %}
       </div>
     </div>
 
@@ -77,29 +73,27 @@
         <i class="material-icons">info_outline</i> {{ 'Database information'|trans({}, 'Admin.Advparameters.Feature') }}
       </h3>
       <div class="card-body">
-        <div class="card-text">
-          <p>
-            <strong>{{ 'MySQL version:'|trans }}</strong> {{ system.database.version }}
-          </p>
-          <p>
-            <strong>{{ 'MySQL server:'|trans }}</strong> {{ system.database.server }}
-          </p>
-          <p>
-            <strong>{{ 'MySQL name:'|trans }}</strong> {{ system.database.name }}
-          </p>
-          <p>
-            <strong>{{ 'MySQL user:'|trans }}</strong> {{ system.database.user }}
-          </p>
-          <p>
-            <strong>{{ 'Tables prefix:'|trans }}</strong> {{ system.database.prefix }}
-          </p>
-          <p>
-            <strong>{{ 'MySQL engine:'|trans }}</strong> {{ system.database.engine }}
-          </p>
-          <p>
-            <strong>{{ 'MySQL driver:'|trans }}</strong> {{ system.database.driver }}
-          </p>
-        </div>
+        <p class="mb-0">
+          <strong>{{ 'MySQL version:'|trans }}</strong> {{ system.database.version }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'MySQL server:'|trans }}</strong> {{ system.database.server }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'MySQL name:'|trans }}</strong> {{ system.database.name }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'MySQL user:'|trans }}</strong> {{ system.database.user }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'Tables prefix:'|trans }}</strong> {{ system.database.prefix }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'MySQL engine:'|trans }}</strong> {{ system.database.engine }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'MySQL driver:'|trans }}</strong> {{ system.database.driver }}
+        </p>
       </div>
     </div>
 
@@ -108,19 +102,17 @@
         <i class="material-icons">info_outline</i> {{ 'List of overrides'|trans({}, 'Admin.Advparameters.Feature') }}
       </h3>
       <div class="card-body">
-        <div class="card-text">
-          {% if system.overrides is empty %}
-            <div class="alert alert-success mb-0" role="alert"><p class="alert-text">
-              {{ 'No overrides have been found.'|trans({}, 'Admin.Advparameters.Feature') }}
-            </p></div>
-          {% else %}
-            <ul>
-              {% for override in system.overrides %}
-                <li>{{ override }}</li>
-              {% endfor %}
-            </ul>
-          {% endif %}
-        </div>
+        {% if system.overrides is empty %}
+          <div class="alert alert-success mb-0" role="alert"><p class="alert-text">
+            {{ 'No overrides have been found.'|trans({}, 'Admin.Advparameters.Feature') }}
+          </p></div>
+        {% else %}
+          <ul>
+            {% for override in system.overrides %}
+              <li>{{ override }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
       </div>
     </div>
   </div>
@@ -130,20 +122,18 @@
         <i class="material-icons">info_outline</i> {{ 'Store information'|trans }}
       </h3>
       <div class="card-body">
-        <div class="card-text">
-          <p>
-            <strong>{{ 'PrestaShop version:'|trans }}</strong> {{ system.shop.version }}
-          </p>
-          <p>
-            <strong>{{ 'Shop URL:'|trans }}</strong> {{ system.shop.url }}
-          </p>
-          <p>
-            <strong>{{ 'Shop path:'|trans }}</strong> {{ system.shop.path }}
-          </p>
-          <p>
-            <strong>{{ 'Current theme in use:'|trans }}</strong> {{ system.shop.theme }}
-          </p>
-        </div>
+        <p class="mb-0">
+          <strong>{{ 'PrestaShop version:'|trans }}</strong> {{ system.shop.version }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'Shop URL:'|trans }}</strong> {{ system.shop.url }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'Shop path:'|trans }}</strong> {{ system.shop.path }}
+        </p>
+        <p class="mb-0">
+          <strong>{{ 'Current theme in use:'|trans }}</strong> {{ system.shop.theme }}
+        </p>
       </div>
     </div>
 
@@ -152,42 +142,40 @@
         <i class="material-icons">info_outline</i> {{ 'Mail configuration'|trans }}
       </h3>
       <div class="card-body">
-        <div class="card-text">
-          {% if system.isNativePHPmail %}
-            <p>
-              <strong>{{ 'Mail method:'|trans }}</strong> {{ 'You are using /usr/sbin/sendmail'|trans }}
-            </p>
-          {% else %}
-            <p>
-              <strong>{{ 'Mail method:'|trans }}</strong> {{ 'You are using your own SMTP parameters.'|trans }}
-            </p>
-            <p>
-              <strong>{{ 'SMTP server:'|trans }}</strong> {{ system.smtp.server }}
-            </p>
-            <p>
-              <strong>{{ 'SMTP username:'|trans }}</strong>
-              {% if system.smtp.user is not empty %}
-                {{ 'Defined'|trans }}
-              {% else %}
-                <span style="color:red;">{{ 'Not defined'|trans }}</span>
-              {% endif %}
-            </p>
-            <p>
-              <strong>{{ 'SMTP password:'|trans }}</strong>
-              {% if system.smtp.password is not empty %}
-                {{ 'Defined'|trans }}
-              {% else %}
-                <span style="color:red;">{{ 'Not defined'|trans }}</span>
-              {% endif %}
-            </p>
-            <p>
-              <strong>{{ 'Encryption:'|trans }}</strong> {{ system.smtp.encryption }}
-            </p>
-            <p>
-              <strong>{{ 'SMTP port:'|trans }}</strong> {{ system.smtp.port }}
-            </p>
-          {% endif %}
-        </div>
+        {% if system.isNativePHPmail %}
+          <p class="mb-0">
+            <strong>{{ 'Mail method:'|trans }}</strong> {{ 'You are using /usr/sbin/sendmail'|trans }}
+          </p>
+        {% else %}
+          <p class="mb-0">
+            <strong>{{ 'Mail method:'|trans }}</strong> {{ 'You are using your own SMTP parameters.'|trans }}
+          </p>
+          <p class="mb-0">
+            <strong>{{ 'SMTP server:'|trans }}</strong> {{ system.smtp.server }}
+          </p>
+          <p class="mb-0">
+            <strong>{{ 'SMTP username:'|trans }}</strong>
+            {% if system.smtp.user is not empty %}
+              {{ 'Defined'|trans }}
+            {% else %}
+              <span style="color:red;">{{ 'Not defined'|trans }}</span>
+            {% endif %}
+          </p>
+          <p class="mb-0">
+            <strong>{{ 'SMTP password:'|trans }}</strong>
+            {% if system.smtp.password is not empty %}
+              {{ 'Defined'|trans }}
+            {% else %}
+              <span style="color:red;">{{ 'Not defined'|trans }}</span>
+            {% endif %}
+          </p>
+          <p class="mb-0">
+            <strong>{{ 'Encryption:'|trans }}</strong> {{ system.smtp.encryption }}
+          </p>
+          <p class="mb-0">
+            <strong>{{ 'SMTP port:'|trans }}</strong> {{ system.smtp.port }}
+          </p>
+        {% endif %}
       </div>
     </div>
 
@@ -196,11 +184,9 @@
         <i class="material-icons">info_outline</i> {{ 'Your information'|trans }}
       </h3>
       <div class="card-body">
-        <div class="card-text">
-          <p>
-            <strong>{{ 'Your web browser:'|trans }}</strong> {{ userAgent }}
-          </p>
-        </div>
+        <p class="mb-0">
+          <strong>{{ 'Your web browser:'|trans }}</strong> {{ userAgent }}
+        </p>
       </div>
     </div>
 
@@ -209,46 +195,44 @@
         <i class="material-icons">info_outline</i> {{ 'Check your configuration'|trans }}
       </h3>
       <div class="card-body">
-        <div class="card-text">
-          {% if requirements.failRequired == false %}
-            <p>
-              <strong>{{ 'Required parameters:'|trans }}</strong>
+        {% if requirements.failRequired == false %}
+          <p class="mb-0">
+            <strong>{{ 'Required parameters:'|trans }}</strong>
+            <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+          </p>
+        {% else %}
+          <p class="mb-0">
+            <strong>{{ 'Required parameters:'|trans }}</strong>
+            <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
+          </p>
+          <ul>
+            {% for key, value in requirements.testsRequired %}
+              {% if 'fail' == value %}
+                <li>{{ requirements.testsErrors[key] }}</li>
+              {% endif %}
+            {% endfor %}
+          </ul>
+        {% endif %}
+        {% if requirements.failOptional is defined %}
+          {% if requirements.failOptional == false %}
+            <p class="mb-0">
+              <strong>{{ 'Optional parameters:'|trans }}</strong>
               <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
             </p>
           {% else %}
-            <p>
-              <strong>{{ 'Required parameters:'|trans }}</strong>
+            <p class="mb-0">
+              <strong>{{ 'Optional parameters:'|trans }}</strong>
               <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
             </p>
             <ul>
-              {% for key, value in requirements.testsRequired %}
+              {% for key, value in requirements.testsOptional %}
                 {% if 'fail' == value %}
                   <li>{{ requirements.testsErrors[key] }}</li>
                 {% endif %}
               {% endfor %}
             </ul>
           {% endif %}
-          {% if requirements.failOptional is defined %}
-            {% if requirements.failOptional == false %}
-              <p>
-                <strong>{{ 'Optional parameters:'|trans }}</strong>
-                <span class="text-success">{{ 'OK'|trans({}, 'Admin.Advparameters.Notification') }}</span>
-              </p>
-            {% else %}
-              <p>
-                <strong>{{ 'Optional parameters:'|trans }}</strong>
-                <span class="text-danger">{{ 'Please fix the following error(s)'|trans({}, 'Admin.Advparameters.Notification') }}</span>
-              </p>
-              <ul>
-                {% for key, value in requirements.testsOptional %}
-                  {% if 'fail' == value %}
-                    <li>{{ requirements.testsErrors[key] }}</li>
-                  {% endif %}
-                {% endfor %}
-              </ul>
-            {% endif %}
-          {% endif %}
-        </div>
+        {% endif %}
       </div>
     </div>
   </div>
@@ -258,10 +242,8 @@
   <h3 class="card-header">
     <i class="material-icons">info_outline</i> {{ 'List of changed files'|trans }}
   </h3>
-  <div class="card-body">
-    <div class="card-text" id="changedFiles">
-      <i class="material-icons">loop</i> {{ 'Checking files...'|trans({}, 'Admin.Advparameters.Notification') }}
-    </div>
+  <div class="card-body" id="changedFiles">
+    <i class="material-icons">loop</i> {{ 'Checking files...'|trans({}, 'Admin.Advparameters.Notification') }}
   </div>
 </div>
 
@@ -290,7 +272,7 @@
         if (json.missing.length || json.updated.length) {
           $('#changedFiles').html('<div class="alert alert-warning" role="alert"><p class="alert-text">' + translations.changesDetected + '</p></div>');
         } else {
-          $('#changedFiles').html('<div class="alert alert-success" role="alert"><p class="alert-text">' + translations.noChangeDetected + '</p></div>');
+          $('#changedFiles').html('<div class="alert alert-success mb-0" role="alert"><p class="alert-text">' + translations.noChangeDetected + '</p></div>');
         }
 
         $.each(tab, function(key, lang) {

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -109,11 +109,17 @@
       </h3>
       <div class="card-body">
         <div class="card-text">
-          <ul>
-            {% for override in system.overrides %}
-              <li>{{ override }}</li>
-            {% endfor %}
-          </ul>
+          {% if system.overrides is empty %}
+            <div class="alert alert-success mb-0" role="alert"><p class="alert-text">
+              {{ 'No overrides have been found.'|trans({}, 'Admin.Advparameters.Feature') }}
+            </p></div>
+          {% else %}
+            <ul>
+              {% for override in system.overrides %}
+                <li>{{ override }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -33,7 +33,7 @@
         <i class="material-icons">info_outline</i> {{ 'Configuration information'|trans }}
       </h3>
       <div class="card-body">
-        <p class="mb-0">{{ 'This information must be provided when you report an issue on GitHub or on the forum.'|trans }}</p>
+        <p class="mb-0">{{ 'You must provide this information when reporting an issue on GitHub or on the forum.'|trans }}</p>
       </div>
     </div>
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below. Code changes are minimal, removing `card-text`, adding `mb-0` and adding one if condition and alert. The big changed blocks are because of indentation change. Didn't touch any other logic.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Related PRs       | 
| How to test?      | Check that `Advanced Parameters > Information` and the top of `Advanced Parameters > Logs` pages look good.
| Possible impacts? |  None

### Changes
- Added a missing alert if no overrides were found.
- Removed extra spacing after alerts and paragraphs.
- Removed additional `card-text` divs, those have no effect, `card-body` makes the padding.

### Screenshot
![information](https://user-images.githubusercontent.com/6097524/208320652-a8f5ad01-94ea-48a6-987f-47d3e4dbe403.jpg)
