### PR TITLE
Allow override.css to be used in the new back office theme

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2658,8 +2658,6 @@ class AdminControllerCore extends Controller
                 $this->addJS(_PS_JS_DIR_ . 'admin/notifications.js');
             }
 
-            // Specific Admin Theme
-            $this->addCSS(__PS_BASE_URI__ . $this->admin_webpath . '/themes/' . $this->bo_theme . '/css/overrides.css', 'all', PHP_INT_MAX);
             $username = $this->get('prestashop.user_provider')->getUsername();
             $token = $this->get('security.csrf.token_manager')
                 ->getToken($username)
@@ -2672,6 +2670,9 @@ class AdminControllerCore extends Controller
                 ],
             ]);
         }
+
+        // Specific Admin Theme
+        $this->addCSS(__PS_BASE_URI__ . $this->admin_webpath . '/themes/' . $this->bo_theme . '/css/overrides.css', 'all', PHP_INT_MAX);
 
         $this->addCSS(__PS_BASE_URI__ . $this->admin_webpath . '/themes/new-theme/public/create_product_default_theme.css', 'all', 0);
         $this->addJS([


### PR DESCRIPTION
With this solution, it will be possible to customize any backoffice theme by simply adding these customization CSS elements in a file named overrides.css as it is possible to customize a PrestaShop store with the custom.css file

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Allow on PrestaShop 1.7 and 8 to customize any backoffice theme.
| Type?             | improvement
| Category?         | BO 
| BC breaks?        |  no
| Fixed ticket?     | Fixes #30664.



<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
