### PR TITLE
Order Statuses/Order Return Statuses : Use the new form theme

### DIFF
--- a/src/Adapter/File/Uploader/OrderStateFileUploader.php
+++ b/src/Adapter/File/Uploader/OrderStateFileUploader.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\File\Uploader;
+
+use PrestaShop\PrestaShop\Core\Configuration\UploadSizeConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateUploadFailedException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\OrderStateFileUploaderInterface;
+use Symfony\Component\HttpFoundation\File\Exception\FileException;
+
+/**
+ * Uploads order state file
+ */
+class OrderStateFileUploader implements OrderStateFileUploaderInterface
+{
+    /**
+     * @var UploadSizeConfigurationInterface
+     */
+    protected $uploadSizeConfiguration;
+
+    /**
+     * @param UploadSizeConfigurationInterface $uploadSizeConfiguration
+     */
+    public function __construct(UploadSizeConfigurationInterface $uploadSizeConfiguration)
+    {
+        $this->uploadSizeConfiguration = $uploadSizeConfiguration;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param bool $throwExceptionOnFailure
+     *
+     * @throws OrderStateConstraintException
+     * @throws OrderStateUploadFailedException
+     */
+    public function upload(
+        string $filePath,
+        int $id,
+        int $fileSize,
+        bool $throwExceptionOnFailure = true
+    ): void {
+        $this->checkFileAllowedForUpload($fileSize);
+        $this->uploadFile($filePath, $id);
+    }
+
+    /**
+     * @param string $filePath
+     * @param int $id
+     *
+     * @throws OrderStateUploadFailedException
+     */
+    protected function uploadFile(string $filePath, int $id): void
+    {
+        try {
+            move_uploaded_file($filePath, _PS_ORDER_STATE_IMG_DIR_ . $id . '.gif');
+        } catch (FileException $e) {
+            throw new OrderStateUploadFailedException(sprintf('Failed to copy the file %s.', $filePath), 0, $e);
+        }
+    }
+
+    /**
+     * @param int $fileSize
+     *
+     * @throws OrderStateConstraintException
+     */
+    protected function checkFileAllowedForUpload(int $fileSize): void
+    {
+        $maxFileSize = $this->uploadSizeConfiguration->getMaxUploadSizeInBytes();
+
+        if ($maxFileSize > 0 && $fileSize > $maxFileSize) {
+            throw new OrderStateConstraintException(
+                sprintf('Max file size allowed is "%s" bytes. Uploaded file size is "%s".', $maxFileSize, $fileSize),
+                OrderStateConstraintException::INVALID_FILE_SIZE
+            );
+        }
+    }
+}

--- a/src/Adapter/OrderState/CommandHandler/AddOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/AddOrderStateHandler.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\CommandBus\Attributes\AsCommandHandler;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\AddOrderStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\CommandHandler\AddOrderStateHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\OrderStateFileUploaderInterface;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
 
 /**
@@ -42,6 +43,19 @@ use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
 #[AsCommandHandler]
 final class AddOrderStateHandler extends AbstractOrderStateHandler implements AddOrderStateHandlerInterface
 {
+    /**
+     * @var OrderStateFileUploaderInterface
+     */
+    protected $fileUploader;
+
+    /**
+     * @param OrderStateFileUploaderInterface $fileUploader
+     */
+    public function __construct(OrderStateFileUploaderInterface $fileUploader)
+    {
+        $this->fileUploader = $fileUploader;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -57,6 +71,9 @@ final class AddOrderStateHandler extends AbstractOrderStateHandler implements Ad
         }
 
         $orderState->add();
+        if ($command->getFilePathName()) {
+            $this->fileUploader->upload($command->getFilePathName(), (int) $orderState->id, $command->getFileSize());
+        }
 
         return new OrderStateId((int) $orderState->id);
     }

