### PR TITLE
Add shop constraint on SetAssociatedProductCategoriesCommand and RemoveAllAssociatedProductCategoriesCommand

### DIFF
--- a/classes/shop/Shop.php
+++ b/classes/shop/Shop.php
@@ -244,6 +244,7 @@ class ShopCore extends ObjectModel
     public function add($autodate = true, $null_values = false)
     {
         $res = parent::add($autodate, $null_values);
+        Shop::resetStaticCache();
         Shop::cacheShops(true);
 
         return $res;

--- a/src/Adapter/Category/Repository/CategoryRepository.php
+++ b/src/Adapter/Category/Repository/CategoryRepository.php
@@ -321,7 +321,7 @@ class CategoryRepository extends AbstractObjectModelRepository
         $maxPositions = $this->connection
             ->createQueryBuilder()
             ->from($this->dbPrefix . 'category_product', 'cp')
-            ->select('cp.id_category, MAX(cp.position)')
+            ->select('cp.id_category, MAX(cp.position) AS position')
             ->andWhere('cp.id_category IN (:categories)')
             ->setParameter('categories', $categoryIds, Connection::PARAM_INT_ARRAY)
             ->groupBy('cp.id_category')
@@ -334,7 +334,7 @@ class CategoryRepository extends AbstractObjectModelRepository
             $maxCategoryPosition = 1;
             foreach ($maxPositions as $maxPosition) {
                 if ((int) $maxPosition['id_category'] === $categoryId) {
-                    $maxCategoryPosition = (int) $maxPosition['id_category'] + 1;
+                    $maxCategoryPosition = (int) $maxPosition['position'] + 1;
                 }
             }
 

--- a/src/Adapter/Product/CommandHandler/RemoveAllAssociatedProductCategoriesHandler.php
+++ b/src/Adapter/Product/CommandHandler/RemoveAllAssociatedProductCategoriesHandler.php
@@ -28,9 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Update\ProductCategoryUpdater;
-use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllAssociatedProductCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\RemoveAllAssociatedProductCategoriesHandlerInterface;
 
@@ -40,33 +38,17 @@ use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\RemoveAllAssociated
 final class RemoveAllAssociatedProductCategoriesHandler implements RemoveAllAssociatedProductCategoriesHandlerInterface
 {
     /**
-     * @var int
-     */
-    private $homeCategoryId;
-
-    /**
      * @var ProductCategoryUpdater
      */
     private $productCategoryUpdater;
 
     /**
-     * @var ProductRepository
-     */
-    private $productRepository;
-
-    /**
-     * @param int $homeCategoryId
      * @param ProductCategoryUpdater $productCategoryUpdater
-     * @param ProductRepository $productRepository
      */
     public function __construct(
-        int $homeCategoryId,
-        ProductCategoryUpdater $productCategoryUpdater,
-        ProductRepository $productRepository
+        ProductCategoryUpdater $productCategoryUpdater
     ) {
-        $this->homeCategoryId = $homeCategoryId;
         $this->productCategoryUpdater = $productCategoryUpdater;
-        $this->productRepository = $productRepository;
     }
 
     /**
@@ -74,11 +56,6 @@ final class RemoveAllAssociatedProductCategoriesHandler implements RemoveAllAsso
      */
     public function handle(RemoveAllAssociatedProductCategoriesCommand $command): void
     {
-        $product = $this->productRepository->get($command->getProductId());
-        $categoryId = new CategoryId($this->homeCategoryId);
-
-        // remove all categories associated with this product, keep only home Category
-        // @todo: this is likely to break with multishop
-        $this->productCategoryUpdater->updateCategories($product, [$categoryId], $categoryId);
+        $this->productCategoryUpdater->removeAllCategories($command->getProductId(), $command->getShopConstraint());
     }
 }

--- a/src/Adapter/Product/CommandHandler/SetAssociatedProductCategoriesHandler.php
+++ b/src/Adapter/Product/CommandHandler/SetAssociatedProductCategoriesHandler.php
@@ -28,7 +28,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Update\ProductCategoryUpdater;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetAssociatedProductCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\SetAssociatedProductCategoriesHandlerInterface;
@@ -39,24 +38,16 @@ use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\SetAssociatedProduc
 final class SetAssociatedProductCategoriesHandler implements SetAssociatedProductCategoriesHandlerInterface
 {
     /**
-     * @var ProductRepository
-     */
-    private $productRepository;
-
-    /**
      * @var ProductCategoryUpdater
      */
     private $productCategoryUpdater;
 
     /**
-     * @param ProductRepository $productRepository
      * @param ProductCategoryUpdater $productCategoryUpdater
      */
     public function __construct(
-        ProductRepository $productRepository,
         ProductCategoryUpdater $productCategoryUpdater
     ) {
-        $this->productRepository = $productRepository;
         $this->productCategoryUpdater = $productCategoryUpdater;
     }
 
@@ -65,7 +56,11 @@ final class SetAssociatedProductCategoriesHandler implements SetAssociatedProduc
      */
     public function handle(SetAssociatedProductCategoriesCommand $command): void
     {
-        $product = $this->productRepository->get($command->getProductId());
-        $this->productCategoryUpdater->updateCategories($product, $command->getCategoryIds(), $command->getDefaultCategoryId());
+        $this->productCategoryUpdater->updateCategories(
+            $command->getProductId(),
+            $command->getCategoryIds(),
+            $command->getDefaultCategoryId(),
+            $command->getShopConstraint()
+        );
     }
 }

--- a/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
+++ b/src/Adapter/Product/QueryHandler/GetProductForEditingHandler.php
@@ -275,7 +275,7 @@ class GetProductForEditingHandler implements GetProductForEditingHandlerInterfac
         $shopId = new ShopId($product->getShopId());
         $productId = new ProductId((int) $product->id);
 
-        $categoryIds = $this->categoryRepository->getProductCategoryIds($productId, $shopId);
+        $categoryIds = $this->categoryRepository->getProductCategoryIds($productId, ShopConstraint::shop($shopId->getValue()));
         $defaultCategoryId = (int) $product->id_category_default;
 
         $categoryNames = $this->categoryRepository->getLocalizedNames($categoryIds);

--- a/src/Adapter/Product/Update/ProductCategoryUpdater.php
+++ b/src/Adapter/Product/Update/ProductCategoryUpdater.php
@@ -79,7 +79,7 @@ class ProductCategoryUpdater
      */
     public function removeAllCategories(ProductId $productId, ShopConstraint $shopConstraint): void
     {
-        // Get curren categories based on the provided shop constraint
+        // Get current categories based on the provided shop constraint
         $this->deleteCategoriesAssociations($productId, [], $shopConstraint);
         $this->assignFallbackDefaultCategory($productId);
 

--- a/src/Adapter/Product/Update/ProductCategoryUpdater.php
+++ b/src/Adapter/Product/Update/ProductCategoryUpdater.php
@@ -28,13 +28,19 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Update;
 
+use Cache;
 use Category;
-use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository;
+use PrestaShop\PrestaShop\Adapter\Category\Repository\CategoryRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopId;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
-use PrestaShopException;
 use Product;
+use SpecificPriceRule;
 
 /**
  * Methods to update product & category relations
@@ -42,79 +48,160 @@ use Product;
 class ProductCategoryUpdater
 {
     /**
-     * @var ProductRepository
+     * @var ProductMultiShopRepository
      */
     private $productRepository;
 
     /**
-     * @param ProductRepository $productRepository
+     * @var CategoryRepository
+     */
+    private $categoryRepository;
+
+    /**
+     * @param ProductMultiShopRepository $productRepository
      */
     public function __construct(
-        ProductRepository $productRepository
+        ProductMultiShopRepository $productRepository,
+        CategoryRepository $categoryRepository
     ) {
         $this->productRepository = $productRepository;
+        $this->categoryRepository = $categoryRepository;
     }
 
     /**
-     * @param Product $product
-     * @param CategoryId[] $categoryIds
-     * @param CategoryId $defaultCategoryId
+     * @param ProductId $productId
+     * @param ShopConstraint $shopConstraint
      *
      * Warning: $categoryIds will replace current categories, erasing previous data
      *
      * @throws CannotUpdateProductException
      * @throws CoreException
      */
-    public function updateCategories(Product $product, array $categoryIds, CategoryId $defaultCategoryId): void
+    public function removeAllCategories(ProductId $productId, ShopConstraint $shopConstraint): void
     {
-        $categoryIds = $this->formatCategoryIdsList($categoryIds, $defaultCategoryId);
+        // Get curren categories based on the provided shop constraint
+        $this->deleteCategoriesAssociations($productId, [], $shopConstraint);
+        $this->assignFallbackDefaultCategory($productId);
 
-        try {
-            $this->assertCategoriesExists($categoryIds);
+        SpecificPriceRule::applyAllRules([$productId->getValue()]);
+        Cache::clean('Product::getProductCategories_' . $productId->getValue());
+    }
 
-            if (false === $product->updateCategories($categoryIds)) {
-                throw new CannotUpdateProductException(
-                    sprintf('Failed to update product #%d categories', $product->id),
-                    CannotUpdateProductException::FAILED_UPDATE_CATEGORIES
-                );
+    /**
+     * @param ProductId $productId
+     * @param CategoryId[] $newCategoryIds
+     * @param CategoryId $defaultCategoryId
+     * @param shopConstraint $shopConstraint
+     *
+     * Warning: $categoryIds will replace current categories, erasing previous data, it will only impact the categories
+     * matching the shop constraint though
+     *
+     * @throws CannotUpdateProductException
+     * @throws CoreException
+     */
+    public function updateCategories(ProductId $productId, array $newCategoryIds, CategoryId $defaultCategoryId, ShopConstraint $shopConstraint): void
+    {
+        $newCategoryIds = $this->formatCategoryIdsList($newCategoryIds, $defaultCategoryId);
+        $this->assertCategoriesExists($newCategoryIds);
+
+        // Get curren categories based on the provided shop constraint
+        $this->deleteCategoriesAssociations($productId, $newCategoryIds, $shopConstraint);
+        $this->categoryRepository->addProductAssociations($productId, $newCategoryIds);
+        $this->updateDefaultCategory($productId, $defaultCategoryId, $shopConstraint);
+
+        SpecificPriceRule::applyAllRules([$productId->getValue()]);
+        Cache::clean('Product::getProductCategories_' . $productId->getValue());
+    }
+
+    /**
+     * @param ProductId $productId
+     * @param CategoryId[] $newCategories
+     * @param ShopConstraint $shopConstraint
+     */
+    private function deleteCategoriesAssociations(ProductId $productId, array $newCategories, ShopConstraint $shopConstraint): void
+    {
+        // Get current categories based on provided context, only these ones should be deleted
+        $currentCategoryIds = $this->categoryRepository->getProductCategoryIds($productId, $shopConstraint);
+        $deletedCategories = array_filter($currentCategoryIds, static function (CategoryId $currentCategoryId) use ($newCategories): bool {
+            foreach ($newCategories as $newCategory) {
+                if ($newCategory->getValue() === $currentCategoryId->getValue()) {
+                    return false;
+                }
             }
-            $this->updateDefaultCategory($product, $defaultCategoryId);
-        } catch (PrestaShopException $e) {
-            throw new CoreException(
-                sprintf('Error occurred when trying to update product #%d categories', $product->id),
-                0,
-                $e
+
+            return true;
+        });
+
+        if (!empty($deletedCategories)) {
+            $this->categoryRepository->removeProductAssociations($productId, $deletedCategories);
+        }
+    }
+
+    /**
+     * @param ProductId $productId
+     * @param CategoryId $defaultCategoryId
+     * @param ShopConstraint $shopConstraint
+     */
+    private function updateDefaultCategory(ProductId $productId, CategoryId $defaultCategoryId, ShopConstraint $shopConstraint): void
+    {
+        $product = $this->productRepository->getByShopConstraint($productId, $shopConstraint);
+        $product->id_category_default = $defaultCategoryId->getValue();
+
+        $this->productRepository->partialUpdate(
+            $product,
+            ['id_category_default'],
+            $shopConstraint,
+            CannotUpdateProductException::FAILED_UPDATE_DEFAULT_CATEGORY
+        );
+
+        $this->assignFallbackDefaultCategory($productId);
+    }
+
+    private function assignFallbackDefaultCategory(ProductId $productId): void
+    {
+        // First define every shop that needs a fallback category defined, we perform the new association after each fallback is defined
+        // to avoid the first iteration to influence the fallback choice in following iterations
+        $fallbackCategories = [];
+        foreach ($this->productRepository->getAssociatedShopIds($productId) as $shopId) {
+            $defaultCategoryId = $this->categoryRepository->getProductDefaultCategory($productId, $shopId);
+            if (null === $defaultCategoryId) {
+                $shopConstraint = ShopConstraint::shop($shopId->getValue());
+                $productCategories = $this->categoryRepository->getProductCategoryIds($productId, $shopConstraint);
+                if (empty($productCategories)) {
+                    // If product has no more categories it needs at least the default category from shop
+                    $fallbackDefaultCategory = $this->categoryRepository->getShopDefaultCategory($shopId)->getValue();
+                } else {
+                    // If product has still some categories we use the one with smallest ID as fallback
+                    $fallbackDefaultCategory = min(array_values(array_map(static function (CategoryId $categoryId): int {
+                        return $categoryId->getValue();
+                    }, $productCategories)));
+                }
+                $fallbackCategories[$shopId->getValue()] = $fallbackDefaultCategory;
+            }
+        }
+
+        // We can update each default category for each shop, we also add the missing association
+        foreach ($fallbackCategories as $shopId => $fallbackDefaultCategory) {
+            $this->categoryRepository->addProductAssociations($productId, [new CategoryId($fallbackDefaultCategory)]);
+            $product = $this->productRepository->get($productId, new ShopId($shopId));
+            $product->id_category_default = $fallbackDefaultCategory;
+
+            $this->productRepository->partialUpdate(
+                $product,
+                ['id_category_default'],
+                ShopConstraint::shop($shopId),
+                CannotUpdateProductException::FAILED_UPDATE_DEFAULT_CATEGORY
             );
         }
     }
 
     /**
-     * @param Product $product
-     * @param CategoryId $defaultCategoryId
-     */
-    private function updateDefaultCategory(Product $product, CategoryId $defaultCategoryId): void
-    {
-        $categoryId = $defaultCategoryId->getValue();
-
-        $this->assertCategoriesExists([$categoryId]);
-        $product->id_category_default = $categoryId;
-
-        $this->productRepository->partialUpdate(
-            $product,
-            ['id_category_default'],
-            CannotUpdateProductException::FAILED_UPDATE_DEFAULT_CATEGORY
-        );
-    }
-
-    /**
-     * Re-map array to contain scalar values instead of object,
-     * append default category id to the list
-     * and filter-out duplicate values
+     * Make sure default category ID is in the list and each ID is unique.
      *
      * @param CategoryId[] $categoryIds
      * @param CategoryId $defaultCategoryId
      *
-     * @return int[]
+     * @return CategoryId[]
      */
     private function formatCategoryIdsList(array $categoryIds, CategoryId $defaultCategoryId): array
     {
@@ -125,25 +212,27 @@ class ProductCategoryUpdater
         $categoryIds[] = $defaultCategoryId->getValue();
         $categoryIds = array_unique($categoryIds, SORT_REGULAR);
 
-        return $categoryIds;
+        return array_map(static function (int $categoryId) {
+            return new CategoryId($categoryId);
+        }, $categoryIds);
     }
 
     /**
-     * @param int[] $categoryIds
+     * @param CategoryId[] $categoryIds
      *
      * @throws CannotUpdateProductException|CoreException
      */
     private function assertCategoriesExists(array $categoryIds): void
     {
         try {
-            if (!Category::categoriesExists($categoryIds)) {
-                throw new CannotUpdateProductException(
-                    sprintf('Failed to update product categories. Some of categories doesn\'t exist.'),
-                    CannotUpdateProductException::FAILED_UPDATE_CATEGORIES
-                );
+            foreach ($categoryIds as $categoryId) {
+                $this->categoryRepository->assertCategoryExists($categoryId);
             }
-        } catch (PrestaShopException $e) {
-            throw new CoreException('Error occurred when trying to assert categories existence');
+        } catch (CategoryNotFoundException $e) {
+            throw new CannotUpdateProductException(
+                sprintf('Failed to update product categories. Some of categories doesn\'t exist.'),
+                CannotUpdateProductException::FAILED_UPDATE_CATEGORIES
+            );
         }
     }
 }

--- a/src/Core/Domain/Product/Command/RemoveAllAssociatedProductCategoriesCommand.php
+++ b/src/Core/Domain/Product/Command/RemoveAllAssociatedProductCategoriesCommand.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Removes all product-category associations
@@ -41,11 +42,19 @@ class RemoveAllAssociatedProductCategoriesCommand
     private $productId;
 
     /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
      * @param int $productId
      */
-    public function __construct(int $productId)
-    {
+    public function __construct(
+        int $productId,
+        ShopConstraint $shopConstraint
+    ) {
         $this->productId = new ProductId($productId);
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -54,5 +63,13 @@ class RemoveAllAssociatedProductCategoriesCommand
     public function getProductId(): ProductId
     {
         return $this->productId;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 }

--- a/src/Core/Domain/Product/Command/SetAssociatedProductCategoriesCommand.php
+++ b/src/Core/Domain/Product/Command/SetAssociatedProductCategoriesCommand.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Category\ValueObject\CategoryId;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use RuntimeException;
 
 /**
@@ -53,15 +54,25 @@ class SetAssociatedProductCategoriesCommand
     private $categoryIds;
 
     /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
      * @param int $productId
      * @param int $defaultCategoryId
      * @param int[] $categoryIds
      */
-    public function __construct(int $productId, int $defaultCategoryId, array $categoryIds)
-    {
+    public function __construct(
+        int $productId,
+        int $defaultCategoryId,
+        array $categoryIds,
+        ShopConstraint $shopConstraint
+    ) {
         $this->setCategoryIds($categoryIds);
         $this->defaultCategoryId = new CategoryId($defaultCategoryId);
         $this->productId = new ProductId($productId);
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -86,6 +97,14 @@ class SetAssociatedProductCategoriesCommand
     public function getCategoryIds(): array
     {
         return $this->categoryIds;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 
     /**

--- a/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCategoriesCommandsBuilder.php
+++ b/src/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCategoriesCommandsBuilder.php
@@ -31,16 +31,17 @@ namespace PrestaShop\PrestaShop\Core\Form\IdentifiableObject\CommandBuilder\Prod
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllAssociatedProductCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetAssociatedProductCategoriesCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Builder used to build SetAssociatedProductCategoriesCommand or RemoveAllAssociatedProductCategoriesCommand.
  */
-class ProductCategoriesCommandsBuilder implements ProductCommandsBuilderInterface
+class ProductCategoriesCommandsBuilder implements MultiShopProductCommandsBuilderInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function buildCommands(ProductId $productId, array $formData): array
+    public function buildCommands(ProductId $productId, array $formData, ShopConstraint $singleShopConstraint): array
     {
         if (!isset($formData['description']['categories']['product_categories'])) {
             return [];
@@ -48,7 +49,7 @@ class ProductCategoriesCommandsBuilder implements ProductCommandsBuilderInterfac
 
         if (empty($formData['description']['categories']['product_categories'])) {
             return [
-                new RemoveAllAssociatedProductCategoriesCommand($productId->getValue()),
+                new RemoveAllAssociatedProductCategoriesCommand($productId->getValue(), $singleShopConstraint),
             ];
         }
 
@@ -69,7 +70,7 @@ class ProductCategoriesCommandsBuilder implements ProductCommandsBuilderInterfac
         // If no associated categories is defined remove them all
         if (empty($associatedCategoryIds)) {
             return [
-                new RemoveAllAssociatedProductCategoriesCommand($productId->getValue()),
+                new RemoveAllAssociatedProductCategoriesCommand($productId->getValue(), $singleShopConstraint),
             ];
         }
 
@@ -82,7 +83,8 @@ class ProductCategoriesCommandsBuilder implements ProductCommandsBuilderInterfac
             new SetAssociatedProductCategoriesCommand(
                 $productId->getValue(),
                 $defaultCategoryId,
-                $associatedCategoryIds
+                $associatedCategoryIds,
+                $singleShopConstraint
             ),
         ];
     }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -374,9 +374,8 @@ services:
       - '@PrestaShop\PrestaShop\Adapter\Product\Update\ProductIndexationUpdater'
 
   PrestaShop\PrestaShop\Adapter\Product\Update\ProductCategoryUpdater:
-    arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository'
-      - '@PrestaShop\PrestaShop\Adapter\Category\Repository\CategoryRepository'
+    autowire: true
+    public: false
 
   PrestaShop\PrestaShop\Adapter\Product\CommandHandler\DuplicateProductHandler:
     arguments:
@@ -434,6 +433,7 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Product\Update\ProductShopUpdater:
     autowire: true
+    public: false
 
   PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductHandler:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -179,17 +179,13 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Product\CommandHandler\SetAssociatedProductCategoriesHandler:
     arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository'
       - '@PrestaShop\PrestaShop\Adapter\Product\Update\ProductCategoryUpdater'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Command\SetAssociatedProductCategoriesCommand
 
   PrestaShop\PrestaShop\Adapter\Product\CommandHandler\RemoveAllAssociatedProductCategoriesHandler:
-    arguments:
-      - '@=service("PrestaShop\\PrestaShop\\Adapter\\Configuration").getInt("PS_HOME_CATEGORY")'
-      - '@PrestaShop\PrestaShop\Adapter\Product\Update\ProductCategoryUpdater'
-      - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository'
+    autowire: true
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllAssociatedProductCategoriesCommand
@@ -264,13 +260,10 @@ services:
       - '@PrestaShop\PrestaShop\Adapter\Product\Pack\Repository\ProductPackRepository'
 
   PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository:
+    autowire: true
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
-      - '@PrestaShop\PrestaShop\Adapter\Product\Validate\ProductValidator'
-      - '@=service("PrestaShop\\PrestaShop\\Adapter\\LegacyContext").getContext().shop.id_category'
-      - '@PrestaShop\PrestaShop\Adapter\TaxRulesGroup\Repository\TaxRulesGroupRepository'
-      - '@PrestaShop\PrestaShop\Adapter\Manufacturer\Repository\ManufacturerRepository'
 
   PrestaShop\PrestaShop\Adapter\Product\Update\ProductTypeUpdater:
     arguments:
@@ -382,7 +375,8 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Product\Update\ProductCategoryUpdater:
     arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository'
+      - '@PrestaShop\PrestaShop\Adapter\Category\Repository\CategoryRepository'
 
   PrestaShop\PrestaShop\Adapter\Product\CommandHandler\DuplicateProductHandler:
     arguments:
@@ -439,15 +433,7 @@ services:
       - '@PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository'
 
   PrestaShop\PrestaShop\Adapter\Product\Update\ProductShopUpdater:
-    arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository'
-      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Repository\StockAvailableMultiShopRepository'
-      - '@PrestaShop\PrestaShop\Adapter\Shop\Repository\ShopRepository'
-      - '@PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageMultiShopRepository'
-      - '@PrestaShop\PrestaShop\Adapter\Product\Stock\Update\ProductStockUpdater'
-      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository'
-      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater'
-      - '@PrestaShop\PrestaShop\Adapter\Product\Combination\Update\DefaultCombinationUpdater'
+    autowire: true
 
   PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductHandler:
     arguments:

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePositionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdatePositionFeatureContext.php
@@ -75,9 +75,9 @@ class UpdatePositionFeatureContext extends AbstractProductFeatureContext
     {
         $products = $this->localizeByColumns($tableNode);
         $productRepository = CommonFeatureContext::getContainer()->get(ProductRepository::class);
+        $categoryId = new CategoryId($this->getSharedStorage()->get($categoryReference));
         foreach ($products as $product) {
             $productId = new ProductId($this->getSharedStorage()->get($product['product_reference']));
-            $categoryId = new CategoryId($this->getSharedStorage()->get($categoryReference));
             Assert::assertSame((int) $product['position'], $productRepository->getPositionInCategory($productId, $categoryId));
         }
     }

--- a/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/ShopFeatureContext.php
@@ -213,6 +213,19 @@ class ShopFeatureContext extends AbstractDomainFeatureContext
     }
 
     /**
+     * @When I set :categoryReference as default category for shop :reference
+     *
+     * @param string $categoryReference
+     * @param string $shopReference
+     */
+    public function defineShopDefaultCategory(string $categoryReference, string $shopReference): void
+    {
+        $shop = new Shop($this->referenceToId($shopReference));
+        $shop->id_category = $this->referenceToId($categoryReference);
+        $shop->save();
+    }
+
+    /**
      * @Given single shop context is loaded
      */
     public function singleShopContextIsLoaded(): void

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_categories.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_categories.feature
@@ -1,0 +1,52 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-categories
+@restore-products-before-feature
+@clear-cache-before-feature
+@restore-shops-after-feature
+@restore-languages-after-feature
+@reset-img-after-feature
+@clear-cache-after-feature
+@product-multi-shop
+@update-multi-shop-categories
+Feature: Copy product from shop to shop.
+  As a BO user I want to be able to copy product from shop to shop.
+
+  Background:
+    Given I enable multishop feature
+    And language with iso code "en" is the default one
+    And shop "shop1" with name "test_shop" exists
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "test_second_shop" and color "red" for the group "default_shop_group"
+    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And single shop context is loaded
+    And language "french" with locale "fr-FR" exists
+    And category "home" in default language named "Home" exists
+    And category "home" is the default one
+    And category "men" in default language named "Men" exists
+    And category "clothes" in default language named "Clothes" exists
+    And category "women" in default language named "Women" exists
+    And category "accessories" in default language named "Accessories" exists
+
+  Scenario: I assign product to categories they are the same on all shops, but default one can be different
+    Given I add product "product1" to shop shop2 with following information:
+      | name[en-US] | eastern european tracksuit |
+      | type        | standard                   |
+    When I copy product productWithPrices from shop shop2 to shop shop1
+    And product "product1" should be assigned to following categories for shops "shop1,shop2":
+      | id reference | name | is default |
+      | home         | Home | true       |
+    When I assign product product1 to following categories for shop shop1:
+      | categories       | [home, men, clothes] |
+      | default category | clothes              |
+    # The associations are shared on all shops, but the default category can be different
+    Then product product1 should be assigned to following categories for shops "shop1":
+      | id reference | name    | is default |
+      | home         | Home    | false      |
+      | men          | Men     | false      |
+      | clothes      | Clothes | true       |
+    And product product1 should be assigned to following categories for shops "shop2":
+      | id reference | name    | is default |
+      | home         | Home    | true       |
+      | men          | Men     | false      |
+      | clothes      | Clothes | false      |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_categories.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_categories.feature
@@ -27,7 +27,6 @@ Feature: Copy product from shop to shop.
     And category "clothes" in default language named "Clothes" exists
     And category "women" in default language named "Women" exists
     And category "accessories" in default language named "Accessories" exists
-    And I set "women" as default category for shop shop2
     And I edit home category "home" with following details:
       | associated shops | shop1,shop2,shop3,shop4 |
     And I edit category "clothes" with following details:
@@ -37,11 +36,12 @@ Feature: Copy product from shop to shop.
     # Men is only associated in shop1
     And I edit category "men" with following details:
       | associated shops | shop1 |
-    # Men is only associated in shop2
+    # Women is only associated in shop2 and is the default category
     And I edit category "women" with following details:
       | associated shops | shop2 |
+    And I set "women" as default category for shop shop2
 
-  Scenario: I assign product to categories they are the same on all shops, but default one can be different
+  Scenario: I assign product to categories which are associated to different shops, the default fallback depends on which shops are associated
     Given I add product "product1" to shop shop2 with following information:
       | name[en-US] | eastern european tracksuit |
       | type        | standard                   |
@@ -50,7 +50,8 @@ Feature: Copy product from shop to shop.
       | id reference | name  | is default |
       | women        | Women | true       |
     When I copy product product1 from shop shop2 to shop shop1
-    # Women is not associated to shop1, so shop1's default category is used as default, thus it is also part of shop2's categories
+    # Women is not associated to shop1, we need to pick another default category for shop1 (home is picked since it's the shop's default category)
+    # Since the associations are common to all shops, shop2 is already assigned to home now
     Then product "product1" should be assigned to following categories for shop shop2:
       | id reference | name  | is default |
       | women        | Women | true       |
@@ -58,10 +59,10 @@ Feature: Copy product from shop to shop.
     And product "product1" should be assigned to following categories for shop shop1:
       | id reference | name | is default |
       | home         | Home | true       |
+    # Now we set categories for shop1 with some categories common to all shops, and one specific to shop1 (men)
     When I assign product product1 to following categories for shop shop1:
       | categories       | [home, men, clothes] |
       | default category | clothes              |
-    # The associations are shared on all shops, but the default category can be different
     Then product product1 should be assigned to following categories for shops "shop1":
       | id reference | name    | is default |
       | home         | Home    | false      |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_categories.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_multishop_categories.feature
@@ -27,13 +27,35 @@ Feature: Copy product from shop to shop.
     And category "clothes" in default language named "Clothes" exists
     And category "women" in default language named "Women" exists
     And category "accessories" in default language named "Accessories" exists
+    And I set "women" as default category for shop shop2
+    And I edit home category "home" with following details:
+      | associated shops | shop1,shop2,shop3,shop4 |
+    And I edit category "clothes" with following details:
+      | associated shops | shop1,shop2,shop3,shop4 |
+    And I edit category "accessories" with following details:
+      | associated shops | shop1,shop2,shop3,shop4 |
+    # Men is only associated in shop1
+    And I edit category "men" with following details:
+      | associated shops | shop1 |
+    # Men is only associated in shop2
+    And I edit category "women" with following details:
+      | associated shops | shop2 |
 
   Scenario: I assign product to categories they are the same on all shops, but default one can be different
     Given I add product "product1" to shop shop2 with following information:
       | name[en-US] | eastern european tracksuit |
       | type        | standard                   |
-    When I copy product productWithPrices from shop shop2 to shop shop1
-    And product "product1" should be assigned to following categories for shops "shop1,shop2":
+    # Default category associated is the one from the shop
+    Then product "product1" should be assigned to following categories for shop shop2:
+      | id reference | name  | is default |
+      | women        | Women | true       |
+    When I copy product product1 from shop shop2 to shop shop1
+    # Women is not associated to shop1, so shop1's default category is used as default, thus it is also part of shop2's categories
+    Then product "product1" should be assigned to following categories for shop shop2:
+      | id reference | name  | is default |
+      | women        | Women | true       |
+      | home         | Home  | false      |
+    And product "product1" should be assigned to following categories for shop shop1:
       | id reference | name | is default |
       | home         | Home | true       |
     When I assign product product1 to following categories for shop shop1:
@@ -45,8 +67,35 @@ Feature: Copy product from shop to shop.
       | home         | Home    | false      |
       | men          | Men     | false      |
       | clothes      | Clothes | true       |
+    # Men is filtered since it doesn't belong to shop2, women is still the default category since it was not removed
     And product product1 should be assigned to following categories for shops "shop2":
       | id reference | name    | is default |
-      | home         | Home    | true       |
-      | men          | Men     | false      |
+      | home         | Home    | false      |
       | clothes      | Clothes | false      |
+      | women        | Women   | true       |
+    # Now update for shop2, clothes is associated to shop2 but not in the updated list so it will be removed
+    When I assign product product1 to following categories for shop shop2:
+      | categories       | [home, accessories, women] |
+      | default category | accessories                |
+    Then product product1 should be assigned to following categories for shops "shop2":
+      | id reference | name        | is default |
+      | home         | Home        | false      |
+      | accessories  | Accessories | true       |
+      | women        | Women       | false      |
+    # Clothes has been removed but since Men doesn't belong to shop2 it was not removed
+    # Since clothes has been removed a new default category has been assigned though
+    And product product1 should be assigned to following categories for shops "shop1":
+      | id reference | name        | is default |
+      | home         | Home        | true       |
+      | accessories  | Accessories | false      |
+      | men          | Men         | false      |
+    # Now delete all categories, at least the default one of each shop should remain
+    When I delete all categories from product product1 for shop shop2
+    # Shop2 had all its categories removed so it has to use the shop's default one
+    Then product product1 should be assigned to following categories for shops "shop2":
+      | id reference | name  | is default |
+      | women        | Women | true       |
+    # Shop1 still had the Men category so it can be kept as the default one
+    And product product1 should be assigned to following categories for shops "shop1":
+      | id reference | name | is default |
+      | men          | Men  | true       |

--- a/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCategoriesCommandsBuilderTest.php
+++ b/tests/Unit/Core/Form/IdentifiableObject/CommandBuilder/Product/ProductCategoriesCommandsBuilderTest.php
@@ -43,7 +43,7 @@ class ProductCategoriesCommandsBuilderTest extends AbstractProductCommandBuilder
     public function testBuildCommand(array $formData, array $expectedCommands): void
     {
         $builder = new ProductCategoriesCommandsBuilder();
-        $builtCommands = $builder->buildCommands($this->getProductId(), $formData);
+        $builtCommands = $builder->buildCommands($this->getProductId(), $formData, $this->getSingleShopConstraint());
         $this->assertEquals($expectedCommands, $builtCommands);
     }
 
@@ -72,7 +72,8 @@ class ProductCategoriesCommandsBuilderTest extends AbstractProductCommandBuilder
         $command = new SetAssociatedProductCategoriesCommand(
             $this->getProductId()->getValue(),
             42,
-            [42, 49, 51]
+            [42, 49, 51],
+            $this->getSingleShopConstraint()
         );
         yield [
             [
@@ -101,7 +102,8 @@ class ProductCategoriesCommandsBuilderTest extends AbstractProductCommandBuilder
         $command = new SetAssociatedProductCategoriesCommand(
             $this->getProductId()->getValue(),
             51,
-            [42, 49, 51]
+            [42, 49, 51],
+            $this->getSingleShopConstraint()
         );
         yield [
             [
@@ -127,7 +129,8 @@ class ProductCategoriesCommandsBuilderTest extends AbstractProductCommandBuilder
         $command = new SetAssociatedProductCategoriesCommand(
             $this->getProductId()->getValue(),
             42,
-            [42, 49, 51]
+            [42, 49, 51],
+            $this->getSingleShopConstraint()
         );
         yield [
             [
@@ -153,7 +156,7 @@ class ProductCategoriesCommandsBuilderTest extends AbstractProductCommandBuilder
         ];
 
         // No associations means remove all
-        $command = new RemoveAllAssociatedProductCategoriesCommand($this->getProductId()->getValue());
+        $command = new RemoveAllAssociatedProductCategoriesCommand($this->getProductId()->getValue(), $this->getSingleShopConstraint());
         yield [
             [
                 'description' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle shop constraint for product categories commands, depending on the provided shop constraint the commands only removed categories matching the defined constraints. The query for product editing also returns only the categories associated to the provided shop constraint. Thus when switching from a shop context to another the user can only see relevant categories and edit them without risking to delete associations on another shop.<br>Note: this PR is blocking for the `DuplicateProductCommand` in multishop mode
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI test green
| Fixed ticket?     | ~
| Related PRs       | ~
| Sponsor company   | ~
