### PR TITLE
Limit the size of changelog for module updates

### DIFF
--- a/admin-dev/themes/new-theme/scss/theme.scss
+++ b/admin-dev/themes/new-theme/scss/theme.scss
@@ -189,3 +189,8 @@ table.table {
     }
   }
 }
+
+.scroll-300 {
+  max-height: 300px;
+  overflow-y: auto;
+}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -81,7 +81,7 @@
             {% endif %}
           </div>
         </div>
-        <div class="col-md-8 col-lg-7">
+        <div class="col-md-8 col-lg-7 pre-scrollable">
           {% block addon_description %}
             {{ module.attributes.description|raw }}
             {% if module.attributes.description|length > 0 and module.attributes.description|length < module.attributes.fullDescription|length %}

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/Includes/card_list.html.twig
@@ -81,7 +81,7 @@
             {% endif %}
           </div>
         </div>
-        <div class="col-md-8 col-lg-7 pre-scrollable">
+        <div class="col-md-8 col-lg-7 scroll-300">
           {% block addon_description %}
             {{ module.attributes.description|raw }}
             {% if module.attributes.description|length > 0 and module.attributes.description|length < module.attributes.fullDescription|length %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Some modules add very long changelog on Modules > Module manager : Update tab. This fix limits its size to make whole page more compact.
| Type?             | improvement
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Needs update available for modules with long changelog eg. ps_metrics, ps_facebook, ps_mbo
| Fixed ticket?     | ~
| Related PRs       | ~
| Sponsor company   |  ~

### Before
![obraz](https://user-images.githubusercontent.com/5007456/221811924-ad56e431-397a-4a36-ad61-280a5f64f628.png)

### After
![psupdates](https://user-images.githubusercontent.com/5007456/221813042-58a95c7c-e4e5-46b2-9813-1c341ecb2e43.gif)
