### PR TITLE
Product page v2 : Footer UX improvements

### DIFF
--- a/admin-dev/themes/default/template/header.tpl
+++ b/admin-dev/themes/default/template/header.tpl
@@ -112,7 +112,7 @@
 </head>
 
 {if $display_header}
-<body class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} ps_back-office{if $employee->bo_menu} page-sidebar{if $collapse_menu} page-sidebar-closed{/if}{else} page-topbar{/if} {$controller_name|escape|strtolower}{if isset($debug_mode) && $debug_mode == true} developer-mode{/if}"
+<body class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} ps_back-office{if $employee->bo_menu} page-sidebar{if $collapse_menu} page-sidebar-closed{/if}{else} page-topbar{/if} {$controller_name|escape|strtolower}{if !empty($debug_mode)} developer-mode{/if}"
       {if isset($js_router_metadata.base_url)}data-base-url="{$js_router_metadata.base_url}"{/if}
       {if isset($js_router_metadata.token)}data-token="{$js_router_metadata.token}"{/if}>
   {* begin  HEADER *}

--- a/admin-dev/themes/new-theme/js/app/utils/watch-symfony-debug-bar.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/watch-symfony-debug-bar.ts
@@ -48,16 +48,12 @@ const waitForDebugContent = (debugToken: string): void => {
 };
 
 const initToggleWatching = (debugToken: string): void => {
-  document.getElementById(`sfToolbarMiniToggler-${debugToken}`)?.addEventListener('click', () => {
-    toggleDebugMode();
-  });
-  document.getElementById(`sfToolbarHideButton-${debugToken}`)?.addEventListener('click', () => {
-    toggleDebugMode();
-  });
+  document.getElementById(`sfToolbarMiniToggler-${debugToken}`)?.addEventListener('click', toggleDebugMode);
+  document.getElementById(`sfToolbarHideButton-${debugToken}`)?.addEventListener('click', toggleDebugMode);
   toggleDebugMode();
 };
 
