### PR TITLE
Take locale into account when deciding whether module translation should fall back to the legacy system

### DIFF
--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -62,7 +62,7 @@ trait PrestaShopTranslatorTrait
             $locale = null;
         }
 
-        if ($this->shouldFallbackToLegacyModuleTranslation($id, $domain)) {
+        if ($this->shouldFallbackToLegacyModuleTranslation($id, $domain, $locale)) {
             return $this->translateUsingLegacySystem($id, $parameters, $domain, $locale);
         }
 
@@ -171,16 +171,17 @@ trait PrestaShopTranslatorTrait
      *
      * @param string $message Message to translate
      * @param ?string $domain Translation domain
+     * @param ?string $locale Translation locale
      *
      * @return bool
      */
-    private function shouldFallbackToLegacyModuleTranslation(string $message, ?string $domain): bool
+    private function shouldFallbackToLegacyModuleTranslation(string $message, ?string $domain, ?string $locale): bool
     {
         return
             'Modules.' === substr($domain ?? '', 0, 8)
             && (
                 !method_exists($this, 'getCatalogue')
-                || !$this->getCatalogue()->has($message, $this->normalizeDomain($domain))
+                || !$this->getCatalogue($locale)->has($message, $this->normalizeDomain($domain))
             )
             ;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Locale (if given) isn't currently taken into account when checking whether the translation catalog contains a given message, so the translation has to exist in both the desired and the default language for the string to be translated.
| Type?             | bug fix
| Category?         | LO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See steps in ticket
| Fixed ticket?     | Fixes #31665
| Sponsor company   | Vilkas Group

I think that this issue was previously mitigated by the `$message === $translated` check which was removed in https://github.com/PrestaShop/PrestaShop/pull/29584, which is why locale overrides used to work in previous versions of PrestaShop. The translator would attempt to translate the string once, and then compare it to the original message. Since the strings wouldn't be equal, the system would never fall back to the legacy translation system.

Currently the system just checks whether the translation catalogue for the default locale contains the message, but that's not where we're supposed to look, since the message might not be translated in the default language at all (if a module just uses the translation keys themselves for the default translations, for example).

Also, how would one go about creating tests for this scenario in the future? The test suite only installs one language in the database, but I think testing this would require two.