### PR TITLE
Redirect to product list with warning message instead of raising an exception when we try to access a product which doesn't exist

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Controller\Admin;
 
 use Category;
 use Exception;
+use LogicException;
 use PrestaShop\PrestaShop\Adapter\Product\ListParametersUpdater;
 use PrestaShop\PrestaShop\Adapter\Tax\TaxRuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Warehouse\WarehouseDataProvider;
@@ -112,7 +113,7 @@ class ProductController extends FrameworkBundleAdminController
      *
      * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      * @throws \Symfony\Component\Routing\Exception\RouteNotFoundException
-     * @throws \LogicException
+     * @throws LogicException
      * @throws \Symfony\Component\Routing\Exception\MissingMandatoryParametersException
      * @throws \Symfony\Component\Routing\Exception\InvalidParameterException
      * @throws \Symfony\Component\Form\Exception\LogicException
@@ -387,7 +388,7 @@ class ProductController extends FrameworkBundleAdminController
      *
      * @return RedirectResponse
      *
-     * @throws \LogicException
+     * @throws LogicException
      * @throws \PrestaShopException
      */
     public function newAction()
@@ -438,7 +439,7 @@ class ProductController extends FrameworkBundleAdminController
      *
      * @return array|Response Template vars
      *
-     * @throws \LogicException
+     * @throws Exception
      */
     public function formAction($id, Request $request)
     {
@@ -455,9 +456,18 @@ class ProductController extends FrameworkBundleAdminController
         }
 
         $productAdapter = $this->get('prestashop.adapter.data_provider.product');
-        $product = $productAdapter->getProduct($id);
+        try {
+            $product = $productAdapter->getProduct($id);
+        } catch (LogicException $e) {
+            $product = null;
+        }
 
         if (!$product || empty($product->id)) {
+            $this->addFlash(
+                'warning',
+                $this->trans('The product you are trying to access doesn\'t exist', 'AdminLoginNotification')
+            );
+
             return $this->redirectToRoute('admin_product_catalog');
         }
 
@@ -1251,7 +1261,7 @@ class ProductController extends FrameworkBundleAdminController
      * @deprecated since 1.7.5.0, to be removed in 1.8 rely on CommonController::renderFieldAction
      *
      * @throws \OutOfBoundsException
-     * @throws \LogicException
+     * @throws LogicException
      * @throws \PrestaShopException
      */
     public function renderFieldAction($productId, $step, $fieldName)

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -465,7 +465,7 @@ class ProductController extends FrameworkBundleAdminController
         if (!$product || empty($product->id)) {
             $this->addFlash(
                 'warning',
-                $this->trans('The product you are trying to access doesn\'t exist', 'AdminLoginNotification')
+                $this->trans('The product you are trying to access doesn\'t exist', 'Admin.Catalog.Notification')
             );
 
             return $this->redirectToRoute('admin_product_catalog');

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductPosit
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\InvalidProductTypeException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\DuplicateFeatureValueAssociationException;
 use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\InvalidAssociatedFeatureException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductIsEnabled;
@@ -324,6 +325,13 @@ class ProductController extends FrameworkBundleAdminController
             ]);
         } catch (ShopAssociationNotFound $e) {
             return $this->renderMissingAssociation($productId);
+        } catch (ProductNotFoundException $e) {
+            $this->addFlash(
+                'warning',
+                $this->trans('The product you are trying to access doesn\'t exist', 'Admin.Catalog.Notification')
+            );
+
+            return $this->redirectToRoute('admin_product_catalog');
         }
 
         try {

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
@@ -143,7 +143,7 @@
                 {% if productDetail.id %}
                   <a class="px-0 external-link" href="{{ path('admin_product_form', {'id': productDetail.id}) }}" target="_blank">{{ productDetail.name }}</a>
                 {% else %}
-                  {{ productDetail.name }} ({{ 'Product deleted'|trans({}, 'Admin.Global') }})
+                  {{ productDetail.name }} ({{ 'Product deleted'|trans({}, 'Admin.Catalog.Feature') }})
                 {% endif %}
               </td>
               <td class="p-1">{{ productDetail.reference }}</td>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/preview.html.twig
@@ -139,7 +139,13 @@
           <tbody>
           {% for productDetail in orderPreview.productDetails %}
             <tr class="{% if loop.index > productsPreviewLimit %}js-product-preview-more d-none{% endif %}">
-              <td class="p-1"><a class="px-0 external-link" href="{{ path('admin_product_form', {'id': productDetail.id}) }}" target="_blank">{{ productDetail.name }}</a></td>
+              <td class="p-1">
+                {% if productDetail.id %}
+                  <a class="px-0 external-link" href="{{ path('admin_product_form', {'id': productDetail.id}) }}" target="_blank">{{ productDetail.name }}</a>
+                {% else %}
+                  {{ productDetail.name }} ({{ 'Product deleted'|trans({}, 'Admin.Global') }})
+                {% endif %}
+              </td>
               <td class="p-1">{{ productDetail.reference }}</td>
               <td class="p-1 js-cell-product-stock-location">
                 {% if productDetail.location is not empty %}{{ productDetail.location }}{% endif %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x
| Description?      | Redirect to product list with warning message instead of raising an exception when we try to access a product which doesn't exist
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/29913
| Fixed ticket?     | Fixes #29913
| Related PRs       | 
| Sponsor company   |
