### PR TITLE
Use customization in displayed prices calculation

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5619,73 +5619,56 @@ class ProductCore extends ObjectModel
             $quantity = (int) $row['minimal_quantity'];
         }
 
-        // We save value in $priceTaxExcluded and $priceTaxIncluded before they may be rounded
-        $row['price_tax_exc'] = $priceTaxExcluded = Product::getPriceStatic(
-            (int) $row['id_product'],
-            false,
+        $specific_price_output = null;
+        $productId = (int) $row['id_product'];
+        $customizationId = key_exists('id_customization', $row) ? (int) $row['id_customization'] : null;
+
+        $getPrice = function (bool $useTax = true, int $decimals = 6, bool $useReduc = true) use (
+            $productId,
             $id_product_attribute,
-            (self::$_taxCalculationMethod == PS_TAX_EXC ? Context::getContext()->getComputingPrecision() : 6),
-            null,
+            $quantity,
+            $specific_price_output,
+            $customizationId
+        ): ?float {
+            return Product::getPriceStatic(
+                $productId,
+                $useTax,
+                $id_product_attribute,
+                $decimals,
+                null,
+                false,
+                $useReduc,
+                $quantity,
+                false,
+                null,
+                null,
+                null,
+                $specific_price_output,
+                true,
+                true,
+                null,
+                true,
+                $customizationId
+            );
+        };
+
+        // We save value in $priceTaxExcluded and $priceTaxIncluded before they may be rounded
+        $row['price_tax_exc'] = $priceTaxExcluded = $getPrice(
             false,
-            true,
-            $quantity
+            (self::$_taxCalculationMethod == PS_TAX_EXC ? Context::getContext()->getComputingPrecision() : 6)
         );
 
         if (self::$_taxCalculationMethod == PS_TAX_EXC) {
             $row['price_tax_exc'] = Tools::ps_round($priceTaxExcluded, Context::getContext()->getComputingPrecision());
-            $row['price'] = $priceTaxIncluded = Product::getPriceStatic(
-                (int) $row['id_product'],
-                true,
-                $id_product_attribute,
-                6,
-                null,
-                false,
-                true,
-                $quantity
-            );
+            $row['price'] = $priceTaxIncluded = $getPrice();
+
             $row['price_without_reduction'] =
-            $row['price_without_reduction_without_tax'] = Product::getPriceStatic(
-                (int) $row['id_product'],
-                false,
-                $id_product_attribute,
-                2,
-                null,
-                false,
-                false,
-                $quantity
-            );
+            $row['price_without_reduction_without_tax'] = $getPrice(false, 2, false);
         } else {
-            $priceTaxIncluded = Product::getPriceStatic(
-                (int) $row['id_product'],
-                true,
-                $id_product_attribute,
-                6,
-                null,
-                false,
-                true,
-                $quantity
-            );
+            $priceTaxIncluded = $getPrice();
             $row['price'] = Tools::ps_round($priceTaxIncluded, Context::getContext()->getComputingPrecision());
-            $row['price_without_reduction'] = Product::getPriceStatic(
-                (int) $row['id_product'],
-                true,
-                $id_product_attribute,
-                6,
-                null,
-                false,
-                false,
-                $quantity
-            );
-            $row['price_without_reduction_without_tax'] = Product::getPriceStatic(
-                (int) $row['id_product'],
-                false,
-                $id_product_attribute,
-                6,
-                null,
-                false,
-                false,
-                $quantity
-            );
+            $row['price_without_reduction'] = $getPrice(true, 6, false);
+            $row['price_without_reduction_without_tax'] = $getPrice(false, 6, false);
         }
 
         $row['reduction'] = Product::getPriceStatic(

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -1197,6 +1197,19 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
         $product['ecotax_tax_inc'] = $this->product->getEcotax(null, true, true);
         $product['ecotax'] = Tools::convertPrice($this->getProductEcotax($product), $this->context->currency, true, $this->context);
 
+        if ($product['customizable']) {
+            $customizations = $this->context->cart->getProductCustomization(
+                $product['id_product'],
+                null,
+                true
+            );
+
+            $product['id_customization'] = 0;
+            foreach ($customizations as $customization) {
+                $product['id_customization'] = $customization['id_customization'];
+            }
+        }
+
         $product_full = Product::getProductProperties($this->context->language->id, $product, $this->context);
 
         $product_full = $this->addProductCustomizationData($product_full);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use customization when calculating the prices to display. Useless for the core but useful for module developers when adding prices for customization fields.
| Type?             | improvement
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | #30849
| Related PRs       | N/A
| How to test?      | Customize a customizable product in FO and change its price in `customized_data` table. Refresh the page and customization price should be added to product initial price.
| Possible impacts? | None


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
