### PR TITLE
Do not enable add to cart button if catalog mode is enabled

### DIFF
--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -621,18 +621,6 @@ class ProductLazyArray extends AbstractLazyArray
     }
 
     /**
-     * The "Add to cart" button should be shown for products available for order.
-     *
-     * @param array $product
-     *
-     * @return bool
-     */
-    private function shouldShowAddToCartButton(array $product): bool
-    {
-        return (bool) $product['available_for_order'];
-    }
-
-    /**
      * @param array $product
      *
      * @return bool

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -825,6 +825,16 @@ class ProductLazyArray extends AbstractLazyArray
             return false;
         }
 
+        // Disable because of catalog mode enabled in Prestashop settings
+        if ($this->settings->catalog_mode) {
+            return false;
+        }
+
+        // Disable because of "Available for order" checkbox unchecked in product settings
+        if ((bool) $product['available_for_order'] === false) {
+            return false;
+        }
+
         if (($product['customizable'] == 2 || !empty($product['customization_required']))) {
             $shouldEnable = false;
 
@@ -840,8 +850,7 @@ class ProductLazyArray extends AbstractLazyArray
             $shouldEnable = true;
         }
 
-        $shouldEnable = $shouldEnable && $this->shouldShowAddToCartButton($product);
-
+        // Disable because of stock management
         if ($settings->stock_management_enabled
             && !$product['allow_oosp']
             && ($product['quantity'] <= 0


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Add to cart button did not take catalog mode into consideration. Given we want to maybe ship hummingbird optionally with 8.1 and it has add to cart feature from product lists, this should be handled on the core side. @nizelg made a [PR for the theme](https://github.com/PrestaShop/hummingbird/pull/471), but it should not be theme's responsibility.
| Type?             | bug fix
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install hummingbird, enable catalog mode, add to cart buttons will disappear from product lists. Clear cache if they don't disappear from modules on homepage. You don't have to test anything other than product miniature and product page in front office. And focus only on product add to cart button and displaying of delivery time.
| Fixed ticket?     | Fixes https://github.com/PrestaShop/hummingbird/issues/455
| Related PRs       | 
| Sponsor company   | 

For reviewers - `$this->shouldShowAddToCartButton($product)` just returns `$product['available_for_order']`. It's A) a bad name for such a function and B) why the hell it should call a function to return one value.