### PR TITLE
Duplicate product multishop (part 1)

### DIFF
--- a/src/Adapter/Product/CommandHandler/BulkDuplicateProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/BulkDuplicateProductHandler.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Product\ProductDuplicator;
+use PrestaShop\PrestaShop\Adapter\Product\Update\ProductDuplicator;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\BulkDuplicateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\BulkDuplicateProductHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\BulkProductException;

--- a/src/Adapter/Product/CommandHandler/BulkDuplicateProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/BulkDuplicateProductHandler.php
@@ -58,18 +58,18 @@ class BulkDuplicateProductHandler extends AbstractBulkHandler implements BulkDup
      */
     public function handle(BulkDuplicateProductCommand $command): array
     {
-        return $this->handleBulkAction($command->getProductIds());
+        return $this->handleBulkAction($command->getProductIds(), $command);
     }
 
     /**
      * @param ProductId $productId
-     * @param null $command
+     * @param BulkDuplicateProductCommand $command
      *
      * @return ProductId
      */
     protected function handleSingleAction(ProductId $productId, $command = null)
     {
-        return $this->productDuplicator->duplicate($productId);
+        return $this->productDuplicator->duplicate($productId, $command->getShopConstraint());
     }
 
     protected function buildBulkException(): BulkProductException

--- a/src/Adapter/Product/CommandHandler/DuplicateProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/DuplicateProductHandler.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Product\ProductDuplicator;
+use PrestaShop\PrestaShop\Adapter\Product\Update\ProductDuplicator;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\DuplicateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\CommandHandler\DuplicateProductHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;

--- a/src/Adapter/Product/CommandHandler/DuplicateProductHandler.php
+++ b/src/Adapter/Product/CommandHandler/DuplicateProductHandler.php
@@ -57,6 +57,6 @@ final class DuplicateProductHandler implements DuplicateProductHandlerInterface
      */
     public function handle(DuplicateProductCommand $command): ProductId
     {
-        return $this->productDuplicator->duplicate($command->getProductId());
+        return $this->productDuplicator->duplicate($command->getProductId(), $command->getShopConstraint());
     }
 }

--- a/src/Adapter/Product/Repository/ProductMultiShopRepository.php
+++ b/src/Adapter/Product/Repository/ProductMultiShopRepository.php
@@ -39,7 +39,6 @@ use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\NoManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotAddProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotDeleteProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotDuplicateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
@@ -561,32 +560,6 @@ class ProductMultiShopRepository extends AbstractMultiShopObjectModelRepository
         $defaultShopId = $this->getProductDefaultShopId($productId);
 
         return $this->getProductByShopId($productId, $defaultShopId);
-    }
-
-    /**
-     * Add product to a specific shop (forces creation by unsetting the initial ID if present),
-     * the provided product instance is not modified.
-     *
-     * @param Product $product
-     *
-     * @return Product
-     *
-     * @throws CoreException
-     * @throws CannotDuplicateProductException
-     * @throws ProductConstraintException
-     * @throws ProductException
-     */
-    public function addProductToShop(Product $product, ShopId $shopId): Product
-    {
-        // Force unsetting the IDs (just in case) so that a new product row is created
-        $newProduct = clone $product;
-        unset($newProduct->id, $newProduct->id_product);
-
-        $this->productValidator->validateCreation($newProduct);
-        $this->productValidator->validate($newProduct);
-        $this->addObjectModelToShops($newProduct, [$shopId], CannotDuplicateProductException::class);
-
-        return $newProduct;
     }
 
     private function getProductByShopGroup(ProductId $productId, ShopGroupId $shopGroupId): Product

--- a/src/Adapter/Product/Repository/ProductRepository.php
+++ b/src/Adapter/Product/Repository/ProductRepository.php
@@ -43,7 +43,6 @@ use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerExcepti
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\ManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Manufacturer\ValueObject\NoManufacturerId;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotDeleteProductException;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotDuplicateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\CannotUpdateProductException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
@@ -110,33 +109,6 @@ class ProductRepository extends AbstractObjectModelRepository
         $this->productValidator = $productValidator;
         $this->taxRulesGroupRepository = $taxRulesGroupRepository;
         $this->manufacturerRepository = $manufacturerRepository;
-    }
-
-    /**
-     * @todo: Not sure this should be in the repository as it gives a false feeling the the repository can duplicate a
-     *        product on its own, but you actually need to use the ProductDuplicator service to do it right, this method
-     *        should be removed and the duplicator service should rely on repository to add/update but it is the one that
-     *        must perform the required modifications on the object instance
-     * Duplicates product entity without relations
-     *
-     * @param Product $product
-     *
-     * @return Product
-     *
-     * @throws CoreException
-     * @throws CannotDuplicateProductException
-     * @throws ProductConstraintException
-     * @throws ProductException
-     */
-    public function duplicate(Product $product): Product
-    {
-        unset($product->id, $product->id_product);
-
-        $this->productValidator->validateCreation($product);
-        $this->productValidator->validate($product);
-        $this->addObjectModel($product, CannotDuplicateProductException::class);
-
-        return $product;
     }
 
     /**

--- a/src/Adapter/Product/SpecificPrice/Repository/SpecificPriceRepository.php
+++ b/src/Adapter/Product/SpecificPrice/Repository/SpecificPriceRepository.php
@@ -193,6 +193,24 @@ class SpecificPriceRepository extends AbstractObjectModelRepository
 
     /**
      * @param ProductId $productId
+     *
+     * @return SpecificPriceId[]
+     */
+    public function getProductSpecificPricesIds(ProductId $productId): array
+    {
+        return array_map(static function (array $specificPrice): SpecificPriceId {
+            return new SpecificPriceId((int) $specificPrice['id_specific_price']);
+        }, $this->connection
+            ->createQueryBuilder()
+            ->from($this->dbPrefix . 'specific_price', 'sp')
+            ->select('sp.id_specific_price')
+            ->where('sp.id_product = :productId')
+            ->setParameter('productId', $productId->getValue())
+            ->execute()->fetchAllAssociative());
+    }
+
+    /**
+     * @param ProductId $productId
      * @param LanguageId $langId
      * @param array<string, mixed> $filters
      *

--- a/src/Core/Domain/Product/Command/BulkDuplicateProductCommand.php
+++ b/src/Core/Domain/Product/Command/BulkDuplicateProductCommand.php
@@ -30,6 +30,7 @@ namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Deletes multiple products
@@ -42,15 +43,23 @@ class BulkDuplicateProductCommand
     private $productIds;
 
     /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
      * @param int[] $productIds
      *
      * @throws ProductConstraintException
      */
