### PR TITLE
Update workflows events to ignore tests PRs on pull requests

### DIFF
--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -1,10 +1,6 @@
 name: Behaviour tests
 on:
   push:
-    # Do not run after merging a pull request
-    branches-ignore:
-      - 'develop'
-      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -4,8 +4,7 @@ on:
     # Do not run after merging a pull request
     branches-ignore:
       - 'develop'
-      - '8.0.x'
-      - '1.7.8.x'
+      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:

--- a/.github/workflows/behaviour.yml
+++ b/.github/workflows/behaviour.yml
@@ -1,5 +1,16 @@
 name: Behaviour tests
-on: [ push, pull_request ]
+on:
+  push:
+    # Do not run after merging a pull request
+    branches-ignore:
+      - 'develop'
+      - '8.0.x'
+      - '1.7.8.x'
+  pull_request:
+    # Do not run when only tests are updated
+    paths-ignore:
+      - 'tests/UI/**'
+
 permissions:
   contents: read   #   to clone the repos and get release assets (shivammathur/setup-php)
 concurrency:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,16 @@
 name: Integration tests
-on: [ push, pull_request ]
+on:
+  push:
+    # Do not run after merging a pull request
+    branches-ignore:
+      - 'develop'
+      - '8.0.x'
+      - '1.7.8.x'
+  pull_request:
+    # Do not run when only tests are updated
+    paths-ignore:
+      - 'tests/UI/**'
+
 permissions:
   contents: read   #   to clone the repos and get release assets (shivammathur/setup-php)
 concurrency:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,8 +4,7 @@ on:
     # Do not run after merging a pull request
     branches-ignore:
       - 'develop'
-      - '8.0.x'
-      - '1.7.8.x'
+      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,6 @@
 name: Integration tests
 on:
   push:
-    # Do not run after merging a pull request
-    branches-ignore:
-      - 'develop'
-      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -4,8 +4,7 @@ on:
     # Do not run after merging a pull request
     branches-ignore:
       - 'develop'
-      - '8.0.x'
-      - '1.7.8.x'
+      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,10 +1,6 @@
 name: Js
 on:
   push:
-    # Do not run after merging a pull request
-    branches-ignore:
-      - 'develop'
-      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,5 +1,16 @@
 name: Js
-on: [ push, pull_request ]
+on:
+  push:
+    # Do not run after merging a pull request
+    branches-ignore:
+      - 'develop'
+      - '8.0.x'
+      - '1.7.8.x'
+  pull_request:
+    # Do not run when only tests are updated
+    paths-ignore:
+      - 'tests/UI/**'
+
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,7 @@ on:
     # Do not run after merging a pull request
     branches-ignore:
       - 'develop'
-      - '8.0.x'
-      - '1.7.8.x'
+      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,16 @@
 name: Lint
-on: [ push, pull_request ]
+on:
+  push:
+    # Do not run after merging a pull request
+    branches-ignore:
+      - 'develop'
+      - '8.0.x'
+      - '1.7.8.x'
+  pull_request:
+    # Do not run when only tests are updated
+    paths-ignore:
+      - 'tests/UI/**'
+
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,6 @@
 name: Lint
 on:
   push:
-    # Do not run after merging a pull request
-    branches-ignore:
-      - 'develop'
-      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,5 +1,16 @@
 name: PHP
-on: [ push, pull_request ]
+on:
+  push:
+    # Do not run after merging a pull request
+    branches-ignore:
+      - 'develop'
+      - '8.0.x'
+      - '1.7.8.x'
+  pull_request:
+    # Do not run when only tests are updated
+    paths-ignore:
+      - 'tests/UI/**'
+
 permissions:
   contents: read
 concurrency:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,8 +4,7 @@ on:
     # Do not run after merging a pull request
     branches-ignore:
       - 'develop'
-      - '8.0.x'
-      - '1.7.8.x'
+      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,10 +1,6 @@
 name: PHP
 on:
   push:
-    # Do not run after merging a pull request
-    branches-ignore:
-      - 'develop'
-      - '**.x'
   pull_request:
     # Do not run when only tests are updated
     paths-ignore:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update workflows events to ignore tests PRs on pull requests
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | no
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | N/A

This was a suggestion for @kpodemski to not run some workflows when only tests are updated
Docs : 
- [Paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore)
