### PR TITLE
Migrate customer view cart and order tables to grid

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/customer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.ts
@@ -73,6 +73,14 @@ $(() => {
   customerAddressesGrid.addExtension(new SortingExtension());
   customerAddressesGrid.addExtension(new LinkRowActionExtension());
 
+  const customerOrdersGrid = new Grid('customer_order');
+  customerOrdersGrid.addExtension(new SortingExtension());
+  customerOrdersGrid.addExtension(new LinkRowActionExtension());
+
+  const customerCartsGrid = new Grid('customer_cart');
+  customerCartsGrid.addExtension(new SortingExtension());
+  customerCartsGrid.addExtension(new LinkRowActionExtension());
+
   const showcaseCard = new ShowcaseCard('customersShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());
 

--- a/admin-dev/themes/new-theme/js/pages/customer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.ts
@@ -75,10 +75,12 @@ $(() => {
 
   const customerOrdersGrid = new Grid('customer_order');
   customerOrdersGrid.addExtension(new SortingExtension());
+  customerOrdersGrid.addExtension(new SubmitRowActionExtension());
   customerOrdersGrid.addExtension(new LinkRowActionExtension());
 
   const customerCartsGrid = new Grid('customer_cart');
   customerCartsGrid.addExtension(new SortingExtension());
+  customerCartsGrid.addExtension(new SubmitRowActionExtension());
   customerCartsGrid.addExtension(new LinkRowActionExtension());
 
   const showcaseCard = new ShowcaseCard('customersShowcaseCard');

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -26,11 +26,9 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Customer\QueryHandler;
 
-use Cart;
 use CartRule;
 use Category;
 use Context;
-use Currency;
 use Customer;
 use CustomerThread;
 use Db;
@@ -38,7 +36,6 @@ use Gender;
 use Group;
 use Language;
 use Link;
-use Order;
 use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForViewing;
@@ -51,7 +48,6 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\GeneralInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\GroupInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\LastConnectionInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\MessageInformation;
-use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\OrderInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\OrdersInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\PersonalInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\ProductsInformation;

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -293,32 +293,15 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
     }
 
     /**
+     * @deprecated Since 9.0.0 for performance reasons and returns only empty array. Use CustomerCart grid.
+     *
      * @param Customer $customer
      *
      * @return CartInformation[]
      */
     private function getCustomerCarts(Customer $customer)
     {
-        $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-        SELECT c.id_cart, c.date_add, ca.name as carrier_name, c.id_currency, cu.iso_code as currency_iso_code
-        FROM ' . _DB_PREFIX_ . 'cart c
-        LEFT JOIN ' . _DB_PREFIX_ . 'carrier ca ON ca.id_carrier = c.id_carrier
-        LEFT JOIN ' . _DB_PREFIX_ . 'currency cu ON cu.id_currency = c.id_currency
-        WHERE c.`id_customer` = ' . (int) $customer->id . '
-        ORDER BY c.`date_add` DESC');
-
-        $customerCarts = [];
-        foreach ($result as $row) {
-            $cart = new Cart((int) $row['id_cart']);
-            $customerCarts[] = new CartInformation(
-                sprintf('%06d', $row['id_cart']),
-                Tools::displayDate($row['date_add'], true),
-                $this->locale->formatPrice($cart->getOrderTotal(true), $row['currency_iso_code']),
-                $row['carrier_name']
-            );
-        }
-
-        return $customerCarts;
+        return [];
     }
 
     /**

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -131,14 +131,14 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
             $this->getGeneralInformation($customer),
             $this->getPersonalInformation($customer),
             $this->getCustomerOrders($customer),
-            $this->getCustomerCarts($customer),
+            [],
             $this->getCustomerProducts($customer),
             $this->getCustomerMessages($customer),
-            $this->getCustomerDiscounts($customer),
+            [],
             $this->getLastEmailsSentToCustomer($customer),
             $this->getLastCustomerConnections($customer),
             $this->getCustomerGroups($customer),
-            $this->getCustomerAddresses($customer)
+            []
         );
     }
 
@@ -271,18 +271,6 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
     }
 
     /**
-     * @deprecated Since 9.0.0 for performance reasons and returns only empty array.
-     *
-     * @param Customer $customer
-     *
-     * @return CartInformation[]
-     */
-    private function getCustomerCarts(Customer $customer)
-    {
-        return [];
-    }
-
-    /**
      * @param Customer $customer
      *
      * @return ProductsInformation
@@ -387,32 +375,6 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
     /**
      * @param Customer $customer
      *
-     * @return DiscountInformation[]
-     */
-    private function getCustomerDiscounts(Customer $customer)
-    {
-        $discounts = CartRule::getAllCustomerCartRules($customer->id);
-
-        $customerDiscounts = [];
-
-        foreach ($discounts as $discount) {
-            $availableQuantity = $discount['quantity'] > 0 ? (int) $discount['quantity_for_user'] : 0;
-
-            $customerDiscounts[] = new DiscountInformation(
-                (int) $discount['id_cart_rule'],
-                $discount['code'],
-                $discount['name'],
-                (bool) $discount['active'],
-                $availableQuantity
-            );
-        }
-
-        return $customerDiscounts;
-    }
-
-    /**
-     * @param Customer $customer
-     *
      * @return SentEmailInformation[]
      */
     private function getLastEmailsSentToCustomer(Customer $customer)
@@ -484,40 +446,6 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
         }
 
         return $customerGroups;
-    }
-
-    /**
-     * @param Customer $customer
-     *
-     * @return AddressInformation[]
-     */
-    private function getCustomerAddresses(Customer $customer)
-    {
-        $addresses = $customer->getAddresses($this->contextLangId);
-        $customerAddresses = [];
-
-        foreach ($addresses as $address) {
-            $company = $address['company'] ?: '--';
-            $fullAddress = sprintf(
-                '%s %s %s %s',
-                $address['address1'],
-                $address['address2'] ?: '',
-                $address['postcode'],
-                $address['city']
-            );
-
-            $customerAddresses[] = new AddressInformation(
-                (int) $address['id_address'],
-                $company,
-                sprintf('%s %s', $address['firstname'], $address['lastname']),
-                $fullAddress,
-                $address['country'],
-                (string) $address['phone'],
-                (string) $address['phone_mobile']
-            );
-        }
-
-        return $customerAddresses;
     }
 
     /**

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -26,7 +26,6 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Customer\QueryHandler;
 
-use CartRule;
 use Category;
 use Context;
 use Customer;
@@ -40,10 +39,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyContext;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForViewing;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryHandler\GetCustomerForViewingHandlerInterface;
-use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\AddressInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\BoughtProductInformation;
-use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\CartInformation;
-use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\DiscountInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\GeneralInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\GroupInformation;
 use PrestaShop\PrestaShop\Core\Domain\Customer\QueryResult\LastConnectionInformation;

--- a/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
+++ b/src/Adapter/Customer/QueryHandler/GetCustomerForViewingHandler.php
@@ -271,7 +271,7 @@ final class GetCustomerForViewingHandler implements GetCustomerForViewingHandler
     }
 
     /**
-     * @deprecated Since 9.0.0 for performance reasons and returns only empty array. Use CustomerCart grid.
+     * @deprecated Since 9.0.0 for performance reasons and returns only empty array.
      *
      * @param Customer $customer
      *

--- a/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
+++ b/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
@@ -118,14 +118,14 @@ class ViewableCustomer
         GeneralInformation $generalInformation,
         PersonalInformation $personalInformation,
         OrdersInformation $ordersInformation,
-        array $cartsInformation = [],
+        array $cartsInformation,
         ProductsInformation $productsInformation,
         array $messagesInformation,
-        array $discountsInformation = [],
+        array $discountsInformation,
         array $sentEmailsInformation,
         array $lastConnectionsInformation,
         array $groupsInformation,
-        array $addressesInformation = []
+        array $addressesInformation
     ) {
         $this->customerId = $customerId;
         $this->personalInformation = $personalInformation;

--- a/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
+++ b/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
@@ -66,6 +66,8 @@ class ViewableCustomer
     private $messagesInformation;
 
     /**
+     * @deprecated Since 9.0.0, returns only empty array.
+     *
      * @var DiscountInformation[]
      */
     private $discountsInformation;
@@ -86,6 +88,8 @@ class ViewableCustomer
     private $groupsInformation;
 
     /**
+     * @deprecated Since 9.0.0, returns only empty array.
+     *
      * @var AddressInformation[]
      */
     private $addressesInformation;
@@ -114,14 +118,14 @@ class ViewableCustomer
         GeneralInformation $generalInformation,
         PersonalInformation $personalInformation,
         OrdersInformation $ordersInformation,
-        array $cartsInformation,
+        array $cartsInformation = [],
         ProductsInformation $productsInformation,
         array $messagesInformation,
-        array $discountsInformation,
+        array $discountsInformation = [],
         array $sentEmailsInformation,
         array $lastConnectionsInformation,
         array $groupsInformation,
-        array $addressesInformation
+        array $addressesInformation = []
     ) {
         $this->customerId = $customerId;
         $this->personalInformation = $personalInformation;
@@ -188,6 +192,8 @@ class ViewableCustomer
     }
 
     /**
+     * @deprecated Since 9.0.0, returns only empty array.
+     *
      * @return DiscountInformation[]
      */
     public function getDiscountsInformation()
@@ -220,6 +226,8 @@ class ViewableCustomer
     }
 
     /**
+     * @deprecated Since 9.0.0, returns only empty array.
+     *
      * @return AddressInformation[]
      */
     public function getAddressesInformation()

