### PR TITLE
check if feature['feature'] is empty when saving product in BO to avoid duplicate features

### DIFF
--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -901,6 +901,9 @@ class AdminProductsControllerCore extends AdminController
                 $features = isset($form['step1']['features']) ? $form['step1']['features'] : [];
                 if (is_array($features)) {
                     foreach ($features as $feature) {
+                        if (empty($feature['feature'])) {
+                            continue;
+                        }
                         if (!empty($feature['value'])) {
                             $product->addFeaturesToDB($feature['feature'], $feature['value']);
                         } elseif ($defaultValue = $this->checkFeatures($languages, $feature)) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix the duplication issue when saving a product with features without feature selected. Check #16306 for more infos and videos.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | No
| Deprecations?     | No
| How to test?      | Try to save a product with features without any feature selected in the dropdown.<br>**Note for QA** this PR only fixes the issue on product page V1 so it can be tested and merged if validated, but **the issue must be kept open** so that we handle a different fix for V2
| Fixed ticket?     | Fixes #16306
| Related PRs       | None
| Sponsor company   | None

Tested in 1.7.8.7.

Note : it might be useful to update the deleteFeatures() function in Product class, to delete "empty features". Because of the LEFT JOIN with the ps_feature_shop table, they do not show up and therefore are not deleted. So when saving, it keep the old ones and add the new ones as well.

I can update this PR if necessary.

Also, this fix should be deploy on other version of Prestashop, especially 1.7.8.x, 1.7.7.x and older.