-    public function __construct(array $productIds)
-    {
+    public function __construct(
+        array $productIds,
+        ShopConstraint $shopConstraint
+    ) {
         foreach ($productIds as $productId) {
             $this->productIds[] = new ProductId($productId);
         }
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -59,5 +68,13 @@ class BulkDuplicateProductCommand
     public function getProductIds(): array
     {
         return $this->productIds;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 }

--- a/src/Core/Domain/Product/Command/DuplicateProductCommand.php
+++ b/src/Core/Domain/Product/Command/DuplicateProductCommand.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\Product\Command;
 
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductId;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
  * Duplicates product
@@ -41,11 +42,19 @@ class DuplicateProductCommand
     private $productId;
 
     /**
+     * @var ShopConstraint
+     */
+    private $shopConstraint;
+
+    /**
      * @param int $productId
      */
-    public function __construct(int $productId)
-    {
+    public function __construct(
+        int $productId,
+        ShopConstraint $shopConstraint
+    ) {
         $this->productId = new ProductId($productId);
+        $this->shopConstraint = $shopConstraint;
     }
 
     /**
@@ -54,5 +63,13 @@ class DuplicateProductCommand
     public function getProductId(): ProductId
     {
         return $this->productId;
+    }
+
+    /**
+     * @return ShopConstraint
+     */
+    public function getShopConstraint(): ShopConstraint
+    {
+        return $this->shopConstraint;
     }
 }

--- a/src/Core/Domain/Product/Exception/CannotDuplicateProductException.php
+++ b/src/Core/Domain/Product/Exception/CannotDuplicateProductException.php
@@ -46,7 +46,7 @@ class CannotDuplicateProductException extends ProductException
     /**
      * When product attributes duplication fails
      */
-    public const FAILED_DUPLICATE_ATTRIBUTES = 30;
+    public const FAILED_DUPLICATE_COMBINATIONS = 30;
 
     /**
      * When product group reduction duplication fails

--- a/src/Core/Domain/Product/Exception/CannotUpdateProductException.php
+++ b/src/Core/Domain/Product/Exception/CannotUpdateProductException.php
@@ -125,4 +125,9 @@ class CannotUpdateProductException extends ProductException
      * When type update fails
      */
     public const FAILED_SHOP_COPY = 170;
+
+    /**
+     * When type update fails
+     */
+    public const FAILED_DUPLICATION = 180;
 }

--- a/src/Core/Domain/Product/Exception/CannotUpdateProductException.php
+++ b/src/Core/Domain/Product/Exception/CannotUpdateProductException.php
@@ -122,12 +122,12 @@ class CannotUpdateProductException extends ProductException
     public const FAILED_UPDATE_STATUS = 170;
 
     /**
-     * When type update fails
+     * When copying from shop to shop fails
      */
     public const FAILED_SHOP_COPY = 170;
 
     /**
-     * When type update fails
+     * When product duplication fails
      */
     public const FAILED_DUPLICATION = 180;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -552,7 +552,10 @@ class ProductController extends FrameworkBundleAdminController
     {
         try {
             /** @var ProductId $newProductId */
-            $newProductId = $this->getCommandBus()->handle(new DuplicateProductCommand($productId));
+            $newProductId = $this->getCommandBus()->handle(new DuplicateProductCommand(
+                $productId,
+                ShopConstraint::allShops()
+            ));
             $this->addFlash(
                 'success',
                 $this->trans('Successful duplication', 'Admin.Notifications.Success')
@@ -788,7 +791,8 @@ class ProductController extends FrameworkBundleAdminController
         try {
             $this->getCommandBus()->handle(
                 new BulkDuplicateProductCommand(
-                    $this->getProductIdsFromRequest($request)
+                    $this->getProductIdsFromRequest($request),
+                    ShopConstraint::allShops()
                 )
             );
         } catch (Exception $e) {

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -297,7 +297,7 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Product\CommandHandler\BulkDuplicateProductHandler:
     arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Product\ProductDuplicator'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Update\ProductDuplicator'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Command\BulkDuplicateProductCommand
@@ -386,7 +386,7 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Product\CommandHandler\DuplicateProductHandler:
     arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Product\ProductDuplicator'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Update\ProductDuplicator'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Command\DuplicateProductCommand
@@ -407,7 +407,7 @@ services:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Shop\Command\DeleteProductFromShopsCommand
 
-  PrestaShop\PrestaShop\Adapter\Product\ProductDuplicator:
+  PrestaShop\PrestaShop\Adapter\Product\Update\ProductDuplicator:
     arguments:
       - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository'
       - '@PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface'

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -408,11 +408,10 @@ services:
         command: PrestaShop\PrestaShop\Core\Domain\Product\Shop\Command\DeleteProductFromShopsCommand
 
   PrestaShop\PrestaShop\Adapter\Product\Update\ProductDuplicator:
+    autowire: true
     arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository'
-      - '@PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface'
-      - '@translator'
-      - '@PrestaShop\PrestaShop\Core\Util\String\StringModifier'
+      $connection: '@doctrine.dbal.default_connection'
+      $dbPrefix: '%database_prefix%'
 
   PrestaShop\PrestaShop\Adapter\Product\ProductStatusUpdater:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -409,10 +409,8 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Product\ProductDuplicator:
     arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductRepository'
+      - '@PrestaShop\PrestaShop\Adapter\Product\Repository\ProductMultiShopRepository'
       - '@PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface'
-      - '@=service("PrestaShop\\PrestaShop\\Adapter\\Configuration").getBoolean("PS_SEARCH_INDEXATION")'
-      - '@prestashop.adapter.shop.context'
       - '@translator'
       - '@PrestaShop\PrestaShop\Core\Util\String\StringModifier'
 

--- a/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CommonFeatureContext.php
@@ -85,6 +85,7 @@ use OrderSlip;
 use OrderState;
 use Pack;
 use Page;
+use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use Product;
 use ProductAttribute;
@@ -371,6 +372,47 @@ class CommonFeatureContext extends AbstractPrestaShopFeatureContext
     {
         $tables = explode(',', $tableNames);
         DatabaseDump::restoreTables($tables);
+    }
+
+    /**
+     * @Then :firstReference and :secondReference have different values
+     *
+     * @param string $firstReference
+     * @param string $secondReference
+     */
+    public function assertDifferentValues(string $firstReference, string $secondReference): void
+    {
+        Assert::assertNotEquals(
+            SharedStorage::getStorage()->get($firstReference),
+            SharedStorage::getStorage()->get($secondReference),
+            sprintf(
+                '%s and %s are expected to be different but they have same value %s',
+                $firstReference,
+                $secondReference,
+                (string) SharedStorage::getStorage()->get($firstReference)
+            )
+        );
+    }
+
+    /**
+     * @Then :firstReference and :secondReference have same value
+     *
+     * @param string $firstReference
+     * @param string $secondReference
+     */
+    public function assertSameValue(string $firstReference, string $secondReference): void
+    {
+        Assert::assertEquals(
+            SharedStorage::getStorage()->get($firstReference),
+            SharedStorage::getStorage()->get($secondReference),
+            sprintf(
+                '%s and %s are expected to be equals but they have different values %s != %s',
+                $firstReference,
+                $secondReference,
+                (string) SharedStorage::getStorage()->get($firstReference),
+                (string) SharedStorage::getStorage()->get($secondReference)
+            )
+        );
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/DetailsAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/DetailsAssertionFeatureContext.php
@@ -63,10 +63,29 @@ class DetailsAssertionFeatureContext extends AbstractProductFeatureContext
      * @param string $productReference
      * @param ProductDetails $expectedDetails
      */
-    public function assertDetails(string $productReference, ProductDetails $expectedDetails): void
+    public function assertDetailsForDefaultShop(string $productReference, ProductDetails $expectedDetails): void
+    {
+        $this->assertDetails($productReference, $expectedDetails, $this->getDefaultShopId());
+    }
+
+    /**
+     * @Then product :productReference should have following details for shop(s) :shopReferences:
+     *
+     * @param string $productReference
+     * @param string $shopReferences
+     * @param ProductDetails $expectedDetails
+     */
+    public function assertDetailsForShops(string $productReference, string $shopReferences, ProductDetails $expectedDetails): void
+    {
+        foreach ($this->referencesToIds($shopReferences) as $shopId) {
+            $this->assertDetails($productReference, $expectedDetails, $shopId);
+        }
+    }
+
+    private function assertDetails(string $productReference, ProductDetails $expectedDetails, int $shopId): void
     {
         $properties = ['ean13', 'isbn', 'mpn', 'reference', 'upc'];
-        $actualDetails = $this->getProductForEditing($productReference)->getDetails();
+        $actualDetails = $this->getProductForEditing($productReference, $shopId)->getDetails();
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         foreach ($properties as $propertyName) {

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
@@ -88,6 +88,23 @@ class DuplicateProductFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
+     * @When I duplicate product :productReference to a :newProductReference for shop group :shopGroupReference
+     *
+     * @param string $productReference
+     * @param string $newProductReference
+     * @param string $shopGroupReference
+     */
+    public function duplicateForShopGroup(string $productReference, string $newProductReference, string $shopGroupReference): void
+    {
+        $newProductId = $this->getCommandBus()->handle(new DuplicateProductCommand(
+            $this->getSharedStorage()->get($productReference),
+            ShopConstraint::shopGroup($this->referenceToId($shopGroupReference))
+        ));
+
+        $this->getSharedStorage()->set($newProductReference, $newProductId->getValue());
+    }
+
+    /**
      * @When I bulk duplicate following products:
      *
      * @param TableNode $productsList

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
@@ -72,6 +72,22 @@ class DuplicateProductFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
+     * @When I duplicate product :productReference to a :newProductReference for all shops
+     *
+     * @param string $productReference
+     * @param string $newProductReference
+     */
+    public function duplicateForAllShops(string $productReference, string $newProductReference): void
+    {
+        $newProductId = $this->getCommandBus()->handle(new DuplicateProductCommand(
+            $this->getSharedStorage()->get($productReference),
+            ShopConstraint::allShops()
+        ));
+
+        $this->getSharedStorage()->set($newProductReference, $newProductId->getValue());
+    }
+
+    /**
      * @When I bulk duplicate following products:
      *
      * @param TableNode $productsList

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
@@ -44,10 +44,28 @@ class DuplicateProductFeatureContext extends AbstractProductFeatureContext
      * @param string $productReference
      * @param string $newProductReference
      */
-    public function duplicate(string $productReference, string $newProductReference): void
+    public function duplicateForDefaultShop(string $productReference, string $newProductReference): void
     {
         $newProductId = $this->getCommandBus()->handle(new DuplicateProductCommand(
-            $this->getSharedStorage()->get($productReference)
+            $this->getSharedStorage()->get($productReference),
+            ShopConstraint::shop($this->getDefaultShopId())
+        ));
+
+        $this->getSharedStorage()->set($newProductReference, $newProductId->getValue());
+    }
+
+    /**
+     * @When I duplicate product :productReference to a :newProductReference for shop :shopReference
+     *
+     * @param string $productReference
+     * @param string $newProductReference
+     * @param string $shopReference
+     */
+    public function duplicateForShop(string $productReference, string $newProductReference, string $shopReference): void
+    {
+        $newProductId = $this->getCommandBus()->handle(new DuplicateProductCommand(
+            $this->getSharedStorage()->get($productReference),
+            ShopConstraint::shop($this->referenceToId($shopReference))
         ));
 
         $this->getSharedStorage()->set($newProductReference, $newProductId->getValue());
@@ -66,7 +84,7 @@ class DuplicateProductFeatureContext extends AbstractProductFeatureContext
         }
 
         try {
-            $newProductIds = $this->getCommandBus()->handle(new BulkDuplicateProductCommand($productIds));
+            $newProductIds = $this->getCommandBus()->handle(new BulkDuplicateProductCommand($productIds, ShopConstraint::shop($this->getDefaultShopId())));
         } catch (ProductException $e) {
             $this->setLastException($e);
 

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPriceContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPriceContext.php
@@ -105,18 +105,16 @@ class SpecificPriceContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Transform table:id reference,combination,reduction type,reduction value,includes tax,fixed price,from quantity,shop,currency,currencyISOCode,country,group,customer,from,to
-     *
      * @param TableNode $tableNode
      *
      * @return SpecificPriceList
      */
-    public function transformSpecificPriceList(TableNode $tableNode): SpecificPriceList
+    private function transformSpecificPriceList(TableNode $tableNode): SpecificPriceList
     {
         $dataRows = $tableNode->getColumnsHash();
         $specificPrices = [];
         foreach ($dataRows as $dataRow) {
-            $specificPriceId = $this->getSharedStorage()->get($dataRow['id reference']);
+            $specificPriceId = !empty($dataRow['price id']) ? $this->getSharedStorage()->get($dataRow['price id']) : 0;
             $fixedPrice = $dataRow['fixed price'];
             $specificPrices[] = new SpecificPriceForListing(
                 $specificPriceId,
@@ -232,7 +230,7 @@ class SpecificPriceContext extends AbstractProductFeatureContext
 
         $specificPricePropertyNames = [
             'reductionType', 'includesTax', 'fromQuantity', 'shopId',
-            'currencyId', 'countryId', 'groupId', 'productId',
+            'currencyId', 'countryId', 'groupId', 'productId', 'combinationId',
         ];
         foreach ($specificPricePropertyNames as $propertyName) {
             Assert::assertSame(
@@ -282,16 +280,15 @@ class SpecificPriceContext extends AbstractProductFeatureContext
      *
      * @param string $productReference
      * @param string $langIso
-     * @param SpecificPriceList $expectedList
-     *
-     * @see transformSpecificPriceList
+     * @param TableNode $tableNode
      */
-    public function assertSpecificPriceList(string $productReference, string $langIso, SpecificPriceList $expectedList): void
+    public function assertSpecificPriceList(string $productReference, string $langIso, TableNode $tableNode): void
     {
         $langId = (int) Language::getIdByIso($langIso);
         $productId = $this->getSharedStorage()->get($productReference);
         /** @var SpecificPriceList $actualList */
         $actualList = $this->getQueryBus()->handle(new GetSpecificPriceList($productId, $langId));
+        $expectedList = $this->transformSpecificPriceList($tableNode);
 
         Assert::assertEquals(
             $expectedList->getTotalSpecificPricesCount(),
@@ -302,11 +299,13 @@ class SpecificPriceContext extends AbstractProductFeatureContext
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         $actualSpecificPrices = $actualList->getSpecificPrices();
+        $dataRows = $tableNode->getColumnsHash();
         foreach ($expectedList->getSpecificPrices() as $key => $expectedItem) {
             $actualItem = $actualSpecificPrices[$key];
+            $dataRow = $dataRows[$key];
 
             $scalarPropertyNames = [
-                'specificPriceId', 'reductionType', 'includesTax',
+                'reductionType', 'includesTax',
                 'fromQuantity', 'shopName', 'currencyName', 'currencyISOCode', 'countryName',
                 'groupName', 'customerName', 'combinationName',
             ];
@@ -317,6 +316,15 @@ class SpecificPriceContext extends AbstractProductFeatureContext
                     $propertyAccessor->getValue($actualItem, $propertyName),
                     sprintf('Unexpected specificPriceForListing "%s"', $propertyName)
                 );
+            }
+
+            // If the specific price id was specified we check for its value
+            if ($expectedItem->getSpecificPriceId() !== 0) {
+                Assert::assertSame($expectedItem->getSpecificPriceId(), $actualItem->getSpecificPriceId());
+            }
+            // If the reference column was specified we assign the reference ith the matching ID
+            if (!empty($dataRow['id reference'])) {
+                $this->getSharedStorage()->set($dataRow['id reference'], $actualItem->getSpecificPriceId());
             }
 
             $decimalProperties = ['reductionValue', 'fixedPrice.value'];

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
@@ -221,19 +221,39 @@ class VirtualProductFileFeatureContext extends AbstractProductFeatureContext
      * @param string $fileReference
      * @param TableNode $dataTable
      */
-    public function assertFile(string $productReference, string $fileReference, TableNode $dataTable): void
+    public function assertFileAndReference(string $productReference, string $fileReference, TableNode $dataTable): void
     {
         $actualFile = $this->getProductForEditing($productReference)->getVirtualProductFile();
         if (!$actualFile) {
             throw new RuntimeException('Expected virtual product to have a file');
         }
-
         Assert::assertEquals(
             $this->getSharedStorage()->get($fileReference),
             $actualFile->getId(),
             'Unexpected virtual product file (ids do not match)'
         );
+        $this->assertVirtualFile($actualFile, $dataTable);
+    }
 
+    /**
+     * @Then product :productReference should have a virtual product file which reference is :fileReference and has following details:
+     *
+     * @param string $productReference
+     * @param string $fileReference
+     * @param TableNode $dataTable
+     */
+    public function assertNewFile(string $productReference, string $fileReference, TableNode $dataTable): void
+    {
+        $actualFile = $this->getProductForEditing($productReference)->getVirtualProductFile();
+        if (!$actualFile) {
+            throw new RuntimeException('Expected virtual product to have a file');
+        }
+        $this->getSharedStorage()->set($fileReference, $actualFile->getId());
+        $this->assertVirtualFile($actualFile, $dataTable);
+    }
+
+    private function assertVirtualFile(VirtualProductFileForEditing $actualFile, TableNode $dataTable): void
+    {
         $dataRows = $dataTable->getRowsHash();
         Assert::assertEquals($dataRows['display name'], $actualFile->getDisplayName(), 'Unexpected display file name');
         unset($dataRows['display name']);

--- a/tests/Integration/Behaviour/Features/Context/Domain/TaxFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/TaxFeatureContext.php
@@ -47,6 +47,7 @@ use Tests\Integration\Behaviour\Features\Context\CommonFeatureContext;
 use Tests\Integration\Behaviour\Features\Context\SharedStorage;
 use Tests\Integration\Behaviour\Features\Context\Util\NoExceptionAlthoughExpectedException;
 use Tests\Integration\Behaviour\Features\Context\Util\PrimitiveUtils;
+use Tests\Resources\Resetter\TaxesResetter;
 
 class TaxFeatureContext extends AbstractDomainFeatureContext
 {
@@ -60,6 +61,22 @@ class TaxFeatureContext extends AbstractDomainFeatureContext
         $this->defaultLangId = CommonFeatureContext::getContainer()
             ->get('prestashop.adapter.legacy.configuration')
             ->get('PS_LANG_DEFAULT');
+    }
+
+    /**
+     * @BeforeFeature @restore-taxes-before-feature
+     */
+    public static function restoreTaxesTablesBeforeFeature(): void
+    {
+        TaxesResetter::resetTaxes();
+    }
+
+    /**
+     * @AfterFeature @restore-taxes-after-feature
+     */
+    public static function restoreTaxesTablesAfterFeature(): void
+    {
+        TaxesResetter::resetTaxes();
     }
 
     /**

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
@@ -36,7 +36,15 @@ Feature: Copy product from shop to shop.
     And carrier carrier2 named "Fast carry" exists
 
   Scenario: I duplicate a product all its direct fields are correctly copied
-    When I add product "productWithFields" with following information:
+    Given I add new tax "us-tax-state-1" with following properties:
+      | name       | US Tax (6%) |
+      | rate       | 6           |
+      | is_enabled | true        |
+    And I add the tax rule group "us-tax-group-multiple-states" for the tax "us-tax-state-1" with the following conditions:
+      | name    | US Tax group |
+      | country | US           |
+      | state   | AK           |
+    When I add product "productWithFields" to shop shop2 with following information:
       | name[en-US] | smart sunglasses   |
       | name[fr-FR] | lunettes de soleil |
       | type        | standard           |
@@ -44,7 +52,11 @@ Feature: Copy product from shop to shop.
       | name[en-US] | dumb sunglasses   |
       | name[fr-FR] | lunettes de nuage |
       | type        | standard          |
-    And I update product "productWithFields" with following values:
+    And I add product "productForRedirection2" with following information:
+      | name[en-US] | moonglasses      |
+      | name[fr-FR] | lunettes de lune |
+      | type        | standard         |
+    And I update product "productWithFields" for shop shop2 with following values:
       | description[en-US]                      | nice sunglasses            |
       | description[fr-FR]                      | belles lunettes            |
       | description_short[en-US]                | Simple & nice sunglasses   |
@@ -85,29 +97,59 @@ Feature: Copy product from shop to shop.
       | delivery time out of stock notes[en-US] | product out of stock       |
       | delivery time out of stock notes[fr-FR] | En rupture de stock        |
       | active                                  | true                       |
-    And I copy product productWithFields from shop shop1 to shop shop2
+    And I copy product productWithFields from shop shop2 to shop shop1
+    And I copy product productWithFields from shop shop2 to shop shop3
+    And I update product "productWithFields" for shop shop3 with following values:
+      | name[en-US]                             | smart sunglasses3           |
+      | name[fr-FR]                             | lunettes de soleil3         |
+      | description[en-US]                      | nice sunglasses3            |
+      | description[fr-FR]                      | belles lunettes3            |
+      | description_short[en-US]                | Simple & nice sunglasses3   |
+      | description_short[fr-FR]                | lunettes simples et belles3 |
+      | price                                   | 103.00                      |
+      | ecotax                                  | 3                           |
+      | tax rules group                         | US Tax group                |
+      | on_sale                                 | false                       |
+      | wholesale_price                         | 73                          |
+      | unit_price                              | 1030                        |
+      | unity                                   | bag of twenty               |
+      | meta_title[en-US]                       | SUNGLASSES meta title3      |
+      | meta_description[en-US]                 | Its so smart3               |
+      | meta_description[fr-FR]                 | lel joke3                   |
+      | link_rewrite[en-US]                     | smart-sunglasses3           |
+      | link_rewrite[fr-FR]                     | lunettes-de-soleil3         |
+      | redirect_type                           | 302-product                 |
+      | redirect_target                         | productForRedirection2      |
+      | delivery time in stock notes[en-US]     | product in stock3           |
+      | delivery time in stock notes[fr-FR]     | en stock3                   |
+      | delivery time out of stock notes[en-US] | product out of stock3       |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock3        |
+      | active                                  | false                       |
     Then product productWithFields is associated to shop shop1
-    Then product productWithFields is associated to shop shop2
-    And product productWithFields is not associated to shop shop3
+    And product productWithFields is associated to shop shop2
+    And product productWithFields is associated to shop shop3
     And product productWithFields is not associated to shop shop4
-    And default shop for product productWithFields is shop1
-    When I duplicate product productWithFields to a productWithFieldsCopy for shop shop2
+    And default shop for product productWithFields is shop2
+    #
+    # Duplicate for shop 1
+    #
+    When I duplicate product productWithFields to a productWithFieldsCopy for shop shop1
     # Even if the initial product was active the copy is disabled by default
-    Then product "productWithFieldsCopy" should be disabled for shops "shop2"
-    And product "productWithFieldsCopy" type should be standard for shop shop2
-    And product "productWithFieldsCopy" localized "name" for shops "shop2" should be:
+    Then product "productWithFieldsCopy" should be disabled for shops "shop1"
+    And product "productWithFieldsCopy" type should be standard for shop shop1
+    And product "productWithFieldsCopy" localized "name" for shops "shop1" should be:
       | locale | value                       |
       | en-US  | copy of smart sunglasses    |
       | fr-FR  | copie de lunettes de soleil |
-    And product "productWithFieldsCopy" localized "description" for shops "shop2" should be:
+    And product "productWithFieldsCopy" localized "description" for shops "shop1" should be:
       | locale | value           |
       | en-US  | nice sunglasses |
       | fr-FR  | belles lunettes |
-    And product "productWithFieldsCopy" localized "description_short" for shops "shop2" should be:
+    And product "productWithFieldsCopy" localized "description_short" for shops "shop1" should be:
       | locale | value                      |
       | en-US  | Simple & nice sunglasses   |
       | fr-FR  | lunettes simples et belles |
-    And product "productWithFieldsCopy" should have following options for shops shop2:
+    And product "productWithFieldsCopy" should have following options for shops shop1:
       | product option      | value        |
       | visibility          | catalog      |
       | available_for_order | false        |
@@ -116,14 +158,14 @@ Feature: Copy product from shop to shop.
       | condition           | used         |
       | show_condition      | false        |
       | manufacturer        | studioDesign |
-    And product "productWithFieldsCopy" should have following details for shops shop2:
+    And product "productWithFieldsCopy" should have following details for shops shop1:
       | product detail | value             |
       | isbn           | 978-3-16-148410-0 |
       | upc            | 72527273070       |
       | ean13          | 978020137962      |
       | mpn            | mpn1              |
       | reference      | ref1              |
-    And product productWithFieldsCopy should have following prices information for shops shop2:
+    And product productWithFieldsCopy should have following prices information for shops shop1:
       | price                   | 100.00          |
       | ecotax                  | 0               |
       | tax rules group         | US-AL Rate (4%) |
@@ -133,21 +175,21 @@ Feature: Copy product from shop to shop.
       | unit_price_tax_included | 520             |
       | unit_price_ratio        | 0.2             |
       | unity                   | bag of ten      |
-    And product "productWithFieldsCopy" localized "meta_title" for shops shop2 should be:
+    And product "productWithFieldsCopy" localized "meta_title" for shops shop1 should be:
       | locale | value                 |
       | en-US  | SUNGLASSES meta title |
-    And product "productWithFieldsCopy" localized "meta_description" for shops shop2 should be:
+    And product "productWithFieldsCopy" localized "meta_description" for shops shop1 should be:
       | locale | value        |
       | en-US  | Its so smart |
       | fr-FR  | lel joke     |
-    And product "productWithFieldsCopy" localized "link_rewrite" for shops shop2 should be:
+    And product "productWithFieldsCopy" localized "link_rewrite" for shops shop1 should be:
       | locale | value              |
       | en-US  | smart-sunglasses   |
       | fr-FR  | lunettes-de-soleil |
-    And product productWithFieldsCopy should have following seo options for shops shop2:
+    And product productWithFieldsCopy should have following seo options for shops shop1:
       | redirect_type   | 301-product           |
       | redirect_target | productForRedirection |
-    And product "productWithFieldsCopy" should have following shipping information for shops "shop2":
+    And product "productWithFieldsCopy" should have following shipping information for shops "shop1":
       | width                                   | 10.5                 |
       | height                                  | 6                    |
       | depth                                   | 7                    |
@@ -160,8 +202,87 @@ Feature: Copy product from shop to shop.
       | delivery time out of stock notes[fr-FR] | En rupture de stock  |
       | carriers                                | []                   |
     And productWithFields and productWithFieldsCopy have different values
-    And product productWithFieldsCopy is associated to shop shop2
-    And product productWithFieldsCopy is not associated to shop shop1
+    And product productWithFieldsCopy is associated to shop shop1
+    And product productWithFieldsCopy is not associated to shop shop2
     And product productWithFieldsCopy is not associated to shop shop3
     And product productWithFieldsCopy is not associated to shop shop4
-    And default shop for product productWithFieldsCopy is shop2
+    And default shop for product productWithFieldsCopy is shop1
+    #
+    # Duplicate for shop 3
+    #
+    When I duplicate product productWithFields to a productWithFieldsCopy3 for shop shop3
+    # Even if the initial product was active the copy is disabled by default
+    Then product "productWithFieldsCopy3" should be disabled for shops "shop3"
+    And product "productWithFieldsCopy3" type should be standard for shop shop3
+    And product "productWithFieldsCopy3" localized "name" for shops "shop3" should be:
+      | locale | value                        |
+      | en-US  | copy of smart sunglasses3    |
+      | fr-FR  | copie de lunettes de soleil3 |
+    And product "productWithFieldsCopy3" localized "description" for shops "shop3" should be:
+      | locale | value            |
+      | en-US  | nice sunglasses3 |
+      | fr-FR  | belles lunettes3 |
+    And product "productWithFieldsCopy3" localized "description_short" for shops "shop3" should be:
+      | locale | value                       |
+      | en-US  | Simple & nice sunglasses3   |
+      | fr-FR  | lunettes simples et belles3 |
+    And product "productWithFieldsCopy3" should have following options for shops shop3:
+      | product option      | value        |
+      | visibility          | catalog      |
+      | available_for_order | false        |
+      | online_only         | true         |
+      | show_price          | false        |
+      | condition           | used         |
+      | show_condition      | false        |
+      | manufacturer        | studioDesign |
+    And product "productWithFieldsCopy3" should have following details for shops shop3:
+      | product detail | value             |
+      | isbn           | 978-3-16-148410-0 |
+      | upc            | 72527273070       |
+      | ean13          | 978020137962      |
+      | mpn            | mpn1              |
+      | reference      | ref1              |
+    And product productWithFieldsCopy3 should have following prices information for shops shop3:
+      | price                   | 103.00        |
+      | ecotax                  | 3.0           |
+      | tax rules group         | US Tax group  |
+      | on_sale                 | false         |
+      | wholesale_price         | 73            |
+      | unit_price              | 1030          |
+      | unit_price_tax_included | 1091.80       |
+      # 103 / 1030
+      | unit_price_ratio        | 0.1           |
+      | unity                   | bag of twenty |
+    And product "productWithFieldsCopy3" localized "meta_title" for shops shop3 should be:
+      | locale | value                  |
+      | en-US  | SUNGLASSES meta title3 |
+    And product "productWithFieldsCopy3" localized "meta_description" for shops shop3 should be:
+      | locale | value         |
+      | en-US  | Its so smart3 |
+      | fr-FR  | lel joke3     |
+    And product "productWithFieldsCopy3" localized "link_rewrite" for shops shop3 should be:
+      | locale | value               |
+      | en-US  | smart-sunglasses3   |
+      | fr-FR  | lunettes-de-soleil3 |
+    And product productWithFieldsCopy3 should have following seo options for shops shop3:
+      | redirect_type   | 302-product            |
+      | redirect_target | productForRedirection2 |
+    And product "productWithFieldsCopy3" should have following shipping information for shops "shop3":
+      | width                                   | 10.5                  |
+      | height                                  | 6                     |
+      | depth                                   | 7                     |
+      | weight                                  | 0.5                   |
+      | additional_shipping_cost                | 12                    |
+      | delivery time notes type                | specific              |
+      | delivery time in stock notes[en-US]     | product in stock3     |
+      | delivery time in stock notes[fr-FR]     | en stock3             |
+      | delivery time out of stock notes[en-US] | product out of stock3 |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock3  |
+      | carriers                                | []                    |
+    And productWithFields and productWithFieldsCopy3 have different values
+    And productWithFieldsCopy and productWithFieldsCopy3 have different values
+    And product productWithFieldsCopy3 is associated to shop shop3
+    And product productWithFieldsCopy3 is not associated to shop shop1
+    And product productWithFieldsCopy3 is not associated to shop shop2
+    And product productWithFieldsCopy3 is not associated to shop shop4
+    And default shop for product productWithFieldsCopy3 is shop3

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
@@ -1,0 +1,167 @@
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags duplicate-multi-shop-product
+@restore-products-before-feature
+@clear-cache-before-feature
+@restore-shops-after-feature
+@restore-languages-after-feature
+@reset-img-after-feature
+@clear-cache-after-feature
+@product-multi-shop
+@duplicate-multi-shop-product
+Feature: Copy product from shop to shop.
+  As a BO user I want to be able to duplicate products for specific shop, group shop and all shops
+
+  Background:
+    Given I enable multishop feature
+    And language "english" with locale "en-US" exists
+    And language "french" with locale "fr-FR" exists
+    And language with iso code "en" is the default one
+    And attribute group "Size" named "Size" in en language exists
+    And attribute group "Color" named "Color" in en language exists
+    And attribute "S" named "S" in en language exists
+    And attribute "M" named "M" in en language exists
+    And attribute "L" named "L" in en language exists
+    And attribute "White" named "White" in en language exists
+    And attribute "Black" named "Black" in en language exists
+    And attribute "Blue" named "Blue" in en language exists
+    And attribute "Red" named "Red" in en language exists
+    And shop "shop1" with name "test_shop" exists
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "test_second_shop" and color "red" for the group "default_shop_group"
+    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And single shop context is loaded
+    Given manufacturer studioDesign named "Studio Design" exists
+    And carrier carrier1 named "ecoCarrier" exists
+    And carrier carrier2 named "Fast carry" exists
+
+  Scenario: I duplicate a product all its direct fields are correctly copied
+    When I add product "productWithFields" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I add product "productForRedirection" with following information:
+      | name[en-US] | dumb sunglasses   |
+      | name[fr-FR] | lunettes de nuage |
+      | type        | standard          |
+    And I update product "productWithFields" with following values:
+      | description[en-US]                      | nice sunglasses            |
+      | description[fr-FR]                      | belles lunettes            |
+      | description_short[en-US]                | Simple & nice sunglasses   |
+      | description_short[fr-FR]                | lunettes simples et belles |
+      | visibility                              | catalog                    |
+      | available_for_order                     | false                      |
+      | online_only                             | true                       |
+      | show_price                              | false                      |
+      | condition                               | used                       |
+      | manufacturer                            | studioDesign               |
+      | isbn                                    | 978-3-16-148410-0          |
+      | upc                                     | 72527273070                |
+      | ean13                                   | 978020137962               |
+      | mpn                                     | mpn1                       |
+      | reference                               | ref1                       |
+      | price                                   | 100.00                     |
+      | ecotax                                  | 0                          |
+      | tax rules group                         | US-AL Rate (4%)            |
+      | on_sale                                 | true                       |
+      | wholesale_price                         | 70                         |
+      | unit_price                              | 500                        |
+      | unity                                   | bag of ten                 |
+      | meta_title[en-US]                       | SUNGLASSES meta title      |
+      | meta_description[en-US]                 | Its so smart               |
+      | meta_description[fr-FR]                 | lel joke                   |
+      | link_rewrite[en-US]                     | smart-sunglasses           |
+      | link_rewrite[fr-FR]                     | lunettes-de-soleil         |
+      | redirect_type                           | 301-product                |
+      | redirect_target                         | productForRedirection      |
+      | width                                   | 10.5                       |
+      | height                                  | 6                          |
+      | depth                                   | 7                          |
+      | weight                                  | 0.5                        |
+      | additional_shipping_cost                | 12                         |
+      | delivery time notes type                | specific                   |
+      | delivery time in stock notes[en-US]     | product in stock           |
+      | delivery time in stock notes[fr-FR]     | en stock                   |
+      | delivery time out of stock notes[en-US] | product out of stock       |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock        |
+      | active                                  | true                       |
+    And I copy product productWithFields from shop shop1 to shop shop2
+    Then product productWithFields is associated to shop shop1
+    Then product productWithFields is associated to shop shop2
+    And product productWithFields is not associated to shop shop3
+    And product productWithFields is not associated to shop shop4
+    And default shop for product productWithFields is shop1
+    When I duplicate product productWithFields to a productWithFieldsCopy for shop shop2
+    # Even if the initial product was active the copy is disabled by default
+    Then product "productWithFieldsCopy" should be disabled for shops "shop2"
+    And product "productWithFieldsCopy" type should be standard for shop shop2
+    And product "productWithFieldsCopy" localized "name" for shops "shop2" should be:
+      | locale | value                       |
+      | en-US  | copy of smart sunglasses    |
+      | fr-FR  | copie de lunettes de soleil |
+    And product "productWithFieldsCopy" localized "description" for shops "shop2" should be:
+      | locale | value           |
+      | en-US  | nice sunglasses |
+      | fr-FR  | belles lunettes |
+    And product "productWithFieldsCopy" localized "description_short" for shops "shop2" should be:
+      | locale | value                      |
+      | en-US  | Simple & nice sunglasses   |
+      | fr-FR  | lunettes simples et belles |
+    And product "productWithFieldsCopy" should have following options for shops shop2:
+      | product option      | value        |
+      | visibility          | catalog      |
+      | available_for_order | false        |
+      | online_only         | true         |
+      | show_price          | false        |
+      | condition           | used         |
+      | show_condition      | false        |
+      | manufacturer        | studioDesign |
+    And product "productWithFieldsCopy" should have following details for shops shop2:
+      | product detail | value             |
+      | isbn           | 978-3-16-148410-0 |
+      | upc            | 72527273070       |
+      | ean13          | 978020137962      |
+      | mpn            | mpn1              |
+      | reference      | ref1              |
+    And product productWithFieldsCopy should have following prices information for shops shop2:
+      | price                   | 100.00          |
+      | ecotax                  | 0               |
+      | tax rules group         | US-AL Rate (4%) |
+      | on_sale                 | true            |
+      | wholesale_price         | 70              |
+      | unit_price              | 500             |
+      | unit_price_tax_included | 520             |
+      | unit_price_ratio        | 0.2             |
+      | unity                   | bag of ten      |
+    And product "productWithFieldsCopy" localized "meta_title" for shops shop2 should be:
+      | locale | value                 |
+      | en-US  | SUNGLASSES meta title |
+    And product "productWithFieldsCopy" localized "meta_description" for shops shop2 should be:
+      | locale | value        |
+      | en-US  | Its so smart |
+      | fr-FR  | lel joke     |
+    And product "productWithFieldsCopy" localized "link_rewrite" for shops shop2 should be:
+      | locale | value              |
+      | en-US  | smart-sunglasses   |
+      | fr-FR  | lunettes-de-soleil |
+    And product productWithFieldsCopy should have following seo options for shops shop2:
+      | redirect_type   | 301-product           |
+      | redirect_target | productForRedirection |
+    And product "productWithFieldsCopy" should have following shipping information for shops "shop2":
+      | width                                   | 10.5                 |
+      | height                                  | 6                    |
+      | depth                                   | 7                    |
+      | weight                                  | 0.5                  |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time in stock notes[fr-FR]     | en stock             |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock  |
+      | carriers                                | []                   |
+    And productWithFields and productWithFieldsCopy have different values
+    And product productWithFieldsCopy is associated to shop shop2
+    And product productWithFieldsCopy is not associated to shop shop1
+    And product productWithFieldsCopy is not associated to shop shop3
+    And product productWithFieldsCopy is not associated to shop shop4
+    And default shop for product productWithFieldsCopy is shop2

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
@@ -10,7 +10,7 @@
 Feature: Copy product from shop to shop.
   As a BO user I want to be able to duplicate products for specific shop, group shop and all shops
 
-  Background:
+  Scenario: This are pre-requisite steps but it is only done once, that is why we don't use Background here
     Given I enable multishop feature
     And language "english" with locale "en-US" exists
     And language "french" with locale "fr-FR" exists
@@ -34,9 +34,8 @@ Feature: Copy product from shop to shop.
     Given manufacturer studioDesign named "Studio Design" exists
     And carrier carrier1 named "ecoCarrier" exists
     And carrier carrier2 named "Fast carry" exists
-
-  Scenario: I duplicate a product all its direct fields are correctly copied
-    Given I add new tax "us-tax-state-1" with following properties:
+    # Prepare a few data
+    And I add new tax "us-tax-state-1" with following properties:
       | name       | US Tax (6%) |
       | rate       | 6           |
       | is_enabled | true        |
@@ -44,10 +43,6 @@ Feature: Copy product from shop to shop.
       | name    | US Tax group |
       | country | US           |
       | state   | AK           |
-    When I add product "productWithFields" to shop shop2 with following information:
-      | name[en-US] | smart sunglasses   |
-      | name[fr-FR] | lunettes de soleil |
-      | type        | standard           |
     And I add product "productForRedirection" with following information:
       | name[en-US] | dumb sunglasses   |
       | name[fr-FR] | lunettes de nuage |
@@ -56,6 +51,12 @@ Feature: Copy product from shop to shop.
       | name[en-US] | moonglasses      |
       | name[fr-FR] | lunettes de lune |
       | type        | standard         |
+
+  Scenario: I duplicate a product all its direct fields are correctly copied
+    When I add product "productWithFields" to shop shop2 with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
     And I update product "productWithFields" for shop shop2 with following values:
       | description[en-US]                      | nice sunglasses            |
       | description[fr-FR]                      | belles lunettes            |
@@ -211,7 +212,6 @@ Feature: Copy product from shop to shop.
     # Duplicate for shop 3
     #
     When I duplicate product productWithFields to a productWithFieldsCopy3 for shop shop3
-    # Even if the initial product was active the copy is disabled by default
     Then product "productWithFieldsCopy3" should be disabled for shops "shop3"
     And product "productWithFieldsCopy3" type should be standard for shop shop3
     And product "productWithFieldsCopy3" localized "name" for shops "shop3" should be:
@@ -286,3 +286,149 @@ Feature: Copy product from shop to shop.
     And product productWithFieldsCopy3 is not associated to shop shop2
     And product productWithFieldsCopy3 is not associated to shop shop4
     And default shop for product productWithFieldsCopy3 is shop3
+
+  Scenario: I duplicate a product for all shops all its associated data is copied (based on created product in previous scenario)
+    When I duplicate product productWithFields to a productWithFieldsOnAllShops for all shops
+    # Shop1 and shop2 have the same values
+    Then product "productWithFieldsOnAllShops" should be disabled for shops "shop1,shop2"
+    And product "productWithFieldsOnAllShops" type should be standard for shops "shop1,shop2"
+    And product "productWithFieldsOnAllShops" localized "name" for shops "shop1,shop2" should be:
+      | locale | value                       |
+      | en-US  | copy of smart sunglasses    |
+      | fr-FR  | copie de lunettes de soleil |
+    And product "productWithFieldsOnAllShops" localized "description" for shops "shop1,shop2" should be:
+      | locale | value           |
+      | en-US  | nice sunglasses |
+      | fr-FR  | belles lunettes |
+    And product "productWithFieldsOnAllShops" localized "description_short" for shops "shop1,shop2" should be:
+      | locale | value                      |
+      | en-US  | Simple & nice sunglasses   |
+      | fr-FR  | lunettes simples et belles |
+    And product "productWithFieldsOnAllShops" should have following options for shops "shop1,shop2":
+      | product option      | value        |
+      | visibility          | catalog      |
+      | available_for_order | false        |
+      | online_only         | true         |
+      | show_price          | false        |
+      | condition           | used         |
+      | show_condition      | false        |
+      | manufacturer        | studioDesign |
+    And product "productWithFieldsOnAllShops" should have following details for shops "shop1,shop2":
+      | product detail | value             |
+      | isbn           | 978-3-16-148410-0 |
+      | upc            | 72527273070       |
+      | ean13          | 978020137962      |
+      | mpn            | mpn1              |
+      | reference      | ref1              |
+    And product productWithFieldsOnAllShops should have following prices information for shops "shop1,shop2":
+      | price                   | 100.00          |
+      | ecotax                  | 0               |
+      | tax rules group         | US-AL Rate (4%) |
+      | on_sale                 | true            |
+      | wholesale_price         | 70              |
+      | unit_price              | 500             |
+      | unit_price_tax_included | 520             |
+      | unit_price_ratio        | 0.2             |
+      | unity                   | bag of ten      |
+    And product "productWithFieldsOnAllShops" localized "meta_title" for shops "shop1,shop2" should be:
+      | locale | value                 |
+      | en-US  | SUNGLASSES meta title |
+    And product "productWithFieldsOnAllShops" localized "meta_description" for shops "shop1,shop2" should be:
+      | locale | value        |
+      | en-US  | Its so smart |
+      | fr-FR  | lel joke     |
+    And product "productWithFieldsOnAllShops" localized "link_rewrite" for shops "shop1,shop2" should be:
+      | locale | value              |
+      | en-US  | smart-sunglasses   |
+      | fr-FR  | lunettes-de-soleil |
+    And product productWithFieldsOnAllShops should have following seo options for shops "shop1,shop2":
+      | redirect_type   | 301-product           |
+      | redirect_target | productForRedirection |
+    And product "productWithFieldsOnAllShops" should have following shipping information for shops "shop1,shop2":
+      | width                                   | 10.5                 |
+      | height                                  | 6                    |
+      | depth                                   | 7                    |
+      | weight                                  | 0.5                  |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time in stock notes[fr-FR]     | en stock             |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock  |
+      | carriers                                | []                   |
+    # Values for shop3 are customized
+    Then product "productWithFieldsOnAllShops" should be disabled for shops "shop3"
+    And product "productWithFieldsOnAllShops" type should be standard for shop shop3
+    And product "productWithFieldsOnAllShops" localized "name" for shops "shop3" should be:
+      | locale | value                        |
+      | en-US  | copy of smart sunglasses3    |
+      | fr-FR  | copie de lunettes de soleil3 |
+    And product "productWithFieldsOnAllShops" localized "description" for shops "shop3" should be:
+      | locale | value            |
+      | en-US  | nice sunglasses3 |
+      | fr-FR  | belles lunettes3 |
+    And product "productWithFieldsOnAllShops" localized "description_short" for shops "shop3" should be:
+      | locale | value                       |
+      | en-US  | Simple & nice sunglasses3   |
+      | fr-FR  | lunettes simples et belles3 |
+    And product "productWithFieldsOnAllShops" should have following options for shops shop3:
+      | product option      | value        |
+      | visibility          | catalog      |
+      | available_for_order | false        |
+      | online_only         | true         |
+      | show_price          | false        |
+      | condition           | used         |
+      | show_condition      | false        |
+      | manufacturer        | studioDesign |
+    And product "productWithFieldsOnAllShops" should have following details for shops shop3:
+      | product detail | value             |
+      | isbn           | 978-3-16-148410-0 |
+      | upc            | 72527273070       |
+      | ean13          | 978020137962      |
+      | mpn            | mpn1              |
+      | reference      | ref1              |
+    And product productWithFieldsOnAllShops should have following prices information for shops shop3:
+      | price                   | 103.00        |
+      | ecotax                  | 3.0           |
+      | tax rules group         | US Tax group  |
+      | on_sale                 | false         |
+      | wholesale_price         | 73            |
+      | unit_price              | 1030          |
+      | unit_price_tax_included | 1091.80       |
+      # 103 / 1030
+      | unit_price_ratio        | 0.1           |
+      | unity                   | bag of twenty |
+    And product "productWithFieldsOnAllShops" localized "meta_title" for shops shop3 should be:
+      | locale | value                  |
+      | en-US  | SUNGLASSES meta title3 |
+    And product "productWithFieldsOnAllShops" localized "meta_description" for shops shop3 should be:
+      | locale | value         |
+      | en-US  | Its so smart3 |
+      | fr-FR  | lel joke3     |
+    And product "productWithFieldsOnAllShops" localized "link_rewrite" for shops shop3 should be:
+      | locale | value               |
+      | en-US  | smart-sunglasses3   |
+      | fr-FR  | lunettes-de-soleil3 |
+    And product productWithFieldsOnAllShops should have following seo options for shops shop3:
+      | redirect_type   | 302-product            |
+      | redirect_target | productForRedirection2 |
+    And product "productWithFieldsOnAllShops" should have following shipping information for shops "shop3":
+      | width                                   | 10.5                  |
+      | height                                  | 6                     |
+      | depth                                   | 7                     |
+      | weight                                  | 0.5                   |
+      | additional_shipping_cost                | 12                    |
+      | delivery time notes type                | specific              |
+      | delivery time in stock notes[en-US]     | product in stock3     |
+      | delivery time in stock notes[fr-FR]     | en stock3             |
+      | delivery time out of stock notes[en-US] | product out of stock3 |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock3  |
+      | carriers                                | []                    |
+    And productWithFields and productWithFieldsOnAllShops have different values
+    And productWithFieldsCopy and productWithFieldsOnAllShops have different values
+    And product productWithFieldsOnAllShops is associated to shop shop1
+    And product productWithFieldsOnAllShops is associated to shop shop2
+    And product productWithFieldsOnAllShops is associated to shop shop3
+    And product productWithFieldsOnAllShops is not associated to shop shop4
+    # The default shop is the same as the initial one
+    And default shop for product productWithFieldsOnAllShops is shop2

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
@@ -3,6 +3,7 @@
 @clear-cache-before-feature
 @restore-shops-after-feature
 @restore-languages-after-feature
+@restore-taxes-after-feature
 @reset-img-after-feature
 @clear-cache-after-feature
 @product-multi-shop

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_multishop_product.feature
@@ -432,3 +432,159 @@ Feature: Copy product from shop to shop.
     And product productWithFieldsOnAllShops is not associated to shop shop4
     # The default shop is the same as the initial one
     And default shop for product productWithFieldsOnAllShops is shop2
+
+  Scenario: I duplicate a product for a shop group all its associated data is copied (based on created product in previous scenario)
+    When I duplicate product productWithFields to a productWithFieldsDefaultGroup for shop group default_shop_group
+    # Shop1 and shop2 have the same values
+    Then product "productWithFieldsDefaultGroup" should be disabled for shops "shop1,shop2"
+    And product "productWithFieldsDefaultGroup" type should be standard for shops "shop1,shop2"
+    And product "productWithFieldsDefaultGroup" localized "name" for shops "shop1,shop2" should be:
+      | locale | value                       |
+      | en-US  | copy of smart sunglasses    |
+      | fr-FR  | copie de lunettes de soleil |
+    And product "productWithFieldsDefaultGroup" localized "description" for shops "shop1,shop2" should be:
+      | locale | value           |
+      | en-US  | nice sunglasses |
+      | fr-FR  | belles lunettes |
+    And product "productWithFieldsDefaultGroup" localized "description_short" for shops "shop1,shop2" should be:
+      | locale | value                      |
+      | en-US  | Simple & nice sunglasses   |
+      | fr-FR  | lunettes simples et belles |
+    And product "productWithFieldsDefaultGroup" should have following options for shops "shop1,shop2":
+      | product option      | value        |
+      | visibility          | catalog      |
+      | available_for_order | false        |
+      | online_only         | true         |
+      | show_price          | false        |
+      | condition           | used         |
+      | show_condition      | false        |
+      | manufacturer        | studioDesign |
+    And product "productWithFieldsDefaultGroup" should have following details for shops "shop1,shop2":
+      | product detail | value             |
+      | isbn           | 978-3-16-148410-0 |
+      | upc            | 72527273070       |
+      | ean13          | 978020137962      |
+      | mpn            | mpn1              |
+      | reference      | ref1              |
+    And product productWithFieldsDefaultGroup should have following prices information for shops "shop1,shop2":
+      | price                   | 100.00          |
+      | ecotax                  | 0               |
+      | tax rules group         | US-AL Rate (4%) |
+      | on_sale                 | true            |
+      | wholesale_price         | 70              |
+      | unit_price              | 500             |
+      | unit_price_tax_included | 520             |
+      | unit_price_ratio        | 0.2             |
+      | unity                   | bag of ten      |
+    And product "productWithFieldsDefaultGroup" localized "meta_title" for shops "shop1,shop2" should be:
+      | locale | value                 |
+      | en-US  | SUNGLASSES meta title |
+    And product "productWithFieldsDefaultGroup" localized "meta_description" for shops "shop1,shop2" should be:
+      | locale | value        |
+      | en-US  | Its so smart |
+      | fr-FR  | lel joke     |
+    And product "productWithFieldsDefaultGroup" localized "link_rewrite" for shops "shop1,shop2" should be:
+      | locale | value              |
+      | en-US  | smart-sunglasses   |
+      | fr-FR  | lunettes-de-soleil |
+    And product productWithFieldsDefaultGroup should have following seo options for shops "shop1,shop2":
+      | redirect_type   | 301-product           |
+      | redirect_target | productForRedirection |
+    And product "productWithFieldsDefaultGroup" should have following shipping information for shops "shop1,shop2":
+      | width                                   | 10.5                 |
+      | height                                  | 6                    |
+      | depth                                   | 7                    |
+      | weight                                  | 0.5                  |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time in stock notes[fr-FR]     | en stock             |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock  |
+      | carriers                                | []                   |
+    And productWithFields and productWithFieldsDefaultGroup have different values
+    And product productWithFieldsDefaultGroup is associated to shop shop1
+    And product productWithFieldsDefaultGroup is associated to shop shop2
+    And product productWithFieldsDefaultGroup is not associated to shop shop3
+    And product productWithFieldsDefaultGroup is not associated to shop shop4
+    # The default shop is the same as the initial one because it is part of the group
+    And default shop for product productWithFieldsDefaultGroup is shop2
+    #
+    # Now copy to other group
+    #
+    When I duplicate product productWithFields to a productWithFieldsSecondGroup for shop group test_second_shop_group
+    Then product "productWithFieldsSecondGroup" should be disabled for shops "shop3"
+    And product "productWithFieldsSecondGroup" type should be standard for shop shop3
+    And product "productWithFieldsSecondGroup" localized "name" for shops "shop3" should be:
+      | locale | value                        |
+      | en-US  | copy of smart sunglasses3    |
+      | fr-FR  | copie de lunettes de soleil3 |
+    And product "productWithFieldsSecondGroup" localized "description" for shops "shop3" should be:
+      | locale | value            |
+      | en-US  | nice sunglasses3 |
+      | fr-FR  | belles lunettes3 |
+    And product "productWithFieldsSecondGroup" localized "description_short" for shops "shop3" should be:
+      | locale | value                       |
+      | en-US  | Simple & nice sunglasses3   |
+      | fr-FR  | lunettes simples et belles3 |
+    And product "productWithFieldsSecondGroup" should have following options for shops shop3:
+      | product option      | value        |
+      | visibility          | catalog      |
+      | available_for_order | false        |
+      | online_only         | true         |
+      | show_price          | false        |
+      | condition           | used         |
+      | show_condition      | false        |
+      | manufacturer        | studioDesign |
+    And product "productWithFieldsSecondGroup" should have following details for shops shop3:
+      | product detail | value             |
+      | isbn           | 978-3-16-148410-0 |
+      | upc            | 72527273070       |
+      | ean13          | 978020137962      |
+      | mpn            | mpn1              |
+      | reference      | ref1              |
+    And product productWithFieldsSecondGroup should have following prices information for shops shop3:
+      | price                   | 103.00        |
+      | ecotax                  | 3.0           |
+      | tax rules group         | US Tax group  |
+      | on_sale                 | false         |
+      | wholesale_price         | 73            |
+      | unit_price              | 1030          |
+      | unit_price_tax_included | 1091.80       |
+      # 103 / 1030
+      | unit_price_ratio        | 0.1           |
+      | unity                   | bag of twenty |
+    And product "productWithFieldsSecondGroup" localized "meta_title" for shops shop3 should be:
+      | locale | value                  |
+      | en-US  | SUNGLASSES meta title3 |
+    And product "productWithFieldsSecondGroup" localized "meta_description" for shops shop3 should be:
+      | locale | value         |
+      | en-US  | Its so smart3 |
+      | fr-FR  | lel joke3     |
+    And product "productWithFieldsSecondGroup" localized "link_rewrite" for shops shop3 should be:
+      | locale | value               |
+      | en-US  | smart-sunglasses3   |
+      | fr-FR  | lunettes-de-soleil3 |
+    And product productWithFieldsSecondGroup should have following seo options for shops shop3:
+      | redirect_type   | 302-product            |
+      | redirect_target | productForRedirection2 |
+    And product "productWithFieldsSecondGroup" should have following shipping information for shops "shop3":
+      | width                                   | 10.5                  |
+      | height                                  | 6                     |
+      | depth                                   | 7                     |
+      | weight                                  | 0.5                   |
+      | additional_shipping_cost                | 12                    |
+      | delivery time notes type                | specific              |
+      | delivery time in stock notes[en-US]     | product in stock3     |
+      | delivery time in stock notes[fr-FR]     | en stock3             |
+      | delivery time out of stock notes[en-US] | product out of stock3 |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock3  |
+      | carriers                                | []                    |
+    And productWithFields and productWithFieldsSecondGroup have different values
+    And productWithFieldsCopy and productWithFieldsSecondGroup have different values
+    And product productWithFieldsSecondGroup is associated to shop shop3
+    And product productWithFieldsSecondGroup is not associated to shop shop1
+    And product productWithFieldsSecondGroup is not associated to shop shop2
+    And product productWithFieldsSecondGroup is not associated to shop shop4
+    # The default shop is shop3 as it's the first associated one in the second group
+    And default shop for product productWithFieldsSecondGroup is shop3

--- a/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_prices_listing.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/SpecificPrice/specific_prices_listing.feature
@@ -1,4 +1,4 @@
-#./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags specific-prices-listing
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags specific-prices-listing
 @restore-products-before-feature
 @clear-cache-before-feature
 @specific-prices
@@ -67,7 +67,7 @@ Feature: List specific prices for product in Back Office (BO)
       | combination     | product1SWhite |
     And product "product1" should have 3 specific prices
     Then product "product1" should have following list of specific prices in "en" language:
-      | id reference | combination             | reduction type | reduction value | includes tax | fixed price | from quantity | shop      | currency | currencyISOCode | country       | group   | customer | from                | to                  |
-      | price1       |                         | amount         | 111.50          | true         | 400         | 1             |           |          |                 |               |         |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
-      | price2       |                         | amount         | 12.56           | true         | 45.78       | 1             | test_shop | USD      | USD             | United States | Visitor | John DOE | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
-      | price3       | Size - S, Color - White | percentage     | 30              | false        | 0           | 1             |           |          |                 |               |         |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+      | price id | combination             | reduction type | reduction value | includes tax | fixed price | from quantity | shop      | currency | currencyISOCode | country       | group   | customer | from                | to                  |
+      | price1   |                         | amount         | 111.50          | true         | 400         | 1             |           |          |                 |               |         |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+      | price2   |                         | amount         | 12.56           | true         | 45.78       | 1             | test_shop | USD      | USD             | United States | Visitor | John DOE | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+      | price3   | Size - S, Color - White | percentage     | 30              | false        | 0           | 1             |           |          |                 |               |         |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -8,13 +8,7 @@ Feature: Duplicate product from Back Office (BO).
   As an employee I want to be able to duplicate product
 
   Background:
-    Given category "home" in default language named "Home" exists
-    And category "home" is the default one
-    And shop "shop1" with name "test_shop" exists
-    And single shop shop1 context is loaded
-    And category "men" in default language named "Men" exists
-    And category "clothes" in default language named "Clothes" exists
-    And manufacturer studioDesign named "Studio Design" exists
+    Given manufacturer studioDesign named "Studio Design" exists
     And language "language1" with locale "en-US" exists
     And language with iso code "en" is the default one
     And language "language2" with locale "fr-FR" exists
@@ -23,15 +17,19 @@ Feature: Duplicate product from Back Office (BO).
     And attribute group "Color" named "Color" in en language exists
     And attribute "Red" named "Red" in en language exists
     And attribute "Blue" named "Blue" in en language exists
-    And I add product "product1" with following information:
+    And shop "shop1" with name "test_shop" exists
+    And single shop shop1 context is loaded
+
+  Scenario: I duplicate a product all its direct fields are correctly copied
+    When I add product "productWithFields" with following information:
       | name[en-US] | smart sunglasses   |
       | name[fr-FR] | lunettes de soleil |
       | type        | standard           |
-    And I add product "product2" with following information:
-      | name[en-US] | Reading glasses |
-      | name[fr-FR] | lunettes        |
-      | type        | standard        |
-    And I update product "product1" with following values:
+    And I add product "productForRedirection" with following information:
+      | name[en-US] | dumb sunglasses   |
+      | name[fr-FR] | lunettes de nuage |
+      | type        | standard          |
+    And I update product "productWithFields" with following values:
       | description[en-US]                      | nice sunglasses            |
       | description[fr-FR]                      | belles lunettes            |
       | description_short[en-US]                | Simple & nice sunglasses   |
@@ -60,7 +58,7 @@ Feature: Duplicate product from Back Office (BO).
       | link_rewrite[en-US]                     | smart-sunglasses           |
       | link_rewrite[fr-FR]                     | lunettes-de-soleil         |
       | redirect_type                           | 301-product                |
-      | redirect_target                         | product2                   |
+      | redirect_target                         | productForRedirection      |
       | width                                   | 10.5                       |
       | height                                  | 6                          |
       | depth                                   | 7                          |
@@ -71,18 +69,236 @@ Feature: Duplicate product from Back Office (BO).
       | delivery time in stock notes[fr-FR]     | en stock                   |
       | delivery time out of stock notes[en-US] | product out of stock       |
       | delivery time out of stock notes[fr-FR] | En rupture de stock        |
-      | redirect_type                           | 301-product                |
-      | redirect_target                         | product2                   |
       | active                                  | true                       |
-    And I update product "product1" tags with following values:
-      | tags[en-US] | smart,glasses,sunglasses,men |
-      | tags[fr-FR] | lunettes,bien,soleil         |
-    And I assign product product1 to following categories:
+    When I duplicate product productWithFields to a productWithFieldsCopy
+    # Even if the initial product was active the copy is disabled by default
+    Then product "productWithFieldsCopy" should be disabled
+    And product "productWithFieldsCopy" type should be standard
+    And product "productWithFieldsCopy" localized "name" should be:
+      | locale | value                       |
+      | en-US  | copy of smart sunglasses    |
+      | fr-FR  | copie de lunettes de soleil |
+    And product "productWithFieldsCopy" localized "description" should be:
+      | locale | value           |
+      | en-US  | nice sunglasses |
+      | fr-FR  | belles lunettes |
+    And product "productWithFieldsCopy" localized "description_short" should be:
+      | locale | value                      |
+      | en-US  | Simple & nice sunglasses   |
+      | fr-FR  | lunettes simples et belles |
+    And product "productWithFieldsCopy" should have following options:
+      | product option      | value        |
+      | visibility          | catalog      |
+      | available_for_order | false        |
+      | online_only         | true         |
+      | show_price          | false        |
+      | condition           | used         |
+      | show_condition      | false        |
+      | manufacturer        | studioDesign |
+    And product "productWithFieldsCopy" should have following details:
+      | product detail | value             |
+      | isbn           | 978-3-16-148410-0 |
+      | upc            | 72527273070       |
+      | ean13          | 978020137962      |
+      | mpn            | mpn1              |
+      | reference      | ref1              |
+    And product productWithFieldsCopy should have following prices information:
+      | price                   | 100.00          |
+      | ecotax                  | 0               |
+      | tax rules group         | US-AL Rate (4%) |
+      | on_sale                 | true            |
+      | wholesale_price         | 70              |
+      | unit_price              | 500             |
+      | unit_price_tax_included | 520             |
+      | unit_price_ratio        | 0.2             |
+      | unity                   | bag of ten      |
+    And product "productWithFieldsCopy" localized "meta_title" should be:
+      | locale | value                 |
+      | en-US  | SUNGLASSES meta title |
+    And product "productWithFieldsCopy" localized "meta_description" should be:
+      | locale | value        |
+      | en-US  | Its so smart |
+      | fr-FR  | lel joke     |
+    And product "productWithFieldsCopy" localized "link_rewrite" should be:
+      | locale | value              |
+      | en-US  | smart-sunglasses   |
+      | fr-FR  | lunettes-de-soleil |
+    And product productWithFieldsCopy should have following seo options:
+      | redirect_type   | 301-product           |
+      | redirect_target | productForRedirection |
+    And product "productWithFieldsCopy" should have following shipping information:
+      | width                                   | 10.5                 |
+      | height                                  | 6                    |
+      | depth                                   | 7                    |
+      | weight                                  | 0.5                  |
+      | additional_shipping_cost                | 12                   |
+      | delivery time notes type                | specific             |
+      | delivery time in stock notes[en-US]     | product in stock     |
+      | delivery time in stock notes[fr-FR]     | en stock             |
+      | delivery time out of stock notes[en-US] | product out of stock |
+      | delivery time out of stock notes[fr-FR] | En rupture de stock  |
+      | carriers                                | []                   |
+    And productWithFields and productWithFieldsCopy have different values
+
+  #@todo: assert stock info
+
+  Scenario: I duplicate a product all its categories are correctly copied
+    Given category "home" in default language named "Home" exists
+    And category "home" is the default one
+    And category "men" in default language named "Men" exists
+    And category "clothes" in default language named "Clothes" exists
+    And I add product "productWithCategories" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I assign product productWithCategories to following categories:
       | categories       | [home, men, clothes] |
       | default category | clothes              |
-    And I assign product product1 with following carriers:
+    When I duplicate product productWithCategories to a productWithCategoriesCopy
+    Then product productWithCategoriesCopy should be assigned to following categories:
+      | id reference | name    | is default |
+      | home         | Home    | false      |
+      | men          | Men     | false      |
+      | clothes      | Clothes | true       |
+
+  Scenario: I duplicate a product its tags are copied
+    Given I add product "productWithTags" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I update product "productWithTags" tags with following values:
+      | tags[en-US] | smart,glasses,sunglasses,men |
+      | tags[fr-FR] | lunettes,bien,soleil         |
+    When I duplicate product productWithTags to a productWithTagsCopy
+    Then product "productWithTagsCopy" localized "tags" should be:
+      | locale | value                        |
+      | en-US  | smart,glasses,sunglasses,men |
+      | fr-FR  | lunettes,bien,soleil         |
+
+  Scenario: I duplicate a product its related products are copied
+    Given I add product "productWithRelations" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I add product "relatedProduct" with following information:
+      | name[en-US] | Reading glasses |
+      | name[fr-FR] | lunettes        |
+      | type        | standard        |
+    And I set following related products to product productWithRelations:
+      | relatedProduct |
+    When I duplicate product productWithRelations to a productWithRelationsCopy
+    And product productWithRelationsCopy should have following related products:
+      | product        | name            | reference | image url                                             |
+      | relatedProduct | Reading glasses |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
+
+  Scenario: I duplicate a product its carriers are copied
+    Given I add product "productWithCarriers" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I assign product productWithCarriers with following carriers:
       | carrier1 |
       | carrier2 |
+    When I duplicate product productWithCarriers to a productWithCarriersCopy
+    And product "productWithCarriersCopy" should have following shipping information:
+      | width                                   | 0                   |
+      | height                                  | 0                   |
+      | depth                                   | 0                   |
+      | weight                                  | 0                   |
+      | additional_shipping_cost                | 0                   |
+      | delivery time notes type                | default             |
+      | delivery time in stock notes[en-US]     |                     |
+      | delivery time in stock notes[fr-FR]     |                     |
+      | delivery time out of stock notes[en-US] |                     |
+      | delivery time out of stock notes[fr-FR] |                     |
+      | carriers                                | [carrier1,carrier2] |
+
+  Scenario: I duplicate a product its customization fields are copied
+    Given I add product "productWithCustomizations" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I update product productWithCustomizations with following customization fields:
+      | reference    | type | name[en-US]               | name[fr-FR]                         | is required |
+      | customField1 | text | text on top of left lense | texte en haut de la lentille gauche | true        |
+    When I duplicate product productWithCustomizations to a productWithCustomizationsCopy
+    And product productWithCustomizationsCopy should have identical customization fields to productWithCustomizations
+    And product productWithCustomizationsCopy should have 1 customizable text field
+    And product productWithCustomizationsCopy should have 0 customizable file fields
+    # assert new customization values and check that new ID as created
+
+  Scenario: I duplicate a product its attachments are copied
+    Given I add product "productWithAttachments" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I add new attachment "att1" with following properties:
+      | description[en-US] | puffin photo nr1 |
+      | description[fr-FR] | macareux         |
+      | name[en-US]        | puffin           |
+      | name[fr-FR]        | macareux         |
+      | file_name          | app_icon.png     |
+    And I associate product productWithAttachments with following attachments: "[att1]"
+    When I duplicate product productWithAttachments to a productWithAttachmentsCopy
+    # Product is duplicated but both are related to the same attachment
+    And product productWithAttachmentsCopy should have following attachments associated:
+      | attachment reference | title                       | description                           | file name    | type      | size  |
+      | att1                 | en-US:puffin;fr-Fr:macareux | en-US:puffin photo nr1;fr-Fr:macareux | app_icon.png | image/png | 19187 |
+
+  #todo: add specific prices & priorities
+  Scenario: I duplicate a product its specific prices are copied
+    Given I add product "productWithSpecificPrices" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I add a specific price price1 to product productWithSpecificPrices with following details:
+      | fixed price     | 0.00   |
+      | reduction type  | amount |
+      | reduction value | 5.00   |
+      | includes tax    | true   |
+      | from quantity   | 1      |
+    When I duplicate product productWithSpecificPrices to a productWithSpecificPricesCopy
+    And product "productWithSpecificPricesCopy" should have 1 specific prices
+    Then product "productWithSpecificPricesCopy" should have following list of specific prices in "en" language:
+      | id reference | combination | reduction type | reduction value | includes tax | fixed price | from quantity | shop | currency | currencyISOCode | country | group | customer | from                | to                  |
+      | price1Copy   |             | amount         | 5.0             | true         | 0.0         | 1             |      |          |                 |         |       |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+    And specific price price1 should have following details:
+      | specific price detail | value                     |
+      | reduction type        | amount                    |
+      | reduction value       | 5.0                       |
+      | includes tax          | true                      |
+      | fixed price           | 0.0                       |
+      | from quantity         | 1                         |
+      | from                  | 0000-00-00 00:00:00       |
+      | to                    | 0000-00-00 00:00:00       |
+      | shop                  |                           |
+      | currency              |                           |
+      | country               |                           |
+      | group                 |                           |
+      | customer              |                           |
+      | product               | productWithSpecificPrices |
+    And specific price price1Copy should have following details:
+      | specific price detail | value                         |
+      | reduction type        | amount                        |
+      | reduction value       | 5.0                           |
+      | includes tax          | true                          |
+      | fixed price           | 0.0                           |
+      | from quantity         | 1                             |
+      | from                  | 0000-00-00 00:00:00           |
+      | to                    | 0000-00-00 00:00:00           |
+      | shop                  |                               |
+      | currency              |                               |
+      | country               |                               |
+      | group                 |                               |
+      | customer              |                               |
+      | product               | productWithSpecificPricesCopy |
+    And price1 and price1Copy have different values
+
+  Scenario: I duplicate a product its suppliers are copied
+    Given I add product "productWithSuppliers" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
     And I add new supplier supplier1 with the following properties:
       | name                    | my supplier 1      |
       | address                 | Donelaicio st. 1   |
@@ -94,172 +310,151 @@ Feature: Duplicate product from Back Office (BO).
       | meta description[en-US] |                    |
       | meta keywords[en-US]    | sup,1              |
       | shops                   | [shop1]            |
-    When I associate suppliers to product "product1"
+    When I associate suppliers to product "productWithSuppliers"
       | supplier  | product_supplier  |
       | supplier1 | product1supplier1 |
-    And I update product product1 suppliers:
-      | product_supplier  | supplier  | reference                      | currency | price_tax_excluded |
-      | product1supplier1 | supplier1 | my first supplier for product1 | USD      | 10                 |
-    And I set following related products to product product1:
-      | product2 |
-    And I update product product1 with following customization fields:
-      | reference    | type | name[en-US]               | name[fr-FR]                         | is required |
-      | customField1 | text | text on top of left lense | texte en haut de la lentille gauche | true        |
-    And I add new attachment "att1" with following properties:
-      | description[en-US] | puffin photo nr1 |
-      | description[fr-FR] | macareux         |
-      | name[en-US]        | puffin           |
-      | name[fr-FR]        | macareux         |
-      | file_name          | app_icon.png     |
-    And I associate product product1 with following attachments: "[att1]"
-    And I add a specific price specific_price1 to product product1 with following details:
-      | fixed price     | 0.00   |
-      | reduction type  | amount |
-      | reduction value | 5.00   |
-      | includes tax    | true   |
-      | from quantity   | 1      |
-    And product "product1" should have 1 specific prices
-
-  Scenario: I duplicate product
-#todo: add specific prices & priorities, test combinations
-    When I duplicate product product1 to a copy_of_product1
-    And product "copy_of_product1" should be disabled
-    And product "copy_of_product1" type should be standard
-    And product "copy_of_product1" localized "name" should be:
-      | locale | value                       |
-      | en-US  | copy of smart sunglasses    |
-      | fr-FR  | copie de lunettes de soleil |
-    And product "copy_of_product1" localized "description" should be:
-      | locale | value           |
-      | en-US  | nice sunglasses |
-      | fr-FR  | belles lunettes |
-    And product "copy_of_product1" localized "description_short" should be:
-      | locale | value                      |
-      | en-US  | Simple & nice sunglasses   |
-      | fr-FR  | lunettes simples et belles |
-    And product copy_of_product1 should be assigned to following categories:
-      | id reference | name    | is default |
-      | home         | Home    | false      |
-      | men          | Men     | false      |
-      | clothes      | Clothes | true       |
-    And product "copy_of_product1" should have following options:
-      | product option      | value        |
-      | visibility          | catalog      |
-      | available_for_order | false        |
-      | online_only         | true         |
-      | show_price          | false        |
-      | condition           | used         |
-      | show_condition      | false        |
-      | manufacturer        | studioDesign |
-    And product "copy_of_product1" should have following details:
-      | product detail | value             |
-      | isbn           | 978-3-16-148410-0 |
-      | upc            | 72527273070       |
-      | ean13          | 978020137962      |
-      | mpn            | mpn1              |
-      | reference      | ref1              |
-    And product "copy_of_product1" localized "tags" should be:
-      | locale | value                        |
-      | en-US  | smart,glasses,sunglasses,men |
-      | fr-FR  | lunettes,bien,soleil         |
-    And product copy_of_product1 should have following suppliers:
+    And I update product productWithSuppliers suppliers:
       | supplier  | reference                      | currency | price_tax_excluded |
       | supplier1 | my first supplier for product1 | USD      | 10                 |
-    And product copy_of_product1 should have following prices information:
-      | price                   | 100.00          |
-      | ecotax                  | 0               |
-      | tax rules group         | US-AL Rate (4%) |
-      | on_sale                 | true            |
-      | wholesale_price         | 70              |
-      | unit_price              | 500             |
-      | unit_price_tax_included | 520             |
-      | unit_price_ratio        | 0.2             |
-      | unity                   | bag of ten      |
-    And product "copy_of_product1" localized "meta_title" should be:
-      | locale | value                 |
-      | en-US  | SUNGLASSES meta title |
-    And product "copy_of_product1" localized "meta_description" should be:
-      | locale | value        |
-      | en-US  | Its so smart |
-      | fr-FR  | lel joke     |
-    And product "copy_of_product1" localized "link_rewrite" should be:
-      | locale | value              |
-      | en-US  | smart-sunglasses   |
-      | fr-FR  | lunettes-de-soleil |
-    And product copy_of_product1 should have following seo options:
-      | redirect_type   | 301-product |
-      | redirect_target | product2    |
-    And product "copy_of_product1" should have following shipping information:
-      | width                                   | 10.5                 |
-      | height                                  | 6                    |
-      | depth                                   | 7                    |
-      | weight                                  | 0.5                  |
-      | additional_shipping_cost                | 12                   |
-      | delivery time notes type                | specific             |
-      | delivery time in stock notes[en-US]     | product in stock     |
-      | delivery time in stock notes[fr-FR]     | en stock             |
-      | delivery time out of stock notes[en-US] | product out of stock |
-      | delivery time out of stock notes[fr-FR] | En rupture de stock  |
-      | carriers                                | [carrier1,carrier2]  |
-    And product copy_of_product1 should have following related products:
-      | product  | name            | reference | image url                                             |
-      | product2 | Reading glasses |           | http://myshop.com/img/p/{no_picture}-home_default.jpg |
-    And product copy_of_product1 should have following attachments associated:
-      | attachment reference | title                       | description                           | file name    | type      | size  |
-      | att1                 | en-US:puffin;fr-Fr:macareux | en-US:puffin photo nr1;fr-Fr:macareux | app_icon.png | image/png | 19187 |
-    And product copy_of_product1 should have identical customization fields to product1
-    And product copy_of_product1 should have 1 customizable text field
-    And product copy_of_product1 should have 0 customizable file fields
-    And product "copy_of_product1" should have 1 specific prices
-#@todo: assert stock info
-#@todo: add tests for other type of products Pack, Virtual, Combinations
+    When I duplicate product productWithSuppliers to a productWithSuppliersCopy
+    And product productWithSuppliersCopy should have following suppliers:
+      | supplier  | reference                      | currency | price_tax_excluded |
+      | supplier1 | my first supplier for product1 | USD      | 10                 |
+    # assign reference to new product supplier and check that they are not equal
 
   Scenario: I duplicate product with combinations
-    When I add product product_with_combinations with following information:
+    When I add product productWithCombinations with following information:
       | name[en-US] | Jar of sand  |
       | type        | combinations |
-    And I generate combinations for product product_with_combinations using following attributes:
+    And I generate combinations for product productWithCombinations using following attributes:
       | Color | [Red,Blue] |
-    Then product "product_with_combinations" should have following combinations:
-      | id reference                  | combination name | reference | attributes   | impact on price | quantity | is default |
-      | product_with_combinationsRed  | Color - Red      |           | [Color:Red]  | 0               | 0        | true       |
-      | product_with_combinationsBlue | Color - Blue     |           | [Color:Blue] | 0               | 0        | false      |
-    When I add a specific price specific_price1 to product product_with_combinations with following details:
-      | fixed price     | 123.00                       |
-      | combination     | product_with_combinationsRed |
-      | reduction type  | amount                       |
-      | reduction value | 0.00                         |
-      | includes tax    | true                         |
-      | from quantity   | 1                            |
-    And I add a specific price specific_price2 to product product_with_combinations with following details:
+    Then product "productWithCombinations" should have following combinations:
+      | id reference                | combination name | reference | attributes   | impact on price | quantity | is default |
+      | productWithCombinationsRed  | Color - Red      |           | [Color:Red]  | 0               | 0        | true       |
+      | productWithCombinationsBlue | Color - Blue     |           | [Color:Blue] | 0               | 0        | false      |
+    When I add a specific price price2 to product productWithCombinations with following details:
+      | fixed price     | 123.00                     |
+      | combination     | productWithCombinationsRed |
+      | reduction type  | amount                     |
+      | reduction value | 0.00                       |
+      | includes tax    | true                       |
+      | from quantity   | 1                          |
+    And I add a specific price price3 to product productWithCombinations with following details:
       | fixed price     | 0.00   |
       | reduction type  | amount |
       | reduction value | 5.00   |
       | includes tax    | true   |
       | from quantity   | 1      |
-    Then product "product_with_combinations" should have 2 specific prices
-    When I duplicate product product_with_combinations to a copy_of_product_with_combinations
-    Then product "copy_of_product_with_combinations" should have 2 specific prices
-    # TODO: all sorts of other checks
+    Then product "productWithCombinations" should have 2 specific prices
+    And product "productWithCombinations" should have following list of specific prices in "en" language:
+      | price id | combination | reduction type | reduction value | includes tax | fixed price | from quantity | shop | currency | currencyISOCode | country | group | customer | from                | to                  |
+      | price2   | Color - Red | amount         | 0.0             | true         | 123.00      | 1             |      |          |                 |         |       |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+      | price3   |             | amount         | 5.0             | true         | 0.00        | 1             |      |          |                 |         |       |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+    When I duplicate product productWithCombinations to a productWithCombinationsCopy
+    Then product productWithCombinationsCopy type should be combinations
+    And product "productWithCombinationsCopy" should be disabled
+    And product "productWithCombinationsCopy" should have following combinations:
+      | id reference                    | combination name | reference | attributes   | impact on price | quantity | is default |
+      | productWithCombinationsCopyRed  | Color - Red      |           | [Color:Red]  | 0               | 0        | true       |
+      | productWithCombinationsCopyBlue | Color - Blue     |           | [Color:Blue] | 0               | 0        | false      |
+    And productWithCombinations and productWithCombinationsCopy have different values
+    And productWithCombinationsRed and productWithCombinationsCopyRed have different values
+    And productWithCombinationsBlue and productWithCombinationsCopyBlue have different values
+    Then product "productWithCombinationsCopy" should have 2 specific prices
+    And product "productWithCombinationsCopy" should have following list of specific prices in "en" language:
+      | id reference | combination | reduction type | reduction value | includes tax | fixed price | from quantity | shop | currency | currencyISOCode | country | group | customer | from                | to                  |
+      | price2Copy   | Color - Red | amount         | 0.0             | true         | 123.00      | 1             |      |          |                 |         |       |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+      | price3Copy   |             | amount         | 5.0             | true         | 0.00        | 1             |      |          |                 |         |       |          | 0000-00-00 00:00:00 | 0000-00-00 00:00:00 |
+    And specific price price2Copy should have following details:
+      | specific price detail | value                          |
+      | reduction type        | amount                         |
+      | reduction value       | 0.0                            |
+      | includes tax          | true                           |
+      | fixed price           | 123.0                          |
+      | from quantity         | 1                              |
+      | from                  | 0000-00-00 00:00:00            |
+      | to                    | 0000-00-00 00:00:00            |
+      | shop                  |                                |
+      | currency              |                                |
+      | country               |                                |
+      | group                 |                                |
+      | customer              |                                |
+      | product               | productWithCombinationsCopy    |
+      | combination           | productWithCombinationsCopyRed |
+    And specific price price3Copy should have following details:
+      | specific price detail | value                       |
+      | reduction type        | amount                      |
+      | reduction value       | 5.0                         |
+      | includes tax          | true                        |
+      | fixed price           | 0.0                         |
+      | from quantity         | 1                           |
+      | from                  | 0000-00-00 00:00:00         |
+      | to                    | 0000-00-00 00:00:00         |
+      | shop                  |                             |
+      | currency              |                             |
+      | country               |                             |
+      | group                 |                             |
+      | customer              |                             |
+      | product               | productWithCombinationsCopy |
+    And price2 and price2Copy have different values
+    And price3 and price3Copy have different values
 
   Scenario: I duplicate packed product
-    Given I add product "product3" with following information:
-      | name[en-US] | packed product  |
-      | name[fr-FR] | produit packagé |
-      | type        | pack            |
-    And I update pack "product3" with following product quantities:
-      | product  | combination | quantity |
-      | product1 |             | 2        |
-      | product2 |             | 3        |
-    When I duplicate product product3 to a copy_of_product3
-    And product "copy_of_product3" should be disabled
-    And product "copy_of_product3" type should be pack
-    And product "copy_of_product3" localized "name" should be:
-      | locale | value                    |
-      | en-US  | copy of packed product   |
-      | fr-FR  | copie de produit packagé |
-    And pack copy_of_product3 should contain products with following details:
-      | product  | combination | name             | quantity | image url                                              |
-      | product1 |             | smart sunglasses | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
-      | product2 |             | Reading glasses  | 3        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    Given I add product "packedProduct" with following information:
+      | name[en-US] | packed product   |
+      | name[fr-FR] | pack de produits |
+      | type        | pack             |
+    And I add product "subProduct1" with following information:
+      | name[en-US] | sub product 1  |
+      | name[fr-FR] | sous produit 1 |
+      | type        | standard       |
+    And I add product "subProduct2" with following information:
+      | name[en-US] | sub product 2  |
+      | name[fr-FR] | sous produit 2 |
+      | type        | combinations   |
+    And I generate combinations for product subProduct2 using following attributes:
+      | Color | [Red,Blue] |
+    And product "subProduct2" should have following combinations:
+      | id reference    | combination name | reference | attributes   | impact on price | quantity | is default |
+      | subProduct2Red  | Color - Red      |           | [Color:Red]  | 0               | 0        | true       |
+      | subProduct2Blue | Color - Blue     |           | [Color:Blue] | 0               | 0        | false      |
+    And I update pack "packedProduct" with following product quantities:
+      | product     | combination     | quantity |
+      | subProduct1 |                 | 2        |
+      | subProduct2 | subProduct2Blue | 3        |
+    When I duplicate product packedProduct to a packedProductCopy
+    And product "packedProductCopy" should be disabled
+    And product "packedProductCopy" type should be pack
+    And product "packedProductCopy" localized "name" should be:
+      | locale | value                     |
+      | en-US  | copy of packed product    |
+      | fr-FR  | copie de pack de produits |
+    And pack packedProductCopy should contain products with following details:
+      | product     | combination     | name                        | quantity | image url                                              |
+      | subProduct1 |                 | sub product 1               | 2        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+      | subProduct2 | subProduct2Blue | sub product 2: Color - Blue | 3        | http://myshop.com/img/p/{no_picture}-small_default.jpg |
+    And packedProduct and packedProductCopy have different values
 
+  Scenario: I duplicate virtual product its file should be copied
+    Given I add product "virtualProduct" with following information:
+      | name[en-US] | puffin icon |
+      | type        | virtual     |
+    When I add virtual product file "file1" to product "virtualProduct" with following details:
+      | display name | puffin-logo.png |
+      | file name    | app_icon.png    |
+    Then product "virtualProduct" should have a virtual product file "file1" with following details:
+      | display name         | puffin-logo.png |
+      | access days          | 0               |
+      | download times limit | 0               |
+      | expiration date      |                 |
+    And file "file1" for product "virtualProduct" should exist in system
+    When I duplicate product virtualProduct to a virtualProductCopy
+    Then product virtualProductCopy type should be virtual
+    And product "virtualProductCopy" should be disabled
+    And product virtualProductCopy should have a virtual product file which reference is file1Copy and has following details:
+      | display name         | puffin-logo.png |
+      | access days          | 0               |
+      | download times limit | 0               |
+      | expiration date      |                 |
+    And virtualProduct and virtualProductCopy have different values
+    And file1 and file1Copy have different values

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-prices
 @restore-products-before-feature
+@restore-taxes-after-feature
 @update-product-prices
 @update-prices
 Feature: Update product price fields from Back Office (BO) when default country has states.

--- a/tests/Integration/Behaviour/Features/Scenario/Product/update_prices_without_states.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/update_prices_without_states.feature
@@ -1,5 +1,6 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-prices-without-states
 @restore-products-before-feature
+@restore-taxes-after-feature
 @reboot-kernel-before-feature
 @clear-cache-before-feature
 @update-prices-without-states

--- a/tests/Resources/Resetter/TaxesResetter.php
+++ b/tests/Resources/Resetter/TaxesResetter.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Resources\Resetter;
+
+use Tests\Resources\DatabaseDump;
+
+class TaxesResetter
+{
+    public static function resetTaxes(): void
+    {
+        DatabaseDump::restoreMatchingTables('/.*tax.*/');
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Handle shop constraint in duplicate command, this is the first part that includes a partial refacto of the ProductDuplicator, and it can accurately duplicate product fields in multishop. The rest of the refacto and multishop duplications will be handled in a second PR.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI tests green
| Fixed ticket?     | ~
| Related PRs       | ~
| Sponsor company   | ~
