### PR TITLE
Fix base image format generation, enable it for new image system, simplify

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -24,8 +24,6 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
-
 /**
  * Class ImageManagerCore.
  *
@@ -253,7 +251,7 @@ class ImageManagerCore
             $sourceHeight = $tmpHeight;
         }
 
-        // If the filetype is not forced and we are requesting a JPG file, we must 
+        // If the filetype is not forced and we are requesting a JPG file, we must
         // adjust the format inside according to PS_IMAGE_QUALITY in some cases.
         if (!$forceType && $destinationFileType === 'jpg') {
             if (Configuration::get('PS_IMAGE_QUALITY') == 'png_all'

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -178,8 +178,8 @@ class ImageManagerCore
      * @param string $destinationFile Destination filename
      * @param int $destinationWidth Desired width (optional)
      * @param int $destinationHeight Desired height (optional)
-     * @param string $fileType Desired file_type (may be override by PS_IMAGE_QUALITY)
-     * @param bool $forceType Don't override $file_type
+     * @param string $destinationFileType Desired file_type (may be override by PS_IMAGE_QUALITY)
+     * @param bool $forceType Don't override $file_type by PS_IMAGE_QUALITY, used when generating webp and avif files
      * @param int $error Out error code
      * @param int $targetWidth Needed by AdminImportController to speed up the import process
      * @param int $targetHeight Needed by AdminImportController to speed up the import process
@@ -194,7 +194,7 @@ class ImageManagerCore
         $destinationFile,
         $destinationWidth = null,
         $destinationHeight = null,
-        $fileType = 'jpg',
+        $destinationFileType = 'jpg',
         $forceType = false,
         &$error = 0,
         &$targetWidth = null,
@@ -205,13 +205,14 @@ class ImageManagerCore
     ) {
         clearstatcache(true, $sourceFile);
 
+        // Check if original file exists
         if (!file_exists($sourceFile) || !filesize($sourceFile)) {
             $error = self::ERROR_FILE_NOT_EXIST;
 
             return false;
         }
 
-        list($tmpWidth, $tmpHeight, $type) = getimagesize($sourceFile);
+        list($tmpWidth, $tmpHeight, $sourceFileType) = getimagesize($sourceFile);
         $rotate = 0;
         if (function_exists('exif_read_data')) {
             $exif = @exif_read_data($sourceFile);
@@ -252,28 +253,18 @@ class ImageManagerCore
             $sourceHeight = $tmpHeight;
         }
 
-        $isMultipleImageFormatFeatureActive = FeatureFlag::isEnabled(FeatureFlagSettings::FEATURE_FLAG_MULTIPLE_IMAGE_FORMAT);
+        // If the filetype is not forced and we are requesting a JPG file, we must 
+        // adjust the format inside according to PS_IMAGE_QUALITY in some cases.
+        if (!$forceType && $destinationFileType === 'jpg') {
+            if (Configuration::get('PS_IMAGE_QUALITY') == 'png_all'
+                || (Configuration::get('PS_IMAGE_QUALITY') == 'png' && $sourceFileType == IMAGETYPE_PNG)) {
+                $destinationFileType = 'png';
+            }
 
-        // If PS_IMAGE_QUALITY is activated, the generated image will be a PNG with .jpg as a file extension.
-        // This allow for higher quality and for transparency. JPG source files will also benefit from a higher quality
-        // because JPG reencoding by GD, even with max quality setting, degrades the image.
-        if (Configuration::get('PS_IMAGE_QUALITY') == 'png_all'
-            || (Configuration::get('PS_IMAGE_QUALITY') == 'png' && $type == IMAGETYPE_PNG) && !$forceType
-            || $isMultipleImageFormatFeatureActive && $type == IMAGETYPE_PNG && !$forceType) {
-            $fileType = 'png';
-        }
-
-        // If PS_IMAGE_QUALITY is activated, the generated image will be a WEBP with .jpg as a file extension.
-        // This allow for higher quality and for transparency. JPG source files will also benefit from a higher quality
-        // because JPG reencoding by GD, even with max quality setting, degrades the image.
-        if (Configuration::get('PS_IMAGE_QUALITY') == 'webp_all'
-            || (Configuration::get('PS_IMAGE_QUALITY') == 'webp' && $type == IMAGETYPE_WEBP) && !$forceType
-            || $isMultipleImageFormatFeatureActive && $type == IMAGETYPE_WEBP && !$forceType) {
-            $fileType = 'webp';
-        }
-
-        if ($isMultipleImageFormatFeatureActive && $type == self::PS_IMAGETYPE_AVIF && !$forceType) {
-            $fileType = 'avif';
+            if (Configuration::get('PS_IMAGE_QUALITY') == 'webp_all'
+                || (Configuration::get('PS_IMAGE_QUALITY') == 'webp' && $sourceFileType == IMAGETYPE_WEBP)) {
+                $destinationFileType = 'webp';
+            }
         }
 
         if (!$sourceWidth) {
@@ -319,7 +310,7 @@ class ImageManagerCore
         $destImage = imagecreatetruecolor($destinationWidth, $destinationHeight);
 
         // If the output is PNG, fill with transparency. Else fill with white background.
-        if ($fileType == 'png' || $fileType == 'webp' || $fileType == 'avif') {
+        if ($destinationFileType == 'png' || $destinationFileType == 'webp' || $destinationFileType == 'avif') {
             imagealphablending($destImage, false);
             imagesavealpha($destImage, true);
             $transparent = imagecolorallocatealpha($destImage, 255, 255, 255, 127);
@@ -329,7 +320,7 @@ class ImageManagerCore
             imagefilledrectangle($destImage, 0, 0, $destinationWidth, $destinationHeight, $white);
         }
 
-        $srcImage = ImageManager::create($type, $sourceFile);
+        $srcImage = ImageManager::create($sourceFileType, $sourceFile);
         if ($rotate) {
             /** @phpstan-ignore-next-line */
             $srcImage = imagerotate($srcImage, $rotate, 0);
