### PR TITLE
app/AppKernel: store logs in `_PS_ROOT_DIR_`, not `_PS_CORE_DIR_`

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -146,7 +146,7 @@ class AppKernel extends Kernel
      */
     public function getLogDir()
     {
-        return dirname(__DIR__) . '/var/logs';
+        return _PS_ROOT_DIR_ . '/var/logs';
     }
 
     /**


### PR DESCRIPTION
`_PS_CORE_DIR_` (i.e. `dirname(__DIR__)`, where the source code lives) is potentially read-only, while `_PS_ROOT_DIR_` should contain site-specific writable files.

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop (see above)
| Description?      | See above.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Install with different "core"/"root" directory, check where logs get written to
| Fixed ticket?     | n/a
| Related PRs       | n/a
| Sponsor company   | IONOS SE
