### PR TITLE
Cron PHP Update Modules : The option `--latest` doesn't exist

### DIFF
--- a/.github/workflows/cron_php_update_modules.yml
+++ b/.github/workflows/cron_php_update_modules.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install Composer dependencies
         run: |
-          composer self-update --latest
+          composer self-update --stable
           composer install --prefer-dist
 
       - name: Execute script for updating modules


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Cron PHP Update Modules : The option `--latest` doesn't exist<br>Link : https://github.com/PrestaShop/PrestaShop/actions/runs/4257611404<br>![image](https://user-images.githubusercontent.com/1533248/221124998-ac8cf916-66dc-44c7-adec-9aa068411c96.png)<br>Check the documentation : https://getcomposer.org/doc/03-cli.md#self-update-selfupdate
| Type?             | bug fix
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | N/A
| Fixed ticket?     | N/A
| Related PRs       | Relative to #31395 by @nicosomb 
| Sponsor company   | @PrestaShopCorp
