### PR TITLE
Fix customer isLogged property in FO

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -1054,7 +1054,7 @@ class HookCore extends ObjectModel
             if ($use_groups) {
                 if ($customer instanceof Customer && $customer->isLogged()) {
                     $groups = $customer->getGroups();
-                } elseif ($customer instanceof Customer && $customer->isLogged(true)) {
+                } elseif ($customer instanceof Customer && $customer->isGuest()) {
                     $groups = [(int) Configuration::get('PS_GUEST_GROUP')];
                 } else {
                     $groups = [(int) Configuration::get('PS_UNIDENTIFIED_GROUP')];

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -80,6 +80,7 @@ class FrontControllerCore extends Controller
     /**
      * If set to true, user can be logged in as guest when checking if logged in.
      *
+     * @deprecated Since 8.0 and will be removed in the next major.
      * @see $auth
      *
      * @var bool
@@ -307,7 +308,7 @@ class FrontControllerCore extends Controller
             $this->context->cookie->id_cart = (int) $id_cart;
         }
 
-        if ($this->auth && !$this->context->customer->isLogged($this->guestAllowed)) {
+        if ($this->auth && !$this->context->customer->isLogged()) {
             Tools::redirect('index.php?controller=authentication' . ($this->authRedirection ? '&back=' . $this->authRedirection : ''));
         }
 
@@ -1570,7 +1571,7 @@ class FrontControllerCore extends Controller
         );
 
         $cust['id'] = $this->context->customer->id;
-        $cust['is_logged'] = $this->context->customer->isLogged(true);
+        $cust['is_logged'] = $this->context->customer->isLogged();
 
         $cust['gender'] = $this->objectPresenter->present(new Gender($cust['id_gender']));
         unset($cust['id_gender']);


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.0.x
| Description?      | See below
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | See below
| Fixed ticket?     | Fixes #30991
| Related PRs       | 
| Sponsor company   | 

### Changes explained
- I removed the usage of `withGuest` parameter of isLogged function that causes it to return true even if the customer is guest.
- A) In FO, we always need the real value, that's why the change in `$cust['is_logged'] = $this->context->customer->isLogged();`.
- B) Then there is the line that redirects to login controller if `$auth` is `true` and `isLogged` is `false`. It's passing an attribute called `guestAllowed`, which is always `false` and not used at all in whole core or modules.
- C) And last usage of this parameter was in `Hook` class. I simply used `isGuest` check instead of this.
- Keeping it now to not introduce BC, but I will remove this parameter completely in v9. IsLogged should be what it is, and not magically return true even for guests.

### What to test
- To test A), check scenario I described in the issue. Finish step 1 in checkout without entering a password (guest order), go to homepage, see that the dumped data and links in footer are correct.
- To test B), check that if you are logged out and you try to go to `/addresses` (or some other page that requires login) for example, it will still redirect you to login screen and there will be no change in behaviour.
- To test C)
  - Register yourself through register page. (not checkout, there is a group assignment bug fixed on develop only I think)
  - Go to `Customer groups`, edit Guest group (2) and uncheck search bar module for example.
  - Now go to `Customers`, edit your customer and try changing his user groups. 
    - Assign him to group 1, default group 1 - search module is visible in FO. 
    - Assign him to group 2, default group 2, module disappears in FO. 
    - Assign him to group 3, module reappears again.