### PR TITLE
Remove legacy images

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -442,9 +442,6 @@ class ImageCore extends ObjectModel
                 $newPath = $imageNew->getPathForCreation();
                 foreach ($imagesTypes as $imageType) {
                     if (file_exists(_PS_PRODUCT_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '.jpg')) {
-                        if (!Configuration::get('PS_LEGACY_IMAGES')) {
-                            $imageNew->createImgFolder();
-                        }
                         copy(
                             _PS_PRODUCT_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '.jpg',
                         $newPath . '-' . $imageType['name'] . '.jpg'
@@ -742,11 +739,7 @@ class ImageCore extends ObjectModel
         }
 
         if (!$this->existing_path) {
-            if (Configuration::get('PS_LEGACY_IMAGES') && file_exists(_PS_PRODUCT_IMG_DIR_ . $this->id_product . '-' . $this->id . '.' . $this->image_format)) {
-                $this->existing_path = $this->id_product . '-' . $this->id;
-            } else {
-                $this->existing_path = $this->getImgPath();
-            }
+            $this->existing_path = $this->getImgPath();
         }
 
         return $this->existing_path;
@@ -926,15 +919,8 @@ class ImageCore extends ObjectModel
         if (!$this->id) {
             return false;
         }
-        if (Configuration::get('PS_LEGACY_IMAGES')) {
-            if (!$this->id_product) {
-                return false;
-            }
-            $path = $this->id_product . '-' . $this->id;
-        } else {
-            $path = $this->getImgPath();
-            $this->createImgFolder();
-        }
+        $path = $this->getImgPath();
+        $this->createImgFolder();
 
         return _PS_PRODUCT_IMG_DIR_ . $path;
     }

--- a/classes/Image.php
+++ b/classes/Image.php
@@ -442,6 +442,7 @@ class ImageCore extends ObjectModel
                 $newPath = $imageNew->getPathForCreation();
                 foreach ($imagesTypes as $imageType) {
                     if (file_exists(_PS_PRODUCT_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '.jpg')) {
+                        $imageNew->createImgFolder();
                         copy(
                             _PS_PRODUCT_IMG_DIR_ . $imageOld->getExistingImgPath() . '-' . $imageType['name'] . '.jpg',
                         $newPath . '-' . $imageType['name'] . '.jpg'

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -981,7 +981,7 @@ class LinkCore
      * Note: image filesystem stores product images in subdirectories of img/p/.
      *
      * @param string $name Rewrite link of the image
-     * @param string $idImage Numeric ID of product image or a name of default image like "fr-default"
+     * @param string|int $idImage Numeric ID of product image or a name of default image like "fr-default"
      * @param string|null $type
      *
      * @return string
@@ -989,6 +989,7 @@ class LinkCore
     public function getImageLink($name, $idImage, $type = null, string $extension = 'jpg')
     {
         $type = ($type ? '-' . $type : '');
+        $idImage = (string) $idImage;
 
         // Default image like "fr-default"
         if (strpos($idImage, 'default') !== false) {

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -981,7 +981,7 @@ class LinkCore
      * Note: image filesystem stores product images in subdirectories of img/p/.
      *
      * @param string $name Rewrite link of the image
-     * @param string|int $idImage Numeric ID of product image or a name of default image like "fr-default".
+     * @param string|int $idImage numeric ID of product image or a name of default image like "fr-default"
      * @param string|null $type
      *
      * @return string
@@ -999,7 +999,7 @@ class LinkCore
         // Regular image with numeric ID
         } else {
             // We will still process the old way of requesting images in a form of productID-imageID, but notify developers
-            if (strpos($idImage, "-")) {
+            if (strpos($idImage, '-')) {
                 $idImage = explode('-', $idImage)[1];
                 if (_PS_MODE_DEV_) {
                     trigger_error(

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -981,7 +981,7 @@ class LinkCore
      * Note: image filesystem stores product images in subdirectories of img/p/.
      *
      * @param string $name Rewrite link of the image
-     * @param string|int $idImage Numeric ID of product image or a name of default image like "fr-default"
+     * @param string|int $idImage Numeric ID of product image or a name of default image like "fr-default".
      * @param string|null $type
      *
      * @return string
@@ -998,6 +998,17 @@ class LinkCore
 
         // Regular image with numeric ID
         } else {
+            // We will still process the old way of requesting images in a form of productID-imageID, but notify developers
+            if (strpos($idImage, "-")) {
+                $idImage = explode('-', $idImage)[1];
+                if (_PS_MODE_DEV_) {
+                    trigger_error(
+                        'Passing image identifier in the old format is deprecated, use only image ID. This fallback will be removed in next major.',
+                        E_USER_DEPRECATED
+                    );
+                }
+            }
+
             $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . $type . '-' . (int) Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
 
             // If friendly URLs are enabled

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -981,20 +981,31 @@ class LinkCore
      * Note: image filesystem stores product images in subdirectories of img/p/.
      *
      * @param string $name Rewrite link of the image
-     * @param string $idImage ID of product image
+     * @param string $idImage Numeric ID of product image or a name of default image like "fr-default"
      * @param string|null $type
      *
      * @return string
      */
     public function getImageLink($name, $idImage, $type = null, string $extension = 'jpg')
     {
-        $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . '-' . (int) Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
-        // If friendly URLs are enabled
-        if ($this->allow) {
-            $uriPath = __PS_BASE_URI__ . $idImage . ($type ? '-' . $type : '') . $theme . '/' . $name . '.' . $extension;
-        // If friendly URLs are disabled
+        $type = ($type ? '-' . $type : '');
+
+        // Default image like "fr-default"
+        if (strpos($idImage, 'default') !== false) {
+            $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . $idImage . $type . '-' . Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
+            $uriPath = _THEME_PROD_DIR_ . $idImage . $type . $theme . '.' . $extension;
+
+        // Regular image with numeric ID
         } else {
-            $uriPath = _THEME_PROD_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . $theme . '.' . $extension;
+            $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . $type . '-' . (int) Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
+
+            // If friendly URLs are enabled
+            if ($this->allow) {
+                $uriPath = __PS_BASE_URI__ . $idImage . $type . $theme . '/' . $name . '.' . $extension;
+            // If friendly URLs are disabled
+            } else {
+                $uriPath = _THEME_PROD_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . $type . $theme . '.' . $extension;
+            }
         }
 
         return $this->protocol_content . Tools::getMediaServer($uriPath) . $uriPath;

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -988,29 +988,17 @@ class LinkCore
      */
     public function getImageLink($name, $ids, $type = null, string $extension = 'jpg')
     {
-        $notDefault = false;
-        $psLegacyImages = Configuration::get('PS_LEGACY_IMAGES');
-
         // legacy mode or default image
         $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . '-' . Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
-        if (($psLegacyImages
-                && (file_exists(_PS_PRODUCT_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . $theme . '.' . $extension)))
-            || ($notDefault = strpos($ids, 'default') !== false)) {
-            if ($this->allow && !$notDefault) {
-                $uriPath = __PS_BASE_URI__ . $ids . ($type ? '-' . $type : '') . $theme . '/' . $name . '.' . $extension;
-            } else {
-                $uriPath = _THEME_PROD_DIR_ . $ids . ($type ? '-' . $type : '') . $theme . '.' . $extension;
-            }
+
+        // if ids if of the form id_product-id_image, we want to extract the id_image part
+        $splitIds = explode('-', $ids);
+        $idImage = (isset($splitIds[1]) ? $splitIds[1] : $splitIds[0]);
+        $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . '-' . (int) Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
+        if ($this->allow) {
+            $uriPath = __PS_BASE_URI__ . $idImage . ($type ? '-' . $type : '') . $theme . '/' . $name . '.' . $extension;
         } else {
-            // if ids if of the form id_product-id_image, we want to extract the id_image part
-            $splitIds = explode('-', $ids);
-            $idImage = (isset($splitIds[1]) ? $splitIds[1] : $splitIds[0]);
-            $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . '-' . (int) Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
-            if ($this->allow) {
-                $uriPath = __PS_BASE_URI__ . $idImage . ($type ? '-' . $type : '') . $theme . '/' . $name . '.' . $extension;
-            } else {
-                $uriPath = _THEME_PROD_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . $theme . '.' . $extension;
-            }
+            $uriPath = _THEME_PROD_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . $theme . '.' . $extension;
         }
 
         return $this->protocol_content . Tools::getMediaServer($uriPath) . $uriPath;

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -978,25 +978,21 @@ class LinkCore
 
     /**
      * Returns a link to a product image for display
-     * Note: the new image filesystem stores product images in subdirectories of img/p/.
+     * Note: image filesystem stores product images in subdirectories of img/p/.
      *
-     * @param string $name rewrite link of the image
-     * @param string $ids id part of the image filename - can be "id_product-id_image" (legacy support, recommended) or "id_image" (new)
+     * @param string $name Rewrite link of the image
+     * @param string $idImage ID of product image
      * @param string|null $type
      *
      * @return string
      */
-    public function getImageLink($name, $ids, $type = null, string $extension = 'jpg')
+    public function getImageLink($name, $idImage, $type = null, string $extension = 'jpg')
     {
-        // legacy mode or default image
-        $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . $ids . ($type ? '-' . $type : '') . '-' . Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
-
-        // if ids if of the form id_product-id_image, we want to extract the id_image part
-        $splitIds = explode('-', $ids);
-        $idImage = (isset($splitIds[1]) ? $splitIds[1] : $splitIds[0]);
         $theme = ((Shop::isFeatureActive() && file_exists(_PS_PRODUCT_IMG_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . '-' . (int) Context::getContext()->shop->theme_name . '.jpg')) ? '-' . Context::getContext()->shop->theme_name : '');
+        // If friendly URLs are enabled
         if ($this->allow) {
             $uriPath = __PS_BASE_URI__ . $idImage . ($type ? '-' . $type : '') . $theme . '/' . $name . '.' . $extension;
+        // If friendly URLs are disabled
         } else {
             $uriPath = _THEME_PROD_DIR_ . Image::getImgFolderStatic($idImage) . $idImage . ($type ? '-' . $type : '') . $theme . '.' . $extension;
         }

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -5529,8 +5529,8 @@ class ProductCore extends ObjectModel
      */
     public static function defineProductImage($row, $id_lang)
     {
-        if (isset($row['id_image']) && $row['id_image']) {
-            return $row['id_product'] . '-' . $row['id_image'];
+        if (!empty($row['id_image'])) {
+            return $row['id_image'];
         }
 
         return Language::getIsoById((int) $id_lang) . '-default';

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2456,14 +2456,6 @@ class ToolsCore
                 if ($rewrite_settings) {
                     // Compatibility with the old image filesystem
                     fwrite($write_fd, "# Images\n");
-                    if (Configuration::get('PS_LEGACY_IMAGES')) {
-                        fwrite($write_fd, $media_domains);
-                        fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^([a-z0-9]+\-[a-z0-9]+\-[-\w]*)/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/p/$1$2.jpg [L]' . PHP_EOL);
-                        fwrite($write_fd, $media_domains);
-                        fwrite($write_fd, $domain_rewrite_cond);
-                        fwrite($write_fd, 'RewriteRule ^([\d]+(?:\-[\d]+){1,2})/.+(\.(?:jpe?g|webp|png|avif))$ %{ENV:REWRITEBASE}img/p/$1$2.jpg [L]' . PHP_EOL);
-                    }
 
                     // Rewrite product images < 10 millions
                     $path_components = [];

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1093,7 +1093,7 @@ class AdminControllerCore extends Controller
             foreach ($this->fields_list as $key => $params) {
                 $field_value = isset($row[$key]) ? Tools::htmlentitiesDecodeUTF8(Tools::nl2br($row[$key])) : '';
                 if ($key == 'image') {
-                    if ($params['image'] != 'p' || Configuration::get('PS_LEGACY_IMAGES')) {
+                    if ($params['image'] != 'p') {
                         $path_to_image = Tools::getShopDomain(true) . _PS_IMG_ . $params['image'] . '/' . $row['id_' . $this->table] . (isset($row['id_image']) ? '-' . (int) $row['id_image'] : '') . '.' . $this->imageType;
                     } else {
                         $path_to_image = Tools::getShopDomain(true) . _PS_IMG_ . $params['image'] . '/' . Image::getImgFolderStatic($row['id_image']) . (int) $row['id_image'] . '.' . $this->imageType;

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -377,7 +377,7 @@ class HelperListCore extends Helper
                 } elseif (isset($params['image'])) {
                     // item_id is the product id in a product image context, else it is the image id.
                     $item_id = isset($params['image_id']) ? $tr[$params['image_id']] : $id;
-                    if ($params['image'] != 'p' || Configuration::get('PS_LEGACY_IMAGES')) {
+                    if ($params['image'] != 'p') {
                         $path_to_image = _PS_IMG_DIR_ . $params['image'] . '/' . $item_id . (isset($tr['id_image']) ? '-' . (int) $tr['id_image'] : '') . '.' . $this->imageType;
                     } else {
                         $path_to_image = _PS_IMG_DIR_ . $params['image'] . '/' . Image::getImgFolderStatic($tr['id_image']) . (int) $tr['id_image'] . '.' . $this->imageType;

--- a/classes/order/OrderDetail.php
+++ b/classes/order/OrderDetail.php
@@ -924,7 +924,7 @@ class OrderDetailCore extends ObjectModel
                 foreach ($order_products as &$order_product) {
                     $order_product['image'] = Context::getContext()->link->getImageLink(
                         $order_product['link_rewrite'],
-                        (int) $order_product['product_id'] . '-' . (int) $order_product['id_image'],
+                        (int) $order_product['id_image'],
                         ImageType::getFormattedName('medium')
                     );
                     $order_product['link'] = Context::getContext()->link->getProductLink(

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -34,7 +34,7 @@ class AdminImagesControllerCore extends AdminController
 {
     protected $start_time = 0;
     protected $max_execution_time = 7200;
-    protected $display_move;
+    protected $display_move = false;
 
     /**
      * @var bool
@@ -72,20 +72,6 @@ class AdminImagesControllerCore extends AdminController
             'suppliers' => ['title' => $this->trans('Suppliers', [], 'Admin.Global'), 'align' => 'center', 'type' => 'bool', 'callback' => 'printEntityActiveIcon', 'orderby' => false],
             'stores' => ['title' => $this->trans('Stores', [], 'Admin.Global'), 'align' => 'center', 'type' => 'bool', 'callback' => 'printEntityActiveIcon', 'orderby' => false],
         ];
-
-        // No need to display the old image system migration tool except if product images are in _PS_PRODUCT_IMG_DIR_
-        $this->display_move = false;
-        $dir = _PS_PRODUCT_IMG_DIR_;
-        if (is_dir($dir)) {
-            if ($dh = opendir($dir)) {
-                while (($file = readdir($dh)) !== false && $this->display_move == false) {
-                    if (!is_dir($dir . DIRECTORY_SEPARATOR . $file) && $file[0] != '.' && is_numeric($file[0])) {
-                        $this->display_move = true;
-                    }
-                }
-                closedir($dh);
-            }
-        }
     }
 
     public function init()
@@ -226,18 +212,6 @@ class AdminImagesControllerCore extends AdminController
                 'submit' => ['title' => $this->trans('Save', [], 'Admin.Actions')],
             ],
         ];
-
-        if ($this->display_move) {
-            $this->fields_options['product_images']['fields']['PS_LEGACY_IMAGES'] = [
-                'title' => $this->trans('Use the legacy image filesystem', [], 'Admin.Design.Feature'),
-                'hint' => $this->trans('This should be set to yes unless you successfully moved images in "Images" page under the "Preferences" menu.', [], 'Admin.Design.Help'),
-                'validation' => 'isBool',
-                'cast' => 'intval',
-                'required' => false,
-                'type' => 'bool',
-                'visibility' => Shop::CONTEXT_ALL,
-            ];
-        }
 
         $this->fields_form = [
             'legend' => [

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -745,7 +745,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
                                 if (isset($product_images[$id_image])) {
                                     $cover = $product_images[$id_image];
                                 }
-                                $cover['id_image'] = (Configuration::get('PS_LEGACY_IMAGES') ? ($this->product->id . '-' . $id_image) : (int) $id_image);
+                                $cover['id_image'] = (int) $id_image;
                                 $cover['id_image_only'] = (int) $id_image;
                                 $this->context->smarty->assign('cover', $cover);
                             }

--- a/controllers/front/ProductController.php
+++ b/controllers/front/ProductController.php
@@ -907,7 +907,7 @@ class ProductControllerCore extends ProductPresentingFrontControllerCore
     {
         $reg = '/\[img\-([0-9]+)\-(left|right)\-([a-zA-Z0-9-_]+)\]/';
         while (preg_match($reg, $desc, $matches)) {
-            $link_lmg = $this->context->link->getImageLink($this->product->link_rewrite, $this->product->id . '-' . $matches[1], $matches[3]);
+            $link_lmg = $this->context->link->getImageLink($this->product->link_rewrite, $matches[1], $matches[3]);
             $class = $matches[2] == 'left' ? 'class="imageFloatLeft"' : 'class="imageFloatRight"';
             $html_img = '<img src="' . $link_lmg . '" alt="" ' . $class . '/>';
             $desc = str_replace($matches[0], $html_img, $desc);

--- a/install-dev/data/xml/configuration.xml
+++ b/install-dev/data/xml/configuration.xml
@@ -386,9 +386,6 @@
   <configuration id="PS_OS_COD_VALIDATION" name="PS_OS_COD_VALIDATION">
     <value>13</value>
   </configuration>
-  <configuration id="PS_LEGACY_IMAGES" name="PS_LEGACY_IMAGES">
-    <value>0</value>
-  </configuration>
   <configuration id="PS_IMAGE_QUALITY" name="PS_IMAGE_QUALITY">
     <value>jpg</value>
   </configuration>

--- a/tests/Resources/modules_tests/override/AdminProductsController.php
+++ b/tests/Resources/modules_tests/override/AdminProductsController.php
@@ -3512,7 +3512,7 @@ class AdminProductsController extends AdminProductsControllerCore
         $images = Image::getImages($this->context->language->id, $product->id);
         if (is_array($images)) {
             foreach ($images as $k => $image) {
-                $images[$k]['src'] = $this->context->link->getImageLink($product->link_rewrite[$this->context->language->id], $product->id . '-' . $image['id_image'], ImageType::getFormattedName('small'));
+                $images[$k]['src'] = $this->context->link->getImageLink($product->link_rewrite[$this->context->language->id], $image['id_image'], ImageType::getFormattedName('small'));
             }
             $data->assign('images', $images);
         }

--- a/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -3660,7 +3660,7 @@ class AdminProductsController extends AdminProductsControllerCore
 
         if (is_array($images)) {
             foreach ($images as $k => $image) {
-                $images[$k]['src'] = $this->context->link->getImageLink($product->link_rewrite[$this->context->language->id], $product->id . '-' . $image['id_image'], ImageType::getFormattedName('small'));
+                $images[$k]['src'] = $this->context->link->getImageLink($product->link_rewrite[$this->context->language->id], $image['id_image'], ImageType::getFormattedName('small'));
             }
             $data->assign('images', $images);
         }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removes old functionality regarding legacy images. This was an old structure of images where all product images were in single folder, like categories or manufacturers. Prestashop is using the new system by default since 1.5.1.0.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | yes - It won't offer the migration in admin image controller. Also, requesting an image in old format idProduct-idImage will throw a deprecation notice in developer mode. `Deprecated: Passing image identifier in the old format is deprecated, use only image ID. This fallback will be removed in next major.`
| How to test?      | See that nothing changes and images still work fine. Maybe a dev could do the QA.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 
