### PR TITLE
Fix PHP session test for One Click Upgrade

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -407,11 +407,7 @@ class ConfigurationTestCore
 
     public static function test_sessions()
     {
-        if (!$path = @ini_get('session.save_path')) {
-            return true;
-        }
-
-        return is_writable($path);
+        return in_array(session_status(), [PHP_SESSION_ACTIVE, PHP_SESSION_NONE], true);
     }
 
     public static function test_dom()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      |  The core PHP session test of PrestaShop checks if the sessions directory is writable, which does not always work as expected. Combined with an `open_basedir` configured without the `session.save_path`, PHP sessions are still working as intended, but the test_sessions function fails. In such a case, the One Click Upgrade module will fail checking its prerequisites in an attempt to make an upgrade. This fix should target the specifically the 1.7.8.x branch as it impacts the upgrading process, but it may also be useful on 8.0.x and develop branches.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Have a PrestaShop 1.7.8.x or higher. Configure open_basedir and don't include session.save_path. Go to Module list > Upgrade One Click Upgrade to 4.15.0 > Configure the module, then see the error.
| Fixed ticket?     | Fixes #30658
| Related PRs       | n/a
| Sponsor company   | Profileo
