### PR TITLE
Validate product image size depending on upload quota configuration

### DIFF
--- a/src/Adapter/Image/ImageValidator.php
+++ b/src/Adapter/Image/ImageValidator.php
@@ -46,11 +46,11 @@ class ImageValidator
     protected $maxUploadSize;
 
     /**
-     * @param int $maxUploadSize
+     * @param int $maxUploadSizeInBytes
      */
-    public function __construct(int $maxUploadSize)
+    public function __construct(int $maxUploadSizeInBytes)
     {
-        $this->maxUploadSize = $maxUploadSize;
+        $this->maxUploadSize = $maxUploadSizeInBytes;
     }
 
     /**

--- a/src/Adapter/Image/ProductImageFileValidator.php
+++ b/src/Adapter/Image/ProductImageFileValidator.php
@@ -35,7 +35,7 @@ use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageSizeExcepti
 
 class ProductImageFileValidator extends ImageValidator
 {
-    private const MEGABYTE_IN_BYTES = 1000000;
+    private const MEGABYTE_IN_BYTES = 1048576;
 
     /**
      * @var DataConfigurationInterface
@@ -43,10 +43,10 @@ class ProductImageFileValidator extends ImageValidator
     private $uploadQuotaConfiguration;
 
     public function __construct(
-        int $maxUploadSize,
+        int $maxUploadSizeInBytes,
         DataConfigurationInterface $uploadQuotaConfiguration
     ) {
-        parent::__construct($maxUploadSize);
+        parent::__construct($maxUploadSizeInBytes);
         $this->uploadQuotaConfiguration = $uploadQuotaConfiguration;
     }
 

--- a/src/Adapter/Product/Image/CommandHandler/AddProductImageHandler.php
+++ b/src/Adapter/Product/Image/CommandHandler/AddProductImageHandler.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Image\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Image\ImageValidator;
+use PrestaShop\PrestaShop\Adapter\Image\ProductImageFileValidator;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Uploader\ProductImageUploader;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\AddProductImageCommand;
@@ -46,7 +46,7 @@ final class AddProductImageHandler implements AddProductImageHandlerInterface
     private $productImageUploader;
 
     /**
-     * @var ImageValidator
+     * @var ProductImageFileValidator
      */
     private $imageValidator;
 
