### PR TITLE
Rename behats multishop features for easier to follow convention

### DIFF
--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/combinations_listing_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/combinations_listing_multishop.feature
@@ -1,9 +1,9 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags combinations-multi-shop-listing
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags combinations-listing-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
-@product-multi-shop
-@combinations-multi-shop-listing
+@product-multishop
+@combinations-listing-multishop
 Feature: List attribute combinations for product in Back Office (BO) of multiple shops
   As an employee
   I need to be able to see and manipulate a list of product attribute combinations in BO of multiple shops

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/copy_combinations_to_shop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/copy_combinations_to_shop.feature
@@ -4,7 +4,7 @@
 @restore-shops-after-feature
 @clear-cache-after-feature
 @product-combination
-@product-multi-shop
+@product-multishop
 @copy-combinations-to-shop
 Feature: Copy combinations from Back Office (BO) when using multi-shop feature
   As a BO user

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_combination_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/delete_combination_multishop.feature
@@ -1,12 +1,12 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-multi-shop-combination
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-combination-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @clear-cache-after-feature
 @product-combination
 @delete-combination
-@product-multi-shop
-@delete-multi-shop-combination
+@product-multishop
+@delete-combination-multishop
 Feature: Delete combination from Back Office (BO) in multiple shops
   As a BO user
   I need to be able to delete product combinations from BO in multiple shops

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/generate_combination_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/generate_combination_multishop.feature
@@ -1,12 +1,12 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags generate-multi-shop-combination
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags generate-combination-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @clear-cache-after-feature
 @product-combination
 @generate-combination
-@product-multi-shop
-@generate-multi-shop-combination
+@product-multishop
+@generate-combination-multishop
 Feature: Generate combination from Back Office (BO) when using multi-shop feature
   As a BO user
   I need to be able to generate product combinations from BO for specified shop when using multi-shop feature

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/set_default_combination_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/set_default_combination_multishop.feature
@@ -1,8 +1,8 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags set-default-multi-shop-combination
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags set-default-combination-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
-@set-default-multi-shop-combination
+@set-default-combination-multishop
 Feature: Set default combination for product in Back Office (BO) in multi shop context
   As an employee
   I need to be able to set default combination from BO in multiple shops

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_combination_details_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_combination_details_multishop.feature
@@ -1,8 +1,8 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-multi-shop-details
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-details-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
-@update-combination-multi-shop-details
+@update-combination-details-multishop
 Feature: Update product combination details in Back Office (BO) in multi shop context
   As an employee
   I need to be able to update product combination details from BO in multiple shops

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_combination_prices_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_combination_prices_multishop.feature
@@ -1,9 +1,9 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-multi-shop-prices
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-prices-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
 @update-product-prices
-@update-combination-multi-shop-prices
+@update-combination-prices-multishop
 Feature: Update product combination prices in Back Office (BO) in multi shop context
   As an employee
   I need to be able to update product combination prices from BO for multiple shops

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_combination_stock_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Combination/Shop/update_combination_stock_multishop.feature
@@ -1,8 +1,8 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-combination-stock
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-combination-stock-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @product-combination
-@update-multi-shop-combination-stock
+@update-combination-stock-multishop
 Feature: Update product combination stock information in Back Office (BO) in multi shop context
   As an employee
   I need to be able to update product combination stock information from BO for multiple shops

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/add_image_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/add_image_multishop.feature
@@ -1,10 +1,10 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add-multishop-image
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags add-image-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @restore-shops-after-feature
 @product-image
-@add-multishop-image
+@add-image-multishop
 Feature: Add product image from Back Office (BO)
   As an employee I need to be able to add new product image in multishop context
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/bulk_delete_product_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/bulk_delete_product_multishop.feature
@@ -1,12 +1,12 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags bulk-multi-shop-delete-product
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags bulk-delete-product-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @restore-languages-after-feature
 @reset-img-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@bulk-multi-shop-delete-product
+@product-multishop
+@bulk-delete-product-multishop
 Feature: Copy product from shop to shop.
   As a BO user I want to be able to bulk product depending on shop context.
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/bulk_update_product_status_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/bulk_update_product_status_multishop.feature
@@ -1,12 +1,12 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags bulk-multi-shop-update-product-status
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags bulk-update-product-status-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @restore-languages-after-feature
 @reset-img-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@bulk-multi-shop-update-product-status
+@product-multishop
+@bulk-update-product-status-multishop
 Feature: Copy product from shop to shop.
   As a BO user I want to be able to copy product from shop to shop.
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/delete_image_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/delete_image_multishop.feature
@@ -1,9 +1,9 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-multishop-image
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags delete-image-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-image
-@delete-multishop-image
+@delete-image-multishop
 Feature: Delete product image from Back Office (BO)
   As an employee I need to be able to delete product image
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
@@ -1,4 +1,4 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags duplicate-multi-shop-product
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags duplicate-product-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
@@ -6,8 +6,8 @@
 @restore-taxes-after-feature
 @reset-img-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@duplicate-multi-shop-product
