### PR TITLE
Avoid potencial fatal error in `Link::getCategoryLink`

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -440,7 +440,7 @@ class LinkCore
         $params = [];
         if (Validate::isLoadedObject($category)) {
             $params['id'] = $category->id;
-        } elseif (isset($category['id_category'])) {
+        } elseif (is_array($category) && isset($category['id_category'])) {
             $params['id'] = $category['id_category'];
         } elseif (is_int($category) || (is_string($category) && ctype_digit($category))) {
             $params['id'] = (int) $category;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Avoid potencial fatal error `Got error 'PHP message: PHP Fatal error:  Uncaught Error: Cannot use object of type Category as array`.
| Type?             | refacto
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See description bellow.
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | PululuK

## How to test

- Try this code

```php

<?php

$myInvalidCategory = new Category();
Context::getContext()->link->getCategoryLink($myInvalidCategory);

```

- See the error 

`Got error 'PHP message: PHP Fatal error:  Uncaught Error: Cannot use object of type Category as array`.