--- a/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
+++ b/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
@@ -49,7 +49,7 @@ class ViewableCustomer
     private $ordersInformation;
 
     /**
-     * @deprecated Since 9.0.0 for performance reasons and returns only empty array. Use CustomerCart grid.
+     * @deprecated Since 9.0.0 for performance reasons and returns only empty array.
      *
      * @var CartInformation[]
      */
@@ -162,7 +162,7 @@ class ViewableCustomer
     }
 
     /**
-     * @deprecated Since 9.0.0 for performance reasons and returns only empty array. Use CustomerCart grid.
+     * @deprecated Since 9.0.0 for performance reasons and returns only empty array.
      *
      * @return CartInformation[]
      */

--- a/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
+++ b/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
@@ -49,6 +49,8 @@ class ViewableCustomer
     private $ordersInformation;
 
     /**
+     * @deprecated Since 9.0.0 for performance reasons and returns only empty array. Use CustomerCart grid.
+     *
      * @var CartInformation[]
      */
     private $cartsInformation;
@@ -160,6 +162,8 @@ class ViewableCustomer
     }
 
     /**
+     * @deprecated Since 9.0.0 for performance reasons and returns only empty array. Use CustomerCart grid.
+     *
      * @return CartInformation[]
      */
     public function getCartsInformation()

--- a/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
@@ -96,7 +96,7 @@ final class CustomerCartGridDataFactoryDecorator implements GridDataFactoryInter
     }
 
     /**
-     * @param RecordCollectionInterface $record
+     * @param RecordCollectionInterface $records
      *
      * @return RecordCollection
      */

--- a/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
@@ -29,13 +29,12 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
-use Cart;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForViewing;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
-use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
-use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForViewing;
 
 /**
  * Class CustomerCartGridDataFactoryDecorator decorates data from customer carts doctrine data factory.

--- a/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
+use Cart;
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
@@ -95,13 +96,11 @@ final class CustomerCartGridDataFactoryDecorator implements GridDataFactoryInter
         $modifiedRecord = [];
 
         foreach ($records as $r) {
-            if (!empty($r['total_paid_tax_incl'])) {
-                $r['total_paid_tax_incl'] = $this->locale->formatPrice(
-                    $r['total_paid_tax_incl'],
-                    $this->contextCurrencyIsoCode
-                );
-            }
-
+            $cart = new Cart($r['id_cart']);
+            $r['total'] = $this->locale->formatPrice(
+                $cart->getOrderTotal(true),
+                $this->contextCurrencyIsoCode
+            );
             $modifiedRecord[] = $r;
         }
 

--- a/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
@@ -90,11 +90,11 @@ final class CustomerCartGridDataFactoryDecorator implements GridDataFactoryInter
      *
      * @return RecordCollection
      */
