### PR TITLE
Remove the Cart in DB when the user clears it in FO

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -1856,6 +1856,9 @@ class CartCore extends ObjectModel
         bool $preserveGiftsRemoval = true,
         bool $useOrderPrices = false
     ) {
+        if(!count(self::$_nbProducts)){
+            return self::delete();
+        }
         if (isset(self::$_nbProducts[$this->id])) {
             unset(self::$_nbProducts[$this->id]);
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the normal user flow, it is not being considered to remove the shopping carts that are cleaned by the same users. They appear at $0.00 in the BO cart list, even in the 8.x demo. I suggest a minor change to improve the shopping cart list, recommended by the experience of our team users. ![image](https://user-images.githubusercontent.com/108596802/212759236-9eded7b9-062d-4146-8421-509b81125515.png)
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add a product to your cart (doesn't matter if you are logged in), then delete it. In BO it should no longer appear.
| Sponsor company   | [Certerus](https://certerus.com)
