### PR TITLE
Send proper welcome emails to customers

### DIFF
--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1194,23 +1194,21 @@ class CustomerCore extends ObjectModel
 
         $this->is_guest = false;
 
-        /*
-        * If this is an anonymous conversion and we want the customer to set his own password,
-        * we set a random one for now.
-        * TODO - This should be revised in the future because 16 chars can be outside of bounds of
-        * isAcceptablePasswordLength. It should not be checked.
-        */
-        if (empty($password)) {
-            $password = Tools::passwdGen(16, 'RANDOM');
-        }
-
-        if (!Validate::isAcceptablePasswordLength($password) || !Validate::isAcceptablePasswordScore($password)) {
-            return false;
-        }
-
         /** @var \PrestaShop\PrestaShop\Core\Crypto\Hashing $crypto */
         $crypto = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Core\\Crypto\\Hashing');
-        $this->passwd = $crypto->hash($password);
+
+        /*
+        * If this is an anonymous conversion and we want the customer to set his own password,
+        * we set a random one for now. If a password was provided, we check it's validity.
+        */
+        if (empty($password)) {
+            $this->passwd = $crypto->hash(Tools::passwdGen(16, 'RANDOM'));
+        } else {
+            if (!Validate::isAcceptablePasswordLength($password) || !Validate::isAcceptablePasswordScore($password)) {
+                return false;
+            }
+            $this->passwd = $crypto->hash($password);
+        }
 
         /*
         * Now, we need to update his group. The guest should have had a PS_GUEST_GROUP previously, but if
@@ -1228,27 +1226,66 @@ class CustomerCore extends ObjectModel
             return false;
         }
 
+        // If it's an anonymous conversion, we send him a link to set his new password.
+        // Otherwise, just a welcome email, if configured.
+        if (empty($password)) {
+            $this->sendWelcomeEmail($idLang, true);
+        } else {
+            $this->sendWelcomeEmail($idLang, false);
+        }
+
+        return true;
+    }
+
+    /**
+     * Sends an informational email to the customer, to notify him that
+     * his account was created.
+     *
+     * This email can optionally contain a link to set his new password.
+     *
+     * @param int $idLang Language ID to send the email in
+     * @param bool $sendPasswordLink Should a template with a password reset link be used
+     *
+     * @return bool If the mail was sent successfully
+     */
+    public function sendWelcomeEmail(int $idLang, bool $sendPasswordLink = false)
+    {
+        // If it's just a basic welcome email, we will check if we want to send these kind of emails first
+        if ($sendPasswordLink === false && !Configuration::get('PS_CUSTOMER_CREATION_EMAIL')) {
+            return true;
+        }
+
+        // Use provided lang ID, or take the one from context
         $language = new Language($idLang);
         if (!Validate::isLoadedObject($language)) {
             $language = Context::getContext()->language;
         }
 
-        /*
-        * Now, we will send out an email where he can set his new password.
-        *
-        * TODO:
-        * This 'guest_to_customer' email should be sent only if password was not provided. Otherwise,
-        * it should send an 'account' email without an URL. This is what CustomerPersister does. (These functions
-        * should be unified.)
-        *
-        * OrderConfirmationController and GuestTrackingController call this logic with a password and user still
-        * receives the below email, that should be changed.
-        */
+        // Build basic email variables
+        $template = 'account';
+        $subject = Context::getContext()->getTranslator()->trans(
+            'Welcome!',
+            [],
+            'Emails.Subject',
+            $language->locale
+        );
         $vars = [
             '{firstname}' => $this->firstname,
             '{lastname}' => $this->lastname,
             '{email}' => $this->email,
-            '{url}' => Context::getContext()->link->getPageLink(
+        ];
+
+        // If we are also sending a link to password, we will alter the template,
+        // change subject and add password URL to variables.
+        if ($sendPasswordLink) {
+            $template = 'guest_to_customer';
+            $subject = Context::getContext()->getTranslator()->trans(
+                'Your guest account has been transformed into a customer account',
+                [],
+                'Emails.Subject',
+                $language->locale
+            );
+            $vars['{url}'] = Context::getContext()->link->getPageLink(
                 'password',
                 true,
                 null,
@@ -1258,17 +1295,13 @@ class CustomerCore extends ObjectModel
                     (int) $this->id,
                     $this->reset_password_token
                 )
-            ),
-        ];
-        Mail::Send(
+            );
+        }
+
+        return Mail::Send(
             (int) $idLang,
-            'guest_to_customer',
-            Context::getContext()->getTranslator()->trans(
-                'Your guest account has been transformed into a customer account',
-                [],
-                'Emails.Subject',
-                $language->locale
-            ),
+            $template,
+            $subject,
             $vars,
             $this->email,
             $this->firstname . ' ' . $this->lastname,
@@ -1280,8 +1313,6 @@ class CustomerCore extends ObjectModel
             false,
             (int) $this->id_shop
         );
