### PR TITLE
Fix issue #26568 about customer blank schema

### DIFF
--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -666,7 +666,7 @@ class WebserviceOutputBuilderCore
                             $value = $object_assoc;
                         }
                         if (empty($fields_assoc)) {
-                            $fields_assoc = [['id' => $value['id']]];
+                            $fields_assoc = [['id' => ($value['id'] ?? null)]];
                         }
                         $output_details .= $this->renderFlatAssociation($object, $depth, $assoc_name, $association['resource'], $fields_assoc, $value, $parent_details);
                     } else {


### PR DESCRIPTION
Hi @kpodemski, I didn’t succeed to rebase correctly to the 8.0.x branch so I have made a new PR… 

Pull Request #28280 does not fix totally this PHP 7.4 bug described in issue #26568 

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fix PHP 7.4 Notice error `Trying to access array offset on value of type null (/home/.../public_html/classes/webservice/WebserviceOutputBuilder.php, line 669)` when requesting `/api/customers?schema=blank`
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #26568
| Related PRs       | #28280 #29258
| How to test?      | test /api/customers?schema=blank with PHP 7.4
| Possible impacts? | none


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
