### PR TITLE
Simplify stock_threshold_alert field in UpdateProductCommand and UpdateCombinationCommand

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/combination/bulk.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/bulk.ts
@@ -26,6 +26,7 @@
 import ImageSelector from '@pages/product/combination/form/image-selector';
 import QuantityModeSwitcher from '@pages/product/combination/quantity-mode-switcher';
 import CombinationFormMapping from '@pages/product/combination/form/combination-form-mapping';
+import FormFieldToggler from '@components/form/form-field-toggler';
 
 // @ts-ignore
 const {$} = window;
@@ -41,6 +42,13 @@ $(() => {
   ]);
   new ImageSelector();
   new QuantityModeSwitcher();
+
+  // DisablingSwitch is already used in low_stock_alert field to decide if form field is intended to be updated or not
+  // so we toggle low_stock_threshold availability by low_stock_alert field here by initiating toggler manually.
+  new FormFieldToggler({
+    disablingInputSelector: 'input[name="bulk_combination[stock][low_stock_threshold][low_stock_alert]"]',
+    targetSelector: '#bulk_combination_stock_low_stock_threshold_threshold_value',
+  });
 
   const priceExcludedTaxId = CombinationFormMapping['price.excludedTaxId'];
   const priceIncludedTaxId = CombinationFormMapping['price.includedTaxId'];

--- a/src/Adapter/Product/Combination/Update/Filler/StockInformationFiller.php
+++ b/src/Adapter/Product/Combination/Update/Filler/StockInformationFiller.php
@@ -62,19 +62,17 @@ class StockInformationFiller implements CombinationFillerInterface
             $updatableProperties[] = 'available_date';
         }
 
-        if (null !== $command->getLowStockThreshold()) {
-            $combination->low_stock_threshold = $command->getLowStockThreshold();
+        $lowStockThreshold = $command->getLowStockThreshold();
+        if (null !== $lowStockThreshold) {
+            $combination->low_stock_threshold = $lowStockThreshold->getValue();
+            $combination->low_stock_alert = $lowStockThreshold->isEnabled();
             $updatableProperties[] = 'low_stock_threshold';
+            $updatableProperties[] = 'low_stock_alert';
         }
 
         if (null !== $command->getMinimalQuantity()) {
             $combination->minimal_quantity = $command->getMinimalQuantity();
             $updatableProperties[] = 'minimal_quantity';
-        }
-
-        if (null !== $command->isLowStockAlertEnabled()) {
-            $combination->low_stock_alert = $command->isLowStockAlertEnabled();
-            $updatableProperties[] = 'low_stock_alert';
         }
 
         return $updatableProperties;

--- a/src/Adapter/Product/Update/Filler/StockInformationFiller.php
+++ b/src/Adapter/Product/Update/Filler/StockInformationFiller.php
@@ -61,14 +61,19 @@ class StockInformationFiller implements ProductFillerInterface
             $product->available_now = $localizedNowLabels;
             $updatableProperties['available_now'] = array_keys($localizedNowLabels);
         }
