### PR TITLE
Enable Order Creation in BO with a virtual product and a customer add…

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
@@ -84,6 +84,7 @@ export interface CartShipping {
   giftMessage: string;
   recycledPackaging: boolean;
   selectedCarrierId: number | null | string;
+  virtual: boolean;
 }
 
 export interface CartSummary {
@@ -732,6 +733,9 @@ export default class CreateOrderPage {
 
     $(createOrderMap.cartBlock).removeClass('d-none');
     $(createOrderMap.cartBlock).data('cartId', cartInfo.cartId);
+    if(cartInfo.shipping.virtual){
+      $(createOrderMap.shippingBlock).addClass('d-none');
+    }
   }
 
   /**

--- a/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create/create-order-page.ts
@@ -733,7 +733,7 @@ export default class CreateOrderPage {
 
     $(createOrderMap.cartBlock).removeClass('d-none');
     $(createOrderMap.cartBlock).data('cartId', cartInfo.cartId);
-    if(cartInfo.shipping.virtual){
+    if (cartInfo.shipping.virtual) {
       $(createOrderMap.shippingBlock).addClass('d-none');
     }
   }

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -390,7 +390,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
     private function fetchCartDeliveryOptions(array $deliveryOptionsByAddress, int $deliveryAddressId)
     {
         $deliveryOptions = [];
-        if(empty($deliveryOptionsByAddress)){
+        if (empty($deliveryOptionsByAddress)) {
             return $deliveryOptions;
         }
         // legacy multishipping feature allowed to split cart shipping to multiple addresses.

--- a/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
+++ b/src/Adapter/Cart/QueryHandler/GetCartForOrderCreationHandler.php
@@ -359,7 +359,7 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
         $deliveryAddress = (int) $cart->id_address_delivery;
 
         //Check if there is any delivery options available for cart delivery address
-        if (!array_key_exists($deliveryAddress, $deliveryOptionsByAddress)) {
+        if (!array_key_exists($deliveryAddress, $deliveryOptionsByAddress) && !$cart->isVirtualCart()) {
             return null;
         }
 
@@ -374,7 +374,8 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
             (int) $carrier->id ?: $this->defaultCarrierId ?: null,
             (bool) $cart->gift,
             (bool) $cart->recyclable,
-            $cart->gift_message
+            $cart->gift_message,
+            $cart->isVirtualCart()
         );
     }
 
@@ -389,6 +390,9 @@ final class GetCartForOrderCreationHandler extends AbstractCartHandler implement
     private function fetchCartDeliveryOptions(array $deliveryOptionsByAddress, int $deliveryAddressId)
     {
         $deliveryOptions = [];
+        if(empty($deliveryOptionsByAddress)){
+            return $deliveryOptions;
+        }
         // legacy multishipping feature allowed to split cart shipping to multiple addresses.
         // now when the multishipping feature is removed
         // the list of carriers should be shared across whole cart for single delivery address

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartShipping.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartShipping.php
@@ -69,7 +69,7 @@ class CartShipping
     /**
      * @var bool
      */
-    private $isVirtual;    
+    private $isVirtual;
 
     /**
      * @param string $shippingPrice
@@ -163,5 +163,5 @@ class CartShipping
     public function isVirtual(): bool
     {
         return $this->isVirtual;
-    }    
+    }
 }

--- a/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartShipping.php
+++ b/src/Core/Domain/Cart/QueryResult/CartForOrderCreation/CartShipping.php
@@ -67,6 +67,11 @@ class CartShipping
     private $giftMessage;
 
     /**
+     * @var bool
+     */
+    private $isVirtual;    
+
+    /**
      * @param string $shippingPrice
      * @param bool $freeShipping
      * @param CartDeliveryOption[] $deliveryOptions
@@ -74,6 +79,7 @@ class CartShipping
      * @param bool $isGift
      * @param bool $isRecycledPackaging
      * @param string $giftMessage
+     * @param bool $isVirtual
      */
     public function __construct(
         string $shippingPrice,
@@ -82,7 +88,8 @@ class CartShipping
         ?int $selectedCarrierId,
         bool $isGift,
         bool $isRecycledPackaging,
-        string $giftMessage
+        string $giftMessage,
+        bool $isVirtual
     ) {
         $this->shippingPrice = $shippingPrice;
         $this->freeShipping = $freeShipping;
@@ -91,6 +98,7 @@ class CartShipping
         $this->isGift = $isGift;
         $this->isRecycledPackaging = $isRecycledPackaging;
         $this->giftMessage = $giftMessage;
+        $this->isVirtual = $isVirtual;
     }
 
     /**
@@ -148,4 +156,12 @@ class CartShipping
     {
         return $this->giftMessage;
     }
+
+    /**
+     * @return bool
+     */
+    public function isVirtual(): bool
+    {
+        return $this->isVirtual;
+    }    
 }


### PR DESCRIPTION
…ress that is from a Country that is not served by any carrier.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | In the front office customers can complete orders for digital products even if their address country is not served by any carrier, it just requires to the country to be enabled. When triying to do the same in the BO you are unable to create the order.
| Type?             | bug fix 
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     |  no
| How to test?      | Go to Orders  - Click Add new order - Select customer - select/add an address which uses the country THAT IS NOT SERVED BY ANY CARRIER.  - Add a virtual product to the order - you should be able to proceed with the order creation
| Fixed ticket?     | Fixes #31594

