### PR TITLE
Fix conversion of hex color codes

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2227,7 +2227,7 @@ class ToolsCore
         $hex = str_replace('#', '', $hex);
 
         if (Tools::strlen($hex) == 3) {
-            $hex .= $hex;
+            $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
         }
 
         $r = hexdec(substr($hex, 0, 2));

--- a/src/Core/Util/ColorBrightnessCalculator.php
+++ b/src/Core/Util/ColorBrightnessCalculator.php
@@ -60,7 +60,7 @@ final class ColorBrightnessCalculator
         $hexColor = str_replace('#', '', $hexColor);
 
         if (strlen($hexColor) === 3) {
-            $hexColor = $hexColor[0] . $hexColor[0] . $hexColor[1] . $hexColor[1] . $hexColor[2] . $hexColor[3];
+            $hexColor = $hexColor[0] . $hexColor[0] . $hexColor[1] . $hexColor[1] . $hexColor[2] . $hexColor[2];
         }
 
         $r = hexdec(substr($hexColor, 0, 2));

--- a/src/Core/Util/ColorBrightnessCalculator.php
+++ b/src/Core/Util/ColorBrightnessCalculator.php
@@ -60,7 +60,7 @@ final class ColorBrightnessCalculator
         $hexColor = str_replace('#', '', $hexColor);
 
         if (strlen($hexColor) === 3) {
-            $hexColor .= $hexColor;
+            $hexColor = $hexColor[0] . $hexColor[0] . $hexColor[1] . $hexColor[1] . $hexColor[2] . $hexColor[3];
         }
 
         $r = hexdec(substr($hexColor, 0, 2));

--- a/tests/Unit/Core/Util/ColorBrightnessCalculatorTest.php
+++ b/tests/Unit/Core/Util/ColorBrightnessCalculatorTest.php
@@ -58,6 +58,8 @@ class ColorBrightnessCalculatorTest extends TestCase
         yield ['#E0FFFF', true];
         yield ['#E0FFFF', true];
         yield ['#00008B', false];
+        yield ['#00F', false];
+        yield ['#0F1', true];
         yield ['transparent', true];
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Fix conversion of hex color codes (used for the display of the order state's colors in the BO)
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | The color #0F1 is handled as dark color (#0F10F1), but should be handled as bright (#00FF11). see https://github.com/PrestaShop/PrestaShop/issues/31002#issuecomment-1401527109
| Fixed ticket?     | Fixes #31002
| Related PRs       | Non
| Sponsor company   | Société Biblique de Genève
