### PR TITLE
Deprecate some useless classes related to legacy upload system

### DIFF
--- a/classes/FileUploader.php
+++ b/classes/FileUploader.php
@@ -23,6 +23,10 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+/**
+ * @deprecated deprecated since version 8.1, will be dropped in 9.0
+ */
 class FileUploaderCore
 {
     protected $allowedExtensions = [];
@@ -33,6 +37,8 @@ class FileUploaderCore
 
     public function __construct(array $allowedExtensions = [], $sizeLimit = 10485760)
     {
+        @trigger_error('This class is deprecated since 8.1 and will be dropped in 9.0.', E_USER_DEPRECATED);
+
         $allowedExtensions = array_map('strtolower', $allowedExtensions);
 
         $this->allowedExtensions = $allowedExtensions;

--- a/classes/QqUploadedFileForm.php
+++ b/classes/QqUploadedFileForm.php
@@ -23,8 +23,17 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
+/**
+ * @deprecated deprecated since version 8.1, will be dropped in 9.0
+ */
 class QqUploadedFileFormCore
 {
+    public function __construct()
+    {
+        @trigger_error('This class is deprecated since 8.1 and will be dropped in 9.0.', E_USER_DEPRECATED);
+    }
+
     /**
      * Save the file to the specified path.
      *

--- a/classes/QqUploadedFileXhr.php
+++ b/classes/QqUploadedFileXhr.php
@@ -25,10 +25,17 @@
  */
 
 /**
+ * @deprecated deprecated since version 8.1, will be dropped in 9.0
+ *
  * Handle file uploads via XMLHttpRequest.
  */
 class QqUploadedFileXhrCore
 {
+    public function __construct()
+    {
+        @trigger_error('This class is deprecated since 8.1 and will be dropped in 9.0.', E_USER_DEPRECATED);
+    }
+
     /**
      * Save the file to the specified path.
      *


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | deprecate classes `FileUploaderCore`, `QqUploadedFileFormCore`and `QqUploadedFileXhrCore` because they are not used nor needed anymore.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | CI is green
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | PrestaShop SA