### PR TITLE
Fix undefined index precision

### DIFF
--- a/classes/Context.php
+++ b/classes/Context.php
@@ -554,9 +554,9 @@ class ContextCore
     {
         if ($this->priceComputingPrecision === null) {
             $computingPrecision = new ComputingPrecision();
-            //If currency is not set, we use the default currency
-            if(!isset($this->currency)){
-                $currency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
+            // If the currency is not set, we use the default currency
+            if (!isset($this->currency)) {
+                $currency = new Currency((int) Configuration::get('PS_CURRENCY_DEFAULT'));
                 $this->currency = $currency;
             }
             $this->priceComputingPrecision = $computingPrecision->getPrecision($this->currency->precision);

--- a/classes/Context.php
+++ b/classes/Context.php
@@ -554,9 +554,13 @@ class ContextCore
     {
         if ($this->priceComputingPrecision === null) {
             $computingPrecision = new ComputingPrecision();
+            //If currency is not set, we use the default currency
+            if(!isset($this->currency)){
+                $currency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
+                $this->currency = $currency;
+            }
             $this->priceComputingPrecision = $computingPrecision->getPrecision($this->currency->precision);
         }
-
         return $this->priceComputingPrecision;
     }
 }


### PR DESCRIPTION
Fix this error
Argument 1 passed to PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision::getPrecision() must be of the type int, null given, called in /var/www/vhost/xxx.com/home/html/classes/Context.php on line 489


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | When you use this method with a currency without this variable, php throw this exception: <br>Argument 1 passed to PrestaShop\PrestaShop\Core\Localization\CLDR\ComputingPrecision::getPrecision() must be of the type int, null given, called in /var/www/vhost/xxx.com/home/html/classes/Context.php on line 489
| Type?             | bug fix 
| Category?         |  FO
| BC breaks?        | yes 
| Deprecations?     | no
| Fixed ticket?     | -
| Related PRs       |  https://github.com/PrestaShop/PrestaShop/pull/30167
| How to test?      | Use a currency with no currency on context
| Possible impacts? | Do not crash when no currency->precision


<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
