### PR TITLE
Improve error stack trace if an exception is thrown during the product save process

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -596,7 +596,13 @@ class ProductController extends FrameworkBundleAdminController
             // so we need to return the right type of response if an exception it thrown
             if ($request->isXmlHttpRequest()) {
                 return $this->returnErrorJsonResponse(
-                    [],
+                    [
+                        "Error code: ".$e->getCode(),
+                        "Error: ".$e->getMessage(),
+                        "Trace: ".$e->getTraceAsString(),
+                        "File: ".$e->getFile()."#".$e->getLine(),
+                        "Previous: ".$e->getPrevious()
+                    ],
                     Response::HTTP_INTERNAL_SERVER_ERROR
                 );
             }

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -597,11 +597,11 @@ class ProductController extends FrameworkBundleAdminController
             if ($request->isXmlHttpRequest()) {
                 return $this->returnErrorJsonResponse(
                     [
-                        "Error code: ".$e->getCode(),
-                        "Error: ".$e->getMessage(),
-                        "Trace: ".$e->getTraceAsString(),
-                        "File: ".$e->getFile()."#".$e->getLine(),
-                        "Previous: ".$e->getPrevious()
+                        'Error code: ' . $e->getCode(),
+                        'Error: ' . $e->getMessage(),
+                        'Trace: ' . $e->getTraceAsString(),
+                        'File: ' . $e->getFile() . '#' . $e->getLine(),
+                        'Previous: ' . $e->getPrevious(),
                     ],
                     Response::HTTP_INTERNAL_SERVER_ERROR
                 );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If an exception is thrown during the product save process, under certain circumstances, you will get no error codes or stack trace, very hard to debug.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | Follow this issue #30610 to see that you get nothing in browser console, very annoying 😊
| Possible impacts? | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
