### PR TITLE
Fix sales value in customer grid list

### DIFF
--- a/src/Core/Grid/Query/CustomerQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerQueryBuilder.php
@@ -146,7 +146,7 @@ final class CustomerQueryBuilder extends AbstractDoctrineQueryBuilder
     private function appendTotalSpentQuery(QueryBuilder $queryBuilder)
     {
         $totalSpentQueryBuilder = $this->connection->createQueryBuilder()
-            ->select('SUM(total_paid_real / conversion_rate)')
+            ->select('SUM(total_paid_tax_incl / conversion_rate)')
             ->from($this->dbPrefix . 'orders', 'o')
             ->where('o.id_customer = c.id_customer')
             ->andWhere('o.id_shop IN (:context_shop_ids)')


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In https://github.com/PrestaShop/PrestaShop/pull/31104, we fixed total sale value for some users in customer detail page - when the built in invoicing was disabled. I forgot to do it also in the customer grid - here we go.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/31157
| Related PRs       | 
| Sponsor company   | 

1. Go to orders > invoices and disable built-in invoicing.
2. Order something in front office, visit that order and set order status to `Payment accepted` (or any other status that considers the order as valid)
3. Visit Customers section in backoffice.
4. Without this PR, you will see 0,00 EUR 🔴 , with this PR, the value of the order. ✅ 