+@product-multishop
+@duplicate-product-multishop
 Feature: Copy product from shop to shop.
   As a BO user I want to be able to duplicate products for specific shop, group shop and all shops
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/shop_management.feature
@@ -1,12 +1,12 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-management
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags shop-management
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @restore-languages-after-feature
 @reset-img-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@update-multi-shop-management
+@product-multishop
+@shop-management
 Feature: Copy product from shop to shop.
   As a BO user I want to be able to copy product from shop to shop.
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_basic_information_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_basic_information_multishop.feature
@@ -1,10 +1,10 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-basic-information
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-basic-information-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@update-multi-shop-basic-information
+@product-multishop
+@update-basic-information-multishop
 Feature: Update product basic information from Back Office (BO)
   As a BO user
   I need to be able to update product basic information from BO

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_categories_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_categories_multishop.feature
@@ -1,12 +1,12 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-categories
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-categories-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @restore-languages-after-feature
 @reset-img-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@update-multi-shop-categories
+@product-multishop
+@update-categories-multishop
 Feature: Copy product from shop to shop.
   As a BO user I want to be able to copy product from shop to shop.
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_customization_fields_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_customization_fields_multishop.feature
@@ -4,6 +4,7 @@
 @restore-shops-after-feature
 @restore-languages-after-feature
 @clear-cache-before-feature
+@product-multishop
 @update-customization-fields-multishop
 Feature: Set product images for all shops from Back Office (BO)
   As an employee I need to be able to edit customization fields for each shop

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_image_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_image_multishop.feature
@@ -1,9 +1,9 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multishop-image
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-image-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @reset-img-after-feature
 @product-image
-@update-multishop-image
+@update-image-multishop
 Feature: Update product image from Back Office (BO)
   As an employee I need to be able to update new product image
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_options_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_options_multishop.feature
@@ -1,11 +1,11 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-options
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-options-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @restore-languages-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@update-multi-shop-options
+@product-multishop
+@update-options-multishop
 Feature: Feature: Update product options from Back Office (BO) for multiple shops
   As a BO user
   I want to be able to update product fields associated with options in multiple shops.

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_pack_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_pack_multishop.feature
@@ -1,10 +1,10 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-pack
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-pack-multishop
 @restore-products-before-feature
 @clear-cache-after-feature
 @restore-shops-before-feature
 @restore-shops-after-feature
-@product-multi-shop
-@update-multi-shop-pack
+@product-multishop
+@update-pack-multishop
 Feature: Add product to pack from Back Office (BO)
   As a BO user
   I need to be able to add product to pack from BO

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_prices_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_prices_multishop.feature
@@ -1,10 +1,10 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-prices
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-prices-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@update-multi-shop-prices
+@product-multishop
+@update-prices-multishop
 Feature: Update product price fields from Back Office (BO) for multiple shops.
   As a BO user I want to be able to update product fields associated with price for multiple shops.
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_seo_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_seo_multishop.feature
@@ -1,10 +1,10 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-seo
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-seo-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@update-multi-shop-seo
+@product-multishop
+@update-seo-multishop
 Feature: Update product SEO options from Back Office (BO)
   As a BO user
   I need to be able to update product SEO options from BO

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_shipping_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_shipping_multishop.feature
@@ -1,11 +1,11 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-shipping
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-shipping-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @restore-languages-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@update-multi-shop-shipping
+@product-multishop
+@update-shipping-multishop
 Feature: Update product shipping information from Back Office (BO) for multiple shops.
   As a BO user I want to be able to update product fields associated with shipping for multiple shops.
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_status_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_status_multishop.feature
@@ -1,10 +1,10 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-status
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-status-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@update-multi-shop-status
+@product-multishop
+@update-status-multishop
 Feature: Feature: Update product options from Back Office (BO) for multiple shops
   As a BO user
   I want to be able to update product fields associated with options in multiple shops.

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_stock_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/update_stock_multishop.feature
@@ -1,11 +1,11 @@
-# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-multi-shop-stock
+# ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags update-stock-multishop
 @restore-products-before-feature
 @clear-cache-before-feature
 @restore-shops-after-feature
 @restore-languages-after-feature
 @clear-cache-after-feature
-@product-multi-shop
-@update-multi-shop-stock
+@product-multishop
+@update-stock-multishop
 Feature: Update product price fields from Back Office (BO) for multiple shops.
   As a BO user I want to be able to update product fields associated with price for multiple shops.
 


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Just a little naming change, so its easier to follow the convention by adding the "multishop" suffix at the end of feature, instead of mixing it somewhere in the middle.
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI passing will be enough as it purely only change for behat tests
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 
