### PR TITLE
Disable module if enabled during upgrade

### DIFF
--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -177,6 +177,12 @@ class ModuleManager implements ModuleManagerInterface
 
         $this->assertIsInstalled($name);
 
+        define('IS_ENABLED', $this->isEnabled($name));
+
+        if (IS_ENABLED) {
+            $this->disable($name);
+        }
+
         if ($source !== null) {
             $handler = $this->sourceFactory->getHandler($source);
             $handler->handle($source);
@@ -186,6 +192,10 @@ class ModuleManager implements ModuleManagerInterface
 
         $module = $this->moduleRepository->getModule($name);
         $upgraded = $this->upgradeMigration($name) && $module->onUpgrade($module->get('version'));
+
+        if (IS_ENABLED) {
+            $this->enable($name);
+        }
 
         $this->dispatch(ModuleManagementEvent::UPGRADE, $module);
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When we upgrade a module which is concerned in the upgrade (eg: ps_distributionapiclient) we may have some issue. In fact, in this kind of module if a service constructor has changed from a version to another, there is a phase difference between the container cache service definition (which is build or get first) and the new service (which is download second) it means when we want to instantiate this service, the container will inject a wrong configuration. Moreover, if we ask to the container a service inside the concerned module before downloading the new version and again after downloading the new version, the container will always return the old version of this service. This may lead to weird behaviour. 
The idea here is to disable a module before upgrading it and enabled it back after upgrading.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to upgrade ps_distributionapiclient manually and check that there is no error.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   |
