### PR TITLE
New hook for performing actions when address change on cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -337,6 +337,8 @@ class CartCore extends ObjectModel
             WHERE  `id_cart` = ' . (int) $this->id . '
                 AND `id_address_delivery` = ' . (int) $id_address;
         Db::getInstance()->execute($sql);
+
+        Hook::exec('actionUpdateCartAddress', ['cart' => $this, 'oldAddressId' => (int) $id_address, 'newAddressId' => (int) $id_address_new]);
     }
 
     /**
@@ -363,6 +365,8 @@ class CartCore extends ObjectModel
             WHERE  `id_cart` = ' . (int) $this->id . '
                 AND `id_address_delivery` = ' . $currentAddressId;
         Db::getInstance()->execute($sql);
+
+        Hook::exec('actionUpdateCartAddress', ['cart' => $this, 'oldAddressId' => $currentAddressId, 'newAddressId' => $newAddressId]);
     }
 
     /**

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4494,5 +4494,10 @@
       <title>Modify customer thread grid template data</title>
       <description>This hook allows to modify data which is about to be used in template for customer thread grid</description>
     </hook>
+    <hook id="actionUpdateCartAddress">
+      <name>actionUpdateCartAddress</name>
+      <title>Triggers after changing address on the cart</title>
+      <description>This hook is called after address is changed on the cart</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
New hook for performing actions when address change on cart

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This PR adds a new hooks actionUpdateCartAddress that triggers when address is changed on cart. This is usefull for recalculating shipping or checking if customer changes from private to buisness address for instance.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   |  Prestaworks AB
| Related PRs | https://github.com/PrestaShop/autoupgrade/pull/563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new event trigger that activates after the delivery address on the cart is updated, allowing integrations to respond to address changes in the cart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->