### PR TITLE
Introduce manufacturer presenter

### DIFF
--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -25,6 +25,7 @@
  */
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+use PrestaShop\PrestaShop\Adapter\Presenter\Manufacturer\ManufacturerPresenter;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Product\ProductListingPresenter;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
@@ -434,15 +435,11 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 $product_for_template = $filteredProduct['object'];
             }
 
-            $productManufacturer = new Manufacturer((int) $this->product->id_manufacturer, $this->context->language->id);
-
-            $manufacturerImageUrl = $this->context->link->getManufacturerImageLink($productManufacturer->id);
-            $undefinedImage = $this->context->link->getManufacturerImageLink(0);
-            if ($manufacturerImageUrl === $undefinedImage) {
-                $manufacturerImageUrl = null;
-            }
-
-            $productBrandUrl = $this->context->link->getManufacturerLink($productManufacturer->id);
+            $manufacturerPresenter = new ManufacturerPresenter($this->context->link);
+            $productManufacturer = $manufacturerPresenter->present(
+                new Manufacturer((int) $this->product->id_manufacturer, $this->context->language->id),
+                $this->context->language
+            );
 
             $this->context->smarty->assign([
                 'priceDisplay' => $priceDisplay,
@@ -453,8 +450,8 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                 'product' => $product_for_template,
                 'displayUnitPrice' => !empty($this->product->unity) && $this->product->unit_price > 0.000000,
                 'product_manufacturer' => $productManufacturer,
-                'manufacturer_image_url' => $manufacturerImageUrl,
-                'product_brand_url' => $productBrandUrl,
+                'manufacturer_image_url' => $productManufacturer['image']['small']['url'],
+                'product_brand_url' => $productManufacturer['url'],
             ]);
 
             // Assign attribute groups to the template

