### PR TITLE
Deprecate renderForm methods

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -72,7 +72,7 @@ class MetaController extends FrameworkBundleAdminController
             $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
         }
 
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->doRenderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**
@@ -263,7 +263,7 @@ class MetaController extends FrameworkBundleAdminController
             $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
         }
 
-        return $this->renderForm($request, $filters, $formProcessResult, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
+        return $this->doRenderForm($request, $filters, $formProcessResult, $shopUrlsForm, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**
@@ -296,7 +296,7 @@ class MetaController extends FrameworkBundleAdminController
             $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
         }
 
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $formProcessResult, $seoOptionsForm, $urlSchemaForm);
+        return $this->doRenderForm($request, $filters, $setUpUrlsForm, $formProcessResult, $seoOptionsForm, $urlSchemaForm);
     }
 
     /**
@@ -324,7 +324,7 @@ class MetaController extends FrameworkBundleAdminController
         $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
         $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
 
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $formProcessResult);
+        return $this->doRenderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $seoOptionsForm, $formProcessResult);
     }
 
     /**
@@ -357,7 +357,7 @@ class MetaController extends FrameworkBundleAdminController
             $urlSchemaForm = $this->getUrlSchemaFormHandler()->getForm();
         }
 
-        return $this->renderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $formProcessResult, $urlSchemaForm);
+        return $this->doRenderForm($request, $filters, $setUpUrlsForm, $shopUrlsForm, $formProcessResult, $urlSchemaForm);
     }
 
     /**
@@ -400,6 +400,8 @@ class MetaController extends FrameworkBundleAdminController
     }
 
     /**
+     * @deprecated since 8.1.0 and will be removed in next major version.
+     *
      * @param Request $request
      * @param MetaFilters $filters
      * @param FormInterface $setUpUrlsForm
@@ -410,6 +412,42 @@ class MetaController extends FrameworkBundleAdminController
      * @return Response
      */
     protected function renderForm(
+        Request $request,
+        MetaFilters $filters,
+        FormInterface $setUpUrlsForm,
+        FormInterface $shopUrlsForm,
+        FormInterface $seoOptionsForm,
+        ?FormInterface $urlSchemaForm = null
+    ): Response {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.1.0 and will be removed in the next major version. Use doRenderForm() instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return $this->doRenderForm(
+            $request,
+            $filters,
+            $setUpUrlsForm,
+            $shopUrlsForm,
+            $seoOptionsForm,
+            $urlSchemaForm
+        );
+    }
+
+    /**
+     * @param Request $request
+     * @param MetaFilters $filters
+     * @param FormInterface $setUpUrlsForm
+     * @param FormInterface $shopUrlsForm
+     * @param FormInterface $seoOptionsForm
+     * @param FormInterface|null $urlSchemaForm
+     *
+     * @return Response
+     */
+    private function doRenderForm(
         Request $request,
         MetaFilters $filters,
         FormInterface $setUpUrlsForm,

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/PreferencesController.php
@@ -55,7 +55,7 @@ class PreferencesController extends FrameworkBundleAdminController
     {
         $form = $this->get('prestashop.adapter.preferences.form_handler')->getForm();
 
-        return $this->renderForm($request, $form);
+        return $this->doRenderForm($request, $form);
     }
 
     /**
@@ -100,10 +100,10 @@ class PreferencesController extends FrameworkBundleAdminController
             $this->flashErrors($saveErrors);
         }
 
-        return $this->renderForm($request, $form);
+        return $this->doRenderForm($request, $form);
     }
 
-    private function renderForm(Request $request, FormInterface $form): Response
+    private function doRenderForm(Request $request, FormInterface $form): Response
     {
         /** @var Tools $toolsAdapter */
         $toolsAdapter = $this->get(Tools::class);

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
@@ -167,9 +167,9 @@ class PreferencesController extends FrameworkBundleAdminController
      * @param FormInterface $carrierOptionsForm
      * @param Request $request
      *
-     * @return Response|null
+     * @return Response
      */
-    private function doRenderForm($handlingForm, $carrierOptionsForm, $request)
+    private function doRenderForm($handlingForm, $carrierOptionsForm, $request): Response
     {
         $legacyController = $request->attributes->get('_legacy_controller');
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
@@ -52,7 +52,7 @@ class PreferencesController extends FrameworkBundleAdminController
         $handlingForm = $this->getHandlingFormHandler()->getForm();
         $carrierOptionsForm = $this->getCarrierOptionsFormHandler()->getForm();
 
-        return $this->renderForm($handlingForm, $carrierOptionsForm, $request);
+        return $this->doRenderForm($handlingForm, $carrierOptionsForm, $request);
     }
 
     /**
@@ -90,7 +90,7 @@ class PreferencesController extends FrameworkBundleAdminController
             $this->flashErrors($saveErrors);
         }
 
-        return $this->renderForm($this->getHandlingFormHandler()->getForm(), $form, $request);
+        return $this->doRenderForm($this->getHandlingFormHandler()->getForm(), $form, $request);
     }
 
     /**
@@ -127,7 +127,7 @@ class PreferencesController extends FrameworkBundleAdminController
             }
         }
 
-        return $this->renderForm($form, $this->getCarrierOptionsFormHandler()->getForm(), $request);
+        return $this->doRenderForm($form, $this->getCarrierOptionsFormHandler()->getForm(), $request);
     }
 
     /**
@@ -147,13 +147,29 @@ class PreferencesController extends FrameworkBundleAdminController
     }
 
     /**
+     * @deprecated since 8.1.0 and will be removed in next major version.
+     */
+    protected function renderForm($handlingForm, $carrierOptionsForm, $request)
+    {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.1.0 and will be removed in the next major version. Use doRenderForm() instead.',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
+        return $this->doRenderForm($handlingForm, $carrierOptionsForm, $request);
+    }
+
+    /**
      * @param FormInterface $handlingForm
      * @param FormInterface $carrierOptionsForm
      * @param Request $request
      *
      * @return Response|null
      */
-    protected function renderForm($handlingForm, $carrierOptionsForm, $request)
+    private function doRenderForm($handlingForm, $carrierOptionsForm, $request)
     {
         $legacyController = $request->attributes->get('_legacy_controller');
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | We need this to be deprecated before migrating to sf5 or sf 6 as it will conflict with the renderForm of the Symfony `AbstractController`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | CI 🟢 & automated tests