### PR TITLE
Remove FrameworkExtraBundle `@Template` annotation.

### DIFF
--- a/phpstan-disallowed-calls.neon
+++ b/phpstan-disallowed-calls.neon
@@ -288,6 +288,11 @@ parameters:
             message: 'use Symfony\Contracts\Translation\TranslatorInterface instead'
             disallowIn:
                 - src/Core/*
+        -
+            class: 'Sensio\Bundle\FrameworkExtraBundle\Configuration\Template'
+            message: 'The @template annotation is deprecated and will be removed in future versions. We should not add any usages of it. '
+            disallowIn:
+                - src/PrestaShopBundle/*
   disallowedMethodCalls:
         -
             method: 'PrestaShopBundle\Form\Admin\Type\CommonAbstractType::getConfiguration()'

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -39,7 +39,6 @@ use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\Grid\ControllerResponseBuilder;
 use PrestaShopBundle\Service\Grid\ResponseBuilder;
 use ReflectionClass;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -99,8 +98,6 @@ class CommonController extends FrameworkBundleAdminController
      * {% render controller('PrestaShopBundle\\Controller\\Admin\\CommonController::paginationAction',
      *   {'limit': limit, 'offset': offset, 'total': product_count, 'caller_parameters': pagination_parameters}) %}
      *
-     * @Template("@PrestaShop/Admin/Common/pagination.html.twig")
-     *
      * @param Request $request
      * @param int $limit
      * @param int $offset
@@ -108,9 +105,9 @@ class CommonController extends FrameworkBundleAdminController
      * @param string $view full|quicknav To change default template used to render the content
      * @param string $prefix Indicates the params prefix (eg: ?limit=10&offset=20 -> ?scope[limit]=10&scope[offset]=20)
      *
-     * @return array|Response
+     * @return Response
      */
-    public function paginationAction(Request $request, $limit = 10, $offset = 0, $total = 0, $view = 'full', $prefix = '')
+    public function paginationAction(Request $request, $limit = 10, $offset = 0, $total = 0, $view = 'full', $prefix = ''): Response
     {
         $offsetParam = empty($prefix) ? 'offset' : sprintf('%s[offset]', $prefix);
         $limitParam = empty($prefix) ? 'limit' : sprintf('%s[limit]', $prefix);
@@ -196,7 +193,7 @@ class CommonController extends FrameworkBundleAdminController
             return $this->render('@PrestaShop/Admin/Common/pagination_' . $view . '.html.twig', $vars);
         }
 
