### PR TITLE
Improve duplicate customer exceptions

### DIFF
--- a/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/AddCustomerHandler.php
@@ -110,7 +110,10 @@ final class AddCustomerHandler extends AbstractCustomerHandler implements AddCus
         $customer->getByEmail($email->getValue());
 
         if ($customer->id) {
-            throw new DuplicateCustomerEmailException($email, sprintf('Registered customer with email "%s" already exists', $email->getValue()));
+            throw new DuplicateCustomerEmailException(
+                $email, sprintf('Registered customer with email "%s" already exists', $email->getValue()),
+                DuplicateCustomerEmailException::ADD
+            );
         }
     }
 

--- a/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
+++ b/src/Adapter/Customer/CommandHandler/EditCustomerHandler.php
@@ -227,7 +227,10 @@ final class EditCustomerHandler extends AbstractCustomerHandler implements EditC
         $customerByEmail->getByEmail($command->getEmail()->getValue());
 
         if ($customerByEmail->id) {
-            throw new DuplicateCustomerEmailException($command->getEmail(), sprintf('Customer with email "%s" already exists', $command->getEmail()->getValue()));
+            throw new DuplicateCustomerEmailException(
+                $command->getEmail(), sprintf('Registered customer with email "%s" already exists', $command->getEmail()->getValue()),
+                DuplicateCustomerEmailException::EDIT
+            );
         }
     }
 

--- a/src/Core/Domain/Customer/Exception/DuplicateCustomerEmailException.php
+++ b/src/Core/Domain/Customer/Exception/DuplicateCustomerEmailException.php
@@ -34,6 +34,16 @@ use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
 class DuplicateCustomerEmailException extends CustomerException
 {
     /**
+     * @var int Code is used when the check fails during adding the customer
+     */
+    public const ADD = 1;
+
+    /**
+     * @var int Code is used when the check fails during editing the customer
+     */
+    public const EDIT = 2;
+
+    /**
      * @var Email
      */
     private $email;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -914,11 +914,18 @@ class CustomerController extends AbstractAdminController
                 'This customer does not exist.',
                 'Admin.Orderscustomers.Notification'
             ),
-            DuplicateCustomerEmailException::class => $this->trans(
-                'You can\'t update the email to "%s", because a registered customer with this email already exists.',
-                'Admin.Orderscustomers.Notification',
-                [$e instanceof DuplicateCustomerEmailException ? $e->getEmail()->getValue() : '']
-            ),
+            DuplicateCustomerEmailException::class => [
+                DuplicateCustomerEmailException::ADD => $this->trans(
+                    'You can\'t create a registered customer with email "%s", because a registered customer with this email already exists.',
+                    'Admin.Orderscustomers.Notification',
+                    [$e instanceof DuplicateCustomerEmailException ? $e->getEmail()->getValue() : '']
+                ),
+                DuplicateCustomerEmailException::EDIT => $this->trans(
+                    'You can\'t update the email to "%s", because a registered customer with this email already exists.',
+                    'Admin.Orderscustomers.Notification',
+                    [$e instanceof DuplicateCustomerEmailException ? $e->getEmail()->getValue() : '']
+                ),
+            ],
             CustomerDefaultGroupAccessException::class => $this->trans(
                 'A default customer group must be selected in group box.',
                 'Admin.Orderscustomers.Notification'

--- a/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Customer/customer_management.feature
@@ -180,7 +180,7 @@ Feature: Customer Management
       | password  | PrestaShopForever1_!          |
     And I attempt to edit customer "CUST-10" and I change the following properties:
       | email | customereleven@prestashop.com |
-    Then I should be returned an error message 'Customer with email "customereleven@prestashop.com" already exists'
+    Then I should be returned an error message 'Registered customer with email "customereleven@prestashop.com" already exists'
 
   Scenario: Fail to create a customer with mismatching groups
     When I attempt to create a customer "CUST-12" with following properties:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There was a common exception wording for duplicate customers. I extended this so each case has more understandable error message. For edit, it's the original one `You can\'t update the email to "%s", because a registered customer with this email already exists.`. For creating a new one, there is a simmilar new wording - `You can\'t create a registered customer with email "%s", because a registered customer with this email already exists.`.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   |

### How to test
- Go to BO > Customers.
- Create two registered customers.
- Try to create a third customer with the same email as one of the two. See:
![creating](https://user-images.githubusercontent.com/6097524/220129979-c9fa3f07-55e8-4707-955d-d5671470a7ae.jpg)
- Go edit the second customer and try to set his email the same as the first customer. See:
![editing](https://user-images.githubusercontent.com/6097524/220129982-d0cad609-667c-46d5-8594-2b0339536658.jpg)

