### PR TITLE
Ignore attribute_quantity if stock management disabled

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -1285,6 +1285,7 @@ class ProductController extends FrameworkBundleAdminController
             $this->get('prestashop.adapter.data_provider.pack'),
             $this->get('prestashop.adapter.shop.context'),
             $this->get('prestashop.adapter.data_provider.tax'),
+            $this->get('prestashop.adapter.legacy.configuration'),
             $this->get('router')
         );
         $form = $this->createFormBuilder($modelMapper->getFormData($product));

--- a/src/PrestaShopBundle/Controller/Admin/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/SupplierController.php
@@ -82,6 +82,7 @@ class SupplierController extends FrameworkBundleAdminController
             $this->get('prestashop.adapter.data_provider.pack'),
             $this->get('prestashop.adapter.shop.context'),
             $this->get('prestashop.adapter.data_provider.tax'),
+            $this->get('prestashop.adapter.legacy.configuration'),
             $this->get('router')
         );
         $allFormData = $modelMapper->getFormData($product);

--- a/src/PrestaShopBundle/Controller/Admin/WarehouseController.php
+++ b/src/PrestaShopBundle/Controller/Admin/WarehouseController.php
@@ -68,6 +68,7 @@ class WarehouseController extends FrameworkBundleAdminController
             $this->get('prestashop.adapter.data_provider.pack'),
             $this->get('prestashop.adapter.shop.context'),
             $this->get('prestashop.adapter.data_provider.tax'),
+            $this->get('prestashop.adapter.legacy.configuration'),
             $this->get('router')
         );
         $allFormData = $modelMapper->getFormData($product);

--- a/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/services.yml
@@ -97,6 +97,7 @@ services:
       - "@prestashop.adapter.data_provider.pack"
       - "@prestashop.adapter.shop.context"
       - "@prestashop.adapter.data_provider.tax"
+      - '@prestashop.adapter.legacy.configuration'
       - "@router"
       - "@prestashop.utils.float_parser"
 

--- a/tests/Integration/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
+++ b/tests/Integration/PrestaShopBundle/Model/Product/AdminModelAdapterTest.php
@@ -187,6 +187,7 @@ class AdminModelAdapterTest extends KernelTestCase
             self::$kernel->getContainer()->get('prestashop.adapter.data_provider.pack'),
             self::$kernel->getContainer()->get('prestashop.adapter.shop.context'),
             self::$kernel->getContainer()->get('prestashop.adapter.data_provider.tax'),
+            self::$kernel->getContainer()->get('prestashop.adapter.legacy.configuration'),
             self::$kernel->getContainer()->get('router'),
             self::$kernel->getContainer()->get('prestashop.utils.float_parser')
         );


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When stock management is disabled, it's impossible to create a product with combinations.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Disable stock management, create a product with declinaison and save
| Fixed ticket?     | Fixes #30179
