### PR TITLE
Use 6 decimals while getting unit price

### DIFF
--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -706,7 +706,7 @@ class OrderDetailCore extends ObjectModel
             (int) $product['id_product'],
             true,
             ($product['id_product_attribute'] ? (int) ($product['id_product_attribute']) : null),
-            2,
+            6,
             null,
             false,
             true,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use 6 decimals to avoid false calculation, as seen on the linked issue.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #31025
| Sponsor company   | @Wepika
