### PR TITLE
Functional Tests : Fixed Warning `Warning: fetchStandardFontData: failed to fetch file "FoxitSans.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".`

### DIFF
--- a/tests/UI/utils/files.ts
+++ b/tests/UI/utils/files.ts
@@ -62,7 +62,10 @@ export default {
    * @returns {Promise<boolean>}
    */
   async isTextInPDF(filePath: string, text: string): Promise<boolean> {
-    const pdf = await getDocument(filePath).promise;
+    const pdf = await getDocument({
+      url: filePath,
+      standardFontDataUrl: path.join(path.dirname(__dirname), 'node_modules/pdfjs-dist/standard_fonts/'),
+    }).promise;
     const maxPages = pdf.numPages;
     const pageTextPromises = [];
 
@@ -81,7 +84,10 @@ export default {
    * @return {Promise<number>}
    */
   async getImageNumberInPDF(filePath: string): Promise<number> {
-    const pdf = await getDocument(filePath).promise;
+    const pdf = await getDocument({
+      url: filePath,
+      standardFontDataUrl: path.join(path.dirname(__dirname), 'node_modules/pdfjs-dist/standard_fonts/'),
+    }).promise;
     const nbrPages = pdf.numPages;
     let imageNumber = 0;
 


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Functional Tests : Fixed Warning `Warning: fetchStandardFontData: failed to fetch file "FoxitSans.pfb" with "UnknownErrorException: The standard font "baseUrl" parameter must be specified, ensure that the "standardFontDataUrl" API parameter is provided.".`
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4134620724
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## Before
![image](https://user-images.githubusercontent.com/1533248/217822576-430abd17-e6fb-4fe3-98ac-f4ec7b518ac3.png)

## After
![image](https://user-images.githubusercontent.com/1533248/217822657-47d75d85-16e7-487c-b6fb-cd73fcdf1b1a.png)


