### PR TITLE
Link to the "data transparency" page inside installer

### DIFF
--- a/install-dev/theme/views/license.php
+++ b/install-dev/theme/views/license.php
@@ -29,14 +29,28 @@
 <h2 id="licenses-agreement"><?php echo $this->translator->trans('License Agreements', [], 'Install'); ?></h2>
 <p><strong><?php echo $this->translator->trans('To enjoy the many features that are offered for free by PrestaShop, please read the license terms below. PrestaShop core is licensed under OSL 3.0, while the modules and themes are licensed under AFL 3.0.', [], 'Install'); ?></strong></p>
 <div style="height:200px; border:1px solid #ccc; margin-bottom:8px; padding:5px; background:#fff; overflow: auto; overflow-x:hidden; overflow-y:scroll;">
-  <?php echo $this->getTemplate('license_content'); ?>
+    <?php echo $this->getTemplate('license_content'); ?>
 </div>
 
-<div>
-  <input type="checkbox" id="set_license" class="required" name="licence_agrement" value="1" style="vertical-align: middle;float:left" <?php if ($this->session->licence_agrement) { ?>checked="checked"<?php } ?> />
-  <div style="float:left;width:600px;margin-left:8px">
-    <label for="set_license">
-      <strong><?php echo $this->translator->trans('I agree to the above terms and conditions.', [], 'Install'); ?></strong>
-    </label>
-  </div>
+<div class="clearfix">
+    <input type="checkbox" id="set_license" class="required" name="licence_agrement" value="1" style="vertical-align: middle;float:left" <?php if ($this->session->licence_agrement) { ?>checked="checked"<?php } ?> />
+    <div style="float:left;width:600px;margin-left:8px">
+        <label for="set_license">
+            <strong><?php echo $this->translator->trans('I agree to the above terms and conditions.', [], 'Install'); ?></strong>
+        </label>
+    </div>
+</div>
+<div class="infosBlock" style="margin-top: 10px">
+    <h4><?php echo $this->translator->trans('Privacy note', [], 'Install'); ?></h4>
+    <p>
+        <?php echo $this->translator->trans(
+            'Some project modules may submit public and technical information about your store to the PrestaShop Project for analytics purposes. To learn more and make an informed choice, read %link%.',
+            [
+                '%link%' => '<a href="https://www.prestashop-project.org/data-transparency/" target="_blank">' .
+                    $this->translator->trans('this article', [], 'Install')
+                    . '</a>'
+            ],
+            'Install'
+        ); ?>
+    </p>
 </div>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Adding link to the data transparency from the project's website
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | go to /install-dev/index.php and see if the message is well display (see the image  further in the description)
| Fixed ticket?     | Fixes #31625
| Related PRs       | 
| Sponsor company   |

![Capture d’écran 2023-03-09 à 11 31 04](https://user-images.githubusercontent.com/16019289/225293662-8e1da5cf-9dc5-43e0-a901-70621565d392.png)