### PR TITLE
Fix blank schema with null values

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7175,7 +7175,7 @@ class ProductCore extends ObjectModel
     {
         $result = $this->getCover($this->id);
 
-        return $result['id_image'];
+        return $result ? $result['id_image'] : null;
     }
 
     /**

--- a/classes/webservice/WebserviceOutputBuilder.php
+++ b/classes/webservice/WebserviceOutputBuilder.php
@@ -713,10 +713,10 @@ class WebserviceOutputBuilderCore
             if (!is_array($this->fieldsToDisplay) || in_array($field_name, $this->fieldsToDisplay[$assoc_name])) {
                 if ($field_name == 'id' && !isset($field['sqlId'])) {
                     $field['sqlId'] = 'id';
-                    $field['value'] = $object_assoc['id'];
+                    $field['value'] = isset($object_assoc['id']) ? $object_assoc['id'] : null;
                 } elseif (!isset($field['sqlId'])) {
                     $field['sqlId'] = $field_name;
-                    $field['value'] = $object_assoc[$field_name];
+                    $field['value'] = isset($object_assoc[$field_name]) ? $object_assoc[$field_name] : null;
                 }
                 $field['entities_name'] = $assoc_name;
                 $field['entity_name'] = $resource_name;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | While trying to fetch a blank schema for products reference, you'll get a 500 error while trying to fill null association as example
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | still don't know what it means sorry
| Deprecations?     | no
| How to test?      | Try to fetch `https://example.prestashop.com/api/products?schema=blank` route to get products blank schema
| Fixed ticket?     | Fixes #31263 
| Related PRs       | https://github.com/PrestaShop/PrestaShop/commit/26b6234c75e9fec8c4df8fb4ab11f826fc9f4429 for develop branch
| Sponsor company   | None
