### PR TITLE
Fix a typo in xml hook list

### DIFF
--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -71,8 +71,8 @@
       <title>Main wrapper section (bottom)</title>
       <description>This hook displays new elements in the bottom of the main wrapper</description>
     </hook>
-    <hook id="dipslayContactContent">
-      <name>dipslayContactContent</name>
+    <hook id="displayContactContent">
+      <name>displayContactContent</name>
       <title>Content wrapper section of the contact page</title>
       <description>This hook displays new elements in the content wrapper of the contact page</description>
     </hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x 
| Description?      | Fixed a typo in the xml hook list. ps_contactinfo, hummingbird and classic_theme does not have the typo error.
| Type?             | bug fix 
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | -
| Fixed ticket?     | Fixes #31270 

