### PR TITLE
Fix default value behavior in `Tools::getValue`

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -463,7 +463,7 @@ class ToolsCore
             $value = static::$fallbackParameters[$key];
         }
 
-        if (!isset($value)) {
+        if (empty($value)) {
             $value = $default_value;
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix `Tools::getValue` to retrieve default_value properly when value is set but empty.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31570 
| Fixed ticket?     | Fixes #31570
| Related PRs       | #31571
| Sponsor company   | 

In fact, first of all we have some issue with our `Tools::getValue` when we need a default value. 
When we go to `/cart?...&qty=` qty is set but empty and default value isn't set as value, but if we omit `qty` in request default value is set.

And with `abs` function:
```<?php
var_dump(abs(12));	// int(12)
var_dump(abs("12"));	// int(12)
var_dump(abs(false));	// int(0)
var_dump(abs(""));	// PHP 7.4: int(0)
			// PHP 8.X: Fatal error: must be of type int|float...
```
So with `abs` function and default value set, no need to cast into int !
What do you think about this solution @lmeyer1 ?