### PR TITLE
Add validation rule to avoid special characters in virtual urls

### DIFF
--- a/controllers/admin/AdminShopUrlController.php
+++ b/controllers/admin/AdminShopUrlController.php
@@ -459,7 +459,7 @@ class AdminShopUrlControllerCore extends AdminController
         }
 
         $unallowed = str_replace('/', '', Tools::getValue('virtual_uri'));
-        if ($unallowed == 'c' || $unallowed == 'img' || is_numeric($unallowed)) {
+        if ($unallowed == 'c' || $unallowed == 'img' || is_numeric($unallowed) || !preg_match('/^[a-z\d\-_]*$/i', $unallowed)) {
             $this->errors[] = $this->trans(
                 'A shop virtual URL cannot be "%URL%"',
                 [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When we use special characters for virtual urls in multistore mode, BO and FO are break. This PR add validation rule to avoid special characters.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31607 
| Fixed ticket?     | Fixes #31607 
| Related PRs       | 
| Sponsor company   | 

Now, we validate virtual urls with this regex : `/^[a-z\d\-_]*$/i`.