### PR TITLE
Don't catch exception that implements ModuleErrorInterface

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyLogger;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Module\Exception\ModuleErrorInterface;
 use PrestaShop\PrestaShop\Core\Module\WidgetInterface;
 
 class HookCore extends ObjectModel
@@ -423,6 +424,9 @@ class HookCore extends ObjectModel
                     return static::coreCallHook($module, $methodName, $hookArgs);
                 }
             }
+        } catch (ModuleErrorInterface $e) {
+            // Exceptions that implements ModuleErrorInterface are usefull to display error messages
+            throw $e;
         } catch (Exception $e) {
             $environment = ServiceLocator::get('\\PrestaShop\\PrestaShop\\Adapter\\Environment');
             if ($environment->isDebug()) {


### PR DESCRIPTION
Theses exception are usefull to display error messages https://github.com/PrestaShop/PrestaShop/issues/31221

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Rehabilitation of the functionality allowing modules to display error messages using ModuleErrorInterface
| Type?             | bug fix
| Category?         | BO
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Install [attached module](https://github.com/PrestaShop/PrestaShop/files/10663154/module_for_pr_hook_error.zip)<br>Go to Back-Office customer page<br>Update a customer<br>An error message is displayed to the user
| Fixed ticket?     | Fixes #31221
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/14239
