### PR TITLE
Fix position in category setter from WS

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7176,7 +7176,9 @@ class ProductCore extends ObjectModel
         // result is indexed by recordset order and not position. positions start at index 1 so we need an empty element
         array_unshift($result, null);
         foreach ($result as &$value) {
-            $value = $value['id_product'];
+            if (null !== $value) {
+                $value = $value['id_product'];
+            }
         }
 
         $current_position = $this->getWsPositionInCategory();

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7173,13 +7173,11 @@ class ProductCore extends ObjectModel
             return false;
         }
 
+        foreach ($result as &$value) {
+            $value = $value['id_product'];
+        }
         // result is indexed by recordset order and not position. positions start at index 1 so we need an empty element
         array_unshift($result, null);
-        foreach ($result as &$value) {
-            if (null !== $value) {
-                $value = $value['id_product'];
-            }
-        }
 
         $current_position = $this->getWsPositionInCategory();
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When trying to fetch and update a product using the WS you'll get this error if you fetch and return all the writable informations, the modified code seems obvious that if you prepend null and try to find a key on an null object it will throw an error
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | idk what it means
| Deprecations?     | no
| How to test?      | Try to fetch a product with `'display' => 'full'`, remove `manufacturer_name` and `quantity` bc it's not writable and push that product, you'll get this 500 error as a NOTICE
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/31252
| Related PRs       | None
| Sponsor company   | 
