### PR TITLE
Add `new-products` page in global urls smarty

### DIFF
--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1495,7 +1495,7 @@ class FrontControllerCore extends Controller
                 'discount', 'guest-tracking', 'history', 'identity', 'index', 'my-account',
                 'order-confirmation', 'order-detail', 'order-follow', 'order', 'order-return',
                 'order-slip', 'pagenotfound', 'password', 'pdf-invoice', 'pdf-order-return', 'pdf-order-slip',
-                'prices-drop', 'product', 'registration', 'search', 'sitemap', 'stores', 'supplier',
+                'prices-drop', 'product', 'registration', 'search', 'sitemap', 'stores', 'supplier', 'new-products',
             ];
             foreach ($p as $page_name) {
                 $index = str_replace('-', '_', $page_name);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?   | Add `new-products` page in global urls smarty   
| Type?             | improvement 
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     |  no
| Fixed ticket?     | N/ A
| Related PRs       |  N/ A
| How to test?      | See  description Bellow 
| Possible impacts? |  N /A 

## How to test 
In tpl try this code:
```smarty 
{$urls['pages']['new_products']} 
```
and make sure that will return the  new Products page url 


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
