### PR TITLE
Migrate cookie constants usages to PSR4

### DIFF
--- a/classes/Cookie.php
+++ b/classes/Cookie.php
@@ -25,6 +25,7 @@
  */
 use Defuse\Crypto\Key;
 use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\Http\CookieOptions;
 use PrestaShop\PrestaShop\Core\Session\SessionInterface;
 
 /**
@@ -44,15 +45,22 @@ use PrestaShop\PrestaShop\Core\Session\SessionInterface;
  */
 class CookieCore
 {
-    public const SAMESITE_NONE = 'None';
-    public const SAMESITE_LAX = 'Lax';
-    public const SAMESITE_STRICT = 'Strict';
-
-    public const SAMESITE_AVAILABLE_VALUES = [
-        self::SAMESITE_NONE => self::SAMESITE_NONE,
-        self::SAMESITE_LAX => self::SAMESITE_LAX,
-        self::SAMESITE_STRICT => self::SAMESITE_STRICT,
-    ];
+    /**
+     * @deprecated since 9.0 use CookieOptions constants instead.
+     */
+    public const SAMESITE_NONE = CookieOptions::SAMESITE_NONE;
+    /**
+     * @deprecated since 9.0 use CookieOptions constants instead.
+     */
+    public const SAMESITE_LAX = CookieOptions::SAMESITE_LAX;
+    /**
+     * @deprecated since 9.0 use CookieOptions constants instead.
+     */
+    public const SAMESITE_STRICT = CookieOptions::SAMESITE_STRICT;
+    /**
+     * @deprecated since 9.0 use CookieOptions constants instead.
+     */
+    public const SAMESITE_AVAILABLE_VALUES = CookieOptions::SAMESITE_AVAILABLE_VALUES;
 
     /** @var array Contain cookie content in a key => value format */
     protected $_content = [];
@@ -392,7 +400,7 @@ class CookieCore
                 'domain' => (string) $this->_domain,
                 'secure' => $this->_secure,
                 'httponly' => true,
-                'samesite' => in_array((string) $this->_sameSite, static::SAMESITE_AVAILABLE_VALUES) ? (string) $this->_sameSite : static::SAMESITE_NONE,
+                'samesite' => in_array((string) $this->_sameSite, CookieOptions::SAMESITE_AVAILABLE_VALUES) ? (string) $this->_sameSite : CookieOptions::SAMESITE_NONE,
             ]
         );
     }

