### PR TITLE
Fix a dashboard page with an empty date

### DIFF
--- a/classes/helper/HelperCalendar.php
+++ b/classes/helper/HelperCalendar.php
@@ -145,12 +145,8 @@ class HelperCalendarCore extends Helper
         return $this->_date_format;
     }
 
-    public function setDateFrom($value = '')
+    public function setDateFrom($value = '-31 days')
     {
-        if (empty($value)) {
-            $value = '-31 days';
-        }
-
         if (!is_string($value)) {
             throw new PrestaShopException('Date must be a string');
         }
@@ -169,12 +165,8 @@ class HelperCalendarCore extends Helper
         return $this->_date_from;
     }
 
-    public function setDateTo($value = '')
+    public function setDateTo($value = '-31 days')
     {
-        if (empty($value)) {
-            $value = '-31 days';
-        }
-
         if (!is_string($value)) {
             throw new PrestaShopException('Date must be a string');
         }

--- a/classes/helper/HelperCalendar.php
+++ b/classes/helper/HelperCalendar.php
@@ -145,8 +145,12 @@ class HelperCalendarCore extends Helper
         return $this->_date_format;
     }
 
-    public function setDateFrom($value = '-31 days')
+    public function setDateFrom($value)
     {
+        if (empty($value)) {
+            $value = '-31 days';
+        }
+
         if (!is_string($value)) {
             throw new PrestaShopException('Date must be a string');
         }
@@ -165,8 +169,12 @@ class HelperCalendarCore extends Helper
         return $this->_date_from;
     }
 
-    public function setDateTo($value = '-31 days')
+    public function setDateTo($value)
     {
+        if (empty($value)) {
+            $value = '-31 days';
+        }
+
         if (!is_string($value)) {
             throw new PrestaShopException('Date must be a string');
         }

--- a/classes/helper/HelperCalendar.php
+++ b/classes/helper/HelperCalendar.php
@@ -148,7 +148,7 @@ class HelperCalendarCore extends Helper
     public function setDateFrom($value = '')
     {
         if (empty($value)) {
-            $value = strtotime('-31 days');
+            $value = '-31 days';
         }
 
         if (!is_string($value)) {
@@ -172,7 +172,7 @@ class HelperCalendarCore extends Helper
     public function setDateTo($value = '')
     {
         if (empty($value)) {
-            $value = strtotime('-31 days');
+            $value = '-31 days';
         }
 
         if (!is_string($value)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | While working on an Edition store support ticket, I noticed a bug when insert an empty date on the Dashboard. Prestashop Exception "Date must be a string". I checked the HelpCalendar file and I found that we do a strtotime for nothing when initializing the parameter because we are doing it again in fact as a method and that the test in the middle bugs because of that.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26751
| Related PRs       | No
| How to test?      | Indicate empty date on dashboard BackOffice for period
| Possible impacts? | Other period used with file HelpCalendar.php


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
