### PR TITLE
Add guest customer edit test

### DIFF
--- a/tests/Integration/Behaviour/Features/Context/CustomerManagerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/CustomerManagerFeatureContext.php
@@ -99,16 +99,15 @@ class CustomerManagerFeatureContext extends AbstractPrestaShopFeatureContext
             throw new Exception('Password must be provided, if creating a registered customer');
         }
 
-        // Process data and apply fallbacks
-        $password = $data['password'];
-        $defaultGroupId = $data['defaultGroupId'] ?? $defaultGroups->getCustomersGroup()->getId();
-        $groupIds = $data['groupIds'] ?? [$defaultGroups->getCustomersGroup()->getId()];
-
         // Apply minor differences for guests
         if (!empty($data['isGuest'])) {
             $password = (new PasswordGenerator(new OpenSSL()))->generatePassword(16, 'RANDOM');
             $defaultGroupId = $defaultGroups->getGuestsGroup()->getId();
             $groupIds = [$defaultGroups->getGuestsGroup()->getId()];
+        } else {
+            $password = $data['password'];
+            $defaultGroupId = $data['defaultGroupId'] ?? $defaultGroups->getCustomersGroup()->getId();
+            $groupIds = $data['groupIds'] ?? [$defaultGroups->getCustomersGroup()->getId()];
         }
 
         $command = new AddCustomerCommand(

--- a/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/CustomerFeatureContext.php
@@ -157,16 +157,15 @@ class CustomerFeatureContext extends AbstractDomainFeatureContext
             throw new Exception('Password must be provided, if creating a registered customer');
         }
 
-        // Process data and apply fallbacks
-        $password = $data['password'];
-        $defaultGroupId = $data['defaultGroupId'] ?? $defaultGroups->getCustomersGroup()->getId();
-        $groupIds = $data['groupIds'] ?? [$defaultGroups->getCustomersGroup()->getId()];
-
         // Apply minor differences for guests
         if (!empty($data['isGuest'])) {
             $password = (new PasswordGenerator(new OpenSSL()))->generatePassword(16, 'RANDOM');
             $defaultGroupId = $defaultGroups->getGuestsGroup()->getId();
             $groupIds = [$defaultGroups->getGuestsGroup()->getId()];
+        } else {
+            $password = $data['password'];
+            $defaultGroupId = $data['defaultGroupId'] ?? $defaultGroups->getCustomersGroup()->getId();
+            $groupIds = $data['groupIds'] ?? [$defaultGroups->getCustomersGroup()->getId()];
         }
 
         $command = new AddCustomerCommand(

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -45,7 +45,6 @@ Feature: Customer Management
       | firstName | Mathieu                     |
       | lastName  | Napoler                     |
       | email     | naapoler.dev@prestashop.com |
-      | password  | PrestaShopForever1_!        |
       | isGuest   | true                        |
     And I query customer "CUST-3" I should get a Customer with properties:
       | firstName      | Mathieu                     |
@@ -167,7 +166,23 @@ Feature: Customer Management
       | groupIds       | [Guest]                      |
     And customer "CUST-7" should be soft deleted
 
-  Scenario: Edit registered customer email
+  Scenario: Edit guest customer email, even if a registered customer with the same email exists
+    When I create a customer "CUST-8" with following properties:
+      | firstName      | Mathieu                     |
+      | lastName       | Guest                       |
+      | email          | guest@prestashop.com        |
+      | isGuest        | true                        |
+    And I create a customer "CUST-9" with following properties:
+      | firstName | Mathieu                     |
+      | lastName  | Customer                    |
+      | email     | customernine@prestashop.com |
+      | password  | PrestaShopForever1_!        |
+    And I edit customer "CUST-8" and I change the following properties:
+      | email | customernine@prestashop.com |
+    Then I query customer "CUST-8" I should get a Customer with properties:
+      | email | customernine@prestashop.com |
+
+  Scenario: Attempt to edit registered customer email, while another customer with this email exists
     When I create a customer "CUST-10" with following properties:
       | firstName | Mathieu                       |
       | lastName  | Customer                      |


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Since we can now [create guests using the command](https://github.com/PrestaShop/PrestaShop/pull/31375), we can also add a test that verify if a guest customer's email can be freely edited. Also, I fixed creating guests without a password parameter, it shouldn't be needed when creating a guest. Extracted from https://github.com/PrestaShop/PrestaShop/pull/27769.
| Type?             | refacto
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | If tests are green, you can merge.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 