-const toggleDebugMode = () => {
+const toggleDebugMode = (): void => {
   if (getPreference('toolbar/displayState') === 'none') {
     document.body.classList.add('debug-toolbar-hidden');
     document.body.classList.remove('debug-toolbar-shown');

--- a/admin-dev/themes/new-theme/js/app/utils/watch-symfony-debug-bar.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/watch-symfony-debug-bar.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+// Mimic Symfony debug toolbar getPreference function to get the toolbar state
+const profilerStorageKey = 'symfony/profiler/';
+const getPreference = (name: string): string | null => {
+  if (!window.localStorage) {
+    return null;
+  }
+
+  return localStorage.getItem(profilerStorageKey + name);
+};
+
+const refreshDelay = 100;
+const waitForDebugContent = (debugToken: string): void => {
+  // Wait until the toolbar content is present on page
+  const debugBarContentId = `sfToolbarMainContent-${debugToken}`;
+
+  const toolbar = document.getElementById(debugBarContentId);
+
+  if (toolbar) {
+    initToggleWatching(debugToken);
+  } else {
+    setTimeout(() => waitForDebugContent(debugToken), refreshDelay);
+  }
+};
+
+const initToggleWatching = (debugToken: string): void => {
+  document.getElementById(`sfToolbarMiniToggler-${debugToken}`)?.addEventListener('click', () => {
+    toggleDebugMode();
+  });
+  document.getElementById(`sfToolbarHideButton-${debugToken}`)?.addEventListener('click', () => {
+    toggleDebugMode();
+  });
+  toggleDebugMode();
+};
+
+const toggleDebugMode = () => {
+  if (getPreference('toolbar/displayState') === 'block') {
+    document.body.classList.add('debug-toolbar-shown');
+    document.body.classList.remove('debug-toolbar-hidden');
+  } else {
+    document.body.classList.add('debug-toolbar-hidden');
+    document.body.classList.remove('debug-toolbar-shown');
+  }
+};
+
+const watchSymfonyDebugBar = (): void => {
+  const debugToolbar = document.querySelector<HTMLElement>('[id^=sfwdt]');
+
+  if (!debugToolbar) {
+    // If initial container is not present the debug toolbar will never be displayed, so nothing to do
+    return;
+  }
+
+  const debugToken = debugToolbar.id.replace(/^sfwdt/, '');
+  waitForDebugContent(debugToken);
+};
+
+export default watchSymfonyDebugBar;

--- a/admin-dev/themes/new-theme/js/app/utils/watch-symfony-debug-bar.ts
+++ b/admin-dev/themes/new-theme/js/app/utils/watch-symfony-debug-bar.ts
@@ -58,12 +58,13 @@ const initToggleWatching = (debugToken: string): void => {
 };
 
 const toggleDebugMode = () => {
-  if (getPreference('toolbar/displayState') === 'block') {
-    document.body.classList.add('debug-toolbar-shown');
-    document.body.classList.remove('debug-toolbar-hidden');
-  } else {
+  if (getPreference('toolbar/displayState') === 'none') {
     document.body.classList.add('debug-toolbar-hidden');
     document.body.classList.remove('debug-toolbar-shown');
+  } else {
+    // Alternative is block (set as shown) or null (default setting is shown)
+    document.body.classList.add('debug-toolbar-shown');
+    document.body.classList.remove('debug-toolbar-hidden');
   }
 };
 

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
@@ -231,32 +231,52 @@ export default class ProductPartialUpdater {
     const updatedData = this.getUpdatedFormData();
 
     if (this.listEditionMode) {
-      this.$productFormSubmitButton.prop('disabled', true);
-      this.$productFormCancelButton.addClass('disabled');
-      this.$productFormGoToCatalogButton.addClass('disabled');
-      this.$productFormPreviewButton.addClass('disabled');
-      this.$productFormDuplicateButton.addClass('disabled');
-      this.$productFormNewProductButton.addClass('disabled');
+      this.toggleButtonsState([
+        this.$productFormSubmitButton,
+        this.$productFormCancelButton,
+        this.$productFormGoToCatalogButton,
+        this.$productFormPreviewButton,
+        this.$productFormDuplicateButton,
+        this.$productFormNewProductButton,
+        this.$productTypePreview,
+      ], false);
+      // Disable type button permanently
       this.$productTypePreview.off('click');
-      this.$productTypePreview.addClass('disabled');
+      this.$productTypePreview.addClass('disabled').prop('disabled', true);
     } else if (updatedData === null) {
-      this.$productFormSubmitButton.prop('disabled', true);
-      this.$productFormCancelButton.addClass('disabled');
-      this.$productFormGoToCatalogButton.removeClass('disabled');
-      this.$productFormPreviewButton.removeClass('disabled');
-      this.$productFormDuplicateButton.removeClass('disabled');
-      this.$productFormNewProductButton.removeClass('disabled');
-      this.$productTypePreview.removeClass('disabled');
+      this.toggleButtonsState([
+        this.$productFormSubmitButton,
+        this.$productFormCancelButton,
+      ], false);
+      this.toggleButtonsState([
+        this.$productFormGoToCatalogButton,
+        this.$productFormPreviewButton,
+        this.$productFormDuplicateButton,
+        this.$productFormNewProductButton,
+        this.$productTypePreview,
+      ], true);
     } else {
-      this.$productFormSubmitButton.prop('disabled', false);
-      this.$productFormCancelButton.removeClass('disabled');
-      this.$productFormGoToCatalogButton.addClass('disabled');
-      this.$productFormPreviewButton.addClass('disabled');
-      this.$productFormDuplicateButton.addClass('disabled');
-      this.$productFormNewProductButton.addClass('disabled');
+      this.toggleButtonsState([
+        this.$productFormSubmitButton,
+        this.$productFormCancelButton,
+      ], true);
+      this.toggleButtonsState([
+        this.$productFormGoToCatalogButton,
+        this.$productFormPreviewButton,
+        this.$productFormDuplicateButton,
+        this.$productFormNewProductButton,
+      ], false);
+      // Disable type button permanently
       this.$productTypePreview.off('click');
-      this.$productTypePreview.addClass('disabled');
+      this.$productTypePreview.addClass('disabled').prop('disabled', true);
     }
+  }
+
+  private toggleButtonsState(buttons: JQuery[], enabled: boolean): void {
+    buttons.forEach(($button: JQuery) => {
+      $button.prop('disabled', !enabled);
+      $button.toggleClass('disabled', !enabled);
+    });
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
@@ -242,7 +242,6 @@ export default class ProductPartialUpdater {
       ], false);
       // Disable type button permanently
       this.$productTypePreview.off('click');
-      this.$productTypePreview.addClass('disabled').prop('disabled', true);
     } else if (updatedData === null) {
       this.toggleButtonsState([
         this.$productFormSubmitButton,
@@ -265,10 +264,10 @@ export default class ProductPartialUpdater {
         this.$productFormPreviewButton,
         this.$productFormDuplicateButton,
         this.$productFormNewProductButton,
+        this.$productTypePreview,
       ], false);
       // Disable type button permanently
       this.$productTypePreview.off('click');
-      this.$productTypePreview.addClass('disabled').prop('disabled', true);
     }
   }
 

--- a/admin-dev/themes/new-theme/js/theme.ts
+++ b/admin-dev/themes/new-theme/js/theme.ts
@@ -54,6 +54,7 @@ import initInvalidFields from '@js/app/utils/fields';
 import initEmailFields from '@js/app/utils/email-idn';
 import initNumberCommaTransformer from '@js/app/utils/number-comma-transformer';
 import initPrestashopComponents from '@app/utils/init-components';
+import watchSymfonyDebugBar from '@app/utils/watch-symfony-debug-bar';
 import '@js/components/header/search-form';
 
 const {$} = window;
@@ -70,4 +71,5 @@ $(() => {
   initInvalidFields();
   initEmailFields('input[type="email"]');
   initNumberCommaTransformer('.js-comma-transformer');
+  watchSymfonyDebugBar();
 });

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -33,7 +33,13 @@ $product-page-padding-bottom: 80px !default;
   &.debug-toolbar-shown {
     .product-page {
       .product-footer {
-        padding-bottom: calc($grid-gutter-width / 2 + 2.25rem);
+        padding-bottom: 0.6rem + 2.25rem;
+      }
+    }
+
+    .combination-page {
+      #combination_form {
+        padding-bottom: 1rem;
       }
     }
   }

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -20,10 +20,21 @@
 
 $product-page-padding-bottom: 80px !default;
 
+// Adapt footer padding to be correctly displayed with Symfony debug bar (both when hidden and/or shown)
 .developer-mode {
-  .product-page {
-    .product-footer {
-      padding-bottom: calc($grid-gutter-width / 2 + 2.25rem);
+  &.debug-toolbar-hidden {
+    .product-page {
+      .product-footer {
+        padding-right: 2.25rem;
+      }
+    }
+  }
+
+  &.debug-toolbar-shown {
+    .product-page {
+      .product-footer {
+        padding-bottom: calc($grid-gutter-width / 2 + 2.25rem);
+      }
     }
   }
 }

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -440,13 +440,18 @@ $product-page-padding-bottom: 80px !default;
     .dropdown-menu > .dropdown-item a.btn.disabled,
     .dropdown-menu > .dropdown-item button.btn.disabled {
       color: #b3c7cd;
-      pointer-events: auto;
-      cursor: not-allowed;
+      pointer-events: none;
       background-color: transparent;
 
       .material-icons {
         color: #b3c7cd;
       }
+    }
+
+    // Little hack to have the not-allowed cursor on buttons even though they ahev pointer-events to none
+    // The not-allowed is actually on the parent "under" the buttons that are disabled
+    #product_footer_actions {
+      cursor: not-allowed;
     }
   }
 

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -1304,7 +1304,7 @@ $product-page-padding-bottom: 80px !default;
     list-style: none;
   }
 
-  #product_specifications_references {
+  #product_details_references {
     input {
       max-width: 415px;
     }

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -379,8 +379,8 @@ $product-page-padding-bottom: 80px !default;
     background: $white;
     box-shadow: $gray-dark 0 0 10px;
     padding: {
-      top: $grid-gutter-width / 2;
-      bottom: $grid-gutter-width / 2;
+      top: 0.6rem;
+      bottom: 0.6rem;
     }
 
     .form-group {

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -415,10 +415,6 @@ $product-page-padding-bottom: 80px !default;
         min-width: 6rem;
         padding-top: 0.25rem;
       }
-
-      .delete-product-button {
-        padding: 0.5rem;
-      }
     }
   }
 

