### PR TITLE
Fix the bypass of censorship of sensitive data in sql queries

### DIFF
--- a/src/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandler.php
+++ b/src/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandler.php
@@ -27,6 +27,7 @@
 namespace PrestaShop\PrestaShop\Adapter\SqlManager\QueryHandler;
 
 use Db;
+use PHPSQLParser\PHPSQLParser;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestException;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetSqlRequestExecutionResult;
@@ -65,7 +66,7 @@ final class GetSqlRequestExecutionResultHandler implements GetSqlRequestExecutio
             }
 
             $columns = array_keys(reset($rows));
-            $rows = $this->hideSensitiveData($rows);
+            $rows = $this->hideSensitiveData($rows, $entity->sql);
 
             return new SqlRequestExecutionResult(
                 $columns,
@@ -80,15 +81,16 @@ final class GetSqlRequestExecutionResultHandler implements GetSqlRequestExecutio
      * Replaces sensitive data with placeholder values.
      *
      * @param array $records
+     * @param string $query
      *
-     * @return array Records with hidden sensitive data
-     *
-     * @throws PrestaShopException
+     * @return array
      */
-    private function hideSensitiveData(array $records)
+    private function hideSensitiveData(array $records, string $query): array
     {
+        $sensitiveAttributes = $this->getSensitiveAttributes($query);
+
         foreach ($records as $key => $record) {
-            foreach ((new RequestSql())->attributes as $sensitiveAttribute => $placeholder) {
+            foreach ($sensitiveAttributes as $sensitiveAttribute => $placeholder) {
                 if (isset($record[$sensitiveAttribute])) {
                     $records[$key][$sensitiveAttribute] = $placeholder;
                 }
@@ -96,5 +98,35 @@ final class GetSqlRequestExecutionResultHandler implements GetSqlRequestExecutio
         }
 
         return $records;
+    }
+
+    /**
+     * Detect from list of sensitive attributes if function or alias are used in the sql query
+     * then add alias in the list of sensitives attributes to hide.
+     *
+     * @param string $query
+     *
+     * @return array
+     */
+    private function getSensitiveAttributes(string $query): array
+    {
+        $sensitiveAttributes = (new RequestSql())->attributes;
+        $parser = new PHPSQLParser();
+        $parsed = $parser->parse($query);
+        foreach ($parsed['SELECT'] as $selectField) {
+            if (is_array($selectField['alias'])) {
+                $alias = $selectField['alias']['name'];
+                while (is_array($selectField['sub_tree'])) {
+                    $selectField = $selectField['sub_tree'][0];
+                }
+                $field = end($selectField['no_quotes']['parts']);
+                if (array_key_exists($field, $sensitiveAttributes)) {
+                    $alias = str_replace(['"', "'", '`'], '', $alias);
+                    $sensitiveAttributes[$alias] = $sensitiveAttributes[$field];
+                }
+            }
+        }
+
+        return $sensitiveAttributes;
     }
 }

--- a/tests/Integration/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandlerTest.php
+++ b/tests/Integration/Adapter/SqlManager/QueryHandler/GetSqlRequestExecutionResultHandlerTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Integration\Adapter\SqlManager\QueryHandler;
+
+use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\AddSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetSqlRequestExecutionResult;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\SqlRequestExecutionResult;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\ValueObject\SqlRequestId;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Tests\Resources\DatabaseDump;
+
+class GetSqlRequestExecutionResultHandlerTest extends KernelTestCase
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $queryBus;
+
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        static::resetDatabase();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        static::resetDatabase();
+    }
+
+    protected static function resetDatabase(): void
+    {
+        DatabaseDump::restoreTables([
+            'request_sql',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->queryBus = self::$container->get('prestashop.core.query_bus');
+        $this->commandBus = self::$container->get('prestashop.core.command_bus');
+    }
+
+    public function testSensitiveDataAreHidden(): void
+    {
+        /** @var SqlRequestId $sqlRequestId */
+        $sqlRequestId = $this->commandBus->handle(new AddSqlRequestCommand('request1', 'SELECT e.email, e.lastname, e.firstname, e.passwd FROM ps_employee e;'));
+        $query = new GetSqlRequestExecutionResult($sqlRequestId->getValue());
+        /** @var SqlRequestExecutionResult $sqlRequestExecutionResult */
+        $sqlRequestExecutionResult = $this->queryBus->handle($query);
+        self::assertEquals('*******************', $sqlRequestExecutionResult->getRows()[0]['passwd']);
+
+        /** @var SqlRequestId $sqlRequestId */
+        $sqlRequestId = $this->commandBus->handle(new AddSqlRequestCommand('request1', 'SELECT e.email, e.lastname, e.firstname, e.passwd as "MyStrongPassword" FROM ps_employee e;'));
+        $query = new GetSqlRequestExecutionResult($sqlRequestId->getValue());
+        /** @var SqlRequestExecutionResult $sqlRequestExecutionResult */
+        $sqlRequestExecutionResult = $this->queryBus->handle($query);
+        self::assertEquals('*******************', $sqlRequestExecutionResult->getRows()[0]['MyStrongPassword']);
+
+        /** @var SqlRequestId $sqlRequestId */
+        $sqlRequestId = $this->commandBus->handle(new AddSqlRequestCommand('request1', 'SELECT e.email, e.lastname, e.firstname, e.passwd as  `MyStrongPassword` FROM ps_employee e;'));
+        $query = new GetSqlRequestExecutionResult($sqlRequestId->getValue());
+        /** @var SqlRequestExecutionResult $sqlRequestExecutionResult */
+        $sqlRequestExecutionResult = $this->queryBus->handle($query);
+        self::assertEquals('*******************', $sqlRequestExecutionResult->getRows()[0]['MyStrongPassword']);
+
+        /** @var SqlRequestId $sqlRequestId */
+        $sqlRequestId = $this->commandBus->handle(new AddSqlRequestCommand('request1', 'SELECT e.email, e.lastname, e.firstname, LOWER(LOWER(e.passwd)) as MyStrongPassword FROM ps_employee e;'));
+        $query = new GetSqlRequestExecutionResult($sqlRequestId->getValue());
+        /** @var SqlRequestExecutionResult $sqlRequestExecutionResult */
+        $sqlRequestExecutionResult = $this->queryBus->handle($query);
+        self::assertEquals('*******************', $sqlRequestExecutionResult->getRows()[0]['MyStrongPassword']);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The application provides a function within the administration environment to store and execute SQL queries. If sensitive data such as password hashes are requested, they are displayed in censored form. By renaming the corresponding column within the SQL query, this protection mechanism is bypassed, and password hashes are displayed in plain text.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Try to create SQL queries with sensitive field like employee password and add an alias in the sql query
| Fixed ticket?     | -
| Related PRs       | -
| Sponsor company   | https://github.com/PrestaShopCorp
