### PR TITLE
Changing wording and adding text helper for product name error input

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
+++ b/src/PrestaShopBundle/Form/Admin/Product/ProductInformation.php
@@ -213,11 +213,21 @@ class ProductInformation extends CommonAbstractType
             ])
             ->add('name', TranslateType::class, [
                 'type' => FormType\TextType::class,
+                'help' => $this->translator->trans(
+                    'Invalid characters are: %invalidCharacters%',
+                    ['%invalidCharacters%' => '<>;=#{}'],
+                    'Admin.Catalog.Feature'
+                ),
                 'options' => [
                     'constraints' => [
                         new Assert\Regex([
                             'pattern' => '/[<>;=#{}]/',
                             'match' => false,
+                            'message' => $this->translator->trans(
+                                'This field contains invalid characters: %invalidCharacters%',
+                                ['%invalidCharacters%' => '<>;=#{}'],
+                                'Admin.Catalog.Feature'
+                            ),
                         ]),
                         new Assert\NotBlank(),
                         new Assert\Length(['min' => 3, 'max' => 128]),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -82,10 +82,24 @@ class HeaderType extends TranslatorAwareType
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Product name', 'Admin.Catalog.Feature'),
                 'type' => TextType::class,
+                'help' => $this->trans(
+                    'Invalid characters are: %invalidCharacters%',
+                    'Admin.Catalog.Feature',
+                    ['%invalidCharacters%' => '<>;=#{}']
+                ),
                 'constraints' => $options['active'] ? [new DefaultLanguage()] : [],
                 'options' => [
                     'constraints' => [
-                        new TypedRegex(TypedRegex::TYPE_CATALOG_NAME),
+                        new TypedRegex(
+                            [
+                                'type' => TypedRegex::TYPE_CATALOG_NAME,
+                                'message' => $this->trans(
+                                    'This field contains invalid characters: %invalidCharacters%',
+                                    'Admin.Catalog.Feature',
+                                    ['%invalidCharacters%' => '<>;=#{}']
+                                ),
+                            ]
+                        ),
                         new Length(['max' => ProductSettings::MAX_NAME_LENGTH]),
                     ],
                     'attr' => [

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -240,6 +240,7 @@
                 <div data-locale="{{ translationsFields.vars.label }}" class="translationsFields-{{ translationsFields.vars.id }} tab-pane translation-field {% if hideTabs == false and form|length > 1 %}panel panel-default{% endif %} {% if defaultLocale.id_lang == translationsFields.vars.name %}show active{% endif %} {% if not form.vars.valid %}field-error{% endif %} translation-label-{{ translationsFields.vars.label }}">
                     {{ form_errors(translationsFields) }}
                     {{ form_widget(translationsFields) }}
+                    {{- block('form_help') -}}
                 </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
…t helper below the input

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Changing wording and adding text helper for product name error input
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #25905
| Related PRs       |
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/25905
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
