### PR TITLE
Duplicate product for multishop final part

### DIFF
--- a/src/Adapter/Product/Image/Repository/ProductImageMultiShopRepository.php
+++ b/src/Adapter/Product/Image/Repository/ProductImageMultiShopRepository.php
@@ -276,19 +276,24 @@ class ProductImageMultiShopRepository extends AbstractMultiShopObjectModelReposi
 
     /**
      * Duplicate an image and associates it to another product, the same shop association are kept based on
-     * specified shop constraint.
+     * specified shop constraint. Unles the image is associated to no shops matching the shop constraint, in
+     * which case no duplication is done and null is returned.
      *
      * @param ImageId $sourceImageId
      * @param ProductId $newProductId
      * @param ShopConstraint $shopConstraint
      *
-     * @return Image
+     * @return Image|null
      *
      * @throws CoreException
      */
-    public function duplicate(ImageId $sourceImageId, ProductId $newProductId, ShopConstraint $shopConstraint): Image
+    public function duplicate(ImageId $sourceImageId, ProductId $newProductId, ShopConstraint $shopConstraint): ?Image
     {
         $associatedShopIds = $this->getAssociatedShopIdsByShopConstraint($sourceImageId, $shopConstraint);
+        if (empty($associatedShopIds)) {
+            return null;
+        }
+
         $sourceImage = $this->getImageById($sourceImageId);
         $newImage = clone $sourceImage;
         unset($newImage->id, $newImage->id_image);

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -706,6 +706,11 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
             $specificPrice->id_product_attribute = $combinationMatching[(int) $specificPrice->id_product_attribute] ?? 0;
             $this->specificPriceRepository->add($specificPrice);
         }
