### PR TITLE
Add admin tabs hook

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2020,6 +2020,8 @@ class AdminControllerCore extends Controller
         }
 
         $tabs = $this->getTabs();
+        Hook::exec('adminTabs', ['tabs' => &$tabs], null, true);
+
         $currentTabLevel = 0;
         foreach ($tabs as $tab) {
             $currentTabLevel = isset($tab['current_level']) ? $tab['current_level'] : $currentTabLevel;
@@ -2119,7 +2121,7 @@ class AdminControllerCore extends Controller
         return $tips[$type][array_rand($tips[$type])];
     }
 
-    private function getTabs($parentId = 0, $level = 0)
+    public function getTabs($parentId = 0, $level = 0)
     {
         $tabs = Tab::getTabs($this->context->language->id, $parentId);
         $current_id = Tab::getCurrentParentId();

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2020,7 +2020,7 @@ class AdminControllerCore extends Controller
         }
 
         $tabs = $this->getTabs();
-        Hook::exec('adminTabs', ['tabs' => &$tabs], null, true);
+        Hook::exec('actionAdminMenuTabsModifier', ['tabs' => &$tabs], null, true);
 
         $currentTabLevel = 0;
         foreach ($tabs as $tab) {

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -2121,7 +2121,7 @@ class AdminControllerCore extends Controller
         return $tips[$type][array_rand($tips[$type])];
     }
 
-    public function getTabs($parentId = 0, $level = 0)
+    private function getTabs($parentId = 0, $level = 0)
     {
         $tabs = Tab::getTabs($this->context->language->id, $parentId);
         $current_id = Tab::getCurrentParentId();

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4494,5 +4494,10 @@
       <title>Modify customer thread grid template data</title>
       <description>This hook allows to modify data which is about to be used in template for customer thread grid</description>
     </hook>
+    <hook id="adminTabs">
+      <name>adminTabs</name>
+      <title>Modify admin tabs</title>
+      <description>This hook allows to modify admin tabs which is about to be used in template for user menu</description>
+    </hook>
   </entities>
 </entity_hook>

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4494,10 +4494,10 @@
       <title>Modify customer thread grid template data</title>
       <description>This hook allows to modify data which is about to be used in template for customer thread grid</description>
     </hook>
-    <hook id="adminTabs">
-      <name>adminTabs</name>
-      <title>Modify admin tabs</title>
-      <description>This hook allows to modify admin tabs which is about to be used in template for user menu</description>
+    <hook id="actionAdminMenuTabsModifier">
+      <name>actionAdminMenuTabsModifier</name>
+      <title>Modify back office menu</title>
+      <description>This hook allows modifying back office menu tabs</description>
     </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Hooks: Allow customizing the admin tabs for user menu
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You can test it using `ps_qualityassurance` module, all the details available below
| Fixed ticket?     | N/A
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/575
| Sponsor company   | @PrestaShopCorp

Using the ps_qualityassurance module

1. Register the `actionAdminMenuTabsModifier` hook and assign the `tabs` param:

```php
public function hookActionAdminMenuTabsModifier(array &$params): void
{
    array_pop($params['tabs']);
    array_pop($params['tabs']);
    array_pop($params['tabs']);
    array_pop($params['tabs']);
}
```

2. In the back-office, you should see only the `WELCOME` section. The code above has removed the menu entries we did not want.

---

PR for autoupgrade module: https://github.com/PrestaShop/autoupgrade/pull/575