### PR TITLE
Load default language if employee id lang does not exist

### DIFF
--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -7,6 +7,7 @@ services:
     arguments:
       - "@prestashop.adapter.legacy.context"
       - "@prestashop.adapter.legacy.configuration"
+      - "@prestashop.core.admin.lang.repository"
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 15 }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/event_listener.yml
@@ -6,6 +6,7 @@ services:
     class: PrestaShopBundle\EventListener\UserLocaleListener
     arguments:
       - "@prestashop.adapter.legacy.context"
+      - "@prestashop.adapter.legacy.configuration"
     tags:
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: 15 }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Load default language if employee id lang does not exist
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #30091
| How to test?      | See #30091


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
