### PR TITLE
Update PHPStan performance

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.0' # will be overriden by platform.php in composer.json see https://phpstan.org/config-reference#phpversion
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
-          coverage: none
+          coverage: none # disable coverage to disable xdebug in the action.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           php-version: '8.0'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv, simplexml
+          coverage: none
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Update PHPStan performance, Xdebug is enabled by default and it is not used, so there's no need for it. This will speed up checks on the CI.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Dev tools
| Sponsor company   | 