### PR TITLE
Add GITHUB_TOKEN to the github action env

### DIFF
--- a/.github/actions/setup-prestashop-env/action.yml
+++ b/.github/actions/setup-prestashop-env/action.yml
@@ -27,6 +27,10 @@ inputs:
     required: false
     description: False to disable dev mode
     default: "true"
+  github-token:
+    required: false
+    description: GITHUB_TOKEN to be used by composer
+    default: ""
 
 runs:
   using: "composite"
@@ -36,6 +40,8 @@ runs:
       with:
         php-version: ${{ inputs.php-version }}
         extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml, pdo, mysql
+      env:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
 
     - name: Setup Apache
       shell: bash

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1
         with:

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           php-version: ${{ env.PHP_VERSION }}
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1

--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           php-version: ${{ env.PHP_VERSION }}
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -29,6 +29,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup MySQL
         uses: mirromutth/mysql-action@v1.1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,6 +60,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
 
       - name: Get Composer Cache Directory
@@ -118,6 +120,8 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
 
       - name: Get Composer Cache Directory

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           php-version: 8.0
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v3
 
       - name: Get Composer Cache Directory
@@ -56,6 +58,8 @@ jobs:
         with:
           php-version: '8.0'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
 
@@ -93,6 +97,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/sanity-productV2.yml
+++ b/.github/workflows/sanity-productV2.yml
@@ -35,6 +35,7 @@ jobs:
           npm-version: '7'
           ps-auto-install: 'true'
           ps-dev-mode: 'false'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@v3

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -28,6 +28,7 @@ jobs:
           mysql-root-password: 'password'
           node-version: '16'
           npm-version: '7'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@v3


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR aims to fix the CI issue that says that the repository atomiix/jwt could not be cloned. The bug seems to happen because of Github rate limitation. By giving a token, this limit is not an issue anymore.
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Related PRs       | 
| How to test?      | CI should be green
| Possible impacts? | 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
