### PR TITLE
Add `_legacy_feature_flag` for customer threads routes

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/customer_threads.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/customer_threads.yml
@@ -17,6 +17,7 @@ admin_customer_threads_filter:
     gridDefinitionFactoryServiceId: prestashop.core.grid.definition.factory.customer_thread
     redirectRoute: admin_customer_threads
     _legacy_controller: AdminCustomerThreads
+    _legacy_feature_flag: customer_threads
 
 admin_customer_threads_view:
   path: /{customerThreadId}/view
@@ -27,6 +28,7 @@ admin_customer_threads_view:
     _legacy_parameters:
       id_customer_thread: customerThreadId
     _legacy_link: AdminCustomerThreads:viewcustomer_thread
+    _legacy_feature_flag: customer_threads
   requirements:
     customerThreadId: \d+
   options:

--- a/tests/UI/campaigns/functional/BO/05_customerService/01_customerService/01_viewCustomerService.ts
+++ b/tests/UI/campaigns/functional/BO/05_customerService/01_customerService/01_viewCustomerService.ts
@@ -121,7 +121,7 @@ describe('BO - Customer Service : View messages', async () => {
     const text = await viewPage.getCustomerMessage(page);
     expect(text).to.contains(contactUsData.emailAddress);
     expect(text).to.contains(contactUsData.subject);
-    expect(text).to.contains(`${messageDateTime.substr(0, 10)} access_time - ${messageDateTime.substr(11, 5)}`);
+    expect(text).to.contains(`${messageDateTime.substr(0, 10)} - ${messageDateTime.substr(11, 5)}`);
     expect(text).to.contains('Attachment');
     expect(text).to.contains(contactUsData.message);
   });
@@ -143,7 +143,7 @@ describe('BO - Customer Service : View messages', async () => {
 
     const text = await viewPage.getOrdersAndMessagesTimeline(page);
     expect(text).to.contains('Orders and messages timeline');
-    expect(text).to.contains(`${messageDateTime.substr(0, 10)} access_time ${messageDateTime.substr(11, 5)}`);
+    expect(text).to.contains(`${messageDateTime.substr(0, 10)} - ${messageDateTime.substr(11, 5)}`);
     expect(text).to.contains(`Message to: ${contactUsData.subject}`);
     expect(text).to.contains(contactUsData.message);
   });

--- a/tests/UI/campaigns/functional/BO/15_header/08_checkNotifications.ts
+++ b/tests/UI/campaigns/functional/BO/15_header/08_checkNotifications.ts
@@ -14,6 +14,7 @@ import foLoginPage from '@pages/FO/login';
 import foMyAccountPage from '@pages/FO/myAccount';
 import foOrderHistoryPage from '@pages/FO/myAccount/orderHistory';
 import orderDetails from '@pages/FO/myAccount/orderDetails';
+import customerServicePage from '@pages/BO/customerService/customerService';
 import viewOrderMessagePage from '@pages/BO/customerService/orderMessages/add';
 import orderPageTabListBlock from '@pages/BO/orders/view/tabListBlock';
 import viewCustomerPage from '@pages/BO/customers/view';
@@ -211,8 +212,8 @@ describe('BO - Header : Check notifications', async () => {
 
       await dashboardPage.clickOnNotification(page, 'messages');
 
-      const pageTitle = await viewOrderMessagePage.getPageTitle(page);
-      await expect(pageTitle).to.contains(viewOrderMessagePage.pageTitleView);
+      const pageTitle = await customerServicePage.getPageTitle(page);
+      await expect(pageTitle).to.contains(customerServicePage.pageTitle);
     });
   });
 

--- a/tests/UI/campaigns/functional/FO/05_contactUs/04_addAttachment.ts
+++ b/tests/UI/campaigns/functional/FO/05_contactUs/04_addAttachment.ts
@@ -174,10 +174,11 @@ describe('FO - Contact us : Add attachment', async () => {
     await expect(badgeNumber).to.contains(idCustomer);
 
     const text = await viewPage.getCustomerMessage(page);
+    console.log(text);
     expect(text)
       .to.contains(contactUsData.emailAddress)
       .and.to.contains(contactUsData.subject)
-      .and.to.contains(`${messageDateTime.substr(0, 10)} access_time - ${messageDateTime.substr(11, 5)}`)
+      .and.to.contains(`${messageDateTime.substr(0, 10)} - ${messageDateTime.substr(11, 5)}`)
       .and.to.contains('Attachment')
       .and.to.contains(contactUsData.message);
   });

