### PR TITLE
Security improvements

### DIFF
--- a/classes/Access.php
+++ b/classes/Access.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
+
 /**
  * Class AccessCore.
  */
@@ -214,7 +216,7 @@ class AccessCore extends ObjectModel
      */
     public static function sluggifyTab($tab, $authorization = '')
     {
-        return sprintf('ROLE_MOD_TAB_%s_%s', strtoupper($tab['class_name'] ?? ''), $authorization);
+        return sprintf('%s%s_%s', Permission::PREFIX, strtoupper($tab['class_name'] ?? ''), $authorization);
     }
 
     /**
@@ -344,7 +346,7 @@ class AccessCore extends ObjectModel
         $idTab = (int) $idTab;
 
         if ($idTab == -1) {
-            $slug = 'ROLE_MOD_TAB_%_';
+            $slug = Permission::PREFIX . '%_';
         } else {
             $slug = self::findSlugByIdTab($idTab);
         }

--- a/classes/Access.php
+++ b/classes/Access.php
@@ -406,7 +406,7 @@ class AccessCore extends ObjectModel
         $idModule = (int) $idModule;
 
         if ($idModule == -1) {
-            $slug = Permission::PREFIX_MODULE.'%_';
+            $slug = Permission::PREFIX_MODULE . '%_';
         } else {
             $slug = self::findSlugByIdModule($idModule);
         }

--- a/classes/Access.php
+++ b/classes/Access.php
@@ -216,7 +216,7 @@ class AccessCore extends ObjectModel
      */
     public static function sluggifyTab($tab, $authorization = '')
     {
-        return sprintf('%s%s_%s', Permission::PREFIX, strtoupper($tab['class_name'] ?? ''), $authorization);
+        return sprintf('%s%s_%s', Permission::PREFIX_TAB, strtoupper($tab['class_name'] ?? ''), $authorization);
     }
 
     /**
@@ -229,7 +229,7 @@ class AccessCore extends ObjectModel
      */
     public static function sluggifyModule($module, $authorization = '')
     {
-        return sprintf('ROLE_MOD_MODULE_%s_%s', strtoupper($module['name'] ?? ''), $authorization);
+        return sprintf('%s%s_%s', Permission::PREFIX_MODULE, strtoupper($module['name'] ?? ''), $authorization);
     }
 
     /**
@@ -346,7 +346,7 @@ class AccessCore extends ObjectModel
         $idTab = (int) $idTab;
 
         if ($idTab == -1) {
-            $slug = Permission::PREFIX . '%_';
+            $slug = Permission::PREFIX_TAB . '%_';
         } else {
             $slug = self::findSlugByIdTab($idTab);
         }
@@ -406,7 +406,7 @@ class AccessCore extends ObjectModel
         $idModule = (int) $idModule;
 
         if ($idModule == -1) {
-            $slug = 'ROLE_MOD_MODULE_%_';
+            $slug = Permission::PREFIX_MODULE.'%_';
         } else {
             $slug = self::findSlugByIdModule($idModule);
         }

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
+
 /**
  * Class TabCore.
  */
@@ -149,7 +151,7 @@ class TabCore extends ObjectModel
         }
 
         /* Right management */
