### PR TITLE
Fix sitemap url conflict, allow using the hook with fallbacks

### DIFF
--- a/controllers/front/SitemapController.php
+++ b/controllers/front/SitemapController.php
@@ -35,7 +35,7 @@ class SitemapControllerCore extends FrontController
      */
     public function initContent()
     {
-        $urls = [
+        $sitemapUrls = [
             'our_offers' => [
                 'name' => $this->trans('Our Offers', [], 'Shop.Theme.Global'),
                 'links' => $this->getOffersLinks(),
@@ -55,34 +55,12 @@ class SitemapControllerCore extends FrontController
         ];
 
         /*
-         * Backward compatibility with older themes.
-         * Intentionally not modifiable by a hook, so somebody doesn't remove a group completely.
-         * (this would break the theme relying on the var on being there)
-         * This should be removed as soon as possible, because $pages variable is overwriting
-         * our global template variable assigned in FrontController.
-         */
-        $this->context->smarty->assign(
-            [
-                'our_offers' => $urls['our_offers']['name'],
-                'categories' => $urls['categories']['name'],
-                'your_account' => $urls['your_account']['name'],
-                'pages' => $urls['pages']['name'],
-                'links' => [
-                    'offers' => $urls['our_offers']['links'],
-                    'pages' => $urls['pages']['links'],
-                    'user_account' => $urls['your_account']['links'],
-                    'categories' => $urls['categories']['links'],
-                ],
-            ]
-        );
-
-        /*
          * Allows modules to add own urls (even whole new groups) to frontend sitemap.
          * For example landing pages, blog posts and others.
          */
         Hook::exec(
             'actionModifyFrontendSitemap',
-            ['urls' => &$urls],
+            ['urls' => &$sitemapUrls],
             null,
             false,
             true,
@@ -91,7 +69,27 @@ class SitemapControllerCore extends FrontController
             true
         );
 
-        $this->context->smarty->assign('urls', $urls);
+        /*
+         * Backward compatibility with older themes.
+         * This should be removed as soon as possible, because $pages variable is overwriting
+         * our global template variable assigned in FrontController.
+         */
+        $this->context->smarty->assign(
+            [
+                'our_offers' => !empty($sitemapUrls['our_offers']['name']) ? $sitemapUrls['our_offers']['name'] : '',
+                'categories' => !empty($sitemapUrls['categories']['name']) ? $sitemapUrls['categories']['name'] : '',
+                'your_account' => !empty($sitemapUrls['your_account']['name']) ? $sitemapUrls['your_account']['name'] : '',
+                'pages' => !empty($sitemapUrls['pages']['name']) ? $sitemapUrls['pages']['name'] : '',
+                'links' => [
+                    'offers' => !empty($sitemapUrls['our_offers']['links']) ? $sitemapUrls['our_offers']['links'] : [],
+                    'pages' => !empty($sitemapUrls['pages']['links']) ? $sitemapUrls['pages']['links'] : [],
+                    'user_account' => !empty($sitemapUrls['your_account']['links']) ? $sitemapUrls['your_account']['links'] : [],
+                    'categories' => !empty($sitemapUrls['categories']['links']) ? $sitemapUrls['categories']['links'] : [],
+                ],
+            ]
+        );
+
+        $this->context->smarty->assign('sitemapUrls', $sitemapUrls);
         parent::initContent();
         $this->setTemplate('cms/sitemap');
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           |  8.1.x
| Description?      | This PR fixes a mistake in my previous PR https://github.com/PrestaShop/PrestaShop/pull/29797. I have put all sitemap links into a single variable that can be modified by a hook, instead passing 8 separater variables. But, I found out that the new `$urls` variable is overriden by `FrontController`, so I needed to change the name. Also, I found a better way to assign the fallbacks, they can now also take advantage of the new logic.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no - 8.1 was not yet released and I don't change the hook naming
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/31619
| Related PRs       | 
| Sponsor company   | 

### How to test $urls conflict
`{dump($sitemapUrls)}` in `/themes/theme/templates/cms/sitemap.tpl` and see that it now contains proper links. Without this PR, if you dumped `{dump($urls)}`, they contained something else than those 4 sitemap link groups.

### How to test ability to remove a group without an error
Try to `unset($sitemapUrls['categories']);` in `SitemapController` after `$sitemapUrls = [...` and see that if you check sitemap page in FO, you don't get an error but a blank column.