### PR TITLE
Disable module's hook before upgrading it

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -54,6 +54,7 @@ framework:
     handler_id: ~
   fragments: ~
   http_method_override: true
+  http_client: ~
   cache:
     pools:
       '%cache.driver%':

--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -64,6 +64,8 @@ class HookCore extends ObjectModel
 
     public static $native_module;
 
+    protected static $disabledHookModules = [];
+
     /**
      * @see ObjectModel::$definition
      */
@@ -717,6 +719,19 @@ class HookCore extends ObjectModel
     }
 
     /**
+     * Add a module ID to the list of modules that should not execute hooks
+     */
+    public static function disableHooksForModule(int $moduleId): void
+    {
+        if (in_array($moduleId, self::$disabledHookModules)) {
+            return;
+        }
+
+        self::$disabledHookModules[] = $moduleId;
+        Cache::clean(self::MODULE_LIST_BY_HOOK_KEY . '*');
+    }
+
+    /**
      * Execute modules for specified hook.
      *
      * @param string $hook_name Hook Name
@@ -1144,6 +1159,10 @@ class HookCore extends ObjectModel
                     $sql->where('mg.`id_group` IN (' . implode(', ', $groups) . ')');
                 }
             }
+        }
+
+        if (!empty(self::$disabledHookModules)) {
+            $sql->where('m.id_module NOT IN (' . implode(', ', self::$disabledHookModules) . ')');
         }
 
         $sql->groupBy('hm.id_hook, hm.id_module');

--- a/src/Adapter/HookManager.php
+++ b/src/Adapter/HookManager.php
@@ -101,4 +101,9 @@ class HookManager
             }
         }
     }
+
+    public function disableHooksForModule(int $moduleId): void
+    {
+        Hook::disableHooksForModule($moduleId);
+    }
 }

--- a/src/Adapter/Module/AdminModuleDataProvider.php
+++ b/src/Adapter/Module/AdminModuleDataProvider.php
@@ -221,10 +221,14 @@ class AdminModuleDataProvider implements ModuleInterface
                     ]);
                     continue;
                 }
-                $urls[$action] = $this->router->generate('admin_module_manage_action', [
+                $parameters = [
                     'action' => $action,
                     'module_name' => $moduleAttributes->get('name'),
-                ]);
+                ];
+                if ($action === 'upgrade' && $moduleAttributes->get('download_url') !== null) {
+                    $parameters['source'] = $moduleAttributes->get('download_url');
+                }
+                $urls[$action] = $this->router->generate('admin_module_manage_action', $parameters);
             }
 
             if ($module->isInstalled()) {

--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -182,6 +182,8 @@ class ModuleManager implements ModuleManagerInterface
             $handler->handle($source);
         }
 
+        $this->hookManager->disableHooksForModule($this->moduleDataProvider->getModuleIdByName($name));
+
         $this->hookManager->exec('actionBeforeUpgradeModule', ['moduleName' => $name, 'source' => $source]);
 
         $module = $this->moduleRepository->getModule($name);

--- a/src/Core/Module/SourceHandler/Exception/SourceNotHandledException.php
+++ b/src/Core/Module/SourceHandler/Exception/SourceNotHandledException.php
@@ -26,36 +26,10 @@
 
 declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Core\Module\SourceHandler;
+namespace PrestaShop\PrestaShop\Core\Module\SourceHandler\Exception;
 
-class SourceHandlerFactory
+use RuntimeException;
+
+class SourceNotHandledException extends RuntimeException
 {
-    /** @var SourceHandlerInterface[] */
-    private $sourceHandlers = [];
-
-    /**
-     * @param SourceHandlerInterface[] $handlers
-     */
-    public function __construct(iterable $handlers = [])
-    {
-        foreach ($handlers as $handler) {
-            $this->addHandler($handler);
-        }
-    }
-
-    public function addHandler(SourceHandlerInterface $sourceHandler): void
-    {
-        $this->sourceHandlers[] = $sourceHandler;
-    }
-
-    public function getHandler($source): SourceHandlerInterface
-    {
-        foreach ($this->sourceHandlers as $handler) {
-            if ($handler->canHandle($source)) {
-                return $handler;
-            }
-        }
-
-        throw new SourceHandlerNotFoundException(sprintf('Handler not found for source %s', $source));
-    }
 }

