### PR TITLE
Display error message when language file is missing

### DIFF
--- a/classes/Language.php
+++ b/classes/Language.php
@@ -1257,7 +1257,8 @@ class LanguageCore extends ObjectModel implements LanguageInterface
 
         $content = Tools::file_get_contents($url, false, null, static::PACK_DOWNLOAD_TIMEOUT);
 
-        if (empty($content)) {
+        //Check if response is empty or not a valid zip file
+        if (empty($content) || strpos($content, "\x50\x4b\x03\x04") === false) {
             $errors[] = Context::getContext()->getTranslator()->trans('Language pack unavailable.', [], 'Admin.International.Notification') . ' ' . $url;
 
             return false;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | If language file is missing, display error message.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Follow instructions in issue
| Fixed ticket?     | Fixes #31384
| Sponsor company   | Prestaworks AB