@@ -340,13 +331,13 @@ class ImageManagerCore
         } else {
             ImageManager::imagecopyresampled($destImage, $srcImage, (int) (($destinationWidth - $nextWidth) / 2), (int) (($destinationHeight - $nextHeight) / 2), 0, 0, $nextWidth, $nextHeight, $sourceWidth, $sourceHeight, $quality);
         }
-        $writeFile = ImageManager::write($fileType, $destImage, $destinationFile);
-        Hook::exec('actionOnImageResizeAfter', ['dst_file' => $destinationFile, 'file_type' => $fileType]);
+        $writeFile = ImageManager::write($destinationFileType, $destImage, $destinationFile);
+        Hook::exec('actionOnImageResizeAfter', ['dst_file' => $destinationFile, 'file_type' => $destinationFileType]);
         @imagedestroy($srcImage);
 
         file_put_contents(
             dirname($destinationFile) . DIRECTORY_SEPARATOR . 'fileType',
-            $fileType
+            $destinationFileType
         );
 
         return $writeFile;

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -37,9 +37,6 @@ class ImageManagerCore
     public const ERROR_FILE_WIDTH = 2;
     public const ERROR_MEMORY_LIMIT = 3;
 
-    // IMAGETYPE_AVIF constant is only available in php 8.1, so we make our own here
-    private const PS_IMAGETYPE_AVIF = 19;
-
     public const MIME_TYPE_SUPPORTED = [
         'image/gif',
         'image/jpg',

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -662,7 +662,7 @@ class AdminImagesControllerCore extends AdminController
         /*
          * Let's resolve which formats we will use for image generation.
          * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
-         * 
+         *
          * In case of .jpg images, the actual format inside is decided by ImageManager.
          */
         if ($this->isMultipleImageFormatFeatureEnabled) {
@@ -697,11 +697,11 @@ class AdminImagesControllerCore extends AdminController
                                     $this->errors[] = $this->trans('Source file does not exist or is empty (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
                                 } else {
                                     if (!ImageManager::resize(
-                                        $dir . $image, 
-                                        $newDir . substr(str_replace('_thumb.', '.', $image), 0, -4) . '-' . stripslashes($imageType['name']) . '.' . $imageFormat, 
-                                        (int) $imageType['width'], 
-                                        (int) $imageType['height'], 
-                                        $imageFormat, 
+                                        $dir . $image,
+                                        $newDir . substr(str_replace('_thumb.', '.', $image), 0, -4) . '-' . stripslashes($imageType['name']) . '.' . $imageFormat,
+                                        (int) $imageType['width'],
+                                        (int) $imageType['height'],
+                                        $imageFormat,
                                         $forceFormat
                                         )) {
                                         $this->errors[] = $this->trans('Failed to resize image file (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
@@ -711,8 +711,8 @@ class AdminImagesControllerCore extends AdminController
                                         $dir . $image,
                                         $newDir . substr($image, 0, -4) . '-' . stripslashes($imageType['name']) . '2x.' . $imageFormat,
                                         (int) $imageType['width'] * 2,
-                                        (int) $imageType['height'] * 2, 
-                                        $imageFormat, 
+                                        (int) $imageType['height'] * 2,
+                                        $imageFormat,
                                         $forceFormat
                                     )) {
                                         $this->errors[] = $this->trans('Failed to resize image file to high resolution (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
@@ -744,7 +744,7 @@ class AdminImagesControllerCore extends AdminController
                                     $dir . $imageObj->getExistingImgPath() . '-' . stripslashes($imageType['name']) . '.' . $imageFormat,
                                     (int) $imageType['width'],
                                     (int) $imageType['height'],
-                                    $imageFormat, 
+                                    $imageFormat,
                                     $forceFormat
                                 )) {
                                     $this->errors[] = $this->trans(
@@ -764,7 +764,7 @@ class AdminImagesControllerCore extends AdminController
                                             $dir . $imageObj->getExistingImgPath() . '-' . stripslashes($imageType['name']) . '2x.' . $imageFormat,
                                             (int) $imageType['width'] * 2,
                                             (int) $imageType['height'] * 2,
-                                            $imageFormat, 
+                                            $imageFormat,
                                             $forceFormat
                                         )) {
                                         $this->errors[] = $this->trans(
@@ -818,7 +818,7 @@ class AdminImagesControllerCore extends AdminController
         /*
          * Let's resolve which formats we will use for image generation.
          * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
-         * 
+         *
          * In case of .jpg images, the actual format inside is decided by ImageManager.
          */
         if ($this->isMultipleImageFormatFeatureEnabled) {
@@ -841,19 +841,19 @@ class AdminImagesControllerCore extends AdminController
                         if (!ImageManager::resize(
                             $file,
                             $dir . $language['iso_code'] . '-default-' . stripslashes($image_type['name']) . '.' . $imageFormat,
-                            (int) $image_type['width'], 
-                            (int) $image_type['height'], 
-                            $imageFormat, 
+                            (int) $image_type['width'],
+                            (int) $image_type['height'],
+                            $imageFormat,
                             $forceFormat
                         )) {
                             $errors = true;
                         }
                         if ($generate_high_dpi_images && !ImageManager::resize(
-                            $file, 
-                            $dir . $language['iso_code'] . '-default-' . stripslashes($image_type['name']) . '2x.' . $imageFormat, 
-                            (int) $image_type['width'] * 2, 
-                            (int) $image_type['height'] * 2, 
-                            $imageFormat, 
+                            $file,
+                            $dir . $language['iso_code'] . '-default-' . stripslashes($image_type['name']) . '2x.' . $imageFormat,
+                            (int) $image_type['width'] * 2,
+                            (int) $image_type['height'] * 2,
+                            $imageFormat,
                             $forceFormat
                         )) {
                             $errors = true;

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -659,11 +659,16 @@ class AdminImagesControllerCore extends AdminController
         // Should we generate high DPI images?
         $generate_high_dpi_images = (bool) Configuration::get('PS_HIGHT_DPI');
 
-        // What formats should we generate?
+        /*
+         * Let's resolve which formats we will use for image generation.
+         * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
+         * 
+         * In case of .jpg images, the actual format inside is decided by ImageManager.
+         */
         if ($this->isMultipleImageFormatFeatureEnabled) {
-            $imageConfiguredFormats = $this->imageFormatConfiguration->getGenerationFormats();
+            $configuredImageFormats = $this->imageFormatConfiguration->getGenerationFormats();
         } else {
-            $imageConfiguredFormats = ['jpg'];
+            $configuredImageFormats = ['jpg'];
         }
 
         if (!$productsImages) {
@@ -681,7 +686,9 @@ class AdminImagesControllerCore extends AdminController
                             $image = str_replace('.', '_thumb.', $image);
                         }
 
-                        foreach ($imageConfiguredFormats as $imageFormat) {
+                        foreach ($configuredImageFormats as $imageFormat) {
+                            // For JPG images, we let Imagemanager decide what to do and choose between JPG/PNG.
+                            // For webp and avif extensions, we want it to follow our command and ignore the original format.
                             $forceFormat = ($imageFormat !== 'jpg');
                             // If thumbnail does not exist
                             if (!file_exists($newDir . substr($image, 0, -4) . '-' . stripslashes($imageType['name']) . '.' . $imageFormat)) {
@@ -727,7 +734,9 @@ class AdminImagesControllerCore extends AdminController
                 $existing_img = $dir . $imageObj->getExistingImgPath() . '.jpg';
                 if (file_exists($existing_img) && filesize($existing_img)) {
                     foreach ($type as $imageType) {
-                        foreach ($imageConfiguredFormats as $imageFormat) {
+                        foreach ($configuredImageFormats as $imageFormat) {
+                            // For JPG images, we let Imagemanager decide what to do and choose between JPG/PNG.
+                            // For webp and avif extensions, we want it to follow our command and ignore the original format.
                             $forceFormat = ($imageFormat !== 'jpg');
                             if (!file_exists($dir . $imageObj->getExistingImgPath() . '-' . stripslashes($imageType['name']) . '.' . $imageFormat)) {
                                 if (!ImageManager::resize(
@@ -806,11 +815,16 @@ class AdminImagesControllerCore extends AdminController
         // Should we generate high DPI images?
         $generate_high_dpi_images = (bool) Configuration::get('PS_HIGHT_DPI');
 
-        // What formats should we generate?
+        /*
+         * Let's resolve which formats we will use for image generation.
+         * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
+         * 
+         * In case of .jpg images, the actual format inside is decided by ImageManager.
+         */
         if ($this->isMultipleImageFormatFeatureEnabled) {
-            $imageConfiguredFormats = $this->imageFormatConfiguration->getGenerationFormats();
+            $configuredImageFormats = $this->imageFormatConfiguration->getGenerationFormats();
         } else {
-            $imageConfiguredFormats = ['jpg'];
+            $configuredImageFormats = ['jpg'];
         }
 
         foreach ($type as $image_type) {
@@ -819,7 +833,9 @@ class AdminImagesControllerCore extends AdminController
                 if (!file_exists($file)) {
                     $file = _PS_PRODUCT_IMG_DIR_ . Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT')) . '.jpg';
                 }
-                foreach ($imageConfiguredFormats as $imageFormat) {
+                foreach ($configuredImageFormats as $imageFormat) {
+                    // For JPG images, we let Imagemanager decide what to do and choose between JPG/PNG.
+                    // For webp and avif extensions, we want it to follow our command and ignore the original format.
                     $forceFormat = ($imageFormat !== 'jpg');
                     if (!file_exists($dir . $language['iso_code'] . '-default-' . stripslashes($image_type['name']) . '.' . $imageFormat)) {
                         if (!ImageManager::resize(

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -700,17 +700,15 @@ class AdminImagesControllerCore extends AdminController
                                         $this->errors[] = $this->trans('Failed to resize image file (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
                                     }
 
-                                    if ($generate_high_dpi_images) {
-                                        if (!ImageManager::resize(
-                                            $dir . $image,
-                                            $newDir . substr($image, 0, -4) . '-' . stripslashes($imageType['name']) . '2x.' . $imageFormat,
-                                            (int) $imageType['width'] * 2,
-                                            (int) $imageType['height'] * 2, 
-                                            $imageFormat, 
-                                            $forceFormat
-                                        )) {
-                                            $this->errors[] = $this->trans('Failed to resize image file to high resolution (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
-                                        }
+                                    if ($generate_high_dpi_images && !ImageManager::resize(
+                                        $dir . $image,
+                                        $newDir . substr($image, 0, -4) . '-' . stripslashes($imageType['name']) . '2x.' . $imageFormat,
+                                        (int) $imageType['width'] * 2,
+                                        (int) $imageType['height'] * 2, 
+                                        $imageFormat, 
+                                        $forceFormat
+                                    )) {
+                                        $this->errors[] = $this->trans('Failed to resize image file to high resolution (%filepath%)', ['%filepath%' => $dir . $image], 'Admin.Design.Notification');
                                     }
                                 }
                             }

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -103,7 +103,6 @@ class AdminImagesControllerCore extends AdminController
         $formFields = [];
 
         if ($this->isMultipleImageFormatFeatureEnabled) {
-
             $imageFormatsDisabled = [];
             $imageFormatsDisabled['jpg'] = true; // jpg is mandatory, see https://github.com/PrestaShop/PrestaShop/issues/30944
             if (false === $this->canGenerateAvif) {

--- a/controllers/admin/AdminImagesController.php
+++ b/controllers/admin/AdminImagesController.php
@@ -130,6 +130,7 @@ class AdminImagesControllerCore extends AdminController
                         'avif' => in_array('avif', $configuredImageFormats),
                     ],
                     'disabled' => $imageFormatsDisabled,
+                    'desc' => $this->trans('Choose which image formats you want to be generated. Base image will always have .jpg extension, other formats will have .webp or .avif.', [], 'Admin.Design.Help'),
                 ],
                 'PS_IMAGE_QUALITY' => [
                     'title' => $this->trans('Base format', [], 'Admin.Design.Feature'),
@@ -137,9 +138,9 @@ class AdminImagesControllerCore extends AdminController
                     'required' => true,
                     'type' => 'radio',
                     'choices' => [
-                        'jpg' => $this->trans('Use JPEG.', [], 'Admin.Design.Feature'),
-                        'png' => $this->trans('Use PNG only if the base image is in PNG format.', [], 'Admin.Design.Feature'),
-                        'png_all' => $this->trans('Use PNG for all images.', [], 'Admin.Design.Feature'),
+                        'jpg' => $this->trans('Use JPEG', [], 'Admin.Design.Feature'),
+                        'png' => $this->trans('Use PNG only if the base image is in PNG format', [], 'Admin.Design.Feature'),
+                        'png_all' => $this->trans('Use PNG', [], 'Admin.Design.Feature'),
                     ],
                 ],
                 'PS_AVIF_QUALITY' => [

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2879,12 +2879,12 @@ class AdminProductsControllerCore extends AdminController
                     // Should we generate high DPI images?
                     $generate_hight_dpi_images = (bool) Configuration::get('PS_HIGHT_DPI');
 
-                    $sfContainer = SymfonyContainer::getInstance();    
+                    $sfContainer = SymfonyContainer::getInstance();
 
                     /*
                     * Let's resolve which formats we will use for image generation.
                     * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
-                    * 
+                    *
                     * In case of .jpg images, the actual format inside is decided by ImageManager.
                     */
                     if ($sfContainer->get('prestashop.core.admin.feature_flag.repository')->isEnabled(FeatureFlagSettings::FEATURE_FLAG_MULTIPLE_IMAGE_FORMAT)) {
@@ -2899,7 +2899,7 @@ class AdminProductsControllerCore extends AdminController
                             $forceFormat = ($imageFormat !== 'jpg');
                             if (!ImageManager::resize(
                                 $file['save_path'],
-                                $new_path . '-' . stripslashes($imageType['name']) . '.' . $imageFormat, 
+                                $new_path . '-' . stripslashes($imageType['name']) . '.' . $imageFormat,
                                 $imageType['width'],
                                 $imageType['height'],
                                 $imageFormat,

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2889,7 +2889,7 @@ class AdminProductsControllerCore extends AdminController
                             $forceFormat = ($imageFormat !== 'jpg');
                             if (!ImageManager::resize(
                                 $file['save_path'],
-                                $new_path . '-' . stripslashes($imageType['name']) . '.' . $image->image_format, 
+                                $new_path . '-' . stripslashes($imageType['name']) . '.' . $imageFormat, 
                                 $imageType['width'],
                                 $imageType['height'],
                                 $imageFormat,
@@ -2903,7 +2903,7 @@ class AdminProductsControllerCore extends AdminController
                             if ($generate_hight_dpi_images) {
                                 if (!ImageManager::resize(
                                     $file['save_path'],
-                                    $new_path . '-' . stripslashes($imageType['name']) . '2x.' . $image->image_format,
+                                    $new_path . '-' . stripslashes($imageType['name']) . '2x.' . $imageFormat,
                                     (int) $imageType['width'] * 2,
                                     (int) $imageType['height'] * 2,
                                     $imageFormat,

--- a/controllers/admin/AdminStoresController.php
+++ b/controllers/admin/AdminStoresController.php
@@ -411,6 +411,8 @@ class AdminStoresControllerCore extends AdminController
     protected function postImage($id)
     {
         $ret = parent::postImage($id);
+
+        // Should we generate high DPI images?
         $generate_hight_dpi_images = (bool) Configuration::get('PS_HIGHT_DPI');
 
         if (($id_store = (int) Tools::getValue('id_store')) && count($_FILES) && file_exists(_PS_STORE_IMG_DIR_ . $id_store . '.jpg')) {

--- a/controllers/admin/AdminSuppliersController.php
+++ b/controllers/admin/AdminSuppliersController.php
@@ -433,6 +433,8 @@ class AdminSuppliersControllerCore extends AdminController
     protected function afterImageUpload()
     {
         $return = true;
+
+        // Should we generate high DPI images?
         $generate_hight_dpi_images = (bool) Configuration::get('PS_HIGHT_DPI');
 
         /* Generate image with differents size */

--- a/src/Adapter/Image/ImageGenerator.php
+++ b/src/Adapter/Image/ImageGenerator.php
@@ -104,7 +104,7 @@ class ImageGenerator
         /*
          * Let's resolve which formats we will use for image generation.
          * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
-         * 
+         *
          * In case of .jpg images, the actual format inside is decided by ImageManager.
          */
         if ($this->featureFlagRepository->isEnabled(FeatureFlagSettings::FEATURE_FLAG_MULTIPLE_IMAGE_FORMAT)) {

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -192,7 +192,7 @@ class ImageRetriever
         /*
          * Let's resolve which formats we will use for image generation.
          * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
-         * 
+         *
          * In case of .jpg images, the actual format inside is decided by ImageManager.
          */
         if ($this->isMultipleImageFormatFeatureActive) {

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -189,10 +189,13 @@ class ImageRetriever
             $id_image . '.jpg',
         ]);
 
-        // In legacy image system, image extension is always JPG and there could be JPG, PNG or webp image inside
-        // The format is decided by ImageManager
+        /*
+         * Let's resolve which formats we will use for image generation.
+         * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
+         * 
+         * In case of .jpg images, the actual format inside is decided by ImageManager.
+         */
         if ($this->isMultipleImageFormatFeatureActive) {
-            // Get image format list that we will use in case of new image system
             $configuredImageFormats = explode(',', Configuration::get('PS_IMAGE_FORMAT'));
         } else {
             $configuredImageFormats = ['jpg'];
@@ -293,8 +296,8 @@ class ImageRetriever
             $fileName,
         ]);
 
-        // For JPG files, we let the decision on what is inside to PS_IMAGE_QUALITY settings.
-        // For other formats, we always force it regardless of what is in the original file.
+        // For JPG images, we let Imagemanager decide what to do and choose between JPG/PNG.
+        // For webp and avif extensions, we want it to follow our command and ignore the original format.
         $forceFormat = ($imageFormat !== 'jpg');
 
         // Check if the thumbnail exists and generate it if needed

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -228,7 +228,7 @@ class ImageRetriever
                     $sources[$imageFormat] = $this->link->$getImageURL($rewrite, $id_image, $image_type['name'], $imageFormat);
                 }
             }
-            
+
             // Let's resolve the base image URL we will use
             if (isset($sources['jpg'])) {
                 $baseUrl = $sources['jpg'];

--- a/src/Adapter/Image/ImageRetriever.php
+++ b/src/Adapter/Image/ImageRetriever.php
@@ -273,17 +273,17 @@ class ImageRetriever
      * @param string $imageFolderPath
      * @param int $idImage
      * @param array $imageTypeData
-     * @param string $ext
+     * @param string $imageFormat
      * @param bool $hdpi
      *
      * @return void
      */
-    private function checkOrGenerateImageType(string $originalImagePath, string $imageFolderPath, int $idImage, array $imageTypeData, string $ext, bool $hdpi = false)
+    private function checkOrGenerateImageType(string $originalImagePath, string $imageFolderPath, int $idImage, array $imageTypeData, string $imageFormat, bool $hdpi = false)
     {
-        $fileName = sprintf('%s-%s.%s', $idImage, $imageTypeData['name'], $ext);
+        $fileName = sprintf('%s-%s.%s', $idImage, $imageTypeData['name'], $imageFormat);
 
         if ($hdpi) {
-            $fileName = sprintf('%s-%s2x.%s', $idImage, $imageTypeData['name'], $ext);
+            $fileName = sprintf('%s-%s2x.%s', $idImage, $imageTypeData['name'], $imageFormat);
             $imageTypeData['width'] *= 2;
             $imageTypeData['height'] *= 2;
         }
@@ -293,14 +293,19 @@ class ImageRetriever
             $fileName,
         ]);
 
+        // For JPG files, we let the decision on what is inside to PS_IMAGE_QUALITY settings.
+        // For other formats, we always force it regardless of what is in the original file.
+        $forceFormat = ($imageFormat !== 'jpg');
+
+        // Check if the thumbnail exists and generate it if needed
         if (!file_exists($resizedImagePath)) {
             ImageManager::resize(
                 $originalImagePath,
                 $resizedImagePath,
                 (int) $imageTypeData['width'],
                 (int) $imageTypeData['height'],
-                $ext,
-                true
+                $imageFormat,
+                $forceFormat
             );
         }
     }

--- a/src/Adapter/Image/Uploader/AbstractImageUploader.php
+++ b/src/Adapter/Image/Uploader/AbstractImageUploader.php
@@ -160,17 +160,24 @@ abstract class AbstractImageUploader
         $width = $imageType['width'];
         $height = $imageType['height'];
 
-        if (Configuration::get('PS_HIGHT_DPI')) {
-            $ext = '2x.jpg';
-            $width *= 2;
-            $height *= 2;
-        }
-
-        return ImageManager::resize(
+        if (!ImageManager::resize(
             $imageDir . $id . '.jpg',
             $imageDir . $id . '-' . stripslashes($imageType['name']) . $ext,
             (int) $width,
             (int) $height
-        );
+        )) {
+            return false;
+        }
+
+        if ((bool) Configuration::get('PS_HIGHT_DPI') && !ImageManager::resize(
+            $imageDir . $id . '.jpg',
+            $imageDir . $id . '-' . stripslashes($imageType['name']) . '2x' . $ext,
+            (int) $width * 2,
+            (int) $height * 2
+        )) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -154,12 +154,20 @@ class LogoUploader
                         throw new PrestaShopException(sprintf('An error occurred while attempting to copy shop logo %s.', $logoName));
                     }
                 } else {
+                    /*
+                    * Let's resolve which formats we will use for image generation.
+                    * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
+                    * 
+                    * In case of .jpg images, the actual format inside is decided by ImageManager.
+                    */
                     if ($this->featureFlagRepository->isEnabled(FeatureFlagSettings::FEATURE_FLAG_MULTIPLE_IMAGE_FORMAT)) {
-                        $imageFormatsList = $this->imageFormatConfiguration->getGenerationFormats();
+                        $configuredImageFormats = $this->imageFormatConfiguration->getGenerationFormats();
                     } else {
-                        $imageFormatsList = ['jpg'];
+                        $configuredImageFormats = ['jpg'];
                     }
-                    foreach ($imageFormatsList as $imageFormat) {
+                    foreach ($configuredImageFormats as $imageFormat) {
+                        // For JPG images, we let Imagemanager decide what to do and choose between JPG/PNG.
+                        // For webp and avif extensions, we want it to follow our command and ignore the original format.
                         $forceFormat = ($imageFormat !== 'jpg');
                         if (!ImageManager::resize(
                             $tmpName,

--- a/src/Core/Shop/LogoUploader.php
+++ b/src/Core/Shop/LogoUploader.php
@@ -157,7 +157,7 @@ class LogoUploader
                     /*
                     * Let's resolve which formats we will use for image generation.
                     * In new image system, it's multiple formats. In case of legacy, it's only .jpg.
-                    * 
+                    *
                     * In case of .jpg images, the actual format inside is decided by ImageManager.
                     */
                     if ($this->featureFlagRepository->isEnabled(FeatureFlagSettings::FEATURE_FLAG_MULTIPLE_IMAGE_FORMAT)) {


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Read below
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/31488
| Related PRs       | 
| Sponsor company   |

### Description
- Multiple issues arose when implementing the image generation. This should fix everything.
- The new image system broke image generation with the old one. Regardless on what was set in `PS_IMAGE_QUALITY` it was always generating a JPG file and completely ignoring what was inside the file.
- It didn't work at all on legacy product page for example.
- Also, this PR enables to choose the base format for files with JPG extension when using the new generation system.
- I fixed the multiple images generation everywhere where it was previously implemented. If it was not implemented, I didn't implement it, because it would be generated in FO automatically.

### Settings with new image system
When enabling new image system, the settings are changed a bit. You can now configure the format for base PNG images and the new checkboxes.
![newimagesettings](https://user-images.githubusercontent.com/6097524/220628333-ea374e93-3b6c-421a-a2db-cbb75c9a2fb9.jpg)

### Summary
- Old system - we generate:
  - JPG file with JPG/PNG/WEBP image inside
- New system - we generate:
  - JPG file with JPG/PNG image inside
  - optionally WEBP file with WEBP inside
  - optionally AVIF file with AVIF inside

### How to test - GENERAL
- To easily test it, download https://www.xnview.com/en/xnconvert/ and just drop whole folders into there and you will immediately see the file formats inside.
- Test generation when uploading on old product page.
- Test generation when uploading on new product page.
- Test manual regeneration in backoffice.
- Test automatic generation in front office. Just delete thumbnails and visit the product, they should be regenerated automatically.
- Product images should automatically generate on upload, but others may not. 
- The main thing to check that it generates nothing **WRONG** in backoffice. If it generates only jpg **PROPERLY** (with correct format inside) and the rest on the fly in front office, it's OK.

### How to test - OLD IMAGE SYSTEM
- Disable new multiple image generation feature flag.
- Set image settings to `Use PNG only if the base image is in PNG format`.
- Make a product, upload one JPG and one PNG image.
- Go to FO to this product to generate the thumbnails.
- Go to img/p folder and find the folder with images. Drop them all into XNCONVERT or simmilar software, or anything that will let you see what is inside. See that the thumbnail contain proper files.
- Then you can try again with "Use PNG" or "Use JPG" options. Just delete all the thumbnails and refresh the product in FO, so you don't have to create it again.

### How to test - NEW IMAGE SYSTEM
- Enable new multiple image generation feature flag.
- Set image settings to `Use PNG only if the base image is in PNG format` and enable webp AND/OR AVIF.
- Make a product, upload one JPG and one PNG image.
- Go to FO to this product to generate the thumbnails.
- Go to img/p folder and find the folder with images. Drop them all into XNCONVERT or simmilar software, or anything that will let you see what is inside. See that the thumbnail contain proper files. It will look something like this:
![filetypes](https://user-images.githubusercontent.com/6097524/220628128-63934ea4-3d23-49e5-8693-e9a7efa723fe.jpg)

### Known issues
- If you are on old image system and set image format to "WEBP" or "webp when original image is webp", then go enable new image system, when you go to image settings, you may not see the selected value. Everything will work, but you will get two WEBP images, one with jpg extension, one with webp extension. This can get fixed in another PR, I didn't want to mess with the experimental feature enabling.