### PR TITLE
Fix #30973, compare zip format to selected country

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -120,6 +120,10 @@ class CustomerAddressFormCore extends AbstractForm
 
         $postcode = $this->getField('postcode');
         if ($postcode && $postcode->isRequired()) {
+            $id_country_selected = $this->getField('id_country')->getValue();
+            if (!empty($id_country_selected)) {
+                $this->formatter->setCountry(new Country($id_country_selected));
+            }
             $country = $this->formatter->getCountry();
             if (!$country->checkZipCode($postcode->getValue())) {
                 $postcode->addError($this->translator->trans(


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | In certain circumstances the zip code is not validated against the selected country, but against another country (different from the configured default country). Thus the customer cannot create his address. This PR fixes that bug.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow the instructions in #30973
| Fixed ticket?     | Fixes #30973
| Related PRs       | none
| Sponsor company   | Société Biblique de Genève