-        return $vars;
+        return $this->render('@PrestaShop/Admin/Common/pagination.html.twig', $vars);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
@@ -28,9 +28,9 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Responsible of "Configure > Advanced Parameters > Information" page display.
@@ -39,19 +39,18 @@ class SystemInformationController extends FrameworkBundleAdminController
 {
     /**
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
-     * @Template("@PrestaShop/Admin/Configure/AdvancedParameters/system_information.html.twig")
      *
      * @param Request $request
      *
-     * @return array<string, array|bool|string|null>
+     * @return Response
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         $legacyController = $request->get('_legacy_controller');
         $requirementsSummary = $this->getRequirementsChecker()->getSummary();
         $systemInformationSummary = $this->getSystemInformation()->getSummary();
 
-        return [
+        return $this->render('@PrestaShop/Admin/Configure/AdvancedParameters/system_information.html.twig', [
             'layoutHeaderToolbarBtn' => [],
             'layoutTitle' => $this->trans('Information', 'Admin.Navigation.Menu'),
             'requireBulkActions' => false,
@@ -63,7 +62,7 @@ class SystemInformationController extends FrameworkBundleAdminController
             'system' => $systemInformationSummary,
             'requirements' => $requirementsSummary,
             'userAgent' => $request->headers->get('User-Agent'),
-        ];
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -34,7 +34,6 @@ use PrestaShop\PrestaShop\Core\Domain\Hook\Exception\HookUpdateHookException;
 use PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetHookStatus;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -52,22 +51,21 @@ class PositionsController extends FrameworkBundleAdminController
     /**
      * Display hooks positions.
      *
-     * @Template("@PrestaShop/Admin/Improve/Design/positions.html.twig")
      * @AdminSecurity(
      *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
      *     message="Access denied.")
      *
      * @param Request $request
      *
-     * @return array<string, mixed>
+     * @return Response
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         $isSingleShopContext = $this->get('prestashop.adapter.shop.context')->isSingleShopContext();
         if (!$isSingleShopContext) {
-            return [
+            return $this->render('@PrestaShop/Admin/Improve/Design/positions.html.twig', [
                 'isSingleShopContext' => $isSingleShopContext,
-            ];
+            ]);
         }
 
         $moduleAdapter = $this->get('prestashop.adapter.legacy.module');
@@ -127,7 +125,7 @@ class PositionsController extends FrameworkBundleAdminController
         }
         $saveUrl = $legacyContextService->getAdminLink('AdminModulesPositions', true, $saveUrlParams);
 
-        return [
+        return $this->render('@PrestaShop/Admin/Improve/Design/positions.html.twig', [
             'layoutHeaderToolbarBtn' => [
                 'save' => [
                     'class' => 'btn-primary transplant-module-button',
@@ -145,7 +143,7 @@ class PositionsController extends FrameworkBundleAdminController
             'hooks' => $hooks,
             'modules' => $modules,
             'isSingleShopContext' => $isSingleShopContext,
-        ];
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -67,7 +67,6 @@ use PrestaShopBundle\Service\DataUpdater\Admin\ProductInterface as ProductInterf
 use PrestaShopBundle\Service\Hook\HookFinder;
 use Product;
 use Psr\Log\LoggerInterface;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
@@ -106,7 +105,6 @@ class ProductController extends FrameworkBundleAdminController
      * URL example: /product/catalog/40/20/id_product/asc
      *
      * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
-     * @Template("@PrestaShop/Admin/Product/CatalogPage/catalog.html.twig")
      *
      * @param Request $request
      * @param int $limit The size of the listing
@@ -114,7 +112,7 @@ class ProductController extends FrameworkBundleAdminController
      * @param string $orderBy To order product list
      * @param string $sortOrder To order product list
      *
-     * @return array|Template|RedirectResponse|Response
+     * @return Response
      *
      * @throws \Symfony\Component\Translation\Exception\InvalidArgumentException
      * @throws \Symfony\Component\Routing\Exception\RouteNotFoundException
@@ -226,7 +224,7 @@ class ProductController extends FrameworkBundleAdminController
         $activateDragAndDrop = 'position_ordering' === $orderBy && $hasCategoryFilter;
 
         // Template vars injection
-        return array_merge(
+        return $this->render('@PrestaShop/Admin/Product/CatalogPage/catalog.html.twig', array_merge(
             $cleanFilterParameters,
             [
                 'limit' => $limit,
@@ -254,15 +252,13 @@ class ProductController extends FrameworkBundleAdminController
                 'permission_error' => $permissionError,
                 'layoutTitle' => $this->trans('Products', 'Admin.Global'),
             ]
-        );
+        ));
     }
 
     /**
      * Get only the list of products to display on the main Admin Product page.
      * The full page that shows products list will subcall this action (from catalogAction).
      * URL example: /product/list/html/40/20/id_product/asc.
-     *
-     * @Template("@PrestaShop/Admin/Product/CatalogPage/Lists/list.html.twig")
      *
      * @param Request $request
      * @param int $limit The size of the listing
@@ -271,7 +267,7 @@ class ProductController extends FrameworkBundleAdminController
      * @param string $sortOrder To order product list
      * @param string $view full|quicknav To change default template used to render the content
      *
-     * @return array|Template|Response
+     * @return Response
      */
     public function listAction(
         Request $request,
@@ -280,7 +276,7 @@ class ProductController extends FrameworkBundleAdminController
         $orderBy = 'id_product',
         $sortOrder = 'asc',
         $view = 'full'
-    ) {
+    ): Response {
         if (!$this->isGranted(Permission::READ, self::PRODUCT_OBJECT)) {
             return $this->redirect('admin_dashboard');
         }
@@ -366,7 +362,7 @@ class ProductController extends FrameworkBundleAdminController
             );
         }
 
