### PR TITLE
Delete all combinations when removing product from shop

### DIFF
--- a/src/Adapter/Product/Shop/CommandHandler/DeleteProductFromShopsHandler.php
+++ b/src/Adapter/Product/Shop/CommandHandler/DeleteProductFromShopsHandler.php
@@ -67,14 +67,13 @@ class DeleteProductFromShopsHandler implements DeleteProductFromShopsHandlerInte
     {
         $shopIds = $command->getShopIds();
         $productId = $command->getProductId();
+
+        if ($this->productRepository->hasCombinations($command->getProductId())) {
+            foreach ($shopIds as $shopId) {
+                $this->combinationMultiShopRepository->deleteByProductId($productId, ShopConstraint::shop($shopId->getValue()));
+            }
+        }
+
         $this->productRepository->deleteFromShops($command->getProductId(), $shopIds);
-
-        if (!$this->productRepository->hasCombinations($command->getProductId())) {
-            return;
-        }
-
-        foreach ($shopIds as $shopId) {
-            $this->combinationMultiShopRepository->deleteByProductId($productId, ShopConstraint::shop($shopId->getValue()));
-        }
     }
 }

--- a/src/Adapter/Product/Update/ProductShopUpdater.php
+++ b/src/Adapter/Product/Update/ProductShopUpdater.php
@@ -126,6 +126,7 @@ class ProductShopUpdater
 
         /** @var Product $sourceProduct */
         $sourceProduct = $this->productRepository->getByShopConstraint($productId, ShopConstraint::shop($sourceShopId->getValue()));
+        $productType = $sourceProduct->getProductType();
         $this->productRepository->update(
             $sourceProduct,
             ShopConstraint::shop($targetShopId->getValue()),

--- a/src/Adapter/Product/Update/ProductShopUpdater.php
+++ b/src/Adapter/Product/Update/ProductShopUpdater.php
@@ -126,7 +126,6 @@ class ProductShopUpdater
 
         /** @var Product $sourceProduct */
         $sourceProduct = $this->productRepository->getByShopConstraint($productId, ShopConstraint::shop($sourceShopId->getValue()));
-        $productType = $sourceProduct->getProductType();
         $this->productRepository->update(
             $sourceProduct,
             ShopConstraint::shop($targetShopId->getValue()),

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -431,6 +431,7 @@ services:
     class: PrestaShop\PrestaShop\Adapter\Product\Shop\CommandHandler\DeleteProductFromShopsHandler
     arguments:
       - '@prestashop.adapter.product.repository.product_multi_shop_repository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationMultiShopRepository'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Shop\Command\DeleteProductFromShopsCommand

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
@@ -11,6 +11,15 @@ Feature: Copy product from shop to shop.
 
   Background:
     Given I enable multishop feature
+    And language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
     And shop "shop1" with name "test_shop" exists
     And shop group "default_shop_group" with name "Default" exists
     And I add a shop "shop2" with name "test_second_shop" and color "red" for the group "default_shop_group"
@@ -579,3 +588,31 @@ Feature: Copy product from shop to shop.
     # Now I delete product from remaining shops it should be completely removed
     When I delete product productToDelete from shops "shop1,shop3"
     Then product productToDelete should not exist anymore
+
+  Scenario: Product combinations are copied/deleted when product is being copied/deleted to/from shop.
+    Given I add product "product1" with following information:
+      | name[en-US] | universal T-shirt |
+      | type        | combinations      |
+    And product product1 type should be combinations
+    And I generate combinations in shop "shop1" for product product1 using following attributes:
+      | Size  | [L]                |
+      | Color | [White,Black,Blue] |
+    And product "product1" should have the following combinations for shops "shop1":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1LWhite | Size - L, Color - White |           | [Size:L,Color:White] | 0               | 0        | true       |
+      | product1LBlack | Size - L, Color - Black |           | [Size:L,Color:Black] | 0               | 0        | false      |
+      | product1LBlue  | Size - L, Color - Blue  |           | [Size:L,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" should have no combinations for shops "shop2"
+    When I copy product "product1" from shop shop1 to shop shop2
+    Then product "product1" should have the following combinations for shops "shop1,shop2":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1LWhite | Size - L, Color - White |           | [Size:L,Color:White] | 0               | 0        | true       |
+      | product1LBlack | Size - L, Color - Black |           | [Size:L,Color:Black] | 0               | 0        | false      |
+      | product1LBlue  | Size - L, Color - Blue  |           | [Size:L,Color:Blue]  | 0               | 0        | false      |
+    When I delete product "product1" from shops "shop2"
+    Then product "product1" should have the following combinations for shops "shop1":
+      | id reference   | combination name        | reference | attributes           | impact on price | quantity | is default |
+      | product1LWhite | Size - L, Color - White |           | [Size:L,Color:White] | 0               | 0        | true       |
+      | product1LBlack | Size - L, Color - Black |           | [Size:L,Color:Black] | 0               | 0        | false      |
+      | product1LBlue  | Size - L, Color - Blue  |           | [Size:L,Color:Blue]  | 0               | 0        | false      |
+    And product "product1" should have no combinations for shops "shop2"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Combinations wasn't being delete during shop selection for product i shop was unselected.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #30751
| How to test?      |  refer to fixed ticket
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
