### PR TITLE
Move hook

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -3868,6 +3868,35 @@ class ProductCore extends ObjectModel
         } else {
             $price = (float) $specific_price['price'];
         }
+        
+        Hook::exec('actionProductPriceCalculation', [
+            'id_shop' => $id_shop,
+            'id_product' => $id_product,
+            'id_product_attribute' => $id_product_attribute,
+            'id_customization' => $id_customization,
+            'id_country' => $id_country,
+            'id_state' => $id_state,
+            'zip_code' => $zipcode,
+            'id_currency' => $id_currency,
+            'id_group' => $id_group,
+            'id_cart' => $id_cart,
+            'id_customer' => $id_customer,
+            'use_customer_price' => $use_customer_price,
+            'quantity' => $quantity,
+            'real_quantity' => $real_quantity,
+            'use_tax' => $use_tax,
+            'decimals' => $decimals,
+            'only_reduc' => $only_reduc,
+            'use_reduc' => $use_reduc,
+            'with_ecotax' => $with_ecotax,
+            'specific_price' => &$specific_price,
+            'use_group_reduction' => $use_group_reduction,
+            'address' => $address,
+            'context' => $context,
+            'specific_price_reduction' => &$specific_price_reduction,
+            'price' => &$price,
+        ]);
+        
         // convert only if the specific price is in the default currency (id_currency = 0)
         if (
             !$specific_price ||
@@ -3977,34 +4006,7 @@ class ProductCore extends ObjectModel
 
             $price -= $group_reduction;
         }
-
-        Hook::exec('actionProductPriceCalculation', [
-            'id_shop' => $id_shop,
-            'id_product' => $id_product,
-            'id_product_attribute' => $id_product_attribute,
-            'id_customization' => $id_customization,
-            'id_country' => $id_country,
-            'id_state' => $id_state,
-            'zip_code' => $zipcode,
-            'id_currency' => $id_currency,
-            'id_group' => $id_group,
-            'id_cart' => $id_cart,
-            'id_customer' => $id_customer,
-            'use_customer_price' => $use_customer_price,
-            'quantity' => $quantity,
-            'real_quantity' => $real_quantity,
-            'use_tax' => $use_tax,
-            'decimals' => $decimals,
-            'only_reduc' => $only_reduc,
-            'use_reduc' => $use_reduc,
-            'with_ecotax' => $with_ecotax,
-            'specific_price' => &$specific_price,
-            'use_group_reduction' => $use_group_reduction,
-            'address' => $address,
-            'context' => $context,
-            'specific_price_reduction' => &$specific_price_reduction,
-            'price' => &$price,
-        ]);
+        
         if ($only_reduc) {
             return Tools::ps_round($specific_price_reduction, $decimals);
         }


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.0.x / 1.7.8.x
| Description?      | Currently, the hook overwrites the price of the product. Unfortunately, placing it at the end of the "priceCalculation" function prevents the use of further price modifications provided for in the standard Prestashop functionality, for example: modifying the price based on attributes (Attribute price), adding taxes (Tax), discounts (Reduction), group discounts (Group reduction) etc. For someone who doesn't use the listed price modifiers, it doesn't matter - the price will be as set in Hook, but if I use rebates, discounts and other additional modifications, I need these functions. Example: I am fetching a price from an external API. This price is the official selling price excluding tax. I can give a discount to my clients and instead of using what is already built into Prestashop, I have to additionally combine appropriate solutions in my module. This forces me to do extra work, and I have the same thing ready in Presatshop. Only Hook is in the wrong place (in my opinion).
| Type?             |  improvement 
| Category?         | FO 
| How to test?      | tested. 
