### PR TITLE
Fix widget call for nonexistent modules

### DIFF
--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -61,7 +61,11 @@ function withWidget($params, callable $cb)
 {
     // Check if name was provided
     if (empty($params['name'])) {
-        throw new Exception('When using {widget}, you must provide at least the `name` parameter.');
+        trigger_error(
+            'When using {widget}, you must provide at least the `name` parameter.',
+            E_USER_NOTICE
+        );
+        return;
     }
 
     // Get module name
@@ -73,15 +77,20 @@ function withWidget($params, callable $cb)
 
     // If it's not installed, nothing to do here
     if (empty($moduleInstance)) {
+        trigger_error(
+            sprintf('Module `%1$s` cannot be used as a widget, because it\'s not installed.', $moduleName),
+            E_USER_NOTICE
+        );
         return;
     }
 
     // Check if this module supports widget interface
     if (!$moduleInstance instanceof PrestaShop\PrestaShop\Core\Module\WidgetInterface) {
-        throw new Exception(sprintf(
-            'Module `%1$s` is not a WidgetInterface.',
-            $moduleName
-        ));
+        trigger_error(
+            sprintf('Module `%1$s` cannot be used as a widget, because it\'s not a WidgetInterface.', $moduleName),
+            E_USER_NOTICE
+        );
+        return;
     }
 
     return $cb($moduleInstance, $params);

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -59,15 +59,24 @@ smartyRegisterFunction($smarty, 'block', 'widget_block', 'smartyWidgetBlock');
 
 function withWidget($params, callable $cb)
 {
-    if (!isset($params['name'])) {
-        throw new Exception('Smarty helper `render_widget` expects at least the `name` parameter.');
+    // Check if name was provided
+    if (empty($params['name'])) {
+        throw new Exception('When using {widget}, you must provide at least the `name` parameter.');
     }
 
+    // Get module name
     $moduleName = $params['name'];
     unset($params['name']);
 
+    // Try to load module
     $moduleInstance = Module::getInstanceByName($moduleName);
 
+    // If it's not installed, nothing to do here
+    if (empty($moduleInstance)) {
+        return;
+    }
+
+    // Check if this module supports widget interface
     if (!$moduleInstance instanceof PrestaShop\PrestaShop\Core\Module\WidgetInterface) {
         throw new Exception(sprintf(
             'Module `%1$s` is not a WidgetInterface.',

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -115,17 +115,13 @@ function withWidget($params, callable $cb, $smarty)
 
 function smartyWidget($params, &$smarty)
 {
-    return withWidget(
-        $params,
-        function ($widget, $params) {
-            return Hook::coreRenderWidget(
-                $widget,
-                isset($params['hook']) ? $params['hook'] : null,
-                $params
-            );
-        }, 
-        $smarty
-    );
+    return withWidget($params, function ($widget, $params) {
+        return Hook::coreRenderWidget(
+            $widget,
+            isset($params['hook']) ? $params['hook'] : null,
+            $params
+        );
+    }, $smarty);
 }
 
 function smartyRender($params, &$smarty)
@@ -178,7 +174,7 @@ function smartyWidgetBlock($params, $content, $smarty)
                 $smarty->assign($key, $value);
             }
             $backedUpVariablesStack[] = $backedUpVariables;
-        });
+        }, $smarty);
         // We don't display anything since the template is not rendered yet.
         return '';
     } else {

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -61,10 +61,12 @@ function withWidget($params, callable $cb)
 {
     // Check if name was provided
     if (empty($params['name'])) {
-        trigger_error(
-            'When using {widget}, you must provide at least the `name` parameter.',
-            E_USER_NOTICE
-        );
+        if (_PS_MODE_DEV_) {
+            trigger_error(
+                'When using {widget}, you must provide at least the `name` parameter.',
+                E_USER_NOTICE
+            );
+        }
         return;
     }
 
@@ -77,19 +79,23 @@ function withWidget($params, callable $cb)
 
     // If it's not installed, nothing to do here
     if (empty($moduleInstance)) {
-        trigger_error(
-            sprintf('Module `%1$s` cannot be used as a widget, because it\'s not installed.', $moduleName),
-            E_USER_NOTICE
-        );
+        if (_PS_MODE_DEV_) {
+            trigger_error(
+                sprintf('Module `%1$s` cannot be used as a widget, because it\'s not installed.', $moduleName),
+                E_USER_NOTICE
+            );
+        }
         return;
     }
 
     // Check if this module supports widget interface
     if (!$moduleInstance instanceof PrestaShop\PrestaShop\Core\Module\WidgetInterface) {
-        trigger_error(
-            sprintf('Module `%1$s` cannot be used as a widget, because it\'s not a WidgetInterface.', $moduleName),
-            E_USER_NOTICE
-        );
+        if (_PS_MODE_DEV_) {
+            trigger_error(
+                sprintf('Module `%1$s` cannot be used as a widget, because it\'s not a WidgetInterface.', $moduleName),
+                E_USER_NOTICE
+            );
+        }
         return;
     }
 

--- a/config/smartyfront.config.inc.php
+++ b/config/smartyfront.config.inc.php
@@ -57,13 +57,16 @@ smartyRegisterFunction($smarty, 'function', 'render', 'smartyRender');
 smartyRegisterFunction($smarty, 'function', 'form_field', 'smartyFormField');
 smartyRegisterFunction($smarty, 'block', 'widget_block', 'smartyWidgetBlock');
 
-function withWidget($params, callable $cb)
+function withWidget($params, callable $cb, $smarty)
 {
     // Check if name was provided
     if (empty($params['name'])) {
         if (_PS_MODE_DEV_) {
             trigger_error(
-                'When using {widget}, you must provide at least the `name` parameter.',
+                sprintf(
+                    'When using {widget}, you must provide at least the `name` parameter. Template - %1$s',
+                    $smarty->source->filepath
+                ),
                 E_USER_NOTICE
             );
         }
@@ -81,7 +84,11 @@ function withWidget($params, callable $cb)
     if (empty($moduleInstance)) {
         if (_PS_MODE_DEV_) {
             trigger_error(
-                sprintf('Module `%1$s` cannot be used as a widget, because it\'s not installed.', $moduleName),
+                sprintf(
+                    'Module %1$s cannot be used as a widget, because it\'s not installed. Template - %2$s',
+                    $moduleName,
+                    $smarty->source->filepath
+                ),
                 E_USER_NOTICE
             );
         }
@@ -92,7 +99,11 @@ function withWidget($params, callable $cb)
     if (!$moduleInstance instanceof PrestaShop\PrestaShop\Core\Module\WidgetInterface) {
         if (_PS_MODE_DEV_) {
             trigger_error(
-                sprintf('Module `%1$s` cannot be used as a widget, because it\'s not a WidgetInterface.', $moduleName),
+                sprintf(
+                    'Module `%1$s` cannot be used as a widget, because it\'s not a WidgetInterface. Template - %2$s',
+                    $moduleName,
+                    $smarty->source->filepath
+                ),
                 E_USER_NOTICE
             );
         }
@@ -104,13 +115,17 @@ function withWidget($params, callable $cb)
 
 function smartyWidget($params, &$smarty)
 {
-    return withWidget($params, function ($widget, $params) {
-        return Hook::coreRenderWidget(
-            $widget,
-            isset($params['hook']) ? $params['hook'] : null,
-            $params
-        );
-    });
+    return withWidget(
+        $params,
+        function ($widget, $params) {
+            return Hook::coreRenderWidget(
+                $widget,
+                isset($params['hook']) ? $params['hook'] : null,
+                $params
+            );
+        }, 
+        $smarty
+    );
 }
 
 function smartyRender($params, &$smarty)


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When a template contains a widget call to a module that is not installed, it completely kills the page. This fixes it by checking if this module instance actually exists. If there is any problem with calling the widget, it will throw a notice in debug mode.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Add `{widget name="blablabla"}` to any theme TPL, try to visit that page.
| Fixed ticket?     | Fixes #30340
| Related PRs       |
| Sponsor company   | 

![not installed](https://user-images.githubusercontent.com/6097524/215500901-686ba0ff-0c9c-4382-835e-8047760fef71.jpg)
![cannot be used](https://user-images.githubusercontent.com/6097524/215500907-487e4fef-9067-48e2-8855-ce2f0affecb0.jpg)

