### PR TITLE
Update db_structure.sql because it's cleaner

### DIFF
--- a/install-dev/data/db_structure.sql
+++ b/install-dev/data/db_structure.sql
@@ -29,6 +29,9 @@ CREATE TABLE `PREFIX_address` (
   `other` text,
   `phone` varchar(32) DEFAULT NULL,
   `phone_mobile` varchar(32) DEFAULT NULL,
+  /* @TODO : Because it is more cleaner than stuffing it all into DNI that is not (SIRET OR APE) And EU kvk numbers maby 15? The idear is given but never implemented. */
+  `siret` varchar(15) DEFAULT NULL,
+  `ape` varchar(5) DEFAULT NULL,
   `vat_number` varchar(32) DEFAULT NULL,
   `dni` varchar(16) DEFAULT NULL,
   `date_add` datetime NOT NULL,
@@ -612,8 +615,10 @@ CREATE TABLE `PREFIX_customer` (
   `id_lang` int(10) unsigned NULL,
   `id_risk` int(10) unsigned NOT NULL DEFAULT '1',
   `company` varchar(255),
-  `siret` varchar(14),
+ /* @TODO : make it clean and EU ( Like KVK and Chamber of comm etc numbers )   */
+  `siret` varchar(15),
   `ape` varchar(5),
+  `vat_number` varchar(35),
   `firstname` varchar(255) NOT NULL,
   `lastname` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL,
@@ -1249,6 +1254,7 @@ CREATE TABLE `PREFIX_orders` (
   `round_mode` tinyint(1) NOT NULL DEFAULT '2',
   `round_type` tinyint(1) NOT NULL DEFAULT '1',
   `invoice_number` int(10) unsigned NOT NULL DEFAULT '0',
+/* @TODO : Make under invoice_number or invoice_date the store_Siret and store_vat_number or some were under with store info */
   `delivery_number` int(10) unsigned NOT NULL DEFAULT '0',
   `invoice_date` datetime NOT NULL,
   `delivery_date` datetime NOT NULL,
@@ -1286,6 +1292,7 @@ CREATE TABLE `PREFIX_order_detail_tax` (
 CREATE TABLE `PREFIX_order_invoice` (
   `id_order_invoice` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
   `id_order` int(11) NOT NULL,
+/* @TODO : Make under invoice_number or invoice_date the store_Siret and store_vat_number or some were under with store info */
   `number` int(11) NOT NULL,
   `delivery_number` int(11) NOT NULL,
   `delivery_date` datetime,
@@ -2116,6 +2123,11 @@ CREATE TABLE `PREFIX_store` (
   `longitude` decimal(13, 8) DEFAULT NULL,
   `phone` varchar(16) DEFAULT NULL,
   `fax` varchar(16) DEFAULT NULL,
+/* @TODO : Make siret -ape- vat_number avalable in store info. because note is not same and DNI or what you call it is not all the same. */
+  `siret` varchar(14) DEFAULT NULL,
+  `ape` varchar(5) DEFAULT NULL,
+  `vat_number` varchar(34) DEFAULT NULL,
+  `IBAN` varchar(34) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
   `active` tinyint(1) unsigned NOT NULL DEFAULT '0',
   `date_add` datetime NOT NULL,
@@ -2129,6 +2141,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_store_lang` (
   `name` varchar(255) NOT NULL,
   `address1` varchar(255) NOT NULL,
   `address2` varchar(255) DEFAULT NULL,
+/* @TODO : OR here if you want? Make siret -ape- avalable in store info. because note is not same and DNI or what you call it is not all the same. */
   `hours` text,
   `note` text,
   PRIMARY KEY (`id_store`, `id_lang`)


### PR DESCRIPTION
Update db_structure.sql because it's cleaner and clear what what is. Siret = Siret Ape =Ape  vat_number = vat_number  DNI=DNI and IBAN=IBAN and don't sell prestashop short by stuffing it all into DNI. or Siret or even vat into siret??? No let''s keep a clean shop and don't put it into a box in the corner of the shop. Because the are people and corporations also looking and the see it or see the box's in the shop laying around.


| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 8.0.x
| Description?      | Editing Siret and Ape and Vat and Iban and at last DNI. Because now it stuffed into sometimes all in 1. It''s clear what , what is and you can also translate better. 
| Type?             | improvement / new feature / 
| Category?         | FO / BO / DB
| BC breaks?        |  no
| Deprecations?     |  no
| How to test?      | Because a testes it in 8.0 and in 1.7.8.8 by changing only this and the shop / store works as there is no problem but had to make translations because it's clear what what is. but every body can do this in BO. Because it is automated. 
| Fixed ticket?     | 
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related . It''s upgradable if you take it into the SQL or update installation. because it's the hole installation of database.  Like i did the test by 8.0 and update came 8.0.1 and poef a had to manual go to phpmyadmin and insert the rows. and it works again. 
------------------------------------------------------------------------------------------------------------------------------------
BO (back office) 

![Store information](https://user-images.githubusercontent.com/124369064/222849497-0a68dad0-e79a-4dea-9e4f-4dcd164b6e6c.jpg)

-------------------------------------------------------------------------------------------------------------------------------------------
FO (front Office)  Left is [Contact us] store information that you click by footer. Middel is all page''s and right is also by footer if you open [Stores] Is it not nice and even translated. You can translate to all over the world and the know what what is. and not like must i give my id number. I will buy some where els. !

![Store information front](https://user-images.githubusercontent.com/124369064/222849550-af38d64b-5c8e-4caa-b573-4fff20e38508.jpg)

-----------------------------------------------------------------------------------------------------------------------------------

FR: APE Use in (presta shop like fo )
  
EN: Principal Business Activity 
NL: NACE-code (Nomenclature of Economic Activities) of SBI-code:Standaard Bedrijfsindeling
IT: Attività Principale dell'Impresa
SP: APE "CNAE" (Clasificación Nacional de Actividades Económicas).
DE: APE "NACE" "Klassifikation der Wirtschaftszweige" or "Wirtschaftszweigsystematik"


EN: VAT number (Value Added Tax number) (used FO in Prestashop B2B ) 
NL: Btw-nummer
DE: USt-IdNr. (Umsatzsteuer-Identifikationsnummer)
FR: Numéro de TVA (Numéro d'identification fiscale)
IT: Partita IVA (Partita Identificazione Fiscale)
SP: Número de IVA (Número de identificación fiscal)

FR: Siret  ( also FO in presta   but a little edit in BO by note like trow here your junk why should a B2B shop only have the costumer DNI because somewhere it''s all cooperated to DNI)
FR: Siret  
NL: KvK nummer
German: Handelskammer-Nummer
English: Chamber of Commerce number
French: numéro de la Chambre de commerce
Italian: numero della Camera di Commercio
Spanish: número de la Cámara de Comercio


SP: DNI   (it''s spanis in FO) 
In Dutch, "Nationaal identiteitsbewijs".BSN-nummer: 
In German, "Personalausweis".
In English, "National identity card".
In French, "Carte nationale d'identité".
In Italian, "Carta d'identità".
In Spanish, "Documento Nacional de Identidad".

(Not in prestashop but if we are writing why not show your company IBAN?) 
Dutch: Bankrekeningnummer (IBAN ):
German: Bankkontonummer (IBAN ):
English: Bank Account Number (IBAN ):
French: Numéro de compte bancaire (IBAN ):
Italian: Numero di conto bancario (IBAN ):
Spanish: Número de cuenta bancaria (IBAN ):

===================================================================

So to sum up. many is used only FO for regristration. But why doesn''t the store / Shop have a place to show it''s Siret? Ape? vat? Iban?  in FO or invoice or to input in BO?? Let''s keep it simple. it was also a simple extra editing in some place's. 

