### PR TITLE
Remove Tools::encrypt() and Tools::encryptIV() (deprecated)

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1141,20 +1141,6 @@ class ToolsCore
     /**
      * Hash password.
      *
-     * @param string $passwd String to hash
-     *
-     * @return string Hashed password
-     *
-     * @deprecated 1.7.0
-     */
-    public static function encrypt($passwd)
-    {
-        return self::hash($passwd);
-    }
-
-    /**
-     * Hash password.
-     *
      * @param string $passwd String to has
      *
      * @return string Hashed password
@@ -1164,20 +1150,6 @@ class ToolsCore
     public static function hash($passwd)
     {
         return (new Hashing())->hash($passwd, _COOKIE_KEY_);
-    }
-
-    /**
-     * Hash data string.
-     *
-     * @param string $data String to encrypt
-     *
-     * @return string Hashed IV
-     *
-     * @deprecated 1.7.0
-     */
-    public static function encryptIV($data)
-    {
-        return self::hashIV($data);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated features on v9
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | -
| Related PRs       | -
| How to test?      | I only removed code deprecated in previous version and that was not used, so not behavior should be modified. I believe automated tests should tell us if something was broken although in theory it should not happen.
| Possible impacts? | No, only deprecated and not used code has been removed
| Sponsor company   | 


Needs https://github.com/PrestaShop/gsitemap/pull/159 to be merged first



**:notebook: BC Breaks**
* Removed method : `encryptIV()` in `Tools`
* Removed method : `encrypt()` in `Tools`

