### PR TITLE
Fix product position in empty category

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7162,7 +7162,7 @@ class ProductCore extends ObjectModel
         $listIds = array_column($result, 'id_product');
         $count = count($result);
         if ($position > $count && in_array($this->id, $listIds)
-            || $position > $count + 1 && !in_array($this->id, $listIds)    
+            || $position > $count + 1 && !in_array($this->id, $listIds)
         ) {
             WebserviceRequest::getInstance()->setError(
                 500,

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7159,7 +7159,11 @@ class ProductCore extends ObjectModel
             'ORDER BY `position`'
         );
 
-        if ($position > count($result)) {
+        $listIds = array_column($result, 'id_product');
+        $count = count($result);
+        if ($position > $count && in_array($this->id, $listIds)
+            || $position > $count + 1 && !in_array($this->id, $listIds)    
+        ) {
             WebserviceRequest::getInstance()->setError(
                 500,
                 $this->trans(


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 1.7.8.8
| Description?      | When trying to push a product with the key position_in_category to 1 in an empty category you will trigger the error 135, saying that the product position is higher than the category's products count. This sould normally work. It should also work if I have already 3 products in my category and I want to set a new one to the 4th position.
| Type?             | bug fix / improvement
| Category?         | WS
| BC breaks?        | ?
| Deprecations?     | no
| How to test?      | Try to push a product in a empty category in `id_category_default` with `position_in_category` set to 1. It should work properly. Same as if you want to set a new category to a product. The category containing 3 products you want your product to be in 4th place. So push the `id_category_default` and `position_in_category` set to 4. It should work. Then test again the same request but with `position_in_category` set to 5, it should not work.
| Fixed ticket?     | Fixes #31340 , Fixes #14903 , Fixes #26761
| Related PRs       | 
| Sponsor company   | 
