### PR TITLE
Fix and unify sort orders in default search providers

### DIFF
--- a/src/Adapter/Category/CategoryProductSearchProvider.php
+++ b/src/Adapter/Category/CategoryProductSearchProvider.php
@@ -31,7 +31,8 @@ use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchProviderInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchResult;
-use PrestaShop\PrestaShop\Core\Product\Search\SortOrderFactory;
+use PrestaShop\PrestaShop\Core\Product\Search\SortOrder;
+use PrestaShop\PrestaShop\Core\Product\Search\SortOrdersCollection;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -39,9 +40,20 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class CategoryProductSearchProvider implements ProductSearchProviderInterface
 {
+    /**
+     * @var TranslatorInterface
+     */
     private $translator;
+
+    /**
+     * @var Category
+     */
     private $category;
-    private $sortOrderFactory;
+
+    /**
+     * @var SortOrdersCollection
+     */
+    private $sortOrdersCollection;
 
     public function __construct(
         TranslatorInterface $translator,
@@ -49,7 +61,7 @@ class CategoryProductSearchProvider implements ProductSearchProviderInterface
     ) {
         $this->translator = $translator;
         $this->category = $category;
-        $this->sortOrderFactory = new SortOrderFactory($this->translator);
+        $this->sortOrdersCollection = new SortOrdersCollection($this->translator);
     }
 
     /**
@@ -112,8 +124,15 @@ class CategoryProductSearchProvider implements ProductSearchProviderInterface
                 ->setProducts($products)
                 ->setTotalProductsCount($count);
 
+            // We use default set of sort orders + option to sort by position, which makes sense only here
             $result->setAvailableSortOrders(
-                $this->sortOrderFactory->getDefaultSortOrders()
+                array_merge(
+                [
+                    (new SortOrder('product', 'position', 'asc'))->setLabel(
+                        $this->translator->trans('Relevance', [], 'Shop.Theme.Catalog')
+                    ),
+                ],
+                $this->sortOrdersCollection->getDefaults())
             );
         }
 

--- a/src/Adapter/Category/CategoryProductSearchProvider.php
+++ b/src/Adapter/Category/CategoryProductSearchProvider.php
@@ -124,7 +124,7 @@ class CategoryProductSearchProvider implements ProductSearchProviderInterface
                 ->setProducts($products)
                 ->setTotalProductsCount($count);
 
-            // We use default set of sort orders + option to sort by position, which makes sense only here
+            // We use default set of sort orders + option to sort by position, which makes sense only here and on search page
             $result->setAvailableSortOrders(
                 array_merge(
                 [

--- a/src/Adapter/Manufacturer/ManufacturerProductSearchProvider.php
+++ b/src/Adapter/Manufacturer/ManufacturerProductSearchProvider.php
@@ -31,14 +31,25 @@ use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchProviderInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchResult;
-use PrestaShop\PrestaShop\Core\Product\Search\SortOrderFactory;
+use PrestaShop\PrestaShop\Core\Product\Search\SortOrdersCollection;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ManufacturerProductSearchProvider implements ProductSearchProviderInterface
 {
+    /**
+     * @var TranslatorInterface
+     */
     private $translator;
+
+    /**
+     * @var Manufacturer
+     */
     private $manufacturer;
-    private $sortOrderFactory;
+
+    /**
+     * @var SortOrdersCollection
+     */
+    private $sortOrdersCollection;
 
     public function __construct(
         TranslatorInterface $translator,
@@ -46,7 +57,7 @@ class ManufacturerProductSearchProvider implements ProductSearchProviderInterfac
     ) {
         $this->translator = $translator;
         $this->manufacturer = $manufacturer;
-        $this->sortOrderFactory = new SortOrderFactory($this->translator);
+        $this->sortOrdersCollection = new SortOrdersCollection($this->translator);
     }
 
     /**
@@ -94,8 +105,9 @@ class ManufacturerProductSearchProvider implements ProductSearchProviderInterfac
                 ->setProducts($products)
                 ->setTotalProductsCount($count);
 
+            // We use only default set of sort orders
             $result->setAvailableSortOrders(
-                $this->sortOrderFactory->getDefaultSortOrders()
+                $this->sortOrdersCollection->getDefaults()
             );
         }
 

--- a/src/Adapter/NewProducts/NewProductsProductSearchProvider.php
+++ b/src/Adapter/NewProducts/NewProductsProductSearchProvider.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchProviderInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchResult;
 use PrestaShop\PrestaShop\Core\Product\Search\SortOrder;
+use PrestaShop\PrestaShop\Core\Product\Search\SortOrdersCollection;
 use Product;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -44,10 +45,16 @@ class NewProductsProductSearchProvider implements ProductSearchProviderInterface
      */
     private $translator;
 
+    /**
+     * @var SortOrdersCollection
+     */
+    private $sortOrdersCollection;
+
     public function __construct(
         TranslatorInterface $translator
     ) {
         $this->translator = $translator;
+        $this->sortOrdersCollection = new SortOrdersCollection($this->translator);
     }
 
     /**
@@ -94,7 +101,9 @@ class NewProductsProductSearchProvider implements ProductSearchProviderInterface
                 ->setProducts($products)
                 ->setTotalProductsCount($count);
 
+            // We use default set of sort orders + option to sort by date
             $result->setAvailableSortOrders(
+                array_merge(
                 [
                     (new SortOrder('product', 'date_add', 'desc'))->setLabel(
                         $this->translator->trans('Date added, newest to oldest', [], 'Shop.Theme.Catalog')
@@ -102,19 +111,8 @@ class NewProductsProductSearchProvider implements ProductSearchProviderInterface
                     (new SortOrder('product', 'date_add', 'asc'))->setLabel(
                         $this->translator->trans('Date added, oldest to newest', [], 'Shop.Theme.Catalog')
                     ),
-                    (new SortOrder('product', 'name', 'asc'))->setLabel(
-                        $this->translator->trans('Name, A to Z', [], 'Shop.Theme.Catalog')
-                    ),
-                    (new SortOrder('product', 'name', 'desc'))->setLabel(
-                        $this->translator->trans('Name, Z to A', [], 'Shop.Theme.Catalog')
-                    ),
-                    (new SortOrder('product', 'price', 'asc'))->setLabel(
-                        $this->translator->trans('Price, low to high', [], 'Shop.Theme.Catalog')
-                    ),
-                    (new SortOrder('product', 'price', 'desc'))->setLabel(
-                        $this->translator->trans('Price, high to low', [], 'Shop.Theme.Catalog')
-                    ),
-                ]
+                ],
+                $this->sortOrdersCollection->getDefaults())
             );
         }
 

--- a/src/Adapter/PricesDrop/PricesDropProductSearchProvider.php
+++ b/src/Adapter/PricesDrop/PricesDropProductSearchProvider.php
@@ -30,7 +30,7 @@ use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchProviderInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchResult;
-use PrestaShop\PrestaShop\Core\Product\Search\SortOrder;
+use PrestaShop\PrestaShop\Core\Product\Search\SortOrdersCollection;
 use Product;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -44,10 +44,16 @@ class PricesDropProductSearchProvider implements ProductSearchProviderInterface
      */
     private $translator;
 
+    /**
+     * @var SortOrdersCollection
+     */
+    private $sortOrdersCollection;
+
     public function __construct(
         TranslatorInterface $translator
     ) {
         $this->translator = $translator;
+        $this->sortOrdersCollection = new SortOrdersCollection($this->translator);
     }
 
     /**
@@ -91,21 +97,9 @@ class PricesDropProductSearchProvider implements ProductSearchProviderInterface
                 ->setProducts($products)
                 ->setTotalProductsCount($count);
 
+            // We use only default set of sort orders
             $result->setAvailableSortOrders(
-                [
-                    (new SortOrder('product', 'name', 'asc'))->setLabel(
-                        $this->translator->trans('Name, A to Z', [], 'Shop.Theme.Catalog')
-                    ),
-                    (new SortOrder('product', 'name', 'desc'))->setLabel(
-                        $this->translator->trans('Name, Z to A', [], 'Shop.Theme.Catalog')
-                    ),
-                    (new SortOrder('product', 'price', 'asc'))->setLabel(
-                        $this->translator->trans('Price, low to high', [], 'Shop.Theme.Catalog')
-                    ),
-                    (new SortOrder('product', 'price', 'desc'))->setLabel(
-                        $this->translator->trans('Price, high to low', [], 'Shop.Theme.Catalog')
-                    ),
-                ]
+                $this->sortOrdersCollection->getDefaults()
             );
         }
 

--- a/src/Adapter/Search/SearchProductSearchProvider.php
+++ b/src/Adapter/Search/SearchProductSearchProvider.php
@@ -31,7 +31,7 @@ use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchProviderInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchResult;
-use PrestaShop\PrestaShop\Core\Product\Search\SortOrderFactory;
+use PrestaShop\PrestaShop\Core\Product\Search\SortOrdersCollection;
 use Search;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tools;
@@ -49,15 +49,15 @@ class SearchProductSearchProvider implements ProductSearchProviderInterface
     private $translator;
 
     /**
-     * @var SortOrderFactory
+     * @var SortOrdersCollection
      */
-    private $sortOrderFactory;
+    private $sortOrdersCollection;
 
     public function __construct(
         TranslatorInterface $translator
     ) {
         $this->translator = $translator;
-        $this->sortOrderFactory = new SortOrderFactory($this->translator);
+        $this->sortOrdersCollection = new SortOrdersCollection($this->translator);
     }
 
     /**
@@ -137,8 +137,9 @@ class SearchProductSearchProvider implements ProductSearchProviderInterface
                 ->setProducts($products)
                 ->setTotalProductsCount($count);
 
+            // We use only default set of sort orders
             $result->setAvailableSortOrders(
-                $this->sortOrderFactory->getDefaultSortOrders()
+                $this->sortOrdersCollection->getDefaults()
             );
         }
 

--- a/src/Adapter/Search/SearchProductSearchProvider.php
+++ b/src/Adapter/Search/SearchProductSearchProvider.php
@@ -137,9 +137,15 @@ class SearchProductSearchProvider implements ProductSearchProviderInterface
                 ->setProducts($products)
                 ->setTotalProductsCount($count);
 
-            // We use only default set of sort orders
+            // We use default set of sort orders + option to sort by position (relevance), which makes sense only here and on category page
             $result->setAvailableSortOrders(
-                $this->sortOrdersCollection->getDefaults()
+                array_merge(
+                [
+                    (new SortOrder('product', 'position', 'asc'))->setLabel(
+                        $this->translator->trans('Relevance', [], 'Shop.Theme.Catalog')
+                    ),
+                ],
+                $this->sortOrdersCollection->getDefaults())
             );
         }
 

--- a/src/Adapter/Search/SearchProductSearchProvider.php
+++ b/src/Adapter/Search/SearchProductSearchProvider.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchProviderInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchResult;
+use PrestaShop\PrestaShop\Core\Product\Search\SortOrder;
 use PrestaShop\PrestaShop\Core\Product\Search\SortOrdersCollection;
 use Search;
 use Symfony\Contracts\Translation\TranslatorInterface;

--- a/src/Adapter/Supplier/SupplierProductSearchProvider.php
+++ b/src/Adapter/Supplier/SupplierProductSearchProvider.php
@@ -30,7 +30,7 @@ use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchContext;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchProviderInterface;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchQuery;
 use PrestaShop\PrestaShop\Core\Product\Search\ProductSearchResult;
-use PrestaShop\PrestaShop\Core\Product\Search\SortOrderFactory;
+use PrestaShop\PrestaShop\Core\Product\Search\SortOrdersCollection;
 use Supplier;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -52,9 +52,9 @@ class SupplierProductSearchProvider implements ProductSearchProviderInterface
     private $supplier;
 
     /**
-     * @var SortOrderFactory
+     * @var SortOrdersCollection
      */
-    private $sortOrderFactory;
+    private $sortOrdersCollection;
 
     public function __construct(
         TranslatorInterface $translator,
@@ -62,7 +62,7 @@ class SupplierProductSearchProvider implements ProductSearchProviderInterface
     ) {
         $this->translator = $translator;
         $this->supplier = $supplier;
-        $this->sortOrderFactory = new SortOrderFactory($this->translator);
+        $this->sortOrdersCollection = new SortOrdersCollection($this->translator);
     }
 
     /**
@@ -109,8 +109,9 @@ class SupplierProductSearchProvider implements ProductSearchProviderInterface
                 ->setProducts($products)
                 ->setTotalProductsCount($count);
 
+            // We use only default set of sort orders
             $result->setAvailableSortOrders(
-                $this->sortOrderFactory->getDefaultSortOrders()
+                $this->sortOrdersCollection->getDefaults()
             );
         }
 

--- a/src/Core/Product/Search/SortOrdersCollection.php
+++ b/src/Core/Product/Search/SortOrdersCollection.php
@@ -44,6 +44,8 @@ final class SortOrdersCollection
     }
 
     /**
+     * Returns a set of default sort orders used by core search providers on all pages.
+     *
      * @return array
      *
      * @throws \Exception
@@ -51,9 +53,6 @@ final class SortOrdersCollection
     public function getDefaults()
     {
         return [
-            (new SortOrder('product', 'position', 'asc'))->setLabel(
-                $this->translator->trans('Relevance', [], 'Shop.Theme.Catalog')
-            ),
             (new SortOrder('product', 'name', 'asc'))->setLabel(
                 $this->translator->trans('Name, A to Z', [], 'Shop.Theme.Catalog')
             ),


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | -
| Related PRs       | -
| Sponsor company   | -

### What this is about
- Default search providers are used, if no filtering module says that he wants to filter products for current query.
- Every search provider must return sort orders available back to the controller. There was some mess in it.

### Changes
- Removed a hardcode override of sort order in `BestSalesProductSearchProvider`. Added a fallback instead for random order, which is coming from `ps_bestsellers` module. This order is not supported in `getBestSales` function and should be removed from the module - https://github.com/PrestaShop/ps_bestsellers/pull/27.
- Added PHPDoc for all attributes.
- Used `SortOrdersCollection` instead of deprecated `SortOrderFactory`.
- `Relevance/Position in category` order removed from the default set, because it makes sense only in category controller.
- Instead of repeating the same code again and again on some providers, providers now use `getDefaults` of `SortOrdersCollection` to get the basic set - Name desc/asc, price desc/asc. Then we only enrich it by special orders for specific pages:
  - Position order added on category page and search page.
  - Sales order added on best sales page.
  - Date order added on new products page.

### How to test
- ❗Uninstall or disable faceted search.
- Check all FO listing pages and see that sort orders show properly.
- Only difference you should see that "Relevance" or "Position" order won't be available on pages other than category and search. It does not make sense in other pages.