--- a/phpstan-disallowed-calls.neon
+++ b/phpstan-disallowed-calls.neon
@@ -399,3 +399,19 @@ parameters:
                 - src/*
                 - classes/*
                 - controllers/*
+        -
+            class: CookieCore
+            constant: ['SAMESITE_NONE', 'SAMESITE_LAX', 'SAMESITE_STRICT', 'SAMESITE_AVAILABLE_VALUES']
+            message: 'Use \PrestaShop\PrestaShop\Core\Http\CookieOptions constants instead.'
+            disallowIn:
+                - src/*
+                - classes/*
+                - controllers/*
+        -
+            class: PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\GeneralDataProvider
+            constant: ['MAX_COOKIE_VALUE']
+            message: 'Use \PrestaShop\PrestaShop\Core\Http\CookieOptions constants instead.'
+            disallowIn:
+                - src/*
+                - classes/*
+                - controllers/*

--- a/src/Adapter/GeneralConfiguration.php
+++ b/src/Adapter/GeneralConfiguration.php
@@ -28,6 +28,7 @@ namespace PrestaShop\PrestaShop\Adapter;
 
 use Cookie;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Http\CookieOptions;
 
 /**
  * Manages the configuration data about general options.
@@ -106,7 +107,7 @@ class GeneralConfiguration implements DataConfigurationInterface
                 $configuration['back_cookie_lifetime']
             ) && in_array(
                 $configuration['cookie_samesite'],
-                Cookie::SAMESITE_AVAILABLE_VALUES
+                CookieOptions::SAMESITE_AVAILABLE_VALUES
             );
 
         return (bool) $isValid;
@@ -123,7 +124,7 @@ class GeneralConfiguration implements DataConfigurationInterface
     protected function validateSameSite(string $sameSite): bool
     {
         $forceSsl = $this->configuration->get('PS_SSL_ENABLED') && $this->configuration->get('PS_SSL_ENABLED_EVERYWHERE');
-        if ($sameSite === Cookie::SAMESITE_NONE) {
+        if ($sameSite === CookieOptions::SAMESITE_NONE) {
             return $forceSsl;
         }
 

--- a/src/Adapter/Preferences/PreferencesConfiguration.php
+++ b/src/Adapter/Preferences/PreferencesConfiguration.php
@@ -26,9 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Preferences;
 
-use Cookie;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Http\CookieOptions;
 
 /**
  * This class will provide Shop Preferences configuration.
@@ -124,7 +124,7 @@ class PreferencesConfiguration implements DataConfigurationInterface
             $configuration['enable_ssl'] === false
             || $configuration['enable_ssl_everywhere'] === false
         )
-            && $this->configuration->get('PS_COOKIE_SAMESITE') === Cookie::SAMESITE_NONE;
+            && $this->configuration->get('PS_COOKIE_SAMESITE') === CookieOptions::SAMESITE_NONE;
     }
 
     /**

--- a/src/Core/Http/CookieOptions.php
+++ b/src/Core/Http/CookieOptions.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PrestaShop\PrestaShop\Core\Http;
+
+final class CookieOptions
+{
+    /**
+     * If you set cookie lifetime value too high there can be multiple problems.
+     * Hours are converted to seconds, so int might be turned to float if it's way to high.
+     * Cookie classes crash if lifetime goes beyond year 9999, there are probably multiple other things.
+     * So we need to set some sort of max value. 100 years seems like a lifetime beyond reasonable use.
+     */
+    public const MAX_COOKIE_VALUE = 876000;
+
+    public const SAMESITE_NONE = 'None';
+    public const SAMESITE_LAX = 'Lax';
+    public const SAMESITE_STRICT = 'Strict';
+
+    public const SAMESITE_AVAILABLE_VALUES = [
+        self::SAMESITE_NONE => self::SAMESITE_NONE,
+        self::SAMESITE_LAX => self::SAMESITE_LAX,
+        self::SAMESITE_STRICT => self::SAMESITE_STRICT,
+    ];
+
+    // This class should not be instanciated
+    private function __construct()
+    {
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
@@ -27,10 +27,10 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Http\CookieOptions;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Controller\Exception\FieldNotFoundException;
 use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\FormDataProvider;
-use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\GeneralDataProvider;
 use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\GeneralType;
 use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\UploadQuotaType;
 use PrestaShopBundle\Form\Exception\DataProviderException;
@@ -244,7 +244,7 @@ class AdministrationController extends FrameworkBundleAdminController
                     'Admin.Notifications.Error',
                     [
                         $this->getFieldLabel($error->getFieldName()),
-                        GeneralDataProvider::MAX_COOKIE_VALUE,
+                        CookieOptions::MAX_COOKIE_VALUE,
                     ]
                 );
             case FormDataProvider::ERROR_COOKIE_SAMESITE_NONE:
@@ -259,7 +259,7 @@ class AdministrationController extends FrameworkBundleAdminController
             'Admin.Notifications.Error',
             [
                 $this->getFieldLabel($error->getFieldName()),
-                GeneralDataProvider::MAX_COOKIE_VALUE,
+                CookieOptions::MAX_COOKIE_VALUE,
             ]
         );
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralDataProvider.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralDataProvider.php
@@ -28,9 +28,9 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
-use Cookie;
 use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Form\FormDataProviderInterface;
+use PrestaShop\PrestaShop\Core\Http\CookieOptions;
 use PrestaShopBundle\Form\Exception\DataProviderException;
 use PrestaShopBundle\Form\Exception\InvalidConfigurationDataError;
 use PrestaShopBundle\Form\Exception\InvalidConfigurationDataErrorCollection;
@@ -46,6 +46,8 @@ final class GeneralDataProvider implements FormDataProviderInterface
      * Hours are converted to seconds, so int might be turned to float if it's way to high.
      * Cookie classes crash if lifetime goes beyond year 9999, there are probably multiple other things.
      * So we need to set some sort of max value. 100 years seems like a lifetime beyond reasonable use.
+     *
+     * @deprecated since 9.0 use CookieOptions constants instead.
      */
     public const MAX_COOKIE_VALUE = 876000;
 
