### PR TITLE
Add avif to htaccess allowed formats

### DIFF
--- a/img/.htaccess
+++ b/img/.htaccess
@@ -2,7 +2,7 @@
 <IfModule !mod_authz_core.c>
     Order deny,allow
     Deny from all
-    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp)$">
+    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|avif)$">
         Allow from all
     </Files>
 </IfModule>
@@ -10,7 +10,7 @@
 # Apache 2.4
 <IfModule mod_authz_core.c>
     Require all denied
-    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp)$">
+    <Files ~ "(?i)^.*\.(jpg|jpeg|gif|png|bmp|tiff|svg|pdf|mov|mpeg|mp4|avi|mpg|wma|flv|webm|ico|webp|avif)$">
         Require all granted
     </Files>
 </IfModule>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Adds avif to allowed file formats in `/img` folder. Generated AVIF thumbnails were not accessible and were throwing 403 forbidden errors.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Generate avif thumbnails, try to access it in FO, will work. Does not work without this PR. If you don't have access to AVIF enabled environment, just rename any jpg or webp thumbnail to avif and try to access it in your browser. @kpodemski will QA it.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 