-        $slug = 'ROLE_MOD_TAB_' . strtoupper(self::getClassNameById($idTab));
+        $slug = Permission::PREFIX . strtoupper(self::getClassNameById($idTab));
 
         foreach (['CREATE', 'READ', 'UPDATE', 'DELETE'] as $action) {
             /*
@@ -183,7 +185,7 @@ class TabCore extends ObjectModel
     public function delete()
     {
         if (parent::delete()) {
-            $slug = 'ROLE_MOD_TAB_' . strtoupper($this->class_name);
+            $slug = Permission::PREFIX . strtoupper($this->class_name);
 
             foreach (['CREATE', 'READ', 'UPDATE', 'DELETE'] as $action) {
                 Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'authorization_role` WHERE `slug` = "' . $slug . '_' . $action . '"');

--- a/classes/Tab.php
+++ b/classes/Tab.php
@@ -151,7 +151,7 @@ class TabCore extends ObjectModel
         }
 
         /* Right management */
-        $slug = Permission::PREFIX . strtoupper(self::getClassNameById($idTab));
+        $slug = Permission::PREFIX_TAB . strtoupper(self::getClassNameById($idTab));
 
         foreach (['CREATE', 'READ', 'UPDATE', 'DELETE'] as $action) {
             /*
@@ -185,7 +185,7 @@ class TabCore extends ObjectModel
     public function delete()
     {
         if (parent::delete()) {
-            $slug = Permission::PREFIX . strtoupper($this->class_name);
+            $slug = Permission::PREFIX_TAB . strtoupper($this->class_name);
 
             foreach (['CREATE', 'READ', 'UPDATE', 'DELETE'] as $action) {
                 Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . 'authorization_role` WHERE `slug` = "' . $slug . '_' . $action . '"');

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -4736,28 +4736,28 @@ class AdminControllerCore extends Controller
     {
         if (
             Access::isGranted(
-                Permission::PREFIX . strtoupper($this->controller_name) . '_DELETE',
+                Permission::PREFIX_TAB . strtoupper($this->controller_name) . '_DELETE',
                 $this->context->employee->id_profile
             )
         ) {
             return AdminController::LEVEL_DELETE;
         } elseif (
             Access::isGranted(
-                Permission::PREFIX . strtoupper($this->controller_name) . '_CREATE',
+                Permission::PREFIX_TAB . strtoupper($this->controller_name) . '_CREATE',
                 $this->context->employee->id_profile
             )
         ) {
             return AdminController::LEVEL_ADD;
         } elseif (
             Access::isGranted(
-                Permission::PREFIX . strtoupper($this->controller_name) . '_UPDATE',
+                Permission::PREFIX_TAB . strtoupper($this->controller_name) . '_UPDATE',
                 $this->context->employee->id_profile
             )
         ) {
             return AdminController::LEVEL_EDIT;
         } elseif (
             Access::isGranted(
-                Permission::PREFIX . strtoupper($this->controller_name) . '_READ',
+                Permission::PREFIX_TAB . strtoupper($this->controller_name) . '_READ',
                 $this->context->employee->id_profile
             )
         ) {

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Feature\TokenInUrls;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Number as NumberSpecification;
 use PrestaShop\PrestaShop\Core\Localization\Specification\Price as PriceSpecification;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
@@ -4735,28 +4736,28 @@ class AdminControllerCore extends Controller
     {
         if (
             Access::isGranted(
-                'ROLE_MOD_TAB_' . strtoupper($this->controller_name) . '_DELETE',
+                Permission::PREFIX . strtoupper($this->controller_name) . '_DELETE',
                 $this->context->employee->id_profile
             )
         ) {
             return AdminController::LEVEL_DELETE;
         } elseif (
             Access::isGranted(
-                'ROLE_MOD_TAB_' . strtoupper($this->controller_name) . '_CREATE',
+                Permission::PREFIX . strtoupper($this->controller_name) . '_CREATE',
                 $this->context->employee->id_profile
             )
         ) {
             return AdminController::LEVEL_ADD;
         } elseif (
             Access::isGranted(
-                'ROLE_MOD_TAB_' . strtoupper($this->controller_name) . '_UPDATE',
+                Permission::PREFIX . strtoupper($this->controller_name) . '_UPDATE',
                 $this->context->employee->id_profile
             )
         ) {
             return AdminController::LEVEL_EDIT;
         } elseif (
             Access::isGranted(
-                'ROLE_MOD_TAB_' . strtoupper($this->controller_name) . '_READ',
+                Permission::PREFIX . strtoupper($this->controller_name) . '_READ',
                 $this->context->employee->id_profile
             )
         ) {

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -258,17 +258,33 @@ class AdminControllerCore extends Controller
     /** @var string */
     public $override_folder;
 
-    /** @var int DELETE access level */
-    public const LEVEL_DELETE = 4;
+    /**
+     * @deprecated since 9.0
+     *
+     * @var int DELETE access level
+     */
+    public const LEVEL_DELETE = Permission::LEVEL_DELETE;
 
-    /** @var int ADD access level */
-    public const LEVEL_ADD = 3;
+    /**
+     * @deprecated since 9.0
+     *
+     * @var int ADD access level
+     */
+    public const LEVEL_ADD = Permission::LEVEL_CREATE;
 
-    /** @var int EDIT access level */
-    public const LEVEL_EDIT = 2;
+    /**
+     * @deprecated since 9.0
+     *
+     * @var int EDIT access level
+     */
+    public const LEVEL_EDIT = Permission::LEVEL_UPDATE;
 
-    /** @var int VIEW access level */
-    public const LEVEL_VIEW = 1;
+    /**
+     * @deprecated since 9.0
+     *
+     * @var int VIEW access level
+     */
+    public const LEVEL_VIEW = Permission::LEVEL_READ;
 
     /**
      * Actions to execute on multiple selections.
@@ -4740,28 +4756,28 @@ class AdminControllerCore extends Controller
                 $this->context->employee->id_profile
             )
         ) {
-            return AdminController::LEVEL_DELETE;
+            return Permission::LEVEL_DELETE;
         } elseif (
             Access::isGranted(
                 Permission::PREFIX_TAB . strtoupper($this->controller_name) . '_CREATE',
                 $this->context->employee->id_profile
             )
         ) {
-            return AdminController::LEVEL_ADD;
+            return Permission::LEVEL_CREATE;
         } elseif (
             Access::isGranted(
                 Permission::PREFIX_TAB . strtoupper($this->controller_name) . '_UPDATE',
                 $this->context->employee->id_profile
             )
         ) {
-            return AdminController::LEVEL_EDIT;
+            return Permission::LEVEL_UPDATE;
         } elseif (
             Access::isGranted(
                 Permission::PREFIX_TAB . strtoupper($this->controller_name) . '_READ',
                 $this->context->employee->id_profile
             )
         ) {
-            return AdminController::LEVEL_VIEW;
+            return Permission::LEVEL_READ;
         } else {
             return 0;
         }

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -26,6 +26,7 @@
 
 use PrestaShop\PrestaShop\Core\Search\SearchPanel;
 use PrestaShop\PrestaShop\Core\Search\SearchPanelInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 
 class AdminSearchControllerCore extends AdminController
 {
@@ -288,7 +289,7 @@ class AdminSearchControllerCore extends AdminController
                 continue;
             }
             // Remove pages without access
-            if (!Access::isGranted('ROLE_MOD_TAB_' . strtoupper($row['class_name']) . '_READ', $this->context->employee->id_profile)) {
+            if (!Access::isGranted(Permission::PREFIX . strtoupper($row['class_name']) . '_READ', $this->context->employee->id_profile)) {
                 continue;
             }
             $tab = Tab::getInstanceFromClassName($row['class_name']);

--- a/controllers/admin/AdminSearchController.php
+++ b/controllers/admin/AdminSearchController.php
@@ -289,7 +289,7 @@ class AdminSearchControllerCore extends AdminController
                 continue;
             }
             // Remove pages without access
-            if (!Access::isGranted(Permission::PREFIX . strtoupper($row['class_name']) . '_READ', $this->context->employee->id_profile)) {
+            if (!Access::isGranted(Permission::PREFIX_TAB . strtoupper($row['class_name']) . '_READ', $this->context->employee->id_profile)) {
                 continue;
             }
             $tab = Tab::getInstanceFromClassName($row['class_name']);

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -26,6 +26,7 @@
 use PrestaShop\PrestaShop\Core\Addon\Theme\Theme;
 use PrestaShop\PrestaShop\Core\Addon\Theme\ThemeManagerBuilder;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 
 class AdminTranslationsControllerCore extends AdminController
 {
@@ -190,10 +191,10 @@ class AdminTranslationsControllerCore extends AdminController
             !in_array(
                 $this->authorizationLevel(),
                 [
-                    AdminController::LEVEL_VIEW,
-                    AdminController::LEVEL_EDIT,
-                    AdminController::LEVEL_ADD,
-                    AdminController::LEVEL_DELETE,
+                    Permission::LEVEL_READ,
+                    Permission::LEVEL_UPDATE,
+                    Permission::LEVEL_CREATE,
+                    Permission::LEVEL_DELETE,
                 ]
             )
         ) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -93,4 +93,10 @@ parameters:
             message: 'Use \PrestaShop\PrestaShop\Core\Security\Permission constants instead.'
             disallowIn:
                 - src/*
+        -
+            class: AdminController
+            constant: ['LEVEL_DELETE', 'LEVEL_ADD', 'LEVEL_VIEW', 'LEVEL_EDIT']
+            message: 'Use \PrestaShop\PrestaShop\Core\Security\Permission constants instead.'
+            disallowIn:
+                - src/*
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -86,3 +86,11 @@ parameters:
             disallowIn:
                 - src/*
 
+  disallowedConstants:
+        -
+            class: PrestaShopBundle\Security\Voter\PageVoter
+            constant: ['CREATE', 'READ', 'UPDATE', 'DELETE', 'LEVEL_DELETE', 'LEVEL_CREATE', 'LEVEL_READ', 'LEVEL_UPDATE']
+            message: 'Use \PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface constants instead.'
+            disallowIn:
+                - src/*
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -99,4 +99,6 @@ parameters:
             message: 'Use \PrestaShop\PrestaShop\Core\Security\Permission constants instead.'
             disallowIn:
                 - src/*
+                - classes/*
+                - controllers/*
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -90,7 +90,7 @@ parameters:
         -
             class: PrestaShopBundle\Security\Voter\PageVoter
             constant: ['CREATE', 'READ', 'UPDATE', 'DELETE', 'LEVEL_DELETE', 'LEVEL_CREATE', 'LEVEL_READ', 'LEVEL_UPDATE']
-            message: 'Use \PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface constants instead.'
+            message: 'Use \PrestaShop\PrestaShop\Core\Security\Permission constants instead.'
             disallowIn:
                 - src/*
 

--- a/src/Adapter/Profile/Permission/QueryHandler/GetPermissionsForConfigurationHandler.php
+++ b/src/Adapter/Profile/Permission/QueryHandler/GetPermissionsForConfigurationHandler.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Query\GetPermissionsFor
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\QueryHandler\GetPermissionsForConfigurationHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\QueryResult\ConfigurablePermissions;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\ValueObject\ControllerPermission;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use Profile;
 use RuntimeException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -96,7 +96,7 @@ class GetPermissionsForConfigurationHandler implements GetPermissionsForConfigur
         $modulePermissionsForProfiles = $this->getModulePermissionsForProfiles($profiles);
 
         $employeeProfileId = $query->getEmployeeProfileId()->getValue();
-        $canEmployeeEditPermissions = $this->authorizationChecker->isGranted(AccessCheckerInterface::UPDATE, 'AdminAccess');
+        $canEmployeeEditPermissions = $this->authorizationChecker->isGranted(Permission::UPDATE, 'AdminAccess');
 
         $bulkConfigurationPermissions = $this->getBulkConfigurationForProfiles(
             $employeeProfileId,

--- a/src/Adapter/Profile/Permission/QueryHandler/GetPermissionsForConfigurationHandler.php
+++ b/src/Adapter/Profile/Permission/QueryHandler/GetPermissionsForConfigurationHandler.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Query\GetPermissionsFor
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\QueryHandler\GetPermissionsForConfigurationHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\QueryResult\ConfigurablePermissions;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\ValueObject\ControllerPermission;
-use PrestaShopBundle\Security\Voter\PageVoter;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use Profile;
 use RuntimeException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -96,7 +96,7 @@ class GetPermissionsForConfigurationHandler implements GetPermissionsForConfigur
         $modulePermissionsForProfiles = $this->getModulePermissionsForProfiles($profiles);
 
         $employeeProfileId = $query->getEmployeeProfileId()->getValue();
-        $canEmployeeEditPermissions = $this->authorizationChecker->isGranted(PageVoter::UPDATE, 'AdminAccess');
+        $canEmployeeEditPermissions = $this->authorizationChecker->isGranted(AccessCheckerInterface::UPDATE, 'AdminAccess');
 
         $bulkConfigurationPermissions = $this->getBulkConfigurationForProfiles(
             $employeeProfileId,

--- a/src/Adapter/Security/Access.php
+++ b/src/Adapter/Security/Access.php
@@ -11,7 +11,7 @@ class Access implements AccessCheckerInterface, EmployeePermissionProviderInterf
 {
     public function isEmployeeGranted(string $action, int $employeeProfileId): bool
     {
-        return LegacyAccess::isGranted(Permission::PREFIX . strtoupper($action), $employeeProfileId);
+        return LegacyAccess::isGranted(Permission::PREFIX_TAB . strtoupper($action), $employeeProfileId);
     }
 
     public function getRoles(int $employeeProfileId): array

--- a/src/Adapter/Security/Access.php
+++ b/src/Adapter/Security/Access.php
@@ -5,12 +5,13 @@ namespace PrestaShop\PrestaShop\Adapter\Security;
 use Access as LegacyAccess;
 use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShop\PrestaShop\Core\Security\EmployeePermissionProviderInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 
 class Access implements AccessCheckerInterface, EmployeePermissionProviderInterface
 {
     public function isEmployeeGranted(string $action, int $employeeProfileId): bool
     {
-        return LegacyAccess::isGranted('ROLE_MOD_TAB_' . strtoupper($action), $employeeProfileId);
+        return LegacyAccess::isGranted(Permission::PREFIX . strtoupper($action), $employeeProfileId);
     }
 
     public function getRoles(int $employeeProfileId): array

--- a/src/Adapter/Security/Access.php
+++ b/src/Adapter/Security/Access.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Adapter\Security;
+
+use Access as LegacyAccess;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\EmployeePermissionProviderInterface;
+
+class Access implements AccessCheckerInterface, EmployeePermissionProviderInterface
+{
+    public function isEmployeeGranted(string $action, int $employeeProfileId): bool
+    {
+        return LegacyAccess::isGranted('ROLE_MOD_TAB_' . strtoupper($action), $employeeProfileId);
+    }
+
+    public function getRoles(int $employeeProfileId): array
+    {
+        return LegacyAccess::getRoles($employeeProfileId);
+    }
+}

--- a/src/Core/Security/AccessCheckerInterface.php
+++ b/src/Core/Security/AccessCheckerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Security;
+
+interface AccessCheckerInterface
+{
+    public const CREATE = 'create';
+    public const UPDATE = 'update';
+    public const DELETE = 'delete';
+    public const READ = 'read';
+
+    public const LEVEL_READ = 1;
+    public const LEVEL_UPDATE = 2;
+    public const LEVEL_CREATE = 3;
+    public const LEVEL_DELETE = 4;
+
+    public function isEmployeeGranted(string $action, int $employeeProfileId): bool;
+}

--- a/src/Core/Security/AccessCheckerInterface.php
+++ b/src/Core/Security/AccessCheckerInterface.php
@@ -1,18 +1,32 @@
 <?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
 
 namespace PrestaShop\PrestaShop\Core\Security;
 
 interface AccessCheckerInterface
 {
-    public const CREATE = 'create';
-    public const UPDATE = 'update';
-    public const DELETE = 'delete';
-    public const READ = 'read';
-
-    public const LEVEL_READ = 1;
-    public const LEVEL_UPDATE = 2;
-    public const LEVEL_CREATE = 3;
-    public const LEVEL_DELETE = 4;
-
     public function isEmployeeGranted(string $action, int $employeeProfileId): bool;
 }

--- a/src/Core/Security/EmployeePermissionProviderInterface.php
+++ b/src/Core/Security/EmployeePermissionProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Security;
+
+interface EmployeePermissionProviderInterface
+{
+    public function getRoles(int $employeeProfileId): array;
+}

--- a/src/Core/Security/EmployeePermissionProviderInterface.php
+++ b/src/Core/Security/EmployeePermissionProviderInterface.php
@@ -1,4 +1,28 @@
 <?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
 
 namespace PrestaShop\PrestaShop\Core\Security;
 

--- a/src/Core/Security/Permission.php
+++ b/src/Core/Security/Permission.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Security;
+
+class Permission
+{
+    public const CREATE = 'create';
+    public const UPDATE = 'update';
+    public const DELETE = 'delete';
+    public const READ = 'read';
+
+    public const LEVEL_READ = 1;
+    public const LEVEL_UPDATE = 2;
+    public const LEVEL_CREATE = 3;
+    public const LEVEL_DELETE = 4;
+
+    // This class should not be instanciated
+    private function __construct()
+    {
+    }
+}

--- a/src/Core/Security/Permission.php
+++ b/src/Core/Security/Permission.php
@@ -1,4 +1,28 @@
 <?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
 
 namespace PrestaShop\PrestaShop\Core\Security;
 

--- a/src/Core/Security/Permission.php
+++ b/src/Core/Security/Permission.php
@@ -4,6 +4,8 @@ namespace PrestaShop\PrestaShop\Core\Security;
 
 class Permission
 {
+    public const PREFIX = 'ROLE_MOD_TAB_';
+
     public const CREATE = 'create';
     public const UPDATE = 'update';
     public const DELETE = 'delete';

--- a/src/Core/Security/Permission.php
+++ b/src/Core/Security/Permission.php
@@ -4,7 +4,8 @@ namespace PrestaShop\PrestaShop\Core\Security;
 
 class Permission
 {
-    public const PREFIX = 'ROLE_MOD_TAB_';
+    public const PREFIX_TAB = 'ROLE_MOD_TAB_';
+    public const PREFIX_MODULE = 'ROLE_MOD_MODULE_';
 
     public const CREATE = 'create';
     public const UPDATE = 'update';

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
@@ -29,7 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 use PrestaShop\PrestaShop\Core\Email\MailOption;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\EmailLogsFilter;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email\TestEmailSendingType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -240,10 +240,10 @@ class EmailController extends FrameworkBundleAdminController
         if (!in_array(
             $this->authorizationLevel($request->attributes->get('_legacy_controller')),
             [
-                AccessCheckerInterface::LEVEL_READ,
-                AccessCheckerInterface::LEVEL_UPDATE,
-                AccessCheckerInterface::LEVEL_CREATE,
-                AccessCheckerInterface::LEVEL_DELETE,
+                Permission::LEVEL_READ,
+                Permission::LEVEL_UPDATE,
+                Permission::LEVEL_CREATE,
+                Permission::LEVEL_DELETE,
             ]
         )) {
             return $this->json([

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
@@ -29,11 +29,11 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 use PrestaShop\PrestaShop\Core\Email\MailOption;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\EmailLogsFilter;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Email\TestEmailSendingType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -240,10 +240,10 @@ class EmailController extends FrameworkBundleAdminController
         if (!in_array(
             $this->authorizationLevel($request->attributes->get('_legacy_controller')),
             [
-                PageVoter::LEVEL_READ,
-                PageVoter::LEVEL_UPDATE,
-                PageVoter::LEVEL_CREATE,
-                PageVoter::LEVEL_DELETE,
+                AccessCheckerInterface::LEVEL_READ,
+                AccessCheckerInterface::LEVEL_UPDATE,
+                AccessCheckerInterface::LEVEL_CREATE,
+                AccessCheckerInterface::LEVEL_DELETE,
             ]
         )) {
             return $this->json([

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -49,11 +49,11 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterf
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\EmployeeFilters;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProviderInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -327,7 +327,7 @@ class EmployeeController extends FrameworkBundleAdminController
 
         // If employee is editing his own profile - he doesn't need to have access to the edit form.
         if ($contextEmployeeProvider->getId() != $employeeId) {
-            if (!$this->isGranted(PageVoter::UPDATE, $request->get('_legacy_controller'))) {
+            if (!$this->isGranted(AccessCheckerInterface::UPDATE, $request->get('_legacy_controller'))) {
                 $this->addFlash(
                     'error',
                     $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -49,7 +49,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterf
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandler;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\EmployeeFilters;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProviderInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -327,7 +327,7 @@ class EmployeeController extends FrameworkBundleAdminController
 
         // If employee is editing his own profile - he doesn't need to have access to the edit form.
         if ($contextEmployeeProvider->getId() != $employeeId) {
-            if (!$this->isGranted(AccessCheckerInterface::UPDATE, $request->get('_legacy_controller'))) {
+            if (!$this->isGranted(Permission::UPDATE, $request->get('_legacy_controller'))) {
                 $this->addFlash(
                     'error',
                     $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -29,7 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 use PrestaShop\PrestaShop\Core\Import\Exception\NotSupportedImportEntityException;
 use PrestaShop\PrestaShop\Core\Import\Exception\UnavailableImportFileException;
 use PrestaShop\PrestaShop\Core\Import\ImportDirectory;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Exception\FileUploadException;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -130,9 +130,9 @@ class ImportController extends FrameworkBundleAdminController
         }
 
         if (!in_array($this->authorizationLevel($legacyController), [
-            AccessCheckerInterface::LEVEL_CREATE,
-            AccessCheckerInterface::LEVEL_UPDATE,
-            AccessCheckerInterface::LEVEL_DELETE,
+            Permission::LEVEL_CREATE,
+            Permission::LEVEL_UPDATE,
+            Permission::LEVEL_DELETE,
         ])) {
             return $this->json([
                 'error' => $this->trans('You do not have permission to update this.', 'Admin.Notifications.Error'),
@@ -350,9 +350,9 @@ class ImportController extends FrameworkBundleAdminController
         }
 
         if (!in_array($this->authorizationLevel($legacyController), [
-            AccessCheckerInterface::LEVEL_CREATE,
-            AccessCheckerInterface::LEVEL_UPDATE,
-            AccessCheckerInterface::LEVEL_DELETE,
+            Permission::LEVEL_CREATE,
+            Permission::LEVEL_UPDATE,
+            Permission::LEVEL_DELETE,
         ])) {
             $this->addFlash(
                 'error',

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -29,11 +29,11 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 use PrestaShop\PrestaShop\Core\Import\Exception\NotSupportedImportEntityException;
 use PrestaShop\PrestaShop\Core\Import\Exception\UnavailableImportFileException;
 use PrestaShop\PrestaShop\Core\Import\ImportDirectory;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Exception\FileUploadException;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -130,9 +130,9 @@ class ImportController extends FrameworkBundleAdminController
         }
 
         if (!in_array($this->authorizationLevel($legacyController), [
-            PageVoter::LEVEL_CREATE,
-            PageVoter::LEVEL_UPDATE,
-            PageVoter::LEVEL_DELETE,
+            AccessCheckerInterface::LEVEL_CREATE,
+            AccessCheckerInterface::LEVEL_UPDATE,
+            AccessCheckerInterface::LEVEL_DELETE,
         ])) {
             return $this->json([
                 'error' => $this->trans('You do not have permission to update this.', 'Admin.Notifications.Error'),
@@ -350,9 +350,9 @@ class ImportController extends FrameworkBundleAdminController
         }
 
         if (!in_array($this->authorizationLevel($legacyController), [
-            PageVoter::LEVEL_CREATE,
-            PageVoter::LEVEL_UPDATE,
-            PageVoter::LEVEL_DELETE,
+            AccessCheckerInterface::LEVEL_CREATE,
+            AccessCheckerInterface::LEVEL_UPDATE,
+            AccessCheckerInterface::LEVEL_DELETE,
         ])) {
             $this->addFlash(
                 'error',

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
@@ -27,10 +27,10 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Adapter\Cache\MemcacheServerManager;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -90,10 +90,10 @@ class MemcacheServerController extends FrameworkBundleAdminController
         if (!in_array(
             $this->authorizationLevel($this::CONTROLLER_NAME),
             [
-                PageVoter::LEVEL_READ,
-                PageVoter::LEVEL_UPDATE,
-                PageVoter::LEVEL_CREATE,
-                PageVoter::LEVEL_DELETE,
+                AccessCheckerInterface::LEVEL_READ,
+                AccessCheckerInterface::LEVEL_UPDATE,
+                AccessCheckerInterface::LEVEL_CREATE,
+                AccessCheckerInterface::LEVEL_DELETE,
             ]
         )) {
             return new JsonResponse(
@@ -149,10 +149,10 @@ class MemcacheServerController extends FrameworkBundleAdminController
         if (!in_array(
             $this->authorizationLevel($this::CONTROLLER_NAME),
             [
-                PageVoter::LEVEL_READ,
-                PageVoter::LEVEL_UPDATE,
-                PageVoter::LEVEL_CREATE,
-                PageVoter::LEVEL_DELETE,
+                AccessCheckerInterface::LEVEL_READ,
+                AccessCheckerInterface::LEVEL_UPDATE,
+                AccessCheckerInterface::LEVEL_CREATE,
+                AccessCheckerInterface::LEVEL_DELETE,
             ]
         )) {
             return new JsonResponse(

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
@@ -27,7 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Adapter\Cache\MemcacheServerManager;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -90,10 +90,10 @@ class MemcacheServerController extends FrameworkBundleAdminController
         if (!in_array(
             $this->authorizationLevel($this::CONTROLLER_NAME),
             [
-                AccessCheckerInterface::LEVEL_READ,
-                AccessCheckerInterface::LEVEL_UPDATE,
-                AccessCheckerInterface::LEVEL_CREATE,
-                AccessCheckerInterface::LEVEL_DELETE,
+                Permission::LEVEL_READ,
+                Permission::LEVEL_UPDATE,
+                Permission::LEVEL_CREATE,
+                Permission::LEVEL_DELETE,
             ]
         )) {
             return new JsonResponse(
@@ -149,10 +149,10 @@ class MemcacheServerController extends FrameworkBundleAdminController
         if (!in_array(
             $this->authorizationLevel($this::CONTROLLER_NAME),
             [
-                AccessCheckerInterface::LEVEL_READ,
-                AccessCheckerInterface::LEVEL_UPDATE,
-                AccessCheckerInterface::LEVEL_CREATE,
-                AccessCheckerInterface::LEVEL_DELETE,
+                Permission::LEVEL_READ,
+                Permission::LEVEL_UPDATE,
+                Permission::LEVEL_CREATE,
+                Permission::LEVEL_DELETE,
             ]
         )) {
             return new JsonResponse(

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Help\Documentation;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
@@ -243,20 +244,20 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function authorizationLevel($controller)
     {
-        if ($this->isGranted(PageVoter::DELETE, $controller)) {
-            return PageVoter::LEVEL_DELETE;
+        if ($this->isGranted(AccessCheckerInterface::DELETE, $controller)) {
+            return AccessCheckerInterface::LEVEL_DELETE;
         }
 
-        if ($this->isGranted(PageVoter::CREATE, $controller)) {
-            return PageVoter::LEVEL_CREATE;
+        if ($this->isGranted(AccessCheckerInterface::CREATE, $controller)) {
+            return AccessCheckerInterface::LEVEL_CREATE;
         }
 
-        if ($this->isGranted(PageVoter::UPDATE, $controller)) {
-            return PageVoter::LEVEL_UPDATE;
+        if ($this->isGranted(AccessCheckerInterface::UPDATE, $controller)) {
+            return AccessCheckerInterface::LEVEL_UPDATE;
         }
 
-        if ($this->isGranted(PageVoter::READ, $controller)) {
-            return PageVoter::LEVEL_READ;
+        if ($this->isGranted(AccessCheckerInterface::READ, $controller)) {
+            return AccessCheckerInterface::LEVEL_READ;
         }
 
         return 0;
@@ -318,13 +319,13 @@ class FrameworkBundleAdminController extends AbstractController
     protected function actionIsAllowed($action, $object = '', $suffix = '')
     {
         return (
-                $action === 'delete' . $suffix && $this->isGranted(PageVoter::DELETE, $object)
+                $action === 'delete' . $suffix && $this->isGranted(AccessCheckerInterface::DELETE, $object)
             ) || (
                 ($action === 'activate' . $suffix || $action === 'deactivate' . $suffix) &&
-                $this->isGranted(PageVoter::UPDATE, $object)
+                $this->isGranted(AccessCheckerInterface::UPDATE, $object)
             ) || (
                 ($action === 'duplicate' . $suffix) &&
-                ($this->isGranted(PageVoter::UPDATE, $object) || $this->isGranted(PageVoter::CREATE, $object))
+                ($this->isGranted(AccessCheckerInterface::UPDATE, $object) || $this->isGranted(AccessCheckerInterface::CREATE, $object))
             );
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
+++ b/src/PrestaShopBundle/Controller/Admin/FrameworkBundleAdminController.php
@@ -33,8 +33,7 @@ use PrestaShop\PrestaShop\Core\Help\Documentation;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
-use PrestaShopBundle\Security\Voter\PageVoter;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
@@ -244,20 +243,20 @@ class FrameworkBundleAdminController extends AbstractController
      */
     protected function authorizationLevel($controller)
     {
-        if ($this->isGranted(AccessCheckerInterface::DELETE, $controller)) {
-            return AccessCheckerInterface::LEVEL_DELETE;
+        if ($this->isGranted(Permission::DELETE, $controller)) {
+            return Permission::LEVEL_DELETE;
         }
 
-        if ($this->isGranted(AccessCheckerInterface::CREATE, $controller)) {
-            return AccessCheckerInterface::LEVEL_CREATE;
+        if ($this->isGranted(Permission::CREATE, $controller)) {
+            return Permission::LEVEL_CREATE;
         }
 
-        if ($this->isGranted(AccessCheckerInterface::UPDATE, $controller)) {
-            return AccessCheckerInterface::LEVEL_UPDATE;
+        if ($this->isGranted(Permission::UPDATE, $controller)) {
+            return Permission::LEVEL_UPDATE;
         }
 
-        if ($this->isGranted(AccessCheckerInterface::READ, $controller)) {
-            return AccessCheckerInterface::LEVEL_READ;
+        if ($this->isGranted(Permission::READ, $controller)) {
+            return Permission::LEVEL_READ;
         }
 
         return 0;
@@ -319,13 +318,13 @@ class FrameworkBundleAdminController extends AbstractController
     protected function actionIsAllowed($action, $object = '', $suffix = '')
     {
         return (
-                $action === 'delete' . $suffix && $this->isGranted(AccessCheckerInterface::DELETE, $object)
+                $action === 'delete' . $suffix && $this->isGranted(Permission::DELETE, $object)
             ) || (
                 ($action === 'activate' . $suffix || $action === 'deactivate' . $suffix) &&
-                $this->isGranted(AccessCheckerInterface::UPDATE, $object)
+                $this->isGranted(Permission::UPDATE, $object)
             ) || (
                 ($action === 'duplicate' . $suffix) &&
-                ($this->isGranted(AccessCheckerInterface::UPDATE, $object) || $this->isGranted(AccessCheckerInterface::CREATE, $object))
+                ($this->isGranted(Permission::UPDATE, $object) || $this->isGranted(Permission::CREATE, $object))
             );
     }
 

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -52,12 +52,12 @@ use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeImportSource;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeName;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
 use PrestaShopBundle\Form\Admin\Improve\Design\Theme\AdaptThemeToRTLLanguagesType;
 use PrestaShopBundle\Form\Admin\Improve\Design\Theme\ImportThemeType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -434,7 +434,7 @@ class ThemeController extends AbstractAdminController
     protected function canCustomizePageLayouts(Request $request)
     {
         return !$this->isDemoModeEnabled() &&
-            $this->isGranted(PageVoter::UPDATE, $request->attributes->get('_legacy_controller'));
+            $this->isGranted(AccessCheckerInterface::UPDATE, $request->attributes->get('_legacy_controller'));
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -52,7 +52,7 @@ use PrestaShop\PrestaShop\Core\Domain\Theme\Exception\ThemeException;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeImportSource;
 use PrestaShop\PrestaShop\Core\Domain\Theme\ValueObject\ThemeName;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
 use PrestaShopBundle\Form\Admin\Improve\Design\Theme\AdaptThemeToRTLLanguagesType;
 use PrestaShopBundle\Form\Admin\Improve\Design\Theme\ImportThemeType;
@@ -434,7 +434,7 @@ class ThemeController extends AbstractAdminController
     protected function canCustomizePageLayouts(Request $request)
     {
         return !$this->isDemoModeEnabled() &&
-            $this->isGranted(AccessCheckerInterface::UPDATE, $request->attributes->get('_legacy_controller'));
+            $this->isGranted(Permission::UPDATE, $request->attributes->get('_legacy_controller'));
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -58,7 +58,7 @@ use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository as CldrLocaleR
 use PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Search\Filters\CurrencyFilters;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Entity\Repository\LangRepository;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -405,7 +405,7 @@ class CurrencyController extends FrameworkBundleAdminController
 
         $authLevel = $this->authorizationLevel($request->attributes->get('_legacy_controller'));
 
-        if (!in_array($authLevel, [AccessCheckerInterface::LEVEL_UPDATE, AccessCheckerInterface::LEVEL_DELETE])) {
+        if (!in_array($authLevel, [Permission::LEVEL_UPDATE, Permission::LEVEL_DELETE])) {
             return $this->json([
                 'status' => false,
                 'message' => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -58,11 +58,11 @@ use PrestaShop\PrestaShop\Core\Localization\CLDR\LocaleRepository as CldrLocaleR
 use PrestaShop\PrestaShop\Core\Localization\Currency\PatternTransformer;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Search\Filters\CurrencyFilters;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Entity\Repository\LangRepository;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -405,7 +405,7 @@ class CurrencyController extends FrameworkBundleAdminController
 
         $authLevel = $this->authorizationLevel($request->attributes->get('_legacy_controller'));
 
-        if (!in_array($authLevel, [PageVoter::LEVEL_UPDATE, PageVoter::LEVEL_DELETE])) {
+        if (!in_array($authLevel, [AccessCheckerInterface::LEVEL_UPDATE, AccessCheckerInterface::LEVEL_DELETE])) {
             return $this->json([
                 'status' => false,
                 'message' => $this->trans(

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -177,11 +177,9 @@ class ModuleController extends ModuleAbstractController
             case ModuleAdapter::ACTION_INSTALL:
                 $deniedAccess = $this->checkPermission(AccessCheckerInterface::CREATE);
                 break;
+            case ModuleAdapter::ACTION_DELETE:
             case ModuleAdapter::ACTION_UNINSTALL:
                 $deniedAccess = $this->checkPermission(AccessCheckerInterface::DELETE);
-                break;
-            case ModuleAdapter::ACTION_DELETE:
-                $deniedAccess = $this->checkPermission(PageVoter::DELETE);
                 break;
 
             default:

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -33,10 +33,10 @@ use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Module as ModuleAdapter;
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerNotFoundException;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Controller\Admin\Improve\Modules\ModuleAbstractController;
 use PrestaShopBundle\Entity\ModuleHistory;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use PrestaShopBundle\Service\DataProvider\Admin\CategoriesProvider;
 use Symfony\Component\Form\Util\ServerParams;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -172,13 +172,13 @@ class ModuleController extends ModuleAbstractController
             case ModuleAdapter::ACTION_DISABLE:
             case ModuleAdapter::ACTION_ENABLE_MOBILE:
             case ModuleAdapter::ACTION_DISABLE_MOBILE:
-                $deniedAccess = $this->checkPermission(PageVoter::UPDATE);
+                $deniedAccess = $this->checkPermission(AccessCheckerInterface::UPDATE);
                 break;
             case ModuleAdapter::ACTION_INSTALL:
-                $deniedAccess = $this->checkPermission(PageVoter::CREATE);
+                $deniedAccess = $this->checkPermission(AccessCheckerInterface::CREATE);
                 break;
             case ModuleAdapter::ACTION_UNINSTALL:
-                $deniedAccess = $this->checkPermission(PageVoter::DELETE);
+                $deniedAccess = $this->checkPermission(AccessCheckerInterface::DELETE);
                 break;
             case ModuleAdapter::ACTION_DELETE:
                 $deniedAccess = $this->checkPermission(PageVoter::DELETE);
@@ -309,8 +309,8 @@ class ModuleController extends ModuleAbstractController
 
         $deniedAccess = $this->checkPermissions(
             [
-                PageVoter::LEVEL_CREATE,
-                PageVoter::LEVEL_DELETE,
+                AccessCheckerInterface::LEVEL_CREATE,
+                AccessCheckerInterface::LEVEL_DELETE,
             ]
         );
         if (null !== $deniedAccess) {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -33,7 +33,7 @@ use PrestaShop\PrestaShop\Adapter\Module\AdminModuleDataProvider;
 use PrestaShop\PrestaShop\Adapter\Module\Module as ModuleAdapter;
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerNotFoundException;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\Improve\Modules\ModuleAbstractController;
 use PrestaShopBundle\Entity\ModuleHistory;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -172,14 +172,14 @@ class ModuleController extends ModuleAbstractController
             case ModuleAdapter::ACTION_DISABLE:
             case ModuleAdapter::ACTION_ENABLE_MOBILE:
             case ModuleAdapter::ACTION_DISABLE_MOBILE:
-                $deniedAccess = $this->checkPermission(AccessCheckerInterface::UPDATE);
+                $deniedAccess = $this->checkPermission(Permission::UPDATE);
                 break;
             case ModuleAdapter::ACTION_INSTALL:
-                $deniedAccess = $this->checkPermission(AccessCheckerInterface::CREATE);
+                $deniedAccess = $this->checkPermission(Permission::CREATE);
                 break;
             case ModuleAdapter::ACTION_DELETE:
             case ModuleAdapter::ACTION_UNINSTALL:
-                $deniedAccess = $this->checkPermission(AccessCheckerInterface::DELETE);
+                $deniedAccess = $this->checkPermission(Permission::DELETE);
                 break;
 
             default:
@@ -307,8 +307,8 @@ class ModuleController extends ModuleAbstractController
 
         $deniedAccess = $this->checkPermissions(
             [
-                AccessCheckerInterface::LEVEL_CREATE,
-                AccessCheckerInterface::LEVEL_DELETE,
+                Permission::LEVEL_CREATE,
+                Permission::LEVEL_DELETE,
             ]
         );
         if (null !== $deniedAccess) {

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php
@@ -28,7 +28,7 @@ namespace PrestaShopBundle\Controller\Admin\Improve\Modules;
 
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepositoryInterface;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 
 abstract class ModuleAbstractController extends FrameworkBundleAdminController
@@ -77,8 +77,8 @@ abstract class ModuleAbstractController extends FrameworkBundleAdminController
         if (!in_array(
             $this->authorizationLevel($this::CONTROLLER_NAME),
             [
-                AccessCheckerInterface::LEVEL_READ,
-                AccessCheckerInterface::LEVEL_UPDATE,
+                Permission::LEVEL_READ,
+                Permission::LEVEL_UPDATE,
             ]
         )) {
             $toolbarButtons['add_module'] = [

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/ModuleAbstractController.php
@@ -28,8 +28,8 @@ namespace PrestaShopBundle\Controller\Admin\Improve\Modules;
 
 use PrestaShop\PrestaShop\Core\Module\ModuleCollection;
 use PrestaShop\PrestaShop\Core\Module\ModuleRepositoryInterface;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use PrestaShopBundle\Security\Voter\PageVoter;
 
 abstract class ModuleAbstractController extends FrameworkBundleAdminController
 {
@@ -77,8 +77,8 @@ abstract class ModuleAbstractController extends FrameworkBundleAdminController
         if (!in_array(
             $this->authorizationLevel($this::CONTROLLER_NAME),
             [
-                PageVoter::LEVEL_READ,
-                PageVoter::LEVEL_UPDATE,
+                AccessCheckerInterface::LEVEL_READ,
+                AccessCheckerInterface::LEVEL_UPDATE,
             ]
         )) {
             $toolbarButtons['add_module'] = [

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcher;
 use PrestaShop\PrestaShop\Core\Product\ProductCsvExporter;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Entity\AdminFilter;
 use PrestaShopBundle\Entity\Attribute;
@@ -60,7 +61,6 @@ use PrestaShopBundle\Form\Admin\Product\ProductSeo;
 use PrestaShopBundle\Form\Admin\Product\ProductShipping;
 use PrestaShopBundle\Model\Product\AdminModelAdapter;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use PrestaShopBundle\Service\DataProvider\Admin\ProductInterface as ProductInterfaceProvider;
 use PrestaShopBundle\Service\DataProvider\StockInterface;
 use PrestaShopBundle\Service\DataUpdater\Admin\ProductInterface as ProductInterfaceUpdater;
@@ -281,7 +281,7 @@ class ProductController extends FrameworkBundleAdminController
         $sortOrder = 'asc',
         $view = 'full'
     ) {
-        if (!$this->isGranted(PageVoter::READ, self::PRODUCT_OBJECT)) {
+        if (!$this->isGranted(AccessCheckerInterface::READ, self::PRODUCT_OBJECT)) {
             return $this->redirect('admin_dashboard');
         }
 
@@ -398,7 +398,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function newAction()
     {
-        if (!$this->isGranted(PageVoter::CREATE, self::PRODUCT_OBJECT)) {
+        if (!$this->isGranted(AccessCheckerInterface::CREATE, self::PRODUCT_OBJECT)) {
             $errorMessage = $this->trans('You do not have permission to add this.', 'Admin.Notifications.Error');
             $this->get('session')->getFlashBag()->add('permission_error', $errorMessage);
 
@@ -454,7 +454,7 @@ class ProductController extends FrameworkBundleAdminController
 
         gc_disable();
 
-        foreach ([PageVoter::READ, PageVoter::UPDATE, PageVoter::CREATE] as $permission) {
+        foreach ([AccessCheckerInterface::READ, AccessCheckerInterface::UPDATE, AccessCheckerInterface::CREATE] as $permission) {
             if (!$this->isGranted($permission, self::PRODUCT_OBJECT)) {
                 return $this->redirect('admin_dashboard');
             }
@@ -667,7 +667,7 @@ class ProductController extends FrameworkBundleAdminController
             'attribute_groups' => $attributeGroups,
             'max_upload_size' => LegacyTools::formatBytes(UploadedFile::getMaxFilesize()),
             'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
-            'editable' => $this->isGranted(PageVoter::UPDATE, self::PRODUCT_OBJECT),
+            'editable' => $this->isGranted(AccessCheckerInterface::UPDATE, self::PRODUCT_OBJECT),
             'drawerModules' => $drawerModules,
             'layoutTitle' => $this->trans('Product', 'Admin.Global'),
             'isCreationMode' => (int) $product->state === Product::STATE_TEMP,
@@ -918,7 +918,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function massEditAction(Request $request, $action)
     {
-        if (!$this->isGranted(PageVoter::UPDATE, self::PRODUCT_OBJECT)) {
+        if (!$this->isGranted(AccessCheckerInterface::UPDATE, self::PRODUCT_OBJECT)) {
             $errorMessage = $this->trans(
                 'You do not have permission to edit this.',
                 'Admin.Notifications.Error'

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -44,7 +44,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductForEditing;
 use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcher;
 use PrestaShop\PrestaShop\Core\Product\ProductCsvExporter;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Entity\AdminFilter;
 use PrestaShopBundle\Entity\Attribute;
@@ -281,7 +281,7 @@ class ProductController extends FrameworkBundleAdminController
         $sortOrder = 'asc',
         $view = 'full'
     ) {
-        if (!$this->isGranted(AccessCheckerInterface::READ, self::PRODUCT_OBJECT)) {
+        if (!$this->isGranted(Permission::READ, self::PRODUCT_OBJECT)) {
             return $this->redirect('admin_dashboard');
         }
 
@@ -398,7 +398,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function newAction()
     {
-        if (!$this->isGranted(AccessCheckerInterface::CREATE, self::PRODUCT_OBJECT)) {
+        if (!$this->isGranted(Permission::CREATE, self::PRODUCT_OBJECT)) {
             $errorMessage = $this->trans('You do not have permission to add this.', 'Admin.Notifications.Error');
             $this->get('session')->getFlashBag()->add('permission_error', $errorMessage);
 
@@ -454,7 +454,7 @@ class ProductController extends FrameworkBundleAdminController
 
         gc_disable();
 
-        foreach ([AccessCheckerInterface::READ, AccessCheckerInterface::UPDATE, AccessCheckerInterface::CREATE] as $permission) {
+        foreach ([Permission::READ, Permission::UPDATE, Permission::CREATE] as $permission) {
             if (!$this->isGranted($permission, self::PRODUCT_OBJECT)) {
                 return $this->redirect('admin_dashboard');
             }
@@ -667,7 +667,7 @@ class ProductController extends FrameworkBundleAdminController
             'attribute_groups' => $attributeGroups,
             'max_upload_size' => LegacyTools::formatBytes(UploadedFile::getMaxFilesize()),
             'is_shop_context' => $this->get('prestashop.adapter.shop.context')->isShopContext(),
-            'editable' => $this->isGranted(AccessCheckerInterface::UPDATE, self::PRODUCT_OBJECT),
+            'editable' => $this->isGranted(Permission::UPDATE, self::PRODUCT_OBJECT),
             'drawerModules' => $drawerModules,
             'layoutTitle' => $this->trans('Product', 'Admin.Global'),
             'isCreationMode' => (int) $product->state === Product::STATE_TEMP,
@@ -918,7 +918,7 @@ class ProductController extends FrameworkBundleAdminController
      */
     public function massEditAction(Request $request, $action)
     {
-        if (!$this->isGranted(AccessCheckerInterface::UPDATE, self::PRODUCT_OBJECT)) {
+        if (!$this->isGranted(Permission::UPDATE, self::PRODUCT_OBJECT)) {
             $errorMessage = $this->trans(
                 'You do not have permission to edit this.',
                 'Admin.Notifications.Error'

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -65,7 +65,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterf
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductFilters;
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Entity\AdminFilter;
 use PrestaShopBundle\Entity\ProductDownload;
@@ -1051,7 +1051,7 @@ class ProductController extends FrameworkBundleAdminController
             'showContentHeader' => false,
             'productForm' => $productForm->createView(),
             'helpLink' => $this->generateSidebarLink('AdminProducts'),
-            'editable' => $this->isGranted(AccessCheckerInterface::UPDATE, self::PRODUCT_CONTROLLER_PERMISSION),
+            'editable' => $this->isGranted(Permission::UPDATE, self::PRODUCT_CONTROLLER_PERMISSION),
         ]);
     }
 
@@ -1079,7 +1079,7 @@ class ProductController extends FrameworkBundleAdminController
             'productForm' => $productForm->createView(),
             'statsLink' => $statsLink,
             'helpLink' => $this->generateSidebarLink('AdminProducts'),
-            'editable' => $this->isGranted(AccessCheckerInterface::UPDATE, self::PRODUCT_CONTROLLER_PERMISSION),
+            'editable' => $this->isGranted(Permission::UPDATE, self::PRODUCT_CONTROLLER_PERMISSION),
             'taxEnabled' => (bool) $configuration->get('PS_TAX'),
             'stockEnabled' => (bool) $configuration->get('PS_STOCK_MANAGEMENT'),
             'isMultistoreActive' => $this->get('prestashop.adapter.multistore_feature')->isActive(),

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -65,6 +65,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterf
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ProductGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductFilters;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Entity\AdminFilter;
 use PrestaShopBundle\Entity\ProductDownload;
@@ -72,7 +73,6 @@ use PrestaShopBundle\Form\Admin\Sell\Product\Category\CategoryFilterType;
 use PrestaShopBundle\Form\Admin\Type\ShopSelectorType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -1051,7 +1051,7 @@ class ProductController extends FrameworkBundleAdminController
             'showContentHeader' => false,
             'productForm' => $productForm->createView(),
             'helpLink' => $this->generateSidebarLink('AdminProducts'),
-            'editable' => $this->isGranted(PageVoter::UPDATE, self::PRODUCT_CONTROLLER_PERMISSION),
+            'editable' => $this->isGranted(AccessCheckerInterface::UPDATE, self::PRODUCT_CONTROLLER_PERMISSION),
         ]);
     }
 
@@ -1079,7 +1079,7 @@ class ProductController extends FrameworkBundleAdminController
             'productForm' => $productForm->createView(),
             'statsLink' => $statsLink,
             'helpLink' => $this->generateSidebarLink('AdminProducts'),
-            'editable' => $this->isGranted(PageVoter::UPDATE, self::PRODUCT_CONTROLLER_PERMISSION),
+            'editable' => $this->isGranted(AccessCheckerInterface::UPDATE, self::PRODUCT_CONTROLLER_PERMISSION),
             'taxEnabled' => (bool) $configuration->get('PS_TAX'),
             'stockEnabled' => (bool) $configuration->get('PS_STOCK_MANAGEMENT'),
             'isMultistoreActive' => $this->get('prestashop.adapter.multistore_feature')->isActive(),

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Api;
 
-use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Api\QueryStockParamsCollection;
 use PrestaShopBundle\Api\Stock\Movement;
 use PrestaShopBundle\Api\Stock\MovementsCollection;
@@ -64,7 +64,7 @@ class StockController extends ApiController
      */
     public function listProductsAction(Request $request)
     {
-        if (!$this->isGranted([AccessCheckerInterface::READ], $request->get('_legacy_controller'))) {
+        if (!$this->isGranted([Permission::READ], $request->get('_legacy_controller'))) {
             return new JsonResponse(null, Response::HTTP_FORBIDDEN);
         }
 
@@ -92,7 +92,7 @@ class StockController extends ApiController
      */
     public function editProductAction(Request $request)
     {
-        if (!$this->isGranted([AccessCheckerInterface::UPDATE], $request->get('_legacy_controller'))) {
+        if (!$this->isGranted([Permission::UPDATE], $request->get('_legacy_controller'))) {
             return new JsonResponse(null, Response::HTTP_FORBIDDEN);
         }
 
@@ -125,7 +125,7 @@ class StockController extends ApiController
      */
     public function bulkEditProductsAction(Request $request)
     {
-        if (!$this->isGranted([AccessCheckerInterface::UPDATE], $request->get('_legacy_controller'))) {
+        if (!$this->isGranted([Permission::UPDATE], $request->get('_legacy_controller'))) {
             return new JsonResponse(null, Response::HTTP_FORBIDDEN);
         }
 
@@ -154,7 +154,7 @@ class StockController extends ApiController
      */
     public function listProductsExportAction(Request $request)
     {
-        if (!$this->isGranted([AccessCheckerInterface::READ], $request->get('_legacy_controller'))) {
+        if (!$this->isGranted([Permission::READ], $request->get('_legacy_controller'))) {
             return new JsonResponse(null, Response::HTTP_FORBIDDEN);
         }
 

--- a/src/PrestaShopBundle/Controller/Api/StockController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Api;
 
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Api\QueryStockParamsCollection;
 use PrestaShopBundle\Api\Stock\Movement;
 use PrestaShopBundle\Api\Stock\MovementsCollection;
@@ -34,7 +35,6 @@ use PrestaShopBundle\Entity\ProductIdentity;
 use PrestaShopBundle\Entity\Repository\StockRepository;
 use PrestaShopBundle\Exception\InvalidPaginationParamsException;
 use PrestaShopBundle\Exception\ProductNotFoundException;
-use PrestaShopBundle\Security\Voter\PageVoter;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -64,7 +64,7 @@ class StockController extends ApiController
      */
     public function listProductsAction(Request $request)
     {
-        if (!$this->isGranted([PageVoter::READ], $request->get('_legacy_controller'))) {
+        if (!$this->isGranted([AccessCheckerInterface::READ], $request->get('_legacy_controller'))) {
             return new JsonResponse(null, Response::HTTP_FORBIDDEN);
         }
 
@@ -92,7 +92,7 @@ class StockController extends ApiController
      */
     public function editProductAction(Request $request)
     {
-        if (!$this->isGranted([PageVoter::UPDATE], $request->get('_legacy_controller'))) {
+        if (!$this->isGranted([AccessCheckerInterface::UPDATE], $request->get('_legacy_controller'))) {
             return new JsonResponse(null, Response::HTTP_FORBIDDEN);
         }
 
@@ -125,7 +125,7 @@ class StockController extends ApiController
      */
     public function bulkEditProductsAction(Request $request)
     {
-        if (!$this->isGranted([PageVoter::UPDATE], $request->get('_legacy_controller'))) {
+        if (!$this->isGranted([AccessCheckerInterface::UPDATE], $request->get('_legacy_controller'))) {
             return new JsonResponse(null, Response::HTTP_FORBIDDEN);
         }
 
@@ -154,7 +154,7 @@ class StockController extends ApiController
      */
     public function listProductsExportAction(Request $request)
     {
-        if (!$this->isGranted([PageVoter::READ], $request->get('_legacy_controller'))) {
+        if (!$this->isGranted([AccessCheckerInterface::READ], $request->get('_legacy_controller'))) {
             return new JsonResponse(null, Response::HTTP_FORBIDDEN);
         }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/security.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/security.yml
@@ -63,3 +63,6 @@ services:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'
       - '@=service("prestashop.adapter.legacy.configuration").get("PS_COOKIE_LIFETIME_BO")'
+
+  PrestaShop\PrestaShop\Adapter\Security\Access:
+    public: false

--- a/src/PrestaShopBundle/Resources/config/services/bundle/security.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/security.yml
@@ -10,12 +10,14 @@ services:
     arguments:
       - "@prestashop.adapter.legacy.context"
       - "@prestashop.static_cache.adapter"
+      - '@PrestaShop\PrestaShop\Core\Security\EmployeePermissionProviderInterface'
 
   prestashop.security.role.dynamic_role_hierarchy:
     class: PrestaShopBundle\Security\Role\DynamicRoleHierarchy
 
   prestashop.security.voter.product:
     class: "%prestashop.security.voter.product.class%"
+    autowire: true
     tags:
       - { name: security.voter }
     public: false

--- a/src/PrestaShopBundle/Resources/config/services/core/security.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/security.yml
@@ -9,3 +9,10 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Security\HtaccessFolderGuard'
     arguments:
       - '%kernel.root_dir%/Resources/security/.htaccess.dist'
+
+  PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface:
+    alias: 'PrestaShop\PrestaShop\Adapter\Security\Access'
+    public: false
+  PrestaShop\PrestaShop\Core\Security\EmployeePermissionProviderInterface:
+    alias: 'PrestaShop\PrestaShop\Adapter\Security\Access'
+    public: false

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig
@@ -53,7 +53,7 @@
       </div>
     {% endif %}
 
-    {% if level > constant('PrestaShop\\PrestaShop\\Core\\Security\\AccessCheckerInterface::LEVEL_UPDATE') and bulkActions is defined %}
+    {% if level > constant('PrestaShop\\PrestaShop\\Core\\Security\\Permission::LEVEL_UPDATE') and bulkActions is defined %}
       <div class="col-md-4 module-top-menu-item disabled">
         <h3>{{ 'Bulk Actions'|trans({}, 'Admin.Global') }}</h3>
         {% include '@PrestaShop/Admin/Module/Includes/dropdown_bulk.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/menu_top.html.twig
@@ -53,7 +53,7 @@
       </div>
     {% endif %}
 
-    {% if level > constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') and bulkActions is defined %}
+    {% if level > constant('PrestaShop\\PrestaShop\\Core\\Security\\AccessCheckerInterface::LEVEL_UPDATE') and bulkActions is defined %}
       <div class="col-md-4 module-top-menu-item disabled">
         <h3>{{ 'Bulk Actions'|trans({}, 'Admin.Global') }}</h3>
         {% include '@PrestaShop/Admin/Module/Includes/dropdown_bulk.html.twig' %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
@@ -31,7 +31,7 @@
         <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
       </div>
       <div class="modal-body">
-        {% if level <= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE') %}
+        {% if level <= constant('PrestaShop\\PrestaShop\\Core\\Security\\AccessCheckerInterface::LEVEL_UPDATE') %}
           <div class="alert alert-danger" role="alert">
             <p class="alert-text">
               {{ errorMessage }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/modal_import.html.twig
@@ -31,7 +31,7 @@
         <button id="module-modal-import-closing-cross" type="button" class="close">&times;</button>
       </div>
       <div class="modal-body">
-        {% if level <= constant('PrestaShop\\PrestaShop\\Core\\Security\\AccessCheckerInterface::LEVEL_UPDATE') %}
+        {% if level <= constant('PrestaShop\\PrestaShop\\Core\\Security\\Permission::LEVEL_UPDATE') %}
           <div class="alert alert-danger" role="alert">
             <p class="alert-text">
               {{ errorMessage }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
@@ -34,7 +34,7 @@
         <span class="module-search-result-title module-search-result-wording">{{ '%nbModules% modules to update'|trans({'%nbModules%' : modules|length}, 'Admin.Modules.Feature') }}</span>
         {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' : "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help'), 'title' : "Modules to update"|trans({}, 'Admin.Modules.Feature') } %}
 
-        {% if (modules|length > 1) and (level >= constant('\\PrestaShop\\PrestaShop\\Core\\Security\\AccessCheckerInterface::LEVEL_UPDATE')) %}
+        {% if (modules|length > 1) and (level >= constant('PrestaShop\\PrestaShop\\Core\\Security\\AccessCheckerInterface::LEVEL_UPDATE')) %}
           <a class="btn btn-primary-reverse float-right btn-outline-primary light-button module_action_menu_upgrade_all" href="#" data-confirm_modal="module-modal-confirm-upgrade-all">{{ "Upgrade All"|trans({}, 'Admin.Modules.Feature') }}</a>
         {% endif %}
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
@@ -34,7 +34,7 @@
         <span class="module-search-result-title module-search-result-wording">{{ '%nbModules% modules to update'|trans({'%nbModules%' : modules|length}, 'Admin.Modules.Feature') }}</span>
         {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' : "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help'), 'title' : "Modules to update"|trans({}, 'Admin.Modules.Feature') } %}
 
-        {% if (modules|length > 1) and (level >= constant('PrestaShopBundle\\Security\\Voter\\PageVoter::LEVEL_UPDATE')) %}
+        {% if (modules|length > 1) and (level >= constant('\\PrestaShop\\PrestaShop\\Core\\Security\\AccessCheckerInterface::LEVEL_UPDATE')) %}
           <a class="btn btn-primary-reverse float-right btn-outline-primary light-button module_action_menu_upgrade_all" href="#" data-confirm_modal="module-modal-confirm-upgrade-all">{{ "Upgrade All"|trans({}, 'Admin.Modules.Feature') }}</a>
         {% endif %}
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/updates.html.twig
@@ -34,7 +34,7 @@
         <span class="module-search-result-title module-search-result-wording">{{ '%nbModules% modules to update'|trans({'%nbModules%' : modules|length}, 'Admin.Modules.Feature') }}</span>
         {% include '@Common/HelpBox/helpbox.html.twig' with { 'content' : "Update these modules to enjoy their latest versions."|trans({}, 'Admin.Modules.Help'), 'title' : "Modules to update"|trans({}, 'Admin.Modules.Feature') } %}
 
-        {% if (modules|length > 1) and (level >= constant('PrestaShop\\PrestaShop\\Core\\Security\\AccessCheckerInterface::LEVEL_UPDATE')) %}
+        {% if (modules|length > 1) and (level >= constant('PrestaShop\\PrestaShop\\Core\\Security\\Permission::LEVEL_UPDATE')) %}
           <a class="btn btn-primary-reverse float-right btn-outline-primary light-button module_action_menu_upgrade_all" href="#" data-confirm_modal="module-modal-confirm-upgrade-all">{{ "Upgrade All"|trans({}, 'Admin.Modules.Feature') }}</a>
         {% endif %}
       </div>

--- a/src/PrestaShopBundle/Security/Admin/EmployeeProvider.php
+++ b/src/PrestaShopBundle/Security/Admin/EmployeeProvider.php
@@ -26,8 +26,8 @@
 
 namespace PrestaShopBundle\Security\Admin;
 
-use Access;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
+use PrestaShop\PrestaShop\Core\Security\EmployeePermissionProviderInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
@@ -47,11 +47,19 @@ class EmployeeProvider implements UserProviderInterface
      * @var CacheItemPoolInterface
      */
     private $cache;
+    /**
+     * @var EmployeePermissionProviderInterface
+     */
+    private $employeePermissionProvider;
 
-    public function __construct(LegacyContext $context, CacheItemPoolInterface $cache)
-    {
+    public function __construct(
+        LegacyContext $context,
+        CacheItemPoolInterface $cache,
+        EmployeePermissionProviderInterface $employeePermissionProvider
+    ) {
         $this->legacyContext = $context->getContext();
         $this->cache = $cache;
+        $this->employeePermissionProvider = $employeePermissionProvider;
     }
 
     /**
@@ -79,7 +87,7 @@ class EmployeeProvider implements UserProviderInterface
         ) {
             $employee = new Employee($this->legacyContext->employee);
             $employee->setRoles(
-                array_merge([self::ROLE_EMPLOYEE], Access::getRoles($this->legacyContext->employee->id_profile))
+                array_merge([self::ROLE_EMPLOYEE], $this->employeePermissionProvider->getRoles($this->legacyContext->employee->id_profile))
             );
 
             $cachedEmployee->set($employee);

--- a/src/PrestaShopBundle/Security/Voter/PageVoter.php
+++ b/src/PrestaShopBundle/Security/Voter/PageVoter.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Security\Voter;
 
-use Access;
+use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
 use PrestaShopBundle\Security\Admin\Employee;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
@@ -36,21 +36,55 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  */
 class PageVoter extends Voter
 {
-    public const CREATE = 'create';
+    /**
+     * @deprecated since 9.0
+     */
+    public const CREATE = AccessCheckerInterface::CREATE;
 
-    public const UPDATE = 'update';
+    /**
+     * @deprecated since 9.0
+     */
+    public const UPDATE = AccessCheckerInterface::UPDATE;
 
-    public const DELETE = 'delete';
+    /**
+     * @deprecated since 9.0
+     */
+    public const DELETE = AccessCheckerInterface::DELETE;
 
-    public const READ = 'read';
+    /**
+     * @deprecated since 9.0
+     */
+    public const READ = AccessCheckerInterface::READ;
 
-    public const LEVEL_DELETE = 4;
+    /**
+     * @deprecated since 9.0
+     */
+    public const LEVEL_DELETE = AccessCheckerInterface::LEVEL_DELETE;
 
-    public const LEVEL_UPDATE = 2;
+    /**
+     * @deprecated since 9.0
+     */
+    public const LEVEL_UPDATE = AccessCheckerInterface::LEVEL_UPDATE;
 
-    public const LEVEL_CREATE = 3;
+    /**
+     * @deprecated since 9.0
+     */
+    public const LEVEL_CREATE = AccessCheckerInterface::LEVEL_CREATE;
 
-    public const LEVEL_READ = 1;
+    /**
+     * @deprecated since 9.0
+     */
+    public const LEVEL_READ = AccessCheckerInterface::LEVEL_READ;
+
+    /**
+     * @var AccessCheckerInterface
+     */
+    private $accessDecisionManager;
+
+    public function __construct(AccessCheckerInterface $accessDecisionManager)
+    {
+        $this->accessDecisionManager = $accessDecisionManager;
+    }
 
     /**
      * Indicates if this voter should pronounce on this attribute and subject.
@@ -62,7 +96,12 @@ class PageVoter extends Voter
      */
     protected function supports($attribute, $subject)
     {
-        return in_array($attribute, [self::CREATE, self::UPDATE, self::DELETE, self::READ]);
+        return in_array($attribute, [
+            AccessCheckerInterface::CREATE,
+            AccessCheckerInterface::UPDATE,
+            AccessCheckerInterface::DELETE,
+            AccessCheckerInterface::READ,
+        ], true);
     }
 
     /**
@@ -94,7 +133,7 @@ class PageVoter extends Voter
      */
     protected function can($action, $employeeProfileId)
     {
-        return Access::isGranted('ROLE_MOD_TAB_' . strtoupper($action), $employeeProfileId);
+        return $this->accessDecisionManager->isEmployeeGranted($action, $employeeProfileId);
     }
 
     /**

--- a/src/PrestaShopBundle/Security/Voter/PageVoter.php
+++ b/src/PrestaShopBundle/Security/Voter/PageVoter.php
@@ -94,7 +94,7 @@ class PageVoter extends Voter
      *
      * @return bool
      */
-    protected function supports($attribute, $subject)
+    protected function supports($attribute, $subject): bool
     {
         return in_array($attribute, [
             AccessCheckerInterface::CREATE,
@@ -111,29 +111,14 @@ class PageVoter extends Voter
      *
      * @return bool
      */
-    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
     {
         /** @var Employee $user */
         $user = $token->getUser();
         $employeeProfileId = $user->getData()->id_profile;
-        $action = $this->buildAction($subject, $attribute);
+        $action = $this->buildAction((string) $subject, (string) $attribute);
 
-        return $this->can($action, $employeeProfileId);
-    }
-
-    /**
-     * Checks if the provided user profile is allowed to perform the requested action.
-     *
-     * @param string $action
-     * @param int $employeeProfileId
-     *
-     * @return bool
-     *
-     * @throws \Exception
-     */
-    protected function can($action, $employeeProfileId)
-    {
-        return $this->accessDecisionManager->isEmployeeGranted($action, $employeeProfileId);
+        return $this->accessDecisionManager->isEmployeeGranted($action, (int) $employeeProfileId);
     }
 
     /**
@@ -144,7 +129,7 @@ class PageVoter extends Voter
      *
      * @return string
      */
-    private function buildAction($subject, $attribute)
+    private function buildAction(string $subject, string $attribute): string
     {
         $action = $subject;
 

--- a/src/PrestaShopBundle/Security/Voter/PageVoter.php
+++ b/src/PrestaShopBundle/Security/Voter/PageVoter.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Security\Voter;
 
 use PrestaShop\PrestaShop\Core\Security\AccessCheckerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Security\Admin\Employee;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
@@ -39,51 +40,51 @@ class PageVoter extends Voter
     /**
      * @deprecated since 9.0
      */
-    public const CREATE = AccessCheckerInterface::CREATE;
+    public const CREATE = Permission::CREATE;
 
     /**
      * @deprecated since 9.0
      */
-    public const UPDATE = AccessCheckerInterface::UPDATE;
+    public const UPDATE = Permission::UPDATE;
 
     /**
      * @deprecated since 9.0
      */
-    public const DELETE = AccessCheckerInterface::DELETE;
+    public const DELETE = Permission::DELETE;
 
     /**
      * @deprecated since 9.0
      */
-    public const READ = AccessCheckerInterface::READ;
+    public const READ = Permission::READ;
 
     /**
      * @deprecated since 9.0
      */
-    public const LEVEL_DELETE = AccessCheckerInterface::LEVEL_DELETE;
+    public const LEVEL_DELETE = Permission::LEVEL_DELETE;
 
     /**
      * @deprecated since 9.0
      */
-    public const LEVEL_UPDATE = AccessCheckerInterface::LEVEL_UPDATE;
+    public const LEVEL_UPDATE = Permission::LEVEL_UPDATE;
 
     /**
      * @deprecated since 9.0
      */
-    public const LEVEL_CREATE = AccessCheckerInterface::LEVEL_CREATE;
+    public const LEVEL_CREATE = Permission::LEVEL_CREATE;
 
     /**
      * @deprecated since 9.0
      */
-    public const LEVEL_READ = AccessCheckerInterface::LEVEL_READ;
+    public const LEVEL_READ = Permission::LEVEL_READ;
 
     /**
      * @var AccessCheckerInterface
      */
-    private $accessDecisionManager;
+    private $accessChecker;
 
-    public function __construct(AccessCheckerInterface $accessDecisionManager)
+    public function __construct(AccessCheckerInterface $accessChecker)
     {
-        $this->accessDecisionManager = $accessDecisionManager;
+        $this->accessChecker = $accessChecker;
     }
 
     /**
@@ -97,10 +98,10 @@ class PageVoter extends Voter
     protected function supports($attribute, $subject): bool
     {
         return in_array($attribute, [
-            AccessCheckerInterface::CREATE,
-            AccessCheckerInterface::UPDATE,
-            AccessCheckerInterface::DELETE,
-            AccessCheckerInterface::READ,
+            Permission::CREATE,
+            Permission::UPDATE,
+            Permission::DELETE,
+            Permission::READ,
         ], true);
     }
 
@@ -118,7 +119,7 @@ class PageVoter extends Voter
         $employeeProfileId = $user->getData()->id_profile;
         $action = $this->buildAction((string) $subject, (string) $attribute);
 
-        return $this->accessDecisionManager->isEmployeeGranted($action, (int) $employeeProfileId);
+        return $this->accessChecker->isEmployeeGranted($action, (int) $employeeProfileId);
     }
 
     /**

--- a/tests/Integration/Utility/PageVoter.php
+++ b/tests/Integration/Utility/PageVoter.php
@@ -40,7 +40,7 @@ class PageVoter extends BaseVoter
      *
      * @return bool
      */
-    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
     {
         return true;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | This PR modifies the code of the permission system but the behavior is identical to before, it is only a refactoring. Please test the back-office login, and check that the employee permissions (create / read / update / delete) work as expected on a back-office page.
| Fixed ticket?     | N/A


- Removing legacy code usages inside PrestaShopBundle `PageVoter`, and `EmployeeProvider`
- Introduce `EmployeePermissionProviderInterface` and `AccessCheckerInterface` to check user permissions.
- Introduce new `Permission` class that contains all the constants for access management.
- Deprecate `AdminController::LEVEL_*` constants (moved inside Permission)
- Deprecate `PageVoter::LEVEL_*` constants (moved inside Permission)
- Deprecate `PageVoter::READ|WRITE|UPDATE|DELETE` constants (moved inside Permission)
- Moving `ROLE_MOD_TAB/MODULE` into constants for easier reading