### PR TITLE
Change limit of filed value on ps_customized_data so that it can accepts more than 255 characters

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -756,7 +756,7 @@ CREATE TABLE `PREFIX_customized_data` (
   `id_customization` int(10) unsigned NOT NULL,
   `type` tinyint(1) NOT NULL,
   `index` int(3) NOT NULL,
-  `value` varchar(255) NOT NULL,
+  `value` varchar(1024) NOT NULL,
   `id_module` int(10) NOT NULL DEFAULT '0',
   `price` decimal(20, 6) NOT NULL DEFAULT '0',
   `weight` decimal(20, 6) NOT NULL DEFAULT '0',


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Change limit of filed value on ps_customized_data so that it can accepts more than 255 characters
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | Fixes #27579
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/556
| Sponsor company   |

This PR comes with https://github.com/PrestaShop/classic-theme/pull/100
1. create a zip from https://github.com/lartist/classic-theme/tree/change-limit-on-customized-product-value (or https://github.com/PrestaShop/classic-theme `develop` if https://github.com/PrestaShop/classic-theme/pull/100 is merged
2. Upload the zip in theme page
3. See the helper text below custom field value in front product page
4. Try to put more than 255 characters. After submitting the form, nothing is truncated

Alternative testing:
You can edit manually the file `themes/classic/templates/catalog/_partials/product-customization.tpl` and change the `maxlength` property to 1024