### PR TITLE
CI : Nightly : Force the push of reports even if there are jobs in error

### DIFF
--- a/.github/workflows/cron_nightly_tests_reusable.yml
+++ b/.github/workflows/cron_nightly_tests_reusable.yml
@@ -193,11 +193,12 @@ jobs:
       - name: Upload to Google Cloud Storage (GCS)
         run: gsutil cp -r "${{ env.COMBINED_REPORT_DIR }}/**" gs://prestashop-core-nightly/reports
 
-  # Add pushed reports to GCp on nightly
+  # Add pushed reports to GCP on nightly
   push-nightly-reports:
     permissions:
       contents: none
     name: Push reports to nightly.prestashop.com
+    if: ${{ always() }}
     needs:
       - merge-upload-reports
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | CI : Nightly : Force the push of reports even if there are jobs in error
| Type?             | bug fix
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | N/A
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp
