### PR TITLE
Combination multishop fix

### DIFF
--- a/classes/stock/StockAvailable.php
+++ b/classes/stock/StockAvailable.php
@@ -498,7 +498,12 @@ class StockAvailableCore extends ObjectModel
             return true;
         }
 
-        $id_shop = (Shop::getContext() != Shop::CONTEXT_GROUP && $this->id_shop ? $this->id_shop : null);
+        // If shop list was explicitly set we ignore the shop context
+        if (count($this->id_shop_list)) {
+            $id_shop = reset($this->id_shop_list);
+        } else {
+            $id_shop = (Shop::getContext() != Shop::CONTEXT_GROUP && $this->id_shop ? $this->id_shop : null);
+        }
 
         if (!Configuration::get('PS_DISP_UNAVAILABLE_ATTR')) {
             $combination = new Combination((int) $this->id_product_attribute);

--- a/src/Adapter/Product/Combination/Repository/CombinationMultiShopRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationMultiShopRepository.php
@@ -347,9 +347,11 @@ class CombinationMultiShopRepository extends AbstractMultiShopObjectModelReposit
      */
     public function delete(CombinationId $combinationId, ShopConstraint $shopConstraint, int $errorCode = 0): void
     {
+        $removedShops = $this->getShopIdsByConstraint($combinationId, $shopConstraint);
         $this->deleteObjectModelFromShops(
-            $this->getByShopConstraint($combinationId, $shopConstraint),
-            $this->getShopIdsByConstraint($combinationId, $shopConstraint),
+            // We get the combination any of the removed ones, it doesn't change much so the first is fine
+            $this->get($combinationId, reset($removedShops)),
+            $removedShops,
             CannotDeleteCombinationException::class,
             $errorCode
         );

--- a/src/Adapter/Product/Combination/Repository/CombinationMultiShopRepository.php
+++ b/src/Adapter/Product/Combination/Repository/CombinationMultiShopRepository.php
@@ -257,6 +257,19 @@ class CombinationMultiShopRepository extends AbstractMultiShopObjectModelReposit
     }
 
     /**
+     * Copy combination data from one shop to another.
+     *
+     * @param CombinationId $combinationId
+     * @param ShopId $sourceId
+     * @param ShopId $targetId
+     */
+    public function copyToShop(CombinationId $combinationId, ShopId $sourceId, ShopId $targetId): void
+    {
+        $combination = $this->get($combinationId, $sourceId);
+        $this->updateObjectModelForShops($combination, [$targetId], CannotUpdateCombinationException::class);
+    }
+
+    /**
      * @param CombinationId $combinationId
      * @param ShopConstraint $shopConstraint
      *

--- a/src/Adapter/Product/Update/ProductShopUpdater.php
+++ b/src/Adapter/Product/Update/ProductShopUpdater.php
@@ -245,14 +245,8 @@ class ProductShopUpdater
         }
 
         foreach ($shopCombinationIds as $shopCombinationId) {
-            $wasAssociated = $this->combinationRepository->isAssociatedWithShop($shopCombinationId, $targetShopId);
-            // Copy values from one shop to another
+            // Copy values from one shop to another, only copy data from Combination, the stock will be handled in copyCombinationsStockToShop
             $this->combinationRepository->copyToShop($shopCombinationId, $sourceShopId, $targetShopId);
-
-            if (!$wasAssociated) {
-                // create dedicated stock_available for combination in related shop
-                $this->stockAvailableRepository->createStockAvailable($productId, $targetShopId, $shopCombinationId);
-            }
         }
 
         if (!$this->combinationRepository->findDefaultCombinationIdForShop($productId, $targetShopId)) {

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -473,6 +473,7 @@ services:
       - '@prestashop.adapter.product.stock.update.product_stock_updater'
       - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
       - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Update\DefaultCombinationUpdater'
 
   prestashop.adapter.product.command_handler.update_product_handler:
     class: PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductHandler

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_stock.yml
@@ -20,6 +20,7 @@ services:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
       - '@prestashop.adapter.product.stock.validate.stock_available_validator'
+      - '@prestashop.adapter.shop.repository.shop_group_repository'
 
   prestashop.adapter.product.stock.repository.stock_movement_repository:
     class: PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockMovementRepository

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
@@ -176,7 +176,7 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
     }
 
     /**
-     * @Then combination ":combinationReference" should have following stock details for shops ":shopReferences":
+     * @Then combination :combinationReference should have following stock details for shops :shopReferences:
      *
      * @param string $combinationReference
      * @param CombinationStock $expectedStock

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/StockAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/StockAssertionFeatureContext.php
@@ -149,18 +149,20 @@ class StockAssertionFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Then combination :combinationReference last stock movements for shop :shopReference should be:
+     * @Then combination :combinationReference last stock movements for shop :shopReferences should be:
      */
     public function assertCombinationLastStockMovementsForSpecificShop(
         string $combinationReference,
-        string $shopReference,
+        string $shopReferences,
         TableNode $table
     ): void {
-        $this->assertLastStockMovementsForCombination(
-            $combinationReference,
-            $this->getSharedStorage()->get(trim($shopReference)),
-            $table
-        );
+        foreach ($this->referencesToIds($shopReferences) as $shopId) {
+            $this->assertLastStockMovementsForCombination(
+                $combinationReference,
+                $shopId,
+                $table
+            );
+        }
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/copy_combinations_to_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/copy_combinations_to_shop.feature
@@ -1,0 +1,137 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags copy-combinations-to-shop
+@restore-products-before-feature
+@clear-cache-before-feature
+@restore-shops-after-feature
+@clear-cache-after-feature
+@product-combination
+@product-multi-shop
+@copy-combinations-to-shop
+Feature: Copy combinations from Back Office (BO) when using multi-shop feature
+  As a BO user
+  I need to be able to copy product combinations from BO from one shop to another when using multi-shop feature
+
+  Background:
+    Given language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
+    And shop "shop1" with name "test_shop" exists
+    And I enable multishop feature
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "default_shop_group" and color "red" for the group "default_shop_group"
+    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And I identify tax rules group named "US-AL Rate (4%)" as "us-al-tax-rate"
+    And single shop context is loaded
+    Given I add product "product1" with following information:
+      | name[en-US] | universal T-shirt |
+      | type        | combinations      |
+    And product product1 type should be combinations
+    When I generate combinations in shop "shop1" for product product1 using following attributes:
+      | Size  | [S,M]              |
+      | Color | [White,Black,Blue] |
+    Then product "product1" should have the following combinations for shops "shop1":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SWhite"
+
+  Scenario: I copy product from a shop to another the combinations are associated to the other shop along with the default
+    Given product "product1" should have no combinations for shops "shop2"
+    And product "product1" should not have a default combination for shop "shop2"
+    When I copy product product1 from shop shop1 to shop shop2
+    Then product "product1" should have the following combinations for shops "shop1,shop2":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SWhite"
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"
+
+  Scenario: I copy updated combinations to another shop the data is also copied
+    Given I update combination "product1SWhite" with following values for shop "shop1":
+      | ean13                      | 978020137962      |
+      | isbn                       | 978-3-16-148410-0 |
+      | mpn                        | mpn1              |
+      | reference                  | ref1              |
+      | upc                        | 72527273070       |
+      | impact on weight           | 17.25             |
+      | eco tax                    | 0.5               |
+      | impact on price            | 10.0              |
+      | impact on unit price       | 0.5               |
+      | wholesale price            | 20                |
+      | minimal quantity           | 10                |
+      | low stock threshold        | 10                |
+      | low stock alert is enabled | true              |
+      | available date             | 2021-10-10        |
+    And I update combination "product1SWhite" stock for shop "shop1" with following details:
+      | delta quantity | 10          |
+      | location       | Storage nr1 |
+    Then combination "product1SWhite" should have following details for shops "shop1":
+      | combination detail         | value             |
+      | ean13                      | 978020137962      |
+      | isbn                       | 978-3-16-148410-0 |
+      | mpn                        | mpn1              |
+      | reference                  | ref1              |
+      | upc                        | 72527273070       |
+      | impact on weight           | 17.25             |
+      | eco tax                    | 0.5               |
+      | impact on price            | 10.0              |
+      | impact on unit price       | 0.5               |
+      | wholesale price            | 20                |
+      | minimal quantity           | 10                |
+      | low stock threshold        | 10                |
+      | low stock alert is enabled | true              |
+      | available date             | 2021-10-10        |
+    And combination "product1SWhite" should have following stock details for shops "shop1":
+      | combination stock detail   | value       |
+      | quantity                   | 10          |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr1 |
+      | available date             | 2021-10-10  |
+    And combination "product1SWhite" last stock movements for shop "shop1" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 10             |
+    When I copy product product1 from shop shop1 to shop shop2
+    Then combination "product1SWhite" should have following details for shops "shop1,shop2":
+      | combination detail         | value             |
+      | ean13                      | 978020137962      |
+      | isbn                       | 978-3-16-148410-0 |
+      | mpn                        | mpn1              |
+      | reference                  | ref1              |
+      | upc                        | 72527273070       |
+      | impact on weight           | 17.25             |
+      | eco tax                    | 0.5               |
+      | impact on price            | 10.0              |
+      | impact on unit price       | 0.5               |
+      | wholesale price            | 20                |
+      | minimal quantity           | 10                |
+      | low stock threshold        | 10                |
+      | low stock alert is enabled | true              |
+      | available date             | 2021-10-10        |
+    And combination "product1SWhite" should have following stock details for shops "shop1,shop2":
+      | combination stock detail   | value       |
+      | quantity                   | 10          |
+      | minimal quantity           | 10          |
+      | low stock threshold        | 10          |
+      | low stock alert is enabled | true        |
+      | location                   | Storage nr1 |
+      | available date             | 2021-10-10  |
+    And combination "product1SWhite" last stock movements for shop "shop1,shop2" should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 10             |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_multishop_combination.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_multishop_combination.feature
@@ -279,3 +279,38 @@ Feature: Delete combination from Back Office (BO) in multiple shops
       | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
     And product "product1" default combination for shop "shop1" should be "product1SBlack"
     And product "product1" default combination for shop "shop2" should be "product1SBlack"
+
+  Scenario: Delete combination for all shops while not associated to default shop anymore
+    When I delete following combinations of product "product1" from shop shop1:
+      | id reference   |
+      | product1SWhite |
+      | product1MBlue  |
+    Then product "product1" should have the following combinations for shops "shop1":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | true       |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+    And product "product1" should have the following combinations for shops "shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SWhite | Size - S, Color - White |           | [Size:S,Color:White] | 0               | 0        | true       |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | false      |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+      | product1MBlue  | Size - M, Color - Blue  |           | [Size:M,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SBlack"
+    And product "product1" default combination for shop "shop2" should be "product1SWhite"
+    # Now delete from all shops but the combinations are not in shop1 anymore
+    When I delete following combinations of product "product1" from all shops:
+      | id reference   |
+      | product1SWhite |
+      | product1MBlue  |
+    Then product "product1" should have the following combinations for shops "shop1,shop2":
+      | combination id | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1SBlack | Size - S, Color - Black |           | [Size:S,Color:Black] | 0               | 0        | true       |
+      | product1SBlue  | Size - S, Color - Blue  |           | [Size:S,Color:Blue]  | 0               | 0        | false      |
+      | product1MWhite | Size - M, Color - White |           | [Size:M,Color:White] | 0               | 0        | false      |
+      | product1MBlack | Size - M, Color - Black |           | [Size:M,Color:Black] | 0               | 0        | false      |
+    And product "product1" default combination for shop "shop1" should be "product1SBlack"
+    And product "product1" default combination for shop "shop2" should be "product1SBlack"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes a few things for multishop on combinations:<br>- bulk delete on all shops when combination is not in default shop<br>- copy from a shop to another copies the combinations<br>- handle combination stock in shop group sharing stock
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Related PRs       | ~
| How to test?      | No functional tests needed, all the modifications are behat tested and the full page has not been manually tested yet
| Possible impacts? | ~


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
