### PR TITLE
Fix prestashop:linter:security-annotation find-missing failed because of non existant methods

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AuthorizationServer/ApiAccessController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AuthorizationServer/ApiAccessController.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\AuthorizationServer;
+
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use PrestaShopBundle\Exception\NotImplementedException;
+
+/**
+ * Manages the "Configure > Advanced Parameters > Authorization Server > Api Access" page.
+ */
+class ApiAccessController extends FrameworkBundleAdminController
+{
+    public function createAction(): void
+    {
+        // TODO: Implement createAction() method in create PR.
+        throw new NotImplementedException();
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AuthorizationServer/ApplicationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AuthorizationServer/ApplicationController.php
@@ -30,7 +30,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters\Authori
 
 use PrestaShop\PrestaShop\Core\Search\Filters\AuthorizedApplicationsFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
-use Symfony\Component\HttpFoundation\Request;
+use PrestaShopBundle\Exception\NotImplementedException;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -57,6 +57,30 @@ class ApplicationController extends FrameworkBundleAdminController
             'layoutHeaderToolbarBtn' => $this->getApplicationToolbarButtons(),
             'grid' => $this->presentGrid($grid),
         ]);
+    }
+
+    public function viewAction(): void
+    {
+        // TODO: Implement viewAction() method in view PR.
+        throw new NotImplementedException();
+    }
+
+    public function createAction(): void
+    {
+        // TODO: Implement createAction() method in create PR.
+        throw new NotImplementedException();
+    }
+
+    public function editAction(): void
+    {
+        // TODO: Implement editAction() method in edit PR.
+        throw new NotImplementedException();
+    }
+
+    public function deleteAction(): void
+    {
+        // TODO: Implement deleteAction() method in delete PR.
+        throw new NotImplementedException();
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix prestashop:linter:security-annotation find-missing failed because of non existant methods / class
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | https://github.com/nesrineabdmouleh/testing_pr/actions/runs/4107533089
| Fixed ticket?     | -
| Related PRs       | -
| Sponsor company   | [@PrestashopCorp](https://github.com/PrestaShopCorp)
