### PR TITLE
Fix extends for exception pages when `_PS_MODE_DEV` false

### DIFF
--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/error.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% extends '::base.html.twig' %}
+{% extends '@PrestaShop/base.html.twig' %}
 
 {% block stylesheets %}
   {{ parent() }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Exception/not_found.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% extends '::base.html.twig' %}
+{% extends '@PrestaShop/base.html.twig' %}
 
 {% block stylesheets %}
   {{ parent() }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | When `_PS_MODE_DEV_` = false, we use admin exception pages but extends base.html.twig can't be found by twig so we have in all case a 500 error.  With this PR, errors are displayed properly with PrestaShop design and `GET /new-api` we get an 404 error instead of 500 error.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31675 
| Fixed ticket?     | Fixes #31675 
| Related PRs       | 
| Sponsor company   | 

<img width="1435" alt="Capture d’écran 2023-03-10 à 10 43 00" src="https://user-images.githubusercontent.com/18699562/224289222-bc4aefb2-e103-4613-9f1d-7ee06bcfe761.png">