@@ -58,12 +58,12 @@ final class AddProductImageHandler implements AddProductImageHandlerInterface
     /**
      * @param ProductImageUploader $productImageUploader
      * @param ProductImageMultiShopRepository $productImageMultiShopRepository
-     * @param ImageValidator $imageValidator
+     * @param ProductImageFileValidator $imageValidator
      */
     public function __construct(
         ProductImageUploader $productImageUploader,
         ProductImageMultiShopRepository $productImageMultiShopRepository,
-        ImageValidator $imageValidator
+        ProductImageFileValidator $imageValidator
     ) {
         $this->productImageUploader = $productImageUploader;
         $this->imageValidator = $imageValidator;

--- a/src/Adapter/Product/Image/CommandHandler/UpdateProductImageHandler.php
+++ b/src/Adapter/Product/Image/CommandHandler/UpdateProductImageHandler.php
@@ -28,7 +28,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\PrestaShop\Adapter\Product\Image\CommandHandler;
 
-use PrestaShop\PrestaShop\Adapter\Image\ImageValidator;
+use PrestaShop\PrestaShop\Adapter\Image\ProductImageFileValidator;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageMultiShopRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Update\ProductImageUpdater;
 use PrestaShop\PrestaShop\Adapter\Product\Image\Uploader\ProductImageUploader;
@@ -57,7 +57,7 @@ class UpdateProductImageHandler implements UpdateProductImageHandlerInterface
     private $productImageUploader;
 
     /**
-     * @var ImageValidator
+     * @var ProductImageFileValidator
      */
     private $imageValidator;
 
@@ -65,13 +65,13 @@ class UpdateProductImageHandler implements UpdateProductImageHandlerInterface
      * @param ProductImageMultiShopRepository $productImageRepository
      * @param ProductImageUpdater $productImageUpdater
      * @param ProductImageUploader $productImageUploader
-     * @param ImageValidator $imageValidator
+     * @param ProductImageFileValidator $imageValidator
      */
     public function __construct(
         ProductImageMultiShopRepository $productImageRepository,
         ProductImageUpdater $productImageUpdater,
         ProductImageUploader $productImageUploader,
-        ImageValidator $imageValidator
+        ProductImageFileValidator $imageValidator
     ) {
         $this->productImageRepository = $productImageRepository;
         $this->productImageUpdater = $productImageUpdater;

--- a/src/Core/Image/Uploader/Exception/UploadedImageSizeException.php
+++ b/src/Core/Image/Uploader/Exception/UploadedImageSizeException.php
@@ -42,7 +42,7 @@ class UploadedImageSizeException extends ImageUploadException
      * @param int $code
      * @param Throwable|null $previous
      *
-     * @return static
+     * @return self
      */
     public static function build(
         int $allowedSizeBytes,

--- a/src/Core/Image/Uploader/Exception/UploadedImageSizeException.php
+++ b/src/Core/Image/Uploader/Exception/UploadedImageSizeException.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Image\Uploader\Exception;
+
+use Throwable;
+
+class UploadedImageSizeException extends ImageUploadException
+{
+    /**
+     * @var int
+     */
+    private $allowedSizeBytes;
+
+    /**
+     * @param int $allowedSizeBytes
+     * @param string|null $message
+     * @param int $code
+     * @param Throwable|null $previous
+     *
+     * @return static
+     */
+    public static function build(
+        int $allowedSizeBytes,
+        string $message = null,
+        int $code = 0,
+        Throwable $previous = null
+    ): self {
+        if (null === $message) {
+            $message = sprintf(
+                'Max file size allowed is "%s" bytes.',
+                $allowedSizeBytes
+            );
+        }
+
+        return new self(
+            $allowedSizeBytes,
+            $message,
+            $code,
+            $previous
+        );
+    }
+
+    /**
+     * @return int
+     */
+    public function getAllowedSizeBytes(): int
+    {
+        return $this->allowedSizeBytes;
+    }
+
+    /**
+     * @param int $allowedSizeBytes
+     * @param string $message
+     * @param int $code
+     * @param Throwable|null $previous
+     */
+    private function __construct(
+        int $allowedSizeBytes,
+        string $message = '',
+        int $code = 0,
+        Throwable $previous = null
+    ) {
+        $this->allowedSizeBytes = $allowedSizeBytes;
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ImageController.php
@@ -52,6 +52,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterf
 use PrestaShop\PrestaShop\Core\Image\Exception\CannotUnlinkImageException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\MemoryLimitException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageSizeException;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -294,9 +295,7 @@ class ImageController extends FrameworkBundleAdminController
      */
     private function getErrorMessages(Exception $e): array
     {
-        $iniConfig = $this->get('prestashop.core.configuration.ini_configuration');
-
-        return [
+        $messages = [
             ProductConstraintException::class => [
                 ProductConstraintException::INVALID_ID => $this->trans(
                     'Invalid ID.',
@@ -308,11 +307,6 @@ class ImageController extends FrameworkBundleAdminController
                 'Admin.Notifications.Error'
             ),
             UploadedImageConstraintException::class => [
-                UploadedImageConstraintException::EXCEEDED_SIZE => $this->trans(
-                'Max file size allowed is "%s" bytes.',
-                'Admin.Notifications.Error',
-                    [$iniConfig->getUploadMaxSizeInBytes()]
-                ),
                 UploadedImageConstraintException::UNRECOGNIZED_FORMAT => $this->trans(
                     'Image format not recognized, allowed formats are: .gif, .jpg, .png',
                     'Admin.Notifications.Error'
@@ -341,5 +335,15 @@ class ImageController extends FrameworkBundleAdminController
                 'Admin.Notifications.Error'
             ),
         ];
+
+        if ($e instanceof UploadedImageSizeException) {
+            $messages[UploadedImageSizeException::class] = $this->trans(
+                'Max file size allowed is "%s" bytes.',
+                'Admin.Notifications.Error',
+                [$e->getAllowedSizeBytes()]
+            );
+        }
+
+        return $messages;
     }
 }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/image.yml
@@ -40,6 +40,11 @@ services:
     arguments:
       - '@=service("prestashop.core.configuration.upload_size_configuration").getMaxUploadSizeInBytes()'
 
+  PrestaShop\PrestaShop\Adapter\Image\ProductImageFileValidator:
+    arguments:
+      - '@=service("prestashop.core.configuration.upload_size_configuration").getMaxUploadSizeInBytes()'
+      - '@prestashop.adapter.upload_quota.configuration'
+
   prestashop.adapter.image.image_validator:
     alias: PrestaShop\PrestaShop\Adapter\Image\ImageValidator
     deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -6,7 +6,7 @@ services:
     arguments:
       - '@PrestaShop\PrestaShop\Adapter\Product\Image\Uploader\ProductImageUploader'
       - '@PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageMultiShopRepository'
-      - '@PrestaShop\PrestaShop\Adapter\Image\ImageValidator'
+      - '@PrestaShop\PrestaShop\Adapter\Image\ProductImageFileValidator'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\AddProductImageCommand
@@ -16,7 +16,7 @@ services:
       - '@PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageMultiShopRepository'
       - '@PrestaShop\PrestaShop\Adapter\Product\Image\Update\ProductImageUpdater'
       - '@PrestaShop\PrestaShop\Adapter\Product\Image\Uploader\ProductImageUploader'
-      - '@PrestaShop\PrestaShop\Adapter\Image\ImageValidator'
+      - '@PrestaShop\PrestaShop\Adapter\Image\ProductImageFileValidator'
     tags:
       - name: tactician.handler
         command: PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\UpdateProductImageCommand

--- a/tests/Unit/Adapter/Image/ProductImageFileValidatorTest.php
+++ b/tests/Unit/Adapter/Image/ProductImageFileValidatorTest.php
@@ -68,17 +68,18 @@ class ProductImageFileValidatorTest extends TestCase
         yield [$appIconPath, 100, 100];
         // when value from quota configuration is lower, then it should be checked instead of php.ini config value
         yield [$appIconPath, 5000000, 100];
-        // when value from quota php.ini configuration is lower, then quota config value should be ignored
+        // when value from php.ini configuration is lower, then quota config value should be ignored
         yield [$appIconPath, 100, 5000000];
     }
 
-    private function mockQuotaConfiguration(int $maxSize): DataConfigurationInterface
+    private function mockQuotaConfiguration(int $maxSizeInBytes): DataConfigurationInterface
     {
         $configuration = $this->createMock(DataConfigurationInterface::class);
         $configuration
             ->method('getConfiguration')
             ->willReturn([
-                'max_size_product_image' => $maxSize,
+                // set size in megabytes
+                'max_size_product_image' => $maxSizeInBytes / 1000000,
             ]);
 
         return $configuration;

--- a/tests/Unit/Adapter/Image/ProductImageFileValidatorTest.php
+++ b/tests/Unit/Adapter/Image/ProductImageFileValidatorTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+declare(strict_types=1);
+
+namespace Tests\Unit\Adapter\Image;
+
+use PHPUnit\Framework\TestCase;
+use PrestaShop\PrestaShop\Adapter\Image\ProductImageFileValidator;
+use PrestaShop\PrestaShop\Core\Configuration\DataConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageUploadException;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
+use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageSizeException;
+use Tests\Resources\DummyFileUploader;
+
+class ProductImageFileValidatorTest extends TestCase
+{
+    /**
+     * @dataProvider getInvalidMaxUploadSizesForFile
+     *
+     * @param string $filePath
+     * @param int $maxPhpIniUploadSize
+     * @param int $maxUploadQuotaSize
+     *
+     * @throws UploadedImageConstraintException
+     * @throws ImageUploadException
+     */
+    public function testItThrowsExceptionWhenFileSizeIsLargerThanMaxUploadSize(
+        string $filePath,
+        int $maxPhpIniUploadSize,
+        int $maxUploadQuotaSize
+    ) {
+        $imageValidator = new ProductImageFileValidator($maxPhpIniUploadSize, $this->mockQuotaConfiguration($maxUploadQuotaSize));
+
+        $this->expectException(UploadedImageSizeException::class);
+
+        $imageValidator->assertFileUploadLimits($filePath);
+    }
+
+    public function getInvalidMaxUploadSizesForFile(): iterable
+    {
+        $logoPath = DummyFileUploader::getDummyFilesPath() . 'logo.jpg';
+        $appIconPath = DummyFileUploader::getDummyFilesPath() . 'app_icon.png';
+
+        yield [$logoPath, 2750, 2750];
+        yield [$appIconPath, 100, 100];
+        // when value from quota configuration is lower, then it should be checked instead of php.ini config value
+        yield [$appIconPath, 5000000, 100];
+        // when value from quota php.ini configuration is lower, then quota config value should be ignored
+        yield [$appIconPath, 100, 5000000];
+    }
+
+    private function mockQuotaConfiguration(int $maxSize): DataConfigurationInterface
+    {
+        $configuration = $this->createMock(DataConfigurationInterface::class);
+        $configuration
+            ->method('getConfiguration')
+            ->willReturn([
+                'max_size_product_image' => $maxSize,
+            ]);
+
+        return $configuration;
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | https://github.com/PrestaShop/PrestaShop/issues/29480. Additionally checks image size against value of PS_LIMIT_UPLOAD_IMAGE_VALUE configuration when php.ini max upload size is higher than that value
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/29480
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/29480
| Related PRs       | 
| Sponsor company   | 
