### PR TITLE
Allow searching brands in choices list of product v2

### DIFF
--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Description/ManufacturerType.php
@@ -36,6 +36,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ManufacturerType extends ChoiceType
 {
+    private const MANUFACTURER_MIN_RESULTS_FOR_SEARCH = 7;
+
     /**
      * @var TranslatorInterface
      */
@@ -79,6 +81,7 @@ class ManufacturerType extends ChoiceType
             'choices' => $choices,
             'attr' => [
                 'data-toggle' => 'select2',
+                'data-minimumResultsForSearch' => self::MANUFACTURER_MIN_RESULTS_FOR_SEARCH,
             ],
         ]);
     }


### PR DESCRIPTION


<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The option of minimal results for search to appear was missing, so this PR adds it (Used minimum results of 7, because this way it was done in legacy product page and this is the way we are using in most other similar choice lists)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/30770
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | Product v2 description tab. When you have at least 7 brands available, then the brands choice list should contain a search input, where you can search in brands.
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.
<img width="500" alt="Screenshot 2023-01-09 at 18 12 47" src="https://user-images.githubusercontent.com/31609858/211354997-c37bc3f9-388e-419d-afb0-59581f40eb5f.png">

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
