### PR TITLE
Always set HelperKpi source and use conditional refresh

### DIFF
--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -197,9 +197,8 @@ class AdminCartsControllerCore extends AdminController
         if (ConfigurationKPI::get('AVG_ORDER_VALUE') !== false) {
             $helper->value = $this->trans('%amount% tax excl.', ['%amount%' => ConfigurationKPI::get('AVG_ORDER_VALUE')], 'Admin.Orderscustomers.Feature');
         }
-        if (ConfigurationKPI::get('AVG_ORDER_VALUE_EXPIRE') < $time) {
-            $helper->source = $this->context->link->getAdminLink('AdminStats') . '&ajax=1&action=getKpi&kpi=average_order_value';
-        }
+        $helper->source = $this->context->link->getAdminLink('AdminStats') . '&ajax=1&action=getKpi&kpi=average_order_value';
+        $helper->refresh = ConfigurationKPI::get('AVG_ORDER_VALUE_EXPIRE') < $time;
         $kpis[] = $helper->generate();
 
         $helper = new HelperKpi();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | because the `source` of refresh of the `HelperKpi` is mandatory but wasn't given, it was considered as `null`. In PHP 8.1, using `null` as first parameter of the method `addslashes` is deprecated and lead to an error. This PR fixes it by always giving the `source` but setting the `refresh` property conditionally.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Please see #30203
| Fixed ticket?     | Fixes #30203
| Related PRs       |
| Sponsor company   |
