### PR TITLE
Add `force_hide_bulk_actions_btn` in HelperList for AdminCartsController.php

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_footer.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_footer.tpl
@@ -26,7 +26,7 @@
 </div>
 <div class="row">
 	<div class="col-lg-6">
-		{if $bulk_actions && $has_bulk_actions}
+		{if $bulk_actions && $has_bulk_actions && !$hide_bulk_actions_btn}
 		<div class="btn-group bulk-actions dropup">
 			<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" {if $table}id="bulk_action_menu_{$table}"{/if}>
 				{l s='Bulk actions' d='Admin.Global'} <span class="caret"></span>

--- a/classes/helper/HelperList.php
+++ b/classes/helper/HelperList.php
@@ -112,6 +112,7 @@ class HelperListCore extends Helper
 
     public $bulk_actions = false;
     public $force_show_bulk_actions = false;
+    public $force_hide_bulk_actions_btn = false;
     public $specificConfirmDelete = null;
     public $colorOnBackground;
 
@@ -802,6 +803,7 @@ class HelperListCore extends Helper
             'toolbar_scroll' => $this->toolbar_scroll,
             'toolbar_btn' => $this->toolbar_btn,
             'has_bulk_actions' => $this->hasBulkActions($has_value),
+            'hide_bulk_actions_btn' => $this->force_hide_bulk_actions_btn,
             'filters_has_value' => (bool) $has_value,
         ]);
 

--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -981,6 +981,7 @@ class AdminCartsControllerCore extends AdminController
             $helper->list_skip_actions['delete'] = (array) $skip_list;
         }
         $helper->force_show_bulk_actions = true;
+        $helper->force_hide_bulk_actions_btn = count($helper->list_skip_actions['delete']) === count($this->_list);
 
         return $helper->generateList($this->_list, $this->fields_list);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | The bulk action shouldn't be displayed on the shopping carts page when there is no shopping carts with No ordered status, but in all case, we still need to have 9 columns on this page for ui testing.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31406 
| Fixed ticket?     | Fixes #31406 
| Related PRs       | 
| Sponsor company   | 