--- a/src/Core/Module/SourceHandler/RemoteZipSourceHandler.php
+++ b/src/Core/Module/SourceHandler/RemoteZipSourceHandler.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Module\SourceHandler;
+
+use PrestaShop\PrestaShop\Core\Module\SourceHandler\Exception\SourceNotHandledException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class RemoteZipSourceHandler implements SourceHandlerInterface
+{
+    private const ZIP_FILENAME_PATTERN = '/(\w+)\.zip\b/';
+
+    /**
+     * @var ZipSourceHandler
+     */
+    private $zipSourceHandler;
+
+    /**
+     * @var string
+     */
+    private $downloadDir;
+
+    /**
+     * @var HttpClientInterface
+     */
+    private $httpClient;
+
+    /**
+     * @var string|null
+     */
+    private $moduleName;
+
+    /**
+     * @var mixed
+     */
+    private $handledSource;
+
+    public function __construct(
+        ZipSourceHandler $zipSourceHandler,
+        HttpClientInterface $httpClient,
+        string $downloadDir
+    ) {
+        $this->zipSourceHandler = $zipSourceHandler;
+        $this->httpClient = $httpClient;
+        $this->downloadDir = $downloadDir;
+    }
+
+    public function canHandle($source): bool
+    {
+        if (!is_string($source)) {
+            return false;
+        }
+
+        try {
+            $response = $this->httpClient->request('HEAD', $source);
+        } catch (TransportExceptionInterface $e) {
+            return false;
+        }
+
+        $this->moduleName = null;
+
+        if (preg_match(self::ZIP_FILENAME_PATTERN, $source, $moduleName) === 1) {
+            $this->moduleName = $moduleName[1];
+        }
+
+        $headers = $response->getHeaders(false);
+
+        if (isset($headers['content-disposition'])
+            && preg_match(self::ZIP_FILENAME_PATTERN, reset($headers['content-disposition']), $moduleName) === 1
+        ) {
+            $this->moduleName = $moduleName[1];
+        }
+
+        if (!empty($this->moduleName)
+            && $response->getStatusCode() === 200
+            && isset($headers['content-type'])
+            && reset($headers['content-type']) === 'application/zip'
+        ) {
+            $this->handledSource = $source;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getModuleName($source): ?string
+    {
+        $this->assertSourceHasBeenChecked($source);
+
+        return $this->moduleName;
+    }
+
+    public function handle(string $source): void
+    {
+        $this->assertSourceHasBeenChecked($source);
+
+        $filesystem = new Filesystem();
+        $path = $this->getDownloadDir($this->getModuleName($source));
+        $filesystem->mkdir(dirname($path));
+        $filesystem->dumpFile($path, $this->httpClient->request('GET', $source)->getContent());
+        $this->zipSourceHandler->handle($path);
+    }
+
+    private function getDownloadDir(string $moduleName): string
+    {
+        return implode(DIRECTORY_SEPARATOR, [$this->downloadDir, $moduleName . '.zip']);
+    }
+
+    private function assertSourceHasBeenChecked($source): void
+    {
+        if ($source !== $this->handledSource) {
+            throw new SourceNotHandledException('Method canHandle() should be called first');
+        }
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -193,6 +193,7 @@ class ModuleController extends ModuleAbstractController
         }
 
         $module = $request->get('module_name');
+        $source = $request->query->get('source');
         $moduleManager = $this->container->get('prestashop.module.manager');
         $moduleRepository = $this->container->get('prestashop.core.admin.module.repository');
         $modulesProvider = $this->container->get('prestashop.core.admin.data_provider.module_interface');
@@ -209,6 +210,9 @@ class ModuleController extends ModuleAbstractController
 
         try {
             $args = [$module];
+            if ($source !== null) {
+                $args[] = $source;
+            }
             if ($action === ModuleAdapter::ACTION_UNINSTALL) {
                 $args[] = (bool) ($request->request->get('actionParams', [])['deletion'] ?? false);
                 $response[$module]['refresh_needed'] = $this->moduleNeedsReload($moduleRepository->getModule($module));

--- a/src/PrestaShopBundle/Resources/config/services/core/module.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/module.yml
@@ -10,8 +10,8 @@ services:
       - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
       - '@prestashop.adapter.module.payment_module_provider'
 
-  prestashop.core.admin.module.repository:
-    class: PrestaShop\PrestaShop\Core\Module\ModuleRepository
+  PrestaShop\PrestaShop\Core\Module\ModuleRepository:
+    public: false
     arguments:
       - '@prestashop.adapter.data_provider.module'
       - '@prestashop.adapter.admin.data_provider.module'
@@ -27,24 +27,48 @@ services:
     tags:
       - { name: kernel.event_subscriber }
 
-  prestashop.module.sourcehandler.zip:
-    class: PrestaShop\PrestaShop\Core\Module\SourceHandler\ZipSourceHandler
+  PrestaShop\PrestaShop\Core\Module\ModuleManager:
+    public: false
+    autowire: true
     arguments:
-      - '%modules_dir%'
-      - '@translator'
+      $moduleDataProvider: '@prestashop.adapter.data_provider.module'
+      $adminModuleDataProvider: '@prestashop.core.admin.data_provider.module_interface'
+      $hookManager: '@prestashop.adapter.hook.manager'
+
+  PrestaShop\PrestaShop\Core\Module\SourceHandler\ZipSourceHandler:
+    autowire: true
+    public: false
+    arguments:
+      $modulePath: '%modules_dir%'
+    tags: [ core.module.source_handler ]
+
+  PrestaShop\PrestaShop\Core\Module\SourceHandler\RemoteZipSourceHandler:
+    autowire: true
+    public: false
+    arguments:
+      $downloadDir: '%ps_cache_dir%/downloads'
+    tags: [ core.module.source_handler ]
+
+  PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerFactory:
+    arguments:
+      - !tagged core.module.source_handler
+
+  prestashop.core.admin.module.repository:
+    alias: PrestaShop\PrestaShop\Core\Module\ModuleRepository
+    public: true
+    deprecated: ~
 
   prestashop.module.factory.sourcehandler:
-    class: PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerFactory
-    calls:
-      - [ 'addHandler', [ '@prestashop.module.sourcehandler.zip' ] ]
+    alias: PrestaShop\PrestaShop\Core\Module\SourceHandler\SourceHandlerFactory
+    public: true
+    deprecated: ~
+
+  prestashop.module.sourcehandler.zip:
+    alias: PrestaShop\PrestaShop\Core\Module\SourceHandler\ZipSourceHandler
+    public: true
+    deprecated: ~
 
   prestashop.module.manager:
-    class: PrestaShop\PrestaShop\Core\Module\ModuleManager
-    arguments:
-      - '@prestashop.core.admin.module.repository'
-      - '@prestashop.adapter.data_provider.module'
-      - '@prestashop.adapter.admin.data_provider.module'
-      - '@prestashop.module.factory.sourcehandler'
-      - '@translator'
-      - '@event_dispatcher'
-      - '@prestashop.adapter.hook.manager'
+    alias: PrestaShop\PrestaShop\Core\Module\ModuleManager
+    public: true
+    deprecated: ~

--- a/tests/Unit/Core/Module/ModuleManagerTest.php
+++ b/tests/Unit/Core/Module/ModuleManagerTest.php
@@ -258,6 +258,13 @@ class ModuleManagerTest extends TestCase
             ])
         ;
 
+        $moduleDataProvider->method('getModuleIdByName')
+            ->willReturnMap([
+                [self::INSTALLED_MODULE_NAME, false, 1],
+                [self::UNINSTALLED_MODULE_NAME, false, null],
+            ])
+        ;
+
         $moduleDataProvider->method('isOnDisk')->willReturn(true);
 
         return $moduleDataProvider;

--- a/tests/Unit/Core/Module/SourceHandler/RemoteZipSourceHandlerTest.php
+++ b/tests/Unit/Core/Module/SourceHandler/RemoteZipSourceHandlerTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Core\Module\SourceHandler;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Core\Module\SourceHandler\Exception\SourceNotHandledException;
+use PrestaShop\PrestaShop\Core\Module\SourceHandler\RemoteZipSourceHandler;
+use PrestaShop\PrestaShop\Core\Module\SourceHandler\ZipSourceHandler;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Tests\Resources\ResourceResetter;
+
+class RemoteZipSourceHandlerTest extends TestCase
+{
+    private const VALID_SOURCE_ZIP = __DIR__ . '/../../../../Resources/dummyFile/valid_module.zip';
+    private const INVALID_SOURCE_ZIP = __DIR__ . '/../../../../Resources/dummyFile/invalid_module.zip';
+    private const VALID_SOURCE_URL = 'http://valid-source.local/valid_module.zip';
+    private const INVALID_SOURCE_URL = 'http://valid-source.local/not_a_zipfile.xml';
+
+    /** @var ZipSourceHandler */
+    private $zipSourceHandler;
+
+    /** @var ResourceResetter responsible to reset resources used for tests */
+    private $resourceResetter;
+
+    public function setUp(): void
+    {
+        $this->resourceResetter = new ResourceResetter();
+        $this->resourceResetter->backupTestModules();
+        $this->resourceResetter->backupDownloads();
+
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnArgument(0);
+
+        $this->zipSourceHandler = new ZipSourceHandler($this->resourceResetter::TEST_MODULES_DIR, $translator);
+    }
+
+    private function getMockedZipSourceHandler(MockResponse ...$mockResponses): RemoteZipSourceHandler
+    {
+        return new RemoteZipSourceHandler(
+            $this->zipSourceHandler,
+            new MockHttpClient($mockResponses),
+            _PS_DOWNLOAD_DIR_
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->resourceResetter->resetTestModules();
+        $this->resourceResetter->resetDownloads();
+    }
+
+    public function testCanHandle(): void
+    {
+        $responses = [
+            new MockResponse('', ['response_headers' => ['Content-Type' => 'application/zip']]),
+            new MockResponse('', ['response_headers' => ['Content-Type' => 'application/xml']]),
+            new MockResponse('', ['response_headers' => ['Content-Type' => 'application/zip']]),
+            new MockResponse('', ['response_headers' => ['Content-Type' => 'application/zip', 'Content-Disposition' => 'attachment; filename="valid_module.zip"']]),
+            new MockResponse('', ['http_code' => 401, 'response_headers' => ['Content-Type' => 'application/zip']]),
+        ];
+        $remoteZipSourceHandler = $this->getMockedZipSourceHandler(...$responses);
+
+        $this->assertTrue($remoteZipSourceHandler->canHandle(self::VALID_SOURCE_URL));
+        $this->assertFalse($remoteZipSourceHandler->canHandle(self::INVALID_SOURCE_URL));
+        $this->assertFalse($remoteZipSourceHandler->canHandle(self::INVALID_SOURCE_URL));
+        $this->assertTrue($remoteZipSourceHandler->canHandle(self::INVALID_SOURCE_URL));
+        $this->assertFalse($remoteZipSourceHandler->canHandle(self::VALID_SOURCE_URL));
+    }
+
+    public function testGetModuleNameBeforeTestingHandling(): void
+    {
+        $this->expectException(SourceNotHandledException::class);
+        $remoteZipSourceHandler = $this->getMockedZipSourceHandler();
+        $remoteZipSourceHandler->getModuleName(self::INVALID_SOURCE_ZIP);
+    }
+
+    public function testGetModuleNameForAnotherSource(): void
+    {
+        $this->expectException(SourceNotHandledException::class);
+        $response = new MockResponse('', ['response_headers' => ['Content-Type' => 'application/zip']]);
+        $remoteZipSourceHandler = $this->getMockedZipSourceHandler($response);
+        $this->assertTrue($remoteZipSourceHandler->canHandle(self::VALID_SOURCE_URL));
+        $remoteZipSourceHandler->getModuleName(self::INVALID_SOURCE_URL);
+    }
+
+    public function testGetModuleNameForValidSource(): void
+    {
+        $responses = [
+            new MockResponse('', ['response_headers' => ['Content-Type' => 'application/zip']]),
+            new MockResponse('', ['response_headers' => ['Content-Type' => 'application/zip', 'Content-Disposition' => 'attachment; filename="custom_name.zip"']]),
+        ];
+
+        $remoteZipSourceHandler = $this->getMockedZipSourceHandler(...$responses);
+
+        $this->assertTrue($remoteZipSourceHandler->canHandle(self::VALID_SOURCE_URL));
+        $this->assertSame('valid_module', $remoteZipSourceHandler->getModuleName(self::VALID_SOURCE_URL));
+
+        $this->assertTrue($remoteZipSourceHandler->canHandle(self::VALID_SOURCE_URL));
+        $this->assertSame('custom_name', $remoteZipSourceHandler->getModuleName(self::VALID_SOURCE_URL));
+    }
+
+    public function testHandleBeforeTestingHandling(): void
+    {
+        $this->expectException(SourceNotHandledException::class);
+        $remoteZipSourceHandler = $this->getMockedZipSourceHandler();
+        $remoteZipSourceHandler->handle(self::INVALID_SOURCE_ZIP);
+    }
+
+    public function testHandleForAnotherSource(): void
+    {
+        $this->expectException(SourceNotHandledException::class);
+        $response = new MockResponse('', ['response_headers' => ['Content-Type' => 'application/zip']]);
+        $remoteZipSourceHandler = $this->getMockedZipSourceHandler($response);
+        $this->assertTrue($remoteZipSourceHandler->canHandle(self::VALID_SOURCE_URL));
+        $remoteZipSourceHandler->handle(self::INVALID_SOURCE_URL);
+    }
+
+    public function testHandleForValidSource(): void
+    {
+        $response = new MockResponse(
+            file_get_contents(self::VALID_SOURCE_ZIP),
+            ['response_headers' => ['Content-Type' => 'application/zip']]
+        );
+        $remoteZipSourceHandler = $this->getMockedZipSourceHandler(
+            $response,
+            $response
+        );
+
+        $this->assertTrue($remoteZipSourceHandler->canHandle(self::VALID_SOURCE_URL));
+        $remoteZipSourceHandler->handle(self::VALID_SOURCE_URL);
+        $this->assertFileExists($this->resourceResetter::TEST_MODULES_DIR . '/valid_module/valid_module.php');
+    }
+}

--- a/tests/Unit/Core/Module/SourceHandler/ZipSourceHandlerTest.php
+++ b/tests/Unit/Core/Module/SourceHandler/ZipSourceHandlerTest.php
@@ -67,26 +67,26 @@ class ZipSourceHandlerTest extends TestCase
         $this->resourceResetter->resetTestModules();
     }
 
-    public function testCanHandle()
+    public function testCanHandle(): void
     {
         $this->assertFalse($this->zipSourceHandler->canHandle(self::UNHANDLABLE_SOURCE));
         $this->assertTrue($this->zipSourceHandler->canHandle(self::INVALID_SOURCE));
         $this->assertTrue($this->zipSourceHandler->canHandle(self::VALID_SOURCE));
     }
 
-    public function testGetNameUnexistingSource()
+    public function testGetNameUnexistingSource(): void
     {
         $this->expectException(ModuleErrorException::class);
         $this->zipSourceHandler->getModuleName(self::UNHANDLABLE_SOURCE);
     }
 
-    public function testGetNameInvalidSource()
+    public function testGetNameInvalidSource(): void
     {
         $this->expectException(ModuleErrorException::class);
         $this->zipSourceHandler->getModuleName(self::INVALID_SOURCE);
     }
 
-    public function testGetNameValidSource()
+    public function testGetNameValidSource(): void
     {
         $this->assertSame(
             'valid_module',
@@ -94,13 +94,13 @@ class ZipSourceHandlerTest extends TestCase
         );
     }
 
-    public function testHandleUnhandlableSource()
+    public function testHandleUnhandlableSource(): void
     {
         $this->expectException(ModuleErrorException::class);
         $this->zipSourceHandler->handle(self::UNHANDLABLE_SOURCE);
     }
 
-    public function testHandleValidSource()
+    public function testHandleValidSource(): void
     {
         $this->zipSourceHandler->handle(self::VALID_SOURCE);
         $this->assertFileExists($this->resourceResetter::TEST_MODULES_DIR . '/valid_module/valid_module.php');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Disable module's hook before upgrading it: this avoids the crazy situation where a module is being both used and upgrade simultaneously, which causes plenty issues like #31098 and #29542
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | If you try to test a new version of [ps_distributionapiclient](https://github.com/PrestaShop/ps_distributionapiclient/) (use the `dev` branch of ps_distributionapiclient) like [1.0.3](https://github.com/PrestaShop/ps_distributionapiclient/pull/12), it will fail. However if you use this PR, then try to install a new version of ps_distributionapiclient.<br/>This PR is supposed to help us finally unlock [ps_distributionapiclient release 1.0.3](https://github.com/PrestaShop/ps_distributionapiclient/pull/12)! 😄 
| Fixed ticket?     | Resolves #31098, resolves #29542
| Related PRs       | 
| Sponsor company   |