-        return $vars;
+        return $this->render('@PrestaShop/Admin/Product/CatalogPage/Lists/list.html.twig', $vars);
     }
 
     /**
@@ -437,16 +433,14 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Product form.
      *
-     * @Template("@PrestaShop/Admin/Product/ProductPage/product.html.twig")
-     *
      * @param int $id The product ID
      * @param Request $request
      *
-     * @return array|Response Template vars
+     * @return Response Template vars
      *
      * @throws \LogicException
      */
-    public function formAction($id, Request $request)
+    public function formAction($id, Request $request): Response
     {
         if ($this->shouldRedirectToV2()) {
             return $this->redirectToRoute('admin_products_v2_edit', ['productId' => $id]);
@@ -644,7 +638,7 @@ class ProductController extends FrameworkBundleAdminController
             ->addExpectedInstanceClasses('PrestaShop\PrestaShop\Core\Product\ProductAdminDrawer')
             ->present();
 
-        return [
+        return $this->render('@PrestaShop/Admin/Product/ProductPage/product.html.twig', [
             'form' => $form->createView(),
             'formCombinations' => $formBulkCombinations->createView(),
             'categories' => $this->get('prestashop.adapter.data_provider.category')->getCategoriesWithBreadCrumb(),
@@ -671,7 +665,7 @@ class ProductController extends FrameworkBundleAdminController
             'drawerModules' => $drawerModules,
             'layoutTitle' => $this->trans('Product', 'Admin.Global'),
             'isCreationMode' => (int) $product->state === Product::STATE_TEMP,
-        ];
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductImageController.php
@@ -28,7 +28,6 @@ namespace PrestaShopBundle\Controller\Admin;
 
 use ImageManager;
 use PrestaShop\PrestaShop\Adapter\Product\AdminProductWrapper;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -128,14 +127,12 @@ class ProductImageController extends FrameworkBundleAdminController
     /**
      * Manage form image.
      *
-     * @Template("@PrestaShop/Admin/ProductImage/form.html.twig")
-     *
      * @param string|int $idImage
      * @param Request $request
      *
-     * @return array|JsonResponse|Response
+     * @return Response
      */
-    public function formAction($idImage, Request $request)
+    public function formAction($idImage, Request $request): Response
     {
         $locales = $this->get('prestashop.adapter.legacy.context')->getLanguages();
         $adminProductWrapper = $this->get(AdminProductWrapper::class);
@@ -182,10 +179,10 @@ class ProductImageController extends FrameworkBundleAdminController
             return $jsonResponse;
         }
 
-        return [
+        return $this->render('@PrestaShop/Admin/ProductImage/form.html.twig', [
             'image' => $image,
             'form' => $form->createView(),
-        ];
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
@@ -29,10 +29,10 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Order;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Admin controller for the Order Delivery.
@@ -42,7 +42,6 @@ class DeliveryController extends FrameworkBundleAdminController
     /**
      * Main page for Delivery slips.
      *
-     * @Template("@PrestaShop/Admin/Sell/Order/Delivery/slip.html.twig")
      * @AdminSecurity(
      *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
      *     message="Access denied."
@@ -50,9 +49,9 @@ class DeliveryController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @return array|RedirectResponse
+     * @return Response|RedirectResponse
      */
-    public function slipAction(Request $request)
+    public function slipAction(Request $request): Response
     {
         /** @var FormHandlerInterface $formHandler */
         $formHandler = $this->get('prestashop.adapter.order.delivery.slip.options.form_handler');
@@ -76,7 +75,7 @@ class DeliveryController extends FrameworkBundleAdminController
             return $this->redirectToRoute('admin_order_delivery_slip');
         }
 
-        return [
+        return $this->render('@PrestaShop/Admin/Sell/Order/Delivery/slip.html.twig', [
             'optionsForm' => $form->createView(),
             'pdfForm' => $this->get('prestashop.adapter.order.delivery.slip.pdf.form_handler')->getForm()->createView(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
@@ -84,7 +83,7 @@ class DeliveryController extends FrameworkBundleAdminController
             'requireBulkActions' => false,
             'showContentHeader' => true,
             'enableSidebar' => true,
-        ];
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
@@ -29,9 +29,9 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Order;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Controller responsible of "Sell > Orders > Invoices" page.
@@ -43,12 +43,11 @@ class InvoicesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @Template("@PrestaShop/Admin/Sell/Order/Invoices/invoices.html.twig")
      * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
      *
-     * @return array Template parameters
+     * @return Response Template parameters
      */
-    public function indexAction(Request $request)
+    public function indexAction(Request $request): Response
     {
         $legacyController = $request->attributes->get('_legacy_controller');
 
@@ -56,14 +55,14 @@ class InvoicesController extends FrameworkBundleAdminController
         $byStatusForm = $this->get('prestashop.admin.order.invoices.by_status.form_handler')->getForm();
         $optionsForm = $this->get('prestashop.admin.order.invoices.options.form_handler')->getForm();
 
-        return [
+        return $this->render('@PrestaShop/Admin/Sell/Order/Invoices/invoices.html.twig', [
             'layoutTitle' => $this->trans('Invoices', 'Admin.Navigation.Menu'),
             'enableSidebar' => true,
             'help_link' => $this->generateSidebarLink($legacyController),
             'generateByDateForm' => $byDateForm->createView(),
             'generateByStatusForm' => $byStatusForm->createView(),
             'invoiceOptionsForm' => $optionsForm->createView(),
-        ];
+        ]);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
@@ -33,7 +33,6 @@ use PrestaShop\PrestaShop\Core\Foundation\Database\EntityDataInconsistencyExcept
 use PrestaShop\PrestaShop\Core\Foundation\Database\EntityNotFoundException;
 use PrestaShopBundle\Form\Admin\Product\ProductSpecificPrice as SpecificPriceFormType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -116,17 +115,15 @@ class SpecificPriceController extends FrameworkBundleAdminController
     /**
      * Get one specific price list for a product.
      *
-     * @Template("@PrestaShop/Admin/Product/ProductPage/Forms/form_specific_price.html.twig")
-     *
      * @AdminSecurity(
      *     "is_granted('create', 'ADMINPRODUCTS_') && is_granted('update', 'ADMINPRODUCTS_')"
      * )
      *
      * @param int $idSpecificPrice
      *
-     * @return Response|array
+     * @return Response
      */
-    public function getUpdateFormAction($idSpecificPrice)
+    public function getUpdateFormAction($idSpecificPrice): Response
     {
         /** @var AdminProductWrapper $adminProductWrapper */
         $adminProductWrapper = $this->get(AdminProductWrapper::class);
@@ -158,11 +155,11 @@ class SpecificPriceController extends FrameworkBundleAdminController
         $productAdapter = $this->get('prestashop.adapter.data_provider.product');
         $product = $productAdapter->getProduct((int) $price->id_product);
 
-        return [
+        return $this->render('@PrestaShop/Admin/Product/ProductPage/Forms/form_specific_price.html.twig', [
             'form' => $form->createView()->offsetGet('modal'),
             'has_combinations' => ($product->hasCombinations()),
             'is_modal' => true,
-        ];
+        ]);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The @template annotation is deprecated and will be removed in future versions. We should not add any usages of it. 
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
