### PR TITLE
Handle multishop builders interfaces in bulk form data handler

### DIFF
--- a/src/Core/Form/IdentifiableObject/DataHandler/BulkCombinationFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/BulkCombinationFormDataHandler.php
@@ -29,7 +29,8 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
-use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilderInterface;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\MultiShopCombinationCommandsBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataFormatter\BulkCombinationFormDataFormatter;
 
 class BulkCombinationFormDataHandler implements FormDataHandlerInterface
@@ -40,7 +41,7 @@ class BulkCombinationFormDataHandler implements FormDataHandlerInterface
     private $commandBus;
 
     /**
-     * @var CombinationCommandsBuilderInterface
+     * @var MultiShopCombinationCommandsBuilderInterface
      */
     private $commandsBuilder;
 
@@ -50,18 +51,27 @@ class BulkCombinationFormDataHandler implements FormDataHandlerInterface
     private $bulkCombinationFormDataFormatter;
 
     /**
-     * @param CommandBusInterface $commandBus
-     * @param BulkCombinationFormDataFormatter $bulkCombinationFormDataFormatter
-     * @param CombinationCommandsBuilderInterface $commandsBuilder
+     * @var int
      */
+    private $contextShopId;
+
+    /**
+     * @var int
+     */
+    private $defaultShopId;
+
     public function __construct(
         CommandBusInterface $commandBus,
         BulkCombinationFormDataFormatter $bulkCombinationFormDataFormatter,
-        CombinationCommandsBuilderInterface $commandsBuilder
+        MultiShopCombinationCommandsBuilderInterface $commandsBuilder,
+        int $contextShopId,
+        int $defaultShopId
     ) {
         $this->commandBus = $commandBus;
         $this->commandsBuilder = $commandsBuilder;
         $this->bulkCombinationFormDataFormatter = $bulkCombinationFormDataFormatter;
+        $this->contextShopId = $contextShopId;
+        $this->defaultShopId = $defaultShopId;
     }
 
     /**
@@ -79,8 +89,13 @@ class BulkCombinationFormDataHandler implements FormDataHandlerInterface
     public function update($id, array $data): void
     {
         // @todo: a hook system should be integrated in this handler for extendability
+        $singleShopConstraint = $this->contextShopId ? ShopConstraint::shop($this->contextShopId) : ShopConstraint::shop($this->defaultShopId);
         $formattedData = $this->bulkCombinationFormDataFormatter->format($data);
-        $commands = $this->commandsBuilder->buildCommands(new CombinationId($id), $formattedData);
+        $commands = $this->commandsBuilder->buildCommands(
+            new CombinationId($id),
+            $formattedData,
+            $singleShopConstraint
+        );
 
         foreach ($commands as $command) {
             $this->commandBus->handle($command);

--- a/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/command_builder.yml
@@ -66,7 +66,7 @@ services:
     arguments:
       - !tagged core.combination_command_builder
 
-  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilderInterface: '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilder'
+  PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\MultiShopCombinationCommandsBuilderInterface: '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilder'
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationSuppliersCommandsBuilder:
     tags: [ 'core.combination_command_builder' ]

--- a/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/form/form_data_handler.yml
@@ -200,14 +200,16 @@ services:
       - '@prestashop.core.admin.shop.repository'
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CombinationFormDataHandler:
+    autowire: true
     arguments:
-      - '@prestashop.core.command_bus'
-      - '@PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\CombinationCommandsBuilder'
-      - '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
-      - "@=service('prestashop.adapter.shop.context').getContextShopID()"
+      $contextShopId: '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
+      $defaultShopId: "@=service('prestashop.adapter.shop.context').getContextShopID()"
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\BulkCombinationFormDataHandler:
     autowire: true
+    arguments:
+      $contextShopId: '@=service("prestashop.adapter.legacy.configuration").getInt("PS_SHOP_DEFAULT")'
+      $defaultShopId: "@=service('prestashop.adapter.shop.context').getContextShopID()"
 
   PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataHandler\CombinationListFormDataHandler:
     - '@prestashop.core.command_bus'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The multishop builders for combination command were introduced in this PR https://github.com/PrestaShop/PrestaShop/pull/30538 however the bulk form data handler was not updated at the time so it was failing because the simple interface couldn't be injected anymore This PR updates the bulk handler so that it's compatible with the new interface
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30614
| Related PRs       | ~
| How to test?      | Try to modify some combinations via the bulk edition (in product page v2) (note: there is a bug when updating by impact price included, but it works if tax excluded input is enabled, this bug is not part of this PR's scope and will be fixed another time)
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