--- a/tests/UI/campaigns/functional/FO/05_contactUs/04_addAttachment.ts
+++ b/tests/UI/campaigns/functional/FO/05_contactUs/04_addAttachment.ts
@@ -174,7 +174,6 @@ describe('FO - Contact us : Add attachment', async () => {
     await expect(badgeNumber).to.contains(idCustomer);
 
     const text = await viewPage.getCustomerMessage(page);
-    console.log(text);
     expect(text)
       .to.contains(contactUsData.emailAddress)
       .and.to.contains(contactUsData.subject)

--- a/tests/UI/campaigns/productV2/sanity/03_CRUDProductWithCombinations.ts
+++ b/tests/UI/campaigns/productV2/sanity/03_CRUDProductWithCombinations.ts
@@ -184,7 +184,6 @@ describe('BO - Catalog - Products : CRUD product with combinations', async () =>
       ]);
 
       const productAttributes = await foProductPage.getProductAttributes(page);
-      console.log(result);
       await Promise.all([
         // color
         await expect(productAttributes[0].value).to.equal(newProductData.attributes[1].values.join(' ')),

--- a/tests/UI/pages/BO/customerService/customerService/view.ts
+++ b/tests/UI/pages/BO/customerService/customerService/view.ts
@@ -16,7 +16,7 @@ class ViewCustomer extends BOBasePage {
 
   private readonly attachmentLink: string;
 
-  private readonly statusButton: (statusName: string) => string;
+  private readonly statusButton: (statusID: number) => string;
 
   private readonly yourAnswerFormTitle: string;
 
@@ -31,16 +31,16 @@ class ViewCustomer extends BOBasePage {
   constructor() {
     super();
 
-    this.pageTitle = `View • ${global.INSTALL.SHOP_NAME}`;
+    this.pageTitle = 'Customer Service > View •';
 
     // Selectors
-    this.threadBadge = '#main-div div[data-role="messages-thread"] .card-header strong';
-    this.messagesThredDiv = '#main-div div[data-role="messages-thread"]';
+    this.threadBadge = 'span.badge';
+    this.statusButton = (statusID: number) => `button[name='setstatus'][value='${statusID}']`;
+    this.messagesThredDiv = '#content div.message-item-initial';
+    this.yourAnswerFormTitle = '#reply-form-title';
+    this.yourAnswerFormTextarea = '#reply_message';
+    this.ordersAndMessagesBlock = '#orders-and-messages-block';
     this.attachmentLink = `${this.messagesThredDiv} a[href*='/upload']`;
-    this.statusButton = (statusName: string) => `${this.messagesThredDiv} form input[value='${statusName}'] + button`;
-    this.yourAnswerFormTitle = '#main-div div[data-role="employee-answer"] h3.card-header';
-    this.yourAnswerFormTextarea = '#reply_to_customer_thread_reply_message';
-    this.ordersAndMessagesBlock = '#main-div div[data-role="messages_timeline"]';
   }
 
   /*
@@ -111,35 +111,35 @@ class ViewCustomer extends BOBasePage {
    * @returns {Promise<string>}
    */
   async setStatus(page: Page, status: string): Promise<string> {
-    let statusName: string;
+    let statusID: number = 0;
 
     switch (status) {
       case 'Re-open':
-        statusName = 'open';
+        statusID = 1;
         break;
 
       case 'Handled':
-        statusName = 'closed';
+        statusID = 2;
         break;
 
       case 'Pending 1':
-        statusName = 'pending1';
+        statusID = 3;
         break;
 
       case 'Pending 2':
-        statusName = 'pending2';
+        statusID = 4;
         break;
 
       default:
         throw new Error(`Status ${status} was not found`);
     }
 
-    await this.waitForSelectorAndClick(page, this.statusButton(statusName));
+    await this.waitForSelectorAndClick(page, this.statusButton(statusID));
 
     if (status === 'Re-open') {
-      return this.getTextContent(page, this.statusButton('closed'));
+      return this.getTextContent(page, this.statusButton(2));
     }
-    return this.getTextContent(page, this.statusButton('open'));
+    return this.getTextContent(page, this.statusButton(1));
   }
 }
 

--- a/tests/UI/pages/BO/customerService/customerService/view.ts
+++ b/tests/UI/pages/BO/customerService/customerService/view.ts
@@ -40,7 +40,7 @@ class ViewCustomer extends BOBasePage {
     this.yourAnswerFormTitle = '#reply-form-title';
     this.yourAnswerFormTextarea = '#reply_message';
     this.ordersAndMessagesBlock = '#orders-and-messages-block';
-    this.attachmentLink = `${this.messagesThredDiv} a[href*='/upload']`;
+    this.attachmentLink = `${this.messagesThredDiv} span.message-product a`;
   }
 
   /*


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix redirect to new symfony controller for customer threads if `customer_threads` flag is disabled.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31377 
| Fixed ticket?     | Fixes #31377 
| Related PRs       | 
| Sponsor company   | 