+
+        // Duplicate priorities
+        $oldPriorities = $this->getRows('specific_price_priority', ['id_product' => $oldProductId], CannotDuplicateProductException::FAILED_DUPLICATE_SPECIFIC_PRICES);
+        $newPriorities = $this->replaceInRows($oldPriorities, ['id_product' => $newProductId, 'id_specific_price_priority' => null]);
+        $this->bulkInsert('specific_price_priority', $newPriorities, CannotDuplicateProductException::FAILED_DUPLICATE_SPECIFIC_PRICES);
     }
 
     /**

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -425,10 +425,19 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
      */
     private function duplicateRelatedProducts(int $oldProductId, int $newProductId): void
     {
-        /* @see Product::duplicateAccessories() */
-        $this->duplicateRelation(
-            [Product::class, 'duplicateAccessories'],
-            [$oldProductId, $newProductId],
+        $oldRows = $this->getRows(
+            'accessory',
+            ['id_product_1' => $oldProductId],
+            CannotDuplicateProductException::FAILED_DUPLICATE_RELATED_PRODUCTS
+        );
+
+        if (empty($oldRows)) {
+            return;
+        }
+        $newRows = $this->replaceInRows($oldRows, ['id_product_1' => $newProductId]);
+        $this->bulkInsert(
+            'accessory',
+            $newRows,
             CannotDuplicateProductException::FAILED_DUPLICATE_RELATED_PRODUCTS
         );
     }

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -60,6 +60,7 @@ use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
 use PrestaShop\PrestaShop\Core\Repository\AbstractMultiShopObjectModelRepository;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
 use PrestaShop\PrestaShop\Core\Util\String\StringModifierInterface;
 use PrestaShopException;
 use Product;
@@ -1011,6 +1012,9 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
 
             $bulkInsertSql .= '(' . implode(',', array_map(static function ($columnValue): string {
                 if ($columnValue === null) {
+                    return 'null';
+                } elseif (!empty($columnValue) && DateTime::isNull($columnValue)) {
+                    // We can't use 0000-00-00 as a value it's not valid in Mysql, so we use null instead
                     return 'null';
                 }
 

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -34,7 +34,6 @@ use Doctrine\DBAL\Exception;
 use GroupReduction;
 use Image;
 use Language;
-use Pack;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Repository\CombinationRepository;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockProperties;
 use PrestaShop\PrestaShop\Adapter\Product\Combination\Update\CombinationStockUpdater;
@@ -340,7 +339,6 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
         $this->duplicatePackedProducts($oldProductId, $newProductId);
         $this->duplicateCustomizationFields($oldProductId, $newProductId);
         $this->duplicateTags($oldProductId, $newProductId);
-        $this->duplicateTaxes($oldProductId, $newProductId);
         $this->duplicateDownloads($oldProductId, $newProductId);
         $this->duplicateImages($oldProductId, $newProductId, $combinationMatching);
         $this->duplicateCarriers($oldProductId, $newProductId, $shopIds);
@@ -659,12 +657,9 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
      */
     private function duplicatePackedProducts(int $oldProductId, int $newProductId): void
     {
-        /* @see Pack::duplicate() */
-        $this->duplicateRelation(
-            [Pack::class, 'duplicate'],
-            [$oldProductId, $newProductId],
-            CannotDuplicateProductException::FAILED_DUPLICATE_PACKED_PRODUCTS
-        );
+        $oldPackContent = $this->getRows('pack', ['id_product_pack' => $oldProductId], CannotDuplicateProductException::FAILED_DUPLICATE_PACKED_PRODUCTS);
+        $newPackContent = $this->replaceInRows($oldPackContent, ['id_product_pack' => $newProductId]);
+        $this->bulkInsert('pack', $newPackContent, CannotDuplicateProductException::FAILED_DUPLICATE_PACKED_PRODUCTS);
     }
 
     /**
@@ -718,23 +713,6 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
             $oldProductId,
             $newProductId,
             CannotDuplicateProductException::FAILED_DUPLICATE_TAGS
-        );
-    }
-
-    /**
-     * @param int $oldProductId
-     * @param int $newProductId
-     *
-     * @throws CannotDuplicateProductException
-     * @throws CoreException
-     */
-    private function duplicateTaxes(int $oldProductId, int $newProductId): void
-    {
-        /* @see Product::duplicateTaxes() */
-        $this->duplicateRelation(
-            [Product::class, 'duplicateTaxes'],
-            [$oldProductId, $newProductId],
-            CannotDuplicateProductException::FAILED_DUPLICATE_TAXES
         );
     }
 

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -58,9 +58,6 @@ use Shop;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * @todo for now this service is mainly oriented for single shop (only prices are handled for multi shop)
- *       This service will likely have many things in common with ProductShopUpdater::copyToShop method, so it
- *       might be interesting to refacto and merge them into one at some point
  * Duplicates product
  */
 class ProductDuplicator extends AbstractMultiShopObjectModelRepository

--- a/src/Adapter/Product/Update/ProductDuplicator.php
+++ b/src/Adapter/Product/Update/ProductDuplicator.php
@@ -788,12 +788,7 @@ class ProductDuplicator extends AbstractMultiShopObjectModelRepository
      */
     private function duplicateAttachmentAssociation(int $oldProductId, int $newProductId): void
     {
-        /* @see Product::duplicateAttachmentAssociation() */
-        $this->duplicateRelation(
-            [Product::class, 'duplicateAttachmentAssociation'],
-            [$oldProductId, $newProductId],
-            CannotDuplicateProductException::FAILED_DUPLICATE_ATTACHMENT_ASSOCIATION
-        );
+        $this->duplicateProductTable('product_attachment', $oldProductId, $newProductId, CannotDuplicateProductException::FAILED_DUPLICATE_ATTACHMENT_ASSOCIATION);
     }
 
     /**

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -1243,6 +1243,9 @@ class ProductController extends FrameworkBundleAdminController
             $productIds[$i] = (int) $productId;
         }
 
+        // Return product IDs ordered
+        sort($productIds);
+
         return $productIds;
     }
 

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product.yml
@@ -369,6 +369,7 @@ services:
     arguments:
       $connection: '@doctrine.dbal.default_connection'
       $dbPrefix: '%database_prefix%'
+      $productImageSystemPathFactory: '@prestashop.adapter.product.image.product_image_filesystem_path_factory'
 
   PrestaShop\PrestaShop\Adapter\Product\CommandHandler\UpdateProductTypeHandler:
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/product/_image.yml
@@ -69,7 +69,6 @@ services:
 
   PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageMultiShopRepository:
     autowire: true
-    public: false
     arguments:
       - '@doctrine.dbal.default_connection'
       - '%database_prefix%'

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationAssertionFeatureContext.php
@@ -208,7 +208,7 @@ class CombinationAssertionFeatureContext extends AbstractCombinationFeatureConte
     }
 
     /**
-     * @Then combination :combinationReference should have following stock details for shops :shopReferences:
+     * @Then combination :combinationReference should have following stock details for shop(s) :shopReferences:
      *
      * @param string $combinationReference
      * @param CombinationStock $expectedStock

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/CombinationListingFeatureContext.php
@@ -69,7 +69,7 @@ class CombinationListingFeatureContext extends AbstractCombinationFeatureContext
     }
 
     /**
-     * @Then product ":productReference" should have following combinations:
+     * @Then product :productReference should have following combinations:
      *
      * @param string $productReference
      * @param TableNode $tableNode
@@ -80,7 +80,7 @@ class CombinationListingFeatureContext extends AbstractCombinationFeatureContext
     }
 
     /**
-     * @Then product :productReference should have the following combinations for shops :shopReferences:
+     * @Then product :productReference should have the following combinations for shop(s) :shopReferences:
      *
      * @param string $productReference
      * @param TableNode $tableNode

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/GenerateCombinationFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/GenerateCombinationFeatureContext.php
@@ -51,7 +51,8 @@ class GenerateCombinationFeatureContext extends AbstractCombinationFeatureContex
     }
 
     /**
-     * @When I generate combinations in shop ":shopReference" for product :productReference using following attributes:
+     * @When I generate combinations in shop :shopReference for product :productReference using following attributes:
+     * @When I generate combinations for product :productReference in shop :shopReference using following attributes:
      *
      * @param string $shopReference
      * @param string $productReference
@@ -67,7 +68,7 @@ class GenerateCombinationFeatureContext extends AbstractCombinationFeatureContex
     }
 
     /**
-     * @When I generate combinations for product ":productReference" in all shops using following attributes:
+     * @When I generate combinations for product :productReference in all shops using following attributes:
      *
      * @param string $productReference
      * @param TableNode $table

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/Combination/UpdateCombinationStockFeatureContext.php
@@ -49,7 +49,7 @@ class UpdateCombinationStockFeatureContext extends AbstractCombinationFeatureCon
     }
 
     /**
-     * @When I update combination ":combinationReference" stock for shop ":shopReference" with following details:
+     * @When I update combination :combinationReference stock for shop :shopReference with following details:
      */
     public function updateStockForShop(
         string $combinationReference,

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/DuplicateProductFeatureContext.php
@@ -29,7 +29,6 @@ declare(strict_types=1);
 namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
-use PHPUnit\Framework\Assert;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\BulkDuplicateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Command\DuplicateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductException;
@@ -135,47 +134,6 @@ class DuplicateProductFeatureContext extends AbstractProductFeatureContext
                     $this->getSharedStorage()->set($productInfo['copy_reference'], $newProductId->getValue());
                 }
             }
-        }
-    }
-
-    /**
-     * @Then product :newProductReference should have identical customization fields to :oldProductReference
-     *
-     * @param string $newProductReference
-     * @param string $oldProductReference
-     */
-    public function assertDuplicatedCustomizationFields(string $newProductReference, string $oldProductReference): void
-    {
-        $oldCustomizationFields = $this->getProductCustomizationFields($oldProductReference, ShopConstraint::shop($this->getDefaultShopId()));
-        $newCustomizationFields = $this->getProductCustomizationFields($newProductReference, ShopConstraint::shop($this->getDefaultShopId()));
-
-        Assert::assertEquals(
-            count($oldCustomizationFields),
-            count($newCustomizationFields),
-            'Old product customization fields count differs from new duplicated product'
-        );
-
-        foreach ($oldCustomizationFields as $key => $oldCustomizationField) {
-            Assert::assertEquals(
-                $oldCustomizationField->getLocalizedNames(),
-                $newCustomizationFields[$key]->getLocalizedNames(),
-                'Unexpected localized names of duplicated product customization field'
-            );
-            Assert::assertEquals(
-                $oldCustomizationField->getType(),
-                $newCustomizationFields[$key]->getType(),
-                'Unexpected type of duplicated product customization field'
-            );
-            Assert::assertEquals(
-                $oldCustomizationField->isAddedByModule(),
-                $newCustomizationFields[$key]->isAddedByModule(),
-                'Unexpected "addedByModule" property of duplicated product customization field'
-            );
-            Assert::assertEquals(
-                $oldCustomizationField->isRequired(),
-                $newCustomizationFields[$key]->isRequired(),
-                'Unexpected "required" property of duplicated product customization field'
-            );
         }
     }
 }

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
@@ -610,7 +610,7 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
 
         // Set new references if defined (used for duplication tests) and update reference for following assertion loop
         foreach ($dataRows as $index => $dataRow) {
-            if (isset($dataRow['new image reference']) && !$this->getSharedStorage()->exists($dataRow['new image reference'])) {
+            if (isset($dataRow['new image reference'])) {
                 $actualImage = $images[$index];
                 $this->getSharedStorage()->set($dataRow['new image reference'], $actualImage->getImageId());
                 $dataRows[$index]['image reference'] = $dataRow['new image reference'];

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ProductImageFeatureContext.php
@@ -30,7 +30,7 @@ namespace Tests\Integration\Behaviour\Features\Context\Domain\Product;
 
 use Behat\Gherkin\Node\TableNode;
 use PHPUnit\Framework\Assert;
-use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageRepository;
+use PrestaShop\PrestaShop\Adapter\Product\Image\Repository\ProductImageMultiShopRepository;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\AddProductImageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\DeleteProductImageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\ProductImageSetting;
@@ -56,7 +56,7 @@ use Tests\Resources\DummyFileUploader;
 class ProductImageFeatureContext extends AbstractProductFeatureContext
 {
     /**
-     * @var ProductImageRepository
+     * @var ProductImageMultiShopRepository
      */
     private $productImageRepository;
 
@@ -67,7 +67,7 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
 
     public function __construct()
     {
-        $this->productImageRepository = $this->getContainer()->get(ProductImageRepository::class);
+        $this->productImageRepository = $this->getContainer()->get(ProductImageMultiShopRepository::class);
     }
 
     /**
@@ -607,6 +607,15 @@ class ProductImageFeatureContext extends AbstractProductFeatureContext
             count($images),
             sprintf('Expected and actual images count does not match. ShopConstraint: %s', var_export($shopConstraint, true))
         );
+
+        // Set new references if defined (used for duplication tests) and update reference for following assertion loop
+        foreach ($dataRows as $index => $dataRow) {
+            if (isset($dataRow['new image reference']) && !$this->getSharedStorage()->exists($dataRow['new image reference'])) {
+                $actualImage = $images[$index];
+                $this->getSharedStorage()->set($dataRow['new image reference'], $actualImage->getImageId());
+                $dataRows[$index]['image reference'] = $dataRow['new image reference'];
+            }
+        }
 
         foreach ($dataRows as $index => $dataRow) {
             $imageId = (int) $this->getSharedStorage()->get($dataRow['image reference']);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ShippingAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ShippingAssertionFeatureContext.php
@@ -65,7 +65,7 @@ class ShippingAssertionFeatureContext extends AbstractShippingFeatureContext
     }
 
     /**
-     * @Then product :productReference should have following shipping information for shop(s) ":shopReferences":
+     * @Then product :productReference should have following shipping information for shop(s) :shopReferences:
      *
      * @param string $productReference
      * @param TableNode $tableNode

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/ShippingAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/ShippingAssertionFeatureContext.php
@@ -65,7 +65,7 @@ class ShippingAssertionFeatureContext extends AbstractShippingFeatureContext
     }
 
     /**
-     * @Then product :productReference should have following shipping information for shops ":shopReferences":
+     * @Then product :productReference should have following shipping information for shop(s) ":shopReferences":
      *
      * @param string $productReference
      * @param TableNode $tableNode

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPricePrioritiesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/SpecificPricePrioritiesFeatureContext.php
@@ -144,7 +144,7 @@ class SpecificPricePrioritiesFeatureContext extends AbstractProductFeatureContex
     /**
      * @see transformPriorityList
      *
-     * @Then following specific price priorities should be used for product ":productReference":
+     * @Then following specific price priorities should be used for product :productReference:
      *
      * @param string $productReference
      * @param PriorityList $priorityList

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/StockAssertionFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/StockAssertionFeatureContext.php
@@ -65,7 +65,7 @@ class StockAssertionFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Then product :productReference should have following stock information for shops :shopReferences:
+     * @Then product :productReference should have following stock information for shop(s) :shopReferences:
      */
     public function assertStockInformationForShops(
         string $productReference,
@@ -149,7 +149,7 @@ class StockAssertionFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Then combination :combinationReference last stock movements for shop :shopReferences should be:
+     * @Then combination :combinationReference last stock movements for shop(s) :shopReferences should be:
      */
     public function assertCombinationLastStockMovementsForSpecificShop(
         string $combinationReference,

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateCustomizationFieldsFeatureContext.php
@@ -261,6 +261,21 @@ class UpdateCustomizationFieldsFeatureContext extends AbstractProductFeatureCont
         $actualFields = $this->getProductCustomizationFields($productReference, $shopConstraint);
         $notFoundExpectedFields = [];
 
+        // Assign new references if defined
+        foreach ($data as $index => $expectedField) {
+            if (!isset($expectedField['new reference'])) {
+                break;
+            }
+
+            // If a new reference is being set we match it with the same order as the returned data
+            if (!$this->getSharedStorage()->exists($expectedField['new reference'])) {
+                $actualField = $actualFields[$index];
+                $this->getSharedStorage()->set($expectedField['new reference'], $actualField->getCustomizationFieldId());
+                // New reference becomes the expected reference for the second loop
+                $data[$index]['reference'] = $expectedField['new reference'];
+            }
+        }
+
         foreach ($data as $expectedField) {
             $expectedId = $this->getSharedStorage()->get($expectedField['reference']);
             $foundExpectedField = false;

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProductFeatureValuesFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/UpdateProductFeatureValuesFeatureContext.php
@@ -143,6 +143,19 @@ class UpdateProductFeatureValuesFeatureContext extends AbstractProductFeatureCon
             ));
         }
 
+        foreach ($expectedFeatureValues as $key => $expectedFeatureValue) {
+            // If new custom value is found set a new reference in storage, and set this new reference as the expected one for the second loop
+            if (!empty($expectedFeatureValue['new_feature_value']) && !empty($expectedFeatureValue['custom_values'])) {
+                $localizedValues = $this->localizeByCell($expectedFeatureValue['custom_values']);
+                foreach ($productFeatureValues as $productFeatureValue) {
+                    if ($localizedValues === $productFeatureValue->getLocalizedValues()) {
+                        $this->getSharedStorage()->set($expectedFeatureValue['new_feature_value'], $productFeatureValue->getFeatureValueId());
+                        $expectedFeatureValues[$key]['feature_value'] = $expectedFeatureValue['new_feature_value'];
+                    }
+                }
+            }
+        }
+
         foreach ($expectedFeatureValues as $expectedFeatureValue) {
             $foundMatchingFeatureValue = false;
             $expectedFeatureId = $this->getSharedStorage()->get($expectedFeatureValue['feature']);

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
@@ -169,6 +169,35 @@ class VirtualProductFileFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
+     * @Then file :fileReference for product :productReference should have same file as :dummyFileName
+     *
+     * @param string $productReference
+     * @param string $fileReference
+     * @param string $dummyFileName
+     */
+    public function assertFileIsSameAsDummyFile(string $productReference, string $fileReference, string $dummyFileName): void
+    {
+        $reference = $this->buildSystemFileReference($productReference, $fileReference);
+        if (!$this->getSharedStorage()->exists($reference)) {
+            throw new RuntimeException('No file reference stored in shared storage');
+        }
+
+        $virtualDownloadFilePath = $this->getSharedStorage()->get($reference);
+
+        // This was previously saved during image upload
+        $dummyFilePath = DummyFileUploader::getDummyFilePath($dummyFileName);
+        $dummyMD5 = md5_file($dummyFilePath);
+
+        if ($dummyMD5 !== md5_file($virtualDownloadFilePath)) {
+            throw new RuntimeException(sprintf(
+                'Expected files dummy %s and file %s to be identical',
+                $dummyFileName,
+                $fileReference
+            ));
+        }
+    }
+
+    /**
      * @Given file ":fileReference" for product ":productReference" exists in system
      * @Given file ":fileReference" for product ":productReference" should exist in system
      *

--- a/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/Domain/Product/VirtualProductFileFeatureContext.php
@@ -198,8 +198,8 @@ class VirtualProductFileFeatureContext extends AbstractProductFeatureContext
     }
 
     /**
-     * @Given file ":fileReference" for product ":productReference" exists in system
-     * @Given file ":fileReference" for product ":productReference" should exist in system
+     * @Given file :fileReference for product :productReference exists in system
+     * @Given file :fileReference for product :productReference should exist in system
      *
      * @param string $productReference
      * @param string $fileReference
@@ -279,6 +279,10 @@ class VirtualProductFileFeatureContext extends AbstractProductFeatureContext
         }
         $this->getSharedStorage()->set($fileReference, $actualFile->getId());
         $this->assertVirtualFile($actualFile, $dataTable);
+
+        // Set path for new reference used in other assertions
+        $reference = $this->buildSystemFileReference($productReference, $fileReference);
+        $this->getSharedStorage()->set($reference, _PS_DOWNLOAD_DIR_ . $actualFile->getFileName());
     }
 
     private function assertVirtualFile(VirtualProductFileForEditing $actualFile, TableNode $dataTable): void

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
@@ -4,6 +4,7 @@
 @restore-shops-after-feature
 @restore-languages-after-feature
 @restore-taxes-after-feature
+@reset-downloads-after-feature
 @reset-img-after-feature
 @clear-cache-after-feature
 @product-multishop
@@ -1176,3 +1177,105 @@ Feature: Copy product from shop to shop.
       | customField2Copy | file | field2 shop4 | champ2 shop4 | false       |
     And customField1 and customField1Copy have different values
     And customField2 and customField2Copy have different values
+
+  Scenario: I duplicate a product with images they are correctly duplicated and associated to appropriate shops
+    When I add product "productWithImages" to shop shop1 with following information:
+      | name[en-US] | Jar of sand  |
+      | type        | combinations |
+    And I add new image "image1" named "app_icon.png" to product "productWithImages" for shop "shop1"
+    And I add new image "image2" named "logo.jpg" to product "productWithImages" for shop "shop1"
+    And I copy product productWithImages from shop shop1 to shop shop2
+    And I add new image "image3" named "app_icon.png" to product "productWithImages" for shop "shop2"
+    And I copy product productWithImages from shop shop2 to shop shop3
+    And product "productWithImages" should have following images for shop "shop1,shop2,shop3":
+      | image reference | is cover | legend[en-US] | legend[fr-FR] | position | image url                            | thumbnail url                                      | shops               |
+      | image1          | true     |               |               | 1        | http://myshop.com/img/p/{image1}.jpg | http://myshop.com/img/p/{image1}-small_default.jpg | shop1, shop2, shop3 |
+      | image2          | false    |               |               | 2        | http://myshop.com/img/p/{image2}.jpg | http://myshop.com/img/p/{image2}-small_default.jpg | shop1, shop2, shop3 |
+      | image3          | false    |               |               | 3        | http://myshop.com/img/p/{image3}.jpg | http://myshop.com/img/p/{image3}-small_default.jpg | shop2, shop3        |
+    And images "[image1, image2, image3]" should have following types generated:
+      | name           | width | height |
+      | cart_default   | 125   | 125    |
+      | home_default   | 250   | 250    |
+      | large_default  | 800   | 800    |
+      | medium_default | 452   | 452    |
+      | small_default  | 98    | 98     |
+    And image "image1" should have same file as "app_icon.png"
+    And image "image2" should have same file as "logo.jpg"
+    And image "image3" should have same file as "app_icon.png"
+    # Copy to one shop
+    When I duplicate product productWithImages to a productWithImagesCopyShop1 for shop shop1
+    Then product "productWithImagesCopyShop1" should have following images for shop "shop1":
+      | new image reference | is cover | legend[en-US] | legend[fr-FR] | position | image url                                     | thumbnail url                                               | shops |
+      | image1CopyShop1     | true     |               |               | 1        | http://myshop.com/img/p/{image1CopyShop1}.jpg | http://myshop.com/img/p/{image1CopyShop1}-small_default.jpg | shop1 |
+      | image2CopyShop1     | false    |               |               | 2        | http://myshop.com/img/p/{image2CopyShop1}.jpg | http://myshop.com/img/p/{image2CopyShop1}-small_default.jpg | shop1 |
+    And images "[image1CopyShop1, image2CopyShop1]" should have following types generated:
+      | name           | width | height |
+      | cart_default   | 125   | 125    |
+      | home_default   | 250   | 250    |
+      | large_default  | 800   | 800    |
+      | medium_default | 452   | 452    |
+      | small_default  | 98    | 98     |
+    And image1 and image1CopyShop1 have different values
+    And image2 and image2CopyShop1 have different values
+    And image "image1CopyShop1" should have same file as "app_icon.png"
+    And image "image2CopyShop1" should have same file as "logo.jpg"
+    # Copy to default shop group
+    When I duplicate product productWithImages to a productWithImagesCopyShopGroup1 for shop group default_shop_group
+    Then product "productWithImagesCopyShopGroup1" should have following images for shop "shop1,shop2":
+      | new image reference  | is cover | legend[en-US] | legend[fr-FR] | position | image url                                          | thumbnail url                                                    | shops        |
+      | image1CopyShopGroup1 | true     |               |               | 1        | http://myshop.com/img/p/{image1CopyShopGroup1}.jpg | http://myshop.com/img/p/{image1CopyShopGroup1}-small_default.jpg | shop1, shop2 |
+      | image2CopyShopGroup1 | false    |               |               | 2        | http://myshop.com/img/p/{image2CopyShopGroup1}.jpg | http://myshop.com/img/p/{image2CopyShopGroup1}-small_default.jpg | shop1, shop2 |
+      | image3CopyShopGroup1 | false    |               |               | 3        | http://myshop.com/img/p/{image3CopyShopGroup1}.jpg | http://myshop.com/img/p/{image3CopyShopGroup1}-small_default.jpg | shop2        |
+    And images "[image1CopyShopGroup1, image2CopyShopGroup1, image3CopyShopGroup1]" should have following types generated:
+      | name           | width | height |
+      | cart_default   | 125   | 125    |
+      | home_default   | 250   | 250    |
+      | large_default  | 800   | 800    |
+      | medium_default | 452   | 452    |
+      | small_default  | 98    | 98     |
+    And image1 and image1CopyShopGroup1 have different values
+    And image2 and image2CopyShopGroup1 have different values
+    And image3 and image3CopyShopGroup1 have different values
+    And image "image1CopyShopGroup1" should have same file as "app_icon.png"
+    And image "image2CopyShopGroup1" should have same file as "logo.jpg"
+    And image "image3CopyShopGroup1" should have same file as "app_icon.png"
+    # Copy to second shop group
+    When I duplicate product productWithImages to a productWithImagesCopyShopGroup2 for shop group test_second_shop_group
+    Then product "productWithImagesCopyShopGroup2" should have following images for shop "shop3":
+      | new image reference  | is cover | legend[en-US] | legend[fr-FR] | position | image url                                          | thumbnail url                                                    | shops |
+      | image1CopyShopGroup2 | true     |               |               | 1        | http://myshop.com/img/p/{image1CopyShopGroup2}.jpg | http://myshop.com/img/p/{image1CopyShopGroup2}-small_default.jpg | shop3 |
+      | image2CopyShopGroup2 | false    |               |               | 2        | http://myshop.com/img/p/{image2CopyShopGroup2}.jpg | http://myshop.com/img/p/{image2CopyShopGroup2}-small_default.jpg | shop3 |
+      | image3CopyShopGroup2 | false    |               |               | 3        | http://myshop.com/img/p/{image3CopyShopGroup2}.jpg | http://myshop.com/img/p/{image3CopyShopGroup2}-small_default.jpg | shop3 |
+    And images "[image1CopyShopGroup2, image2CopyShopGroup2, image3CopyShopGroup2]" should have following types generated:
+      | name           | width | height |
+      | cart_default   | 125   | 125    |
+      | home_default   | 250   | 250    |
+      | large_default  | 800   | 800    |
+      | medium_default | 452   | 452    |
+      | small_default  | 98    | 98     |
+    And image1 and image1CopyShopGroup2 have different values
+    And image2 and image2CopyShopGroup2 have different values
+    And image3 and image3CopyShopGroup2 have different values
+    And image "image1CopyShopGroup2" should have same file as "app_icon.png"
+    And image "image2CopyShopGroup2" should have same file as "logo.jpg"
+    And image "image3CopyShopGroup2" should have same file as "app_icon.png"
+    # Copy to all shops
+    When I duplicate product productWithImages to a productWithImagesCopyAllShops for all shops
+    And product "productWithImagesCopyAllShops" should have following images for shop "shop1,shop2,shop3":
+      | new image reference | is cover | legend[en-US] | legend[fr-FR] | position | image url                                        | thumbnail url                                                  | shops               |
+      | image1CopyAllShops  | true     |               |               | 1        | http://myshop.com/img/p/{image1CopyAllShops}.jpg | http://myshop.com/img/p/{image1CopyAllShops}-small_default.jpg | shop1, shop2, shop3 |
+      | image2CopyAllShops  | false    |               |               | 2        | http://myshop.com/img/p/{image2CopyAllShops}.jpg | http://myshop.com/img/p/{image2CopyAllShops}-small_default.jpg | shop1, shop2, shop3 |
+      | image3CopyAllShops  | false    |               |               | 3        | http://myshop.com/img/p/{image3CopyAllShops}.jpg | http://myshop.com/img/p/{image3CopyAllShops}-small_default.jpg | shop2, shop3        |
+    And images "[image1CopyAllShops, image2CopyAllShops, image3CopyAllShops]" should have following types generated:
+      | name           | width | height |
+      | cart_default   | 125   | 125    |
+      | home_default   | 250   | 250    |
+      | large_default  | 800   | 800    |
+      | medium_default | 452   | 452    |
+      | small_default  | 98    | 98     |
+    And image1 and image1CopyAllShops have different values
+    And image2 and image2CopyAllShops have different values
+    And image3 and image3CopyAllShops have different values
+    And image "image1CopyAllShops" should have same file as "app_icon.png"
+    And image "image2CopyAllShops" should have same file as "logo.jpg"
+    And image "image3CopyAllShops" should have same file as "app_icon.png"

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
@@ -619,16 +619,40 @@ Feature: Copy product from shop to shop.
       | men          | Men     | false      |
       | clothes      | Clothes | true       |
     # Duplicate on one shop group
-    When I duplicate product productWithCategories to a productWithCategoriesCopyShop for shop group default_shop_group
-    Then product productWithCategoriesCopyShop should be assigned to following categories for shops "shop1,shop2":
+    When I duplicate product productWithCategories to a productWithCategoriesCopyShopGroup for shop group test_second_shop_group
+    Then product productWithCategoriesCopyShopGroup should be assigned to following categories for shops "shop3,shop4":
       | id reference | name    | is default |
       | home         | Home    | false      |
       | men          | Men     | false      |
       | clothes      | Clothes | true       |
     # Duplicate on all shops
-    When I duplicate product productWithCategories to a productWithCategoriesCopyShop for all shops
-    Then product productWithCategoriesCopyShop should be assigned to following categories for shops "shop1,shop2,shop3,shop4":
+    When I duplicate product productWithCategories to a productWithCategoriesCopyAllShops for all shops
+    Then product productWithCategoriesCopyAllShops should be assigned to following categories for shops "shop1,shop2,shop3,shop4":
       | id reference | name    | is default |
       | home         | Home    | false      |
       | men          | Men     | false      |
       | clothes      | Clothes | true       |
+
+  Scenario: I duplicate a product its carriers are copied
+    Given I add product "productWithCarriers" to shop shop1 with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I assign product productWithCarriers with following carriers:
+      | carrier1 |
+      | carrier2 |
+    And I copy product productWithCarriers from shop shop1 to shop shop2
+    And I copy product productWithCarriers from shop shop1 to shop shop3
+    And I copy product productWithCarriers from shop shop1 to shop shop4
+    # Copy to one shop
+    When I duplicate product productWithCarriers to a productWithCarriersCopyShop for shop shop1
+    And product "productWithCarriersCopyShop" should have following shipping information for shop "shop1":
+      | carriers                                | [carrier1,carrier2] |
+    # Copy to one shop group
+    When I duplicate product productWithCarriers to a productWithCarriersCopyShopGroup for shop group test_second_shop_group
+    And product "productWithCarriersCopyShopGroup" should have following shipping information for shops "shop3,shop4":
+      | carriers                                | [carrier1,carrier2] |
+    # Copy to all shops
+    When I duplicate product productWithCarriers to a productWithCarriersCopyAllShops for all shops
+    And product "productWithCarriersCopyAllShops" should have following shipping information for shops "shop1,shop2,shop3,shop4":
+      | carriers                                | [carrier1,carrier2] |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
@@ -14,9 +14,19 @@ Feature: Copy product from shop to shop.
 
   Scenario: This are pre-requisite steps but it is only done once, that is why we don't use Background here
     Given I enable multishop feature
+    # Prepare languages
     And language "english" with locale "en-US" exists
     And language "french" with locale "fr-FR" exists
     And language with iso code "en" is the default one
+    # Prepare shops
+    And shop "shop1" with name "test_shop" exists
+    And shop group "default_shop_group" with name "Default" exists
+    And I add a shop "shop2" with name "test_second_shop" and color "red" for the group "default_shop_group"
+    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
+    And Shop group test_second_shop_group shares its stock
+    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
+    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    # Prepare attributes
     And attribute group "Size" named "Size" in en language exists
     And attribute group "Color" named "Color" in en language exists
     And attribute "S" named "S" in en language exists
@@ -26,13 +36,21 @@ Feature: Copy product from shop to shop.
     And attribute "Black" named "Black" in en language exists
     And attribute "Blue" named "Blue" in en language exists
     And attribute "Red" named "Red" in en language exists
-    And shop "shop1" with name "test_shop" exists
-    And shop group "default_shop_group" with name "Default" exists
-    And I add a shop "shop2" with name "test_second_shop" and color "red" for the group "default_shop_group"
-    And I add a shop group "test_second_shop_group" with name "Test second shop group" and color "green"
-    And Shop group test_second_shop_group shares its stock
-    And I add a shop "shop3" with name "test_third_shop" and color "blue" for the group "test_second_shop_group"
-    And I add a shop "shop4" with name "test_shop_without_url" and color "blue" for the group "test_second_shop_group"
+    And attribute "Pink" named "Pink" in en language exists
+    And attribute "Green" named "Green" in en language exists
+    And attribute "Orange" named "Orange" in en language exists
+    And I associate attribute group "Size" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute group "Color" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "S" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "M" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "L" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "White" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "Black" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "Blue" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "Red" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "Pink" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "Green" with shops "shop1,shop2,shop3,shop4"
+    And I associate attribute "Orange" with shops "shop1,shop2,shop3,shop4"
     And single shop context is loaded
     Given manufacturer studioDesign named "Studio Design" exists
     And carrier carrier1 named "ecoCarrier" exists
@@ -1279,3 +1297,200 @@ Feature: Copy product from shop to shop.
     And image "image1CopyAllShops" should have same file as "app_icon.png"
     And image "image2CopyAllShops" should have same file as "logo.jpg"
     And image "image3CopyAllShops" should have same file as "app_icon.png"
+
+  Scenario: Duplicate a product with combinations all combinations are duplicated in appropriate shops
+    # First prepare a product with complex combination associations (shop have different combinations and values)
+    When I add product "productWithCombinations" to shop shop1 with following information:
+      | name[en-US] | Jar of sand  |
+      | type        | combinations |
+    And I generate combinations in shop shop1 for product productWithCombinations using following attributes:
+      | Color | [Red,Blue] |
+    And I copy product productWithCombinations from shop shop1 to shop shop2
+    And I copy product productWithCombinations from shop shop1 to shop shop3
+    And I copy product productWithCombinations from shop shop1 to shop shop4
+    Then product productWithCombinations should have the following combinations for shops "shop1,shop2,shop3,shop4":
+      | id reference                | combination name | reference | attributes   | impact on price | quantity | is default |
+      | productWithCombinationsRed  | Color - Red      |           | [Color:Red]  | 0               | 0        | true       |
+      | productWithCombinationsBlue | Color - Blue     |           | [Color:Blue] | 0               | 0        | false      |
+    When I generate combinations for product productWithCombinations in shop shop1 using following attributes:
+      | Color | [Pink] |
+    And I generate combinations for product productWithCombinations in shop shop2 using following attributes:
+      | Color | [Green] |
+    And I generate combinations for product productWithCombinations in shop shop3 using following attributes:
+      | Color | [Black] |
+    And I generate combinations for product productWithCombinations in shop shop4 using following attributes:
+      | Color | [White] |
+    And I generate combinations for product productWithCombinations in all shops using following attributes:
+      | Color | [Orange] |
+    # Identify references for all combinations in all shops (some are common)
+    Then product productWithCombinations should have the following combinations for shop shop1:
+      | id reference                  | combination name | reference | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsRed    | Color - Red      |           | [Color:Red]    | 0               | 0        | true       |
+      | productWithCombinationsBlue   | Color - Blue     |           | [Color:Blue]   | 0               | 0        | false      |
+      | productWithCombinationsPink   | Color - Pink     |           | [Color:Pink]   | 0               | 0        | false      |
+      | productWithCombinationsOrange | Color - Orange   |           | [Color:Orange] | 0               | 0        | false      |
+    And product productWithCombinations should have the following combinations for shop shop2:
+      | id reference                  | combination name | reference | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsRed    | Color - Red      |           | [Color:Red]    | 0               | 0        | true       |
+      | productWithCombinationsBlue   | Color - Blue     |           | [Color:Blue]   | 0               | 0        | false      |
+      | productWithCombinationsGreen  | Color - Green    |           | [Color:Green]  | 0               | 0        | false      |
+      | productWithCombinationsOrange | Color - Orange   |           | [Color:Orange] | 0               | 0        | false      |
+    And product productWithCombinations should have the following combinations for shop shop3:
+      | id reference                  | combination name | reference | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsRed    | Color - Red      |           | [Color:Red]    | 0               | 0        | true       |
+      | productWithCombinationsBlue   | Color - Blue     |           | [Color:Blue]   | 0               | 0        | false      |
+      | productWithCombinationsBlack  | Color - Black    |           | [Color:Black]  | 0               | 0        | false      |
+      | productWithCombinationsOrange | Color - Orange   |           | [Color:Orange] | 0               | 0        | false      |
+    And product productWithCombinations should have the following combinations for shop shop4:
+      | id reference                  | combination name | reference | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsRed    | Color - Red      |           | [Color:Red]    | 0               | 0        | true       |
+      | productWithCombinationsBlue   | Color - Blue     |           | [Color:Blue]   | 0               | 0        | false      |
+      | productWithCombinationsWhite  | Color - White    |           | [Color:White]  | 0               | 0        | false      |
+      | productWithCombinationsOrange | Color - Orange   |           | [Color:Orange] | 0               | 0        | false      |
+    When I set combination "productWithCombinationsBlue" as default for shop "shop2"
+    And I set combination "productWithCombinationsWhite" as default for shop "shop4"
+    And I update combination "productWithCombinationsRed" with following values for all shops:
+      | reference       | redAllShops |
+      | impact on price | 51          |
+    And I update combination "productWithCombinationsOrange" with following values for all shops:
+      | reference       | orangeAllShops |
+      | impact on price | 69             |
+    And I update combination "productWithCombinationsBlue" with following values for shop "shop1":
+      | reference       | blueShop1 |
+      | impact on price | 10        |
+    And I update combination "productWithCombinationsPink" with following values for shop "shop1":
+      | reference       | pinkShop1 |
+      | impact on price | 11        |
+    And I update combination "productWithCombinationsBlue" with following values for shop "shop2":
+      | reference       | blueShop2 |
+      | impact on price | 20        |
+    And I update combination "productWithCombinationsGreen" with following values for shop "shop2":
+      | reference       | greenShop2 |
+      | impact on price | 21         |
+    And I update combination "productWithCombinationsBlue" with following values for shop "shop3":
+      | reference       | blueShop3 |
+      | impact on price | 30        |
+    And I update combination "productWithCombinationsBlack" with following values for shop "shop3":
+      | reference       | blackShop3 |
+      | impact on price | 31         |
+    # Reference is common to all shops so this last update will update all shops for the reference field
+    And I update combination "productWithCombinationsBlue" with following values for shop "shop4":
+      | reference       | blueShop4 |
+      | impact on price | 40        |
+    #
+    # Final check of the product combinations data before duplication
+    #
+    Then product productWithCombinations should have the following combinations for shop shop1:
+      | combination reference         | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsRed    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | true       |
+      | productWithCombinationsBlue   | Color - Blue     | blueShop4      | [Color:Blue]   | 10              | 0        | false      |
+      | productWithCombinationsPink   | Color - Pink     | pinkShop1      | [Color:Pink]   | 11              | 0        | false      |
+      | productWithCombinationsOrange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinations should have the following combinations for shop shop2:
+      | combination reference         | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsRed    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | false      |
+      | productWithCombinationsBlue   | Color - Blue     | blueShop4      | [Color:Blue]   | 20              | 0        | true       |
+      | productWithCombinationsGreen  | Color - Green    | greenShop2     | [Color:Green]  | 21              | 0        | false      |
+      | productWithCombinationsOrange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinations should have the following combinations for shop shop3:
+      | combination reference         | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsRed    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | true       |
+      | productWithCombinationsBlue   | Color - Blue     | blueShop4      | [Color:Blue]   | 30              | 0        | false      |
+      | productWithCombinationsBlack  | Color - Black    | blackShop3     | [Color:Black]  | 31              | 0        | false      |
+      | productWithCombinationsOrange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinations should have the following combinations for shop shop4:
+      | combination reference         | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsRed    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | false      |
+      | productWithCombinationsBlue   | Color - Blue     | blueShop4      | [Color:Blue]   | 40              | 0        | false      |
+      | productWithCombinationsWhite  | Color - White    |                | [Color:White]  | 0               | 0        | true       |
+      | productWithCombinationsOrange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    #
+    # Duplicate for single shop1
+    #
+    When I duplicate product productWithCombinations to a productWithCombinationCopyShop1 for shop shop1
+    Then product productWithCombinationCopyShop1 should have the following combinations for shop shop1:
+      | id reference                          | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationCopyShop1Red    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | true       |
+      | productWithCombinationCopyShop1Blue   | Color - Blue     | blueShop4      | [Color:Blue]   | 10              | 0        | false      |
+      | productWithCombinationCopyShop1Pink   | Color - Pink     | pinkShop1      | [Color:Pink]   | 11              | 0        | false      |
+      | productWithCombinationCopyShop1Orange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinationCopyShop1 is not associated to shop shop2
+    And product productWithCombinationCopyShop1 is not associated to shop shop3
+    And product productWithCombinationCopyShop1 is not associated to shop shop4
+    #
+    # Duplicate for single shop3
+    #
+    When I duplicate product productWithCombinations to a productWithCombinationCopyShop3 for shop shop3
+    And product productWithCombinationCopyShop3 should have the following combinations for shop shop3:
+      | id reference                          | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationCopyShop3Red    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | true       |
+      | productWithCombinationCopyShop3Blue   | Color - Blue     | blueShop4      | [Color:Blue]   | 30              | 0        | false      |
+      | productWithCombinationCopyShop3Black  | Color - Black    | blackShop3     | [Color:Black]  | 31              | 0        | false      |
+      | productWithCombinationCopyShop3Orange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinationCopyShop3 is not associated to shop shop1
+    And product productWithCombinationCopyShop3 is not associated to shop shop2
+    And product productWithCombinationCopyShop3 is not associated to shop shop4
+    #
+    # Duplicate for first shop group
+    #
+    When I duplicate product productWithCombinations to a productWithCombinationsCopyShopGroup1 for shop group default_shop_group
+    Then product productWithCombinationsCopyShopGroup1 should have the following combinations for shop shop1:
+      | id reference                                | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsCopyShopGroup1Red    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | true       |
+      | productWithCombinationsCopyShopGroup1Blue   | Color - Blue     | blueShop4      | [Color:Blue]   | 10              | 0        | false      |
+      | productWithCombinationsCopyShopGroup1Pink   | Color - Pink     | pinkShop1      | [Color:Pink]   | 11              | 0        | false      |
+      | productWithCombinationsCopyShopGroup1Orange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinationsCopyShopGroup1 should have the following combinations for shop shop2:
+      | id reference                                | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsCopyShopGroup1Red    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | false      |
+      | productWithCombinationsCopyShopGroup1Blue   | Color - Blue     | blueShop4      | [Color:Blue]   | 20              | 0        | true       |
+      | productWithCombinationsCopyShopGroup1Green  | Color - Green    | greenShop2     | [Color:Green]  | 21              | 0        | false      |
+      | productWithCombinationsCopyShopGroup1Orange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinationsCopyShopGroup1 is not associated to shop shop3
+    And product productWithCombinationsCopyShopGroup1 is not associated to shop shop4
+    #
+    # Duplicate for second shop group
+    #
+    When I duplicate product productWithCombinations to a productWithCombinationsCopyShopGroup2 for shop group test_second_shop_group
+    Then product productWithCombinationsCopyShopGroup2 should have the following combinations for shop shop3:
+      | id reference                                | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsCopyShopGroup2Red    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | true       |
+      | productWithCombinationsCopyShopGroup2Blue   | Color - Blue     | blueShop4      | [Color:Blue]   | 30              | 0        | false      |
+      | productWithCombinationsCopyShopGroup2Black  | Color - Black    | blackShop3     | [Color:Black]  | 31              | 0        | false      |
+      | productWithCombinationsCopyShopGroup2Orange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinationsCopyShopGroup2 should have the following combinations for shop shop4:
+      | id reference                                | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsCopyShopGroup2Red    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | false      |
+      | productWithCombinationsCopyShopGroup2Blue   | Color - Blue     | blueShop4      | [Color:Blue]   | 40              | 0        | false      |
+      | productWithCombinationsCopyShopGroup2White  | Color - White    |                | [Color:White]  | 0               | 0        | true       |
+      | productWithCombinationsCopyShopGroup2Orange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinationsCopyShopGroup2 is not associated to shop shop1
+    And product productWithCombinationsCopyShopGroup2 is not associated to shop shop2
+    #
+    # Duplicate all shops
+    #
+    When I duplicate product productWithCombinations to a productWithCombinationsCopyAllShops for all shops
+    Then product productWithCombinationsCopyAllShops should have the following combinations for shop shop1:
+      | id reference                  | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsCopyAllShopsRed    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | true       |
+      | productWithCombinationsCopyAllShopsBlue   | Color - Blue     | blueShop4      | [Color:Blue]   | 10              | 0        | false      |
+      | productWithCombinationsCopyAllShopsPink   | Color - Pink     | pinkShop1      | [Color:Pink]   | 11              | 0        | false      |
+      | productWithCombinationsCopyAllShopsOrange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinationsCopyAllShops should have the following combinations for shop shop2:
+      | id reference                  | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsCopyAllShopsRed    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | false      |
+      | productWithCombinationsCopyAllShopsBlue   | Color - Blue     | blueShop4      | [Color:Blue]   | 20              | 0        | true       |
+      | productWithCombinationsCopyAllShopsGreen  | Color - Green    | greenShop2     | [Color:Green]  | 21              | 0        | false      |
+      | productWithCombinationsCopyAllShopsOrange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinationsCopyAllShops should have the following combinations for shop shop3:
+      | id reference                  | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsCopyAllShopsRed    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | true       |
+      | productWithCombinationsCopyAllShopsBlue   | Color - Blue     | blueShop4      | [Color:Blue]   | 30              | 0        | false      |
+      | productWithCombinationsCopyAllShopsBlack  | Color - Black    | blackShop3     | [Color:Black]  | 31              | 0        | false      |
+      | productWithCombinationsCopyAllShopsOrange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |
+    And product productWithCombinationsCopyAllShops should have the following combinations for shop shop4:
+      | id reference                  | combination name | reference      | attributes     | impact on price | quantity | is default |
+      | productWithCombinationsCopyAllShopsRed    | Color - Red      | redAllShops    | [Color:Red]    | 51              | 0        | false      |
+      | productWithCombinationsCopyAllShopsBlue   | Color - Blue     | blueShop4      | [Color:Blue]   | 40              | 0        | false      |
+      | productWithCombinationsCopyAllShopsWhite  | Color - White    |                | [Color:White]  | 0               | 0        | true       |
+      | productWithCombinationsCopyAllShopsOrange | Color - Orange   | orangeAllShops | [Color:Orange] | 69              | 0        | false      |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
@@ -589,3 +589,46 @@ Feature: Copy product from shop to shop.
     And product productWithFieldsSecondGroup is not associated to shop shop4
     # The default shop is shop3 as it's the first associated one in the second group
     And default shop for product productWithFieldsSecondGroup is shop3
+
+  Scenario: I duplicate a product all its categories are correctly copied
+    Given category "home" in default language named "Home" exists
+    And category "home" is the default one
+    And category "men" in default language named "Men" exists
+    And category "clothes" in default language named "Clothes" exists
+    And I edit home category "home" with following details:
+      | associated shops | shop1,shop2,shop3,shop4 |
+    And I edit category "clothes" with following details:
+      | associated shops | shop1,shop2,shop3,shop4 |
+    And I edit category "men" with following details:
+      | associated shops | shop1,shop2,shop3,shop4 |
+    And I add product "productWithCategories" to shop shop1 with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    And I assign product productWithCategories to following categories:
+      | categories       | [home, men, clothes] |
+      | default category | clothes              |
+    And I copy product productWithCategories from shop shop1 to shop shop2
+    And I copy product productWithCategories from shop shop1 to shop shop3
+    And I copy product productWithCategories from shop shop1 to shop shop4
+    # Duplicate on one shop
+    When I duplicate product productWithCategories to a productWithCategoriesCopyShop for shop shop1
+    Then product productWithCategoriesCopyShop should be assigned to following categories for shop shop1:
+      | id reference | name    | is default |
+      | home         | Home    | false      |
+      | men          | Men     | false      |
+      | clothes      | Clothes | true       |
+    # Duplicate on one shop group
+    When I duplicate product productWithCategories to a productWithCategoriesCopyShop for shop group default_shop_group
+    Then product productWithCategoriesCopyShop should be assigned to following categories for shops "shop1,shop2":
+      | id reference | name    | is default |
+      | home         | Home    | false      |
+      | men          | Men     | false      |
+      | clothes      | Clothes | true       |
+    # Duplicate on all shops
+    When I duplicate product productWithCategories to a productWithCategoriesCopyShop for all shops
+    Then product productWithCategoriesCopyShop should be assigned to following categories for shops "shop1,shop2,shop3,shop4":
+      | id reference | name    | is default |
+      | home         | Home    | false      |
+      | men          | Men     | false      |
+      | clothes      | Clothes | true       |

--- a/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/Shop/duplicate_product_multishop.feature
@@ -1109,3 +1109,70 @@ Feature: Copy product from shop to shop.
     And combination "productWithCombinationsBlueCopyAllShops" last stock movements for shops "shop3,shop4" should be:
       | employee   | delta_quantity |
       | Puff Daddy | 13             |
+
+  Scenario: I duplicate a product with customization, the fields are copied along with their multishop translations
+    Given I add product "productWithCustomizationFields" to shop "shop1" with following information:
+      | name[en-US] | bottle of beer |
+      | type        | standard       |
+    And I copy product productWithCustomizationFields from shop shop1 to shop shop2
+    And I copy product productWithCustomizationFields from shop shop1 to shop shop3
+    And I copy product productWithCustomizationFields from shop shop1 to shop shop4
+    And I update product productWithCustomizationFields with following customization fields for shop shop1:
+      | reference    | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1 | text | field1 shop1 | champ1 shop1 | true        |
+      | customField2 | file | field2 shop1 | champ2 shop1 | false       |
+    And I update product productWithCustomizationFields with following customization fields for shop shop2:
+      | reference    | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1 | text | field1 shop2 | champ1 shop2 | true        |
+      | customField2 | file | field2 shop2 | champ2 shop2 | false       |
+    And I update product productWithCustomizationFields with following customization fields for shop shop3:
+      | reference    | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1 | text | field1 shop3 | champ1 shop3 | true        |
+      | customField2 | file | field2 shop3 | champ2 shop3 | false       |
+    And I update product productWithCustomizationFields with following customization fields for shop shop4:
+      | reference    | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1 | text | field1 shop4 | champ1 shop4 | true        |
+      | customField2 | file | field2 shop4 | champ2 shop4 | false       |
+    # The customizability is always the same for all shops since they share the same fields
+    Then product "productWithCustomizationFields" should require customization for shops "shop1,shop2,shop3,shop4"
+    And product productWithCustomizationFields should have 1 customizable text field for shops "shop1,shop2,shop3,shop4"
+    And product productWithCustomizationFields should have 1 customizable file field for shops "shop1,shop2,shop3,shop4"
+    And product productWithCustomizationFields should have following customization fields for shop "shop1":
+      | reference    | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1 | text | field1 shop1 | champ1 shop1 | true        |
+      | customField2 | file | field2 shop1 | champ2 shop1 | false       |
+    And product productWithCustomizationFields should have following customization fields for shop "shop2":
+      | reference    | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1 | text | field1 shop2 | champ1 shop2 | true        |
+      | customField2 | file | field2 shop2 | champ2 shop2 | false       |
+    And product productWithCustomizationFields should have following customization fields for shop "shop3":
+      | reference    | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1 | text | field1 shop3 | champ1 shop3 | true        |
+      | customField2 | file | field2 shop3 | champ2 shop3 | false       |
+    And product productWithCustomizationFields should have following customization fields for shop "shop4":
+      | reference    | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1 | text | field1 shop4 | champ1 shop4 | true        |
+      | customField2 | file | field2 shop4 | champ2 shop4 | false       |
+    # Copy for all shops
+    When I duplicate product productWithCustomizationFields to a productWithCustomizationFieldsCopyAllShops for all shops
+    Then product "productWithCustomizationFieldsCopyAllShops" should require customization for shops "shop1,shop2,shop3,shop4"
+    And product productWithCustomizationFieldsCopyAllShops should have 1 customizable text field for shops "shop1,shop2,shop3,shop4"
+    And product productWithCustomizationFieldsCopyAllShops should have 1 customizable file field for shops "shop1,shop2,shop3,shop4"
+    And product productWithCustomizationFieldsCopyAllShops should have following customization fields for shop "shop1":
+      | new reference    | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1Copy | text | field1 shop1 | champ1 shop1 | true        |
+      | customField2Copy | file | field2 shop1 | champ2 shop1 | false       |
+    And product productWithCustomizationFieldsCopyAllShops should have following customization fields for shop "shop2":
+      | reference        | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1Copy | text | field1 shop2 | champ1 shop2 | true        |
+      | customField2Copy | file | field2 shop2 | champ2 shop2 | false       |
+    And product productWithCustomizationFieldsCopyAllShops should have following customization fields for shop "shop3":
+      | reference        | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1Copy | text | field1 shop3 | champ1 shop3 | true        |
+      | customField2Copy | file | field2 shop3 | champ2 shop3 | false       |
+    And product productWithCustomizationFieldsCopyAllShops should have following customization fields for shop "shop4":
+      | reference        | type | name[en-US]  | name[fr-FR]  | is required |
+      | customField1Copy | text | field1 shop4 | champ1 shop4 | true        |
+      | customField2Copy | file | field2 shop4 | champ2 shop4 | false       |
+    And customField1 and customField1Copy have different values
+    And customField2 and customField2Copy have different values

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/add_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/add_virtual_product_file.feature
@@ -21,6 +21,7 @@ Feature: Add virtual product file from BO (Back Office).
       | download times limit | 0               |
       | expiration date      |                 |
     And file "file1" for product "product1" should exist in system
+    And file file1 for product product1 should have same file as app_icon.png
 
   Scenario: I add virtual product file with limited access days, downloads and expiration date
     Given I add product "product2" with following information:
@@ -58,6 +59,7 @@ Feature: Add virtual product file from BO (Back Office).
       | download times limit | 100                 |
       | expiration date      | 2000-01-20 09:01:01 |
     And file "file3" for product "product3" should exist in system
+    And file file3 for product product3 should have same file as dummy_zip.zip
 
   Scenario: I should not be able to add file to a product which is not virtual
     Given I add product product4 with following information:
@@ -85,6 +87,7 @@ Feature: Add virtual product file from BO (Back Office).
       | access days          | 0                                  |
       | download times limit | 0                                  |
       | expiration date      |                                    |
+    And file file5 for product product5 should have same file as dummy_zip.zip
     When I add virtual product file "file5-5" to product "product5" with following details:
       | file name    | app_icon.png     |
       | display name | puffin-logo2.png |
@@ -95,6 +98,8 @@ Feature: Add virtual product file from BO (Back Office).
       | download times limit | 0                                  |
       | expiration date      |                                    |
     And file "file5" for product "product5" should exist in system
+    # Check that the file as not modified
+    And file file5 for product product5 should have same file as dummy_zip.zip
 
   Scenario: I should not be able to add a file with invalid details
     Given I add product product6 with following information:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/update_virtual_product_file.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/VirtualProductFile/update_virtual_product_file.feature
@@ -21,6 +21,7 @@ Feature: Add virtual product file from BO (Back Office).
       | download times limit | 0               |
       | expiration date      |                 |
     And file "file1" for product "product1" should exist in system
+    And file file1 for product product1 should have same file as app_icon.png
     When I update file "file1" with following details:
       | display name         | puffin-logo-updated1.png |
       | access days          | 7                        |
@@ -32,6 +33,8 @@ Feature: Add virtual product file from BO (Back Office).
       | download times limit | 70                       |
       | expiration date      | 2020-10-10               |
     And file "file1" for product "product1" should exist in system
+    # details were modified but not the file itself
+    And file file1 for product product1 should have same file as app_icon.png
     When I replace product "product1" file "file1" with a new file "file2" named "dummy_zip.zip" and following details:
       | display name         | puffin-logo-updated3.png |
       | access days          | 1                        |
@@ -44,6 +47,8 @@ Feature: Add virtual product file from BO (Back Office).
       | expiration date      | 2020-11-11               |
     And file "file2" for product "product1" should exist in system
     And file "file1" for product "product1" should not exist in system
+    # Check that the new file matches the provided update file
+    And file file2 for product product1 should have same file as dummy_zip.zip
 
   Scenario: I should not be able to update a file with invalid details
     Given product "product1" should have a virtual product file "file2" with following details:
@@ -52,6 +57,7 @@ Feature: Add virtual product file from BO (Back Office).
       | download times limit | 5                        |
       | expiration date      | 2020-11-11               |
     And file "file2" for product "product1" should exist in system
+    And file file2 for product product1 should have same file as dummy_zip.zip
     When I update file "file2" with following details:
       | display name | {logo} |
     Then I should get error that product file "display name" is invalid
@@ -69,3 +75,5 @@ Feature: Add virtual product file from BO (Back Office).
       | download times limit | 5                        |
       | expiration date      | 2020-11-11               |
     And file "file2" for product "product1" should exist in system
+    # The file itself has never been modified
+    And file file2 for product product1 should have same file as dummy_zip.zip

--- a/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/bulk_duplicate_product.feature
@@ -178,7 +178,7 @@ Feature: Duplicate product from Back Office (BO).
       | product1 |
     And I update product product2 with following customization fields:
       | reference    | type | name[en-US]               | name[fr-FR]                         | is required |
-      | customField1 | text | text on top of left lense | texte en haut de la lentille gauche | true        |
+      | customField2 | text | text on top of left lense | texte en haut de la lentille gauche | true        |
     And I enable product "product2"
     And product product2 should have following seo options:
       | redirect_type   | 301-product |
@@ -273,9 +273,13 @@ Feature: Duplicate product from Back Office (BO).
     And product copy_of_product1 should have following attachments associated:
       | attachment reference | title                       | description                           | file name    | type      | size  |
       | att1                 | en-US:puffin;fr-Fr:macareux | en-US:puffin photo nr1;fr-Fr:macareux | app_icon.png | image/png | 19187 |
-    And product copy_of_product1 should have identical customization fields to product1
+
     And product copy_of_product1 should have 1 customizable text field
     And product copy_of_product1 should have 0 customizable file fields
+    And product copy_of_product1 should have following customization fields:
+      | new reference    | type | name[en-US]               | name[fr-FR]                         | is required |
+      | customField1Copy | text | text on top of left lense | texte en haut de la lentille gauche | true        |
+    And customField1 and customField1Copy have different values
 
     And product "copy_of_product2" should be disabled
     And product "copy_of_product2" type should be standard

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -540,9 +540,11 @@ Feature: Duplicate product from Back Office (BO).
       | access days          | 0               |
       | download times limit | 0               |
       | expiration date      |                 |
-    And file "file1Copy" for product "product1" should exist in system
+    And file file1Copy for product virtualProductCopy should exist in system
     And virtualProduct and virtualProductCopy have different values
     And file1 and file1Copy have different values
+    And file file1 for product virtualProduct should have same file as app_icon.png
+    And file file1Copy for product virtualProductCopy should have same file as app_icon.png
 
   Scenario: I duplicate product features
     Given I create product feature "element" with specified properties:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -332,18 +332,29 @@ Feature: Duplicate product from Back Office (BO).
       | attachment reference | title                       | description                           | file name    | type      | size  |
       | att1                 | en-US:puffin;fr-Fr:macareux | en-US:puffin photo nr1;fr-Fr:macareux | app_icon.png | image/png | 19187 |
 
-  #todo: add specific prices & priorities
-  Scenario: I duplicate a product its specific prices are copied
+  Scenario: I duplicate a product its specific prices and priorities are copied
     Given I add product "productWithSpecificPrices" with following information:
       | name[en-US] | smart sunglasses   |
       | name[fr-FR] | lunettes de soleil |
       | type        | standard           |
+    And default specific price priorities are set to following:
+      | priorities  |
+      | id_group    |
+      | id_currency |
+      | id_country  |
+      | id_shop     |
     And I add a specific price price1 to product productWithSpecificPrices with following details:
       | fixed price     | 0.00   |
       | reduction type  | amount |
       | reduction value | 5.00   |
       | includes tax    | true   |
       | from quantity   | 1      |
+    And I set following custom specific price priorities for product productWithSpecificPrices:
+      | priorities  |
+      | id_country  |
+      | id_currency |
+      | id_group    |
+      | id_shop     |
     When I duplicate product productWithSpecificPrices to a productWithSpecificPricesCopy
     And product "productWithSpecificPricesCopy" should have 1 specific prices
     Then product "productWithSpecificPricesCopy" should have following list of specific prices in "en" language:
@@ -380,6 +391,18 @@ Feature: Duplicate product from Back Office (BO).
       | customer              |                               |
       | product               | productWithSpecificPricesCopy |
     And price1 and price1Copy have different values
+    And product productWithSpecificPricesCopy should have following custom specific price priorities:
+      | priorities  |
+      | id_country  |
+      | id_currency |
+      | id_group    |
+      | id_shop     |
+    And following specific price priorities should be used for product productWithSpecificPricesCopy:
+      | priorities  |
+      | id_country  |
+      | id_currency |
+      | id_group    |
+      | id_shop     |
 
   Scenario: I duplicate a product its suppliers are copied
     Given I add product "productWithSuppliers" with following information:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -294,13 +294,22 @@ Feature: Duplicate product from Back Office (BO).
       | name[fr-FR] | lunettes de soleil |
       | type        | standard           |
     And I update product productWithCustomizations with following customization fields:
-      | reference    | type | name[en-US]               | name[fr-FR]                         | is required |
-      | customField1 | text | text on top of left lense | texte en haut de la lentille gauche | true        |
+      | reference    | type | name[en-US]                 | name[fr-FR]                         | is required |
+      | customField1 | text | text on top of left lense   | texte en haut de la lentille gauche | true        |
+      | customField2 | file | image on top of right lense | image en haut de la lentille droite | false       |
+    Then product productWithCustomizations should have following customization fields:
+      | reference    | type | name[en-US]                 | name[fr-FR]                         | is required |
+      | customField1 | text | text on top of left lense   | texte en haut de la lentille gauche | true        |
+      | customField2 | file | image on top of right lense | image en haut de la lentille droite | false       |
     When I duplicate product productWithCustomizations to a productWithCustomizationsCopy
-    And product productWithCustomizationsCopy should have identical customization fields to productWithCustomizations
-    And product productWithCustomizationsCopy should have 1 customizable text field
-    And product productWithCustomizationsCopy should have 0 customizable file fields
-    # assert new customization values and check that new ID as created
+    Then product productWithCustomizationsCopy should have 1 customizable text field
+    And product productWithCustomizationsCopy should have 1 customizable file field
+    And product productWithCustomizationsCopy should have following customization fields:
+      | new reference    | type | name[en-US]                 | name[fr-FR]                         | is required |
+      | customField1Copy | text | text on top of left lense   | texte en haut de la lentille gauche | true        |
+      | customField2Copy | file | image on top of right lense | image en haut de la lentille droite | false       |
+    And customField1 and customField1Copy have different values
+    And customField2 and customField2Copy have different values
 
   Scenario: I duplicate a product its attachments are copied
     Given I add product "productWithAttachments" with following information:

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -542,3 +542,36 @@ Feature: Duplicate product from Back Office (BO).
       | expiration date      |                 |
     And virtualProduct and virtualProductCopy have different values
     And file1 and file1Copy have different values
+
+  Scenario: I duplicate product features
+    Given I create product feature "element" with specified properties:
+      | name | Nature Element |
+    And I create feature value "fire" for feature "element" with following properties:
+      | value[en-US] | Fire |
+      | value[fr-FR] | Feu  |
+    And I create product feature "emotion" with specified properties:
+      | name | Emotion |
+    And I create feature value "anger" for feature "emotion" with following properties:
+      | value[en-US] | Anger  |
+      | value[fr-FR] | Colère |
+    # Now create the product with both regular features and custom ones
+    Given I add product "darkMagicBook" with following information:
+      | name[en-US] | Dark Magic Book |
+      | type        | standard        |
+    And I set to product "darkMagicBook" the following feature values:
+      | feature | feature_value | custom_values                 | custom_reference |
+      | element | fire          |                               |                  |
+      | emotion | anger         |                               |                  |
+      | element |               | en-US:Darkness;fr-FR:Ténèbres | darkness         |
+    Then product "darkMagicBook" should have following feature values:
+      | feature | feature_value | custom_values                 |
+      | element | fire          |                               |
+      | emotion | anger         |                               |
+      | element | darkness      | en-US:Darkness;fr-FR:Ténèbres |
+    When I duplicate product darkMagicBook to a darkMagicBookCopy
+    Then product "darkMagicBookCopy" should have following feature values:
+      | feature | feature_value | new_feature_value | custom_values                 |
+      | element | fire          |                   |                               |
+      | emotion | anger         |                   |                               |
+      | element |               | darknessCopy      | en-US:Darkness;fr-FR:Ténèbres |
+    And darkness and darknessCopy have different values

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -540,6 +540,7 @@ Feature: Duplicate product from Back Office (BO).
       | access days          | 0               |
       | download times limit | 0               |
       | expiration date      |                 |
+    And file "file1Copy" for product "product1" should exist in system
     And virtualProduct and virtualProductCopy have different values
     And file1 and file1Copy have different values
 

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -140,7 +140,82 @@ Feature: Duplicate product from Back Office (BO).
       | carriers                                | []                   |
     And productWithFields and productWithFieldsCopy have different values
 
-  #@todo: assert stock info
+  Scenario: I duplicate a product its stock is copied
+    When I add product "productWithStock" with following information:
+      | name[en-US] | smart sunglasses   |
+      | name[fr-FR] | lunettes de soleil |
+      | type        | standard           |
+    When I update product "productWithStock" stock with following information:
+      | delta_quantity | 51  |
+      | location       | dtc |
+    And I update product "productWithStock" stock with following information:
+      | delta_quantity | -9 |
+    Then product "productWithStock" should have following stock information:
+      | quantity | 42  |
+      | location | dtc |
+    And product "productWithStock" last stock movements should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | -9             |
+      | Puff Daddy | 51             |
+    And product "productWithStock" last stock movement decreased by 9
+    When I duplicate product productWithStock to a productWithStockCopy
+    Then product "productWithStockCopy" should have following stock information:
+      | quantity | 42  |
+      | location | dtc |
+    And product "productWithStockCopy" last stock movements should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 42             |
+
+  Scenario: I duplicate a product with combinations their stock are copied
+    When I add product "productWithCombinationAndStock" with following information:
+      | name[en-US] | Jar of sand  |
+      | type        | combinations |
+    And I generate combinations for product productWithCombinationAndStock using following attributes:
+      | Color | [Red,Blue] |
+    Then product "productWithCombinationAndStock" should have following combinations:
+      | id reference                | combination name | reference | attributes   | impact on price | quantity | is default |
+      | productWithCombinationsRed  | Color - Red      |           | [Color:Red]  | 0               | 0        | true       |
+      | productWithCombinationsBlue | Color - Blue     |           | [Color:Blue] | 0               | 0        | false      |
+    And I update combination "productWithCombinationsRed" stock with following details:
+      | delta quantity | 100         |
+      | location       | Storage nr1 |
+    And I update combination "productWithCombinationsRed" stock with following details:
+      | delta quantity | -40 |
+    And I update combination "productWithCombinationsBlue" stock with following details:
+      | delta quantity | 50          |
+      | location       | Storage nr1 |
+    And I update combination "productWithCombinationsBlue" stock with following details:
+      | delta quantity | 20          |
+      | location       | Storage nr2 |
+    When I duplicate product productWithCombinationAndStock to a productWithCombinationAndStockCopy
+    Then product "productWithCombinationAndStockCopy" should have following combinations:
+      | id reference                    | combination name | reference | attributes   | impact on price | quantity | is default |
+      | productWithCombinationsRedCopy  | Color - Red      |           | [Color:Red]  | 0               | 60       | true       |
+      | productWithCombinationsBlueCopy | Color - Blue     |           | [Color:Blue] | 0               | 70       | false      |
+    And productWithCombinationsRed and productWithCombinationsRedCopy have different values
+    And productWithCombinationsBlue and productWithCombinationsBlueCopy have different values
+    And combination "productWithCombinationsRedCopy" should have following stock details:
+      | combination stock detail   | value       |
+      | quantity                   | 60          |
+      | location                   | Storage nr1 |
+      | minimal quantity           | 1           |
+      | low stock threshold        | 0           |
+      | low stock alert is enabled | false       |
+      | available date             |             |
+    And combination "productWithCombinationsRedCopy" last stock movements should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 60             |
+    And combination "productWithCombinationsBlueCopy" should have following stock details:
+      | combination stock detail   | value       |
+      | quantity                   | 70          |
+      | location                   | Storage nr2 |
+      | minimal quantity           | 1           |
+      | low stock threshold        | 0           |
+      | low stock alert is enabled | false       |
+      | available date             |             |
+    And combination "productWithCombinationsBlueCopy" last stock movements should be:
+      | employee   | delta_quantity |
+      | Puff Daddy | 70             |
 
   Scenario: I duplicate a product all its categories are correctly copied
     Given category "home" in default language named "Home" exists

--- a/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
+++ b/tests/Integration/Behaviour/Features/Scenario/Product/duplicate_product.feature
@@ -1,9 +1,11 @@
 # ./vendor/bin/behat -c tests/Integration/Behaviour/behat.yml -s product --tags duplicate-product
 @restore-products-before-feature
 @restore-languages-after-feature
-@duplicate-product
+@restore-taxes-after-feature
 @reset-downloads-after-feature
+@reset-img-after-feature
 @clear-cache-after-feature
+@duplicate-product
 Feature: Duplicate product from Back Office (BO).
   As an employee I want to be able to duplicate product
 
@@ -601,6 +603,10 @@ Feature: Duplicate product from Back Office (BO).
       | large_default  | 800   | 800    |
       | medium_default | 452   | 452    |
       | small_default  | 98    | 98     |
+    And image "image1" should have same file as "app_icon.png"
+    And image "image2" should have same file as "logo.jpg"
+    And image "image3" should have same file as "app_icon.png"
+    And image "image4" should have same file as "logo.jpg"
     When I generate combinations for product productWithCombinationAndImages using following attributes:
       | Color | [Red,Blue,Pink] |
     Then product "productWithCombinationAndImages" should have following combinations:
@@ -633,6 +639,10 @@ Feature: Duplicate product from Back Office (BO).
     And image2 and image2Copy have different values
     And image3 and image3Copy have different values
     And image4 and image4Copy have different values
+    And image image1Copy should have same file as "app_icon.png"
+    And image image2Copy should have same file as "logo.jpg"
+    And image image3Copy should have same file as "app_icon.png"
+    And image image4Copy should have same file as "logo.jpg"
     And images "[image1Copy, image2Copy, image3Copy, image4Copy]" should have following types generated:
       | name           | width | height |
       | cart_default   | 125   | 125    |

--- a/tests/Resources/DummyFileUploader.php
+++ b/tests/Resources/DummyFileUploader.php
@@ -69,6 +69,11 @@ class DummyFileUploader
         return __DIR__ . '/dummyFile/';
     }
 
+    public static function getDummyFilePath(string $dummyFilename): string
+    {
+        return static::getDummyFilesPath() . $dummyFilename;
+    }
+
     /**
      * @return string
      */

--- a/tests/Resources/Resetter/ProductResetter.php
+++ b/tests/Resources/Resetter/ProductResetter.php
@@ -63,6 +63,7 @@ class ProductResetter
             'customized_data',
             // Specific prices
             'specific_price',
+            'specific_price_priority',
             // Stock
             'stock_available',
             'stock_mvt',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Product duplication was only partially handled, this PR handles the whole product duplication correctly especially in multishop but it also fixed a few bugs in single shop use case It also completely refactored `ProductDuplicator` so that it doesn't rely on legacy duplication methods anymore
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI tests green You can also test duplicating some product (single and/or bulk duplication) in both single shop and multishop mode (all shops and/or shop group should work as well)
| Fixed ticket?     | ~
| Related PRs       | ~
| Sponsor company   | ~
