### PR TITLE
Fix body classes for manufacturer and supplier listings

### DIFF
--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -32,7 +32,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
     /** @var string */
     public $php_self = 'manufacturer';
 
-    /** @var Manufacturer */
+    /** @var Manufacturer|null */
     protected $manufacturer;
     protected $label;
 
@@ -225,7 +225,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
             'url' => $this->context->link->getPageLink('manufacturer', true),
         ];
 
-        if (Validate::isLoadedObject($this->manufacturer) && $this->manufacturer->active && $this->manufacturer->isAssociatedToShop()) {
+        if (!empty($this->manufacturer)) {
             $breadcrumb['links'][] = [
                 'title' => $this->manufacturer->name,
                 'url' => $this->context->link->getManufacturerLink($this->manufacturer),
@@ -239,8 +239,10 @@ class ManufacturerControllerCore extends ProductListingFrontController
     {
         $page = parent::getTemplateVarPage();
 
-        $page['body_classes']['manufacturer-id-' . $this->manufacturer->id] = true;
-        $page['body_classes']['manufacturer-' . $this->manufacturer->name] = true;
+        if (!empty($this->manufacturer)) {
+            $page['body_classes']['manufacturer-id-' . $this->manufacturer->id] = true;
+            $page['body_classes']['manufacturer-' . $this->manufacturer->name] = true;
+        }
 
         return $page;
     }

--- a/controllers/front/listing/SupplierController.php
+++ b/controllers/front/listing/SupplierController.php
@@ -34,7 +34,7 @@ class SupplierControllerCore extends ProductListingFrontController
      */
     public $php_self = 'supplier';
 
-    /** @var Supplier */
+    /** @var Supplier|null */
     protected $supplier;
     protected $label;
 
@@ -228,7 +228,7 @@ class SupplierControllerCore extends ProductListingFrontController
             'url' => $this->context->link->getPageLink('supplier', true),
         ];
 
-        if (Validate::isLoadedObject($this->supplier) && $this->supplier->active && $this->supplier->isAssociatedToShop()) {
+        if (!empty($this->supplier)) {
             $breadcrumb['links'][] = [
                 'title' => $this->supplier->name,
                 'url' => $this->context->link->getSupplierLink($this->supplier),
@@ -242,8 +242,10 @@ class SupplierControllerCore extends ProductListingFrontController
     {
         $page = parent::getTemplateVarPage();
 
-        $page['body_classes']['supplier-id-' . $this->supplier->id] = true;
-        $page['body_classes']['supplier-' . $this->supplier->name] = true;
+        if (!empty($this->supplier)) {
+            $page['body_classes']['supplier-id-' . $this->supplier->id] = true;
+            $page['body_classes']['supplier-' . $this->supplier->name] = true;
+        }
 
         return $page;
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | In https://github.com/PrestaShop/PrestaShop/pull/29264, I did not realize there is also a case when there is no specific manufacturer = their listing. It was missed during QA. It throws `Warning: Attempt to read property "id" on null in controllers\front\listing\ManufacturerController.php on line 242` and `Warning: Attempt to read property "name" on null in controllers\front\listing\ManufacturerController.php on line 243`.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Visit `/brands` and see that the warnings are gone. Visit `/brand/2-graphic-corner` and see that body classes are still there.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/31320
| Related PRs       | 
| Sponsor company   | 
