### PR TITLE
Fix extends for exception pages when `_PS_MODE_DEV` false

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-{% extends '::base.html.twig' %}
+{% extends '@PrestaShop/base.html.twig' %}
 
 {% block stylesheets %}
   {{ parent() }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
-{% extends '::base.html.twig' %}
+{% extends '@PrestaShop/base.html.twig' %}
 
 {% block stylesheets %}
   {{ parent() }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When `_PS_MODE_DEV` is false, we use admin exception pages but extends `base.html.twig` can't be found by twig. With this PR, errors are displayed properly with PrestaShop design.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31675 
| Fixed ticket?     | Fixes #31675 
| Related PRs       | 
| Sponsor company   | 
