### PR TITLE
Prevent email enumeration

### DIFF
--- a/classes/Employee.php
+++ b/classes/Employee.php
@@ -317,7 +317,8 @@ class EmployeeCore extends ObjectModel
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($sql);
         if (!$result) {
-            return false;
+            // Create fake result to make sure computing time does not allow password enumeration
+            $result = ['passwd' => '123456'];
         }
 
         /** @var Hashing $crypto */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | On the BO login page, it is possible to find out if the email of an employee is registered. It can be done by looking at the response time of the POST request.<br/>On my end I got the following result:<br/>Average time if email does not exist: ~0.31<br/>Average time if email exists: ~0.36
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | What this PR must achieve is that it must take the same time to execute the request with correct email as well as incorrect email.<br/>Please test that trying to login on BO with an email that belongs to a registered employee and with an email that does not exist is almost the same. The average time difference must about the same.<br/>You can check the response time by this command: `curl -w %{time_total} -s -X POST http://localhost/prestashop/admin-dev/index.php -d 'ajax=1&token=&controller=AdminLogin&submitLogin=1&passwd=demodemo&email=demo%40demo.com' -o /dev/null`
| Fixed ticket?     | ~
| Related PRs       | 
| Sponsor company   | ~