### PR TITLE
Deprecate FrameworkBundleAdminController::configuration

### DIFF
--- a/src/Core/Domain/Configuration/ShopConfigurationInterface.php
+++ b/src/Core/Domain/Configuration/ShopConfigurationInterface.php
@@ -32,8 +32,8 @@ use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
 /**
- * @method getInt($key, $default = 0)
- * @method getBoolean($key, $default = false)
+ * @method getInt($key, $default = 0, ShopConstraint $shopConstraint = null)
+ * @method getBoolean($key, $default = false, ShopConstraint $shopConstraint = null)
  */
 interface ShopConfigurationInterface extends ConfigurationInterface
 {

--- a/src/Core/Domain/Configuration/ShopConfigurationInterface.php
+++ b/src/Core/Domain/Configuration/ShopConfigurationInterface.php
@@ -31,6 +31,10 @@ namespace PrestaShop\PrestaShop\Core\Domain\Configuration;
 use PrestaShop\PrestaShop\Core\ConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 
+/**
+ * @method getInt($key, $default = 0)
+ * @method getBoolean($key, $default = false)
+ */
 interface ShopConfigurationInterface extends ConfigurationInterface
 {
     /**

--- a/src/PrestaShopBundle/Controller/Admin/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CategoryController.php
@@ -59,7 +59,7 @@ class CategoryController extends FrameworkBundleAdminController
         $shopContext = $this->get('prestashop.adapter.shop.context');
         $shopList = $shopContext->getShops(false, true);
         $currentIdShop = $shopContext->getContextShopID();
-        $defaultLanguageId = $this->get('prestashop.adapter.legacy.configuration')->getInt('PS_LANG_DEFAULT');
+        $defaultLanguageId = $this->getConfiguration()->getInt('PS_LANG_DEFAULT');
 
         $form = $this->createFormBuilder()
             ->add('category', SimpleCategory::class)

--- a/src/PrestaShopBundle/Controller/Admin/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CategoryController.php
@@ -54,7 +54,7 @@ class CategoryController extends FrameworkBundleAdminController
     public function addSimpleCategoryFormAction(Request $request)
     {
         $response = new JsonResponse();
-        $commandBus = $this->get('prestashop.core.command_bus');
+        $commandBus = $this->getCommandBus();
         $tools = $this->get(Tools::class);
         $shopContext = $this->get('prestashop.adapter.shop.context');
         $shopList = $shopContext->getShops(false, true);

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php
@@ -60,7 +60,7 @@ class BackupController extends FrameworkBundleAdminController
     public function indexAction(Request $request, BackupFilters $filters)
     {
         $backupForm = $this->getBackupFormHandler()->getForm();
-        $configuration = $this->get('prestashop.adapter.legacy.configuration');
+        $configuration = $this->getConfiguration();
 
         $hasDownloadFile = false;
         $downloadFile = null;

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
@@ -55,7 +55,7 @@ class EmailController extends FrameworkBundleAdminController
      */
     public function indexAction(Request $request, EmailLogsFilter $filters)
     {
-        $configuration = $this->get('prestashop.adapter.legacy.configuration');
+        $configuration = $this->getConfiguration();
 
         $emailConfigurationForm = $this->getEmailConfigurationFormHandler()->getForm();
         $extensionChecker = $this->get('prestashop.core.configuration.php_extension_checker');

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -421,7 +421,7 @@ class EmployeeController extends FrameworkBundleAdminController
      */
     public function changeFormLanguageAction(Request $request)
     {
-        $configuration = $this->get('prestashop.adapter.legacy.configuration');
+        $configuration = $this->getConfiguration();
 
         if ($configuration->getBoolean('PS_BO_ALLOW_EMPLOYEE_FORM_LANG')) {
             $languageChanger = $this->get('prestashop.adapter.employee.form_language_changer');

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -65,7 +65,7 @@ class MetaController extends FrameworkBundleAdminController
         $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
         $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
         $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
+        $isRewriteSettingEnabled = $this->getConfiguration()->getBoolean('PS_REWRITING_SETTINGS');
 
         $urlSchemaForm = null;
         if ($isRewriteSettingEnabled) {
@@ -256,7 +256,7 @@ class MetaController extends FrameworkBundleAdminController
 
         $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
         $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
+        $isRewriteSettingEnabled = $this->getConfiguration()->getBoolean('PS_REWRITING_SETTINGS');
 
         $urlSchemaForm = null;
         if ($isRewriteSettingEnabled) {
@@ -289,7 +289,7 @@ class MetaController extends FrameworkBundleAdminController
 
         $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
         $seoOptionsForm = $this->getSeoOptionsFormHandler()->getForm();
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
+        $isRewriteSettingEnabled = $this->getConfiguration()->getBoolean('PS_REWRITING_SETTINGS');
 
         $urlSchemaForm = null;
         if ($isRewriteSettingEnabled) {
@@ -350,7 +350,7 @@ class MetaController extends FrameworkBundleAdminController
 
         $setUpUrlsForm = $this->getSetUpUrlsFormHandler()->getForm();
         $shopUrlsForm = $this->getShopUrlsFormHandler()->getForm();
-        $isRewriteSettingEnabled = $this->get('prestashop.adapter.legacy.configuration')->getBoolean('PS_REWRITING_SETTINGS');
+        $isRewriteSettingEnabled = $this->getConfiguration()->getBoolean('PS_REWRITING_SETTINGS');
 
         $urlSchemaForm = null;
         if ($isRewriteSettingEnabled) {
@@ -374,7 +374,7 @@ class MetaController extends FrameworkBundleAdminController
     {
         $robotsTextFileGenerator = $this->get('prestashop.adapter.file.robots_text_file_generator');
 
-        $rootDir = $this->get('prestashop.adapter.legacy.configuration')->get('_PS_ROOT_DIR_');
+        $rootDir = $this->getConfiguration()->get('_PS_ROOT_DIR_');
 
         if (!$robotsTextFileGenerator->generateFile()) {
             $this->addFlash(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderPreferencesController.php
@@ -58,8 +58,8 @@ class OrderPreferencesController extends FrameworkBundleAdminController
             'help_link' => $this->generateSidebarLink($legacyController),
             'generalForm' => $generalForm->createView(),
             'giftOptionsForm' => $giftOptionsForm->createView(),
-            'isMultishippingEnabled' => $this->configuration->getBoolean('PS_ALLOW_MULTISHIPPING'),
-            'isAtcpShipWrapEnabled' => $this->configuration->getBoolean('PS_ATCP_SHIPWRAP'),
+            'isMultishippingEnabled' => $this->getConfiguration()->getBoolean('PS_ALLOW_MULTISHIPPING'),
+            'isAtcpShipWrapEnabled' => $this->getConfiguration()->getBoolean('PS_ATCP_SHIPWRAP'),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/PreferencesController.php
@@ -88,7 +88,7 @@ class PreferencesController extends FrameworkBundleAdminController
                 $this->getCommandBus()->handle(
                     new UpdateTabStatusByClassNameCommand(
                         'AdminShopGroup',
-                        $this->configuration->get('PS_MULTISHOP_FEATURE_ACTIVE')
+                        $this->getConfiguration()->get('PS_MULTISHOP_FEATURE_ACTIVE')
                     )
                 );
 
@@ -120,7 +120,7 @@ class PreferencesController extends FrameworkBundleAdminController
             'help_link' => $this->generateSidebarLink('AdminPreferences'),
             'requireFilterStatus' => false,
             'generalForm' => $form->createView(),
-            'isSslEnabled' => $this->configuration->get('PS_SSL_ENABLED'),
+            'isSslEnabled' => $this->getConfiguration()->get('PS_SSL_ENABLED'),
             'sslUri' => $sslUri,
         ]);
     }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -69,7 +69,7 @@ class FrameworkBundleAdminController extends AbstractController
     {
         @trigger_error(__FUNCTION__ . ' is deprecated since version 8.1 and will be removed in the next major version.', E_USER_DEPRECATED);
 
-        $this->configuration = $this->getConfiguration();
+        $this->configuration = new Configuration();
     }
 
     /**
@@ -94,7 +94,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function getConfiguration(): ShopConfigurationInterface
     {
-        return $this->container->get(ShopConfigurationInterface::class);
+        return $this->container->get('prestashop.adapter.legacy.configuration');
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -69,7 +69,7 @@ class FrameworkBundleAdminController extends AbstractController
     {
         @trigger_error(__FUNCTION__ . ' is deprecated since version 8.1 and will be removed in the next major version.', E_USER_DEPRECATED);
 
-        $this->configuration = new Configuration();
+        $this->configuration = $this->getConfiguration();
     }
 
     /**
@@ -84,7 +84,7 @@ class FrameworkBundleAdminController extends AbstractController
         @trigger_error(__FUNCTION__ . 'is deprecated since version 8.0 and will be removed in the next major version.', E_USER_DEPRECATED);
 
         return [
-            'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
+            'is_shop_context' => $this->container->get('prestashop.adapter.shop.context')->isShopContext(),
             'layoutTitle' => empty($this->layoutTitle) ? '' : $this->trans($this->layoutTitle, 'Admin.Navigation.Menu'),
         ];
     }
@@ -158,7 +158,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function dispatchHook($hookName, array $parameters)
     {
-        $this->get('prestashop.core.hook.dispatcher')->dispatchWithParameters($hookName, $parameters);
+        $this->container->get('prestashop.core.hook.dispatcher')->dispatchWithParameters($hookName, $parameters);
     }
 
     /**
@@ -175,7 +175,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function renderHook($hookName, array $parameters)
     {
-        return $this->get('prestashop.core.hook.dispatcher')->renderForParameters($hookName, $parameters)->getContent();
+        return $this->container->get('prestashop.core.hook.dispatcher')->renderForParameters($hookName, $parameters)->getContent();
     }
 
     /**
@@ -250,7 +250,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function langToLocale($lang)
     {
-        return $this->get('prestashop.service.translation')->langToLocale($lang);
+        return $this->container->get('prestashop.service.translation')->langToLocale($lang);
     }
 
     /**
@@ -310,7 +310,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function trans($key, $domain, array $parameters = [])
     {
-        return $this->get('translator')->trans($key, $parameters, $domain);
+        return $this->container->get('translator')->trans($key, $parameters, $domain);
     }
 
     /**
@@ -335,7 +335,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function redirectToDefaultPage()
     {
-        $legacyContext = $this->get('prestashop.adapter.legacy.context');
+        $legacyContext = $this->container->get('prestashop.adapter.legacy.context');
         $defaultTab = $legacyContext->getDefaultEmployeeTab();
 
         return $this->redirect($legacyContext->getAdminLink($defaultTab));
@@ -403,7 +403,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function getFallbackErrorMessage($type, $code, $message = '')
     {
-        $isDebug = $this->get('kernel')->isDebug();
+        $isDebug = $this->container->get('kernel')->isDebug();
         if ($isDebug && !empty($message)) {
             return $this->trans(
                 'An unexpected error occurred. [%type% code %code%]: %message%',
@@ -437,7 +437,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function getAdminLink($controller, array $params, $withToken = true)
     {
-        return $this->get('prestashop.adapter.legacy.context')->getAdminLink($controller, $withToken, $params);
+        return $this->container->get('prestashop.adapter.legacy.context')->getAdminLink($controller, $withToken, $params);
     }
 
     /**
@@ -449,7 +449,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function presentGrid(GridInterface $grid)
     {
-        return $this->get('prestashop.core.grid.presenter.grid_presenter')->present($grid);
+        return $this->container->get('prestashop.core.grid.presenter.grid_presenter')->present($grid);
     }
 
     /**
@@ -459,7 +459,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function getCommandBus()
     {
-        return $this->get('prestashop.core.command_bus');
+        return $this->container->get('prestashop.core.command_bus');
     }
 
     /**
@@ -469,7 +469,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function getQueryBus()
     {
-        return $this->get('prestashop.core.query_bus');
+        return $this->container->get('prestashop.core.query_bus');
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -28,15 +28,15 @@ namespace PrestaShopBundle\Controller\Admin;
 
 use Exception;
 use PrestaShop\PrestaShop\Adapter\Configuration;
-use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Grid\GridInterface;
+use PrestaShop\PrestaShop\Core\Help\Documentation;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -51,6 +51,8 @@ class FrameworkBundleAdminController extends AbstractController
     public const PRESTASHOP_CORE_CONTROLLERS_TAG = 'prestashop.core.controllers';
 
     /**
+     * @deprecated since version 8.1, use $this->getConfiguration() instead
+     *
      * @var Configuration
      */
     protected $configuration;
@@ -65,6 +67,8 @@ class FrameworkBundleAdminController extends AbstractController
      */
     public function __construct()
     {
+        @trigger_error(__FUNCTION__ . 'is deprecated since version 8.1 and will be removed in the next major version.', E_USER_DEPRECATED);
+
         $this->configuration = new Configuration();
     }
 
@@ -80,9 +84,17 @@ class FrameworkBundleAdminController extends AbstractController
         @trigger_error(__FUNCTION__ . 'is deprecated since version 8.0 and will be removed in the next major version.', E_USER_DEPRECATED);
 
         return [
-            'is_shop_context' => (new Context())->isShopContext(),
+            'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
             'layoutTitle' => empty($this->layoutTitle) ? '' : $this->trans($this->layoutTitle, 'Admin.Navigation.Menu'),
         ];
+    }
+
+    /**
+     * @return ShopConfigurationInterface
+     */
+    protected function getConfiguration(): ShopConfigurationInterface
+    {
+        return $this->container->get('prestashop.adapter.legacy.configuration');
     }
 
     /**
@@ -185,7 +197,7 @@ class FrameworkBundleAdminController extends AbstractController
         $iso = (string) $legacyContext->getEmployeeLanguageIso();
 
         return $this->generateUrl('admin_common_sidebar', [
-            'url' => $this->get('prestashop.core.help.documentation')->generateLink($section, $iso),
+            'url' => $this->container->get(Documentation::class)->generateLink($section, $iso),
             'title' => $title,
         ]);
     }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -67,7 +67,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     public function __construct()
     {
-        @trigger_error(__FUNCTION__ . 'is deprecated since version 8.1 and will be removed in the next major version.', E_USER_DEPRECATED);
+        @trigger_error(__FUNCTION__ . ' is deprecated since version 8.1 and will be removed in the next major version.', E_USER_DEPRECATED);
 
         $this->configuration = new Configuration();
     }

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -258,7 +258,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function isDemoModeEnabled()
     {
-        return $this->get('prestashop.adapter.legacy.configuration')->get('_PS_MODE_DEMO_');
+        return $this->getConfiguration()->get('_PS_MODE_DEMO_');
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -94,7 +94,7 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function getConfiguration(): ShopConfigurationInterface
     {
-        return $this->container->get('prestashop.adapter.legacy.configuration');
+        return $this->container->get(ShopConfigurationInterface::class);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -275,7 +275,7 @@ class MailThemeController extends FrameworkBundleAdminController
      */
     public function sendTestMailAction($theme, $layout, $locale, $module = '')
     {
-        if ($this->configuration->get('PS_MAIL_THEME') !== $theme) {
+        if ($this->getConfiguration()->get('PS_MAIL_THEME') !== $theme) {
             $this->addFlash(
                 'error',
                 $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -28,7 +28,6 @@ namespace PrestaShopBundle\Controller\Admin\Improve\Design;
 
 use Mail;
 use PrestaShop\PrestaShop\Adapter\MailTemplate\MailPreviewVariablesBuilder;
-use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
 use PrestaShop\PrestaShop\Core\Employee\ContextEmployeeProviderInterface;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
@@ -133,8 +132,7 @@ class MailThemeController extends FrameworkBundleAdminController
                     $modulesMailFolder
                 );
 
-                /** @var CommandBusInterface $commandBus */
-                $commandBus = $this->get('prestashop.core.command_bus');
+                $commandBus = $this->getCommandBus();
                 $commandBus->handle($generateCommand);
 
                 if ($data['overwrite']) {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -97,7 +97,7 @@ class ThemeController extends AbstractAdminController
             'faviconPath' => $logoProvider->getFaviconPath(),
             'currentlyUsedTheme' => $themeProvider->getCurrentlyUsedTheme(),
             'notUsedThemes' => $themeProvider->getNotUsedThemes(),
-            'isDevModeOn' => $this->get('prestashop.adapter.legacy.configuration')->get('_PS_MODE_DEV_'),
+            'isDevModeOn' => $this->getConfiguration()->get('_PS_MODE_DEV_'),
             'isSingleShopContext' => $this->get('prestashop.adapter.shop.context')->isSingleShopContext(),
             'isMultiShopFeatureUsed' => $this->get('prestashop.adapter.multistore_feature')->isUsed(),
             'adaptThemeToRtlLanguagesForm' => $this->getAdaptThemeToRtlLanguageForm()->createView(),

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -655,7 +655,7 @@ class ProductController extends FrameworkBundleAdminController
             'asm_globally_activated' => $stockManager->isAsmGloballyActivated(),
             'warehouses' => ($stockManager->isAsmGloballyActivated()) ? $warehouseProvider->getWarehouses() : [],
             'is_multishop_context' => $isMultiShopContext,
-            'is_combination_active' => $this->getConfiguration()->combinationIsActive(),
+            'is_combination_active' => $this->getConfiguration()->getBoolean('PS_COMBINATION_FEATURE_ACTIVE'),
             'showContentHeader' => false,
             'seo_link' => $adminProductWrapper->getPreviewUrl($product, false),
             'preview_link' => $preview_url,

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -655,7 +655,7 @@ class ProductController extends FrameworkBundleAdminController
             'asm_globally_activated' => $stockManager->isAsmGloballyActivated(),
             'warehouses' => ($stockManager->isAsmGloballyActivated()) ? $warehouseProvider->getWarehouses() : [],
             'is_multishop_context' => $isMultiShopContext,
-            'is_combination_active' => $this->get('prestashop.adapter.legacy.configuration')->combinationIsActive(),
+            'is_combination_active' => $this->getConfiguration()->combinationIsActive(),
             'showContentHeader' => false,
             'seo_link' => $adminProductWrapper->getPreviewUrl($product, false),
             'preview_link' => $preview_url,

--- a/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
@@ -63,7 +63,7 @@ class ProductImageController extends FrameworkBundleAdminController
                 'error_bubbling' => true,
                 'constraints' => [
                     new Assert\NotNull(['message' => $this->trans('Please select a file', 'Admin.Catalog.Feature')]),
-                    new Assert\Image(['maxSize' => $this->configuration->get('PS_ATTACHMENT_MAXIMUM_SIZE') . 'M']),
+                    new Assert\Image(['maxSize' => $this->getConfiguration()->get('PS_ATTACHMENT_MAXIMUM_SIZE') . 'M']),
                     new Assert\File([
                         'mimeTypes' => [
                             'image/gif',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -166,7 +166,7 @@ class CategoryController extends FrameworkBundleAdminController
         $categoryFormBuilder = $this->get('prestashop.core.form.identifiable_object.builder.category_form_builder');
         $categoryFormHandler = $this->get('prestashop.core.form.identifiable_object.handler.category_form_handler');
 
-        $parentId = (int) $request->query->get('id_parent', $this->configuration->getInt('PS_HOME_CATEGORY'));
+        $parentId = (int) $request->query->get('id_parent', $this->getConfiguration()->getInt('PS_HOME_CATEGORY'));
 
         $categoryForm = $categoryFormBuilder->getForm(['id_parent' => $parentId]);
         $categoryForm->handleRequest($request);
@@ -226,7 +226,7 @@ class CategoryController extends FrameworkBundleAdminController
                 $this->addFlash('success', $this->trans('Successful creation', 'Admin.Notifications.Success'));
 
                 return $this->redirectToRoute('admin_categories_index', [
-                    'categoryId' => $this->configuration->getInt('PS_ROOT_CATEGORY'),
+                    'categoryId' => $this->getConfiguration()->getInt('PS_ROOT_CATEGORY'),
                 ]);
             }
         } catch (Exception $e) {
@@ -378,7 +378,7 @@ class CategoryController extends FrameworkBundleAdminController
                 $this->addFlash('success', $this->trans('Successful update', 'Admin.Notifications.Success'));
 
                 return $this->redirectToRoute('admin_categories_index', [
-                    'categoryId' => $this->configuration->getInt('PS_ROOT_CATEGORY'),
+                    'categoryId' => $this->getConfiguration()->getInt('PS_ROOT_CATEGORY'),
                 ]);
             }
         } catch (Exception $e) {
@@ -617,7 +617,7 @@ class CategoryController extends FrameworkBundleAdminController
     {
         $deleteCategoriesForm = $this->createForm(DeleteCategoriesType::class);
         $deleteCategoriesForm->handleRequest($request);
-        $idParent = $this->configuration->getInt('PS_HOME_CATEGORY');
+        $idParent = $this->getConfiguration()->getInt('PS_HOME_CATEGORY');
 
         if ($deleteCategoriesForm->isSubmitted()) {
             try {
@@ -664,7 +664,7 @@ class CategoryController extends FrameworkBundleAdminController
     {
         $deleteCategoriesForm = $this->createForm(DeleteCategoriesType::class);
         $deleteCategoriesForm->handleRequest($request);
-        $idParent = $this->configuration->getInt('PS_HOME_CATEGORY');
+        $idParent = $this->getConfiguration()->getInt('PS_HOME_CATEGORY');
 
         if ($deleteCategoriesForm->isSubmitted()) {
             $categoriesDeleteData = $deleteCategoriesForm->getData();
@@ -834,7 +834,7 @@ class CategoryController extends FrameworkBundleAdminController
             $categoryId = $request->attributes->get('categoryId');
         }
         if (empty($categoryId)) {
-            $categoryId = $this->configuration->getInt('PS_HOME_CATEGORY');
+            $categoryId = $this->getConfiguration()->getInt('PS_HOME_CATEGORY');
         }
 
         // Display the button "Add new category" if the current category is not a root category

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -279,7 +279,7 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
     private function renderEditForm(array $parameters = [])
     {
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Features/edit.html.twig', $parameters + [
-            'contextLangId' => $this->configuration->get('PS_LANG_DEFAULT'),
+            'contextLangId' => $this->getConfiguration()->get('PS_LANG_DEFAULT'),
         ]);
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -189,7 +189,7 @@ class ManufacturerController extends FrameworkBundleAdminController
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Manufacturer/view.html.twig', [
             'layoutTitle' => $viewableManufacturer->getName(),
             'viewableManufacturer' => $viewableManufacturer,
-            'isStockManagementEnabled' => $this->configuration->get('PS_STOCK_MANAGEMENT'),
+            'isStockManagementEnabled' => $this->getConfiguration()->get('PS_STOCK_MANAGEMENT'),
             'isAllShopContext' => $this->get('prestashop.adapter.shop.context')->isAllShopContext(),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
@@ -814,7 +814,7 @@ class ManufacturerController extends FrameworkBundleAdminController
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences'));
         $urlEnding = '</a>';
 
-        if ($this->configuration->get('PS_DISPLAY_MANUFACTURERS')) {
+        if ($this->getConfiguration()->get('PS_DISPLAY_MANUFACTURERS')) {
             return $this->trans(
                 'The display of your brands is enabled on your store. Go to %sShop Parameters > General%s to edit settings.',
                 'Admin.Catalog.Notification',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -135,7 +135,7 @@ class CombinationController extends FrameworkBundleAdminController
 
         $shopId = $this->get('prestashop.adapter.shop.context')->getContextShopID();
         if (empty($shopId)) {
-            $shopId = $this->get('prestashop.adapter.legacy.configuration')->getInt('PS_SHOP_DEFAULT');
+            $shopId = $this->getConfiguration()->getInt('PS_SHOP_DEFAULT');
         }
 
         try {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -862,7 +862,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function downloadVirtualFileAction(int $virtualProductFileId): BinaryFileResponse
     {
-        $configuration = $this->get('prestashop.adapter.legacy.configuration');
+        $configuration = $this->getConfiguration();
         $download = $this->getDoctrine()
             ->getRepository(ProductDownload::class)
             ->findOneBy([
@@ -904,7 +904,7 @@ class ProductController extends FrameworkBundleAdminController
 
         $shopId = $this->get('prestashop.adapter.shop.context')->getContextShopID();
         if (empty($shopId)) {
-            $shopId = $this->get('prestashop.adapter.legacy.configuration')->getInt('PS_SHOP_DEFAULT');
+            $shopId = $this->getConfiguration()->getInt('PS_SHOP_DEFAULT');
         }
 
         try {
@@ -976,7 +976,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     private function renderEditProductForm(FormInterface $productForm, int $productId): Response
     {
-        $configuration = $this->get('prestashop.adapter.legacy.configuration');
+        $configuration = $this->getConfiguration();
         $categoryTreeFormBuilder = $this->get('prestashop.core.form.identifiable_object.builder.category_tree_selector_form_builder');
 
         $moduleDataProvider = $this->get('prestashop.adapter.data_provider.module');

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -394,7 +394,7 @@ class SupplierController extends FrameworkBundleAdminController
         return $this->render('@PrestaShop/Admin/Sell/Catalog/Suppliers/view.html.twig', [
             'layoutTitle' => $viewableSupplier->getName(),
             'viewableSupplier' => $viewableSupplier,
-            'isStockManagementEnabled' => $this->configuration->get('PS_STOCK_MANAGEMENT'),
+            'isStockManagementEnabled' => $this->getConfiguration()->get('PS_STOCK_MANAGEMENT'),
             'isAllShopContext' => $this->get('prestashop.adapter.shop.context')->isAllShopContext(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'enableSidebar' => true,
@@ -576,7 +576,7 @@ class SupplierController extends FrameworkBundleAdminController
         $urlOpening = sprintf('<a href="%s">', $this->get('router')->generate('admin_preferences'));
         $urlEnding = '</a>';
 
-        if ($this->configuration->get('PS_DISPLAY_SUPPLIERS')) {
+        if ($this->getConfiguration()->get('PS_DISPLAY_SUPPLIERS')) {
             return $this->trans(
                 'The display of your suppliers is enabled on your store. Go to %sShop Parameters > General%s to edit settings.',
                 'Admin.Catalog.Notification',

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -267,7 +267,7 @@ class CartController extends FrameworkBundleAdminController
      */
     public function updateDeliverySettingsAction(Request $request, int $cartId)
     {
-        $configuration = $this->get('prestashop.adapter.legacy.configuration');
+        $configuration = $this->getConfiguration();
         $recycledPackagingEnabled = (bool) $configuration->get('PS_RECYCLABLE_PACK');
         $giftSettingsEnabled = (bool) $configuration->get('PS_GIFT_WRAPPING');
 

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -251,7 +251,7 @@ class OrderController extends FrameworkBundleAdminController
         );
         $currencies = $this->get('prestashop.core.form.choice_provider.currency_by_id')->getChoices();
 
-        $configuration = $this->get('prestashop.adapter.legacy.configuration');
+        $configuration = $this->getConfiguration();
 
         return $this->render('@PrestaShop/Admin/Sell/Order/Order/create.html.twig', [
             'currencies' => $currencies,
@@ -356,7 +356,7 @@ class OrderController extends FrameworkBundleAdminController
      */
     public function exportAction(OrderFilters $filters)
     {
-        $isB2bEnabled = $this->get('prestashop.adapter.legacy.configuration')->get('PS_B2B_ENABLE');
+        $isB2bEnabled = $this->getConfiguration()->get('PS_B2B_ENABLE');
 
         $filters = new OrderFilters(['limit' => null] + $filters->all());
         $orderGrid = $this->get('prestashop.core.grid.factory.order')->getGrid($filters);
@@ -1825,7 +1825,7 @@ class OrderController extends FrameworkBundleAdminController
     public function searchProductsAction(Request $request): JsonResponse
     {
         try {
-            $defaultCurrencyId = (int) $this->get('prestashop.adapter.legacy.configuration')->get('PS_CURRENCY_DEFAULT');
+            $defaultCurrencyId = (int) $this->getConfiguration()->get('PS_CURRENCY_DEFAULT');
 
             $searchPhrase = $request->query->get('search_phrase');
             $currencyId = $request->query->get('currency_id');

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -517,12 +517,12 @@ class OrderController extends FrameworkBundleAdminController
 
         $this->handleOutOfStockProduct($orderForViewing);
 
-        $merchandiseReturnEnabled = (bool) $this->configuration->get('PS_ORDER_RETURN');
+        $merchandiseReturnEnabled = (bool) $this->getConfiguration()->get('PS_ORDER_RETURN');
 
         /** @var OrderSiblingProviderInterface $orderSiblingProvider */
         $orderSiblingProvider = $this->get('prestashop.adapter.order.order_sibling_provider');
 
-        $paginationNum = (int) $this->configuration->get('PS_ORDER_PRODUCTS_NB_PER_PAGE', self::DEFAULT_PRODUCTS_NUMBER);
+        $paginationNum = (int) $this->getConfiguration()->get('PS_ORDER_PRODUCTS_NB_PER_PAGE', self::DEFAULT_PRODUCTS_NUMBER);
         $paginationNumOptions = self::PRODUCTS_PAGINATION_OPTIONS;
         if (!in_array($paginationNum, $paginationNumOptions)) {
             $paginationNumOptions[] = $paginationNum;
@@ -532,7 +532,7 @@ class OrderController extends FrameworkBundleAdminController
         $metatitle = sprintf(
             '%s %s %s',
             $this->trans('Orders', 'Admin.Orderscustomers.Feature'),
-            $this->configuration->get('PS_NAVIGATION_PIPE', '>'),
+            $this->getConfiguration()->get('PS_NAVIGATION_PIPE', '>'),
             $this->trans(
                 'Order %reference% from %firstname% %lastname%',
                 'Admin.Orderscustomers.Feature',
@@ -571,7 +571,7 @@ class OrderController extends FrameworkBundleAdminController
             'nextOrderId' => $orderSiblingProvider->getNextOrderId($orderId),
             'paginationNum' => $paginationNum,
             'paginationNumOptions' => $paginationNumOptions,
-            'isAvailableQuantityDisplayed' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
+            'isAvailableQuantityDisplayed' => $this->getConfiguration()->getBoolean('PS_STOCK_MANAGEMENT'),
             'internalNoteForm' => $internalNoteForm->createView(),
         ]);
     }
@@ -689,7 +689,7 @@ class OrderController extends FrameworkBundleAdminController
      */
     private function handleOutOfStockProduct(OrderForViewing $orderForViewing)
     {
-        $isStockManagementEnabled = $this->configuration->getBoolean('PS_STOCK_MANAGEMENT');
+        $isStockManagementEnabled = $this->getConfiguration()->getBoolean('PS_STOCK_MANAGEMENT');
         if (!$isStockManagementEnabled || $orderForViewing->isDelivered() || $orderForViewing->isShipped()) {
             return;
         }
@@ -784,7 +784,7 @@ class OrderController extends FrameworkBundleAdminController
                 'product' => $newProduct,
                 'isColumnLocationDisplayed' => $newProduct->getLocation() !== '',
                 'isColumnRefundedDisplayed' => $newProduct->getQuantityRefunded() > 0,
-                'isAvailableQuantityDisplayed' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
+                'isAvailableQuantityDisplayed' => $this->getConfiguration()->getBoolean('PS_STOCK_MANAGEMENT'),
                 'cancelProductForm' => $cancelProductForm->createView(),
                 'orderCurrency' => $orderCurrency,
             ]);
@@ -1049,7 +1049,7 @@ class OrderController extends FrameworkBundleAdminController
             'cancelProductForm' => $cancelProductForm->createView(),
             'isColumnLocationDisplayed' => $product->getLocation() !== '',
             'isColumnRefundedDisplayed' => $product->getQuantityRefunded() > 0,
-            'isAvailableQuantityDisplayed' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
+            'isAvailableQuantityDisplayed' => $this->getConfiguration()->getBoolean('PS_STOCK_MANAGEMENT'),
             'orderCurrency' => $orderCurrency,
             'orderForViewing' => $orderForViewing,
             'product' => $product,
@@ -1581,7 +1581,7 @@ class OrderController extends FrameworkBundleAdminController
         $formBuilder = $this->get('prestashop.core.form.identifiable_object.builder.cancel_product_form_builder');
         $cancelProductForm = $formBuilder->getFormFor($orderId);
 
-        $paginationNum = $this->configuration->getInt('PS_ORDER_PRODUCTS_NB_PER_PAGE', self::DEFAULT_PRODUCTS_NUMBER);
+        $paginationNum = $this->getConfiguration()->getInt('PS_ORDER_PRODUCTS_NB_PER_PAGE', self::DEFAULT_PRODUCTS_NUMBER);
         $paginationNumOptions = self::PRODUCTS_PAGINATION_OPTIONS;
         if (!in_array($paginationNum, $paginationNumOptions)) {
             $paginationNumOptions[] = $paginationNum;
@@ -1607,7 +1607,7 @@ class OrderController extends FrameworkBundleAdminController
             'paginationNum' => $paginationNum,
             'isColumnLocationDisplayed' => $isColumnLocationDisplayed,
             'isColumnRefundedDisplayed' => $isColumnRefundedDisplayed,
-            'isAvailableQuantityDisplayed' => $this->configuration->getBoolean('PS_STOCK_MANAGEMENT'),
+            'isAvailableQuantityDisplayed' => $this->getConfiguration()->getBoolean('PS_STOCK_MANAGEMENT'),
         ]);
     }
 
@@ -1715,7 +1715,7 @@ class OrderController extends FrameworkBundleAdminController
         }
 
         try {
-            $this->configuration->set('PS_ORDER_PRODUCTS_NB_PER_PAGE', $numPerPage);
+            $this->getConfiguration()->set('PS_ORDER_PRODUCTS_NB_PER_PAGE', $numPerPage);
         } catch (Exception $e) {
             return $this->json(
                 ['message' => $this->getErrorMessageForException($e, $this->getErrorMessages($e))],

--- a/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/VirtualProductController.php
@@ -101,7 +101,7 @@ class VirtualProductController extends FrameworkBundleAdminController
      */
     public function downloadFileAction($idProduct)
     {
-        $configuration = $this->get('prestashop.adapter.legacy.configuration');
+        $configuration = $this->getConfiguration();
         $download = $this->getDoctrine()
             ->getRepository(ProductDownload::class)
             ->findOneBy([

--- a/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/shop.yml
@@ -22,7 +22,7 @@ services:
       - '@prestashop.adapter.legacy.context'
       - '@translator'
       - '@router'
-      - '@prestashop.core.help.documentation'
+      - '@PrestaShop\PrestaShop\Core\Help\Documentation'
 
   prestashop.adapter.shop.url.category_provider:
     class: 'PrestaShop\PrestaShop\Adapter\Shop\Url\CategoryProvider'

--- a/src/PrestaShopBundle/Resources/config/services/bundle/bridge/_smarty.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/bridge/_smarty.yml
@@ -45,6 +45,6 @@ services:
     class: PrestaShopBundle\Bridge\Smarty\ToolbarFlagsConfigurator
     arguments:
       - "@prestashop.adapter.legacy.configuration"
-      - "@prestashop.core.help.documentation"
+      - '@PrestaShop\PrestaShop\Core\Help\Documentation'
       - "@=service('prestashop.adapter.environment').isDebug()"
     tags: [ 'prestashop.bridge.smarty_configurator' ]

--- a/src/PrestaShopBundle/Resources/config/services/core/help.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/help.yml
@@ -1,9 +1,16 @@
 services:
   _defaults:
-    public: true
+    public: false
 
-  prestashop.core.help.documentation:
+  # Must be public for now because it is used in controllers and controllers are still using the global container.
+  PrestaShop\PrestaShop\Core\Help\Documentation:
+    public: true
     class: PrestaShop\PrestaShop\Core\Help\Documentation
     arguments:
       - "@prestashop.core.foundation.version"
       - "https://help.prestashop-project.org/"
+
+  prestashop.core.help.documentation:
+    alias: PrestaShop\PrestaShop\Core\Help\Documentation
+    public: true
+    deprecated: ~


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Configuration in adapter is instanciated by hand, this PR deprecates the constructor of the controller and replace all usages
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | CI 🟢 
