### PR TITLE
Fix a typo in the profiler

### DIFF
--- a/tools/profiling/templates/run.tpl
+++ b/tools/profiling/templates/run.tpl
@@ -39,7 +39,7 @@
 
       {foreach from=$run.profiler item=row}
         {if $row['block'] == 'checkAccess' && $row['time'] == $last['time']}
-          {$continue}
+          {continue}
         {/if}
 
         <tr>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Sometimes, when you enable profiler, you may see a warning that {$continue} is undefined, it's obviously a typo
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You may want to try to reproduce it but as you can see in the code there's no guarantee you'll be able to ;) IMHO no need for it
| Fixed ticket?     | n/a
| Related PRs       | n/a
| Sponsor company   | PrestaShop SA
