### PR TITLE
Do not interfere with PDF files

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -2516,11 +2516,6 @@ class ToolsCore
 	<FilesMatch \"\.(ttf|ttc|otf|eot|woff|woff2|svg)$\">
 		Header set Access-Control-Allow-Origin \"*\"
 	</FilesMatch>
-
-    <FilesMatch \"\.pdf$\">
-      Header set Content-Disposition \"Attachment\"
-      Header set X-Content-Type-Options \"nosniff\"
-    </FilesMatch>
 </IfModule>\n\n");
         fwrite($write_fd, '<Files composer.lock>
     # Apache 2.2

--- a/upload/.htaccess
+++ b/upload/.htaccess
@@ -1,3 +1,10 @@
+<IfModule mod_headers.c>
+    <FilesMatch "\.pdf$">
+      Header set Content-Disposition "Attachment"
+      Header set X-Content-Type-Options "nosniff"
+    </FilesMatch>
+</IfModule>
+
 <IfModule !mod_rewrite.c>
   # Apache 2.2
   <IfModule !mod_authz_core.c>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | There was a security "thing" that forced PDF file downloads instead of opening it in browser. This could be good for securing public - uploaded PDFs, but not the ones from merchant. I removed adding this rule to the global root `.htaccess` and added it only to `uploads/.htaccess`, where all these uploads go.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See below
| Fixed ticket?     | Fixes #31602
| Related PRs       | 
| Sponsor company   | 

### Research - user untrusted file uploads
- Message attachments (orderd detail and contact page) - PS_UPLOAD_DIR
- Product customizations - PS_UPLOAD_DIR

### How to test
- _Should be probably tested by a developer, @Robin-Fischer-PS what do you think?
- Clone this.
- Regenerate htaccess file by saving any page meta configuration or delete this bit of rules from htaccess.
- Copy any pdf file to root directory of prestashop and try to open it in browser, it will respect settings of your browser and probably display it, instead of forcing download of the file.
- Copy any pdf file to /uploads directory and try to open it in browser. Should be forced downloaded.

### Disclaimer
It behaves in a weird way sometimes. I am using XAMPP on Windows and either Apache or Chrome is caching it.
- I have a `aaa.pdf` in my prestashop root. When I access it in browser, it downloads. 
- Then I delete the rule from `.htaccess`.
- When I access `aaa.pdf` again, it's still downloading instead of displaying.
- When I rename `aaa.pdf` to `bbb.pdf` and access it, it opens in browser.
- BUT, when I access `aaa.pdf` I still get it and it gets downloaded, even though it doesnt exist anymore. :-) 🤷‍♂️