-        if (null !== $command->isLowStockAlertEnabled()) {
-            $product->low_stock_alert = $command->isLowStockAlertEnabled();
+        if (null !== $command->getLowStockThreshold()) {
+            $product->low_stock_alert = $command->getLowStockThreshold()->isEnabled();
             $updatableProperties[] = 'low_stock_alert';
         }
-        if (null !== $command->getLowStockThreshold()) {
-            $product->low_stock_threshold = $command->getLowStockThreshold();
+
+        $lowStockThreshold = $command->getLowStockThreshold();
+        if (null !== $lowStockThreshold) {
+            $product->low_stock_threshold = $lowStockThreshold->getValue();
+            $product->low_stock_alert = $lowStockThreshold->isEnabled();
             $updatableProperties[] = 'low_stock_threshold';
+            $updatableProperties[] = 'low_stock_alert';
         }
+
         if (null !== $command->getMinimalQuantity()) {
             $product->minimal_quantity = $command->getMinimalQuantity();
             $updatableProperties[] = 'minimal_quantity';

--- a/src/Adapter/Product/Update/Filler/StockInformationFiller.php
+++ b/src/Adapter/Product/Update/Filler/StockInformationFiller.php
@@ -61,10 +61,6 @@ class StockInformationFiller implements ProductFillerInterface
             $product->available_now = $localizedNowLabels;
             $updatableProperties['available_now'] = array_keys($localizedNowLabels);
         }
-        if (null !== $command->getLowStockThreshold()) {
-            $product->low_stock_alert = $command->getLowStockThreshold()->isEnabled();
-            $updatableProperties[] = 'low_stock_alert';
-        }
 
         $lowStockThreshold = $command->getLowStockThreshold();
         if (null !== $lowStockThreshold) {

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
@@ -32,6 +32,7 @@ use DateTimeInterface;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\ValueObject\CombinationId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\LowStockThreshold;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Isbn;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Reference;
@@ -114,14 +115,9 @@ class UpdateCombinationCommand
     private $minimalQuantity;
 
     /**
-     * @var int|null
+     * @var LowStockThreshold|null
      */
     private $lowStockThreshold;
-
-    /**
-     * @var bool|null
-     */
-    private $lowStockAlertEnabled;
 
     /**
      * @var DateTimeInterface|null
@@ -405,9 +401,9 @@ class UpdateCombinationCommand
     }
 
     /**
-     * @return int|null
+     * @return LowStockThreshold|null
      */
-    public function getLowStockThreshold(): ?int
+    public function getLowStockThreshold(): ?LowStockThreshold
     {
         return $this->lowStockThreshold;
     }
@@ -419,7 +415,7 @@ class UpdateCombinationCommand
      */
     public function setLowStockThreshold(int $lowStockThreshold): self
     {
-        $this->lowStockThreshold = $lowStockThreshold;
+        $this->lowStockThreshold = new LowStockThreshold($lowStockThreshold);
 
         return $this;
     }

--- a/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
+++ b/src/Core/Domain/Product/Combination/Command/UpdateCombinationCommand.php
@@ -421,26 +421,6 @@ class UpdateCombinationCommand
     }
 
     /**
-     * @return bool|null
-     */
-    public function isLowStockAlertEnabled(): ?bool
-    {
-        return $this->lowStockAlertEnabled;
-    }
-
-    /**
-     * @param bool $enabled
-     *
-     * @return $this
-     */
-    public function setLowStockAlert(bool $enabled): self
-    {
-        $this->lowStockAlertEnabled = $enabled;
-
-        return $this;
-    }
-
-    /**
      * @return DateTimeInterface|null
      */
     public function getAvailableDate(): ?DateTimeInterface
@@ -458,14 +438,6 @@ class UpdateCombinationCommand
         $this->availableDate = $availableDate;
 
         return $this;
-    }
-
-    /**
-     * @return bool|null
-     */
-    public function getLowStockAlertEnabled(): ?bool
-    {
-        return $this->lowStockAlertEnabled;
     }
 
     /**

--- a/src/Core/Domain/Product/Command/UpdateProductCommand.php
+++ b/src/Core/Domain/Product/Command/UpdateProductCommand.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\UpdateProductHandle
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Exception\ProductPackConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\LowStockThreshold;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Dimension;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\Ean13;
@@ -251,14 +252,9 @@ class UpdateProductCommand
     private $minimalQuantity;
 
     /**
-     * @var int|null
+     * @var LowStockThreshold|null
      */
     private $lowStockThreshold;
-
-    /**
-     * @var bool|null
-     */
-    private $lowStockAlertEnabled;
 
     /**
      * @var string[]|null key value pairs where key is the id of language
@@ -1035,9 +1031,9 @@ class UpdateProductCommand
     }
 
     /**
-     * @return int|null
+     * @return LowStockThreshold|null
      */
-    public function getLowStockThreshold(): ?int
+    public function getLowStockThreshold(): ?LowStockThreshold
     {
         return $this->lowStockThreshold;
     }
@@ -1049,27 +1045,7 @@ class UpdateProductCommand
      */
     public function setLowStockThreshold(int $lowStockThreshold): self
     {
-        $this->lowStockThreshold = $lowStockThreshold;
-
-        return $this;
-    }
-
-    /**
-     * @return bool|null
-     */
-    public function isLowStockAlertEnabled(): ?bool
-    {
-        return $this->lowStockAlertEnabled;
-    }
-
-    /**
-     * @param bool $enabled
-     *
-     * @return self
-     */
-    public function setLowStockAlert(bool $enabled): self
-    {
-        $this->lowStockAlertEnabled = $enabled;
+        $this->lowStockThreshold = new LowStockThreshold($lowStockThreshold);
 
         return $this;
     }

--- a/src/Core/Domain/Product/Stock/ValueObject/LowStockThreshold.php
+++ b/src/Core/Domain/Product/Stock/ValueObject/LowStockThreshold.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject;
+
+class LowStockThreshold
+{
+    /**
+     * Represents a value when low stock alert is considered disabled, therefore the threshold is irrelevant
+     */
+    public const DISABLED_VALUE = 0;
+
+    /**
+     * @var int
+     */
+    private $value;
+
+    public function __construct(
+        int $thresholdValue
+    ) {
+        $this->value = $thresholdValue;
+    }
+
+    /**
+     * @return int
+     */
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this::DISABLED_VALUE !== $this->value;
+    }
+}

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilder.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilder;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\CommandBuilderConfig;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\DataField;
+use PrestaShopBundle\Form\Admin\Extension\DisablingSwitchExtension;
 
 /**
  * This command builder builds the unified UpdateCombinationCommand which includes many sub scopes of the combination
@@ -68,7 +69,7 @@ class UpdateCombinationCommandsBuilder implements MultiShopCombinationCommandsBu
         $this
             ->configurePriceImpact($config)
             ->configureDetails($config)
-            ->configureStock($config)
+            ->configureStock($config, $formData)
         ;
 
         $commandBuilder = new CommandBuilder($config);
@@ -104,16 +105,29 @@ class UpdateCombinationCommandsBuilder implements MultiShopCombinationCommandsBu
         return $this;
     }
 
-    private function configureStock(CommandBuilderConfig $config): self
+    private function configureStock(CommandBuilderConfig $config, array $formData): self
     {
         $config
             ->addMultiShopField('[stock][quantities][minimal_quantity]', 'setMinimalQuantity', DataField::TYPE_INT)
             ->addMultiShopField('[stock][options][low_stock_threshold]', 'setLowStockThreshold', DataField::TYPE_INT)
-            ->addMultiShopField('[stock][options][disabling_switch_low_stock_threshold]', 'setLowStockAlert', DataField::TYPE_BOOL)
             ->addMultiShopField('[stock][available_date]', 'setAvailableDate', DataField::TYPE_DATETIME)
             ->addField('[stock][available_now_label]', 'setLocalizedAvailableNowLabels', DataField::TYPE_ARRAY)
             ->addField('[stock][available_later_label]', 'setLocalizedAvailableLaterLabels', DataField::TYPE_ARRAY)
         ;
+
+        $lowStockThresholdSwitchKey = sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX);
+
+        if (
+            // if low stock threshold switch is falsy, then we must set lowStockThreshold to its disabled value
+            // which will end up being 0 after falsy bool to int conversion
+            isset($formData['stock']['options'][$lowStockThresholdSwitchKey]) &&
+            !$formData['stock']['options'][$lowStockThresholdSwitchKey]
+        ) {
+            $config->addMultiShopField(sprintf('[stock][options][%s]', $lowStockThresholdSwitchKey), 'setLowStockThreshold', DataField::TYPE_INT);
+        } else {
+            // else we simply set the low stock threshold value from the form
+            $config->addMultiShopField('[stock][options][low_stock_threshold]', 'setLowStockThreshold', DataField::TYPE_INT);
+        }
 
         return $this;
     }

--- a/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
+++ b/src/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatter.php
@@ -58,11 +58,8 @@ class BulkCombinationFormDataFormatter extends AbstractFormDataFormatter
             '[stock][fixed_quantity]' => '[stock][quantities][fixed_quantity]',
             '[stock][minimal_quantity]' => '[stock][quantities][minimal_quantity]',
             '[stock][stock_location]' => '[stock][options][stock_location]',
-            '[stock][low_stock_threshold]' => '[stock][options][low_stock_threshold]',
-            sprintf(
-                '[stock][%slow_stock_threshold]',
-                DisablingSwitchExtension::FIELD_PREFIX
-            ) => sprintf(
+            '[stock][low_stock_threshold][threshold_value]' => '[stock][options][low_stock_threshold]',
+            '[stock][low_stock_threshold][low_stock_alert]' => sprintf(
                 '[stock][options][%slow_stock_threshold]',
                 DisablingSwitchExtension::FIELD_PREFIX
             ),

--- a/src/Core/Form/IdentifiableObject/DataProvider/BulkCombinationFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/BulkCombinationFormDataProvider.php
@@ -27,8 +27,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\DataProvider;
 
-use PrestaShopBundle\Form\Admin\Extension\DisablingSwitchExtension;
-
 class BulkCombinationFormDataProvider implements FormDataProviderInterface
 {
     /**
@@ -47,8 +45,10 @@ class BulkCombinationFormDataProvider implements FormDataProviderInterface
                 'fixed_quantity' => 0,
                 'minimal_quantity' => 0,
                 'stock_location' => '',
-                'low_stock_threshold' => 0,
-                sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => false,
+                'low_stock_threshold' => [
+                    'threshold_value' => 0,
+                    'low_stock_alert' => false,
+                ],
                 'available_date' => '',
                 'available_now_label' => [],
                 'available_later_label' => [],

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/BulkCombinationStockType.php
@@ -32,7 +32,6 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Combination\CombinationSettings;
 use PrestaShopBundle\Form\Admin\Type\DatePickerType;
 use PrestaShopBundle\Form\Admin\Type\DeltaQuantityType;
-use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
@@ -40,7 +39,6 @@ use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
@@ -49,11 +47,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class BulkCombinationStockType extends TranslatorAwareType
 {
     /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
      * @var bool
      */
     private $stockManagementEnabled;
