### PR TITLE
Cast `featureId` into int to fix `InvalidFeatureIdException`

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -151,7 +151,7 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
         $featureForm->handleRequest($request);
 
         try {
-            $handlerResult = $featureFormHandler->handleFor($featureId, $featureForm);
+            $handlerResult = $featureFormHandler->handleFor((int) $featureId, $featureForm);
 
             if ($handlerResult->isSubmitted() && $handlerResult->isValid()) {
                 $this->addFlash('success', $this->trans('Successful update', 'Admin.Notifications.Success'));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | To fix `InvalidFeatureIdException` when we edit a feature in BO, we need to cast properly `$featureId` into `int`.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31572 
| Fixed ticket?     | Fixes #31572 
| Related PRs       | 
| Sponsor company   | 
