### PR TITLE
Allow empty (NULL) order invoice address

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -1220,7 +1220,7 @@ CREATE TABLE `PREFIX_orders` (
   `id_cart` int(10) unsigned NOT NULL,
   `id_currency` int(10) unsigned NOT NULL,
   `id_address_delivery` int(10) unsigned NOT NULL,
-  `id_address_invoice` int(10) unsigned NOT NULL,
+  `id_address_invoice` int(10) unsigned,
   `current_state` int(10) unsigned NOT NULL,
   `secure_key` varchar(32) NOT NULL DEFAULT '-1',
   `payment` varchar(255) NOT NULL,

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -223,7 +223,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             $this->getOrderSources($order),
             $this->getLinkedOrders($order),
             $this->addressFormatter->format(new AddressId((int) $order->id_address_delivery)),
-            $this->addressFormatter->format(new AddressId((int) $order->id_address_invoice)),
+            $order->id_address_invoice ? $this->addressFormatter->format(new AddressId((int) $order->id_address_invoice)) : '',
             (string) $order->note
         );
     }
@@ -233,7 +233,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
      *
      * @return OrderCustomerForViewing
      */
-    private function getOrderCustomer(Order $order, OrderInvoiceAddressForViewing $invoiceAddress): OrderCustomerForViewing
+    private function getOrderCustomer(Order $order, ?OrderInvoiceAddressForViewing $invoiceAddress): OrderCustomerForViewing
     {
         $currency = new Currency($order->id_currency);
         $customer = new Customer($order->id_customer);
@@ -338,11 +338,15 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
      *
      * @return OrderInvoiceAddressForViewing
      */
-    private function getOrderInvoiceAddress(Order $order): OrderInvoiceAddressForViewing
+    private function getOrderInvoiceAddress(Order $order): ?OrderInvoiceAddressForViewing
     {
         $address = new Address($order->id_address_invoice);
         $country = new Country($address->id_country);
         $stateName = '';
+
+        if (!$order->id_address_invoice) {
+            return null;
+        }
 
         if ($address->id_state) {
             $state = new State($address->id_state);

--- a/src/Core/Domain/Order/QueryResult/OrderForViewing.php
+++ b/src/Core/Domain/Order/QueryResult/OrderForViewing.php
@@ -251,7 +251,7 @@ class OrderForViewing
         DateTimeImmutable $createdAt,
         ?OrderCustomerForViewing $customer,
         OrderShippingAddressForViewing $shippingAddress,
-        OrderInvoiceAddressForViewing $invoiceAddress,
+        ?OrderInvoiceAddressForViewing $invoiceAddress,
         OrderProductsForViewing $products,
         OrderHistoryForViewing $history,
         OrderDocumentsForViewing $documents,
@@ -374,7 +374,7 @@ class OrderForViewing
     /**
      * @return OrderInvoiceAddressForViewing
      */
-    public function getInvoiceAddress(): OrderInvoiceAddressForViewing
+    public function getInvoiceAddress(): ?OrderInvoiceAddressForViewing
     {
         return $this->invoiceAddress;
     }

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/customer.html.twig
@@ -171,11 +171,13 @@
               </a>
 
               <div class="dropdown-menu dropdown-menu-right">
-                <a class="dropdown-item" id="js-invoice-address-edit-btn"
-                   href="{{ path('admin_order_addresses_edit', {'orderId': orderForViewing.id, 'addressType': 'invoice', 'liteDisplaying': 1, 'submitFormAjax': 1}) }}"
-                >
-                  {{ 'Edit existing address'|trans({}, 'Admin.Actions') }}
-                </a>
+                {% if orderForViewing.invoiceAddress is not null %}
+                  <a class="dropdown-item" id="js-invoice-address-edit-btn"
+                     href="{{ path('admin_order_addresses_edit', {'orderId': orderForViewing.id, 'addressType': 'invoice', 'liteDisplaying': 1, 'submitFormAjax': 1}) }}"
+                  >
+                    {{ 'Edit existing address'|trans({}, 'Admin.Actions') }}
+                  </a>
+                {% endif %}
 
                 <a href="#"
                    class="dropdown-item js-update-customer-address-modal-btn"


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `In some countries / shops / cases the main purchase document is a`<br>`receipt. The main difference (comparing to invoice) is a lack of buyer`<br>`name and address. Issuing invoice for every order may be unneeded or`<br>`highly inconvenient (invoices usually require some extra tax-related`<br>`processing).`<br><br>`To let customers choose a receipt (and skip providing invoice address)`<br>`checkout code / modules have to be adjusted. To allow that core code`<br>`must allow NULL id_address_invoice in the first place.`
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
| Fixed ticket?     | Fixes #31068
| Related PRs       | `autoupgrade` SQL query will be required
| Sponsor company   | 