### PR TITLE
Mitigate multiple function call CartPresenter::present

### DIFF
--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Presenter\Cart;
 
+use Cache;
 use Cart;
 use CartRule;
 use Configuration;

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -315,6 +315,10 @@ class CartPresenter implements PresenterInterface
      */
     public function present($cart, $shouldSeparateGifts = false)
     {
+        $cache_id = 'presentedCart_' . (int)$shouldSeparateGifts;
+        if (Cache::isStored($cache_id)) {
+            return Cache::retrieve($cache_id);
+        }
         if (!is_a($cart, 'Cart')) {
             throw new \Exception('CartPresenter can only present instance of Cart');
         }
@@ -489,6 +493,8 @@ class CartPresenter implements PresenterInterface
         Hook::exec('actionPresentCart',
             ['presentedCart' => &$result]
         );
+
+        Cache::store($cache_id, $result);
 
         return $result;
     }

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -316,7 +316,7 @@ class CartPresenter implements PresenterInterface
      */
     public function present($cart, $shouldSeparateGifts = false)
     {
-        $cache_id = 'presentedCart_' . (int)$shouldSeparateGifts;
+        $cache_id = 'presentedCart_' . (int) $shouldSeparateGifts;
         if (Cache::isStored($cache_id)) {
             return Cache::retrieve($cache_id);
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Mitigate multiple redundant function calls using cache
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Put debug_print_backtrace in the function CAtrPresenter::present and observe.
| Fixed ticket?     | Fixes #31299
| Related PRs       | none
| Sponsor company   | Société Biblique de Genève
