### PR TITLE
Add information about customer default group

### DIFF
--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -514,7 +514,7 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
         $customerGroups = [];
 
         foreach ($groups as $groupId) {
-            $group = new Group($groupId);        
+            $group = new Group($groupId);
             $customerGroups[] = new GroupInformation(
                 (int) $group->id,
                 $group->name[$this->contextLangId],

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -514,11 +514,11 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
         $customerGroups = [];
 
         foreach ($groups as $groupId) {
-            $group = new Group($groupId);
-
+            $group = new Group($groupId);        
             $customerGroups[] = new GroupInformation(
                 (int) $group->id,
-                $group->name[$this->contextLangId]
+                $group->name[$this->contextLangId],
+                (int) $group->id === (int) $customer->id_default_group
             );
         }
 

--- a/src/Core/Domain/Customer/QueryResult/GroupInformation.php
+++ b/src/Core/Domain/Customer/QueryResult/GroupInformation.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult;
 
 /**
@@ -52,9 +54,9 @@ class GroupInformation
      * @param bool $isDefault
      */
     public function __construct(
-        $groupId,
-        $name,
-        $isDefault = false
+        int $groupId,
+        string $name,
+        bool $isDefault = false
     ) {
         $this->groupId = $groupId;
         $this->name = $name;
@@ -64,7 +66,7 @@ class GroupInformation
     /**
      * @return int
      */
-    public function getGroupId()
+    public function getGroupId(): int
     {
         return $this->groupId;
     }
@@ -72,7 +74,7 @@ class GroupInformation
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -80,7 +82,7 @@ class GroupInformation
     /**
      * @return bool
      */
-    public function isDefault()
+    public function isDefault(): bool
     {
         return $this->isDefault;
     }

--- a/src/Core/Domain/Customer/QueryResult/GroupInformation.php
+++ b/src/Core/Domain/Customer/QueryResult/GroupInformation.php
@@ -42,13 +42,23 @@ class GroupInformation
     private $name;
 
     /**
+     * @var bool
+     */
+    private $isDefault;
+
+    /**
      * @param int $groupId
      * @param string $name
+     * @param bool $isDefault
      */
-    public function __construct($groupId, $name)
-    {
+    public function __construct(
+        $groupId,
+        $name,
+        $isDefault = false
+    ){
         $this->groupId = $groupId;
         $this->name = $name;
+        $this->isDefault = $isDefault;
     }
 
     /**
@@ -65,5 +75,13 @@ class GroupInformation
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isDefault()
+    {
+        return $this->isDefault;
     }
 }

--- a/src/Core/Domain/Customer/QueryResult/GroupInformation.php
+++ b/src/Core/Domain/Customer/QueryResult/GroupInformation.php
@@ -55,7 +55,7 @@ class GroupInformation
         $groupId,
         $name,
         $isDefault = false
-    ){
+    ) {
         $this->groupId = $groupId;
         $this->name = $name;
         $this->isDefault = $isDefault;

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/groups.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/groups.html.twig
@@ -55,6 +55,7 @@
               <a href="{{ getAdminLink('AdminGroups', true, {'id_group': group.groupId, 'viewgroup': 1}) }}">
                 {{ group.name }}
               </a>
+              {% if group.isDefault %} ({{ 'default'|trans({}, 'Admin.Orderscustomers.Feature') }}){% endif %}
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Adds information about customer's default group into backoffice customer detail page. I added additional optional property into `GroupInformation` object, so I can use it freely in the template and I can make it non-clickable.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Visit the page and see it works correctly.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

![group](https://user-images.githubusercontent.com/6097524/219875861-5b6e491e-1354-432c-b93e-4f008a30482c.jpg)

