### PR TITLE
Fix doubled message on module upload

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -719,6 +719,7 @@ class AdminModuleController {
        */
       timeout: 0,
       addedfile: () => {
+        $(`${self.moduleImportSuccessSelector}, ${self.moduleImportFailureSelector}`).hide();
         self.animateStartUpload();
       },
       processing: () => {

--- a/controllers/front/listing/BestSalesController.php
+++ b/controllers/front/listing/BestSalesController.php
@@ -71,7 +71,7 @@ class BestSalesControllerCore extends ProductListingFrontController
         $query = new ProductSearchQuery();
         $query
             ->setQueryType('best-sales')
-            ->setSortOrder(new SortOrder('product', 'name', 'asc'));
+            ->setSortOrder(new SortOrder('product', 'sales', 'desc'));
 
         return $query;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixed an issue when you upload an OK module after a failed module, you get doubled messages in the modal.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try it on develop, click upload a module, drag [ps_fail.zip](https://github.com/PrestaShop/PrestaShop/files/10413648/ps_fail.zip), see it fails, then drag [ps_success.zip](https://github.com/PrestaShop/PrestaShop/files/10413649/ps_success.zip) and see that you get both error and success. On my PR, it's fixed.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 


Before
https://drive.google.com/file/d/1ui8qT9yVYzDNoAkdXVAe1Zm_VqVTfQw2/view?usp=sharing

After
https://drive.google.com/file/d/1PtlvD1ZtJsdTX2GJTv_JiHUczCs_cPja/view?usp=sharing