### PR TITLE
Fix text-preview widget to show combination names in list

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -1298,13 +1298,12 @@
       {{ prefix|raw }}
     {% endif %}
 
-    {# This just outputs the value #}
     {% if  form.vars.allow_html %}
       {# This outputs raw value #}
-      {{ form.vars.value|raw }}
+      {{ value|raw }}
     {% else %}
       {# This just outputs the value #}
-      {{ form.vars.value|e('html') }}
+      {{ value|e('html') }}
     {% endif %}
 
     {# Allows to insert content as suffix, like an icon #}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | 
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30830
| Related PRs       | If theme, autoupgrade or other module change is needed, provide a link to related PRs here.
| How to test?      | refer to ticket, you should be able to see the combination names now 
<img width="452" alt="Screenshot 2023-01-12 at 14 28 49" src="https://user-images.githubusercontent.com/31609858/212066667-36321118-d5b8-4360-8b02-8877d49edd52.png">
| Possible impacts? | New merchandised return page was also affected, but as I checked it works there too.


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
