### PR TITLE
Add a display hook in the address step just like other checkout step

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4284,5 +4284,10 @@
       <title>Add or remove links on sitemap page</title>
       <description>This hook allows to modify links on sitemap page of your shop. Useful to improve indexation of your modules.</description>
     </hook>
+    <hook id="displayAddressSelectorBottom">
+      <name>displayAddressSelectorBottom</name>
+      <title>After address selection on checkout page</title>
+      <description>This hook is displayed after the address selection in checkout step.</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | There is no possibility to add something (message) on address step of checkout.So we suggest please add a display hook in the address step also just like other checkout steps.
| Type?             | new feature
| Category?         | FO 
| BC breaks?        |no
| Deprecations?     |no
| Fixed ticket?     | Fixes #30666 
| Related PRs       | Theme PR: https://github.com/PrestaShop/classic-theme/pull/92 Autoupgrade module PR:https://github.com/PrestaShop/autoupgrade/pull/543
| How to test?      | Please indicate how to best verify that this PR is correct.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
