### PR TITLE
Fix error Uncaught TypeError: abs() in CartController

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -76,7 +76,7 @@ class CartControllerCore extends FrontController
         $this->id_product = (int) Tools::getValue('id_product', null);
         $this->id_product_attribute = (int) Tools::getValue('id_product_attribute', Tools::getValue('ipa'));
         $this->customization_id = (int) Tools::getValue('id_customization');
-        $this->qty = abs(Tools::getValue('qty', 1));
+        $this->qty = abs((int) Tools::getValue('qty', 1));
         $this->id_address_delivery = (int) Tools::getValue('id_address_delivery');
         $this->preview = ('1' === Tools::getValue('preview'));
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes `Uncaught TypeError: abs(): Argument https://github.com/PrestaShop/PrestaShop/pull/1 ($num) must be of type int|float, string given in controllers/front/CartController.php`
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No error 500 anymore when accessing URL `/cart?add=1&id_product=41261&qty=` 
| Fixed ticket?     | Fixes #31570
| Related PRs       | None
| Sponsor company   | Société Biblique de Genève
