### PR TITLE
Fix Sanity Product V2 tests blocking CI

### DIFF
--- a/.github/workflows/sanity-productV2.yml
+++ b/.github/workflows/sanity-productV2.yml
@@ -1,6 +1,7 @@
 name: UI tests Product V2
 on:
   pull_request:
+    # This list must be synced with the one in skip-sanity-productV2.yml
     paths:
       - .github/workflows/sanity-productV2.yml
       - tests/UI/campaigns/productV2/**
@@ -9,7 +10,7 @@ on:
       - src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/**
       - src/Core/Domain/Product/**
       - src/Adapter/Product/**
-      - src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/**
+      - src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product
 concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sanity-productV2.yml
+++ b/.github/workflows/sanity-productV2.yml
@@ -10,7 +10,7 @@ on:
       - src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/**
       - src/Core/Domain/Product/**
       - src/Adapter/Product/**
-      - src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product
+      - src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/**
 concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/skip-sanity-productV2.yml
+++ b/.github/workflows/skip-sanity-productV2.yml
@@ -12,7 +12,12 @@ on:
       - src/Adapter/Product/**
       - src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/**
 jobs:
-  build:
+  sanity_product_v2:
     runs-on: ubuntu-latest
+    name: Sanity Product V2
+    strategy:
+      matrix:
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+      fail-fast: false
     steps:
       - run: 'echo "Not required"'

--- a/.github/workflows/skip-sanity-productV2.yml
+++ b/.github/workflows/skip-sanity-productV2.yml
@@ -1,0 +1,18 @@
+name: UI tests Product V2
+on:
+  pull_request:
+    # This list must be synced with the one in sanity-productV2.yml
+    paths-ignore:
+      - .github/workflows/sanity-productV2.yml
+      - tests/UI/campaigns/productV2/**
+      - admin-dev/themes/new-theme/js/pages/product/**
+      - src/PrestaShopBundle/Form/Admin/Sell/Product/**
+      - src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/**
+      - src/Core/Domain/Product/**
+      - src/Adapter/Product/**
+      - src/PrestaShopBundle/Resources/views/Admin/Sell/Catalog/Product/**
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required"'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixing CI for PRs blocked by Sanity Product V2 tests
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI should be green.
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA

Issue and fix described here : https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks