### PR TITLE
Allow controlling profiler from backoffice

### DIFF
--- a/src/Adapter/Debug/DebugProfiling.php
+++ b/src/Adapter/Debug/DebugProfiling.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\Debug;
+
+use Tools;
+
+/**
+ * Utilitary class to manages the Debug profiling legacy application.
+ */
+class DebugProfiling
+{
+    public const DEBUG_PROFILING_SUCCEEDED = 0;
+    public const DEBUG_PROFILING_ERROR_NO_READ_ACCESS = 1;
+    public const DEBUG_PROFILING_ERROR_NO_READ_ACCESS_CUSTOM = 2;
+    public const DEBUG_PROFILING_ERROR_NO_WRITE_ACCESS = 3;
+    public const DEBUG_PROFILING_ERROR_NO_WRITE_ACCESS_CUSTOM = 4;
+    public const DEBUG_PROFILING_ERROR_NO_DEFINITION_FOUND = 5;
+
+    /**
+     * Is the profiler enabled? Checks on custom defines file first.
+     *
+     * @return bool Whether debug profiling is enabled
+     */
+    public function isProfilingEnabled(): bool
+    {
+        $definesClean = '';
+        $customDefinesPath = _PS_ROOT_DIR_ . '/config/defines_custom.inc.php';
+        $definesPath = _PS_ROOT_DIR_ . '/config/defines.inc.php';
+
+        if (is_readable($customDefinesPath)) {
+            $definesClean = php_strip_whitespace($customDefinesPath);
+        }
+
+        if (!preg_match('/define\(\'_PS_DEBUG_PROFILING_\', ([a-zA-Z]+)\);/Ui', $definesClean, $debugProfilingValue)) {
+            $definesClean = php_strip_whitespace($definesPath);
+            if (!preg_match('/define\(\'_PS_DEBUG_PROFILING_\', ([a-zA-Z]+)\);/Ui', $definesClean, $debugProfilingValue)) {
+                return false;
+            }
+        }
+
+        return 'true' === Tools::strtolower($debugProfilingValue[1]);
+    }
+
+    /**
+     * Enable Debug profiling.
+     *
+     * @return int Whether changing debug profiling succeeded or error code
+     */
+    public function enable(): int
+    {
+        return $this->changeProfilingValue('true');
+    }
+
+    /**
+     * Disable debug profiling.
+     *
+     * @return int Whether changing debug profiling succeeded or error code
+     */
+    public function disable(): int
+    {
+        return $this->changeProfilingValue('false');
+    }
+
+    /**
+     * Check read permission on custom defines.inc.php.
+     *
+     * @return bool Whether the file can be read
+     */
+    private function isCustomDefinesReadable(): bool
+    {
+        return is_readable(_PS_ROOT_DIR_ . '/config/defines_custom.inc.php');
+    }
+
+    /**
+     * Check read permission on main defines.inc.php.
+     *
+     * @return bool Whether the file can be read
+     */
+    private function isMainDefinesReadable(): bool
+    {
+        return is_readable(_PS_ROOT_DIR_ . '/config/defines.inc.php');
+    }
+
+    /**
+     * Update Debug profiling value in main defines file.
+     *
+     * @param string $value should be "true" or "false"
+     *
+     * @return int the debug profiling
+     */
+    private function updateProfilingValueInMainFile(string $value): int
+    {
+        $filename = _PS_ROOT_DIR_ . '/config/defines.inc.php';
+        $cleanedFileContent = php_strip_whitespace($filename);
+        $fileContent = Tools::file_get_contents($filename);
+
+        if (!preg_match('/define\(\'_PS_DEBUG_PROFILING_\', ([a-zA-Z]+)\);/Ui', $cleanedFileContent)) {
+            return self::DEBUG_PROFILING_ERROR_NO_DEFINITION_FOUND;
+        }
+
+        $fileContent = preg_replace('/define\(\'_PS_DEBUG_PROFILING_\', ([a-zA-Z]+)\);/Ui', 'define(\'_PS_DEBUG_PROFILING_\', ' . $value . ');', $fileContent);
+        if (!@file_put_contents($filename, $fileContent)) {
+            return self::DEBUG_PROFILING_ERROR_NO_WRITE_ACCESS;
+        }
+
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($filename);
+        }
+
+        return self::DEBUG_PROFILING_SUCCEEDED;
+    }
+
+    /**
+     * Update Debug profiling value in custom defines file.
+     *
+     * @param string $value should be "true" or "false"
+     *
+     * @return int Debug profiling
+     */
+    private function updateProfilingValueInCustomFile(string $value): int
+    {
+        $customFileName = _PS_ROOT_DIR_ . '/config/defines_custom.inc.php';
+        $cleanedFileContent = php_strip_whitespace($customFileName);
+        $fileContent = Tools::file_get_contents($customFileName);
+
+        if (!preg_match('/define\(\'_PS_DEBUG_PROFILING_\', ([a-zA-Z]+)\);/Ui', $cleanedFileContent)) {
+            return self::DEBUG_PROFILING_ERROR_NO_DEFINITION_FOUND;
+        }
+        $fileContent = preg_replace('/define\(\'_PS_DEBUG_PROFILING_\', ([a-zA-Z]+)\);/Ui', 'define(\'_PS_DEBUG_PROFILING_\', ' . $value . ');', $fileContent);
+
+        if (!@file_put_contents($customFileName, $fileContent)) {
+            return self::DEBUG_PROFILING_ERROR_NO_WRITE_ACCESS_CUSTOM;
+        }
+
+        if (function_exists('opcache_invalidate')) {
+            opcache_invalidate($customFileName);
+        }
+
+        return self::DEBUG_PROFILING_SUCCEEDED;
+    }
+
+    /**
+     * Change value of _PS_DEBUG_PROFILING_ constant.
+     *
+     * @param string $value should be "true" or "false"
+     *
+     * @return int the debug profiling
+     */
+    private function changeProfilingValue(string $value): int
+    {
+        // Check custom defines file first
+        if ($this->isCustomDefinesReadable()) {
+            return $this->updateProfilingValueInCustomFile($value);
+        }
+
+        if ($this->isMainDefinesReadable()) {
+            return $this->updateProfilingValueInMainFile($value);
+        }
+
+        return self::DEBUG_PROFILING_ERROR_NO_READ_ACCESS;
+    }
+}

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -49,7 +49,12 @@ class DebugModeType extends TranslatorAwareType
             ->add('debug_mode', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Debug mode', 'Admin.Advparameters.Feature'),
-                'help' => $this->trans('Enable or disable debug mode.', 'Admin.Advparameters.Help'),
+                'help' => $this->trans('Enable or disable debug mode. This will enable extended error reporting, Symfony debug bar and other features.', 'Admin.Advparameters.Help'),
+            ])
+            ->add('debug_profiling', SwitchType::class, [
+                'required' => false,
+                'label' => $this->trans('Debug profiler', 'Admin.Advparameters.Feature'),
+                'help' => $this->trans('Enable or disable debug profiling. This will display performance related information under each page. It allows to find out performance bottlenecks in your store.', 'Admin.Advparameters.Help'),
             ]);
     }
 