--- a/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
+++ b/admin-dev/themes/new-theme/scss/pages/product/product_page.scss
@@ -427,6 +427,21 @@ $product-page-padding-bottom: 80px !default;
         padding-top: 0.25rem;
       }
     }
+
+    // Force disabled buttons to be correctly displayed as such
+    a.btn.disabled,
+    button.btn.disabled,
+    .dropdown-menu > .dropdown-item a.btn.disabled,
+    .dropdown-menu > .dropdown-item button.btn.disabled {
+      color: #b3c7cd;
+      pointer-events: auto;
+      cursor: not-allowed;
+      background-color: transparent;
+
+      .material-icons {
+        color: #b3c7cd;
+      }
+    }
   }
 
   .help-box {

--- a/admin-dev/themes/new-theme/template/layout.tpl
+++ b/admin-dev/themes/new-theme/template/layout.tpl
@@ -5,7 +5,7 @@
 </head>
 
 <body
-  class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} {$controller_name|escape|strtolower}{if $collapse_menu} page-sidebar-closed{/if}{if isset($is_multishop) && $is_multishop} multishop-enabled{/if}{if isset($lite_display) && $lite_display} light_display_layout{/if}{if isset($debug_mode) && $debug_mode == true} developer-mode{/if}"
+  class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} {$controller_name|escape|strtolower}{if $collapse_menu} page-sidebar-closed{/if}{if isset($is_multishop) && $is_multishop} multishop-enabled{/if}{if isset($lite_display) && $lite_display} light_display_layout{/if}{if !empty($debug_mode)} developer-mode{/if}"
   {if isset($js_router_metadata.base_url)}data-base-url="{$js_router_metadata.base_url}"{/if}
   {if isset($js_router_metadata.token)}data-token="{$js_router_metadata.token}"{/if}
 >

