### PR TITLE
Improve customer group selector

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
@@ -53,6 +53,7 @@ export default class CustomerForm {
     let firstGroupInList: number = 0;
     $(customerFormMap.customerGroupCheckboxes).each((index, input) => {
       const groupId = Number(<string> $(input).val());
+
       // We will keep track of all checked groups
       if ($(input).is(':checked')) {
         checkedGroups.push(groupId);

--- a/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
@@ -31,9 +31,55 @@ import ChangePasswordHandler from '../../components/change-password-handler';
  */
 export default class CustomerForm {
   constructor() {
+    // Watch password field change and strength indicator
     const passwordHandler = new ChangePasswordHandler(
       customerFormMap.passwordStrengthFeedbackContainer,
     );
     passwordHandler.watchPasswordStrength($(customerFormMap.passwordInput));
+
+    // Watch customer group checkbox change and if it was unchecked, 
+    // update default group below if it's no longer in the list.
+    $('input[type="checkbox"][name="customer[group_ids][]"]').on('change', (event) => {
+      this.checkOrUpdateDefaultGroup($(event.currentTarget).is(':checked'));
+    });
+  }
+
+  private checkOrUpdateDefaultGroup(wasChecked: boolean): void {
+    // Get currently selected group ID
+    const currentDefaultGroup = parseInt($("#customer_default_group_id option:selected").val() as string);
+
+    // Get all checked groups in group access
+    const checkedGroups: number[] = [];
+    let firstGroupInList: number = 0;
+    $('input[type="checkbox"][name="customer[group_ids][]"]').each((index, value) => {
+      // We will keep track of all checked groups
+      if ($(value).is(":checked")) {
+        checkedGroups.push(parseInt($(value).val() as string))
+      }
+      // And store ID of the first group regardless of it's status
+      if (index === 0) {
+        firstGroupInList = parseInt($(value).val() as string);
+      }
+    });
+
+    // If no groups are selected, use a the first group in the list, no matter 
+    // if it's selected or not.
+    if (!checkedGroups.length) {
+      $("#customer_default_group_id").val(firstGroupInList).trigger('change');
+      return;
+    }
+
+    // If the last change was a newly added group and it's the only one in the list,
+    // we will set it as the default group.
+    if (wasChecked && checkedGroups.length === 1) {
+      $("#customer_default_group_id").val(checkedGroups[0]).trigger('change');
+      return;
+    }
+
+    // If the default group is not in the list anymore, select the first checked group.
+    if (!checkedGroups.includes(currentDefaultGroup)) {
+      $("#customer_default_group_id").val(checkedGroups[0]).trigger('change');
+      return;
+    }
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
@@ -37,7 +37,7 @@ export default class CustomerForm {
     );
     passwordHandler.watchPasswordStrength($(customerFormMap.passwordInput));
 
-    // Watch customer group checkbox change and if it was unchecked, 
+    // Watch customer group checkbox change and if it was unchecked,
     // update default group below if it's no longer in the list.
     $('input[type="checkbox"][name="customer[group_ids][]"]').on('change', (event) => {
       this.checkOrUpdateDefaultGroup($(event.currentTarget).is(':checked'));
@@ -46,40 +46,39 @@ export default class CustomerForm {
 
   private checkOrUpdateDefaultGroup(wasChecked: boolean): void {
     // Get currently selected group ID
-    const currentDefaultGroup = parseInt($("#customer_default_group_id option:selected").val() as string);
+    const currentDefaultGroup = Number($('#customer_default_group_id option:selected').val() as string);
 
     // Get all checked groups in group access
     const checkedGroups: number[] = [];
     let firstGroupInList: number = 0;
     $('input[type="checkbox"][name="customer[group_ids][]"]').each((index, value) => {
       // We will keep track of all checked groups
-      if ($(value).is(":checked")) {
-        checkedGroups.push(parseInt($(value).val() as string))
+      if ($(value).is(':checked')) {
+        checkedGroups.push(Number($(value).val() as string));
       }
       // And store ID of the first group regardless of it's status
       if (index === 0) {
-        firstGroupInList = parseInt($(value).val() as string);
+        firstGroupInList = Number($(value).val() as string);
       }
     });
 
-    // If no groups are selected, use a the first group in the list, no matter 
+    // If no groups are selected, use a the first group in the list, no matter
     // if it's selected or not.
     if (!checkedGroups.length) {
-      $("#customer_default_group_id").val(firstGroupInList).trigger('change');
+      $('#customer_default_group_id').val(firstGroupInList).trigger('change');
       return;
     }
 
     // If the last change was a newly added group and it's the only one in the list,
     // we will set it as the default group.
     if (wasChecked && checkedGroups.length === 1) {
-      $("#customer_default_group_id").val(checkedGroups[0]).trigger('change');
+      $('#customer_default_group_id').val(checkedGroups[0]).trigger('change');
       return;
     }
 
     // If the default group is not in the list anymore, select the first checked group.
     if (!checkedGroups.includes(currentDefaultGroup)) {
-      $("#customer_default_group_id").val(checkedGroups[0]).trigger('change');
-      return;
+      $('#customer_default_group_id').val(checkedGroups[0]).trigger('change');
     }
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
@@ -39,46 +39,46 @@ export default class CustomerForm {
 
     // Watch customer group checkbox change and if it was unchecked,
     // update default group below if it's no longer in the list.
-    $('input[type="checkbox"][name="customer[group_ids][]"]').on('change', (event) => {
+    $(customerFormMap.customerGroupCheckboxes).on('change', (event) => {
       this.checkOrUpdateDefaultGroup($(event.currentTarget).is(':checked'));
     });
   }
 
   private checkOrUpdateDefaultGroup(wasChecked: boolean): void {
     // Get currently selected group ID
-    const currentDefaultGroup = Number($('#customer_default_group_id option:selected').val() as string);
+    const currentDefaultGroup = Number(<string> $(customerFormMap.defaultGroupSelectedOption).val());
 
     // Get all checked groups in group access
     const checkedGroups: number[] = [];
     let firstGroupInList: number = 0;
-    $('input[type="checkbox"][name="customer[group_ids][]"]').each((index, value) => {
+    $(customerFormMap.customerGroupCheckboxes).each((index, input) => {
       // We will keep track of all checked groups
-      if ($(value).is(':checked')) {
-        checkedGroups.push(Number($(value).val() as string));
+      if ($(input).is(':checked')) {
+        checkedGroups.push(Number(<string> $(input).val()));
       }
       // And store ID of the first group regardless of it's status
       if (index === 0) {
-        firstGroupInList = Number($(value).val() as string);
+        firstGroupInList = Number(<string> $(input).val());
       }
     });
 
-    // If no groups are selected, use a the first group in the list, no matter
+    // If no groups are selected, use the first group in the list, no matter
     // if it's selected or not.
     if (!checkedGroups.length) {
-      $('#customer_default_group_id').val(firstGroupInList).trigger('change');
+      $(customerFormMap.defaultGroupSelect).val(firstGroupInList).trigger('change');
       return;
     }
 
     // If the last change was a newly added group and it's the only one in the list,
     // we will set it as the default group.
     if (wasChecked && checkedGroups.length === 1) {
-      $('#customer_default_group_id').val(checkedGroups[0]).trigger('change');
+      $(customerFormMap.defaultGroupSelect).val(checkedGroups[0]).trigger('change');
       return;
     }
 
     // If the default group is not in the list anymore, select the first checked group.
     if (!checkedGroups.includes(currentDefaultGroup)) {
-      $('#customer_default_group_id').val(checkedGroups[0]).trigger('change');
+      $(customerFormMap.defaultGroupSelect).val(checkedGroups[0]).trigger('change');
     }
   }
 }

--- a/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/CustomerForm.ts
@@ -52,13 +52,14 @@ export default class CustomerForm {
     const checkedGroups: number[] = [];
     let firstGroupInList: number = 0;
     $(customerFormMap.customerGroupCheckboxes).each((index, input) => {
+      const groupId = Number(<string> $(input).val());
       // We will keep track of all checked groups
       if ($(input).is(':checked')) {
-        checkedGroups.push(Number(<string> $(input).val()));
+        checkedGroups.push(groupId);
       }
       // And store ID of the first group regardless of it's status
       if (index === 0) {
-        firstGroupInList = Number(<string> $(input).val());
+        firstGroupInList = groupId;
       }
     });
 

--- a/admin-dev/themes/new-theme/js/pages/customer/customer-form-map.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/customer-form-map.ts
@@ -31,4 +31,7 @@ export default {
   passwordStrengthFeedbackContainer: '.password-strength-feedback',
   requiredFieldsFormAlertOptin: '#customerRequiredFieldsAlertMessageOptin',
   requiredFieldsFormCheckboxOptin: '#customerRequiredFieldsContainer input[type="checkbox"][value="optin"]',
+  customerGroupCheckboxes: 'input[type="checkbox"][name="customer[group_ids][]"]',
+  defaultGroupSelect: '#customer_default_group_id',
+  defaultGroupSelectedOption: '#customer_default_group_id option:selected',
 };


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I improved the group selector on customer edit page, now it keeps the default group in sync. If you unselect the group that is currently default, it will jump to the next valid group. If it's the first group you checked, it's gonna get selected. See video.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Clone branch, build new-theme assets, play around with group checkboxes and see that default group reacts to it.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 


https://user-images.githubusercontent.com/6097524/218330746-49a93d1c-ef3f-44cc-b645-591dee58d690.mp4