--- a/src/Adapter/OrderState/CommandHandler/EditOrderStateHandler.php
+++ b/src/Adapter/OrderState/CommandHandler/EditOrderStateHandler.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\EditOrderStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\CommandHandler\EditOrderStateHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\MissingOrderStateRequiredFieldsException;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\OrderStateFileUploaderInterface;
 
 /**
  * Handles commands which edits given order state with provided data.
@@ -42,6 +43,19 @@ use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
 #[AsCommandHandler]
 final class EditOrderStateHandler extends AbstractOrderStateHandler implements EditOrderStateHandlerInterface
 {
+    /**
+     * @var OrderStateFileUploaderInterface
+     */
+    protected $fileUploader;
+
+    /**
+     * @param OrderStateFileUploaderInterface $fileUploader
+     */
+    public function __construct(OrderStateFileUploaderInterface $fileUploader)
+    {
+        $this->fileUploader = $fileUploader;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -62,6 +76,10 @@ final class EditOrderStateHandler extends AbstractOrderStateHandler implements E
 
         if (false === $orderState->update()) {
             throw new OrderStateException('Failed to update order state');
+        }
+
+        if ($command->getFilePathName()) {
+            $this->fileUploader->upload($command->getFilePathName(), $orderStateId->getValue(), $command->getFileSize());
         }
     }
 

--- a/src/Adapter/OrderState/QueryHandler/GetOrderStateForEditingHandler.php
+++ b/src/Adapter/OrderState/QueryHandler/GetOrderStateForEditingHandler.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateNotFoundExc
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Query\GetOrderStateForEditing;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\QueryHandler\GetOrderStateForEditingHandlerInterface;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\QueryResult\EditableOrderState;
+use SplFileInfo;
 
 /**
  * Handles command that gets orderState for editing
@@ -54,9 +55,13 @@ final class GetOrderStateForEditingHandler implements GetOrderStateForEditingHan
             throw new OrderStateNotFoundException($orderStateId, sprintf('OrderState with id "%s" was not found', $orderStateId->getValue()));
         }
 
+        $filePath = _PS_ORDER_STATE_IMG_DIR_ . $orderState->id . '.gif';
+        $file = file_exists($filePath) ? new SplFileInfo($filePath) : null;
+
         return new EditableOrderState(
             $orderStateId,
             $orderState->name,
+            $file,
             $orderState->color,
             (bool) $orderState->logable,
             (bool) $orderState->invoice,

--- a/src/Core/Domain/OrderState/Command/AddOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/AddOrderStateCommand.php
@@ -85,6 +85,26 @@ class AddOrderStateCommand
     private $localizedTemplates;
 
     /**
+     * @var string|null
+     */
+    protected $pathName;
+
+    /**
+     * @var int|null
+     */
+    protected $fileSize;
+
+    /**
+     * @var string|null
+     */
+    protected $mimeType;
+
+    /**
+     * @var string|null
+     */
+    protected $originalName;
+
+    /**
      * @param string[] $localizedNames
      * @param string[] $localizedTemplates
      */
