### PR TITLE
Fix translation page responsivity

### DIFF
--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/app.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/app.vue
@@ -28,7 +28,6 @@
     id="app"
     class="translations-app"
   >
-
     <div class="row justify-content-between align-items-end">
       <div class="col-md-8 mb-3">
         <Search @search="onSearch" />

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/app.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/app.vue
@@ -28,10 +28,13 @@
     id="app"
     class="translations-app"
   >
-    <div class="container-fluid">
-      <div class="row justify-content-between align-items-center">
+
+    <div class="row justify-content-between align-items-end">
+      <div class="col-md-8 mb-3">
         <Search @search="onSearch" />
-        <div class="translations-summary">
+      </div>
+      <div class="col-md-4 mb-3">
+        <div class="translations-summary text-md-right">
           <span>{{ totalTranslations }}</span>
           <span v-show="totalMissingTranslations">
             -
@@ -39,18 +42,23 @@
           </span>
         </div>
       </div>
+    </div>
 
-      <div class="row">
+    <div class="row">
+      <div class="col-md-5 col-lg-4 mb-3">
         <Sidebar
           :modal="$refs.transModal"
           :principal="$refs.principal"
         />
+      </div>
+      <div class="col-md-7 col-lg-8 mb-3">
         <Principal
           :modal="$refs.transModal"
           ref="principal"
         />
       </div>
     </div>
+
     <PSModal
       ref="transModal"
       :translations="translations"

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/header/search.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/header/search.vue
@@ -24,7 +24,9 @@
  *-->
 <template>
   <div id="search">
-    <form class="search-form" @submit.prevent>
+    <form class="search-form"
+      @submit.prevent
+    >
       <label>{{ trans('search_label') }}</label>
       <div class="input-group">
         <PSTags

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/header/search.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/header/search.vue
@@ -23,14 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *-->
 <template>
-  <div
-    id="search"
-    class="col-md-8 mb-4"
-  >
-    <form
-      class="search-form"
-      @submit.prevent
-    >
+  <div id="search">
+    <form class="search-form" @submit.prevent>
       <label>{{ trans('search_label') }}</label>
       <div class="input-group">
         <PSTags

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/header/search.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/header/search.vue
@@ -24,7 +24,8 @@
  *-->
 <template>
   <div id="search">
-    <form class="search-form"
+    <form
+      class="search-form"
       @submit.prevent
     >
       <label>{{ trans('search_label') }}</label>

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
@@ -24,10 +24,7 @@
  *-->
 <template>
   <transition name="fade">
-    <div
-      class="col-sm-9 card"
-      v-if="principalReady"
-    >
+    <div class="card" v-if="principalReady">
       <div class="p-3 translations-wrapper">
         <PSAlert
           v-if="noResult"

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
@@ -24,7 +24,8 @@
  *-->
 <template>
   <transition name="fade">
-    <div class="card"
+    <div
+      class="card"
       v-if="principalReady"
     >
       <div class="p-3 translations-wrapper">

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/index.vue
@@ -24,7 +24,9 @@
  *-->
 <template>
   <transition name="fade">
-    <div class="card" v-if="principalReady">
+    <div class="card"
+      v-if="principalReady"
+    >
       <div class="p-3 translations-wrapper">
         <PSAlert
           v-if="noResult"

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/translation-input.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/translation-input.vue
@@ -42,7 +42,7 @@
           ghost
           @click="resetTranslation"
         >
-        {{ trans('button_reset') }}
+          {{ trans('button_reset') }}
         </PSButton>
       </div>
     </div>

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/translation-input.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/principal/translation-input.vue
@@ -31,15 +31,21 @@
       v-model="getTranslated"
       :class="{ missing : isMissing }"
     />
-    <PSButton
-      class="mt-3 float-sm-right"
-      :primary="false"
-      ghost
-      @click="resetTranslation"
-    >
-      {{ trans('button_reset') }}
-    </PSButton>
-    <small class="mt-3">{{ extraInfo }}</small>
+    <div class="d-flex flex-column flex-md-row justify-content-md-between">
+      <div>
+        <small>{{ extraInfo }}</small>
+      </div>
+      <div>
+        <PSButton
+          class="mt-2"
+          :primary="false"
+          ghost
+          @click="resetTranslation"
+        >
+        {{ trans('button_reset') }}
+        </PSButton>
+      </div>
+    </div>
   </div>
 </template>
 

--- a/admin-dev/themes/new-theme/js/app/pages/translations/components/sidebar/index.vue
+++ b/admin-dev/themes/new-theme/js/app/pages/translations/components/sidebar/index.vue
@@ -23,18 +23,16 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *-->
 <template>
-  <div class="col-sm-3">
-    <div class="card p-3">
-      <PSTree
-        ref="domainsTree"
-        :model="$store.getters.domainsTree"
-        class-name="translationTree"
-        :translations="translations"
-        :current-item="currentItem"
-        v-if="treeReady"
-      />
-      <PSSpinner v-else />
-    </div>
+  <div class="card p-3">
+    <PSTree
+      ref="domainsTree"
+      :model="$store.getters.domainsTree"
+      class-name="translationTree"
+      :translations="translations"
+      :current-item="currentItem"
+      v-if="treeReady"
+    />
+    <PSSpinner v-else />
   </div>
 </template>
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Translations page was using wrong boostrap syntax, was overflowing, had bad responsivity.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Play around with translations page in responsive mode of your browser, see that it behaves much better.
| Fixed ticket?     | 
| Related PRs       |
| Sponsor company   | 

### Screenshots
![desktop](https://user-images.githubusercontent.com/6097524/215568569-0280a322-c77d-4d88-88ec-de954b7f40ce.jpg)
![tablet](https://user-images.githubusercontent.com/6097524/215568575-a2108315-9c9a-4c6c-a05e-b28bd115fdea.jpg)
![mobile](https://user-images.githubusercontent.com/6097524/215571443-9d1ed729-3c19-45e0-959b-70d7505e2384.jpg)
