### PR TITLE
Improved session availability test

### DIFF
--- a/classes/ConfigurationTest.php
+++ b/classes/ConfigurationTest.php
@@ -400,11 +400,7 @@ class ConfigurationTestCore
 
     public static function test_sessions()
     {
-        if (!$path = @ini_get('session.save_path')) {
-            return true;
-        }
-
-        return is_writable($path);
+        return in_array(session_status(), [PHP_SESSION_ACTIVE, PHP_SESSION_NONE], true);
     }
 
     public static function test_dom()


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      |  The core PHP session test of PrestaShop checks if the sessions directory is writable, which does not always work as expected. Combined with an `open_basedir` configured without the `session.save_path`, PHP sessions are still working as intended, but the test_sessions function fails. In such a case, the One Click Upgrade module will fail checking its prerequisites in an attempt to make an upgrade. A fix was already opened for the autoupgrade module itself, but it should be also fixed in the core.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Have a PrestaShop 1.6 or higher. Configure open_basedir and don't include session.save_path. Go to Module list > Upgrade One Click Upgrade to 4.15.0 > Configure the module, then see the error.
| Fixed ticket?     | Fixes #30658
| Related PRs       | Fix in autoupgrade module - the module will use it's own check - https://github.com/PrestaShop/autoupgrade/pull/561
| Sponsor company   | Profileo

Original solution provided by @alexandre-profileo in https://github.com/PrestaShop/PrestaShop/pull/31053