--- a/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
+++ b/src/PrestaShopBundle/Form/Admin/AdvancedParameters/Performance/DebugModeType.php
@@ -49,12 +49,12 @@ class DebugModeType extends TranslatorAwareType
             ->add('debug_mode', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Debug mode', 'Admin.Advparameters.Feature'),
-                'help' => $this->trans('Enable or disable debug mode. This will enable extended error reporting, Symfony debug bar and other features.', 'Admin.Advparameters.Help'),
+                'help' => $this->trans('Enable or disable debug mode. Debug mode will enable extended error reporting, display the Symfony debug bar, and other features.', 'Admin.Advparameters.Help'),
             ])
             ->add('debug_profiling', SwitchType::class, [
                 'required' => false,
                 'label' => $this->trans('Debug profiler', 'Admin.Advparameters.Feature'),
-                'help' => $this->trans('Enable or disable debug profiling. This will display performance related information under each page. It allows to find out performance bottlenecks in your store.', 'Admin.Advparameters.Help'),
+                'help' => $this->trans('Enable or disable debug profiling. Debug profiling will display performance-related information under each page and help find performance bottlenecks in your store.', 'Admin.Advparameters.Help'),
             ]);
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/data_configuration.yml
@@ -51,6 +51,7 @@ services:
       - '@prestashop.adapter.legacy.configuration'
       - '%ps_config_dir%/defines.inc.php'
       - '@prestashop.adapter.cache.clearer.class_index_cache_clearer'
+      - '@prestashop.adapter.debug_profiling'
 
   prestashop.adapter.optional_features.configuration:
     class: 'PrestaShop\PrestaShop\Adapter\OptionalFeatures\OptionalFeaturesConfiguration'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -32,6 +32,9 @@ services:
   prestashop.adapter.debug_mode:
     class: 'PrestaShop\PrestaShop\Adapter\Debug\DebugMode'
 
+  prestashop.adapter.debug_profiling:
+    class: 'PrestaShop\PrestaShop\Adapter\Debug\DebugProfiling'
+
   prestashop.adapter.database:
     class: 'PrestaShop\PrestaShop\Adapter\Database'
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR allows to enable or disable PrestaShop profiler in backoffice. No need to go to `config/defines` file.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| Related PRs       | 
| How to test?      | See below
| Possible impacts? | No

### How to test
- Go to Advanced Configuration > Performance.
- Try to switch profiler on/off.
- See that the profiler appears after saving and `_PS_DEBUG_PROFILING_` in `config/defines.inc.php` is changing.

### The looks
![profiler](https://user-images.githubusercontent.com/6097524/208390223-f27beead-2699-4e55-b6f2-c5b31fc72e2a.jpg)