@@ -61,17 +54,14 @@ class BulkCombinationStockType extends TranslatorAwareType
     /**
      * @param TranslatorInterface $translator
      * @param array $locales
-     * @param RouterInterface $router
      * @param bool $stockManagementEnabled
      */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,
-        RouterInterface $router,
         bool $stockManagementEnabled
     ) {
         parent::__construct($translator, $locales);
-        $this->router = $router;
         $this->stockManagementEnabled = $stockManagementEnabled;
     }
 
@@ -121,37 +111,8 @@ class BulkCombinationStockType extends TranslatorAwareType
                 'disabling_switch' => true,
                 'modify_all_shops' => true,
             ])
-            ->add('low_stock_threshold', NumberType::class, [
-                'label' => $this->trans('Low stock level', 'Admin.Catalog.Feature'),
-                'constraints' => [
-                    new Type(['type' => 'numeric']),
-                ],
-                'required' => false,
-                // These two options allow to have a default data equals to zero but displayed as empty string
-                'default_empty_data' => 0,
-                'empty_view_data' => null,
-                'modify_all_shops' => true,
-                'disabling_switch' => true,
-            ])
-            ->add('low_stock_alert', SwitchType::class, [
-                'required' => false,
-                'label' => $this->trans(
-                    'Receive a low stock alert by email',
-                    'Admin.Catalog.Feature'
-                ),
-                'label_help_box' => $this->trans(
-                    'The email will be sent to all users who have access to the Stock page. To modify permissions, go to [1]Advanced Parameters > Team[/1].',
-                    'Admin.Catalog.Help',
-                    [
-                        '[1]' => sprintf(
-                            '<a target="_blank" href="%s">',
-                            $this->router->generate('admin_employees_index')
-                        ),
-                        '[/1]' => '</a>',
-                    ]
-                ),
-                'disabling_switch' => true,
-                'modify_all_shops' => true,
+            ->add('low_stock_threshold', LowStockThresholdType::class, [
+                'label' => false,
             ])
             ->add('available_date', DatePickerType::class, [
                 'label' => $this->trans('Availability date', 'Admin.Catalog.Feature'),

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/LowStockThresholdType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/LowStockThresholdType.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
+
+use PrestaShopBundle\Form\Admin\Type\SwitchType;
+use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class LowStockThresholdType extends TranslatorAwareType
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        RouterInterface $router
+    ) {
+        parent::__construct($translator, $locales);
+        $this->router = $router;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('low_stock_alert', SwitchType::class, [
+                'show_choices' => false,
+                'required' => false,
+                'label' => $this->trans(
+                    'Receive a low stock alert by email',
+                    'Admin.Catalog.Feature'
+                ),
+                'label_help_box' => $this->trans(
+                    'The email will be sent to all users who have access to the Stock page. To modify permissions, go to [1]Advanced Parameters > Team[/1].',
+                    'Admin.Catalog.Help',
+                    [
+                        '[1]' => sprintf(
+                            '<a target="_blank" href="%s">',
+                            $this->router->generate('admin_employees_index')
+                        ),
+                        '[/1]' => '</a>',
+                    ]
+                ),
+                'disabling_switch' => true,
+                'disabled_value' => false,
+                'modify_all_shops' => true,
+            ])
+            ->add('threshold_value', NumberType::class, [
+                'label' => false,
+                'constraints' => [
+                    new Type(['type' => 'numeric']),
+                ],
+                'required' => false,
+                // These two options allow to have a default data equals to zero but displayed as empty string
+                'default_empty_data' => 0,
+                'empty_view_data' => null,
+                'modify_all_shops' => true,
+                'attr' => [
+                    'class' => 'small-input',
+                ],
+            ]);
+    }
+}

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1954,8 +1954,15 @@ services:
     tags:
       - { name: form.type }
 
-  form.type.sell.product.combination.bulk_combination_stock_type:
-    class: 'PrestaShopBundle\Form\Admin\Sell\Product\Combination\BulkCombinationStockType'
+  PrestaShopBundle\Form\Admin\Sell\Product\Combination\BulkCombinationStockType:
+    parent: 'form.type.translatable.aware'
+    public: true
+    arguments:
+      - "@=service('prestashop.adapter.legacy.configuration').getBoolean('PS_STOCK_MANAGEMENT')"
+    tags:
+      - { name: form.type }
+
+  PrestaShopBundle\Form\Admin\Sell\Product\Combination\LowStockThresholdType:
     parent: 'form.type.translatable.aware'
     public: true
     arguments:

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationFeatureContext.php
@@ -175,9 +175,6 @@ class UpdateCombinationFeatureContext extends AbstractCombinationFeatureContext
         if (isset($dataRows['low stock threshold'])) {
             $command->setLowStockThreshold((int) $dataRows['low stock threshold']);
         }
-        if (isset($dataRows['low stock alert is enabled'])) {
-            $command->setLowStockAlert(PrimitiveUtils::castStringBooleanIntoBoolean($dataRows['low stock alert is enabled']));
-        }
         if (isset($dataRows['available date'])) {
             $command->setAvailableDate(new DateTime($dataRows['available date']));
         }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProductFeatureContext.php
@@ -400,9 +400,6 @@ class UpdateProductFeatureContext extends AbstractProductFeatureContext
         if (isset($data['low_stock_threshold'])) {
             $command->setLowStockThreshold((int) $data['low_stock_threshold']);
         }
-        if (isset($data['low_stock_alert'])) {
-            $command->setLowStockAlert(PrimitiveUtils::castStringBooleanIntoBoolean($data['low_stock_alert']));
-        }
         if (isset($data['available_now_labels'])) {
             $command->setLocalizedAvailableNowLabels($data['available_now_labels']);
         }

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
@@ -57,13 +57,13 @@ Feature: Copy product from shop to shop.
     Then product productWithPrices is associated to shop shop1
     And default shop for product productWithPrices is shop1
     When I update product "productWithPrices" with following values:
-      | price              | 100.99          |
-      | ecotax             | 0               |
-      | tax rules group    | US-AL Rate (4%) |
-      | on_sale            | true            |
-      | wholesale_price    | 70              |
-      | unit_price         | 10              |
-      | unity              | bag of ten      |
+      | price           | 100.99          |
+      | ecotax          | 0               |
+      | tax rules group | US-AL Rate (4%) |
+      | on_sale         | true            |
+      | wholesale_price | 70              |
+      | unit_price      | 10              |
+      | unity           | bag of ten      |
     Then product productWithPrices should have following prices information for shops "shop1":
       | price              | 100.99          |
       | price_tax_included | 105.0296        |
@@ -96,13 +96,13 @@ Feature: Copy product from shop to shop.
     And product productWithPrices is not associated to shop shop4
     # Now modify and copy the values but this time the shop is already associated so it is an update
     When I update product "productWithPrices" with following values:
-      | price              | 200.99            |
-      | ecotax             | 2                 |
-      | tax rules group    | US-AZ Rate (6.6%) |
-      | on_sale            | false             |
-      | wholesale_price    | 60                |
-      | unit_price         | 20                |
-      | unity              | bag of twenty     |
+      | price           | 200.99            |
+      | ecotax          | 2                 |
+      | tax rules group | US-AZ Rate (6.6%) |
+      | on_sale         | false             |
+      | wholesale_price | 60                |
+      | unit_price      | 20                |
+      | unity           | bag of twenty     |
     Then product productWithPrices should have following prices information for shops "shop1":
       | price              | 200.99            |
       | price_tax_included | 214.25534         |
@@ -151,8 +151,8 @@ Feature: Copy product from shop to shop.
       | description[en-US]       | nice mug           |
       | description_short[en-US] | Just a nice mug    |
     Then product "productWithBasic" localized "name" should be:
-      | locale     | value              |
-      | en-US      | photo of funny mug |
+      | locale | value              |
+      | en-US  | photo of funny mug |
     And product "productWithBasic" localized "description" should be:
       | locale | value    |
       | en-US  | nice mug |
@@ -168,8 +168,8 @@ Feature: Copy product from shop to shop.
     And product productWithBasic is associated to shop shop1
     And default shop for product productWithBasic is shop1
     Then product "productWithBasic" localized "name" for shops "shop1,shop2" should be:
-      | locale     | value              |
-      | en-US      | photo of funny mug |
+      | locale | value              |
+      | en-US  | photo of funny mug |
     And product "productWithBasic" localized "description" for shops "shop1,shop2" should be:
       | locale | value    |
       | en-US  | nice mug |
@@ -184,8 +184,8 @@ Feature: Copy product from shop to shop.
       | description[en-US]       | super mug          |
       | description_short[en-US] | Just a super mug   |
     Then product "productWithBasic" localized "name" for shops "shop1" should be:
-      | locale     | value              |
-      | en-US      | photo of super mug |
+      | locale | value              |
+      | en-US  | photo of super mug |
     And product "productWithBasic" localized "description" for shops "shop1" should be:
       | locale | value     |
       | en-US  | super mug |
@@ -193,8 +193,8 @@ Feature: Copy product from shop to shop.
       | locale | value            |
       | en-US  | Just a super mug |
     But product "productWithBasic" localized "name" for shops "shop2" should be:
-      | locale     | value              |
-      | en-US      | photo of funny mug |
+      | locale | value              |
+      | en-US  | photo of funny mug |
     And product "productWithBasic" localized "description" for shops "shop2" should be:
       | locale | value    |
       | en-US  | nice mug |
@@ -205,8 +205,8 @@ Feature: Copy product from shop to shop.
     When I copy product productWithBasic from shop shop1 to shop shop2
     Then product productWithBasic is associated to shop shop2
     And product "productWithBasic" localized "name" for shops "shop1,shop2" should be:
-      | locale     | value              |
-      | en-US      | photo of super mug |
+      | locale | value              |
+      | en-US  | photo of super mug |
     And product "productWithBasic" localized "description" for shops "shop1,shop2" should be:
       | locale | value     |
       | en-US  | super mug |
@@ -260,14 +260,13 @@ Feature: Copy product from shop to shop.
       | pack_stock_type               | pack_only    |
       | minimal_quantity              | 12           |
       | low_stock_threshold           | 42           |
-      | low_stock_alert               | true         |
       | available_now_labels[en-US]   | get it now   |
       | available_later_labels[en-US] | too late bro |
       | available_date                | 1969-07-16   |
     And I update product "productWithStock" stock with following information:
-      | out_of_stock_type             | available    |
-      | delta_quantity                | 42           |
-      | location                      | dtc          |
+      | out_of_stock_type | available |
+      | delta_quantity    | 42        |
+      | location          | dtc       |
     Then product "productWithStock" should have following stock information for shops "shop1":
       | pack_stock_type     | pack_only  |
       | out_of_stock_type   | available  |
@@ -316,15 +315,14 @@ Feature: Copy product from shop to shop.
     When I update product "productWithStock" for shop shop1 with following values:
       | pack_stock_type               | products_only |
       | minimal_quantity              | 24            |
-      | low_stock_threshold           | 51            |
-      | low_stock_alert               | false         |
+      | low_stock_threshold           | 0             |
       | available_now_labels[en-US]   | hurry up      |
       | available_later_labels[en-US] | too slow...   |
       | available_date                | 1969-09-16    |
     When I update product "productWithStock" stock for shop shop1 with following information:
-      | out_of_stock_type             | not_available |
-      | delta_quantity                | 69            |
-      | location                      | upa           |
+      | out_of_stock_type | not_available |
+      | delta_quantity    | 69            |
+      | location          | upa           |
     # First only one shop is updated
     Then product "productWithStock" should have following stock information for shops "shop1":
       | pack_stock_type     | products_only |
@@ -332,7 +330,7 @@ Feature: Copy product from shop to shop.
       | quantity            | 111           |
       | minimal_quantity    | 24            |
       | location            | upa           |
-      | low_stock_threshold | 51            |
+      | low_stock_threshold | 0             |
       | low_stock_alert     | false         |
       | available_date      | 1969-09-16    |
     And product "productWithStock" localized "available_now_labels" for shops "shop1" should be:
@@ -370,7 +368,7 @@ Feature: Copy product from shop to shop.
       | quantity            | 111           |
       | minimal_quantity    | 24            |
       | location            | upa           |
-      | low_stock_threshold | 51            |
+      | low_stock_threshold | 0             |
       | low_stock_alert     | false         |
       | available_date      | 1969-09-16    |
     And product "productWithStock" localized "available_now_labels" for shops "shop1,shop2" should be:
@@ -412,17 +410,17 @@ Feature: Copy product from shop to shop.
     And I add new image "image2" named "some_image.jpg" to product "graphicProduct" for shop "shop1"
     And I copy product graphicProduct from shop shop1 to shop shop2
     Then product "graphicProduct" should have following images for shop "shop1":
-      | image reference |  position | shops        |
-      | image1          |  1        | shop1, shop2 |
-      | image2          |  2        | shop1, shop2 |
+      | image reference | position | shops        |
+      | image1          | 1        | shop1, shop2 |
+      | image2          | 2        | shop1, shop2 |
     And product "graphicProduct" should have following images for shop "shop2":
-      | image reference |  position | shops        |
-      | image1          |  1        | shop1, shop2 |
-      | image2          |  2        | shop1, shop2 |
+      | image reference | position | shops        |
+      | image1          | 1        | shop1, shop2 |
+      | image2          | 2        | shop1, shop2 |
     And product "graphicProduct" should have following images for shop "shop3":
-      | image reference |  position | shops        |
+      | image reference | position | shops |
     And product "graphicProduct" should have following images for shop "shop4":
-      | image reference |  position | shops        |
+      | image reference | position | shops |
     And following image types should be applicable to products:
       | reference     | name           | width | height |
       | cartDefault   | cart_default   | 125   | 125    |
@@ -443,26 +441,25 @@ Feature: Copy product from shop to shop.
       | pack_stock_type               | pack_only    |
       | minimal_quantity              | 12           |
       | low_stock_threshold           | 42           |
-      | low_stock_alert               | true         |
       | available_now_labels[en-US]   | get it now   |
       | available_later_labels[en-US] | too late bro |
       | available_date                | 1969-07-16   |
     And I update product "productToDelete" stock for shop shop2 with following information:
-      | out_of_stock_type             | available    |
-      | delta_quantity                | 42           |
-      | location                      | dtc          |
+      | out_of_stock_type | available |
+      | delta_quantity    | 42        |
+      | location          | dtc       |
     And I update product "productToDelete" for shop shop2 with following values:
       | name[en-US]              | photo of super mug |
       | description[en-US]       | super mug          |
       | description_short[en-US] | Just a super mug   |
     When I update product "productToDelete" for shop shop2 with following values:
-      | price              | 100.99          |
-      | ecotax             | 0               |
-      | tax rules group    | US-AL Rate (4%) |
-      | on_sale            | true            |
-      | wholesale_price    | 70              |
-      | unit_price         | 10              |
-      | unity              | bag of ten      |
+      | price           | 100.99          |
+      | ecotax          | 0               |
+      | tax rules group | US-AL Rate (4%) |
+      | on_sale         | true            |
+      | wholesale_price | 70              |
+      | unit_price      | 10              |
+      | unity           | bag of ten      |
     # Copy values to another shop which was not associated yet
     When I copy product productToDelete from shop shop2 to shop shop1
     And I copy product productToDelete from shop shop2 to shop shop3
@@ -472,8 +469,8 @@ Feature: Copy product from shop to shop.
     And product productToDelete is not associated to shop shop4
     And default shop for product productToDelete is shop2
     And product "productToDelete" localized "name" for shops "shop1,shop2,shop3" should be:
-      | locale     | value              |
-      | en-US      | photo of super mug |
+      | locale | value              |
+      | en-US  | photo of super mug |
     And product "productToDelete" localized "description" for shops "shop1,shop2,shop3" should be:
       | locale | value     |
       | en-US  | super mug |
@@ -533,8 +530,8 @@ Feature: Copy product from shop to shop.
     And default shop for product productToDelete is shop1
     # Check that values are still present for other shops
     And product "productToDelete" localized "name" for shops "shop1,shop3" should be:
-      | locale     | value              |
-      | en-US      | photo of super mug |
+      | locale | value              |
+      | en-US  | photo of super mug |
     And product "productToDelete" localized "description" for shops "shop1,shop3" should be:
       | locale | value     |
       | en-US  | super mug |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_stock.feature
@@ -29,7 +29,6 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | pack_stock_type               | pack_only    |
       | minimal_quantity              | 12           |
       | low_stock_threshold           | 42           |
-      | low_stock_alert               | true         |
       | available_now_labels[en-US]   | get it now   |
       | available_later_labels[en-US] | too late bro |
       | available_date                | 1969-07-16   |
@@ -66,8 +65,7 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
     When I update product "product1" for shop shop2 with following values:
       | pack_stock_type               | products_only |
       | minimal_quantity              | 24            |
-      | low_stock_threshold           | 51            |
-      | low_stock_alert               | false         |
+      | low_stock_threshold           | 0             |
       | available_now_labels[en-US]   | hurry up      |
       | available_later_labels[en-US] | too slow...   |
       | available_date                | 1969-09-16    |
@@ -81,7 +79,7 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | quantity            | 111           |
       | minimal_quantity    | 24            |
       | location            | upa           |
-      | low_stock_threshold | 51            |
+      | low_stock_threshold | 0             |
       | low_stock_alert     | false         |
       | available_date      | 1969-09-16    |
     And product "product1" localized "available_now_labels" for shops "shop2" should be:
@@ -125,8 +123,7 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
     When I update product "product1" for all shops with following values:
       | pack_stock_type               | products_only |
       | minimal_quantity              | 24            |
-      | low_stock_threshold           | 51            |
-      | low_stock_alert               | false         |
+      | low_stock_threshold           | 0             |
       | available_now_labels[en-US]   | hurry up      |
       | available_later_labels[en-US] | too slow...   |
       | available_date                | 1969-09-16    |
@@ -138,7 +135,7 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | out_of_stock_type   | not_available |
       | minimal_quantity    | 24            |
       | location            | upa           |
-      | low_stock_threshold | 51            |
+      | low_stock_threshold | 0             |
       | low_stock_alert     | false         |
       | available_date      | 1969-09-16    |
       | quantity            | 42            |
@@ -158,20 +155,19 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | pack_stock_type               | products_only |
       | minimal_quantity              | 24            |
       | low_stock_threshold           | 51            |
-      | low_stock_alert               | false         |
       | available_now_labels[en-US]   | hurry up      |
       | available_later_labels[en-US] | too slow...   |
       | available_date                | 1969-09-16    |
     And I update product "product1" stock for shop shop2 with following information:
-      | out_of_stock_type             | not_available |
-      | location                      | upa           |
+      | out_of_stock_type | not_available |
+      | location          | upa           |
     And I update product "product1" for all shops with following values:
       | pack_stock_type             | default  |
       | minimal_quantity            | 51       |
       | available_now_labels[en-US] | it is on |
     And I update product "product1" stock for all shops with following information:
-      | out_of_stock_type           | default  |
-      | location                    | surprise |
+      | out_of_stock_type | default  |
+      | location          | surprise |
     Then product "product1" should have following stock information for shops "shop2":
       | pack_stock_type     | default    |
       | out_of_stock_type   | default    |
@@ -179,7 +175,7 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | minimal_quantity    | 51         |
       | location            | surprise   |
       | low_stock_threshold | 51         |
-      | low_stock_alert     | false      |
+      | low_stock_alert     | true       |
       | available_date      | 1969-09-16 |
     And product "product1" localized "available_later_labels" for shops "shop2" should be:
       | locale | value       |
@@ -211,15 +207,14 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | minimal_quantity            | 51       |
       | available_now_labels[en-US] | it is on |
     And I update product "product1" stock for all shops with following information:
-      | out_of_stock_type           | default  |
-      | location                    | surprise |
+      | out_of_stock_type | default  |
+      | location          | surprise |
     And I update product "product1" for shop shop2 with following values:
       | pack_stock_type               | products_only |
       | out_of_stock_type             | not_available |
-      | low_stock_alert               | false         |
       | available_later_labels[en-US] | too slow...   |
     And I update product "product1" stock for shop shop2 with following information:
-      | out_of_stock_type             | not_available |
+      | out_of_stock_type | not_available |
     Then product "product1" should have following stock information for shops "shop2":
       | pack_stock_type     | products_only |
       | out_of_stock_type   | not_available |
@@ -227,7 +222,7 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | minimal_quantity    | 51            |
       | location            | surprise      |
       | low_stock_threshold | 42            |
-      | low_stock_alert     | false         |
+      | low_stock_alert     | true          |
       | available_date      | 1969-07-16    |
     And product "product1" localized "available_later_labels" for shops "shop2" should be:
       | locale | value       |
@@ -452,8 +447,8 @@ Feature: Update product price fields from Back Office (BO) for multiple shops.
       | Puff Daddy | 42             |
     # Edit shop3 also impacts shop4
     When I update product "product1" stock for shop shop4 with following information:
-      | delta_quantity    | 18            |
-      | out_of_stock_type | available     |
+      | delta_quantity    | 18        |
+      | out_of_stock_type | available |
     Then product "product1" should have following stock information for shops "shop1,shop2":
       | out_of_stock_type | available |
       | quantity          | 42        |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
@@ -169,7 +169,6 @@ Feature: Update product stock from Back Office (BO)
     When I update product "product1" with following values:
       | minimal_quantity              | 12           |
       | low_stock_threshold           | 42           |
-      | low_stock_alert               | true         |
       | available_now_labels[en-US]   | get it now   |
       | available_later_labels[en-US] | too late bro |
       | available_date                | 1969-07-16   |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_stock.feature
@@ -4,7 +4,7 @@
 @clear-cache-before-feature
 @reboot-kernel-before-feature
 @update-stock
-@update-stock-classic
+@update-stock-cl./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-stockassic
 Feature: Update product stock from Back Office (BO)
   As a BO user
   I need to be able to update product stock from BO

--- a/tests/Unit/Adapter/Product/Combination/Update/Filler/StockInformationFillerTest.php
+++ b/tests/Unit/Adapter/Product/Combination/Update/Filler/StockInformationFillerTest.php
@@ -112,8 +112,8 @@ class StockInformationFillerTest extends CombinationFillerTestCase
                 'available_now' => [1, 2],
                 'available_date',
                 'low_stock_threshold',
-                'minimal_quantity',
                 'low_stock_alert',
+                'minimal_quantity',
             ],
             $expectedCombination,
         ];

