### PR TITLE
Fix LOGO_MAIL in multistore

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -512,7 +512,7 @@ class MailCore extends ObjectModel
                 $message->setReplyTo($replyTo, ($replyToName !== '' ? $replyToName : null));
             }
 
-            if (false !== Configuration::get('PS_LOGO_MAIL') &&
+            if (false !== Configuration::get('PS_LOGO_MAIL', null, null, $idShop) &&
                 file_exists(_PS_IMG_DIR_ . Configuration::get('PS_LOGO_MAIL', null, null, $idShop))
             ) {
                 $logo = _PS_IMG_DIR_ . Configuration::get('PS_LOGO_MAIL', null, null, $idShop);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When emails are sent with a specific $id_shop in parameter, if a different PS_LOGO_MAIL is configured for this shop it won't be used because Configuration::get uses the  contextualised shop to check if a specific LOGO_EMAIL exists. (this bug was introduced in Prestashop 1.5.4.0...)
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Use a multistore prestashop. Different stores must have a different PS_LOGO_MAIL (configured in Theme). Display an order corresponding to a store that is not the default store of the installation, using the context "all stores" (or another store). Send an email on this order or choose a status that will send an email: the attached logo will not be the one that corresponds to the store
| Fixed ticket?     | [#31033](https://github.com/PrestaShop/PrestaShop/issues/31033)
| Related PRs       | -