-    private function applyModifications(RecordCollectionInterface $record)
+    private function applyModifications(RecordCollectionInterface $records)
     {
         $modifiedRecord = [];
 
-        foreach ($record as $r) {
+        foreach ($records as $r) {
             if (!empty($r['total_paid_tax_incl'])) {
                 $r['total_paid_tax_incl'] = $this->locale->formatPrice(
                     $r['total_paid_tax_incl'],

--- a/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerCartGridDataFactoryDecorator.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
+
+/**
+ * Class CustomerCartGridDataFactoryDecorator decorates data from customer carts doctrine data factory.
+ */
+final class CustomerCartGridDataFactoryDecorator implements GridDataFactoryInterface
+{
+    /**
+     * @var GridDataFactoryInterface
+     */
+    private $customerCartDoctrineGridDataFactory;
+
+    /**
+     * @var LocaleInterface
+     */
+    private $locale;
+
+    /**
+     * @var string
+     */
+    private $contextCurrencyIsoCode;
+
+    /**
+     * @param GridDataFactoryInterface $customerCartDoctrineGridDataFactory
+     * @param LocaleInterface $locale
+     * @param string $contextCurrencyIsoCode
+     */
+    public function __construct(
+        GridDataFactoryInterface $customerCartDoctrineGridDataFactory,
+        LocaleInterface $locale,
+        $contextCurrencyIsoCode
+    ) {
+        $this->customerCartDoctrineGridDataFactory = $customerCartDoctrineGridDataFactory;
+        $this->locale = $locale;
+        $this->contextCurrencyIsoCode = $contextCurrencyIsoCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria)
+    {
+        $customerData = $this->customerCartDoctrineGridDataFactory->getData($searchCriteria);
+
+        $records = $this->applyModifications($customerData->getRecords());
+
+        return new GridData(
+            $records,
+            $customerData->getRecordsTotal(),
+            $customerData->getQuery()
+        );
+    }
+
+    /**
+     * @param RecordCollectionInterface $record
+     *
+     * @return RecordCollection
+     */
+    private function applyModifications(RecordCollectionInterface $record)
+    {
+        $modifiedRecord = [];
+
+        foreach ($record as $r) {
+            if (!empty($r['total_paid_tax_incl'])) {
+                $r['total_paid_tax_incl'] = $this->locale->formatPrice(
+                    $r['total_paid_tax_incl'],
+                    $this->contextCurrencyIsoCode
+                );
+            }
+
+            $modifiedRecord[] = $r;
+        }
+
+        return new RecordCollection($modifiedRecord);
+    }
+}

--- a/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
@@ -86,15 +86,14 @@ final class CustomerOrderGridDataFactoryDecorator implements GridDataFactoryInte
     }
 
     /**
-     * @param RecordCollectionInterface $record
+     * @param RecordCollectionInterface $records
      *
      * @return RecordCollection
      */
-    private function applyModifications(RecordCollectionInterface $record)
+    private function applyModifications(RecordCollectionInterface $records)
     {
-        $modifiedRecord = [];
-
-        foreach ($record as $r) {
+        $modifiedRecords = [];
+        foreach ($records as $r) {
             if (!empty($r['total_paid_tax_incl'])) {
                 $r['total_paid_tax_incl'] = $this->locale->formatPrice(
                     $r['total_paid_tax_incl'],
@@ -102,9 +101,9 @@ final class CustomerOrderGridDataFactoryDecorator implements GridDataFactoryInte
                 );
             }
 
-            $modifiedRecord[] = $r;
+            $modifiedRecords[] = $r;
         }
 
-        return new RecordCollection($modifiedRecord);
+        return new RecordCollection($modifiedRecords);
     }
 }

--- a/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
+use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
+use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
+
+/**
+ * Class CustomerOrderGridDataFactoryDecorator decorates data from customer ordesrs doctrine data factory.
+ */
+final class CustomerOrderGridDataFactoryDecorator implements GridDataFactoryInterface
+{
+    /**
+     * @var GridDataFactoryInterface
+     */
+    private $customerOrderDoctrineGridDataFactory;
+
+    /**
+     * @var LocaleInterface
+     */
+    private $locale;
+
+    /**
+     * @var string
+     */
+    private $contextCurrencyIsoCode;
+
+    /**
+     * @param GridDataFactoryInterface $customerOrderDoctrineGridDataFactory
+     * @param LocaleInterface $locale
+     * @param string $contextCurrencyIsoCode
+     */
+    public function __construct(
+        GridDataFactoryInterface $customerOrderDoctrineGridDataFactory,
+        LocaleInterface $locale,
+        $contextCurrencyIsoCode
+    ) {
+        $this->customerOrderDoctrineGridDataFactory = $customerOrderDoctrineGridDataFactory;
+        $this->locale = $locale;
+        $this->contextCurrencyIsoCode = $contextCurrencyIsoCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(SearchCriteriaInterface $searchCriteria)
+    {
+        $customerData = $this->customerOrderDoctrineGridDataFactory->getData($searchCriteria);
+
+        $records = $this->applyModifications($customerData->getRecords());
+
+        return new GridData(
+            $records,
+            $customerData->getRecordsTotal(),
+            $customerData->getQuery()
+        );
+    }
+
+    /**
+     * @param RecordCollectionInterface $record
+     *
+     * @return RecordCollection
+     */
+    private function applyModifications(RecordCollectionInterface $record)
+    {
+        $modifiedRecord = [];
+
+        foreach ($record as $r) {
+            if (!empty($r['total_paid_tax_incl'])) {
+                $r['total_paid_tax_incl'] = $this->locale->formatPrice(
+                    $r['total_paid_tax_incl'],
+                    $this->contextCurrencyIsoCode
+                );
+            }
+
+            $modifiedRecord[] = $r;
+        }
+
+        return new RecordCollection($modifiedRecord);
+    }
+}

--- a/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
@@ -107,6 +107,10 @@ final class CustomerOrderGridDataFactoryDecorator implements GridDataFactoryInte
                 ' rounded">' . $r['status'] . '</span>';
             }
 
+            if (empty($r['nb_products'])) {
+                $r['nb_products'] = '0';
+            }
+
             $modifiedRecords[] = $r;
         }
 

--- a/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
@@ -29,9 +29,9 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Grid\Data\Factory;
 
 use PrestaShop\PrestaShop\Core\Grid\Data\GridData;
-use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollection;
 use PrestaShop\PrestaShop\Core\Grid\Record\RecordCollectionInterface;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Localization\LocaleInterface;
 
 /**
@@ -102,7 +102,7 @@ final class CustomerOrderGridDataFactoryDecorator implements GridDataFactoryInte
             }
 
             if (!empty($r['status'])) {
-                $r['status'] = '<span class="badge badge-' . 
+                $r['status'] = '<span class="badge badge-' .
                 ($r['valid'] == 1 ? 'success' : 'danger') .
                 ' rounded">' . $r['status'] . '</span>';
             }

--- a/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
+++ b/src/Core/Grid/Data/Factory/CustomerOrderGridDataFactoryDecorator.php
@@ -101,6 +101,12 @@ final class CustomerOrderGridDataFactoryDecorator implements GridDataFactoryInte
                 );
             }
 
+            if (!empty($r['status'])) {
+                $r['status'] = '<span class="badge badge-' . 
+                ($r['valid'] == 1 ? 'success' : 'danger') .
+                ' rounded">' . $r['status'] . '</span>';
+            }
+
             $modifiedRecords[] = $r;
         }
 

--- a/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
@@ -106,6 +106,7 @@ final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFact
                 ->setOptions([
                     'field' => 'date_add',
                     'format' => $this->contextDateFormat,
+                    'clickable' => true,
                 ])
             )
             ->add((new DataColumn('carrier_name'))

--- a/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
@@ -114,10 +114,11 @@ final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFact
                     'field' => 'carrier_name',
                 ])
             )
-            ->add((new DataColumn('total_paid_tax_incl'))
+            ->add((new DataColumn('total'))
                 ->setName($this->trans('Total (Tax incl.)', [], 'Admin.Global'))
                 ->setOptions([
-                    'field' => 'total_paid_tax_incl',
+                    'field' => 'total',
+                    'sortable' => false,
                 ])
             )
             ->add((new ActionColumn('actions'))

--- a/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
@@ -94,33 +94,32 @@ final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFact
     protected function getColumns()
     {
         return (new ColumnCollection())
-            ->add(
-                (new DataColumn('id_cart'))
-                    ->setName($this->trans('ID', [], 'Admin.Global'))
-                    ->setOptions([
-                        'field' => 'id_cart',
-                    ])
+            ->add((new DataColumn('id_cart'))
+            ->setName($this->trans('ID', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'id_cart',
+            ])
             )
             ->add((new DateTimeColumn('date_add'))
-                ->setName($this->trans('Date', [], 'Admin.Global'))
-                ->setOptions([
-                    'field' => 'date_add',
-                    'format' => $this->contextDateFormat,
-                    'clickable' => true,
-                ])
+            ->setName($this->trans('Date', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'date_add',
+                'format' => $this->contextDateFormat,
+                'clickable' => true,
+            ])
             )
             ->add((new DataColumn('carrier_name'))
-                ->setName($this->trans('Carrier', [], 'Admin.Global'))
-                ->setOptions([
-                    'field' => 'carrier_name',
-                ])
+            ->setName($this->trans('Carrier', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'carrier_name',
+            ])
             )
             ->add((new DataColumn('total'))
-                ->setName($this->trans('Total (Tax incl.)', [], 'Admin.Global'))
-                ->setOptions([
-                    'field' => 'total',
-                    'sortable' => false,
-                ])
+            ->setName($this->trans('Total (Tax incl.)', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'total',
+                'sortable' => false,
+            ])
             )
             ->add((new ActionColumn('actions'))
             ->setName($this->trans('Actions', [], 'Admin.Global'))
@@ -137,7 +136,7 @@ final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFact
                             'use_inline_display' => true,
                             'clickable_row' => true,
                         ])
-                )
+                ),
             ])
             );
     }

--- a/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
@@ -50,11 +50,6 @@ final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFact
     /**
      * @var string
      */
-    private $backUrl;
-
-    /**
-     * @var string
-     */
     private $contextDateFormat;
 
     /**
@@ -68,7 +63,6 @@ final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFact
         $contextDateFormat
     ) {
         parent::__construct($hookDispatcher);
-        $this->backUrl = $currentRequest ? $currentRequest->getUri() : '';
         $this->contextDateFormat = $contextDateFormat;
     }
 
@@ -125,18 +119,17 @@ final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFact
             ->setName($this->trans('Actions', [], 'Admin.Global'))
             ->setOptions([
                 'actions' => (new RowActionCollection())
-                ->add(
-                    (new LinkRowAction('view'))
-                        ->setName($this->trans('View', [], 'Admin.Actions'))
-                        ->setIcon('zoom_in')
-                        ->setOptions([
-                            'route' => 'admin_carts_view',
-                            'route_param_name' => 'cartId',
-                            'route_param_field' => 'id_cart',
-                            'use_inline_display' => true,
-                            'clickable_row' => true,
-                        ])
-                ),
+                    ->add((new LinkRowAction('view'))
+                    ->setName($this->trans('View', [], 'Admin.Actions'))
+                    ->setIcon('zoom_in')
+                    ->setOptions([
+                        'route' => 'admin_carts_view',
+                        'route_param_name' => 'cartId',
+                        'route_param_field' => 'id_cart',
+                        'use_inline_display' => true,
+                        'clickable_row' => true,
+                    ])
+                    ),
             ])
             );
     }

--- a/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class CustomerCartGridDefinitionFactory defines customer's cart grid structure.
+ */
+final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    use DeleteActionTrait;
+
+    public const GRID_ID = 'customer_cart';
+
+    /**
+     * @var string
+     */
+    private $backUrl;
+
+    /**
+     * @var string
+     */
+    private $contextDateFormat;
+
+    /**
+     * @param HookDispatcherInterface $hookDispatcher
+     * @param Request $currentRequest
+     * @param string $contextDateFormat
+     */
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        ?Request $currentRequest,
+        $contextDateFormat
+    ) {
+        parent::__construct($hookDispatcher);
+        $this->backUrl = $currentRequest ? $currentRequest->getUri() : '';
+        $this->contextDateFormat = $contextDateFormat;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId()
+    {
+        return self::GRID_ID;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName()
+    {
+        return $this->trans('Carts', [], 'Admin.Global');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns()
+    {
+        return (new ColumnCollection())
+            ->add(
+                (new DataColumn('id_cart'))
+                    ->setName($this->trans('ID', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'id_cart',
+                    ])
+            )
+            ->add((new DateTimeColumn('date_add'))
+                ->setName($this->trans('Date', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'date_add',
+                    'format' => $this->contextDateFormat,
+                ])
+            )
+            ->add((new DataColumn('carrier_name'))
+                ->setName($this->trans('Carrier', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'carrier_name',
+                ])
+            )
+            ->add((new DataColumn('total_paid_tax_incl'))
+                ->setName($this->trans('Total (Tax incl.)', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'total_paid_tax_incl',
+                ])
+            )
+            ->add((new ActionColumn('actions'))
+            ->setName($this->trans('Actions', [], 'Admin.Global'))
+            ->setOptions([
+                'actions' => (new RowActionCollection())
+                ->add(
+                    (new LinkRowAction('view'))
+                        ->setName($this->trans('View', [], 'Admin.Actions'))
+                        ->setIcon('zoom_in')
+                        ->setOptions([
+                            'route' => 'admin_carts_view',
+                            'route_param_name' => 'cartId',
+                            'route_param_field' => 'id_cart',
+                            'use_inline_display' => true,
+                            'clickable_row' => true,
+                        ])
+                )
+            ])
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getViewOptions()
+    {
+        return (new ViewOptionsCollection())
+            ->add('display_name', false);
+    }
+}

--- a/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerCartGridDefinitionFactory.php
@@ -36,7 +36,6 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class CustomerCartGridDefinitionFactory defines customer's cart grid structure.
@@ -54,12 +53,10 @@ final class CustomerCartGridDefinitionFactory extends AbstractGridDefinitionFact
 
     /**
      * @param HookDispatcherInterface $hookDispatcher
-     * @param Request $currentRequest
      * @param string $contextDateFormat
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
-        ?Request $currentRequest,
         $contextDateFormat
     ) {
         parent::__construct($hookDispatcher);

--- a/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\RowActionCollection;
+use PrestaShop\PrestaShop\Core\Grid\Action\Row\Type\LinkRowAction;
+use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Class CustomerOrderGridDefinitionFactory defines customer's order grid structure.
+ */
+final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    use DeleteActionTrait;
+
+    public const GRID_ID = 'customer_order';
+
+    /**
+     * @var string
+     */
+    private $backUrl;
+
+    /**
+     * @var string
+     */
+    private $contextDateFormat;
+
+    /**
+     * @param HookDispatcherInterface $hookDispatcher
+     * @param Request $currentRequest
+     * @param string $contextDateFormat
+     */
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        ?Request $currentRequest,
+        $contextDateFormat
+    ) {
+        parent::__construct($hookDispatcher);
+        $this->backUrl = $currentRequest ? $currentRequest->getUri() : '';
+        $this->contextDateFormat = $contextDateFormat;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId()
+    {
+        return self::GRID_ID;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName()
+    {
+        return $this->trans('Orders', [], 'Admin.Global');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns()
+    {
+        return (new ColumnCollection())
+            ->add(
+                (new DataColumn('id_order'))
+                    ->setName($this->trans('ID', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'id_order',
+                    ])
+            )
+            ->add((new DateTimeColumn('date_add'))
+                ->setName($this->trans('Date', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'date_add',
+                    'format' => $this->contextDateFormat,
+                ])
+            )
+            ->add((new DataColumn('payment'))
+                ->setName($this->trans('Payment', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'payment',
+                ])
+            )
+            ->add(
+                (new DataColumn('status'))
+                    ->setName($this->trans('Status', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'status',
+                    ])
+            )
+            ->add(
+                (new DataColumn('products'))
+                    ->setName($this->trans('Products', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'products',
+                    ])
+            )
+            ->add((new DataColumn('total_paid_tax_incl'))
+                ->setName($this->trans('Total (Tax incl.)', [], 'Admin.Global'))
+                ->setOptions([
+                    'field' => 'total_paid_tax_incl',
+                ])
+            )
+            ->add((new ActionColumn('actions'))
+            ->setName($this->trans('Actions', [], 'Admin.Global'))
+            ->setOptions([
+                'actions' => (new RowActionCollection())
+                ->add(
+                    (new LinkRowAction('view'))
+                        ->setName($this->trans('View', [], 'Admin.Actions'))
+                        ->setIcon('zoom_in')
+                        ->setOptions([
+                            'route' => 'admin_orders_view',
+                            'route_param_name' => 'orderId',
+                            'route_param_field' => 'id_order',
+                            'use_inline_display' => true,
+                            'clickable_row' => true,
+                        ])
+                )
+            ])
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getViewOptions()
+    {
+        return (new ViewOptionsCollection())
+            ->add('display_name', false);
+    }
+}

--- a/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
@@ -34,6 +34,7 @@ use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\HtmlColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -115,7 +116,7 @@ final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFac
                 ])
             )
             ->add(
-                (new DataColumn('status'))
+                (new HtmlColumn('status'))
                     ->setName($this->trans('Status', [], 'Admin.Global'))
                     ->setOptions([
                         'field' => 'status',

--- a/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
@@ -107,6 +107,7 @@ final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFac
                 ->setOptions([
                     'field' => 'date_add',
                     'format' => $this->contextDateFormat,
+                    'clickable' => true,
                 ])
             )
             ->add((new DataColumn('payment'))

--- a/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
@@ -123,10 +123,10 @@ final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFac
                     ])
             )
             ->add(
-                (new DataColumn('products'))
+                (new DataColumn('nb_products'))
                     ->setName($this->trans('Products', [], 'Admin.Global'))
                     ->setOptions([
-                        'field' => 'products',
+                        'field' => 'nb_products',
                     ])
             )
             ->add((new DataColumn('total_paid_tax_incl'))

--- a/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
@@ -51,11 +51,6 @@ final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFac
     /**
      * @var string
      */
-    private $backUrl;
-
-    /**
-     * @var string
-     */
     private $contextDateFormat;
 
     /**
@@ -69,7 +64,6 @@ final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFac
         $contextDateFormat
     ) {
         parent::__construct($hookDispatcher);
-        $this->backUrl = $currentRequest ? $currentRequest->getUri() : '';
         $this->contextDateFormat = $contextDateFormat;
     }
 

--- a/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
@@ -34,8 +34,8 @@ use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\ActionColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
-use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\HtmlColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\HtmlColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -95,52 +95,49 @@ final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFac
     protected function getColumns()
     {
         return (new ColumnCollection())
-            ->add(
-                (new DataColumn('id_order'))
-                    ->setName($this->trans('ID', [], 'Admin.Global'))
-                    ->setOptions([
-                        'field' => 'id_order',
-                    ])
+            ->add((new DataColumn('id_order'))
+            ->setName($this->trans('ID', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'id_order',
+            ])
             )
             ->add((new DateTimeColumn('date_add'))
-                ->setName($this->trans('Date', [], 'Admin.Global'))
-                ->setOptions([
-                    'field' => 'date_add',
-                    'format' => $this->contextDateFormat,
-                    'clickable' => true,
-                ])
+            ->setName($this->trans('Date', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'date_add',
+                'format' => $this->contextDateFormat,
+                'clickable' => true,
+            ])
             )
             ->add((new DataColumn('payment'))
-                ->setName($this->trans('Payment', [], 'Admin.Global'))
-                ->setOptions([
-                    'field' => 'payment',
-                ])
+            ->setName($this->trans('Payment', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'payment',
+            ])
             )
-            ->add(
-                (new HtmlColumn('status'))
-                    ->setName($this->trans('Status', [], 'Admin.Global'))
-                    ->setOptions([
-                        'field' => 'status',
-                    ])
+            ->add((new HtmlColumn('status'))
+            ->setName($this->trans('Status', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'status',
+            ])
             )
-            ->add(
-                (new DataColumn('nb_products'))
-                    ->setName($this->trans('Products', [], 'Admin.Global'))
-                    ->setOptions([
-                        'field' => 'nb_products',
-                    ])
+            ->add((new DataColumn('nb_products'))
+            ->setName($this->trans('Products', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'nb_products',
+            ])
             )
             ->add((new DataColumn('total_paid_tax_incl'))
-                ->setName($this->trans('Total (Tax incl.)', [], 'Admin.Global'))
-                ->setOptions([
-                    'field' => 'total_paid_tax_incl',
-                ])
+            ->setName($this->trans('Total (Tax incl.)', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'total_paid_tax_incl',
+            ])
             )
             ->add((new ActionColumn('actions'))
             ->setName($this->trans('Actions', [], 'Admin.Global'))
             ->setOptions([
                 'actions' => (new RowActionCollection())
-                ->add(
+                    ->add(
                     (new LinkRowAction('view'))
                         ->setName($this->trans('View', [], 'Admin.Actions'))
                         ->setIcon('zoom_in')
@@ -151,7 +148,7 @@ final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFac
                             'use_inline_display' => true,
                             'clickable_row' => true,
                         ])
-                )
+                    ),
             ])
             );
     }

--- a/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerOrderGridDefinitionFactory.php
@@ -37,7 +37,6 @@ use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
 use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\HtmlColumn;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class CustomerOrderGridDefinitionFactory defines customer's order grid structure.
@@ -55,12 +54,10 @@ final class CustomerOrderGridDefinitionFactory extends AbstractGridDefinitionFac
 
     /**
      * @param HookDispatcherInterface $hookDispatcher
-     * @param Request $currentRequest
      * @param string $contextDateFormat
      */
     public function __construct(
         HookDispatcherInterface $hookDispatcher,
-        ?Request $currentRequest,
         $contextDateFormat
     ) {
         parent::__construct($hookDispatcher);

--- a/src/Core/Grid/Query/CustomerCartQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerCartQueryBuilder.php
@@ -43,33 +43,17 @@ final class CustomerCartQueryBuilder extends AbstractDoctrineQueryBuilder
     private $searchCriteriaApplicator;
 
     /**
-     * @var int
-     */
-    private $contextLangId;
-
-    /**
-     * @var int[]
-     */
-    private $contextShopIds;
-
-    /**
      * @param Connection $connection
      * @param string $dbPrefix
      * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
-     * @param int $contextLangId
-     * @param array $contextShopIds
      */
     public function __construct(
         Connection $connection,
         string $dbPrefix,
-        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
-        int $contextLangId,
-        array $contextShopIds
+        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
     ) {
         parent::__construct($connection, $dbPrefix);
         $this->searchCriteriaApplicator = $searchCriteriaApplicator;
-        $this->contextLangId = $contextLangId;
-        $this->contextShopIds = $contextShopIds;
     }
 
     /**

--- a/src/Core/Grid/Query/CustomerCartQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerCartQueryBuilder.php
@@ -82,8 +82,7 @@ final class CustomerCartQueryBuilder extends AbstractDoctrineQueryBuilder
         $qb
             ->select(
                 'c.`id_cart`,
-                c.`date_add`,
-                "123.456" as total_paid_tax_incl'
+                c.`date_add`'
             )
             ->addSelect('ca.`name` as carrier_name')
         ;

--- a/src/Core/Grid/Query/CustomerCartQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerCartQueryBuilder.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Builds search & count queries for customer's cart grid.
+ */
+final class CustomerCartQueryBuilder extends AbstractDoctrineQueryBuilder
+{
+    /**
+     * @var DoctrineSearchCriteriaApplicatorInterface
+     */
+    private $searchCriteriaApplicator;
+
+    /**
+     * @var int
+     */
+    private $contextLangId;
+
+    /**
+     * @var int[]
+     */
+    private $contextShopIds;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
+     * @param int $contextLangId
+     * @param array $contextShopIds
+     */
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
+        int $contextLangId,
+        array $contextShopIds
+    ) {
+        parent::__construct($connection, $dbPrefix);
+        $this->searchCriteriaApplicator = $searchCriteriaApplicator;
+        $this->contextLangId = $contextLangId;
+        $this->contextShopIds = $contextShopIds;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->getQueryBuilder($searchCriteria->getFilters());
+
+        $qb
+            ->select(
+                'c.`id_cart`,
+                c.`date_add`,
+                "TODO" as total_paid_tax_incl'
+            )
+            ->addSelect('ca.`name` as carrier_name')
+        ;
+
+        $this->searchCriteriaApplicator
+            ->applyPagination($searchCriteria, $qb)
+            ->applySorting($searchCriteria, $qb)
+        ;
+
+        return $qb;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        return $this->getQueryBuilder($searchCriteria->getFilters())
+            ->select('COUNT(DISTINCT c.`id_cart`)');
+    }
+
+    /**
+     * Gets query builder with the common sql used for displaying carts list and applying filter actions.
+     *
+     * @param array $filters
+     *
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder(array $filters): QueryBuilder
+    {
+        $qb = $this->connection
+            ->createQueryBuilder()
+            ->from($this->dbPrefix . 'cart', 'c')
+            ->where('c.`id_customer` != 0');
+
+        $qb->leftJoin(
+            'c',
+            $this->dbPrefix . 'carrier',
+            'ca',
+            'c.`id_carrier` = ca.`id_carrier`'
+        );
+
+        $this->applyFilters($qb, $filters);
+
+        return $qb;
+    }
+
+    /**
+     * Apply filters to cart query builder.
+     *
+     * @param array $filters
+     * @param QueryBuilder $qb
+     */
+    private function applyFilters(QueryBuilder $qb, array $filters)
+    {
+        $allowedFiltersMap = [
+            'id_customer' => 'c.id_customer',
+        ];
+
+        foreach ($filters as $filterName => $value) {
+            if (!array_key_exists($filterName, $allowedFiltersMap) || empty($value)) {
+                continue;
+            }
+
+            if ('id_customer' === $filterName) {
+                $qb->andWhere('c.`id_customer` = :' . $filterName);
+                $qb->setParameter($filterName, $value);
+            }
+        }
+    }
+}

--- a/src/Core/Grid/Query/CustomerCartQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerCartQueryBuilder.php
@@ -83,7 +83,7 @@ final class CustomerCartQueryBuilder extends AbstractDoctrineQueryBuilder
             ->select(
                 'c.`id_cart`,
                 c.`date_add`,
-                "TODO" as total_paid_tax_incl'
+                "123.456" as total_paid_tax_incl'
             )
             ->addSelect('ca.`name` as carrier_name')
         ;

--- a/src/Core/Grid/Query/CustomerOrderQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerOrderQueryBuilder.php
@@ -79,8 +79,7 @@ final class CustomerOrderQueryBuilder extends AbstractDoctrineQueryBuilder
     {
         $qb = $this->getQueryBuilder($searchCriteria->getFilters());
 
-        $qb
-            ->select(
+        $qb->select(
                 'o.`id_order`,
                 o.`date_add`,
                 o.`payment`,
@@ -88,7 +87,7 @@ final class CustomerOrderQueryBuilder extends AbstractDoctrineQueryBuilder
                 "TODO" AS products,
                 o.valid AS valid,
                 osl.name AS status'
-            );
+        );
 
         $qb->addSelect('
             (SELECT SUM(od.`product_quantity`) 
@@ -132,7 +131,7 @@ final class CustomerOrderQueryBuilder extends AbstractDoctrineQueryBuilder
                 'osl',
                 'os.id_order_state = osl.id_order_state AND osl.id_lang = :context_lang_id'
             );
-        
+
         $qb->andWhere('o.id_shop IN (:context_shop_ids)')
             ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY)
             ->setParameter('context_lang_id', $this->contextLangId);

--- a/src/Core/Grid/Query/CustomerOrderQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerOrderQueryBuilder.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Builds search & count queries for customer's order grid.
+ */
+final class CustomerOrderQueryBuilder extends AbstractDoctrineQueryBuilder
+{
+    /**
+     * @var DoctrineSearchCriteriaApplicatorInterface
+     */
+    private $searchCriteriaApplicator;
+
+    /**
+     * @var int
+     */
+    private $contextLangId;
+
+    /**
+     * @var int[]
+     */
+    private $contextShopIds;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
+     * @param int $contextLangId
+     * @param array $contextShopIds
+     */
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
+        int $contextLangId,
+        array $contextShopIds
+    ) {
+        parent::__construct($connection, $dbPrefix);
+        $this->searchCriteriaApplicator = $searchCriteriaApplicator;
+        $this->contextLangId = $contextLangId;
+        $this->contextShopIds = $contextShopIds;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->getQueryBuilder($searchCriteria->getFilters());
+
+        $qb
+            ->select(
+                'o.`id_order`,
+                o.`date_add`,
+                o.`payment`,
+                o.`total_paid_tax_incl`,
+                "TODO" AS products,
+                osl.name AS status'
+            );
+
+        $this->searchCriteriaApplicator
+            ->applyPagination($searchCriteria, $qb)
+            ->applySorting($searchCriteria, $qb)
+        ;
+
+        return $qb;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        return $this->getQueryBuilder($searchCriteria->getFilters())
+            ->select('COUNT(DISTINCT o.`id_order`)');
+    }
+
+    /**
+     * Gets query builder with the common sql used for displaying orders list and applying filter actions.
+     *
+     * @param array $filters
+     *
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder(array $filters): QueryBuilder
+    {
+        $qb = $this->connection
+            ->createQueryBuilder()
+            ->from($this->dbPrefix . 'orders', 'o')
+            ->where('o.`id_customer` != 0')
+            ->leftJoin('o', $this->dbPrefix . 'order_state', 'os', 'o.current_state = os.id_order_state')
+            ->leftJoin(
+                'os',
+                $this->dbPrefix . 'order_state_lang',
+                'osl',
+                'os.id_order_state = osl.id_order_state AND osl.id_lang = :context_lang_id'
+            );
+        
+        $qb->andWhere('o.id_shop IN (:context_shop_ids)')
+            ->setParameter('context_shop_ids', $this->contextShopIds, Connection::PARAM_INT_ARRAY)
+            ->setParameter('context_lang_id', $this->contextLangId);
+
+        $this->applyFilters($qb, $filters);
+
+        return $qb;
+    }
+
+    /**
+     * Apply filters to order query builder.
+     *
+     * @param array $filters
+     * @param QueryBuilder $qb
+     */
+    private function applyFilters(QueryBuilder $qb, array $filters)
+    {
+        $allowedFiltersMap = [
+            'id_customer' => 'o.id_customer',
+        ];
+
+        foreach ($filters as $filterName => $value) {
+            if (!array_key_exists($filterName, $allowedFiltersMap) || empty($value)) {
+                continue;
+            }
+
+            if ('id_customer' === $filterName) {
+                $qb->andWhere('o.`id_customer` = :' . $filterName);
+                $qb->setParameter($filterName, $value);
+            }
+        }
+    }
+}

--- a/src/Core/Grid/Query/CustomerOrderQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerOrderQueryBuilder.php
@@ -90,6 +90,11 @@ final class CustomerOrderQueryBuilder extends AbstractDoctrineQueryBuilder
                 osl.name AS status'
             );
 
+        $qb->addSelect('
+            (SELECT SUM(od.`product_quantity`) 
+            FROM `' . $this->dbPrefix . 'order_detail` od 
+            WHERE od.`id_order` = o.`id_order`) nb_products');
+
         $this->searchCriteriaApplicator
             ->applyPagination($searchCriteria, $qb)
             ->applySorting($searchCriteria, $qb)

--- a/src/Core/Grid/Query/CustomerOrderQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerOrderQueryBuilder.php
@@ -86,6 +86,7 @@ final class CustomerOrderQueryBuilder extends AbstractDoctrineQueryBuilder
                 o.`payment`,
                 o.`total_paid_tax_incl`,
                 "TODO" AS products,
+                o.valid AS valid,
                 osl.name AS status'
             );
 

--- a/src/Core/Search/Filters/CustomerCartFilters.php
+++ b/src/Core/Search/Filters/CustomerCartFilters.php
@@ -48,7 +48,7 @@ final class CustomerCartFilters extends Filters
             'limit' => 10,
             'offset' => 0,
             'orderBy' => 'id_cart',
-            'sortOrder' => 'asc',
+            'sortOrder' => 'DESC',
             'filters' => [],
         ];
     }

--- a/src/Core/Search/Filters/CustomerCartFilters.php
+++ b/src/Core/Search/Filters/CustomerCartFilters.php
@@ -47,7 +47,7 @@ final class CustomerCartFilters extends Filters
         return [
             'limit' => 10,
             'offset' => 0,
-            'orderBy' => 'id_address',
+            'orderBy' => 'id_cart',
             'sortOrder' => 'asc',
             'filters' => [],
         ];

--- a/src/Core/Search/Filters/CustomerCartFilters.php
+++ b/src/Core/Search/Filters/CustomerCartFilters.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerCartGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+/**
+ * Default customer's carts list filters
+ */
+final class CustomerCartFilters extends Filters
+{
+    /** @var string */
+    protected $filterId = CustomerCartGridDefinitionFactory::GRID_ID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults(): array
+    {
+        return [
+            'limit' => 10,
+            'offset' => 0,
+            'orderBy' => 'id_address',
+            'sortOrder' => 'asc',
+            'filters' => [],
+        ];
+    }
+}

--- a/src/Core/Search/Filters/CustomerCartFilters.php
+++ b/src/Core/Search/Filters/CustomerCartFilters.php
@@ -48,7 +48,7 @@ final class CustomerCartFilters extends Filters
             'limit' => 10,
             'offset' => 0,
             'orderBy' => 'id_cart',
-            'sortOrder' => 'DESC',
+            'sortOrder' => 'desc',
             'filters' => [],
         ];
     }

--- a/src/Core/Search/Filters/CustomerOrderFilters.php
+++ b/src/Core/Search/Filters/CustomerOrderFilters.php
@@ -48,7 +48,7 @@ final class CustomerOrderFilters extends Filters
             'limit' => 10,
             'offset' => 0,
             'orderBy' => 'id_order',
-            'sortOrder' => 'desc',
+            'sortOrder' => 'DESC',
             'filters' => [],
         ];
     }

