### PR TITLE
Allow custom redirect after login

### DIFF
--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -279,7 +279,7 @@ class AdminLoginControllerCore extends AdminController
                     [
                         'controller' => $this,
                         'employee' => $this->context->employee,
-                        'redirect' => $url,
+                        'redirect' => &$url,
                     ]
                 );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Hooks : Allow customizing the redirect URL after login
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You can test it using `ps_qualityassurance` module, all the details available below
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

1. Register the `actionAdminLoginControllerLoginAfter` hook and assign the `redirect` param:

```php
public function hookActionAdminLoginControllerLoginAfter(array &$params): void 
{
    $params['redirect'] = 'https://www.prestashop-project.org';
}
```

2. After login, you should be redirected to https://www.prestashop-project.org