### PR TITLE
Enable auto_reload for .twig templates in dev env

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -12,6 +12,9 @@ web_profiler:
   toolbar: '%use_debug_toolbar%'
   intercept_redirects: false
 
+twig:
+  auto_reload: true
+
 monolog:
   handlers:
     main:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When you change the .twig template you don't see any changes unless you clear the cache. This option will reload such templates automatically.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | QA by a dev. Details below.
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA

How to test? Before and after PR:

1. Enable dev mode.
2. Edit `src/PrestaShopBundle/Resources/views/Admin/Common/Grid/grid.html.twig`
3. Check if you see your changes on, for instance, the category list in BO.

Before this PR, you won't see any changes, you have to clear the cache. After this change, you'll see changes every time you modify .twig files.
