### PR TITLE
Changed selfupdate composer command

### DIFF
--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer self-update --2.2
+          composer self-update --latest
           composer install --prefer-dist
 
       - name: Execute script for updating modules


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | To avoid using too old composer version (like in https://github.com/PrestaShop/PrestaShop/pull/31266), we should upgrade composer to the last stable version. 
| Type?             | improvement
| Category?         | PM
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Don't know 
| Fixed ticket?     | ~
| Related PRs       | ~
| Sponsor company   | PrestaShop SA 