--- a/src/Core/Search/Filters/CustomerOrderFilters.php
+++ b/src/Core/Search/Filters/CustomerOrderFilters.php
@@ -47,7 +47,7 @@ final class CustomerOrderFilters extends Filters
         return [
             'limit' => 10,
             'offset' => 0,
-            'orderBy' => 'id_address',
+            'orderBy' => 'id_order',
             'sortOrder' => 'desc',
             'filters' => [],
         ];

--- a/src/Core/Search/Filters/CustomerOrderFilters.php
+++ b/src/Core/Search/Filters/CustomerOrderFilters.php
@@ -48,7 +48,7 @@ final class CustomerOrderFilters extends Filters
             'limit' => 10,
             'offset' => 0,
             'orderBy' => 'id_order',
-            'sortOrder' => 'DESC',
+            'sortOrder' => 'desc',
             'filters' => [],
         ];
     }

--- a/src/Core/Search/Filters/CustomerOrderFilters.php
+++ b/src/Core/Search/Filters/CustomerOrderFilters.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerOrderGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+/**
+ * Default customer's order list filters
+ */
+final class CustomerOrderFilters extends Filters
+{
+    /** @var string */
+    protected $filterId = CustomerOrderGridDefinitionFactory::GRID_ID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults(): array
+    {
+        return [
+            'limit' => 10,
+            'offset' => 0,
+            'orderBy' => 'id_address',
+            'sortOrder' => 'desc',
+            'filters' => [],
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -318,21 +318,15 @@ class CustomerController extends AbstractAdminController
 
         // Order listing
         $customerOrderGridFactory = $this->get('prestashop.core.grid.factory.customer.order');
-        $customerOrderFilters = new CustomerOrderFilters([
-            'filters' => [
-                'id_customer' => $customerId,
-            ],
-        ] + $customerOrderFilters->all());
-        $customerOrderGrid = $customerOrderGridFactory->getGrid($customerOrderFilters);
+        $filters = $customerOrderFilters->getDefaults();
+        $filters['filters'] = ['id_customer' => $customerId];
+        $customerOrderGrid = $customerOrderGridFactory->getGrid(new CustomerOrderFilters($filters));
 
         // Cart listing
         $customerCartGridFactory = $this->get('prestashop.core.grid.factory.customer.cart');
-        $customerCartFilters = new CustomerCartFilters([
-            'filters' => [
-                'id_customer' => $customerId,
-            ],
-        ] + $customerCartFilters->all());
-        $customerCartGrid = $customerCartGridFactory->getGrid($customerCartFilters);
+        $filters = $customerCartFilters->getDefaults();
+        $filters['filters'] = ['id_customer' => $customerId];
+        $customerCartGrid = $customerCartGridFactory->getGrid(new CustomerCartFilters($filters));
 
         if ($request->query->has('conf')) {
             $this->manageLegacyFlashes($request->query->get('conf'));

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -300,33 +300,23 @@ class CustomerController extends AbstractAdminController
 
         // Discount listing
         $customerDiscountGridFactory = $this->get('prestashop.core.grid.factory.customer.discount');
-        $customerDiscountFilters = new CustomerDiscountFilters([
-            'filters' => [
-                'id_customer' => $customerId,
-            ],
-        ] + $customerDiscountFilters->all());
+        $customerDiscountFilters->addFilter(['id_customer' => $customerId]);
         $customerDiscountGrid = $customerDiscountGridFactory->getGrid($customerDiscountFilters);
 
         // Addresses listing
         $customerAddressGridFactory = $this->get('prestashop.core.grid.factory.customer.address');
-        $customerAddressFilters = new CustomerAddressFilters([
-            'filters' => [
-                'id_customer' => $customerId,
-            ],
-        ] + $customerAddressFilters->all());
+        $customerAddressFilters->addFilter(['id_customer' => $customerId]);
         $customerAddressGrid = $customerAddressGridFactory->getGrid($customerAddressFilters);
 
         // Order listing
         $customerOrderGridFactory = $this->get('prestashop.core.grid.factory.customer.order');
-        $filters = $customerOrderFilters->getDefaults();
-        $filters['filters'] = ['id_customer' => $customerId];
-        $customerOrderGrid = $customerOrderGridFactory->getGrid(new CustomerOrderFilters($filters));
+        $customerOrderFilters->addFilter(['id_customer' => $customerId]);
+        $customerOrderGrid = $customerOrderGridFactory->getGrid($customerOrderFilters);
 
         // Cart listing
         $customerCartGridFactory = $this->get('prestashop.core.grid.factory.customer.cart');
-        $filters = $customerCartFilters->getDefaults();
-        $filters['filters'] = ['id_customer' => $customerId];
-        $customerCartGrid = $customerCartGridFactory->getGrid(new CustomerCartFilters($filters));
+        $customerCartFilters->addFilter(['id_customer' => $customerId]);
+        $customerCartGrid = $customerCartGridFactory->getGrid($customerCartFilters);
 
         if ($request->query->has('conf')) {
             $this->manageLegacyFlashes($request->query->get('conf'));

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -60,8 +60,8 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGridDefinitionFac
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerAddressFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerCartFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerDiscountFilters;
-use PrestaShop\PrestaShop\Core\Search\Filters\CustomerOrderFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
+use PrestaShop\PrestaShop\Core\Search\Filters\CustomerOrderFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Customer\DeleteCustomersType;

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -96,6 +96,24 @@ services:
       - '@=service("prestashop.adapter.shop.context").getContextListShopIDUsingCustomerSharingSettings()'
     public: true
 
+  prestashop.core.grid.query_builder.customer_cart:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Query\CustomerCartQueryBuilder'
+    parent: 'prestashop.core.grid.abstract_query_builder'
+    arguments:
+      - '@prestashop.core.query.doctrine_search_criteria_applicator'
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - '@=service("prestashop.adapter.shop.context").getContextListShopIDUsingCustomerSharingSettings()'
+    public: true
+
+  prestashop.core.grid.query_builder.customer_order:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Query\CustomerOrderQueryBuilder'
+    parent: 'prestashop.core.grid.abstract_query_builder'
+    arguments:
+      - '@prestashop.core.query.doctrine_search_criteria_applicator'
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - '@=service("prestashop.adapter.shop.context").getContextListShopIDUsingCustomerSharingSettings()'
+    public: true
+
   prestashop.core.grid.quer_.builder.language:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\LanguageQueryBuilder'
     parent: 'prestashop.core.grid.abstract_query_builder'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -133,6 +133,7 @@ services:
       - '@prestashop.core.grid.data_provider.customer_cart'
       - "@prestashop.core.localization.locale.context_locale"
       - "@=service('prestashop.adapter.legacy.context').getContext().currency.iso_code"
+      - '@prestashop.core.query_bus'
 
   prestashop.core.grid.data_provider.customer_order_decorator:
     class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerOrderGridDataFactoryDecorator'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -106,10 +106,40 @@ services:
       - '@prestashop.core.grid.query.doctrine_query_parser'
       - 'customer_address'
 
+  prestashop.core.grid.data_provider.customer_cart:
+    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+    arguments:
+      - '@prestashop.core.grid.query_builder.customer_cart'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.core.grid.query.doctrine_query_parser'
+      - 'customer_cart'
+
+  prestashop.core.grid.data_provider.customer_order:
+    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+    arguments:
+      - '@prestashop.core.grid.query_builder.customer_order'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.core.grid.query.doctrine_query_parser'
+      - 'customer_order'
+
   prestashop.core.grid.data_provider.customer_address_decorator:
     class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerAddressGridDataFactoryDecorator'
     arguments:
       - '@prestashop.core.grid.data_provider.customer_address'
+
+  prestashop.core.grid.data_provider.customer_cart_decorator:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerAddressGridDataFactoryDecorator'
+    arguments:
+      - '@prestashop.core.grid.data_provider.customer_cart'
+      - "@prestashop.core.localization.locale.context_locale"
+      - "@=service('prestashop.adapter.legacy.context').getContext().currency.iso_code"
+
+  prestashop.core.grid.data_provider.customer_order_decorator:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerAddressGridDataFactoryDecorator'
+    arguments:
+      - '@prestashop.core.grid.data_provider.customer_order'
+      - "@prestashop.core.localization.locale.context_locale"
+      - "@=service('prestashop.adapter.legacy.context').getContext().currency.iso_code"
 
   prestashop.core.grid.data.factory.language:
     class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -128,14 +128,14 @@ services:
       - '@prestashop.core.grid.data_provider.customer_address'
 
   prestashop.core.grid.data_provider.customer_cart_decorator:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerAddressGridDataFactoryDecorator'
+    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerCartGridDataFactoryDecorator'
     arguments:
       - '@prestashop.core.grid.data_provider.customer_cart'
       - "@prestashop.core.localization.locale.context_locale"
       - "@=service('prestashop.adapter.legacy.context').getContext().currency.iso_code"
 
   prestashop.core.grid.data_provider.customer_order_decorator:
-    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerAddressGridDataFactoryDecorator'
+    class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerOrderGridDataFactoryDecorator'
     arguments:
       - '@prestashop.core.grid.data_provider.customer_order'
       - "@prestashop.core.localization.locale.context_locale"

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -86,6 +86,22 @@ services:
       - '@=service("request_stack").getCurrentRequest()'
     public: true
 
+  prestashop.core.grid.definition.factory.customer.cart:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerCartGridDefinitionFactory'
+    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+    arguments:
+      - '@=service("request_stack").getCurrentRequest()'
+      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
+    public: true
+
+  prestashop.core.grid.definition.factory.customer.order:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerOrderGridDefinitionFactory'
+    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+    arguments:
+      - '@=service("request_stack").getCurrentRequest()'
+      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
+    public: true
+
   prestashop.core.grid.definition.factory.language:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory'
     parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -90,7 +90,6 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerCartGridDefinitionFactory'
     parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
     arguments:
-      - '@=service("request_stack").getCurrentRequest()'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
     public: true
 
@@ -98,7 +97,6 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerOrderGridDefinitionFactory'
     parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
     arguments:
-      - '@=service("request_stack").getCurrentRequest()'
       - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
     public: true
 

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -104,6 +104,22 @@ services:
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
 
+  prestashop.core.grid.factory.customer.cart:
+    class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+    arguments:
+      - '@prestashop.core.grid.definition.factory.customer.cart'
+      - '@prestashop.core.grid.data_provider.customer_cart_decorator'
+      - '@prestashop.core.grid.filter.form_factory'
+      - '@prestashop.core.hook.dispatcher'
+
+  prestashop.core.grid.factory.customer.order:
+    class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+    arguments:
+      - '@prestashop.core.grid.definition.factory.customer.order'
+      - '@prestashop.core.grid.data_provider.customer_order_decorator'
+      - '@prestashop.core.grid.filter.form_factory'
+      - '@prestashop.core.hook.dispatcher'
+
   prestashop.core.grid.factory.language:
     class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
     arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/addresses.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/addresses.html.twig
@@ -27,7 +27,7 @@
   <h3 class="card-header">
     <i class="material-icons">location_on</i>
     {{ 'Addresses'|trans({}, 'Admin.Global') }}
-    <span class="badge badge-primary rounded">{{ customerInformation.addressesInformation|length }}</span>
+    <span class="badge badge-primary rounded">{{ customerAddressGrid.data.records_total }}</span>
 
     <a href="{{ getAdminLink('AdminAddresses', true, {'id_customer': customerInformation.customerId.value, 'addaddress': 1, 'back': app.request.uri}) }}" class="tooltip-link float-right" 
     data-toggle="pstooltip" title="" data-placement="top" data-original-title="{{ 'Add'|trans({}, 'Admin.Actions') }}">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/carts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/carts.html.twig
@@ -27,67 +27,16 @@
   <h3 class="card-header">
     <i class="material-icons">shopping_cart</i>
     {{ 'Carts'|trans({}, 'Admin.Global') }}
-    <span class="badge badge-primary rounded">{{ customerInformation.cartsInformation|length }}</span>
+    <span class="badge badge-primary rounded">{{ customerCartGrid.data.records_total }}</span>
   </h3>
-  <div class="card-body">
-    {% if customerInformation.cartsInformation is not empty %}
-      <table class="table">
-        <thead>
-          <tr>
-            <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-            <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-            <th>{{ 'Carrier'|trans({}, 'Admin.Global') }}</th>
-            <th>{{ 'Total (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
-            <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for cart in customerInformation.cartsInformation %}
-          {% set cartViewUrl = getAdminLink('AdminCarts', true, {'id_cart': cart.cartId, 'viewcart': 1}) %}
-
-          <tr class="customer-cart">
-            <td class="customer-cart-id js-linkable-item cursor-pointer" data-linkable-href="{{ cartViewUrl }}">{{ cart.cartId }}</td>
-            <td class="customer-cart-date js-linkable-item cursor-pointer" data-linkable-href="{{ cartViewUrl }}">{{ cart.cartCreationDate }}</td>
-            <td class="customer-cart-carrier js-linkable-item cursor-pointer" data-linkable-href="{{ cartViewUrl }}">{{ cart.carrierName }}</td>
-            <td class="customer-cart-total js-linkable-item cursor-pointer" data-linkable-href="{{ cartViewUrl }}">{{ cart.cartTotal }}</td>
-            <td class="customer-cart-actions text-right">
-              <div class="btn-group-action">
-                <div class="btn-group">
-                  <a href="{{ cartViewUrl }}"
-                     class="btn tooltip-link dropdown-item grid-view-row-link"
-                     data-toggle="pstooltip"
-                     data-placement="top"
-                     data-original-title="{{ 'View'|trans({}, 'Admin.Actions') }}"
-                  >
-                    <i class="material-icons">zoom_in</i>
-                  </a>
-                </div>
-              </div>
-            </td>
-          </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-    {% else %}
-      <p class="text-muted text-center mb-0">
-        {{ 'No cart is available'|trans({}, 'Admin.Orderscustomers.Notification') }}
-      </p>
-    {% endif %}
-  </div>
-   ----- NEW -----
   <div class="card-body">
     {% if customerCartGrid.data.records_total > 0 %}
       {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerCartGrid} %}
     {% else %}
-      TODO
       <div class="text-center">
         <p class="text-muted mb-2">
-          {{ '%firstname% %lastname% has not registered any addresses yet'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
+          {{ '%firstname% %lastname% did not create any cart yet'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
         </p> 
-        <a class="btn btn-primary" href="{{ getAdminLink('AdminAddresses', true, {'id_customer': customerInformation.customerId.value, 'addaddress': 1, 'back': app.request.uri}) }}">
-          <i class="material-icons">add_circle</i>
-          {{ 'Create address'|trans({}, 'Admin.Global') }}
-        </a>
       </div>
     {% endif %}
   </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/carts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/carts.html.twig
@@ -74,4 +74,21 @@
       </p>
     {% endif %}
   </div>
+   ----- NEW -----
+  <div class="card-body">
+    {% if customerCartGrid.data.records_total > 0 %}
+      {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerCartGrid} %}
+    {% else %}
+      TODO
+      <div class="text-center">
+        <p class="text-muted mb-2">
+          {{ '%firstname% %lastname% has not registered any addresses yet'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
+        </p> 
+        <a class="btn btn-primary" href="{{ getAdminLink('AdminAddresses', true, {'id_customer': customerInformation.customerId.value, 'addaddress': 1, 'back': app.request.uri}) }}">
+          <i class="material-icons">add_circle</i>
+          {{ 'Create address'|trans({}, 'Admin.Global') }}
+        </a>
+      </div>
+    {% endif %}
+  </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/discounts.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/discounts.html.twig
@@ -27,7 +27,7 @@
   <h3 class="card-header">
     <i class="material-icons">loyalty</i>
     {{ 'Vouchers'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    <span class="badge badge-primary rounded">{{ customerInformation.discountsInformation|length }}</span>
+    <span class="badge badge-primary rounded">{{ customerDiscountGrid.data.records_total }}</span>
 
     <a href="{{ getAdminLink('AdminCartRules', true, {'addcart_rule': 1, 'back': app.request.uri}) }}" class="tooltip-link float-right" 
     data-toggle="pstooltip" title="" data-placement="top" data-original-title="{{ 'Add'|trans({}, 'Admin.Actions') }}">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
@@ -22,16 +22,11 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-
-{% set validOrdersCount = customerInformation.ordersInformation.validOrders|length %}
-{% set invalidOrdersCount = customerInformation.ordersInformation.invalidOrders|length %}
-{% set ordersCount = validOrdersCount + invalidOrdersCount %}
-
 <div class="card customer-orders-card">
   <h3 class="card-header">
     <i class="material-icons">shopping_basket</i>
     {{ 'Orders'|trans({}, 'Admin.Global') }}
-    <span class="badge badge-primary rounded">{{ ordersCount }}</span>
+    <span class="badge badge-primary rounded">{{ customerOrderGrid.data.records_total }}</span>
 
     <a href="{{ path('admin_orders_create') }}" class="tooltip-link float-right" 
     data-toggle="pstooltip" title="" data-placement="top" data-original-title="{{ 'Add'|trans({}, 'Admin.Actions') }}">
@@ -39,19 +34,19 @@
     </a>
   </h3>
   <div class="card-body">
-    {% if ordersCount > 0 %}
+    {% if customerOrderGrid.data.records_total > 0 %}
       <div class="card">
         <div class="card-body">
           <div class="row">
             <div class="col">
               {{ 'Valid orders:'|trans({}, 'Admin.Orderscustomers.Feature') }}
-              <span class="badge badge-success rounded">{{ validOrdersCount }}</span>
+              <span class="badge badge-success rounded">{{ customerInformation.ordersInformation.validOrders|length }}</span>
               {% set totalAmount = '<span id="total-order-amount">'~customerInformation.ordersInformation.totalSpent~'</span>' %}
               {{ 'for a total amount of %s'|trans({}, 'Admin.Orderscustomers.Feature')|format(totalAmount)|raw }}
             </div>
             <div class="col">
               {{ 'Invalid orders:'|trans({}, 'Admin.Orderscustomers.Feature') }}
-              <span class="badge badge-danger rounded">{{ invalidOrdersCount }}</span>
+              <span class="badge badge-danger rounded">{{ customerInformation.ordersInformation.invalidOrders|length }}</span>
             </div>
           </div>
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
@@ -148,4 +148,21 @@
       </div>
     {% endif %}
   </div>
+   ----- NEW -----
+  <div class="card-body">
+    {% if customerOrderGrid.data.records_total > 0 %}
+      {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerOrderGrid} %}
+    {% else %}
+      TODO
+      <div class="text-center">
+        <p class="text-muted mb-2">
+          {{ '%firstname% %lastname% has not registered any addresses yet'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
+        </p> 
+        <a class="btn btn-primary" href="{{ getAdminLink('AdminAddresses', true, {'id_customer': customerInformation.customerId.value, 'addaddress': 1, 'back': app.request.uri}) }}">
+          <i class="material-icons">add_circle</i>
+          {{ 'Create address'|trans({}, 'Admin.Global') }}
+        </a>
+      </div>
+    {% endif %}
+  </div>
 </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/orders.html.twig
@@ -56,86 +56,9 @@
           </div>
         </div>
       </div>
-
-      {% if validOrdersCount %}
-        <table class="table">
-          <thead>
-            <tr>
-              <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Total (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
-              <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for order in customerInformation.ordersInformation.validOrders %}
-              {% set orderViewUrl = getAdminLink('AdminOrders', true, {'id_order': order.orderId, 'vieworder': 1}) %}
-
-              <tr class="customer-valid-order">
-                <td class="customer-valid-order-id js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderId }}</td>
-                <td class="customer-valid-order-date js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderPlacedDate }}</td>
-                <td class="customer-valid-order-payment js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.paymentMethodName }}</td>
-                <td class="customer-valid-order-status js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderStatus }}</td>
-                <td class="customer-valid-order-products js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderProductsCount }}</td>
-                <td class="customer-valid-order-total js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.totalPaid }}</td>
-                <td class="customer-valid-order-actions text-right">
-                  <div class="btn-group-action">
-                    <div class="btn-group">
-                      <a href="{{ orderViewUrl }}" class="btn tooltip-link dropdown-item view-link" data-toggle="pstooltip" data-placement="top" data-original-title="{{ 'View'|trans({}, 'Admin.Actions') }}">
-                        <i class="material-icons">zoom_in</i>
-                      </a>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      {% endif %}
-
-
-      {% if invalidOrdersCount %}
-        <table class="table">
-          <thead>
-            <tr>
-              <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Date'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Payment'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Status'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Products'|trans({}, 'Admin.Global') }}</th>
-              <th>{{ 'Total (Tax incl.)'|trans({}, 'Admin.Orderscustomers.Feature') }}</th>
-              <th class="text-right">{{ 'Actions'|trans({}, 'Admin.Global') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for order in customerInformation.ordersInformation.invalidOrders %}
-              {% set orderViewUrl = getAdminLink('AdminOrders', true, {'id_order': order.orderId, 'vieworder': 1}) %}
-
-              <tr class="customer-invalid-order">
-                <td class="customer-invalid-order-id js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderId }}</td>
-                <td class="customer-invalid-order-date js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderPlacedDate }}</td>
-                <td class="customer-invalid-order-payment js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.paymentMethodName }}</td>
-                <td class="customer-invalid-order-status js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderStatus }}</td>
-                <td class="customer-invalid-order-products js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.orderProductsCount }}</td>
-                <td class="customer-invalid-order-total js-linkable-item cursor-pointer" data-linkable-href="{{ orderViewUrl }}">{{ order.totalPaid }}</td>
-                <td class="text-right customer-invalid-order-actions">
-                  <div class="btn-group-action">
-                    <div class="btn-group">
-                      <a href="{{ orderViewUrl }}" class="btn tooltip-link dropdown-item grid-view-row-link" data-toggle="pstooltip" data-placement="top" data-original-title="{{ 'View'|trans({}, 'Admin.Actions') }}">
-                        <i class="material-icons">zoom_in</i>
-                      </a>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      {% endif %}
-
+    {% endif %}
+    {% if customerOrderGrid.data.records_total > 0 %}
+      {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerOrderGrid} %}
     {% else %}
       <div class="text-center">
         <p class="text-muted mb-2">
@@ -144,23 +67,6 @@
         <a class="btn btn-primary" href="{{ path('admin_orders_create') }}">
           <i class="material-icons">add_circle</i>
           {{ 'Create manual order'|trans({}, 'Admin.Global') }}
-        </a>
-      </div>
-    {% endif %}
-  </div>
-   ----- NEW -----
-  <div class="card-body">
-    {% if customerOrderGrid.data.records_total > 0 %}
-      {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerOrderGrid} %}
-    {% else %}
-      TODO
-      <div class="text-center">
-        <p class="text-muted mb-2">
-          {{ '%firstname% %lastname% has not registered any addresses yet'|trans({'%firstname%': customerInformation.personalInformation.firstName, '%lastname%': customerInformation.personalInformation.lastName}, 'Admin.Orderscustomers.Feature') }}
-        </p> 
-        <a class="btn btn-primary" href="{{ getAdminLink('AdminAddresses', true, {'id_customer': customerInformation.customerId.value, 'addaddress': 1, 'back': app.request.uri}) }}">
-          <i class="material-icons">add_circle</i>
-          {{ 'Create address'|trans({}, 'Admin.Global') }}
         </a>
       </div>
     {% endif %}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | see below
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Check the page and see that it works the same, but limits the amount of shown orders and carts to 10. The main difference will be visible when viewing a customer with many orders and carts (50+).
| Fixed ticket?     | Fixes #25683, Fixes #15444
| Related PRs       | 
| Sponsor company   | [AGRO-LA]( https://eshop.agrola.cz/)

### Details
- Right now, the cart and order listing on customer detail is a simple manually rendered table. When customer has more oders, let's say more than 20, it's incredibly slow because of all the carts loading and computing their data.
- You can see how it looks with 70 orders - https://user-images.githubusercontent.com/6097524/219952122-995c4f22-26dd-4e5b-acd0-de4124d8e59f.png, and I cropped about a kilometer of bought products. 😄
 - So, I changed the implementation of these two tables to grids. 
 - This fixes the insanely slow page load time, makes the page readable and allows the use of standard hooks. I followed address grid as an example.
 - For orders, there were originally two grids for valid and invalid orders. I unified orders to a single grid and marked the valid/invalid thing with a green/red badge. I think it simplifies things and looks quite good. PM validated.
 - When this is approved, I can continue with the list of bought products, which can be also pretty long.

### Screenshot
![localhost_dev_admin-dev_index php_sell_customers_2_view__token=Kzw8BCzesvbRA4l1fN_MoC74wv0Dq5WUYVCa433F5FA customer_order%5BorderBy%5D=id_order customer_order%5BsortOrder%5D=asc](https://user-images.githubusercontent.com/6097524/219899403-1b9fbae8-0ca4-49c3-906b-db057f5873e2.png)
