### PR TITLE
Add whitelist to legacy link linter mechanism

### DIFF
--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -48,6 +48,17 @@ class LegacyLinkLinterCommand extends Command
      */
     private $adminRouteProvider;
 
+    /**
+     * The _legacy_link configuration is not relevant for these routes, no need to apply the linter on them
+     */
+    const ROUTE_WHITE_LIST = [
+        'admin_common_notifications_ack',
+        'admin_common_pagination',
+        'admin_common_sidebar',
+        'admin_common_reset_search',
+        'admin_common_reset_search_by_filter_id'
+    ];
+
     public function __construct(LegacyLinkLinter $legacyLinkLinter, AdminRouteProvider $adminRouteProvider)
     {
         parent::__construct();
@@ -99,7 +110,7 @@ class LegacyLinkLinterCommand extends Command
         $unconfiguredRoutes = [];
 
         foreach ($routes as $routeName => $route) {
-            if (true === $this->legacyLinkLinter->lint('_legacy_link', $route)) {
+            if (in_array($routeName, self::ROUTE_WHITE_LIST) || true === $this->legacyLinkLinter->lint('_legacy_link', $route)) {
                 continue;
             }
             $unconfiguredRoutes[] = $routeName;

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -51,7 +51,7 @@ class LegacyLinkLinterCommand extends Command
     /**
      * The _legacy_link configuration is not relevant for these routes, no need to apply the linter on them
      */
-    const ROUTE_WHITE_LIST = [
+    private const ROUTE_WHITE_LIST = [
         'admin_common_notifications_ack',
         'admin_common_pagination',
         'admin_common_sidebar',

--- a/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
+++ b/src/PrestaShopBundle/Command/LegacyLinkLinterCommand.php
@@ -56,7 +56,7 @@ class LegacyLinkLinterCommand extends Command
         'admin_common_pagination',
         'admin_common_sidebar',
         'admin_common_reset_search',
-        'admin_common_reset_search_by_filter_id'
+        'admin_common_reset_search_by_filter_id',
     ];
 
     public function __construct(LegacyLinkLinter $legacyLinkLinter, AdminRouteProvider $adminRouteProvider)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add a whitelist for routes that don't need to be checked by the legacy link linter command.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | - Launch the command from root of the project: `php bin/console prestashop:linter:legacy-link` <br> - Check that route `admin_common_notifications_ack` is not at the top of the list in the result.
| Fixed ticket?     | partly Fixes #31229
| Related PRs       | 
| Sponsor company   | PrestaShop SA