### PR TITLE
Add delete action to module manager

### DIFF
--- a/admin-dev/themes/new-theme/js/components/module-card.ts
+++ b/admin-dev/themes/new-theme/js/components/module-card.ts
@@ -50,8 +50,6 @@ const BOEvent = {
 
 /**
  * Class is responsible for handling Module Card behavior
- *
- * This is a port of admin-dev/themes/default/js/bundle/module/module_card.js
  */
 export default class ModuleCard {
   moduleActionMenuLinkSelector: string;
@@ -71,6 +69,8 @@ export default class ModuleCard {
   moduleActionMenuResetLinkSelector: string;
 
   moduleActionMenuUpdateLinkSelector: string;
+
+  moduleActionMenuDeleteLinkSelector: string;
 
   moduleItemListSelector: string;
 
@@ -97,6 +97,7 @@ export default class ModuleCard {
     this.moduleActionMenuDisableMobileLinkSelector = 'button.module_action_menu_disableMobile';
     this.moduleActionMenuResetLinkSelector = 'button.module_action_menu_reset';
     this.moduleActionMenuUpdateLinkSelector = 'button.module_action_menu_upgrade';
+    this.moduleActionMenuDeleteLinkSelector = 'button.module_action_menu_delete';
     this.moduleItemListSelector = '.module-item-list';
     this.moduleItemGridSelector = '.module-item-grid';
     this.moduleItemActionsSelector = '.module-actions';
@@ -158,6 +159,18 @@ export default class ModuleCard {
           self.dispatchPreEvent('uninstall', this)
           && self.confirmAction('uninstall', this)
           && self.requestToController('uninstall', $(this))
+        );
+      },
+    );
+
+    $(document).on(
+      'click',
+      this.moduleActionMenuDeleteLinkSelector,
+      function () {
+        return (
+          self.dispatchPreEvent('delete', this)
+          && self.confirmAction('delete', this)
+          && self.requestToController('delete', $(this))
         );
       },
     );

--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -904,6 +904,7 @@ class AdminModuleController {
       'bulk-disable-mobile': 'disableMobile',
       'bulk-enable-mobile': 'enableMobile',
       'bulk-reset': 'reset',
+      'bulk-delete': 'delete',
     };
 
     // Note no grid selector used yet since we do not needed it at dev time

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -58,6 +58,7 @@ class AdminModuleDataProvider implements ModuleInterface
         Module::ACTION_RESET => 'Admin.Actions',
         Module::ACTION_UPGRADE => 'Admin.Actions',
         Module::ACTION_CONFIGURE => 'Admin.Actions',
+        Module::ACTION_DELETE => 'Admin.Actions',
     ];
 
     /**
@@ -73,6 +74,7 @@ class AdminModuleDataProvider implements ModuleInterface
         Module::ACTION_RESET => 'Reset',
         Module::ACTION_UPGRADE => 'Upgrade',
         Module::ACTION_CONFIGURE => 'Configure',
+        Module::ACTION_DELETE => 'Delete',
     ];
 
     /**
@@ -88,6 +90,7 @@ class AdminModuleDataProvider implements ModuleInterface
         Module::ACTION_DISABLE,
         Module::ACTION_RESET,
         Module::ACTION_UNINSTALL,
+        Module::ACTION_DELETE,
     ];
 
     /**
@@ -194,6 +197,10 @@ class AdminModuleDataProvider implements ModuleInterface
             return $this->employee->can('add', 'AdminModulessf');
         }
 
+        if ('delete' === $action) {
+            return $this->employee->can('delete', 'AdminModulessf');
+        }
+
         if ('uninstall' === $action) {
             return $this->employee->can('delete', 'AdminModulessf') && $this->moduleProvider->can('uninstall', $name);
         }
@@ -202,6 +209,9 @@ class AdminModuleDataProvider implements ModuleInterface
     }
 
     /**
+     * Generates a list with actions and their respective URLs, depending on if the module is installed or not,
+     * enabled, upgradable and other variables.
+     *
      * @param ModuleCollection $modules
      * @param string|null $specific_action
      *
@@ -214,6 +224,7 @@ class AdminModuleDataProvider implements ModuleInterface
             $moduleAttributes = $module->getAttributes();
             $moduleDatabaseAttributes = $module->getDatabaseAttributes();
 
+            // Generate target URL for each action we offer
             foreach ($this->moduleActions as $action) {
                 if ($action === 'configure') {
                     $urls[$action] = $this->router->generate('admin_module_configure_action', [
@@ -227,8 +238,10 @@ class AdminModuleDataProvider implements ModuleInterface
                 ]);
             }
 
+            // Let's filter the actions depending on conditions the module is in
             if ($module->isInstalled()) {
                 unset($urls['install']);
+                unset($urls['delete']);
                 if (!$module->isActive()) {
                     unset(
                         $urls['disable'],
@@ -253,9 +266,14 @@ class AdminModuleDataProvider implements ModuleInterface
                     unset($urls['configure']);
                 }
             } else {
-                $urls = ['install' => $urls['install']];
+                $urls = [
+                    'install' => $urls['install'],
+                    'delete' => $urls['delete'],
+                ];
             }
 
+            // Go through the actions and remove all actions that the current environment
+            // doesn't have rights for.
             $filteredUrls = $this->filterAllowedActions($urls, $moduleAttributes->get('name'));
 
             if ($specific_action && array_key_exists($specific_action, $filteredUrls)) {

--- a/src/Adapter/Module/Module.php
+++ b/src/Adapter/Module/Module.php
@@ -48,6 +48,7 @@ class Module implements ModuleInterface
     public const ACTION_RESET = 'reset';
     public const ACTION_UPGRADE = 'upgrade';
     public const ACTION_CONFIGURE = 'configure';
+    public const ACTION_DELETE = 'delete';
 
     /**
      * @var LegacyModule Module The instance of the legacy module

--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -161,6 +161,26 @@ class ModuleManager implements ModuleManagerInterface
         return $uninstalled;
     }
 
+    public function delete(string $name): bool
+    {
+        if (!$this->adminModuleDataProvider->isAllowedAccess(__FUNCTION__, $name)) {
+            throw new Exception($this->translator->trans(
+                'You are not allowed to delete the module %module%.',
+                ['%module%' => $name],
+                'Admin.Modules.Notification'
+            ));
+        }
+
+        $module = $this->moduleRepository->getModule($name);
+
+        $path = $this->moduleRepository->getModulePath($name);
+        $this->filesystem->remove($path);
+
+        $this->dispatch(ModuleManagementEvent::DELETE, $module);
+
+        return true;
+    }
+
     public function upgrade(string $name, $source = null): bool
     {
         if (!$this->adminModuleDataProvider->isAllowedAccess(__FUNCTION__, $name)) {

--- a/src/Core/Module/ModuleManagerInterface.php
+++ b/src/Core/Module/ModuleManagerInterface.php
@@ -26,6 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Core\Module;
 
+/**
+ * @method delete(string $name) will be added in 9.0
+ */
 interface ModuleManagerInterface
 {
     /**
@@ -49,8 +52,6 @@ interface ModuleManagerInterface
     public function disableMobile(string $name): bool;
 
     public function reset(string $name, bool $keepData = false): bool;
-
-    public function delete(string $name): bool;
 
     public function postInstall(string $name): bool;
 

--- a/src/Core/Module/ModuleManagerInterface.php
+++ b/src/Core/Module/ModuleManagerInterface.php
@@ -50,6 +50,8 @@ interface ModuleManagerInterface
 
     public function reset(string $name, bool $keepData = false): bool;
 
+    public function delete(string $name): bool;
+
     public function postInstall(string $name): bool;
 
     public function isInstalled(string $name): bool;

--- a/src/PrestaShopBundle/Command/ModuleCommand.php
+++ b/src/PrestaShopBundle/Command/ModuleCommand.php
@@ -50,6 +50,7 @@ class ModuleCommand extends Command
         'reset',
         'upgrade',
         'configure',
+        'delete',
     ];
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -77,6 +77,7 @@ class ModuleController extends ModuleAbstractController
             'bulk-reset' => $this->trans('Reset', 'Admin.Actions'),
             'bulk-enable-mobile' => $this->trans('Enable Mobile', 'Admin.Modules.Feature'),
             'bulk-disable-mobile' => $this->trans('Disable Mobile', 'Admin.Modules.Feature'),
+            'bulk-delete' => $this->trans('Delete', 'Admin.Modules.Feature'),
         ];
 
         return $this->render(
@@ -179,6 +180,9 @@ class ModuleController extends ModuleAbstractController
             case ModuleAdapter::ACTION_UNINSTALL:
                 $deniedAccess = $this->checkPermission(PageVoter::DELETE);
                 break;
+            case ModuleAdapter::ACTION_DELETE:
+                $deniedAccess = $this->checkPermission(PageVoter::DELETE);
+                break;
 
             default:
                 $deniedAccess = null;
@@ -212,6 +216,9 @@ class ModuleController extends ModuleAbstractController
             if ($action === ModuleAdapter::ACTION_UNINSTALL) {
                 $args[] = (bool) ($request->request->get('actionParams', [])['deletion'] ?? false);
                 $response[$module]['refresh_needed'] = $this->moduleNeedsReload($moduleRepository->getModule($module));
+            }
+            if ($action === ModuleAdapter::ACTION_DELETE) {
+                $response[$module]['refresh_needed'] = false;
             }
             $systemCacheClearEnabled = filter_var(
                 $request->request->get('actionParams', [])['cacheClearEnabled'] ?? true,
@@ -249,7 +256,7 @@ class ModuleController extends ModuleAbstractController
                     '%module%' => $module,
                 ]
             );
-            if ($action !== 'uninstall') {
+            if ($action !== 'uninstall' && $action !== 'delete') {
                 $response[$module]['module_name'] = $module;
                 $response[$module]['is_configurable'] = (bool) $moduleInstance->attributes->get('is_configurable');
             }

--- a/src/PrestaShopBundle/Event/ModuleManagementEvent.php
+++ b/src/PrestaShopBundle/Event/ModuleManagementEvent.php
@@ -40,6 +40,7 @@ class ModuleManagementEvent extends Event
     public const DISABLE_MOBILE = 'module.disable.mobile';
     public const UPGRADE = 'module.upgrade';
     public const RESET = 'module.reset';
+    public const DELETE = 'module.delete';
 
     /** @var ModuleInterface */
     private $module;

--- a/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/improve/modules/_modules.yml
@@ -16,7 +16,7 @@ admin_module_manage_action:
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Improve\ModuleController::moduleAction
   requirements:
-    action: install|uninstall|enable|disable|enableMobile|disableMobile|reset|upgrade
+    action: install|uninstall|enable|disable|enableMobile|disableMobile|reset|upgrade|delete
 
 admin_module_configure_action:
   path: /manage/action/configure/{module_name}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds an option to delete an uninstalled module. Before, you had to install it and uninstall again with "delete" checkbox enabled in the modal. Also working for bulk actions. Keeping a PM label, we talked about it on Slack with @MatShir once and he didn't even knew that this was not implemented. :-)
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Uninstall a module without deleting, refresh page. See that you can now delete the module from disk right away.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | [TRENDO s.r.o.](https://www.trendo.cz)

### For QA, there are known issue that will be fixed in another PR. They are in current develop, not caused by this PR.
- https://github.com/PrestaShop/PrestaShop/issues/30952
- https://github.com/PrestaShop/PrestaShop/issues/30953

### How does it look
![delete](https://user-images.githubusercontent.com/6097524/213472150-645d00f8-ff02-4f06-8c7f-b9ae9242b2b1.jpg)
