### PR TITLE
Always use id_country from request if provided

### DIFF
--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -98,8 +98,11 @@ class CustomerAddressFormCore extends AbstractForm
         // 2) Detect country from browser language settings and matches BO enabled countries
         // 3) Default country set in BO
 
-        if (isset($params['id_country']) && (int) $params['id_country'] !== (int) $this->formatter->getCountry()->id) {
-            $country = new Country($params['id_country'], $this->language->id);
+        if (isset($params['id_country'])) {
+            $country = (int) $params['id_country'] !== (int) $this->formatter->getCountry()->id
+                ? new Country($params['id_country'], $this->language->id)
+                : $this->formatter->getCountry()
+            ;
         } elseif (
             Tools::isCountryFromBrowserAvailable() &&
             Country::getByIso($countryIsoCode = Tools::getCountryIsoCodeFromHeader(), true)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | When id_country was send, it was only used if it was different from the id_country present in the `CustomerAddressFormatter`, if it was the same, either the browser language was used or the shop default country. This PR fixes it by always relying on the id_country if it present in the request.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Please see #30973
| Fixed ticket?     | Fixes #30973
| Related PRs       | 
| Sponsor company   | 
