### PR TITLE
Remove deprecated function testGetFormCombination

### DIFF
--- a/tests/Integration/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
+++ b/tests/Integration/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
@@ -231,7 +231,7 @@ class AdminModelAdapterTest extends KernelTestCase
     /**
      * @todo find a way to check the value of `attribute_quantity` and `name` and `attribute_price_display` that depend on database
      */
-    public function testGetFormCombination(): void
+    public function testGetFormCombinations(): void
     {
         $expectedStructureReturn = [
             'id_product_attribute' => '6',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated function testGetFormCombination. Use testGetFormCombinations instead.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | yes
| Fixed ticket?     | -
| Related PRs       | -
| How to test?      | Check if products combinations (create / update) works as expected
| Possible impacts? | Please indicate what parts of the software we need to check to make sure everything is alright.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
