### PR TITLE
Deprecate `Tools::getDescriptionClean()`

### DIFF
--- a/classes/Category.php
+++ b/classes/Category.php
@@ -178,7 +178,7 @@ class CategoryCore extends ObjectModel
      */
     public static function getDescriptionClean($description)
     {
-        return Tools::getDescriptionClean($description);
+        return strip_tags(stripslashes($description));
     }
 
     /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3825,10 +3825,20 @@ exit;
     /**
      * Allows to display the category description without HTML tags and slashes.
      *
+     * @deprecated since version 8.1.0, to be removed.
+     *
      * @return string
      */
     public static function getDescriptionClean($description)
     {
+        @trigger_error(
+            sprintf(
+                '%s is deprecated since version 8.1.0. There is no replacement',
+                __METHOD__
+            ),
+            E_USER_DEPRECATED
+        );
+
         return strip_tags(stripslashes($description));
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This method is only used in category, and has incorrect name. More, it uses only native php functions, i think we should remove this.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | CI 🟢 & automated tests
