### PR TITLE
Add test for mismatching groups, fix the check in handler

### DIFF
--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -238,7 +238,7 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
         $groupIds = ($command->getGroupIds() === null ? $customer->getGroups() : $command->getGroupIds());
         $defaultGroupId = ($command->getDefaultGroupId() === null ? $customer->id_default_group : $command->getDefaultGroupId());
 
-        // If both was provided, we compare check it against submitted data
+        // Check if the default group is in the list of checked groups
         if (!in_array($defaultGroupId, $groupIds)) {
             throw new CustomerDefaultGroupAccessException(sprintf('Customer default group with id "%s" must be in access groups', $command->getDefaultGroupId()));
         }

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -229,16 +229,17 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
      */
     private function assertCustomerCanAccessDefaultGroup(Customer $customer, EditCustomerCommand $command)
     {
-        // if neither default group
-        // nor group ids are being edited
-        // then no need to assert
-        if (null === $command->getDefaultGroupId()
-            || null === $command->getGroupIds()
-        ) {
+        // If nothing is updated on groups, nothing to do here
+        if (null === $command->getDefaultGroupId() && null === $command->getGroupIds()) {
             return;
         }
 
-        if (!in_array($command->getDefaultGroupId(), $command->getGroupIds())) {
+        // Arrange data to compare, we will use customer's original data if not provided in the command
+        $groupIds = ($command->getGroupIds() === null ? $customer->getGroups() : $command->getGroupIds());
+        $defaultGroupId = ($command->getDefaultGroupId() === null ? $customer->id_default_group : $command->getDefaultGroupId());
+
+        // If both was provided, we compare check it against submitted data
+        if (!in_array($defaultGroupId, $groupIds)) {
             throw new CustomerDefaultGroupAccessException(sprintf('Customer default group with id "%s" must be in access groups', $command->getDefaultGroupId()));
         }
     }

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -176,3 +176,15 @@ Feature: Customer Management
       | defaultGroupId | Visitor                       |
       | groupIds       | [Customer]                    |
     Then I should be returned an error message 'Customer default group with id "1" must be in access groups'
+
+  Scenario: Fail to set mismatching groups on a customer
+    When I create a customer "CUST-13" with following properties:
+      | firstName      | Mathieu                            |
+      | lastName       | Customer                           |
+      | email          | customerethirteen@prestashop.com   |
+      | password       | PrestaShopForever1_!               |
+      | defaultGroupId | Customer                           |
+      | groupIds       | [Customer]                         |
+    And I attempt to edit customer "CUST-13" and I change the following properties:
+      | defaultGroupId | Visitor |
+    Then I should be returned an error message 'Customer default group with id "1" must be in access groups'

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -166,3 +166,13 @@ Feature: Customer Management
     And I attempt to edit customer "CUST-10" and I change the following properties:
       | email | customereleven@prestashop.com |
     Then I should be returned an error message 'Customer with email "customereleven@prestashop.com" already exists'
+
+  Scenario: Fail to create a customer with mismatching groups
+    When I attempt to create a customer "CUST-12" with following properties:
+      | firstName      | Mathieu                       |
+      | lastName       | Napoler                       |
+      | email          | customertwelve@prestashop.com |
+      | password       | PrestaShopForever1_!          |
+      | defaultGroupId | Visitor                       |
+      | groupIds       | [Customer]                    |
+    Then I should be returned an error message 'Customer default group with id "1" must be in access groups'


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below.
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Tests green.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

**Changes**
- Added a test that checks if a group mismatch assertion works correctly when creating a customer.
- Added a test that checks if a group mismatch assertion works correctly when editing a customer.
- When doing this, I discovered that the check in `EditCustomerHandler` works only if both default group and the group list are provided in the command. Which is true when using BO, but not in tests or when editing customer programatically. So I improved the assertion to use customer's original data for this check, if not provided.