### PR TITLE
Fix "generate for all shops" button visibility when multiShop is off

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/product/combination/generator/CombinationGenerator.vue
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/generator/CombinationGenerator.vue
@@ -43,7 +43,10 @@
       </template>
 
       <template #footer-confirmation>
-        <div class="md-checkbox md-checkbox-inline">
+        <div
+          v-if="isMultiStoreActive"
+          class="md-checkbox md-checkbox-inline"
+        >
           <label>
             <input
               v-model="applyToAllShops"
@@ -135,6 +138,10 @@
       },
       shopId: {
         type: Number,
+        required: true,
+      },
+      isMultiStoreActive: {
+        type: Boolean,
         required: true,
       },
       eventEmitter: {

--- a/admin-dev/themes/new-theme/js/pages/product/combination/generator/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/combination/generator/index.ts
@@ -47,6 +47,7 @@ export default function initCombinationGenerator(
     i18n,
     productId,
     shopId,
+    isMultiStoreActive: Boolean(container.dataset.isMultiStoreActive),
     eventEmitter,
   }).use(i18n);
 

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
@@ -28,10 +28,12 @@ declare(strict_types=1);
 
 namespace PrestaShopBundle\Form\Admin\Sell\Product\Combination;
 
+use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * This form type is not really used for product form data. It is actually rendered specifically via its form theme
@@ -45,9 +47,27 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class CombinationManagerType extends TranslatorAwareType
 {
+    /**
+     * @var FeatureInterface
+     */
+    private $multiStoreFeature;
+
+    /**
+     * @param FeatureInterface $multiStoreFeature
+     */
+    public function __construct(
+        TranslatorInterface $translator,
+        array $locales,
+        FeatureInterface $multiStoreFeature
+    ) {
+        parent::__construct($translator, $locales);
+        $this->multiStoreFeature = $multiStoreFeature;
+    }
+
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['productId'] = $options['product_id'];
+        $view->vars['isMultiStoreActive'] = $this->multiStoreFeature->isActive();
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/Combination/CombinationManagerType.php
@@ -52,9 +52,6 @@ class CombinationManagerType extends TranslatorAwareType
      */
     private $multiStoreFeature;
 
-    /**
-     * @param FeatureInterface $multiStoreFeature
-     */
     public function __construct(
         TranslatorInterface $translator,
         array $locales,

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1875,10 +1875,12 @@ services:
       - { name: form.type }
 
   PrestaShopBundle\Form\Admin\Sell\Product\Combination\CombinationManagerType:
-    parent: 'form.type.translatable.aware'
     public: false
+    autowire: true
+    autoconfigure: true
     arguments:
-      - '@PrestaShop\PrestaShop\Adapter\Feature\MultistoreFeature'
+      $locales: "@=service('prestashop.adapter.legacy.context').getLanguages()"
+      $multiStoreFeature: '@PrestaShop\PrestaShop\Adapter\Feature\MultistoreFeature'
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
+++ b/src/PrestaShopBundle/Resources/config/services/bundle/form/form_type.yml
@@ -1874,10 +1874,11 @@ services:
     tags:
       - { name: form.type }
 
-  form.type.sell.product.combination.combination_manager_type:
-    class: 'PrestaShopBundle\Form\Admin\Sell\Product\Combination\CombinationManagerType'
+  PrestaShopBundle\Form\Admin\Sell\Product\Combination\CombinationManagerType:
     parent: 'form.type.translatable.aware'
-    public: true
+    public: false
+    arguments:
+      - '@PrestaShop\PrestaShop\Adapter\Feature\MultistoreFeature'
     tags:
       - { name: form.type }
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/FormTheme/combination.html.twig
@@ -49,6 +49,7 @@
 
     {# Combination generator in a modal #}
     <div id="product_combinations_generator"
+         data-is-multi-store-active="{{ isMultiStoreActive }}"
          data-translations="{{ {
            'generator.open': 'Open combinations generator'|trans({}, 'Admin.Catalog.Feature'),
            'generator.success': 'Successfully generated {combinationsNb} combinations.'|trans({}, 'Admin.Catalog.Feature'),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | https://github.com/PrestaShop/PrestaShop/issues/31431
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | https://github.com/PrestaShop/PrestaShop/issues/31431
| Fixed ticket?     | https://github.com/PrestaShop/PrestaShop/issues/31431
| Related PRs       |
| Sponsor company   | 
