### PR TITLE
Add sponsor company to PR description

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Thank you for contributing to the PrestaShop project!
 Please take the time to edit the "Answers" rows below with the necessary information.
 
 Check out our contribution guidelines to find out how to complete it:
-https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
+https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
 ------------------------------------------------------------------------------>
 
 | Questions         | Answers
@@ -15,10 +15,7 @@ https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-reques
 | Category?         | FO / BO / CO / IN / WS / TE / LO / ME / PM
 | BC breaks?        | yes / no
 | Deprecations?     | yes / no
-| Fixed ticket?     | Fixes #{issue number here}. If your PR fixes multiple issues, use Resolves #{issue number here}, Resolves #{another issue number here}.
-| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
-| How to test?      | Please indicate how to best verify that this PR is correct.
-| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
-
-
-<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
+| Fixed ticket?     | Fixes #{issue number here}, Fixes #{another issue number here}
+| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
+| Sponsor company   | Your company name goes here.
+| How to test?      | Indicate how to verify that this change works as expected.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pul
 | Category?         | FO / BO / CO / IN / WS / TE / LO / ME / PM
 | BC breaks?        | yes / no
 | Deprecations?     | yes / no
+| How to test?      | Indicate how to verify that this change works as expected.
 | Fixed ticket?     | Fixes #{issue number here}, Fixes #{another issue number here}
 | Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
-| Sponsor company   | Your company name goes here.
-| How to test?      | Indicate how to verify that this change works as expected.
+| Sponsor company   | Your company or customer's name goes here (if applicable).


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Added sponsor company to table so that we can more easily track and provide attribution to the companies behind contributors. I also removed the "possible impacts" field that because I feel that no one is using it.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA
| How to test?      | N/A