### PR TITLE
Module from theme with tab using SF routing fails after enabling the theme

### DIFF
--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -110,7 +110,11 @@ class ModuleManager implements ModuleManagerInterface
 
         $module = $this->moduleRepository->getModule($name);
         $installed = $module->onInstall();
-        $this->dispatch(ModuleManagementEvent::INSTALL, $module);
+        if ($installed) {
+            // Only trigger install event if install has succeeded otherwise it could automatically add tabs linked to a
+            // module not installed (@see ModuleTabManagementSubscriber) or other unwanted automatic actions.
+            $this->dispatch(ModuleManagementEvent::INSTALL, $module);
+        }
 
         return $installed;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When a theme installs a module that contains a tab with route_name it redirects to the theme index right away But for the route to be usable the cache needs to be cleared, this operation is handled in a shutdown callback which is why when the page is refreshed at first the cache still has not been cleared yet<br>This results in an exception as the route can not be found, to avoid this blocking exception during the menu rendering we catch the `RouteNotFoundException` and the associated tab is not rendered, after a few seconds when the cache is cleared the page can be refreshed and the tab will be displayed appropriately<br>Additionally during the tests it was found that the INSTALL event for module is triggered even when it failed, this can result in unwanted added tab even if the module failed to install, so now the event is only triggered on install success<br><br>**Note**: this is not an ideal fix but so far I didn't find a proper way to correctly clear the cache without causing side effects bugs on refresh
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See description
| Fixed ticket?     | Fixes #30011
| Related PRs       | ~
| Sponsor company   | ~

### How to test

**Without the PR**
1. Go to Back Office improve -> design -> Theme & logo
2. Download this theme [routing_classic_theme.zip](https://github.com/PrestaShop/PrestaShop/files/10461059/routing_classic_theme.zip)
3. Press Add new theme then Import from your computer and select the provided theme zip
4. Go back to Theme & logo page and try to enable your theme by clicking on "Use this theme" button appearing on the related theme image "Classic routing theme".
5. You should see an error
![Capture d’écran 2023-01-19 à 22 08 38](https://user-images.githubusercontent.com/13801017/213560284-b7bd2195-d19a-475b-a807-3533c63cde7f.png)


**With the PR**
Note: if you don't want to re-install your whole shop from zero you can restore it to the initial state by following these steps:
1. Reset the initial classic theme as your default theme
2. Go to module manager and uninstall the "Routing module" (click the option checkbox to actually remove the module's files)

1. Repeat steps 1 to 4
3. The theme is correctly enabled and you see a success message
4. You will notice that the menu now contains an additional Menu "More" which contains no sub link
![Capture d’écran 2023-01-19 à 22 34 09](https://user-images.githubusercontent.com/13801017/213567275-29f712ca-432d-4fbc-a7ee-52c1175c1e88.png)
5. Wait for a few seconds and refresh the page, now that the cache has been cleared you should see a new Link
![Capture d’écran 2023-01-19 à 22 35 01](https://user-images.githubusercontent.com/13801017/213567297-9f4e45ed-00c0-41dc-ba01-327021e4bde2.png)
6. You can click on this new tab it will show a simple display page, this means the theme, the module and the new tab wor correctly now
![Capture d’écran 2023-01-19 à 22 36 11](https://user-images.githubusercontent.com/13801017/213567424-39b55bd0-d357-43aa-8a14-f05702397b22.png)


#### Optional check
If you go in the Advanced Parameters > Logs section and filter by warning you should see one (or more) warning message indicating that the tab could not be displayed initially
![Capture d’écran 2023-01-19 à 22 06 15](https://user-images.githubusercontent.com/13801017/213559672-2ba47c0c-a4fd-4cb0-857c-2036c309d7d5.png)
