### PR TITLE
Added cache:clear after composer commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install: composer assets
 
 composer:
 	composer install
-	bin/console cache:clear --no-warmup
+	./bin/console cache:clear --no-warmup
 
 assets:
 	./tools/assets/build.sh

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ install: composer assets
 
 composer:
 	composer install
+	bin/console cache:clear --no-warmup
 
 assets:
 	./tools/assets/build.sh

--- a/composer.json
+++ b/composer.json
@@ -244,15 +244,6 @@
         ],
         "unit-tests": [
             "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml"
-        ],
-        "post-cmd": [
-          "bin/console cache:clear --no-warmup"
-        ],
-        "post-install-cmd": [
-          "@post-cmd"
-        ],
-        "post-update-cmd": [
-          "@post-cmd"
         ]
     },
     "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -244,6 +244,15 @@
         ],
         "unit-tests": [
             "@php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c tests/Unit/phpunit.xml"
+        ],
+        "post-cmd": [
+          "bin/console cache:clear --no-warmup"
+        ],
+        "post-install-cmd": [
+          "@post-cmd"
+        ],
+        "post-update-cmd": [
+          "@post-cmd"
         ]
     },
     "scripts-descriptions": {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Because we can have some issues after composer install, I think we should add `cache:clear` after composer commands in the Makefile. 
| Type?             | improvement 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Execute `make install` and check that cache is cleared. 
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | PrestaShop
