### PR TITLE
Add index on ps_orders.'invoice_date'

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1269,7 +1269,7 @@ CREATE TABLE `PREFIX_orders` (
   KEY `id_shop_group` (`id_shop_group`),
   KEY (`current_state`),
   KEY `id_shop` (`id_shop`),
-  INDEX `date_add`(`date_add`)
+  INDEX `date_add`(`date_add`),
   INDEX `invoice_date`(`invoice_date`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 

--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1270,6 +1270,7 @@ CREATE TABLE `PREFIX_orders` (
   KEY (`current_state`),
   KEY `id_shop` (`id_shop`),
   INDEX `date_add`(`date_add`)
+  INDEX `invoice_date`(`invoice_date`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=utf8mb4 COLLATION;
 
 /* Order tax detail */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x
| Description?      |  On AdminStatsController there is a request (BestCategory) taking huge time to execute (14s on my shop) when you have a consequent catalog. This request is executed in getKpi method in Category admin controller (ajax methods).  This index on ps_orders.'invoice_date' reduce this waiting time from 14s to 0s.
| Type?             | improvement
| Category?         | BO
| How to test?      | Go to categories listing page in BO and analyse network timing on this request : index.php?controller=AdminStats&ajax=1&action=getKpi&kpi=top_category. It will be significant if you have a shop with a lot of categories, orders and products. Add the index on ps_orders.'invoice_date' and see the difference 👍 