@@ -106,7 +108,7 @@ final class GeneralDataProvider implements FormDataProviderInterface
                 $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, GeneralType::FIELD_FRONT_COOKIE_LIFETIME));
             }
 
-            if ($frontOfficeLifeTimeCookie > self::MAX_COOKIE_VALUE) {
+            if ($frontOfficeLifeTimeCookie > CookieOptions::MAX_COOKIE_VALUE) {
                 $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED, GeneralType::FIELD_FRONT_COOKIE_LIFETIME));
             }
         }
@@ -117,7 +119,7 @@ final class GeneralDataProvider implements FormDataProviderInterface
                 $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_NOT_NUMERIC_OR_LOWER_THAN_ZERO, GeneralType::FIELD_BACK_COOKIE_LIFETIME));
             }
 
-            if ($backOfficeLifeTimeCookie > self::MAX_COOKIE_VALUE) {
+            if ($backOfficeLifeTimeCookie > CookieOptions::MAX_COOKIE_VALUE) {
                 $errors->add(new InvalidConfigurationDataError(FormDataProvider::ERROR_COOKIE_LIFETIME_MAX_VALUE_EXCEEDED, GeneralType::FIELD_BACK_COOKIE_LIFETIME));
             }
         }
@@ -143,7 +145,7 @@ final class GeneralDataProvider implements FormDataProviderInterface
      */
     protected function validateSameSite(string $sameSite): bool
     {
-        if ($sameSite === Cookie::SAMESITE_NONE) {
+        if ($sameSite === CookieOptions::SAMESITE_NONE) {
             return $this->sslEnabled && $this->sslEnabledEverywhere;
         }
 

--- a/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/AdvancedParameters/Administration/GeneralType.php
@@ -26,7 +26,7 @@
 
 namespace PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration;
 
-use Cookie;
+use PrestaShop\PrestaShop\Core\Http\CookieOptions;
 use PrestaShopBundle\Form\Admin\Type\SwitchType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -63,7 +63,7 @@ class GeneralType extends TranslatorAwareType
             ->add(self::FIELD_COOKIE_SAMESITE, ChoiceType::class, [
                 'label' => $this->trans('Cookie SameSite', 'Admin.Advparameters.Feature'),
                 'help' => $this->trans('Allows you to declare if your cookie should be restricted to a first-party or same-site context.', 'Admin.Advparameters.Help'),
-                'choices' => Cookie::SAMESITE_AVAILABLE_VALUES,
+                'choices' => CookieOptions::SAMESITE_AVAILABLE_VALUES,
             ]);
     }
 

--- a/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
+++ b/tests/Unit/Adapter/Preferences/PreferencesConfigurationTest.php
@@ -28,11 +28,11 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Adapter\Preferences;
 
-use Cookie;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use PrestaShop\PrestaShop\Adapter\Configuration;
 use PrestaShop\PrestaShop\Adapter\Preferences\PreferencesConfiguration;
+use PrestaShop\PrestaShop\Core\Http\CookieOptions;
 
 class PreferencesConfigurationTest extends TestCase
 {
@@ -123,7 +123,7 @@ class PreferencesConfigurationTest extends TestCase
             ->method('get')
             ->willReturnMap(
                 [
-                    ['PS_COOKIE_SAMESITE', null, null, Cookie::SAMESITE_NONE],
+                    ['PS_COOKIE_SAMESITE', null, null, CookieOptions::SAMESITE_NONE],
                 ]
             );
 
@@ -161,7 +161,7 @@ class PreferencesConfigurationTest extends TestCase
             ->method('get')
             ->willReturnMap(
                 [
-                    ['PS_COOKIE_SAMESITE', null, null, Cookie::SAMESITE_NONE],
+                    ['PS_COOKIE_SAMESITE', null, null, CookieOptions::SAMESITE_NONE],
                 ]
             );
         $this->mockConfiguration


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | This will remove constants usages of the `Cookie` class into a new CookieOptions class. That's less legacy to maintain, and this also removes legacy usages from the `PrestaShopBundle` and `Adapter` namespaces.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | CI 🟢 & automated tests should be sufficient. Tests classes that handle cookie, in both front and back office.