@@ -228,5 +248,55 @@ class AddOrderStateCommand
     public function getLocalizedTemplates()
     {
         return $this->localizedTemplates;
+    }
+
+    /**
+     * @param string $pathName
+     * @param int $fileSize
+     * @param string $mimeType
+     * @param string $originalName
+     */
+    public function setFileInformation(
+        string $pathName,
+        int $fileSize,
+        string $mimeType,
+        string $originalName
+    ): void {
+        $this->pathName = $pathName;
+        $this->fileSize = $fileSize;
+        $this->mimeType = $mimeType;
+        $this->originalName = $originalName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFilePathName(): ?string
+    {
+        return $this->pathName;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getFileSize(): ?int
+    {
+        return $this->fileSize;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMimeType(): ?string
+    {
+        return $this->mimeType;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOriginalName(): ?string
+    {
+        return $this->originalName;
     }
 }

--- a/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
+++ b/src/Core/Domain/OrderState/Command/EditOrderStateCommand.php
@@ -107,6 +107,26 @@ class EditOrderStateCommand
     private $template;
 
     /**
+     * @var string|null
+     */
+    protected $pathName;
+
+    /**
+     * @var int|null
+     */
+    protected $fileSize;
+
+    /**
+     * @var string|null
+     */
+    protected $mimeType;
+
+    /**
+     * @var string|null
+     */
+    protected $originalName;
+
+    /**
      * @param int $orderStateId
      */
     public function __construct($orderStateId)
@@ -338,5 +358,55 @@ class EditOrderStateCommand
         $this->template = $template;
 
         return $this;
+    }
+
+    /**
+     * @param string $pathName
+     * @param int $fileSize
+     * @param string $mimeType
+     * @param string $originalName
+     */
+    public function setFileInformation(
+        string $pathName,
+        int $fileSize,
+        string $mimeType,
+        string $originalName
+    ): void {
+        $this->pathName = $pathName;
+        $this->fileSize = $fileSize;
+        $this->mimeType = $mimeType;
+        $this->originalName = $originalName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFilePathName(): ?string
+    {
+        return $this->pathName;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getFileSize(): ?int
+    {
+        return $this->fileSize;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMimeType(): ?string
+    {
+        return $this->mimeType;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getOriginalName(): ?string
+    {
+        return $this->originalName;
     }
 }

--- a/src/Core/Domain/OrderState/Exception/OrderStateUploadFailedException.php
+++ b/src/Core/Domain/OrderState/Exception/OrderStateUploadFailedException.php
@@ -28,20 +28,8 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\OrderState\Exception;
 
 /**
- * Is thrown when order state constraint is violated
+ * Class OrderStateUploadFailedException
  */
-class OrderStateConstraintException extends OrderStateException
+class OrderStateUploadFailedException extends OrderStateException
 {
-    /**
-     * @var int Code is used when invalid name is provided for order state
-     */
-    public const INVALID_NAME = 1;
-    /**
-     * @var int Code is used when empty name is provided for order state
-     */
-    public const EMPTY_NAME = 2;
-    /**
-     * @var int
-     */
-    public const INVALID_FILE_SIZE = 3;
 }

--- a/src/Core/Domain/OrderState/OrderStateFileUploaderInterface.php
+++ b/src/Core/Domain/OrderState/OrderStateFileUploaderInterface.php
@@ -23,25 +23,15 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-declare(strict_types=1);
 
-namespace PrestaShop\PrestaShop\Core\Domain\OrderState\Exception;
+namespace PrestaShop\PrestaShop\Core\Domain\OrderState;
 
-/**
- * Is thrown when order state constraint is violated
- */
-class OrderStateConstraintException extends OrderStateException
+interface OrderStateFileUploaderInterface
 {
     /**
-     * @var int Code is used when invalid name is provided for order state
+     * @param string $filePath
+     * @param int $id
+     * @param int $fileSize
      */
-    public const INVALID_NAME = 1;
-    /**
-     * @var int Code is used when empty name is provided for order state
-     */
-    public const EMPTY_NAME = 2;
-    /**
-     * @var int
-     */
-    public const INVALID_FILE_SIZE = 3;
+    public function upload(string $filePath, int $id, int $fileSize): void;
 }

--- a/src/Core/Domain/OrderState/QueryResult/EditableOrderState.php
+++ b/src/Core/Domain/OrderState/QueryResult/EditableOrderState.php
@@ -28,6 +28,7 @@ declare(strict_types=1);
 namespace PrestaShop\PrestaShop\Core\Domain\OrderState\QueryResult;
 
 use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
+use SplFileInfo;
 
 /**
  * Stores editable data for order state
@@ -42,6 +43,10 @@ class EditableOrderState
      * @var array
      */
     private $localizedNames;
+    /**
+     * @var SplFileInfo|null
+     */
+    protected $icon;
     /**
      * @var string
      */
@@ -94,6 +99,7 @@ class EditableOrderState
     public function __construct(
         OrderStateId $orderStateId,
         array $name,
+        ?SplFileInfo $icon,
         string $color,
         bool $loggable,
         bool $invoice,
@@ -109,6 +115,7 @@ class EditableOrderState
     ) {
         $this->orderStateId = $orderStateId;
         $this->localizedNames = $name;
+        $this->icon = $icon;
         $this->color = $color;
         $this->loggable = $loggable;
         $this->invoice = $invoice;
@@ -233,5 +240,13 @@ class EditableOrderState
     public function getLocalizedTemplates()
     {
         return $this->localizedTemplates;
+    }
+
+    /**
+     * @return SplFileInfo|null
+     */
+    public function getIcon(): ?SplFileInfo
+    {
+        return $this->icon;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataHandler/OrderStateFormDataHandler.php
+++ b/src/Core/Form/IdentifiableObject/DataHandler/OrderStateFormDataHandler.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\CommandBus\CommandBusInterface;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\AddOrderStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\EditOrderStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderState\ValueObject\OrderStateId;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
  * Saves or updates order state data submitted in form
@@ -91,6 +92,18 @@ final class OrderStateFormDataHandler implements FormDataHandlerInterface
             $data['template']
         );
 
+        if (isset($data['icon'])) {
+            /** @var UploadedFile $fileObject */
+            $fileObject = $data['icon'];
+
+            $command->setFileInformation(
+                $fileObject->getPathname(),
+                $fileObject->getSize(),
+                $fileObject->getMimeType(),
+                $fileObject->getClientOriginalName()
+            );
+        }
+
         return $command;
     }
 
@@ -115,6 +128,18 @@ final class OrderStateFormDataHandler implements FormDataHandlerInterface
             ->setDelivery($data['delivery'])
             ->setTemplate($data['template'])
         ;
+
+        /** @var UploadedFile|null $fileObject */
+        $fileObject = $data['icon'];
+
+        if ($fileObject instanceof UploadedFile) {
+            $command->setFileInformation(
+                $fileObject->getPathname(),
+                $fileObject->getSize(),
+                $fileObject->getMimeType(),
+                $fileObject->getClientOriginalName()
+            );
+        }
 
         return $command;
     }

--- a/src/Core/Form/IdentifiableObject/DataProvider/OrderReturnStateFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/OrderReturnStateFormDataProvider.php
@@ -66,10 +66,8 @@ final class OrderReturnStateFormDataProvider implements FormDataProviderInterfac
      */
     public function getDefaultData()
     {
-        $data = [
-            'is_enabled' => true,
+        return [
+            'color' => '#ffffff',
         ];
-
-        return $data;
     }
 }

--- a/src/Core/Form/IdentifiableObject/DataProvider/OrderStateFormDataProvider.php
+++ b/src/Core/Form/IdentifiableObject/DataProvider/OrderStateFormDataProvider.php
@@ -76,10 +76,8 @@ final class OrderStateFormDataProvider implements FormDataProviderInterface
      */
     public function getDefaultData()
     {
-        $data = [
-            'is_enabled' => true,
+        return [
+            'color' => '#ffffff',
         ];
-
-        return $data;
     }
 }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
@@ -41,6 +41,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class OrderReturnStateType extends TranslatorAwareType
 {
+    protected const NAME_CHARS = '!<>,;?=+()@#"{}_$%:';
+
     /**
      * {@inheritdoc}
      */
@@ -48,6 +50,13 @@ class OrderReturnStateType extends TranslatorAwareType
     {
         $builder
             ->add('name', TranslatableType::class, [
+                'label' => $this->trans('Status name', 'Admin.Shopparameters.Feature'),
+                'help' => sprintf(
+                    '%s %s %s',
+                    $this->trans('Status name', 'Admin.Shopparameters.Feature'),
+                    $this->trans('Invalid characters: numbers and', 'Admin.Shopparameters.Feature'),
+                    static::NAME_CHARS
+                ),
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
@@ -61,6 +70,8 @@ class OrderReturnStateType extends TranslatorAwareType
                 ],
             ])
             ->add('color', ColorPickerType::class, [
+                'label' => $this->trans('Color', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Status will be highlighted in this color. HTML colors only.', 'Admin.Shopparameters.Help'),
                 'required' => true,
             ])
         ;

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderReturnStates/OrderReturnStateType.php
@@ -72,7 +72,7 @@ class OrderReturnStateType extends TranslatorAwareType
             ->add('color', ColorPickerType::class, [
                 'label' => $this->trans('Color', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Status will be highlighted in this color. HTML colors only.', 'Admin.Shopparameters.Help'),
-                'required' => true,
+                'required' => false,
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Form\Admin\Configure\ShopParameters\OrderStates;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\MailTemplate\Layout\Layout;
 use PrestaShop\PrestaShop\Core\MailTemplate\ThemeCatalogInterface;
 use PrestaShopBundle\Form\Admin\Type\ColorPickerType;
@@ -48,6 +49,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class OrderStateType extends TranslatorAwareType
 {
+    protected const NAME_CHARS = '!<>,;?=+()@#"{}_$%:';
+
     /**
      * @var array
      */
@@ -65,7 +68,7 @@ class OrderStateType extends TranslatorAwareType
      * @param UrlGeneratorInterface $routing
      * @param ShopConfigurationInterface $configuration
      *
-     * @throws \PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct(
         TranslatorInterface $translator,
@@ -111,6 +114,13 @@ class OrderStateType extends TranslatorAwareType
     {
         $builder
             ->add('name', TranslatableType::class, [
+                'label' => $this->trans('Status name', 'Admin.Shopparameters.Feature'),
+                'help' => sprintf(
+                    '%s %s %s',
+                    $this->trans('Order status (e.g. \'Pending\').', 'Admin.Shopparameters.Help'),
+                    $this->trans('Invalid characters: numbers and', 'Admin.Shopparameters.Help'),
+                    static::NAME_CHARS
+                ),
                 'type' => TextType::class,
                 'constraints' => [
                     new DefaultLanguage(),
@@ -125,6 +135,8 @@ class OrderStateType extends TranslatorAwareType
             ])
             ->add('color', ColorPickerType::class, [
                 'required' => true,
+                'label' => $this->trans('Color', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Status will be highlighted in this color. HTML colors only.', 'Admin.Shopparameters.Help'),
             ])
             ->add('loggable', CheckboxType::class, [
                 'required' => false,
@@ -190,6 +202,7 @@ class OrderStateType extends TranslatorAwareType
                 ],
             ])
             ->add('template', TranslatableChoiceType::class, [
+                'label' => $this->trans('Email template', 'Admin.Shopparameters.Feature'),
                 'hint' => sprintf(
                     '%s<br>%s',
                     $this->trans('Only letters, numbers and underscores ("_") are allowed.', 'Admin.Shopparameters.Help'),
@@ -197,7 +210,15 @@ class OrderStateType extends TranslatorAwareType
                 ),
                 'required' => false,
                 'choices' => $this->templates,
-                'row_attr' => $this->templateAttributes,
+                'row_attr' => $this->templateAttributes + [
+                    'class' => 'order_state_template_select',
+                ],
+                'button' => [
+                    'label' => $this->trans('Preview', 'Admin.Actions'),
+                    'icon' => 'visibility',
+                    'class' => 'btn btn-primary',
+                    'id' => 'order_state_template_preview',
+                ],
             ])
         ;
     }

--- a/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
+++ b/src/PrestaShopBundle/Form/Admin/Configure/ShopParameters/OrderStates/OrderStateType.php
@@ -38,6 +38,7 @@ use PrestaShopBundle\Form\Admin\Type\TranslatableChoiceType;
 use PrestaShopBundle\Form\Admin\Type\TranslatableType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -133,8 +134,13 @@ class OrderStateType extends TranslatorAwareType
                     ],
                 ],
             ])
+            ->add('icon', FileType::class, [
+                'required' => false,
+                'label' => $this->trans('Icon', 'Admin.Shopparameters.Feature'),
+                'help' => $this->trans('Upload an icon from your computer (File type: .gif, suggested size: 16x16).', 'Admin.Shopparameters.Help'),
+            ])
             ->add('color', ColorPickerType::class, [
-                'required' => true,
+                'required' => false,
                 'label' => $this->trans('Color', 'Admin.Shopparameters.Feature'),
                 'help' => $this->trans('Status will be highlighted in this color. HTML colors only.', 'Admin.Shopparameters.Help'),
             ])
@@ -202,7 +208,7 @@ class OrderStateType extends TranslatorAwareType
                 ],
             ])
             ->add('template', TranslatableChoiceType::class, [
-                'label' => $this->trans('Email template', 'Admin.Shopparameters.Feature'),
+                'label' => $this->trans('Template', 'Admin.Shopparameters.Feature'),
                 'hint' => sprintf(
                     '%s<br>%s',
                     $this->trans('Only letters, numbers and underscores ("_") are allowed.', 'Admin.Shopparameters.Help'),

--- a/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/TranslatableChoiceType.php
@@ -42,6 +42,7 @@ class TranslatableChoiceType extends TranslatableType
 
         $view->vars['default_locale'] = reset($options['locales'])['iso_code'];
         $view->vars['choices'] = $options['choices'];
+        $view->vars['button'] = $options['button'];
     }
 
     /**
@@ -50,11 +51,13 @@ class TranslatableChoiceType extends TranslatableType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
+            'button' => [],
             'choices' => [],
             'choice_translation_domain' => false,
             'allow_extra_fields' => true,
         ]);
 
+        $resolver->setAllowedTypes('button', 'array');
         $resolver->setAllowedTypes('choices', 'array');
 
         parent::configureOptions($resolver);

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order_state.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order_state.yml
@@ -5,6 +5,8 @@ services:
   prestashop.adapter.order_state.command_handler.add_order_state:
     class: 'PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler\AddOrderStateHandler'
     autoconfigure: true
+    arguments:
+      - '@PrestaShop\PrestaShop\Adapter\File\Uploader\OrderStateFileUploader'
 
   prestashop.adapter.order_state.query_handler.get_order_state_for_editing:
     class: 'PrestaShop\PrestaShop\Adapter\OrderState\QueryHandler\GetOrderStateForEditingHandler'
@@ -13,6 +15,8 @@ services:
   prestashop.adapter.order_state.command_handler.edit_order_state_handler:
     class: 'PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler\EditOrderStateHandler'
     autoconfigure: true
+    arguments:
+      - '@PrestaShop\PrestaShop\Adapter\File\Uploader\OrderStateFileUploader'
 
   prestashop.adapter.order_state.command_handler.delete_order_state_handler:
     class: 'PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler\DeleteOrderStateHandler'
@@ -21,3 +25,7 @@ services:
   prestashop.adapter.order_state.command_handler.bulk_delete_order_state_handler:
     class: 'PrestaShop\PrestaShop\Adapter\OrderState\CommandHandler\BulkDeleteOrderStateHandler'
     autoconfigure: true
+
+  PrestaShop\PrestaShop\Adapter\File\Uploader\OrderStateFileUploader:
+    arguments:
+      - '@prestashop.core.configuration.upload_size_configuration'

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderReturnStates/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme orderReturnStateForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block order_return_state_form %}
   {{ form_start(orderReturnStateForm) }}
@@ -34,22 +34,7 @@
       </h3>
       <div class="card-body">
         <div class="form-wrapper">
-          {{ form_errors(orderReturnStateForm) }}
-
-          {{ ps.form_group_row(orderReturnStateForm.name, {}, {
-            'label': 'Status name'|trans({}, 'Admin.Shopparameters.Feature'),
-            'help': 'Order\'s return status name.'|trans({}, 'Admin.Shopparameters.Help')
-                    ~ ' '
-                    ~ 'Invalid characters: numbers and'|trans({}, 'Admin.Shopparameters.Help')
-                    ~ ' !<>,;?=+()@#"{}_$%:'
-          }) }}
-
-          {{ ps.form_group_row(orderReturnStateForm.color, {}, {
-            'label': 'Color'|trans({}, 'Admin.Shopparameters.Feature'),
-            'help': 'Status will be highlighted in this color. HTML colors only.'|trans({}, 'Admin.Shopparameters.Help') ~ ' "lightblue", "#CC6600")'
-          }) }}
-
-          {% block order_return_state_form_reset %}
+          {% block order_return_state_form_rest %}
             {{ form_rest(orderReturnStateForm) }}
           {% endblock %}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/ShopParameters/OrderStates/Blocks/form.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% import '@PrestaShop/Admin/macros.html.twig' as ps %}
+{% form_theme orderStateForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
 
 {% block order_state_form %}
   {{ form_start(orderStateForm) }}
@@ -36,55 +36,7 @@
         <div class="form-wrapper">
           {{ form_errors(orderStateForm) }}
 
-          {{ ps.form_group_row(orderStateForm.name, {}, {
-            'label': 'Status name'|trans({}, 'Admin.Shopparameters.Feature'),
-            'help': 'Order status (e.g. \'Pending\').'|trans({}, 'Admin.Shopparameters.Help')
-                    ~ ' '
-                    ~ 'Invalid characters: numbers and'|trans({}, 'Admin.Shopparameters.Help')
-                    ~ ' !<>,;?=+()@#"{}_$%:'
-          }) }}
-
-          {{ ps.form_group_row(orderStateForm.color, {}, {
-            'label': 'Color'|trans({}, 'Admin.Shopparameters.Feature'),
-            'help': 'Status will be highlighted in this color. HTML colors only.'|trans({}, 'Admin.Shopparameters.Help') ~ ' "lightblue", "#CC6600")'
-          }) }}
-
-          {{ ps.form_group_row(orderStateForm.loggable, {}, {'label': ''}) }}
-
-          {{ ps.form_group_row(orderStateForm.invoice, {}, {'label': ''}) }}
-
-          {{ ps.form_group_row(orderStateForm.hidden, {}, {'label': ''}) }}
-
-          {{ ps.form_group_row(orderStateForm.send_email, {}, {'label': ''}) }}
-
-          {{ ps.form_group_row(orderStateForm.pdf_invoice, {}, {'label': ''}) }}
-
-          {{ ps.form_group_row(orderStateForm.pdf_delivery, {}, {'label': ''}) }}
-
-          {{ ps.form_group_row(orderStateForm.shipped, {}, {'label': ''}) }}
-
-          {{ ps.form_group_row(orderStateForm.paid, {}, {'label': ''}) }}
-
-          {{ ps.form_group_row(orderStateForm.delivery, {}, {'label': ''}) }}
-
-          {{ ps.form_group_row(orderStateForm.template, {
-              'options_extra': {
-                'data-preview': templatesPreviewUrl
-              },
-              'button': {
-                'label': 'Preview'|trans({}, 'Admin.Actions'),
-                'icon': 'visibility',
-                'class': 'btn btn-primary',
-                'id': 'order_state_template_preview'
-              }
-            },
-            {
-              'label': 'Email template'|trans({}, 'Admin.Shopparameters.Feature'),
-              'hint': 'Status will be highlighted in this color. HTML colors only.'|trans({}, 'Admin.Shopparameters.Help') ~ ' "lightblue", "#CC6600")',
-              'class': 'order_state_template_select'
-            }) }}
-
-          {% block order_state_form_reset %}
+          {% block order_state_form_rest %}
             {{ form_rest(orderStateForm) }}
           {% endblock %}
         </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/bootstrap_4_layout.html.twig
@@ -364,6 +364,7 @@
     <div class="input-group colorpicker">
       <input type="text" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
     </div>
+    {{- block('form_help') -}}
   {% endapply %}
 {% endblock color_picker_widget %}
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Order Statuses/Order Return Statuses : Use the new form theme
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | * Go to the `/admin-dev/index.php/configure/shop/order-return-states/new` page<br>* The form theme has been updated like in #16482<br>* The Add & Edit works<br>* Go to the `/admin-dev/index.php/configure/shop/order-states/new` page<br>* The form theme has been updated like in #16482<br>* The Add & Edit works
| Fixed ticket?     | N/A
| Related PRs       | Related to #27590 
| Sponsor company   | @PrestaShopCorp

Ping @jolelievre 