--- a/admin-dev/themes/new-theme/template/light_display_layout.tpl
+++ b/admin-dev/themes/new-theme/template/light_display_layout.tpl
@@ -30,7 +30,7 @@
 </head>
 
 <body
-  class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} {$controller_name|escape|strtolower}{if $collapse_menu} page-sidebar-closed{/if}{if isset($debug_mode) && $debug_mode == true} developer-mode{/if}"
+  class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} {$controller_name|escape|strtolower}{if $collapse_menu} page-sidebar-closed{/if}{if !empty($debug_mode)} developer-mode{/if}"
   {if isset($js_router_metadata.base_url)}data-base-url="{$js_router_metadata.base_url}"{/if}
   {if isset($js_router_metadata.token)}data-token="{$js_router_metadata.token}"{/if}
 >

--- a/admin-dev/themes/new-theme/template/light_display_layout.tpl
+++ b/admin-dev/themes/new-theme/template/light_display_layout.tpl
@@ -30,7 +30,7 @@
 </head>
 
 <body
-  class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} {$controller_name|escape|strtolower}{if $collapse_menu} page-sidebar-closed{/if}"
+  class="lang-{$iso_user}{if $lang_is_rtl} lang-rtl{/if} {$controller_name|escape|strtolower}{if $collapse_menu} page-sidebar-closed{/if}{if isset($debug_mode) && $debug_mode == true} developer-mode{/if}"
   {if isset($js_router_metadata.base_url)}data-base-url="{$js_router_metadata.base_url}"{/if}
   {if isset($js_router_metadata.token)}data-token="{$js_router_metadata.token}"{/if}
 >

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -197,6 +197,7 @@ class FooterType extends TranslatorAwareType
             ->add('cancel', IconButtonType::class, [
                 'label' => $this->trans('Cancel', 'Admin.Actions'),
                 'type' => 'link',
+                'icon' => 'cancel',
                 'attr' => [
                     'href' => $editUrl,
                     'class' => 'btn-secondary cancel-button',

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/FooterType.php
@@ -31,6 +31,7 @@ namespace PrestaShopBundle\Form\Admin\Sell\Product;
 use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductPreviewProvider;
 use PrestaShop\PrestaShop\Adapter\Shop\Url\ProductProvider;
 use PrestaShop\PrestaShop\Core\Feature\FeatureInterface;
+use PrestaShopBundle\Form\Admin\Type\ButtonCollectionType;
 use PrestaShopBundle\Form\Admin\Type\IconButtonType;
 use PrestaShopBundle\Form\Admin\Type\TranslatorAwareType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -119,44 +120,79 @@ class FooterType extends TranslatorAwareType
         }
 
         $builder
-            ->add('catalog', IconButtonType::class, [
-                'label' => $this->trans('Go to catalog', 'Admin.Catalog.Feature'),
-                'type' => 'link',
-                'icon' => 'arrow_back_ios',
-                'attr' => [
-                    'class' => 'btn-outline-secondary border-white go-to-catalog-button',
-                    'href' => $this->router->generate('admin_products_v2_index', ['offset' => 'last', 'limit' => 'last']),
+            ->add('actions', ButtonCollectionType::class, [
+                'buttons' => [
+                    'catalog' => [
+                        'type' => IconButtonType::class,
+                        'options' => [
+                            'label' => $this->trans('Go to catalog', 'Admin.Catalog.Feature'),
+                            'type' => 'link',
+                            'icon' => 'arrow_back_ios',
+                            'attr' => [
+                                'class' => 'btn-outline-secondary border-white go-to-catalog-button',
+                                'href' => $this->router->generate('admin_products_v2_index', ['offset' => 'last', 'limit' => 'last']),
+                            ],
+                        ],
+                    ],
+                    'new_product' => [
+                        'type' => IconButtonType::class,
+                        'options' => [
+                            'label' => $this->trans('New product', 'Admin.Catalog.Feature'),
+                            'icon' => 'add',
+                            'type' => 'link',
+                            'attr' => [
+                                'class' => 'btn-outline-secondary new-product-button',
+                                'href' => $this->router->generate('admin_products_v2_create', ['shopId' => $this->contextShopId]),
+                            ],
+                        ],
+                    ],
+                    'delete' => [
+                        'type' => IconButtonType::class,
+                        'options' => [
+                            'label' => $this->trans('Delete', 'Admin.Actions'),
+                            'icon' => 'delete',
+                            'attr' => [
+                                'class' => 'tooltip-link delete-product-button btn-outline-secondary',
+                                'data-modal-title' => $this->trans('Permanently delete this product?', 'Admin.Catalog.Notification'),
+                                'data-modal-apply' => $this->trans('Delete', 'Admin.Actions'),
+                                'data-modal-cancel' => $this->trans('Cancel', 'Admin.Actions'),
+                                'data-confirm-button-class' => 'btn-danger',
+                                'data-button-url' => $deleteUrl,
+                            ],
+                        ],
+                    ],
+                    'duplicate_product' => [
+                        'type' => IconButtonType::class,
+                        'options' => [
+                            'label' => $duplicateLabel,
+                            'icon' => 'content_copy',
+                            'attr' => [
+                                'class' => 'btn-outline-secondary duplicate-product-button',
+                                'data-modal-title' => $this->trans('Duplicate product?', 'Admin.Catalog.Notification'),
+                                'data-modal-apply' => $duplicateLabel,
+                                'data-modal-cancel' => $this->trans('Cancel', 'Admin.Actions'),
+                                'data-confirm-button-class' => 'btn-primary',
+                                'data-button-url' => $duplicateUrl,
+                            ],
+                        ],
+                    ],
+                    'preview' => [
+                        'type' => IconButtonType::class,
+                        'options' => [
+                            'label' => $this->trans('Preview', 'Admin.Actions'),
+                            'icon' => 'visibility',
+                            'type' => 'link',
+                            'attr' => [
+                                'target' => '_blank',
+                                'href' => $productPreviewUrl,
+                                'class' => 'btn-outline-secondary preview-url-button',
+                                'data-seo-url' => $seoUrl,
+                            ],
+                        ],
+                    ],
                 ],
-            ])
-            ->add('duplicate_product', IconButtonType::class, [
-                'label' => $duplicateLabel,
-                'attr' => [
-                    'class' => 'btn-outline-secondary duplicate-product-button',
-                    'data-modal-title' => $this->trans('Duplicate product?', 'Admin.Catalog.Notification'),
-                    'data-modal-apply' => $duplicateLabel,
-                    'data-modal-cancel' => $this->trans('Cancel', 'Admin.Actions'),
-                    'data-confirm-button-class' => 'btn-primary',
-                    'data-button-url' => $duplicateUrl,
-                ],
-            ])
-            ->add('delete', IconButtonType::class, [
-                'label' => $this->trans('Delete', 'Admin.Actions'),
-                'attr' => [
-                    'class' => 'tooltip-link delete-product-button btn-outline-secondary',
-                    'data-modal-title' => $this->trans('Permanently delete this product?', 'Admin.Catalog.Notification'),
-                    'data-modal-apply' => $this->trans('Delete', 'Admin.Actions'),
-                    'data-modal-cancel' => $this->trans('Cancel', 'Admin.Actions'),
-                    'data-confirm-button-class' => 'btn-danger',
-                    'data-button-url' => $deleteUrl,
-                ],
-            ])
-            ->add('new_product', IconButtonType::class, [
-                'label' => $this->trans('New product', 'Admin.Catalog.Feature'),
-                'type' => 'link',
-                'attr' => [
-                    'class' => 'btn-outline-secondary new-product-button',
-                    'href' => $this->router->generate('admin_products_v2_create', ['shopId' => $this->contextShopId]),
-                ],
+                // Only first catalog button is displayed by default, the rest are in a dropdown
+                'inline_buttons_limit' => 1,
             ])
             ->add('cancel', IconButtonType::class, [
                 'label' => $this->trans('Cancel', 'Admin.Actions'),
@@ -165,17 +201,6 @@ class FooterType extends TranslatorAwareType
                     'href' => $editUrl,
                     'class' => 'btn-secondary cancel-button',
                     'disabled' => true,
-                ],
-            ])
-            // These two inputs are displayed separately
-            ->add('preview', IconButtonType::class, [
-                'label' => $this->trans('Preview', 'Admin.Actions'),
-                'type' => 'link',
-                'attr' => [
-                    'target' => '_blank',
-                    'href' => $productPreviewUrl,
-                    'class' => 'btn-outline-secondary preview-url-button',
-                    'data-seo-url' => $seoUrl,
                 ],
             ])
             ->add('save', SubmitType::class, [

--- a/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
+++ b/src/PrestaShopBundle/Form/Admin/Sell/Product/HeaderType.php
@@ -82,11 +82,6 @@ class HeaderType extends TranslatorAwareType
             ->add('name', TranslatableType::class, [
                 'label' => $this->trans('Product name', 'Admin.Catalog.Feature'),
                 'type' => TextType::class,
-                'help' => $this->trans(
-                    'Invalid characters are: %invalidCharacters%',
-                    'Admin.Catalog.Feature',
-                    ['%invalidCharacters%' => '<>;=#{}']
-                ),
                 'constraints' => $options['active'] ? [new DefaultLanguage()] : [],
                 'options' => [
                     'constraints' => [

--- a/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php
+++ b/src/PrestaShopBundle/Form/Admin/Type/ButtonCollectionType.php
@@ -77,6 +77,7 @@ class ButtonCollectionType extends AbstractType
         $view->vars['justify_content'] = $options['justify_content'];
         $view->vars['inline_buttons_limit'] = $options['inline_buttons_limit'];
         $view->vars['use_inline_labels'] = $options['use_inline_labels'];
+        $view->vars['use_button_groups'] = $options['use_button_groups'];
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -88,6 +89,8 @@ class ButtonCollectionType extends AbstractType
                 'justify_content' => 'space-between',
                 'inline_buttons_limit' => null,
                 'use_inline_labels' => true,
+                // Use bootstrap buttons groups (buttons stick to each other as a group)
+                'use_button_groups' => false,
             ])
             ->setAllowedTypes('buttons', 'array')
             ->setAllowedTypes('inline_buttons_limit', ['int', 'null'])

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/Blocks/footer.html.twig
@@ -29,7 +29,7 @@
       {# Only a few selected elements are in the right column #}
       <div class="form-group product-footer-right">
         <div id="product-footer-right" class="footer-buttons-container">
-          {{ form_row(productForm.footer.preview) }}
+          {{ form_row(productForm.footer.cancel) }}
           {{ form_row(productForm.footer.save) }}
         </div>
       </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -1510,7 +1510,7 @@
   }) -%}
   <div {{ block('widget_attributes') }}>
     {% for group, buttons in button_groups %}
-      <div class="btn-group group-{{ group }}">
+      <div class="{% if use_button_groups %}btn-group {% endif %}group-{{ group }}">
         {# Render inline actions #}
         {% set inlineButtonsLimit = form.vars.inline_buttons_limit %}
         {% for action in form.children %}

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/prestashop_ui_kit_base.html.twig
@@ -1527,7 +1527,7 @@
 
         {# Render remaining actions in dropdown #}
         {% if inlineButtonsLimit is not same as(null) and form.children|length > inlineButtonsLimit %}
-          <a class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate"
+          <a id="{{ form.vars.id }}_dropdown" class="btn btn-link dropdown-toggle dropdown-toggle-dots dropdown-toggle-split no-rotate"
              data-toggle="dropdown"
              aria-haspopup="true"
              aria-expanded="false"

--- a/tests/UI/pages/BO/catalog/productsV2/add/index.ts
+++ b/tests/UI/pages/BO/catalog/productsV2/add/index.ts
@@ -36,6 +36,8 @@ class CreateProduct extends BOBasePage {
 
   private readonly productHeaderReference: string;
 
+  private readonly footerProductDropDown: string;
+
   private readonly previewProductButton: string;
 
   private readonly saveProductButton: string;
@@ -77,16 +79,17 @@ class CreateProduct extends BOBasePage {
     this.productHeaderReference = '.product-header-references';
 
     // Footer selectors
-    this.previewProductButton = '#product_footer_preview';
+    this.footerProductDropDown = '#product_footer_actions_dropdown';
+    this.previewProductButton = '#product_footer_actions_preview';
     this.saveProductButton = '#product_footer_save';
-    this.deleteProductButton = '#product_footer_delete';
+    this.deleteProductButton = '#product_footer_actions_delete';
 
     // Footer modal
     this.deleteProductFooterModal = '#delete-product-footer-modal';
     this.deleteProductSubmitButton = `${this.deleteProductFooterModal} button.btn-confirm-submit`;
-    this.newProductButton = '#product_footer_new_product';
-    this.goToCatalogButton = '#product_footer_catalog';
-    this.duplicateProductButton = '#product_footer_duplicate_product';
+    this.newProductButton = '#product_footer_actions_new_product';
+    this.goToCatalogButton = '#product_footer_actions_catalog';
+    this.duplicateProductButton = '#product_footer_actions_duplicate_product';
     this.duplicateProductFooterModal = '#duplicate-product-footer-modal';
     this.duplicateProductFooterModalConfirmSubmit = `${this.duplicateProductFooterModal} button.btn-confirm-submit`;
   }
@@ -174,6 +177,7 @@ class CreateProduct extends BOBasePage {
    * @return {Promise<Page>}
    */
   async previewProduct(page: Page): Promise<Page> {
+    await this.waitForSelectorAndClick(page, this.footerProductDropDown);
     const newPage = await this.openLinkWithTargetBlank(page, this.previewProductButton, 'body a');
     const textBody = await this.getTextContent(newPage, 'body');
 
@@ -189,6 +193,7 @@ class CreateProduct extends BOBasePage {
    * @returns {Promise<string>}
    */
   async deleteProduct(page: Page): Promise<string> {
+    await this.waitForSelectorAndClick(page, this.footerProductDropDown);
     await this.waitForSelectorAndClick(page, this.deleteProductButton);
     await this.waitForVisibleSelector(page, this.deleteProductFooterModal);
     await this.clickAndWaitForNavigation(page, this.deleteProductSubmitButton);
@@ -211,6 +216,7 @@ class CreateProduct extends BOBasePage {
    * @returns {Promise<boolean>}
    */
   async clickOnNewProductButton(page: Page): Promise<boolean> {
+    await this.waitForSelectorAndClick(page, this.footerProductDropDown);
     await this.waitForSelectorAndClick(page, this.newProductButton);
 
     return this.elementVisible(page, productsPage.modalCreateProduct, 1000);
@@ -222,6 +228,7 @@ class CreateProduct extends BOBasePage {
    * @returns {Promise<string>}
    */
   async duplicateProduct(page: Page): Promise<string> {
+    await this.waitForSelectorAndClick(page, this.footerProductDropDown);
     await this.waitForSelectorAndClick(page, this.duplicateProductButton);
 
     await this.waitForSelectorAndClick(page, this.duplicateProductFooterModalConfirmSubmit);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Improve footer display (buttons in dropdown), along with better management of disabled buttons and also better display of the footer depending on the Symfony debug toolbar
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | In product page V2, check that most of the buttons are now displayed in a dropdown but they should still work as previously.
| Fixed ticket?     | Fixes #31586
| Related PRs       | ~
| Sponsor company   | ~
