### PR TITLE
Update sources.html.twig

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
@@ -26,13 +26,14 @@
   {% if orderForViewing.sources.sources is not empty %}
     <div class="card mt-2 d-print-none">
       <div class="card-header">
-        <div class="row">
           <div class="col-md-6">
             <i class="material-icons">public</i>
             {{ 'Sources'|trans({}, 'Admin.Orderscustomers.Feature') }}
             <span class="badge badge-primary rounded">{{ orderForViewing.sources.sources|length }}</span>
           </div>
+        </div>
 
+      <div class="card-body">
           <ul id="order-sources-list">
             {% for source in orderForViewing.sources.sources %}
               <li>
@@ -58,6 +59,5 @@
             {% endfor %}
           </ul>
         </div>
-      </div>
     </div>
   {% endif %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Order/Order/Blocks/View/sources.html.twig
@@ -26,11 +26,9 @@
   {% if orderForViewing.sources.sources is not empty %}
     <div class="card mt-2 d-print-none">
       <div class="card-header">
-          <div class="col-md-6">
             <i class="material-icons">public</i>
             {{ 'Sources'|trans({}, 'Admin.Orderscustomers.Feature') }}
             <span class="badge badge-primary rounded">{{ orderForViewing.sources.sources|length }}</span>
-          </div>
         </div>
 
       <div class="card-body">


### PR DESCRIPTION
On backend sources, it looks not good bottom of the page. Because the header takes over half of the page (col-md-6) and the other half is for sources. I think you can use card-header and card-body classes. If it's possible also can you add scroll for card-body for sources ( something like: overflow: auto; max-height: 40vh;). If the source is long then the admin order page is so long.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x / 8.0.x
| Description?      |  Backend order sources are looks really bad. Header is taking over half of the page.
| Type?             | bug fix 
| Category?         |  BO
| BC breaks?        |  no
| Deprecations?     | no
| How to test?      | Please look the backend admin any order view sources tab before and after this changes
| Fixed ticket?     | I don't have ticket
| Related PRs       | No
| Sponsor company   | 4eck-Media