--- a/tests/Unit/Adapter/Product/Combination/Update/Filler/StockInformationFillerTest.php
+++ b/tests/Unit/Adapter/Product/Combination/Update/Filler/StockInformationFillerTest.php
@@ -92,7 +92,6 @@ class StockInformationFillerTest extends CombinationFillerTestCase
         $command = $this->getEmptyCommand()
             ->setLocalizedAvailableNowLabels($localizedAvailableNow)
             ->setLocalizedAvailableLaterLabels($localizedAvailableLater)
-            ->setLowStockAlert(true)
             ->setLowStockThreshold(42)
             ->setMinimalQuantity(10)
             ->setAvailableDate(new DateTime('2022-10-10'))

--- a/tests/Unit/Adapter/Product/Update/Filler/StockInformationFillerTest.php
+++ b/tests/Unit/Adapter/Product/Update/Filler/StockInformationFillerTest.php
@@ -115,8 +115,8 @@ class StockInformationFillerTest extends ProductFillerTestCase
             [
                 'available_later' => [1, 2],
                 'available_now' => [1, 2],
-                'low_stock_alert',
                 'low_stock_threshold',
+                'low_stock_alert',
                 'minimal_quantity',
                 'pack_stock_type',
                 'available_date',

--- a/tests/Unit/Adapter/Product/Update/Filler/StockInformationFillerTest.php
+++ b/tests/Unit/Adapter/Product/Update/Filler/StockInformationFillerTest.php
@@ -95,7 +95,6 @@ class StockInformationFillerTest extends ProductFillerTestCase
         $command = $this->getEmptyCommand()
             ->setLocalizedAvailableNowLabels($localizedAvailableNow)
             ->setLocalizedAvailableLaterLabels($localizedAvailableLater)
-            ->setLowStockAlert(true)
             ->setLowStockThreshold(42)
             ->setMinimalQuantity(10)
             ->setPackStockType(PackStockType::STOCK_TYPE_BOTH)

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\LowStockThreshol
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder;
 use PrestaShop\PrestaShop\Core\Util\DateTime\NullDateTime;
+use PrestaShopBundle\Form\Admin\Extension\DisablingSwitchExtension;
 
 class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBuilderTest
 {
@@ -239,6 +240,34 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
             [
                 'header' => [
                     'is_default' => null,
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setLowStockThreshold(LowStockThreshold::DISABLED_VALUE);
+        yield 'low stock threshold is overriden by disabling switch when it is falsy' => [
+            [
+                'stock' => [
+                    'options' => [
+                        sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => false,
+                        'low_stock_threshold' => 7,
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setLowStockThreshold(8);
+        yield 'low stock threshold is correctly set when disabling switch is truthy' => [
+            [
+                'stock' => [
+                    'options' => [
+                        sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => true,
+                        'low_stock_threshold' => 8,
+                    ],
                 ],
             ],
             [$command],

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/Combination/UpdateCombinationCommandsBuilderTest.php
@@ -30,6 +30,7 @@ namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product\Combina
 
 use DateTime;
 use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Command\UpdateCombinationCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\LowStockThreshold;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\Combination\UpdateCombinationCommandsBuilder;
 use PrestaShop\PrestaShop\Core\Util\DateTime\NullDateTime;
@@ -176,7 +177,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
         ];
 
         $command = $this->getSingleShopCommand();
-        $command->setLowStockAlert(false);
+        $command->setLowStockThreshold(LowStockThreshold::DISABLED_VALUE);
         yield [
             [
                 'stock' => [
@@ -352,8 +353,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
         $allShopsCommand = $this
             ->getAllShopsCommand()
             ->setMinimalQuantity(1)
-            ->setLowStockThreshold(5)
-            ->setLowStockAlert(false)
+            ->setLowStockThreshold(LowStockThreshold::DISABLED_VALUE)
             ->setAvailableDate(new DateTime('2022-10-10'))
         ;
         yield [
@@ -389,7 +389,7 @@ class UpdateCombinationCommandsBuilderTest extends AbstractCombinationCommandBui
         ;
         $allShopsCommand = $this
             ->getAllShopsCommand()
-            ->setLowStockAlert(false)
+            ->setLowStockThreshold(LowStockThreshold::DISABLED_VALUE)
             ->setAvailableDate(new NullDateTime())
         ;
         yield [

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -31,6 +31,7 @@ namespace Tests\Unit\Core\Form\IdentifiableObject\CommandBuilder\Product;
 use DateTime;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Pack\ValueObject\PackStockType;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\ValueObject\LowStockThreshold;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\DeliveryTimeNoteType;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductCondition;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
@@ -38,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductVisibility;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\RedirectType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Product\UpdateProductCommandsBuilder;
+use PrestaShopBundle\Form\Admin\Extension\DisablingSwitchExtension;
 
 class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
 {
@@ -643,6 +645,50 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
             ],
             [$command],
         ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setLowStockThreshold(LowStockThreshold::DISABLED_VALUE);
+
+        yield 'low stock threshold is set correctly when only disabling switch value is submitted' => [
+            [
+                'stock' => [
+                    'options' => [
+                        sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => false,
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setLowStockThreshold(LowStockThreshold::DISABLED_VALUE);
+
+        yield 'low stock threshold is overriden by disabling switch value when it is falsy' => [
+            [
+                'stock' => [
+                    'options' => [
+                        sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => false,
+                        'low_stock_threshold' => 4,
+                    ],
+                ],
+            ],
+            [$command],
+        ];
+
+        $command = $this->getSingleShopCommand();
+        $command->setLowStockThreshold(4);
+
+        yield 'low stock threshold is correctly set when disabling switch is truthy' => [
+            [
+                'stock' => [
+                    'options' => [
+                        sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => true,
+                        'low_stock_threshold' => 4,
+                    ],
+                ],
+            ],
+            [$command],
+        ];
     }
 
     public function getExpectedCommandsForCombinationsTypeProduct(): iterable
@@ -1119,7 +1165,7 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                         ],
                     ],
                     'options' => [
-                        'disabling_switch_low_stock_threshold' => true,
+                        sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => true,
                         'low_stock_threshold' => 10,
                     ],
                     'pack_stock_type' => PackStockType::STOCK_TYPE_PRODUCTS_ONLY,

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/UpdateProductCommandsBuilderTest.php
@@ -1027,7 +1027,6 @@ class UpdateProductCommandsBuilderTest extends AbstractProductCommandBuilderTest
                 2 => 'Isparduota',
             ])
             ->setActive(true)
-            ->setLowStockAlert(true)
             ->setLowStockThreshold(10)
             ->setLocalizedAvailableLaterLabels($localizedAvailableLaterLabels)
             ->setAvailableDate(new DateTime('2022-10-11'))

--- a/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/DataFormatter/BulkCombinationFormDataFormatterTest.php
@@ -116,8 +116,10 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                     ],
                     'minimal_quantity' => 2,
                     'stock_location' => 'far',
-                    'low_stock_threshold' => 5,
-                    sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => true,
+                    'low_stock_threshold' => [
+                        'threshold_value' => 5,
+                        'low_stock_alert' => true,
+                    ],
                     'available_date' => '2022-01-15',
                 ],
             ],
@@ -148,8 +150,12 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                     ],
                     'minimal_quantity' => 2,
                     'stock_location' => 'far',
-                    'low_stock_threshold' => 5,
-                    sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => true,
+                    'low_stock_threshold' => [
+                        'threshold_value' => 5,
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'threshold_value' => true,
+                        'low_stock_alert' => true,
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'low_stock_alert' => true,
+                    ],
                     'available_date' => '2022-01-15',
                 ],
             ],
@@ -165,7 +171,13 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                     'options' => [
                         'stock_location' => 'far',
                         'low_stock_threshold' => 5,
+                        self::MODIFY_ALL_SHOPS_PREFIX . 'low_stock_threshold' => true,
                         sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => true,
+                        sprintf(
+                            '%s%slow_stock_threshold',
+                            self::MODIFY_ALL_SHOPS_PREFIX,
+                            DisablingSwitchExtension::FIELD_PREFIX
+                        ) => true,
                     ],
                     'available_date' => '2022-01-15',
                 ],
@@ -177,8 +189,10 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                 'stock' => [
                     'fixed_quantity' => 7,
                     'stock_location' => 'close',
-                    'low_stock_threshold' => 2,
-                    sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => false,
+                    'low_stock_threshold' => [
+                        'threshold_value' => 2,
+                        'low_stock_alert' => false,
+                    ],
                     'available_date' => '2022-02-15',
                 ],
             ],
@@ -203,7 +217,10 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                     'fixed_quantity' => 7,
                     self::MODIFY_ALL_SHOPS_PREFIX . 'fixed_quantity' => false,
                     'stock_location' => 'close',
-                    'low_stock_threshold' => 2,
+                    'low_stock_threshold' => [
+                        'threshold_value' => 2,
+                        'low_stock_alert' => false,
+                    ],
                     sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => false,
                     'available_date' => '2022-02-15',
                 ],
@@ -249,14 +266,16 @@ class BulkCombinationFormDataFormatterTest extends TestCase
                     'delta_quantity' => [
                     ],
                     'stock_location' => 'far',
-                    sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => true,
+                    'low_stock_threshold' => [
+                        'low_stock_alert' => false,
+                    ],
                 ],
             ],
             [
                 'stock' => [
                     'options' => [
                         'stock_location' => 'far',
-                        sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => true,
+                        sprintf('%slow_stock_threshold', DisablingSwitchExtension::FIELD_PREFIX) => false,
                     ],
                 ],
             ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | https://github.com/PrestaShop/PrestaShop/issues/30750
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See bellow
| Fixed ticket?     | Closes https://github.com/PrestaShop/PrestaShop/issues/30750
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).

**How to test**
In product page v2 edit product stock tab - make sure that low stock alert switch and low stock level input works as intended (when alert switch is on then you can input the low stock level value, else you cannot and the threshold is not updated)
Same with combination form and combination bulk edition form.