### PR TITLE
Standardize `filterManufacturerContent` hook

### DIFF
--- a/controllers/front/listing/ManufacturerController.php
+++ b/controllers/front/listing/ManufacturerController.php
@@ -149,7 +149,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
 
         $filteredManufacturer = Hook::exec(
             'filterManufacturerContent',
-            ['filtered_content' => $manufacturerVar['description']],
+            ['object' => $manufacturerVar],
             $id_module = null,
             $array_return = false,
             $check_exceptions = true,
@@ -157,8 +157,8 @@ class ManufacturerControllerCore extends ProductListingFrontController
             $id_shop = null,
             $chain = true
         );
-        if (!empty($filteredManufacturer)) {
-            $manufacturerVar['description'] = $filteredManufacturer;
+        if (!empty($filteredManufacturer['object'])) {
+            $manufacturerVar = $filteredManufacturer['object'];
         }
 
         $this->context->smarty->assign([
@@ -177,7 +177,7 @@ class ManufacturerControllerCore extends ProductListingFrontController
             foreach ($manufacturersVar as $k => $manufacturer) {
                 $filteredManufacturer = Hook::exec(
                     'filterManufacturerContent',
-                    ['filtered_content' => $manufacturer['text']],
+                    ['object' => $manufacturer],
                     $id_module = null,
                     $array_return = false,
                     $check_exceptions = true,
@@ -185,8 +185,8 @@ class ManufacturerControllerCore extends ProductListingFrontController
                     $id_shop = null,
                     $chain = true
                 );
-                if (!empty($filteredManufacturer)) {
-                    $manufacturersVar[$k]['text'] = $filteredManufacturer;
+                if (!empty($filteredManufacturer['object'])) {
+                    $manufacturersVar[$k] = $filteredManufacturer['object'];
                 }
             }
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Standardize `filterManufacturerContent` hook with similar hooks :<br> - `filterCategoryContent`<br> - `filterSupplierContent`<br> - `filterCmsContent`<br> - [...]<br><br>Return whole `Manufacturer` object to allow its override.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Hook params should contain whole object like other similar hooks. To be tested by a dev.
| Fixed ticket?     | Fixes #15366
| Related PRs       | -
| Sponsor company   | @Creabilis