--- a/src/Adapter/Presenter/Manufacturer/ManufacturerLazyArray.php
+++ b/src/Adapter/Presenter/Manufacturer/ManufacturerLazyArray.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Manufacturer;
+
+use Language;
+use Link;
+use Manufacturer;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+use PrestaShop\PrestaShop\Adapter\Presenter\AbstractLazyArray;
+
+class ManufacturerLazyArray extends AbstractLazyArray
+{
+    /**
+     * @var ImageRetriever
+     */
+    private $imageRetriever;
+
+    /**
+     * @var Link
+     */
+    private $link;
+
+    /**
+     * @var array
+     */
+    protected $manufacturer;
+
+    /**
+     * @var Language
+     */
+    private $language;
+
+    public function __construct(
+        array $manufacturer,
+        Language $language,
+        ImageRetriever $imageRetriever,
+        Link $link
+    ) {
+        $this->manufacturer = $manufacturer;
+        $this->language = $language;
+        $this->imageRetriever = $imageRetriever;
+        $this->link = $link;
+
+        parent::__construct();
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->manufacturer['id_manufacturer'];
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->manufacturer['name'];
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return string
+     */
+    public function getText()
+    {
+        return $this->manufacturer['short_description'];
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return string
+     */
+    public function getShortDescription()
+    {
+        return $this->manufacturer['short_description'];
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->manufacturer['description'];
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->link->getManufacturerLink($this->manufacturer['id']);
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return array|null
+     */
+    public function getImage()
+    {
+        return $this->imageRetriever->getImage(
+            new Manufacturer($this->manufacturer['id'], $this->language->getId()),
+            $this->manufacturer['id']
+        );
+    }
+
+    /**
+     * @arrayAccess
+     *
+     * @return int
+     */
+    public function getNbProducts()
+    {
+        if (!isset($this->manufacturer['nb_products']) || $this->manufacturer['nb_products'] === null) {
+            $this->manufacturer['nb_products'] = count(
+                (new Manufacturer($this->manufacturer['id'], $this->language->getId()))
+                    ->getProductsLite($this->language->getId())
+            );
+        }
+
+        return $this->manufacturer['nb_products'];
+    }
+}

--- a/src/Adapter/Presenter/Manufacturer/ManufacturerLazyArray.php
+++ b/src/Adapter/Presenter/Manufacturer/ManufacturerLazyArray.php
@@ -148,6 +148,7 @@ class ManufacturerLazyArray extends AbstractLazyArray
      */
     public function getNbProducts()
     {
+        /* @phpstan-ignore-next-line */
         if (!isset($this->manufacturer['nb_products']) || $this->manufacturer['nb_products'] === null) {
             $this->manufacturer['nb_products'] = count(
                 (new Manufacturer($this->manufacturer['id'], $this->language->getId()))

--- a/src/Adapter/Presenter/Manufacturer/ManufacturerLazyArray.php
+++ b/src/Adapter/Presenter/Manufacturer/ManufacturerLazyArray.php
@@ -148,8 +148,7 @@ class ManufacturerLazyArray extends AbstractLazyArray
      */
     public function getNbProducts()
     {
-        /* @phpstan-ignore-next-line */
-        if (!isset($this->manufacturer['nb_products']) || $this->manufacturer['nb_products'] === null) {
+        if (!isset($this->manufacturer['nb_products'])) {
             $this->manufacturer['nb_products'] = count(
                 (new Manufacturer($this->manufacturer['id'], $this->language->getId()))
                     ->getProductsLite($this->language->getId())

--- a/src/Adapter/Presenter/Manufacturer/ManufacturerPresenter.php
+++ b/src/Adapter/Presenter/Manufacturer/ManufacturerPresenter.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+namespace PrestaShop\PrestaShop\Adapter\Presenter\Manufacturer;
+
+use Hook;
+use Language;
+use Link;
+use Manufacturer;
+use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
+
+class ManufacturerPresenter
+{
+    /**
+     * @var ImageRetriever
+     */
+    protected $imageRetriever;
+
+    /**
+     * @var Link
+     */
+    protected $link;
+
+    public function __construct(Link $link)
+    {
+        $this->link = $link;
+        $this->imageRetriever = new ImageRetriever($link);
+    }
+
+    /**
+     * @param array|Manufacturer $manufacturer Manufacturer object or an array
+     * @param Language $language
+     *
+     * @return ManufacturerLazyArray
+     */
+    public function present($manufacturer, $language)
+    {
+        // Convert to array if a Manufacturer object was passed
+        if (is_object($manufacturer)) {
+            $manufacturer = (array) $manufacturer;
+        }
+
+        // Normalize IDs
+        if (empty($manufacturer['id_manufacturer'])) {
+            $manufacturer['id_manufacturer'] = $manufacturer['id'];
+        }
+        if (empty($manufacturer['id'])) {
+            $manufacturer['id'] = $manufacturer['id_manufacturer'];
+        }
+
+        $manufacturerLazyArray = new ManufacturerLazyArray(
+            $manufacturer,
+            $language,
+            $this->imageRetriever,
+            $this->link
+        );
+
+        Hook::exec('actionPresentManufacturer',
+            ['presentedManufacturer' => &$manufacturerLazyArray]
+        );
+
+        return $manufacturerLazyArray;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Introduces manufacturer presenter that allows us to standardize manufacturer object in front office. It standardizes the way image is delivered, allows the use of multiple sizes, image formats, provides manufacturer URL on demand, lazy load things.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | yes - Manufacturer miniature on brands page is accessing $image and as a final url, now it's an standard array with sizes. Also, nb_products now only returns an integer, not a complete string. It should be a template responsibility to do whatever it wants with it.
| Deprecations?     | no
| How to test?      | Install this PR, install PR for classic theme - https://github.com/PrestaShop/classic-theme/pull/112. Check that manufacturers are still correctly displayed on the product page and on their listing. If you enable new image system and enable WebPs, you will see `<picture>` tags on brands page and on product page.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

### BC breaks
- See https://github.com/PrestaShop/classic-theme/pull/112 on how to adapt your theme.
- Accessing manufacturer image syntax must be changed on manufacturer page. On product page, I added a fallback.
- This code needs to be moved into template on manufacturer page:
```
$manufacturers_for_display[$manufacturer['id_manufacturer']]['nb_products'] = $manufacturer['nb_products'] > 1 ? ($this->trans('%number% products', ['%number%' => $manufacturer['nb_products']], 'Shop.Theme.Catalog')) : $this->trans('%number% product', ['%number%' => $manufacturer['nb_products']], 'Shop.Theme.Catalog');
```