### PR TITLE
Allow unselecting default category in category tree

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/categories-manager.ts
@@ -81,7 +81,7 @@ export default class CategoriesManager {
       this.getDefaultCategoryId(),
     ));
     this.eventEmitter.on(ProductEventMap.categories.applyCategoryTreeChanges, (eventData) => {
-      this.tagsRenderer.render(eventData.categories, this.getDefaultCategoryId());
+      this.tagsRenderer.render(eventData.categories);
       this.eventEmitter.emit(ProductEventMap.categories.categoriesUpdated);
     });
   }
@@ -173,12 +173,16 @@ export default class CategoriesManager {
       const newDefaultCategoryId = Number(currentTarget.value);
       const categories = this.collectCategories()
         .map((category) => ({...category, isDefault: category.id === newDefaultCategoryId}));
-      this.tagsRenderer.render(categories, this.getDefaultCategoryId());
+      this.tagsRenderer.render(categories);
     });
   }
 
   private listenCategoryChanges(): void {
-    this.eventEmitter.on(ProductEventMap.categories.categoriesUpdated, () => this.renderDefaultCategorySelection());
+    this.eventEmitter.on(ProductEventMap.categories.categoriesUpdated, () => {
+      this.renderDefaultCategorySelection();
+      // if there is only one category left selected, it must be re-rendered without the removal element
+      this.tagsRenderer.render(this.collectCategories());
+    });
   }
 
   private getDefaultCategoryId(): number {

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -168,12 +168,6 @@ export default class CategoryTreeSelector {
       if (checkbox instanceof HTMLInputElement) {
         const categoryId = Number(checkbox.value);
 
-        // disable main category checkbox
-        if (categoryId === this.defaultCategoryId) {
-          // eslint-disable-next-line no-param-reassign
-          checkbox.disabled = true;
-        }
-
         if (this.selectedCategories.some((category) => category.id === categoryId)) {
           // eslint-disable-next-line no-param-reassign
           checkbox.checked = true;
@@ -188,11 +182,9 @@ export default class CategoryTreeSelector {
             return;
           }
 
-          // do not allow unchecking main category id
-          if (Number(currentTarget.value) === this.defaultCategoryId && !currentTarget.checked) {
+          // do not allow unchecking last remaining category
+          if (this.selectedCategories.length === 1) {
             currentTarget.checked = true;
-
-            return;
           }
 
           this.updateSelectedCategories();
@@ -404,7 +396,14 @@ export default class CategoryTreeSelector {
       return;
     }
 
-    const checkedCheckboxes = this.categoryTree.querySelectorAll(ProductCategoryMap.checkedCheckboxInputs);
+    const checkedCheckboxes = <NodeListOf<HTMLInputElement>> this.categoryTree
+      .querySelectorAll(ProductCategoryMap.checkedCheckboxInputs);
+
+    let onlyOneSelected = false;
+
+    if (checkedCheckboxes.length === 1) {
+      onlyOneSelected = true;
+    }
 
     const categories: Array<Category> = [];
     checkedCheckboxes.forEach((checkbox) => {
@@ -418,6 +417,10 @@ export default class CategoryTreeSelector {
           displayName: searchedCategory.displayName,
         });
       }
+
+      // do not allow to uncheck the checkbox if it is the last one selected category
+      // eslint-disable-next-line no-param-reassign
+      checkbox.disabled = onlyOneSelected;
     });
 
     this.tagsRenderer.render(categories, this.defaultCategoryId);

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/category-tree-selector.ts
@@ -115,7 +115,7 @@ export default class CategoryTreeSelector {
       `${ProductCategoryMap.modalContentContainer} ${ProductCategoryMap.tagsContainer}`,
       ProductEventMap.categories.tagRemoved,
     );
-    this.tagsRenderer.render(this.selectedCategories, this.defaultCategoryId);
+    this.tagsRenderer.render(this.selectedCategories);
     this.treeCategories = await getCategories();
 
     this.initTypeaheadData(this.treeCategories);
@@ -399,12 +399,6 @@ export default class CategoryTreeSelector {
     const checkedCheckboxes = <NodeListOf<HTMLInputElement>> this.categoryTree
       .querySelectorAll(ProductCategoryMap.checkedCheckboxInputs);
 
-    let onlyOneSelected = false;
-
-    if (checkedCheckboxes.length === 1) {
-      onlyOneSelected = true;
-    }
-
     const categories: Array<Category> = [];
     checkedCheckboxes.forEach((checkbox) => {
       const categoryId = Number((checkbox as HTMLInputElement).value);
@@ -420,10 +414,10 @@ export default class CategoryTreeSelector {
 
       // do not allow to uncheck the checkbox if it is the last one selected category
       // eslint-disable-next-line no-param-reassign
-      checkbox.disabled = onlyOneSelected;
+      checkbox.disabled = checkedCheckboxes.length === 1;
     });
 
-    this.tagsRenderer.render(categories, this.defaultCategoryId);
+    this.tagsRenderer.render(categories);
     this.selectedCategories = categories;
   }
 

--- a/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/components/categories/tags-renderer.ts
@@ -46,7 +46,7 @@ export default class TagsRenderer {
     this.listenTagRemoval();
   }
 
-  public render(categories: Array<Category>, defaultCategoryId: number): void {
+  public render(categories: Array<Category>): void {
     this.container.innerHTML = '';
     const tagTemplate = this.container.dataset.prototype;
     const {prototypeName} = this.container.dataset;
@@ -69,8 +69,8 @@ export default class TagsRenderer {
 
         const tagRemoveBtn = frag.querySelector(ProductCategoryMap.tagRemoveBtn) as HTMLElement;
 
-        // don't show the tag removal element for main category or when it is the last category
-        if (category.id === defaultCategoryId || categories.length === 1) {
+        // don't show the tag removal element when it is the last category
+        if (categories.length === 1) {
           tagRemoveBtn.classList.add('d-none');
         } else {
           tagRemoveBtn.classList.remove('d-none');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Part of category tree component improvements in BO product v2 page. It was annoying that default category wasn't allowed to be removed in modal of categories tree. This PR enables to remove it, first available checked category is selected as default in such scenario instead.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | part of https://github.com/PrestaShop/PrestaShop/issues/28135 (depending if we decide more improvements)
| Related PRs       | 
| How to test?      | Go to product page v2 edition page -> categories block. Select Add new category. In shown modal you should be able to unselect category that is selected as default. The closest category should become default automatically. It should still not allow unselecting last remaining selected category though. ⚠️ requires recompiling BO assets (so that the js changes applies)
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
