### PR TITLE
Improve customer view totals

### DIFF
--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -249,13 +249,14 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
         $validOrders = [];
         $invalidOrders = [];
 
+        // Get orders for this customer
         $orders = Order::getCustomerOrders($customer->id, true);
-        $totalSpent = 0;
+        $ordersTotal = 0;
 
         foreach ($orders as $order) {
-            $order['total_paid_real_not_formated'] = $order['total_paid_real'];
-            $order['total_paid_real'] = $this->locale->formatPrice(
-                $order['total_paid_real'],
+            $order['total_paid_tax_incl_not_formated'] = $order['total_paid_tax_incl'];
+            $order['total_paid_tax_incl'] = $this->locale->formatPrice(
+                $order['total_paid_tax_incl'],
                 Currency::getIsoCodeById((int) $order['id_currency'])
             );
 
@@ -273,19 +274,19 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
                 $order['payment'],
                 $order['order_state'],
                 (int) $order['nb_products'],
-                $order['total_paid_real']
+                $order['total_paid_tax_incl']
             );
 
             if ($order['valid']) {
                 $validOrders[] = $customerOrderInformation;
-                $totalSpent += $order['total_paid_real_not_formated'] / $order['conversion_rate'];
+                $ordersTotal += $order['total_paid_tax_incl_not_formated'] / $order['conversion_rate'];
             } else {
                 $invalidOrders[] = $customerOrderInformation;
             }
         }
 
         return new OrdersInformation(
-            $this->locale->formatPrice($totalSpent, $this->context->getContext()->currency->iso_code),
+            $this->locale->formatPrice($ordersTotal, $this->context->getContext()->currency->iso_code),
             $validOrders,
             $invalidOrders
         );

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/carts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/carts.html.twig
@@ -37,7 +37,7 @@
             <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
             <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
             <th>{{ 'Carrier'|trans({}, 'Admin.Global') }}</th>
-            <th>{{ 'Total'|trans({}, 'Admin.Global') }}</th>
+            <th>{{ 'Total (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
             <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
           </tr>
         </thead>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
@@ -61,7 +61,7 @@
               <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
               <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
               <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Total spent'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
+              <th>{{ 'Total (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
               <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
             </tr>
           </thead>
@@ -101,7 +101,7 @@
               <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
               <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
               <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Total spent'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
+              <th>{{ 'Total (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
               <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
             </tr>
           </thead>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check details of any customer that has orders.
| Fixed ticket?     | Fixes #26687 and https://github.com/PrestaShop/PrestaShop/issues/31157
| Related PRs       | 
| Sponsor company   | 

### Changes
- I changed `total_paid_real` to `total_paid_tax_incl`, which: 
  - A) In most cases, produce the same numbers, but doesn't show zeros when the payment module doesn't fill the order_payment table.
  - B) Has more value for the merchant.
- Changed the column headers to `Total (Tax incl.)`, it wasn't clear if the value is with or without tax before.

### Screenshot
![totals](https://user-images.githubusercontent.com/6097524/215522665-b5fe6324-800e-4f3d-aa02-0aa9b5190813.jpg)