### PR TITLE
Use Symfony HttpClient inside WebserviceController instead of Guzzle

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -27,7 +27,6 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use Exception;
-use GuzzleHttp\Client;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\DuplicateWebserviceKeyException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceConstraintException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
@@ -36,6 +35,7 @@ use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -422,22 +422,22 @@ class WebserviceController extends FrameworkBundleAdminController
      */
     private function checkWebserviceEndpoint(string $url): bool
     {
-        $client = new Client();
-
+        $client = HttpClient::create();
+        $statusCode = null;
         try {
             $response = $client->request('GET', $url, [
-                'http_errors' => false,
-                'allow_redirects' => true,
+                'max_redirects' => 5,
             ]);
+            $statusCode = $response->getStatusCode();
         } catch (Exception $e) {
             $this->addFlash('error', $e->getMessage());
 
             return false;
         }
 
-        if ($response->getStatusCode() >= Response::HTTP_OK && $response->getStatusCode() < Response::HTTP_MULTIPLE_CHOICES) {
+        if ($statusCode >= Response::HTTP_OK && $statusCode < Response::HTTP_MULTIPLE_CHOICES) {
             return true;
-        } elseif ($response->getStatusCode() == Response::HTTP_UNAUTHORIZED) {
+        } elseif ($statusCode == Response::HTTP_UNAUTHORIZED) {
             return true;
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove usage of Guzzle (see #30516), by removing Guzzle http call, and using the Symfony http-client instead. I kept the same behavior, using the same 'max_redirects' than before, and being sure all exceptions are catched.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes partially #30516.
| Related PRs       | none
| How to test?      | See below
| Possible impacts? | Only the back-office WebserviceController is modified

## How to test

The WebserviceController uses a curl call to check whether PrestaShop Webservice works as expected. To see it, please install shop, enable webservice and see the back-office page that says it works. You can test this PR by verifying the webservice status check still works

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
