### PR TITLE
Added encryption/decryption for the SMTP password in the database

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -378,7 +378,7 @@ class MailCore extends ObjectModel
                     $configuration['PS_MAIL_SMTP_ENCRYPTION']
                 ))
                     ->setUsername($configuration['PS_MAIL_USER'])
-                    ->setPassword($configuration['PS_MAIL_PASSWD']);
+                    ->setPassword(self::decryptSMTPPass($configuration['PS_MAIL_PASSWD']));
             } else {
                 /**
                  * mail() support was removed from SwiftMailer for security reasons
@@ -757,7 +757,7 @@ class MailCore extends ObjectModel
                     $smtpEncryption
                 ))
                     ->setUsername($smtpLogin)
-                    ->setPassword($smtpPassword);
+                    ->setPassword(self::decryptSMTPPass($smtpPassword));
             } else {
                 /**
                  * mail() support was removed from SwiftMailer for security reasons
@@ -986,5 +986,13 @@ class MailCore extends ObjectModel
             ),
             $die
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static function decryptSMTPPass($encryptedPW)
+    {
+        return openssl_decrypt($encryptedPW,"AES-128-CTR", "PrestaShopSMTP", 0, '3922847190294561');
     }
 }

--- a/src/Core/Email/EmailDataConfigurator.php
+++ b/src/Core/Email/EmailDataConfigurator.php
@@ -98,7 +98,9 @@ final class EmailDataConfigurator implements DataConfigurationInterface
             $smtpPassword = (string) $config['smtp_config']['password'];
 
             if ('' !== $smtpPassword || !$this->configuration->get('PS_MAIL_PASSWD')) {
-                $this->configuration->set('PS_MAIL_PASSWD', $smtpPassword);
+                $encryptedPassword = openssl_encrypt($smtpPassword, "AES-128-CTR",
+                    "PrestaShopSMTP", 0, '3922847190294561');
+                $this->configuration->set('PS_MAIL_PASSWD', $encryptedPassword);
             }
         }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | A encryption for the SMTP password in the database. And decrypt the password when sending emails.
| Type?             | improvement
| Category         | CO
| How to test?      | After this PR your new SMTP password will be encrypted in your database.
| Fixed ticket?     | Fixes #{29676}
| Sponsor company   | Inform-all
