### PR TITLE
Error 500 fix for Admin Categories If description null

### DIFF
--- a/src/Core/Grid/Data/Factory/AbstractCategoryDataFactory.php
+++ b/src/Core/Grid/Data/Factory/AbstractCategoryDataFactory.php
@@ -74,7 +74,7 @@ abstract class AbstractCategoryDataFactory implements GridDataFactoryInterface
     protected function modifyRecords(array $records): array
     {
         foreach ($records as $key => $record) {
-            if($record['description'] !== null) {
+            if ($record['description'] !== null) {
                 $records[$key]['description'] = mb_substr(strip_tags(stripslashes($record['description'])), 0, self::DESCRIPTION_MAX_LENGTH);
             }
         }

--- a/src/Core/Grid/Data/Factory/AbstractCategoryDataFactory.php
+++ b/src/Core/Grid/Data/Factory/AbstractCategoryDataFactory.php
@@ -74,7 +74,9 @@ abstract class AbstractCategoryDataFactory implements GridDataFactoryInterface
     protected function modifyRecords(array $records): array
     {
         foreach ($records as $key => $record) {
-            $records[$key]['description'] = mb_substr(strip_tags(stripslashes($record['description'])), 0, self::DESCRIPTION_MAX_LENGTH);
+            if($record['description'] !== null) {
+                $records[$key]['description'] = mb_substr(strip_tags(stripslashes($record['description'])), 0, self::DESCRIPTION_MAX_LENGTH);
+            }
         }
 
         return $records;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Error fix for stripslashes(): Argument #1 ($string) must be of type string, null given. The parameter is null after migration. Please can we use the if condition and check if it's not null? Because if it is null gives a 500 error.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Error may happen after migration, to be tested by a dev
| Fixed ticket?     | n/a
