### PR TITLE
Remove invalid CartRules in front office

### DIFF
--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -1732,7 +1732,7 @@ class CartRuleCore extends ObjectModel
             return [];
         }
 
-        static $errors = [];
+        $errors = [];
         $now = time();
         foreach ($context->cart->getCartRules(CartRule::FILTER_ACTION_ALL, true, $useOrderPrice) as $cart_rule) {
             if ($error = $cart_rule['obj']->checkValidity($context, true, true, true, $useOrderPrice)) {

--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -90,6 +90,8 @@ class CartControllerCore extends FrontController
                 $this->errors[] = $isAvailable;
             }
         }
+
+        CartRule::autoRemoveFromCart();
     }
 
     /**

--- a/controllers/front/OrderController.php
+++ b/controllers/front/OrderController.php
@@ -73,6 +73,7 @@ class OrderControllerCore extends FrontController
     {
         parent::init();
         $this->cartChecksum = new CartChecksum(new AddressChecksum());
+        CartRule::autoRemoveFromCart();
     }
 
     public function postProcess()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In the front office, we need to check for the CartRule validity at every step of the checkout
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | follow issue
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/19393
| Related PRs       | n/a
| Sponsor company   | PrestaShop SA

Inside `CartRule::checkValidity`, these additional checks are not performed if the voucher is already in the cart. I can understand the reasoning (we don't want to have them removed somewhere inside BO, for example). To make the fix safe, I've added them to the method that removes invalid CartRules from the shopping cart. 
