### PR TITLE
Use PrestaShop's jwt repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -206,7 +206,7 @@
     "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/atomiix/jwt"
+            "url": "https://github.com/PrestaShop/jwt"
         }
     ],
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1cef2a84fa37f88d65400af5ea0ea01",
+    "content-hash": "431863b6b17b54ce7ca55a056373fab0",
     "packages": [
         {
             "name": "api-platform/core",
@@ -2907,12 +2907,12 @@
             "version": "dev-3.4.6-patch",
             "source": {
                 "type": "git",
-                "url": "https://github.com/atomiix/jwt.git",
+                "url": "https://github.com/PrestaShop/jwt.git",
                 "reference": "da86a58c07f37a2fb59e648725910cc82d2a4975"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/atomiix/jwt/zipball/da86a58c07f37a2fb59e648725910cc82d2a4975",
+                "url": "https://api.github.com/repos/PrestaShop/jwt/zipball/da86a58c07f37a2fb59e648725910cc82d2a4975",
                 "reference": "da86a58c07f37a2fb59e648725910cc82d2a4975",
                 "shasum": ""
             },
@@ -2972,7 +2972,7 @@
                 "JWT"
             ],
             "support": {
-                "source": "https://github.com/atomiix/jwt/tree/3.4.6-patch"
+                "source": "https://github.com/PrestaShop/jwt/tree/3.4.6-patch"
             },
             "time": "2022-10-07T13:56:08+00:00"
         },


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR aims to force the use of the PrestaShop/jwt repository instead of atomiix/jwt
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI should be green
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | 
