### PR TITLE
Ignore non existing product while importing by reference

### DIFF
--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1635,6 +1635,16 @@ class AdminImportControllerCore extends AdminController
 
         $product = new Product($id_product);
 
+        if(!$product->id && (!isset($info['name']) || empty($info['name']))) {
+            $this->errors[] = sprintf(
+                $this->trans('Product with reference %1$s (ID: %2$s) cannot be saved : product name missing', [], 'Admin.Advparameters.Notification'),
+                (isset($info['reference']) && !empty($info['reference'])) ? Tools::htmlentitiesUTF8($info['reference']) : 'null',
+                !empty($info['id']) ? Tools::htmlentitiesUTF8($info['id']) : 'null'
+            );
+
+            return;
+        }
+
         $update_advanced_stock_management_value = false;
         if (isset($product->id) && $product->id && Product::existsInDatabase((int) $product->id, 'product')) {
             $product->loadStockData();

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1637,7 +1637,7 @@ class AdminImportControllerCore extends AdminController
 
         if (!$product->id && empty($info['name'])) {
             $this->errors[] = sprintf(
-                $this->trans('Product with reference %1$s (ID: %2$s) cannot be saved: product name is missing', [], 'Admin.Advparameters.Notification'),
+                $this->trans('Product with reference %1$s (ID: %2$s) could not be saved because the product name is missing.', [], 'Admin.Advparameters.Notification'),
                 (!empty($info['reference'])) ? Tools::htmlentitiesUTF8($info['reference']) : 'null',
                 !empty($info['id']) ? Tools::htmlentitiesUTF8($info['id']) : 'null'
             );

--- a/controllers/admin/AdminImportController.php
+++ b/controllers/admin/AdminImportController.php
@@ -1635,10 +1635,10 @@ class AdminImportControllerCore extends AdminController
 
         $product = new Product($id_product);
 
-        if(!$product->id && (!isset($info['name']) || empty($info['name']))) {
+        if (!$product->id && empty($info['name'])) {
             $this->errors[] = sprintf(
-                $this->trans('Product with reference %1$s (ID: %2$s) cannot be saved : product name missing', [], 'Admin.Advparameters.Notification'),
-                (isset($info['reference']) && !empty($info['reference'])) ? Tools::htmlentitiesUTF8($info['reference']) : 'null',
+                $this->trans('Product with reference %1$s (ID: %2$s) cannot be saved: product name is missing', [], 'Admin.Advparameters.Notification'),
+                (!empty($info['reference'])) ? Tools::htmlentitiesUTF8($info['reference']) : 'null',
                 !empty($info['id']) ? Tools::htmlentitiesUTF8($info['id']) : 'null'
             );
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Displays an error message while importing products by reference or id and when the product is not found et and the name is missing. Perform an import setting Match ref to Yes.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Create a CSV file with a column reference and a column active and add a row with a non existing reference. Look at #14306 for details
| Fixed ticket?     | Fixes #14306
| Related PRs       | 
| Sponsor company   | Web Cooking Factory