-
-        return true;
     }
 
     /**

--- a/classes/Customer.php
+++ b/classes/Customer.php
@@ -1230,8 +1230,8 @@ class CustomerCore extends ObjectModel
         // Otherwise, just a welcome email, if configured.
         if (empty($password)) {
             $this->sendWelcomeEmail($idLang, true);
-        } else {
-            $this->sendWelcomeEmail($idLang, false);
+        } elseif (Configuration::get('PS_CUSTOMER_CREATION_EMAIL')) {
+            $this->sendWelcomeEmail($idLang);
         }
 
         return true;
@@ -1250,11 +1250,6 @@ class CustomerCore extends ObjectModel
      */
     public function sendWelcomeEmail(int $idLang, bool $sendPasswordLink = false)
     {
-        // If it's just a basic welcome email, we will check if we want to send these kind of emails first
-        if ($sendPasswordLink === false && !Configuration::get('PS_CUSTOMER_CREATION_EMAIL')) {
-            return true;
-        }
-
         // Use provided lang ID, or take the one from context
         $language = new Language($idLang);
         if (!Validate::isLoadedObject($language)) {

--- a/classes/form/CustomerPersister.php
+++ b/classes/form/CustomerPersister.php
@@ -167,7 +167,11 @@ class CustomerPersisterCore
             if ($guestToCustomerConversion) {
                 $customer->cleanGroups();
                 $customer->addGroups([Configuration::get('PS_CUSTOMER_GROUP')]);
-                $customer->sendWelcomeEmail($this->context->language->id);
+
+                // Send him a welcome email, if enabled
+                if (Configuration::get('PS_CUSTOMER_CREATION_EMAIL')) {
+                    $customer->sendWelcomeEmail($this->context->language->id);
+                }
             }
         }
 
@@ -236,8 +240,8 @@ class CustomerPersisterCore
             $this->context->updateCustomer($customer);
             $this->context->cart->update();
 
-            // Send a welcome information email, only for registered customers
-            if (!$customer->is_guest) {
+            // Send a welcome information email, only for registered customers and if enabled
+            if (!$customer->is_guest && Configuration::get('PS_CUSTOMER_CREATION_EMAIL')) {
                 $customer->sendWelcomeEmail($this->context->language->id);
             }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

### Changes
- I made a new function responsible for sending welcome emails to customers when creating account or converting from guest to customer.
- I fixed a potential issue that could arise if you set minimal password length to more than 16 characters.
- Customer who transformed their account via BO or conversion form received an email with a password setup link even when they entered it during conversion. Now they receive proper email.

### How to test
- Enable sending welcome email to newly registered customers (`PS_CUSTOMER_CREATION_EMAIL`).
- Try registering normally or in checkout - `welcome` email.
- Try going to checkout, entering name, surname, email and confirm. Then go back and enter password and confirm again - `welcome` email.
- Try converting a guest to customer via a form on order confirmation screen or from guest tracking (with password) - `welcome` email.
- Try converting a guest to customer via a button in backoffice - `guest_to_customer` email.