### PR TITLE
Security - Replace string by constants

### DIFF
--- a/src/Core/Stock/StockManager.php
+++ b/src/Core/Stock/StockManager.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Adapter\LegacyContext as ContextAdapter;
 use PrestaShop\PrestaShop\Adapter\Product\ProductDataProvider;
 use PrestaShop\PrestaShop\Adapter\ServiceLocator;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Entity\StockMvt;
 use Product;
 use StockAvailable;
@@ -316,7 +317,7 @@ class StockManager
         foreach (Employee::getEmployees() as $employeeData) {
             $employee = new Employee($employeeData['id_employee']);
 
-            if (Access::isGranted('ROLE_MOD_TAB_ADMINSTOCKMANAGEMENT_READ', $employee->id_profile)) {
+            if (Access::isGranted(Permission::PREFIX_TAB . 'ADMINSTOCKMANAGEMENT_READ', $employee->id_profile)) {
                 $templateVars['{firstname}'] = $employee->firstname;
                 $templateVars['{lastname}'] = $employee->lastname;
 

--- a/src/PrestaShopBundle/Controller/Admin/AttachementProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AttachementProductController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin;
 
 use PrestaShop\PrestaShop\Adapter\Product\AdminProductWrapper;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -39,7 +40,7 @@ class AttachementProductController extends FrameworkBundleAdminController
     /**
      * Manage form add product attachment.
      *
-     * @AdminSecurity("is_granted('create', 'ADMINPRODUCTS_') && is_granted('update', 'ADMINPRODUCTS_')")
+     * @AdminSecurity("is_granted(Permission::CREATE, 'ADMINPRODUCTS_') && is_granted(Permission::UPDATE, 'ADMINPRODUCTS_')")
      *
      * @param int $idProduct
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/AttributeController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin;
 
 use PrestaShop\PrestaShop\Adapter\Attribute\AdminAttributeGeneratorControllerWrapper;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Product;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -40,7 +41,7 @@ class AttributeController extends FrameworkBundleAdminController
     /**
      * get All Attributes as json.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return JsonResponse
      */
@@ -84,7 +85,7 @@ class AttributeController extends FrameworkBundleAdminController
      * Attributes generator.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller'))"
      * )
      *
      * @param Request $request The request
@@ -208,7 +209,7 @@ class AttributeController extends FrameworkBundleAdminController
     /**
      * Delete a product attribute.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param int $idProduct The product ID
      * @param Request $request The request
@@ -245,7 +246,7 @@ class AttributeController extends FrameworkBundleAdminController
     /**
      * Delete all product attributes.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param int $idProduct The product ID
      * @param Request $request The request
@@ -285,7 +286,7 @@ class AttributeController extends FrameworkBundleAdminController
     /**
      * get the images form for a product combinations.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param int $idProduct The product id
      * @param Request $request The request

--- a/src/PrestaShopBundle/Controller/Admin/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CombinationController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin;
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Form\Admin\Product\ProductCombination;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -37,7 +38,7 @@ class CombinationController extends FrameworkBundleAdminController
      * Generate combination
      *
      * @AdminSecurity(
-     *     "is_granted('create', 'ADMINPRODUCTS_') && is_granted('update', 'ADMINPRODUCTS_')"
+     *     "is_granted(Permission::CREATE, 'ADMINPRODUCTS_') && is_granted(Permission::UPDATE, 'ADMINPRODUCTS_')"
      * )
      *
      * @return Response
@@ -72,7 +73,7 @@ class CombinationController extends FrameworkBundleAdminController
     /**
      * Get all Combinations for a product.
      *
-     * @AdminSecurity("is_granted('read', 'ADMINPRODUCTS_')")
+     * @AdminSecurity("is_granted(Permission::READ, 'ADMINPRODUCTS_')")
      *
      * @param int $idProduct The product id
      *

--- a/src/PrestaShopBundle/Controller/Admin/CommonController.php
+++ b/src/PrestaShopBundle/Controller/Admin/CommonController.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFac
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\FilterableGridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInterface;
 use PrestaShop\PrestaShop\Core\Kpi\Row\KpiRowInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\Grid\ControllerResponseBuilder;
 use PrestaShopBundle\Service\Grid\ResponseBuilder;
@@ -300,7 +301,7 @@ class CommonController extends FrameworkBundleAdminController
      * @param string $redirectRoute
      * @param array $redirectQueryParamsToKeep
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return RedirectResponse
      */

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/AdministrationController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Controller\Exception\FieldNotFoundException;
 use PrestaShopBundle\Form\Admin\Configure\AdvancedParameters\Administration\FormDataProvider;
@@ -52,7 +53,7 @@ class AdministrationController extends FrameworkBundleAdminController
     /**
      * Show Administration page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return Response
      */
@@ -82,7 +83,7 @@ class AdministrationController extends FrameworkBundleAdminController
      * Process the Administration general configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_administration")
      * @DemoRestricted(redirectRoute="admin_administration")
@@ -104,7 +105,7 @@ class AdministrationController extends FrameworkBundleAdminController
      * Process the Administration upload quota configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_administration")
      * @DemoRestricted(redirectRoute="admin_administration")
@@ -126,7 +127,7 @@ class AdministrationController extends FrameworkBundleAdminController
      * Process the Administration notifications configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_administration"
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/BackupController.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Backup\Exception\DirectoryIsNotWritableException;
 use PrestaShop\PrestaShop\Core\Backup\Manager\BackupRemoverInterface;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\BackupFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -49,7 +50,7 @@ class BackupController extends FrameworkBundleAdminController
     /**
      * Show backup page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))",
      *           message="You do not have permission to update this.",
      *          redirectRoute="admin_product_catalog"
      * )
@@ -98,7 +99,7 @@ class BackupController extends FrameworkBundleAdminController
     /**
      * Show file download view.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      * @DemoRestricted(redirectRoute="admin_backups_index")
      *
      * @param Request $request
@@ -124,7 +125,7 @@ class BackupController extends FrameworkBundleAdminController
     /**
      * Return a backup content as a download.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      * @DemoRestricted(redirectRoute="admin_backup")
      *
      * @param string $downloadFileName
@@ -142,7 +143,7 @@ class BackupController extends FrameworkBundleAdminController
      * Process backup options saving.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *          message="You do not have permission to update this.",
      *          redirectRoute="admin_backups_index"
      * )
@@ -175,7 +176,7 @@ class BackupController extends FrameworkBundleAdminController
     /**
      * Create new backup.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *          message="You do not have permission to create this.",
      *          redirectRoute="admin_backups_index"
      * )
@@ -216,7 +217,7 @@ class BackupController extends FrameworkBundleAdminController
     /**
      * Process backup file deletion.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *          message="You do not have permission to delete this.",
      *          redirectRoute="admin_backups_index"
      * )
@@ -252,7 +253,7 @@ class BackupController extends FrameworkBundleAdminController
     /**
      * Process bulk backup deletion.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *          message="You do not have permission to delete this.",
      *          redirectRoute="admin_backups_index"
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmailController.php
@@ -46,7 +46,7 @@ class EmailController extends FrameworkBundleAdminController
     /**
      * Show email configuration page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      * @param EmailLogsFilter $filters
@@ -87,7 +87,7 @@ class EmailController extends FrameworkBundleAdminController
     /**
      * @deprecated since 8.0 and will be removed in next major. Use CommonController:searchGridAction instead
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -116,7 +116,7 @@ class EmailController extends FrameworkBundleAdminController
      *
      * @DemoRestricted(redirectRoute="admin_emails_index")
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="Access denied."
      * )
      *
@@ -150,7 +150,7 @@ class EmailController extends FrameworkBundleAdminController
      * Delete selected email logs.
      *
      * @DemoRestricted(redirectRoute="admin_emails_index")
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -179,7 +179,7 @@ class EmailController extends FrameworkBundleAdminController
      * Delete all email logs.
      *
      * @DemoRestricted(redirectRoute="admin_emails_index")
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return RedirectResponse
      */
@@ -198,7 +198,7 @@ class EmailController extends FrameworkBundleAdminController
      * Delete single email log.
      *
      * @DemoRestricted(redirectRoute="admin_emails_index")
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param int $mailId
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/EmployeeController.php
@@ -67,7 +67,7 @@ class EmployeeController extends FrameworkBundleAdminController
     /**
      * Show employees list & options page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param EmployeeFilters $filters
@@ -108,7 +108,7 @@ class EmployeeController extends FrameworkBundleAdminController
      *
      * @DemoRestricted(redirectRoute="admin_employees_index")
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))"
      * )
      *
      * @param Request $request
@@ -140,7 +140,7 @@ class EmployeeController extends FrameworkBundleAdminController
      * Toggle given employee status.
      *
      * @DemoRestricted(redirectRoute="admin_employees_index")
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_employees_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_employees_index")
      *
      * @param int $employeeId
      *
@@ -166,7 +166,7 @@ class EmployeeController extends FrameworkBundleAdminController
      * Bulk enables employee status action.
      *
      * @DemoRestricted(redirectRoute="admin_employees_index")
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -196,7 +196,7 @@ class EmployeeController extends FrameworkBundleAdminController
      * Bulk disables employee status action.
      *
      * @DemoRestricted(redirectRoute="admin_employees_index")
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -226,7 +226,7 @@ class EmployeeController extends FrameworkBundleAdminController
      * Delete employee.
      *
      * @DemoRestricted(redirectRoute="admin_employees_index")
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param int $employeeId
      *
@@ -249,7 +249,7 @@ class EmployeeController extends FrameworkBundleAdminController
      * Delete employees in bulk actions.
      *
      * @DemoRestricted(redirectRoute="admin_employees_index")
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -277,7 +277,7 @@ class EmployeeController extends FrameworkBundleAdminController
      * Show employee creation form page and handle it's submit.
      *
      * @DemoRestricted(redirectRoute="admin_employees_index")
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -447,7 +447,7 @@ class EmployeeController extends FrameworkBundleAdminController
      * Get tabs which are accessible for given profile.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_employees_index"
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/FeatureFlagController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/FeatureFlagController.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\Form\FormInterface;
@@ -41,7 +42,7 @@ use Symfony\Component\HttpFoundation\Response;
 class FeatureFlagController extends FrameworkBundleAdminController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return Response
      */

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportController.php
@@ -52,7 +52,7 @@ class ImportController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return array|RedirectResponse|Response
      */
@@ -164,7 +164,7 @@ class ImportController extends FrameworkBundleAdminController
     /**
      * Delete import file.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_import")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_import")
      * @DemoRestricted(redirectRoute="admin_import")
      *
      * @param Request $request
@@ -186,7 +186,7 @@ class ImportController extends FrameworkBundleAdminController
      * Download import file from history.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.", redirectRoute="admin_import"
      * )
      * @DemoRestricted(redirectRoute="admin_import")
@@ -212,7 +212,7 @@ class ImportController extends FrameworkBundleAdminController
     /**
      * Download import sample file.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_import")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_import")
      *
      * @param string $sampleName
      *
@@ -237,7 +237,7 @@ class ImportController extends FrameworkBundleAdminController
      * Get available entity fields.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     redirectRoute="admin_import"
      * )
      *
@@ -263,7 +263,7 @@ class ImportController extends FrameworkBundleAdminController
      * Process the import.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_import"
      * )
      * @DemoRestricted(redirectRoute="admin_import")

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportDataConfigurationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ImportDataConfigurationController.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
 use PrestaShop\PrestaShop\Core\Import\Exception\UnreadableFileException;
 use PrestaShop\PrestaShop\Core\Import\ImportSettings;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -45,7 +46,7 @@ class ImportDataConfigurationController extends FrameworkBundleAdminController
     /**
      * Shows import data page where the configuration of importable data and the final step of import is handled.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      * @DemoRestricted(redirectRoute="admin_import")
      *
      * @param Request $request
@@ -98,7 +99,7 @@ class ImportDataConfigurationController extends FrameworkBundleAdminController
     /**
      * Create import data match configuration.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_import")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_import")
      * @DemoRestricted(redirectRoute="admin_import")
      *
      * @param Request $request
@@ -135,7 +136,7 @@ class ImportDataConfigurationController extends FrameworkBundleAdminController
     /**
      * Delete import data match configuration.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_import")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_import")
      * @DemoRestricted(redirectRoute="admin_import")
      *
      * @param Request $request
@@ -154,7 +155,7 @@ class ImportDataConfigurationController extends FrameworkBundleAdminController
      * Get import data match configuration.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     redirectRoute="admin_import"
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/LogsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/LogsController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LogGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\LogsFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Entity\Repository\LogRepository;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -48,7 +49,7 @@ class LogsController extends FrameworkBundleAdminController
     public const CONTROLLER_NAME = 'AdminLogs';
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param LogsFilters $filters the list of filters from the request
      *
@@ -75,7 +76,7 @@ class LogsController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.", redirectRoute="admin_logs_index"
      * )
      * @DemoRestricted(redirectRoute="admin_logs_index")
@@ -100,7 +101,7 @@ class LogsController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.", redirectRoute="admin_logs_index"
      * )
      * @DemoRestricted(redirectRoute="admin_logs_index")
@@ -134,7 +135,7 @@ class LogsController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_logs_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to update this.", redirectRoute="admin_logs_index")
      *
      * @return RedirectResponse
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/MemcacheServerController.php
@@ -43,7 +43,7 @@ class MemcacheServerController extends FrameworkBundleAdminController
     public const CONTROLLER_NAME = 'AdminPerformance';
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return JsonResponse
      */
@@ -53,7 +53,7 @@ class MemcacheServerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      * @DemoRestricted(redirectRoute="admin_servers_test")
      *
      * @param Request $request
@@ -78,7 +78,7 @@ class MemcacheServerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))", message="Access denied.")
      * @DemoRestricted(redirectRoute="admin_servers_test")
      *
      * @param Request $request
@@ -137,7 +137,7 @@ class MemcacheServerController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="Access denied.")
      * @DemoRestricted(redirectRoute="admin_servers_test")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PerformanceController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 use Exception;
 use PrestaShop\PrestaShop\Core\Domain\Module\Command\BulkToggleModuleStatusCommand;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -47,7 +48,7 @@ class PerformanceController extends FrameworkBundleAdminController
     /**
      * Displays the Performance main page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return Response
      */
@@ -92,7 +93,7 @@ class PerformanceController extends FrameworkBundleAdminController
      * Process the Performance Smarty configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      * @DemoRestricted(redirectRoute="admin_performance")
@@ -114,7 +115,7 @@ class PerformanceController extends FrameworkBundleAdminController
      * Process the Performance Debug Mode configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      * @DemoRestricted(redirectRoute="admin_performance")
@@ -136,7 +137,7 @@ class PerformanceController extends FrameworkBundleAdminController
      * Process the Performance Optional Features configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      * @DemoRestricted(redirectRoute="admin_performance")
@@ -158,7 +159,7 @@ class PerformanceController extends FrameworkBundleAdminController
      * Process the Performance Combine Compress Cache configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      * @DemoRestricted(redirectRoute="admin_performance")
@@ -180,7 +181,7 @@ class PerformanceController extends FrameworkBundleAdminController
      * Process the Performance Media Servers configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      * @DemoRestricted(redirectRoute="admin_performance")
@@ -202,7 +203,7 @@ class PerformanceController extends FrameworkBundleAdminController
      * Process the Performance Caching configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      * @DemoRestricted(redirectRoute="admin_performance")
@@ -256,7 +257,7 @@ class PerformanceController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="Access denied.")
      * @DemoRestricted(redirectRoute="admin_performance")
      *
      * @return RedirectResponse
@@ -280,7 +281,7 @@ class PerformanceController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_performance"
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PermissionController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/PermissionController.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Command\UpdateModulePer
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Command\UpdateTabPermissionsCommand;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Query\GetPermissionsForConfiguration;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\QueryResult\ConfigurablePermissions;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -47,7 +48,7 @@ class PermissionController extends FrameworkBundleAdminController
     /**
      * Show permissions configuration page
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -80,7 +81,7 @@ class PermissionController extends FrameworkBundleAdminController
     /**
      * Update tab permissions for profile
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -115,7 +116,7 @@ class PermissionController extends FrameworkBundleAdminController
     /**
      * Updates module permissions for profile
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/ProfileController.php
@@ -40,6 +40,7 @@ use PrestaShop\PrestaShop\Core\Domain\Profile\Query\GetProfileForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Profile\QueryResult\EditableProfile;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProfileFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -56,7 +57,7 @@ class ProfileController extends FrameworkBundleAdminController
     /**
      * Show profiles listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param ProfileFilters $filters
      *
@@ -92,7 +93,7 @@ class ProfileController extends FrameworkBundleAdminController
     /**
      * Used for applying filtering actions.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -119,7 +120,7 @@ class ProfileController extends FrameworkBundleAdminController
     /**
      * Show profile's create page
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      * @DemoRestricted(redirectRoute="admin_profiles_index")
      *
      * @param Request $request
@@ -161,7 +162,7 @@ class ProfileController extends FrameworkBundleAdminController
      * Shows profile edit form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      * @DemoRestricted(redirectRoute="admin_profiles_index")
@@ -225,7 +226,7 @@ class ProfileController extends FrameworkBundleAdminController
      * Delete a profile.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      * @DemoRestricted(redirectRoute="admin_profiles_index")
@@ -253,7 +254,7 @@ class ProfileController extends FrameworkBundleAdminController
      * Bulk delete profiles.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      * @DemoRestricted(redirectRoute="admin_profiles_index")

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SecurityController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SecurityController.php
@@ -46,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Exception\CoreException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\Security\Session\CustomerFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\Security\Session\EmployeeFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -61,7 +62,7 @@ class SecurityController extends FrameworkBundleAdminController
     /**
      * Show sessions listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -93,7 +94,7 @@ class SecurityController extends FrameworkBundleAdminController
      * Process the Security general configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))"
      * )
      *
      * @param Request $request
@@ -113,7 +114,7 @@ class SecurityController extends FrameworkBundleAdminController
      * Process the Security password policy configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))"
      * )
      *
      * @param Request $request
@@ -167,7 +168,7 @@ class SecurityController extends FrameworkBundleAdminController
     /**
      * Show Employees sessions listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param EmployeeFilters $filters
      *
@@ -197,7 +198,7 @@ class SecurityController extends FrameworkBundleAdminController
     /**
      * Show Customers sessions listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param CustomerFilters $filters
      *
@@ -225,7 +226,7 @@ class SecurityController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @return RedirectResponse
      */
@@ -245,7 +246,7 @@ class SecurityController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @return RedirectResponse
      */
@@ -267,7 +268,7 @@ class SecurityController extends FrameworkBundleAdminController
     /**
      * Delete an employee session.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param int $sessionId
      *
@@ -291,7 +292,7 @@ class SecurityController extends FrameworkBundleAdminController
     /**
      * Delete a customer session.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param int $sessionId
      *
@@ -315,7 +316,7 @@ class SecurityController extends FrameworkBundleAdminController
     /**
      * Bulk delete customer session.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -341,7 +342,7 @@ class SecurityController extends FrameworkBundleAdminController
     /**
      * Bulk delete employee session.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SqlManagerController.php
@@ -46,6 +46,7 @@ use PrestaShop\PrestaShop\Core\Export\Exception\FileWritingException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\RequestSqlFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -65,7 +66,7 @@ class SqlManagerController extends FrameworkBundleAdminController
     /**
      * Show list of saved SQL's.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param RequestSqlFilters $filters
@@ -103,7 +104,7 @@ class SqlManagerController extends FrameworkBundleAdminController
     /**
      * @deprecated since 1.7.8 and will be removed in next major. Use CommonController:searchGridAction instead
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_sql_requests_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_sql_requests_index")
      * @DemoRestricted(redirectRoute="admin_sql_requests_index")
      *
      * @param Request $request
@@ -133,7 +134,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      *
      * @DemoRestricted(redirectRoute="admin_sql_requests_index")
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *      redirectRoute="admin_sql_requests_index"
      * )
      *
@@ -162,7 +163,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      * Show Request SQL create page.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *      message="You do not have permission to create this.",
      *      redirectRoute="admin_sql_requests_index"
      * )
@@ -209,7 +210,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      *
      * @DemoRestricted(redirectRoute="admin_sql_requests_index")
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_sql_requests_index"
      * )
@@ -256,7 +257,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      * Delete selected Request SQL.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to delete this.",
      *     redirectRoute="admin_sql_requests_index"
      * )
@@ -287,7 +288,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      * Process bulk action delete of RequestSql's.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to delete this.",
      *     redirectRoute="admin_sql_requests_index"
      * )
@@ -320,7 +321,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      * View Request SQL query data.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     message="You do not have permission to view this.",
      *     redirectRoute="admin_sql_requests_index"
      * )
@@ -355,7 +356,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      * Export Request SQL data.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     redirectRoute="admin_sql_requests_index"
      * )
      * @DemoRestricted(redirectRoute="admin_sql_requests_index")
@@ -398,7 +399,7 @@ class SqlManagerController extends FrameworkBundleAdminController
      * Get MySQL table columns data.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     redirectRoute="admin_sql_requests_index"
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/SystemInformationController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\AdvancedParameters;
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -38,7 +39,7 @@ use Symfony\Component\HttpFoundation\Response;
 class SystemInformationController extends FrameworkBundleAdminController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -66,7 +67,7 @@ class SystemInformationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return JsonResponse
      */

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\DuplicateWebserviceKe
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceConstraintException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\WebserviceKeyFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -52,7 +53,7 @@ class WebserviceController extends FrameworkBundleAdminController
     /**
      * Displays the Webservice main page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param WebserviceKeyFilters $filters - filters for webservice list
      * @param Request $request
@@ -67,7 +68,7 @@ class WebserviceController extends FrameworkBundleAdminController
     /**
      * Shows Webservice Key form and handles its submit
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -105,7 +106,7 @@ class WebserviceController extends FrameworkBundleAdminController
     /**
      * Redirects to webservice account form where existing webservice account record can be edited.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $webserviceKeyId
      * @param Request $request
@@ -152,7 +153,7 @@ class WebserviceController extends FrameworkBundleAdminController
      *
      * Searches for specific records.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -180,7 +181,7 @@ class WebserviceController extends FrameworkBundleAdminController
      * Deletes single record.
      *
      * @DemoRestricted(redirectRoute="admin_webservice_keys_index")
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
      *
      * @param int $webserviceKeyId
      *
@@ -207,7 +208,7 @@ class WebserviceController extends FrameworkBundleAdminController
      * Deletes selected records.
      *
      * @DemoRestricted(redirectRoute="admin_webservice_keys_index")
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
      *
      * @param Request $request
      *
@@ -236,7 +237,7 @@ class WebserviceController extends FrameworkBundleAdminController
      * Enables status for selected rows.
      *
      * @DemoRestricted(redirectRoute="admin_webservice_keys_index")
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      *
      * @param Request $request
      *
@@ -261,7 +262,7 @@ class WebserviceController extends FrameworkBundleAdminController
      * Disables status for selected rows.
      *
      * @DemoRestricted(redirectRoute="admin_webservice_keys_index")
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      *
      * @param Request $request
      *
@@ -286,7 +287,7 @@ class WebserviceController extends FrameworkBundleAdminController
      * Toggles webservice account status.
      *
      * @DemoRestricted(redirectRoute="admin_webservice_keys_index")
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      *
      * @param int $webserviceKeyId
      *
@@ -314,7 +315,7 @@ class WebserviceController extends FrameworkBundleAdminController
      *
      * @DemoRestricted(redirectRoute="admin_webservice_keys_index")
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ContactsController.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactConstraintExcepti
 use PrestaShop\PrestaShop\Core\Domain\Contact\Exception\ContactNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Exception\DomainConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\ContactFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -47,7 +48,7 @@ class ContactsController extends FrameworkBundleAdminController
     /**
      * Shows page content.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param ContactFilters $filters
@@ -82,7 +83,7 @@ class ContactsController extends FrameworkBundleAdminController
      *
      * Grid search action.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -110,7 +111,7 @@ class ContactsController extends FrameworkBundleAdminController
      * Display the Contact creation form.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_contacts_index",
      *     message="You do not have permission to add this."
      * )
@@ -156,7 +157,7 @@ class ContactsController extends FrameworkBundleAdminController
      * Display the contact edit form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_contacts_index",
      *     message="You do not have permission to edit this."
      * )
@@ -207,7 +208,7 @@ class ContactsController extends FrameworkBundleAdminController
      * Delete a contact.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_contacts_index",
      *     message="You do not have permission to delete this."
      * )
@@ -238,7 +239,7 @@ class ContactsController extends FrameworkBundleAdminController
      * Bulk delete contacts.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_contacts_index",
      *     message="You do not have permission to delete this."
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerGroupsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerGroupsController.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerGroupsFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,7 +43,7 @@ class CustomerGroupsController extends FrameworkBundleAdminController
     /**
      * Show Groups tab.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      * @param CustomerGroupsFilters $filters
@@ -66,7 +67,7 @@ class CustomerGroupsController extends FrameworkBundleAdminController
      * Displays and handles customer group form.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_customer_groups_index",
      *     message="You need permission to create this."
      * )
@@ -91,7 +92,7 @@ class CustomerGroupsController extends FrameworkBundleAdminController
      * Displays title form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_customer_groups_index",
      *     message="You need permission to edit this."
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/CustomerPreferencesController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -40,7 +41,7 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
     /**
      * Show customer preferences page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -64,7 +65,7 @@ class CustomerPreferencesController extends FrameworkBundleAdminController
      * Process the Customer Preferences configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.", redirectRoute="admin_customer_preferences"
      * )
      * @DemoRestricted(redirectRoute="admin_customer_preferences")

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MaintenanceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MaintenanceController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -42,7 +43,7 @@ class MaintenanceController extends FrameworkBundleAdminController
     public const CONTROLLER_NAME = 'AdminMaintenance';
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param FormInterface $form
@@ -71,7 +72,7 @@ class MaintenanceController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_maintenance")
      * @DemoRestricted(redirectRoute="admin_maintenance")

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/MetaController.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler;
 use PrestaShop\PrestaShop\Core\Search\Filters\MetaFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProviderInterface;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlFileCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
@@ -55,7 +56,7 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Shows index Meta page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param MetaFilters $filters
      * @param Request $request
@@ -82,7 +83,7 @@ class MetaController extends FrameworkBundleAdminController
      *
      * Used for applying filtering actions.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      * @DemoRestricted(redirectRoute="admin_metas_index")
      *
      * @param Request $request
@@ -109,7 +110,7 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Points to the form where new record of meta list can be created.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="You do not have permission to add this.")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))", message="You do not have permission to add this.")
      *
      * @param Request $request
      *
@@ -148,7 +149,7 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Redirects to page where list record can be edited.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      *
      * @param int $metaId
      * @param Request $request
@@ -190,7 +191,7 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Removes single element from meta list.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
      * @DemoRestricted(redirectRoute="admin_metas_index")
      *
      * @param int $metaId
@@ -217,7 +218,7 @@ class MetaController extends FrameworkBundleAdminController
     /**
      * Removes multiple records from meta list.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
      * @DemoRestricted(redirectRoute="admin_metas_index")
      *
      * @param Request $request
@@ -244,7 +245,7 @@ class MetaController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      * @DemoRestricted(redirectRoute="admin_metas_index")
      *
      * @param MetaFilters $filters
@@ -277,7 +278,7 @@ class MetaController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      * @DemoRestricted(redirectRoute="admin_metas_index")
      *
      * @param MetaFilters $filters
@@ -310,7 +311,7 @@ class MetaController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      * @DemoRestricted(redirectRoute="admin_metas_index")
      *
      * @param MetaFilters $filters
@@ -338,7 +339,7 @@ class MetaController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to edit this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to edit this.")
      * @DemoRestricted(redirectRoute="admin_metas_index")
      *
      * @param MetaFilters $filters
@@ -374,7 +375,7 @@ class MetaController extends FrameworkBundleAdminController
      * Generates robots.txt file for Front Office.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))"
      * )
      * @DemoRestricted(redirectRoute="admin_metas_index")
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderPreferencesController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -39,7 +40,7 @@ use Symfony\Component\HttpFoundation\Response;
 class OrderPreferencesController extends FrameworkBundleAdminController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -65,7 +66,7 @@ class OrderPreferencesController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_order_preferences")
      *
@@ -84,7 +85,7 @@ class OrderPreferencesController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_order_preferences")
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/OrderStateController.php
@@ -45,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderReturnStatesGridDefi
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderStatesGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderReturnStatesFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderStatesFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -57,7 +58,7 @@ use Symfony\Component\HttpFoundation\Response;
 class OrderStateController extends FrameworkBundleAdminController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -88,7 +89,7 @@ class OrderStateController extends FrameworkBundleAdminController
     /**
      * Process Grid search.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return RedirectResponse
      */
@@ -115,7 +116,7 @@ class OrderStateController extends FrameworkBundleAdminController
     /**
      * Show order_state create form & handle processing of it.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -162,7 +163,7 @@ class OrderStateController extends FrameworkBundleAdminController
     /**
      * Show order_state edit form & handle processing of it.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -217,7 +218,7 @@ class OrderStateController extends FrameworkBundleAdminController
     /**
      * Show order return state create form & handle processing of it.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -256,7 +257,7 @@ class OrderStateController extends FrameworkBundleAdminController
     /**
      * Show order return state edit form & handle processing of it.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -304,7 +305,7 @@ class OrderStateController extends FrameworkBundleAdminController
     /**
      * Deletes order return state
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_order_states")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_order_states")
      *
      * @param int $orderReturnStateId
      *
@@ -331,7 +332,7 @@ class OrderStateController extends FrameworkBundleAdminController
      * Delete order return states in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_order_states",
      *     message="You do not have permission to delete this."
      * )
@@ -361,7 +362,7 @@ class OrderStateController extends FrameworkBundleAdminController
      * Toggle order state delivery option.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_order_states",
      *     message="You do not have permission to edit this."
      * )
@@ -396,7 +397,7 @@ class OrderStateController extends FrameworkBundleAdminController
      * Toggle order state invoice option.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_order_states",
      *     message="You do not have permission to edit this."
      * )
@@ -431,7 +432,7 @@ class OrderStateController extends FrameworkBundleAdminController
      * Toggle order state send_email option.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_order_states",
      *     message="You do not have permission to edit this."
      * )
@@ -465,7 +466,7 @@ class OrderStateController extends FrameworkBundleAdminController
     /**
      * Deletes order state
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_order_states")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_order_states")
      *
      * @param int $orderStateId
      *
@@ -492,7 +493,7 @@ class OrderStateController extends FrameworkBundleAdminController
      * Delete order states in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_order_states",
      *     message="You do not have permission to delete this."
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/PreferencesController.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
 use PrestaShop\PrestaShop\Adapter\Tools;
 use PrestaShop\PrestaShop\Core\Domain\Tab\Command\UpdateTabStatusByClassNameCommand;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -49,7 +50,7 @@ class PreferencesController extends FrameworkBundleAdminController
      * @return Response
      *
      * @throws \Exception
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      */
     public function indexAction(Request $request, FormInterface $form = null)
     {
@@ -62,7 +63,7 @@ class PreferencesController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_preferences")
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/ProductPreferencesController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Configure\ShopParameters;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -41,7 +42,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
     /**
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -71,7 +72,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_product_preferences"
      * )
@@ -91,7 +92,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_product_preferences"
      * )
@@ -111,7 +112,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_product_preferences"
      * )
@@ -131,7 +132,7 @@ class ProductPreferencesController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_product_preferences"
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchEnginesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/SearchEnginesController.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Domain\SearchEngine\Exception\SearchEngineNotFoun
 use PrestaShop\PrestaShop\Core\Domain\SearchEngine\Query\GetSearchEngineForEditing;
 use PrestaShop\PrestaShop\Core\Domain\SearchEngine\QueryResult\SearchEngineForEditing;
 use PrestaShop\PrestaShop\Core\Search\Filters\SearchEngineFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -51,7 +52,7 @@ class SearchEnginesController extends FrameworkBundleAdminController
     /**
      * Show search engines listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param SearchEngineFilters $filters
@@ -73,7 +74,7 @@ class SearchEnginesController extends FrameworkBundleAdminController
     /**
      * Shows search engine creation form page and handle its submit.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -114,7 +115,7 @@ class SearchEnginesController extends FrameworkBundleAdminController
     /**
      * Show search engine edit form page and handles its submit.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $searchEngineId
      * @param Request $request
@@ -173,7 +174,7 @@ class SearchEnginesController extends FrameworkBundleAdminController
      * Deletes search engine.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_search_engines_index",
      * )
      *
@@ -198,7 +199,7 @@ class SearchEnginesController extends FrameworkBundleAdminController
      * Deletes search engines in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_search_engines_index",
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/TitleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShopParameters/TitleController.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Title\Command\DeleteTitleCommand;
 use PrestaShop\PrestaShop\Core\Domain\Title\Exception\TitleException;
 use PrestaShop\PrestaShop\Core\Domain\Title\Exception\TitleNotFoundException;
 use PrestaShop\PrestaShop\Core\Search\Filters\TitleFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -48,7 +49,7 @@ class TitleController extends FrameworkBundleAdminController
     /**
      * Show customer titles page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      * @param TitleFilters $filters
@@ -72,7 +73,7 @@ class TitleController extends FrameworkBundleAdminController
      * Displays and handles currency form.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_title_index",
      *     message="You need permission to create this."
      * )
@@ -97,7 +98,7 @@ class TitleController extends FrameworkBundleAdminController
      * Displays title form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_title_index",
      *     message="You need permission to edit this."
      * )
@@ -125,7 +126,7 @@ class TitleController extends FrameworkBundleAdminController
      * Deletes title.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_title_index",
      *     message="You need permission to delete this."
      * )
@@ -153,7 +154,7 @@ class TitleController extends FrameworkBundleAdminController
     /**
      * Deletes titles in bulk action
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_title_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_title_index")
      * @DemoRestricted(redirectRoute="admin_title_index")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Configure/ShowcaseCardController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/ShowcaseCardController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Configure;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Command\CloseShowcaseCardCommand;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Exception\InvalidShowcaseCardNameException;
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -51,7 +52,7 @@ class ShowcaseCardController extends FrameworkBundleAdminController
      * @see ShowcaseCard
      *
      * @AdminSecurity(
-     *     "is_granted('create', 'CONFIGURE') && is_granted('update', 'CONFIGURE')"
+     *     "is_granted(Permission::CREATE, 'CONFIGURE') && is_granted(Permission::UPDATE, 'CONFIGURE')"
      * )
      * @DemoRestricted(redirectRoute="admin_metas_index")
      *

--- a/src/PrestaShopBundle/Controller/Admin/ErrorController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ErrorController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin;
 
 use PrestaShop\PrestaShop\Core\Domain\Configuration\Command\SwitchDebugModeCommand;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,7 +41,7 @@ class ErrorController extends FrameworkBundleAdminController
      * Enables debug mode from error page (500 for example)
      *
      * @AdminSecurity(
-     *     "is_granted('update', 'AdminPerformance') && is_granted('create', 'AdminPerformance') && is_granted('delete', 'AdminPerformance')"
+     *     "is_granted(Permission::UPDATE, 'AdminPerformance') && is_granted(Permission::CREATE, 'AdminPerformance') && is_granted(Permission::DELETE', 'AdminPerformance')"
      * )
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/CmsPageController.php
@@ -65,6 +65,7 @@ use PrestaShop\PrestaShop\Core\Grid\Position\GridPositionUpdaterInterface;
 use PrestaShop\PrestaShop\Core\Grid\Position\PositionUpdateFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\CmsPageCategoryFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CmsPageFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShop\PrestaShop\Core\Util\HelperCard\DocumentationLinkProviderInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -82,7 +83,7 @@ class CmsPageController extends FrameworkBundleAdminController
     /**
      * Responsible for displaying page content.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param CmsPageCategoryFilters $categoryFilters
      * @param CmsPageFilters $cmsFilters
@@ -144,7 +145,7 @@ class CmsPageController extends FrameworkBundleAdminController
     /**
      * @deprecated since 1.7.8 and will be removed in next major. Use CommonController:searchGridAction instead
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -177,7 +178,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Creates cms page
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to add this."
@@ -239,7 +240,7 @@ class CmsPageController extends FrameworkBundleAdminController
 
     /**
      *  @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to edit this."
@@ -325,7 +326,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Displays cms category page form and handles create new cms page category logic.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to add this."
@@ -375,7 +376,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Displays cms category page form and handles update cms page category logic.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to edit this."
@@ -447,7 +448,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Deletes cms page category and all its children categories.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to delete this."
@@ -486,7 +487,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Deletes multiple cms page categories.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to delete this."
@@ -529,7 +530,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Updates cms page category position.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to edit this."
@@ -584,7 +585,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Updates cms page listing position.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *      redirectRoute="admin_cms_pages_index",
      *      redirectQueryParamsToKeep={"id_cms_category"},
      *      message="You do not have permission to edit this."
@@ -636,7 +637,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Toggles cms page category status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *      redirectRoute="admin_cms_pages_index",
      *      redirectQueryParamsToKeep={"id_cms_category"},
      *      message="You do not have permission to edit this."
@@ -675,7 +676,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Changes multiple cms page category statuses to enabled.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to edit this."
@@ -718,7 +719,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Changes multiple cms page category statuses to disabled.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to edit this."
@@ -764,7 +765,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Toggles cms page listing status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to edit this."
@@ -801,7 +802,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Disables multiple cms pages.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to edit this."
@@ -844,7 +845,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Enables multiple cms pages.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to edit this."
@@ -892,7 +893,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Deletes multiple cms pages.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to delete this."
@@ -942,7 +943,7 @@ class CmsPageController extends FrameworkBundleAdminController
      * Deletes cms page by given id.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_cms_pages_index",
      *     redirectQueryParamsToKeep={"id_cms_category"},
      *     message="You do not have permission to delete this."

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/MailThemeController.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\MailTemplate\MailTemplateRendererInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\ThemeCatalogInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\ThemeInterface;
 use PrestaShop\PrestaShop\Core\MailTemplate\Transformation\MailVariablesTransformation;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\GenerateMailsType;
 use PrestaShopBundle\Form\Admin\Improve\Design\MailTheme\TranslateMailsBodyType;
@@ -62,7 +63,7 @@ class MailThemeController extends FrameworkBundleAdminController
     /**
      * Show mail theme settings and generation page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -92,7 +93,7 @@ class MailThemeController extends FrameworkBundleAdminController
     /**
      * Manage generation form post and generate mails.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE', request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -181,7 +182,7 @@ class MailThemeController extends FrameworkBundleAdminController
     /**
      * Save mail theme configuration
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -223,7 +224,7 @@ class MailThemeController extends FrameworkBundleAdminController
     /**
      * Preview the list of layouts for a defined theme
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param string $theme
@@ -260,7 +261,7 @@ class MailThemeController extends FrameworkBundleAdminController
      * These modifications will be performed in a future release so for now we can only send test emails
      * with the current email theme using generated static files.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param string $theme
      * @param string $layout
@@ -354,7 +355,7 @@ class MailThemeController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      *
@@ -395,7 +396,7 @@ class MailThemeController extends FrameworkBundleAdminController
     /**
      * Preview a mail layout from a defined theme
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param string $theme
      * @param string $layout
@@ -418,7 +419,7 @@ class MailThemeController extends FrameworkBundleAdminController
     /**
      * Display the raw source of a theme layout (mainly useful for developers/integrators)
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param string $theme
      * @param string $layout

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/PositionsController.php
@@ -32,6 +32,7 @@ use PrestaShop\PrestaShop\Core\Domain\Hook\Exception\HookException;
 use PrestaShop\PrestaShop\Core\Domain\Hook\Exception\HookNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Hook\Exception\HookUpdateHookException;
 use PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetHookStatus;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -52,7 +53,7 @@ class PositionsController extends FrameworkBundleAdminController
      * Display hooks positions.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE', request.get('_legacy_controller')) || is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="Access denied.")
      *
      * @param Request $request
@@ -150,7 +151,7 @@ class PositionsController extends FrameworkBundleAdminController
     /**
      * Unhook module.
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller')~'_')", message="Access denied.")
      *
      * @param Request $request
      *
@@ -247,7 +248,7 @@ class PositionsController extends FrameworkBundleAdminController
     /**
      * Toggle hook status
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')~'_')", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')~'_')", message="Access denied.")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Design/ThemeController.php
@@ -73,7 +73,7 @@ class ThemeController extends AbstractAdminController
      * Show main themes page.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      *
@@ -111,7 +111,7 @@ class ThemeController extends AbstractAdminController
     /**
      * Upload shop logos.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_themes_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_themes_index")
      * @DemoRestricted(redirectRoute="admin_themes_index")
      *
      * @param Request $request
@@ -150,7 +150,7 @@ class ThemeController extends AbstractAdminController
      * Export current theme.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_themes_index",
      *     message="You do not have permission to view this."
      * )
@@ -181,7 +181,7 @@ class ThemeController extends AbstractAdminController
      * Import new theme.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_themes_index",
      *     message="You do not have permission to add this."
      * )
@@ -244,7 +244,7 @@ class ThemeController extends AbstractAdminController
      * Enable selected theme.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_themes_index",
      *     message="You do not have permission to edit this."
      * )
@@ -278,7 +278,7 @@ class ThemeController extends AbstractAdminController
      * Delete selected theme.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_themes_index",
      *     message="You do not have permission to delete this."
      * )
@@ -310,7 +310,7 @@ class ThemeController extends AbstractAdminController
      * Adapts selected theme to RTL languages.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_themes_index",
      *     message="You do not have permission to edit this."
      * )
@@ -355,7 +355,7 @@ class ThemeController extends AbstractAdminController
      * Reset theme's page layouts.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_themes_index",
      *     message="You do not have permission to edit this."
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CountryController.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException
 use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Country\QueryResult\CountryForEditing;
 use PrestaShop\PrestaShop\Core\Search\Filters\CountryFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,7 +49,7 @@ class CountryController extends FrameworkBundleAdminController
     /**
      * Show countries listing page
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param CountryFilters $filters
@@ -72,7 +73,7 @@ class CountryController extends FrameworkBundleAdminController
      * Show "Add new" country form and handles its submit.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_countries_index",
      *     message="You need permission to create new country."
      * )
@@ -113,7 +114,7 @@ class CountryController extends FrameworkBundleAdminController
      * Displays country edit form and handles its submit.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_countries_index",
      *     message="You need permission to edit this."
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/CurrencyController.php
@@ -77,7 +77,7 @@ class CurrencyController extends FrameworkBundleAdminController
     /**
      * Show currency page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param CurrencyFilters $filters
      * @param Request $request
@@ -102,7 +102,7 @@ class CurrencyController extends FrameworkBundleAdminController
     /**
      * @deprecated since 1.7.8 and will be removed in next major. Use CommonController:searchGridAction instead
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -125,7 +125,7 @@ class CurrencyController extends FrameworkBundleAdminController
      * Displays and handles currency form.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_currencies_index",
      *     message="You need permission to create this."
      * )
@@ -163,7 +163,7 @@ class CurrencyController extends FrameworkBundleAdminController
      * Displays currency form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_currencies_index",
      *     message="You need permission to edit this."
      * )
@@ -264,7 +264,7 @@ class CurrencyController extends FrameworkBundleAdminController
      * Deletes currency.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_currencies_index",
      *     message="You need permission to delete this."
      * )
@@ -294,7 +294,7 @@ class CurrencyController extends FrameworkBundleAdminController
      *
      * @param string $currencyIsoCode
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      * @DemoRestricted(redirectRoute="admin_currencies_index")
      *
      * @return JsonResponse
@@ -342,7 +342,7 @@ class CurrencyController extends FrameworkBundleAdminController
      * @param int $currencyId
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_currencies_index",
      *     message="You need permission to edit this."
      * )
@@ -372,7 +372,7 @@ class CurrencyController extends FrameworkBundleAdminController
      * Refresh exchange rates.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_currencies_index",
      *     message="You need permission to edit this."
      * )
@@ -484,7 +484,7 @@ class CurrencyController extends FrameworkBundleAdminController
     /**
      * Toggles currencies status in bulk action
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_currencies_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_currencies_index")
      * @DemoRestricted(redirectRoute="admin_currencies_index")
      *
      * @param Request $request
@@ -517,7 +517,7 @@ class CurrencyController extends FrameworkBundleAdminController
     /**
      * Deletes currencies in bulk action
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_currencies_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_currencies_index")
      * @DemoRestricted(redirectRoute="admin_currencies_index")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/GeolocationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/GeolocationController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -42,7 +43,7 @@ class GeolocationController extends FrameworkBundleAdminController
     /**
      * Show geolocation page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -72,7 +73,7 @@ class GeolocationController extends FrameworkBundleAdminController
      * Process the Geolocation ByIpAddress configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_geolocation_index"
      * )
@@ -95,7 +96,7 @@ class GeolocationController extends FrameworkBundleAdminController
      * Process the Geolocation Whitelist configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_geolocation_index"
      * )
@@ -118,7 +119,7 @@ class GeolocationController extends FrameworkBundleAdminController
      * Process the Geolocation Options configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_geolocation_index"
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LanguageController.php
@@ -43,6 +43,7 @@ use PrestaShop\PrestaShop\Core\Domain\Language\QueryResult\EditableLanguage;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\LanguageFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShop\PrestaShop\Core\Util\Url\UrlFileCheckerInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -60,7 +61,7 @@ class LanguageController extends FrameworkBundleAdminController
     /**
      * Show languages listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param LanguageFilters $filters
@@ -90,7 +91,7 @@ class LanguageController extends FrameworkBundleAdminController
      *
      * Process Grid search.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -112,7 +113,7 @@ class LanguageController extends FrameworkBundleAdminController
     /**
      * Show language creation form page and handle its submit.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -149,7 +150,7 @@ class LanguageController extends FrameworkBundleAdminController
     /**
      * Show language edit form page and handle its submit.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $languageId
      * @param Request $request
@@ -215,7 +216,7 @@ class LanguageController extends FrameworkBundleAdminController
     /**
      * Deletes language
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_languages_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_languages_index")
      * @DemoRestricted(redirectRoute="admin_languages_index")
      *
      * @param int $languageId
@@ -238,7 +239,7 @@ class LanguageController extends FrameworkBundleAdminController
     /**
      * Deletes languages in bulk action
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_languages_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_languages_index")
      * @DemoRestricted(redirectRoute="admin_languages_index")
      *
      * @param Request $request
@@ -266,7 +267,7 @@ class LanguageController extends FrameworkBundleAdminController
     /**
      * Toggles language status
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_languages_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_languages_index")
      * @DemoRestricted(redirectRoute="admin_languages_index")
      *
      * @param int $languageId
@@ -298,7 +299,7 @@ class LanguageController extends FrameworkBundleAdminController
     /**
      * Toggles languages status in bulk action
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_languages_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_languages_index")
      * @DemoRestricted(redirectRoute="admin_languages_index")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/LocalizationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/LocalizationController.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Controller\Admin\Improve\International;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Localization\Pack\Import\LocalizationPackImportConfig;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Improve\International\Localization\ImportLocalizationPackType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -44,7 +45,7 @@ class LocalizationController extends FrameworkBundleAdminController
     /**
      * Show localization settings page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param Request $request
      *
@@ -79,7 +80,7 @@ class LocalizationController extends FrameworkBundleAdminController
      * Process the Localization Configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      * @DemoRestricted(redirectRoute="admin_localization_index")
@@ -101,7 +102,7 @@ class LocalizationController extends FrameworkBundleAdminController
      * Process the Localization Local Units form.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      * @DemoRestricted(redirectRoute="admin_localization_index")
@@ -123,7 +124,7 @@ class LocalizationController extends FrameworkBundleAdminController
      * Process the Localization Advanced form.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      * @DemoRestricted(redirectRoute="admin_localization_index")
@@ -180,7 +181,7 @@ class LocalizationController extends FrameworkBundleAdminController
      * Handles localization pack import.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this."
      * )
      * @DemoRestricted(redirectRoute="admin_localization_index")

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/StateController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/StateController.php
@@ -45,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Domain\Zone\Exception\ZoneNotFoundException;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\StateFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -90,7 +91,7 @@ class StateController extends FrameworkBundleAdminController
     /**
      * Show states listing page
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param StateFilters $filters
@@ -112,7 +113,7 @@ class StateController extends FrameworkBundleAdminController
     /**
      * Deletes state
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_states_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_states_index")
      * @DemoRestricted(redirectRoute="admin_states_index")
      *
      * @param int $stateId
@@ -138,7 +139,7 @@ class StateController extends FrameworkBundleAdminController
      * Handles edit form rendering and submission
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_states_index"
      * )
      *
@@ -189,7 +190,7 @@ class StateController extends FrameworkBundleAdminController
      * Show "Add new" form and handle form submit.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_states_index",
      *     message="You do not have permission to create this."
      * )
@@ -230,7 +231,7 @@ class StateController extends FrameworkBundleAdminController
     /**
      * Toggles state status
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_states_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_states_index")
      * @DemoRestricted(redirectRoute="admin_states_index")
      *
      * @param int $stateId
@@ -264,7 +265,7 @@ class StateController extends FrameworkBundleAdminController
      * Delete states in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_states_index",
      *     message="You do not have permission to delete this."
      * )
@@ -293,7 +294,7 @@ class StateController extends FrameworkBundleAdminController
     /**
      * Enables states on bulk action
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_states_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_states_index")
      * @DemoRestricted(redirectRoute="admin_states_index")
      *
      * @param Request $request
@@ -321,7 +322,7 @@ class StateController extends FrameworkBundleAdminController
     /**
      * Disables states on bulk action
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_states_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_states_index")
      * @DemoRestricted(redirectRoute="admin_states_index")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxController.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Domain\Tax\Query\GetTaxForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Tax\QueryResult\EditableTax;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\TaxFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -54,7 +55,7 @@ class TaxController extends FrameworkBundleAdminController
     /**
      * Show taxes page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param TaxFilters $filters
@@ -81,7 +82,7 @@ class TaxController extends FrameworkBundleAdminController
      * Process tax options configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_taxes_index"
      * )
      * @DemoRestricted(redirectRoute="admin_taxes_index")
@@ -117,7 +118,7 @@ class TaxController extends FrameworkBundleAdminController
      *
      * Provides filters functionality.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -142,7 +143,7 @@ class TaxController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_taxes_index",
      * )
      *
@@ -198,7 +199,7 @@ class TaxController extends FrameworkBundleAdminController
      * Handles tax edit
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_taxes_index",
      * )
      *
@@ -262,7 +263,7 @@ class TaxController extends FrameworkBundleAdminController
      * Deletes tax.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_taxes_index",
      * )
      * @DemoRestricted(redirectRoute="admin_taxes_index")
@@ -291,7 +292,7 @@ class TaxController extends FrameworkBundleAdminController
      * @param int $taxId
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_taxes_index",
      * )
      * @DemoRestricted(redirectRoute="admin_taxes_index")
@@ -321,7 +322,7 @@ class TaxController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_taxes_index",
      * )
      * @DemoRestricted(redirectRoute="admin_taxes_index")
@@ -350,7 +351,7 @@ class TaxController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_taxes_index",
      * )
      * @DemoRestricted(redirectRoute="admin_taxes_index")
@@ -379,7 +380,7 @@ class TaxController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_taxes_index",
      * )
      * @DemoRestricted(redirectRoute="admin_taxes_index")

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxRulesGroupController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TaxRulesGroupController.php
@@ -44,6 +44,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterf
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\TaxRuleFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\TaxRulesGroupFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -58,7 +59,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
     /**
      * Show tax rules group page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param TaxRulesGroupFilters $filters
@@ -80,7 +81,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_tax_rules_groups_index",
      * )
      *
@@ -118,7 +119,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
      * Handles tax rules group edit
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_tax_rules_groups_index",
      * )
      *
@@ -168,7 +169,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
      * Deletes tax rules group.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_tax_rules_groups_index",
      * )
      *
@@ -195,7 +196,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
      * Toggles status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_tax_rules_groups_index",
      * )
      *
@@ -232,7 +233,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_tax_rules_groups_index",
      * )
      *
@@ -261,7 +262,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_tax_rules_groups_index",
      * )
      *
@@ -290,7 +291,7 @@ class TaxRulesGroupController extends FrameworkBundleAdminController
      * @param Request $request
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_tax_rules_groups_index",
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/TranslationsController.php
@@ -29,6 +29,7 @@ namespace PrestaShopBundle\Controller\Admin\Improve\International;
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Language\Copier\LanguageCopierConfig;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ProviderDefinitionInterface;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Exception\InvalidModuleException;
@@ -65,7 +66,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Extract theme using locale and theme name.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -93,7 +94,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Show translations settings page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -125,7 +126,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Modify translations action.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -150,7 +151,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Add language pack for new languages and updates for the existing ones action.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))"))
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))"))
      *
      * @param Request $request
      *
@@ -189,7 +190,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Extract catalogues using locale.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -286,7 +287,7 @@ class TranslationsController extends FrameworkBundleAdminController
     /**
      * Copy language action.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Improve/International/ZoneController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/International/ZoneController.php
@@ -43,6 +43,7 @@ use PrestaShop\PrestaShop\Core\Domain\Zone\Query\GetZoneForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Zone\QueryResult\EditableZone;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\ZoneGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\ZoneFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -58,7 +59,7 @@ class ZoneController extends FrameworkBundleAdminController
     /**
      * Show all zones.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param ZoneFilters $zoneFilters
@@ -81,7 +82,7 @@ class ZoneController extends FrameworkBundleAdminController
     /**
      * Provides filters functionality.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -103,7 +104,7 @@ class ZoneController extends FrameworkBundleAdminController
      * Show "Add new" zone form and handles its submit.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_zones_index",
      *     message="You need permission to create new zone."
      * )
@@ -144,7 +145,7 @@ class ZoneController extends FrameworkBundleAdminController
      * Displays zone edit for and handles its submit.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_zones_index",
      *     message="You need permission to edit this."
      * )
@@ -204,7 +205,7 @@ class ZoneController extends FrameworkBundleAdminController
      * Deletes zone.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_zones_index",
      *     message="You need permission to delete this."
      * )
@@ -233,7 +234,7 @@ class ZoneController extends FrameworkBundleAdminController
      * Toggles zone active status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_zones_index",
      *     message="You do not have permission to edit this."
      * )
@@ -264,7 +265,7 @@ class ZoneController extends FrameworkBundleAdminController
     /**
      * Deletes zones in bulk action
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_zones_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_zones_index")
      * @DemoRestricted(redirectRoute="admin_zones_index")
      *
      * @param Request $request
@@ -293,7 +294,7 @@ class ZoneController extends FrameworkBundleAdminController
      * Bulk toggles zones status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_zones_index",
      * )
      * @DemoRestricted(redirectRoute="admin_zones_index")

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -57,7 +57,7 @@ class ModuleController extends ModuleAbstractController
     /**
      * Controller responsible for displaying "Catalog Module Grid" section of Module management pages with ajax.
      *
-     * @AdminSecurity("is_granted('read', 'ADMINMODULESSF_')")
+     * @AdminSecurity("is_granted(Permission::READ, 'ADMINMODULESSF_')")
      *
      * @return Response
      */
@@ -100,7 +100,7 @@ class ModuleController extends ModuleAbstractController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('read', 'ADMINMODULESSF_') || is_granted('create', 'ADMINMODULESSF_') || is_granted('update', 'ADMINMODULESSF_') || is_granted('delete', 'ADMINMODULESSF_')"
+     *     "is_granted(Permission::READ, 'ADMINMODULESSF_') || is_granted(Permission::CREATE, 'ADMINMODULESSF_') || is_granted(Permission::UPDATE, 'ADMINMODULESSF_') || is_granted(Permission::DELETE', 'ADMINMODULESSF_')"
      * )
      *
      * @param Request $module_name

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AlertsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/AlertsController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\Modules;
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -36,7 +37,7 @@ use Symfony\Component\HttpFoundation\Response;
 class AlertsController extends ModuleAbstractController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return Response
      */

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Modules/UpdatesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Modules/UpdatesController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\Modules;
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -35,7 +36,7 @@ use Symfony\Component\HttpFoundation\Response;
 class UpdatesController extends ModuleAbstractController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return Response
      */

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Payment/PaymentMethodsController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Payment/PaymentMethodsController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Admin\Improve\Payment;
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\Request;
@@ -39,7 +40,7 @@ class PaymentMethodsController extends FrameworkBundleAdminController
     /**
      * Show payment method modules.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Payment/PaymentPreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Payment/PaymentPreferencesController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Improve\Payment;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -42,7 +43,7 @@ class PaymentPreferencesController extends FrameworkBundleAdminController
      * Show payment preferences page.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *      message="Access denied."
      * )
      *
@@ -81,7 +82,7 @@ class PaymentPreferencesController extends FrameworkBundleAdminController
      * Process payment modules preferences form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="Access denied.",
      *     redirectRoute="admin_payment_preferences"
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/CarriersController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/CarriersController.php
@@ -45,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Grid\Position\Exception\PositionUpdateException;
 use PrestaShop\PrestaShop\Core\Grid\Position\GridPositionUpdaterInterface;
 use PrestaShop\PrestaShop\Core\Grid\Position\PositionUpdateFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\CarrierFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -61,7 +62,7 @@ class CarriersController extends FrameworkBundleAdminController
     /**
      * Show carriers listing page
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param CarrierFilters $filters
@@ -94,7 +95,7 @@ class CarriersController extends FrameworkBundleAdminController
     /**
      * Process Grid search.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -129,7 +130,7 @@ class CarriersController extends FrameworkBundleAdminController
      * Deletes carrier.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_carriers_index",
      * )
      * @DemoRestricted(redirectRoute="admin_carriers_index")
@@ -154,7 +155,7 @@ class CarriersController extends FrameworkBundleAdminController
      * Toggles carrier status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_carriers_index",
      *     message="You need permission to edit this."
      * )
@@ -185,7 +186,7 @@ class CarriersController extends FrameworkBundleAdminController
      * Toggles carrier is-free status
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_carriers_index",
      *     message="You need permission to edit this."
      * )
@@ -216,7 +217,7 @@ class CarriersController extends FrameworkBundleAdminController
      * Changes carrier position
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_carriers_index",
      *     message="You need permission to edit this."
      * )
@@ -253,7 +254,7 @@ class CarriersController extends FrameworkBundleAdminController
      * Bulk deletes carriers.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_carriers_index",
      * )
      * @DemoRestricted(redirectRoute="admin_carriers_index")
@@ -283,7 +284,7 @@ class CarriersController extends FrameworkBundleAdminController
      * Enables carrier status on bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_carriers_index",
      * )
      * @DemoRestricted(redirectRoute="admin_carriers_index")
@@ -313,7 +314,7 @@ class CarriersController extends FrameworkBundleAdminController
      * Disables carrier status on bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_carriers_index",
      * )
      * @DemoRestricted(redirectRoute="admin_carriers_index")

--- a/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/Shipping/PreferencesController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Improve\Shipping;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\Form\FormInterface;
@@ -43,7 +44,7 @@ class PreferencesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -57,7 +58,7 @@ class PreferencesController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_shipping_preferences")
      *
@@ -95,7 +96,7 @@ class PreferencesController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_shipping_preferences")
      *

--- a/src/PrestaShopBundle/Controller/Admin/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/ProductController.php
@@ -104,7 +104,7 @@ class ProductController extends FrameworkBundleAdminController
      *
      * URL example: /product/catalog/40/20/id_product/asc
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param int $limit The size of the listing
@@ -1171,7 +1171,7 @@ class ProductController extends FrameworkBundleAdminController
      * Toggle product status
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Address/AddressController.php
@@ -55,6 +55,7 @@ use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundExcepti
 use PrestaShop\PrestaShop\Core\Domain\Order\OrderAddressType;
 use PrestaShop\PrestaShop\Core\Domain\State\Exception\StateConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\AddressFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Address\RequiredFieldsAddressType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -71,7 +72,7 @@ class AddressController extends FrameworkBundleAdminController
     /**
      * Show addresses listing page
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param AddressFilters $filters
@@ -97,7 +98,7 @@ class AddressController extends FrameworkBundleAdminController
      * Process addresses required fields configuration form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_addresses_index"
      * )
      *
@@ -129,7 +130,7 @@ class AddressController extends FrameworkBundleAdminController
     /**
      * Deletes address
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_addresses_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_addresses_index")
      *
      * @param int $addressId
      *
@@ -156,7 +157,7 @@ class AddressController extends FrameworkBundleAdminController
      * Delete addresses in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_addresses_index",
      *     message="You do not have permission to delete this."
      * )
@@ -232,7 +233,7 @@ class AddressController extends FrameworkBundleAdminController
      * Show "Add new" form and handle form submit.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_addresses_index",
      *     message="You do not have permission to create this."
      * )
@@ -323,7 +324,7 @@ class AddressController extends FrameworkBundleAdminController
      * Handles edit form rendering and submission
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_addresses_index"
      * )
      *
@@ -399,7 +400,7 @@ class AddressController extends FrameworkBundleAdminController
      * Handles edit form rendering and submission for order address
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_orders_index"
      * )
      *
@@ -500,7 +501,7 @@ class AddressController extends FrameworkBundleAdminController
      * Handles edit form rendering and submission for cart address
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_orders_index"
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttachmentController.php
@@ -47,6 +47,7 @@ use PrestaShop\PrestaShop\Core\Domain\Attachment\QueryResult\Attachment;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\QueryResult\AttachmentInformation;
 use PrestaShop\PrestaShop\Core\Domain\Attachment\QueryResult\EditableAttachment;
 use PrestaShop\PrestaShop\Core\Search\Filters\AttachmentFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -61,7 +62,7 @@ use Symfony\Component\HttpFoundation\Response;
 class AttachmentController extends FrameworkBundleAdminController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      */
     public function indexAction(Request $request, AttachmentFilters $filters): Response
     {
@@ -80,7 +81,7 @@ class AttachmentController extends FrameworkBundleAdminController
      * Show "Add new" form and handle form submit.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_attachments_index",
      *     message="You do not have permission to create this."
      * )
@@ -134,7 +135,7 @@ class AttachmentController extends FrameworkBundleAdminController
      * Show & process attachment editing.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_attachments_index",
      *     message="You do not have permission to edit this."
      * )
@@ -201,7 +202,7 @@ class AttachmentController extends FrameworkBundleAdminController
      * View attachment.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     redirectRoute="admin_attachments_index",
      *     message="You do not have permission to edit this."
      * )
@@ -223,7 +224,7 @@ class AttachmentController extends FrameworkBundleAdminController
     /**
      * Deletes attachment
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_attachments_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_attachments_index")
      * @DemoRestricted(redirectRoute="admin_attachments_index")
      */
     public function deleteAction(int $attachmentId): RedirectResponse
@@ -245,7 +246,7 @@ class AttachmentController extends FrameworkBundleAdminController
      * Delete attachments in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_attachments_index",
      *     message="You do not have permission to delete this."
      * )
@@ -268,7 +269,7 @@ class AttachmentController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', 'AdminProducts') || is_granted('read', 'AdminAttachments')")
+     * @AdminSecurity("is_granted(Permission::READ, 'AdminProducts') || is_granted(Permission::READ, 'AdminAttachments')")
      *
      * @param int $attachmentId
      *
@@ -282,7 +283,7 @@ class AttachmentController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', 'AdminProducts') || is_granted('read', 'AdminAttachments')")
+     * @AdminSecurity("is_granted(Permission::READ, 'AdminProducts') || is_granted(Permission::READ, 'AdminAttachments')")
      *
      * @param string $searchPhrase
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeController.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Exception\TranslatableCoreException;
 use PrestaShop\PrestaShop\Core\Grid\Position\GridPositionUpdaterInterface;
 use PrestaShop\PrestaShop\Core\Grid\Position\PositionUpdateFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\AttributeFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -50,7 +51,7 @@ class AttributeController extends FrameworkBundleAdminController
     /**
      * Displays Attribute groups > attributes page
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     redirectRoute="admin_attributes_index",
      *     redirectQueryParamsToKeep={"attributeGroupId"}
      * )
@@ -90,7 +91,7 @@ class AttributeController extends FrameworkBundleAdminController
     /**
      * Updates attributes positioning order
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_attributes_index",
      *     redirectQueryParamsToKeep={"attributeGroupId"}
      * )
@@ -129,7 +130,7 @@ class AttributeController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to create this."
      * )
      *
@@ -147,7 +148,7 @@ class AttributeController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      *
@@ -167,7 +168,7 @@ class AttributeController extends FrameworkBundleAdminController
     /**
      * Deletes attribute
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_attributes_index",
      *     redirectQueryParamsToKeep={"attributeGroupId"}
      * )
@@ -197,7 +198,7 @@ class AttributeController extends FrameworkBundleAdminController
     /**
      * Deletes multiple attributes by provided ids from request
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_attributes_index",
      *     redirectQueryParamsToKeep={"attributeGroupId"}
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeGroupController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/AttributeGroupController.php
@@ -37,6 +37,7 @@ use PrestaShop\PrestaShop\Core\Exception\TranslatableCoreException;
 use PrestaShop\PrestaShop\Core\Grid\Position\GridPositionUpdaterInterface;
 use PrestaShop\PrestaShop\Core\Grid\Position\PositionUpdateFactoryInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\AttributeGroupFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -48,7 +49,7 @@ class AttributeGroupController extends FrameworkBundleAdminController
     /**
      * Displays Attribute groups page
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param AttributeGroupFilters $attributeGroupFilters
@@ -76,7 +77,7 @@ class AttributeGroupController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to create this."
      * )
      *
@@ -90,7 +91,7 @@ class AttributeGroupController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      *
@@ -106,7 +107,7 @@ class AttributeGroupController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     message="You do not have permission to export this."
      * )
 
@@ -124,7 +125,7 @@ class AttributeGroupController extends FrameworkBundleAdminController
     /**
      * Updates attribute groups positioning order
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_attribute_groups_index"
      * )
      *
@@ -159,7 +160,7 @@ class AttributeGroupController extends FrameworkBundleAdminController
     /**
      * Deletes attribute group
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_attribute_groups_index",
      * )
      *
@@ -185,7 +186,7 @@ class AttributeGroupController extends FrameworkBundleAdminController
     /**
      * Deletes multiple attribute groups by provided ids from request
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))",
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_attribute_groups_index",
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CartRuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CartRuleController.php
@@ -38,6 +38,7 @@ use PrestaShop\PrestaShop\Core\Domain\CartRule\Query\GetCartRuleForEditing;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\Query\SearchCartRules;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\QueryResult\EditableCartRule;
 use PrestaShop\PrestaShop\Core\Search\Filters\CartRuleFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Security\Annotation\DemoRestricted;
@@ -54,7 +55,7 @@ class CartRuleController extends FrameworkBundleAdminController
     /**
      * Displays cart rule listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param CartRuleFilters $cartRuleFilters
@@ -79,7 +80,7 @@ class CartRuleController extends FrameworkBundleAdminController
     /**
      * Searches for cart rules by provided search phrase
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      *
@@ -109,7 +110,7 @@ class CartRuleController extends FrameworkBundleAdminController
     /**
      * Deletes cart rule
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
      * @DemoRestricted(redirectRoute="admin_cart_rules_index")
      *
      * @param int $cartRuleId
@@ -134,7 +135,7 @@ class CartRuleController extends FrameworkBundleAdminController
     /**
      * Deletes cartRules on bulk action
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
      * @DemoRestricted(redirectRoute="admin_cart_rules_index")
      *
      * @param Request $request
@@ -161,7 +162,7 @@ class CartRuleController extends FrameworkBundleAdminController
     /**
      * Toggles cart rule status
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
      * @DemoRestricted(redirectRoute="admin_cart_rules_index")
      *
      * @param int $cartRuleId
@@ -208,7 +209,7 @@ class CartRuleController extends FrameworkBundleAdminController
     /**
      * Enables cart rules on bulk action
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
      * @DemoRestricted(redirectRoute="admin_cart_rules_index")
      *
      * @param Request $request
@@ -236,7 +237,7 @@ class CartRuleController extends FrameworkBundleAdminController
     /**
      * Disables cart rules on bulk action
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_cart_rules_index")
      * @DemoRestricted(redirectRoute="admin_cart_rules_index")
      *
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CatalogPriceRuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CatalogPriceRuleController.php
@@ -42,6 +42,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterf
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CatalogPriceRuleGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\CatalogPriceRuleFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -62,7 +63,7 @@ class CatalogPriceRuleController extends FrameworkBundleAdminController
     /**
      * Displays catalog price rule listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param CatalogPriceRuleFilters $catalogPriceRuleFilters
@@ -86,7 +87,7 @@ class CatalogPriceRuleController extends FrameworkBundleAdminController
     /**
      * Retrieves catalog prices rules for product.
      *
-     * @AdminSecurity("is_granted('read', 'AdminProducts') || is_granted('read', 'AdminSpecificPriceRule')")
+     * @AdminSecurity("is_granted(Permission::READ, 'AdminProducts') || is_granted(Permission::READ, 'AdminSpecificPriceRule')")
      *
      * @param Request $request
      *
@@ -114,7 +115,7 @@ class CatalogPriceRuleController extends FrameworkBundleAdminController
     /**
      * Provides filters functionality.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -136,7 +137,7 @@ class CatalogPriceRuleController extends FrameworkBundleAdminController
     /**
      * Deletes catalog price rule
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_catalog_price_rules_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_catalog_price_rules_index")
      * @DemoRestricted(redirectRoute="admin_catalog_price_rules_index")
      *
      * @param int|string $catalogPriceRuleId
@@ -161,7 +162,7 @@ class CatalogPriceRuleController extends FrameworkBundleAdminController
     /**
      * Deletes catalogPriceRules on bulk action
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_catalog_price_rules_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_catalog_price_rules_index")
      * @DemoRestricted(redirectRoute="admin_catalog_price_rules_index")
      *
      * @param Request $request
@@ -188,7 +189,7 @@ class CatalogPriceRuleController extends FrameworkBundleAdminController
     /**
      * Show & process catalog price rule creation.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -221,7 +222,7 @@ class CatalogPriceRuleController extends FrameworkBundleAdminController
     /**
      * Show & process catalog price rule editing.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $catalogPriceRuleId
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/CategoryController.php
@@ -59,6 +59,7 @@ use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CategoryGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\CategoryFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Category\DeleteCategoriesType;
@@ -79,7 +80,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Show categories listing.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="You do not have permission to list this."
      * )
      *
@@ -135,7 +136,7 @@ class CategoryController extends FrameworkBundleAdminController
      *
      * Process Grid search.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -158,7 +159,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Show "Add new" form and handle form submit.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to create this.",
      *     redirectRoute="admin_categories_index"
      * )
@@ -209,7 +210,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Show "Add new root category" page & process adding.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to create this.",
      *     redirectRoute="admin_categories_index"
      * )
@@ -259,7 +260,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Show & process category editing.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_categories_index"
      * )
@@ -349,7 +350,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Show and process category editing.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_categories_index"
      * )
@@ -429,7 +430,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Deletes category cover image.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_categories_edit",
      *     redirectQueryParamsToKeep={"categoryId"}
@@ -470,7 +471,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Delete given menu thumbnail for category.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_categories_edit",
      *     redirectQueryParamsToKeep={"categoryId"}
@@ -515,7 +516,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Toggle category status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to update this."
      * )
      *
@@ -557,7 +558,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Process bulk action for categories status enabling.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to update this."
      * )
@@ -591,7 +592,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Process bulk action for categories status disabling.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to update this."
      * )
@@ -625,7 +626,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Processes bulk categories deleting.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to delete this."
      * )
@@ -672,7 +673,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Process single category deleting.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to delete this."
      * )
@@ -713,7 +714,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Export filtered categories.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_categories_index",
      *     message="You do not have permission to view this."
      * )
@@ -759,7 +760,7 @@ class CategoryController extends FrameworkBundleAdminController
      * Updates category position
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_categories_index",
      * )
      *
@@ -791,7 +792,7 @@ class CategoryController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')) || is_granted('create', 'AdminProducts')")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminProducts')")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/FeatureController.php
@@ -33,6 +33,7 @@ use Feature;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Exception\FeatureConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Exception\FeatureNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Feature\Query\GetFeatureForEditing;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Bridge\AdminController\ControllerConfiguration;
 use PrestaShopBundle\Bridge\AdminController\FrameworkBridgeControllerInterface;
 use PrestaShopBundle\Bridge\AdminController\FrameworkBridgeControllerListTrait;
@@ -56,7 +57,7 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
     use FrameworkControllerSmartyTrait;
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      */
     public function indexAction(Request $request): Response
     {
@@ -80,7 +81,7 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
     /**
      * Create feature action.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -122,7 +123,7 @@ class FeatureController extends FrameworkBundleAdminController implements Framew
     /**
      * Edit feature action.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $featureId
      * @param Request $request

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/ManufacturerController.php
@@ -61,6 +61,7 @@ use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\MemoryLimitException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\ManufacturerAddressFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\ManufacturerFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -79,7 +80,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Show manufacturers listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -106,7 +107,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Provides filters functionality
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return RedirectResponse
      */
@@ -134,7 +135,7 @@ class ManufacturerController extends FrameworkBundleAdminController
      * Show & process manufacturer creation.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))"
      * )
      *
      * @return Response
@@ -167,7 +168,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * View single manufacturer details
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param int $manufacturerId
      *
@@ -207,7 +208,7 @@ class ManufacturerController extends FrameworkBundleAdminController
      * Show & process manufacturer editing.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))"
      * )
      *
      * @param int $manufacturerId
@@ -261,7 +262,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Deletes manufacturer
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
      * @param int|string $manufacturerId
@@ -286,7 +287,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Deletes manufacturers on bulk action
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
      * @return RedirectResponse
@@ -311,7 +312,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Enables manufacturers on bulk action
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
      * @return RedirectResponse
@@ -337,7 +338,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Disables manufacturers on bulk action
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
      * @return RedirectResponse
@@ -363,7 +364,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Toggles manufacturer status
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
      * @param int $manufacturerId
@@ -393,7 +394,7 @@ class ManufacturerController extends FrameworkBundleAdminController
      * Export filtered manufacturers.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_manufacturers_index"
      * )
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
@@ -439,7 +440,7 @@ class ManufacturerController extends FrameworkBundleAdminController
      * Deletes manufacturer logo image.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_manufacturers_edit",
      *     redirectQueryParamsToKeep={"manufacturerId"}
@@ -478,7 +479,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Deletes address
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
      * @param int $addressId
@@ -504,7 +505,7 @@ class ManufacturerController extends FrameworkBundleAdminController
      * Export filtered manufacturer addresses.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_manufacturers_index"
      * )
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
@@ -550,7 +551,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Deletes adresses in bulk action
      *
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_manufacturers_index")
      * @DemoRestricted(redirectRoute="admin_manufacturers_index")
      *
      * @return RedirectResponse
@@ -575,7 +576,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Show & process address creation.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -619,7 +620,7 @@ class ManufacturerController extends FrameworkBundleAdminController
     /**
      * Show & process address editing.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $addressId
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/MonitoringController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/MonitoringController.php
@@ -45,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Search\Filters\Monitoring\NoQtyProductWithoutComb
 use PrestaShop\PrestaShop\Core\Search\Filters\Monitoring\ProductWithoutDescriptionFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\Monitoring\ProductWithoutImageFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\Monitoring\ProductWithoutPriceFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Category\DeleteCategoriesType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -61,7 +62,7 @@ class MonitoringController extends FrameworkBundleAdminController
     /**
      * Shows Monitoring listing page
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param EmptyCategoryFilters $emptyCategoryFilters
@@ -118,7 +119,7 @@ class MonitoringController extends FrameworkBundleAdminController
     /**
      * Provides filters functionality
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -143,7 +144,7 @@ class MonitoringController extends FrameworkBundleAdminController
      * Delete monitoring items in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_monitorings_index",
      *     message="You do not have permission to delete this."
      * )

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/CombinationController.php
@@ -54,6 +54,7 @@ use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\ProductCombinationFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -68,7 +69,7 @@ class CombinationController extends FrameworkBundleAdminController
     private const COMBINATIONS_PAGINATION_OPTIONS = [ProductCombinationFilters::LIST_LIMIT, 20, 50, 100];
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param int $combinationId
@@ -112,7 +113,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param string $languageCode
@@ -162,7 +163,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param int $productId
@@ -216,7 +217,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $productId
      *
@@ -238,7 +239,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param int $productId
@@ -301,7 +302,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', 'AdminProducts')")
+     * @AdminSecurity("is_granted(Permission::READ, 'AdminProducts')")
      *
      * Note: role must be hard coded because there is no route associated to this action therefore not
      * _legacy_controller request parameter.
@@ -331,7 +332,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param int $productId
      * @param int|null $shopId
@@ -350,7 +351,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param int|null $shopId
      *
@@ -367,7 +368,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param int $productId
      * @param ProductCombinationFilters $combinationFilters
@@ -391,7 +392,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $productId
      * @param ProductCombinationFilters $filters
@@ -416,7 +417,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param int $combinationId
      * @param int|null $shopId
@@ -442,7 +443,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param int $productId
@@ -503,7 +504,7 @@ class CombinationController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $productId
      * @param Request $request
@@ -544,7 +545,7 @@ class CombinationController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller'))"
      * )
      *
      * @param int $productId

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ImageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ImageController.php
@@ -52,6 +52,7 @@ use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterf
 use PrestaShop\PrestaShop\Core\Image\Exception\CannotUnlinkImageException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\MemoryLimitException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -63,7 +64,7 @@ class ImageController extends FrameworkBundleAdminController
     /**
      * Retrieves images for all shops, but the cover (which is multi-shop compatable) is retrieved based on $shopId
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="You do not have permission to update this.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="You do not have permission to update this.")
      *
      * @param int $productId
      * @param int $shopId
@@ -82,7 +83,7 @@ class ImageController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to red or update this.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to red or update this.")
      *
      * @param int $productId
      *
@@ -113,7 +114,7 @@ class ImageController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to update this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to update this.")
      *
      * @param Request $request
      *
@@ -148,7 +149,7 @@ class ImageController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to update this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to update this.")
      *
      * @param Request $request
      * @param int $productImageId
@@ -181,7 +182,7 @@ class ImageController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to update this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to update this.")
      *
      * @param int $productImageId
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/ProductController.php
@@ -122,7 +122,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Shows products listing.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param ProductFilters $filters
@@ -161,7 +161,7 @@ class ProductController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return RedirectResponse
      */
@@ -197,7 +197,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Reset filters for the grid only (category is kept, it can be cleared via another dedicated action)
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return JsonResponse
      */
@@ -228,7 +228,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Apply the category filter and redirect to list on first page.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return RedirectResponse
      */
@@ -255,7 +255,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Shows products shop details.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param ProductFilters $filters
      * @param int $productId
@@ -287,7 +287,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', 'AdminProducts')")
+     * @AdminSecurity("is_granted(Permission::READ, 'AdminProducts')")
      *
      * @return Response
      */
@@ -307,7 +307,7 @@ class ProductController extends FrameworkBundleAdminController
      * since the LinkRowAction expects a symfony route, so this action is merely used as a proxy for symfony routing
      * and redirects to the appropriate product preview url.
      *
-     * @AdminSecurity("is_granted('read', 'AdminProducts')")
+     * @AdminSecurity("is_granted(Permission::READ, 'AdminProducts')")
      *
      * @return RedirectResponse
      */
@@ -333,7 +333,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="You do not have permission to create this.")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))", message="You do not have permission to create this.")
      *
      * @param Request $request
      * @param int $productId
@@ -371,7 +371,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="You do not have permission to create this.")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))", message="You do not have permission to create this.")
      *
      * @param Request $request
      *
@@ -417,7 +417,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="You do not have permission to update this.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="You do not have permission to update this.")
      *
      * @param Request $request
      * @param int $productId
@@ -488,7 +488,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
      *
      * @param int $productId
      *
@@ -510,7 +510,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
      *
      * @param int $productId
      * @param int $shopId
@@ -533,7 +533,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
      *
      * @param int $productId
      * @param int $shopGroupId
@@ -559,7 +559,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
      *
      * @param int $shopId
      *
@@ -571,7 +571,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", message="You do not have permission to delete this.")
      *
      * @param int $shopGroupId
      *
@@ -583,7 +583,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="You do not have permission to create this.")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))", message="You do not have permission to create this.")
      *
      * @param int $productId
      *
@@ -595,7 +595,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="You do not have permission to create this.")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))", message="You do not have permission to create this.")
      *
      * @param int $productId
      * @param int $shopId
@@ -608,7 +608,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", message="You do not have permission to create this.")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))", message="You do not have permission to create this.")
      *
      * @param int $productId
      * @param int $shopGroupId
@@ -623,7 +623,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Toggles product status
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
      *
      * @param int $productId
      * @param int $shopId
@@ -660,7 +660,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Enable product status for all shops and redirect to product list.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
      *
      * @param int $productId
      *
@@ -674,7 +674,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Enable product status for shop group and redirect to product list.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
      *
      * @param int $productId
      * @param int $shopGroupId
@@ -689,7 +689,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Disable product status for shop group and redirect to product list.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
      *
      * @param int $productId
      * @param int $shopGroupId
@@ -704,7 +704,7 @@ class ProductController extends FrameworkBundleAdminController
     /**
      * Disable product status for all shops and redirect to product list.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_products_v2_index")
      *
      * @param int $productId
      *
@@ -719,7 +719,7 @@ class ProductController extends FrameworkBundleAdminController
      * Updates product position.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     redirectQueryParamsToKeep={"id_category"},
      *     message="You do not have permission to edit this."
@@ -756,7 +756,7 @@ class ProductController extends FrameworkBundleAdminController
      * Delete products in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to delete this."
      * )
@@ -790,7 +790,7 @@ class ProductController extends FrameworkBundleAdminController
      * Enable products in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to edit this."
      * )
@@ -808,7 +808,7 @@ class ProductController extends FrameworkBundleAdminController
      * Enable products in bulk action for a specific shop.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to edit this."
      * )
@@ -827,7 +827,7 @@ class ProductController extends FrameworkBundleAdminController
      * Enable products in bulk action for a specific shop group.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to edit this."
      * )
@@ -846,7 +846,7 @@ class ProductController extends FrameworkBundleAdminController
      * Disable products in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to edit this."
      * )
@@ -864,7 +864,7 @@ class ProductController extends FrameworkBundleAdminController
      * Disable products in bulk action for a specific shop.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to edit this."
      * )
@@ -883,7 +883,7 @@ class ProductController extends FrameworkBundleAdminController
      * Disable products in bulk action for a specific shop group.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to edit this."
      * )
@@ -902,7 +902,7 @@ class ProductController extends FrameworkBundleAdminController
      * Duplicate products in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to edit this."
      * )
@@ -920,7 +920,7 @@ class ProductController extends FrameworkBundleAdminController
      * Duplicate products in bulk action for specific shop.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to edit this."
      * )
@@ -939,7 +939,7 @@ class ProductController extends FrameworkBundleAdminController
      * Duplicate products in bulk action for specific shop group.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_products_v2_index",
      *     message="You do not have permission to edit this."
      * )
@@ -955,7 +955,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="You do not have permission to read this.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="You do not have permission to read this.")
      *
      * Download the content of the virtual product.
      *
@@ -985,7 +985,7 @@ class ProductController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param string $languageCode

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/SpecificPriceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/Product/SpecificPriceController.php
@@ -39,6 +39,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\ValueObject\InitialP
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Reduction;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Builder\FormBuilderInterface;
 use PrestaShop\PrestaShop\Core\Form\IdentifiableObject\Handler\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime as DateTimeUtil;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -51,7 +52,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
     private const UNSPECIFIED_VALUE_FORMAT = '--';
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      */
     public function listAction(Request $request, int $productId): JsonResponse
     {
@@ -74,7 +75,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -106,7 +107,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @return Response
      */
@@ -137,7 +138,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param int $specificPriceId

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/StockController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/StockController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Sell\Catalog;
 
 use PrestaShop\PrestaShop\Adapter\Shop\Context;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 
@@ -36,7 +37,7 @@ use PrestaShopBundle\Security\Annotation\AdminSecurity;
 class StockController extends FrameworkBundleAdminController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      */
     public function overviewAction()
     {

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Catalog/SupplierController.php
@@ -51,6 +51,7 @@ use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\ImageUploadException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\MemoryLimitException;
 use PrestaShop\PrestaShop\Core\Image\Uploader\Exception\UploadedImageConstraintException;
 use PrestaShop\PrestaShop\Core\Search\Filters\SupplierFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -68,7 +69,7 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * Show suppliers listing.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param SupplierFilters $filters
@@ -95,7 +96,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Displays supplier creation form and handles form submit which creates new supplier.
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_suppliers_index",
      *     message="You do not have permission to add this."
      * )
@@ -138,7 +139,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Deletes supplier.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_suppliers_index",
      *     message="You do not have permission to delete this."
      * )
@@ -170,7 +171,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Bulk deletion of suppliers.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_suppliers_index",
      *     message="You do not have permission to delete this."
      * )
@@ -210,7 +211,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Bulk disables supplier statuses.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_suppliers_index",
      *     message="You do not have permission to edit this."
      * )
@@ -249,7 +250,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Bulk enables supplier statuses.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_suppliers_index",
      *     message="You do not have permission to edit this."
      * )
@@ -288,7 +289,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Displays edit supplier form and submits form.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_suppliers_index",
      *     message="You do not have permission to edit this."
      * )
@@ -348,7 +349,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Toggles supplier active status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_suppliers_index",
      *     message="You do not have permission to edit this."
      * )
@@ -379,7 +380,7 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * Views supplier products information.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param int $supplierId
@@ -419,7 +420,7 @@ class SupplierController extends FrameworkBundleAdminController
     /**
      * Exports to csv visible suppliers list data.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param SupplierFilters $filters
      *
@@ -460,7 +461,7 @@ class SupplierController extends FrameworkBundleAdminController
      * Deletes supplier logo image.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to edit this.",
      *     redirectRoute="admin_suppliers_edit",
      *     redirectQueryParamsToKeep={"supplierId"}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -62,6 +62,7 @@ use PrestaShop\PrestaShop\Core\Search\Filters\CustomerCartFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerDiscountFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerOrderFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Customer\DeleteCustomersType;
@@ -85,7 +86,7 @@ class CustomerController extends AbstractAdminController
      * Show customers listing.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     redirectRoute="admin_customers_index",
      *     message="You do not have permission to view this."
      * )
@@ -127,7 +128,7 @@ class CustomerController extends AbstractAdminController
      *
      * Process Grid search.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -148,7 +149,7 @@ class CustomerController extends AbstractAdminController
     /**
      * Show customer create form & handle processing of it.
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -203,7 +204,7 @@ class CustomerController extends AbstractAdminController
     /**
      * Show customer edit form & handle processing of it.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param int $customerId
      * @param Request $request
@@ -266,7 +267,7 @@ class CustomerController extends AbstractAdminController
     /**
      * View customer information.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_customers_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_customers_index")
      * @DemoRestricted(redirectRoute="admin_customers_index")
      *
      * @param int $customerId
@@ -358,7 +359,7 @@ class CustomerController extends AbstractAdminController
      * Set private note about customer.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *      redirectRoute="admin_customers_index"
      * )
      *
@@ -398,7 +399,7 @@ class CustomerController extends AbstractAdminController
      * Transforms guest to customer
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *      redirectRoute="admin_customers_index"
      * )
      *
@@ -435,7 +436,7 @@ class CustomerController extends AbstractAdminController
      * Sets required fields for customer
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *      redirectRoute="admin_customers_index"
      * )
      *
@@ -462,7 +463,7 @@ class CustomerController extends AbstractAdminController
     /**
      * Search for customers by query.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      *
@@ -498,7 +499,7 @@ class CustomerController extends AbstractAdminController
     /**
      * Provides customer information for address creation in json format
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -532,7 +533,7 @@ class CustomerController extends AbstractAdminController
      * Toggle customer status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_customers_index",
      *     message="You do not have permission to edit this."
      * )
@@ -570,7 +571,7 @@ class CustomerController extends AbstractAdminController
      * Toggle customer newsletter subscription status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_customers_index",
      *     message="You do not have permission to edit this."
      * )
@@ -610,7 +611,7 @@ class CustomerController extends AbstractAdminController
      * Toggle customer partner offer subscription status.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_customers_index",
      *     message="You do not have permission to edit this."
      * )
@@ -648,7 +649,7 @@ class CustomerController extends AbstractAdminController
      * Delete customers in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_customers_index",
      *     message="You do not have permission to delete this."
      * )
@@ -693,7 +694,7 @@ class CustomerController extends AbstractAdminController
      * Delete customer.
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_customers_index",
      *     message="You do not have permission to delete this."
      * )
@@ -733,7 +734,7 @@ class CustomerController extends AbstractAdminController
      * Enable customers in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_customers_index",
      *     message="You do not have permission to edit this."
      * )
@@ -765,7 +766,7 @@ class CustomerController extends AbstractAdminController
      * Disable customers in bulk action.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_customers_index",
      *     message="You do not have permission to edit this."
      * )
@@ -796,7 +797,7 @@ class CustomerController extends AbstractAdminController
     /**
      * Export filtered customers
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param CustomerFilters $filters
      *
@@ -851,7 +852,7 @@ class CustomerController extends AbstractAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param int $customerId
      *
@@ -874,7 +875,7 @@ class CustomerController extends AbstractAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param int $customerId
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/OutstandingController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/OutstandingController.php
@@ -30,6 +30,7 @@ namespace PrestaShopBundle\Controller\Admin\Sell\Customer;
 
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OutstandingGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\OutstandingFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use PrestaShopBundle\Service\Grid\ResponseBuilder;
@@ -44,7 +45,7 @@ class OutstandingController extends FrameworkBundleAdminController
     /**
      * Show list of outstandings.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param OutstandingFilters $filters
@@ -66,7 +67,7 @@ class OutstandingController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_outstanding_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_outstanding_index")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/CustomerThreadController.php
@@ -41,6 +41,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryResult\CustomerThread
 use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeEmailById;
 use PrestaShop\PrestaShop\Core\Domain\ValueObject\Email;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerThreadFilter;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\CustomerService\CustomerThread\ForwardCustomerThreadType;
 use PrestaShopBundle\Form\Admin\Sell\CustomerService\ReplyToCustomerThreadType;
@@ -57,7 +58,7 @@ class CustomerThreadController extends FrameworkBundleAdminController
     /**
      * Show list of customer threads
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param CustomerThreadFilter $filters
@@ -81,7 +82,7 @@ class CustomerThreadController extends FrameworkBundleAdminController
      * View customer thread
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     message="You do not have permission to view this.",
      *     redirectRoute="admin_customer_threads_index"
      * )
@@ -125,7 +126,7 @@ class CustomerThreadController extends FrameworkBundleAdminController
      * Reply to customer thread
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_customer_threads_index"
      * )
@@ -185,7 +186,7 @@ class CustomerThreadController extends FrameworkBundleAdminController
      * Update customer thread status
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_customer_threads_index"
      * )
@@ -210,7 +211,7 @@ class CustomerThreadController extends FrameworkBundleAdminController
      * @param int $customerThreadId
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_customer_threads")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_customer_threads")
      *
      * @return RedirectResponse
      */
@@ -225,7 +226,7 @@ class CustomerThreadController extends FrameworkBundleAdminController
      * Forward customer thread to another employee
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to update this.",
      *     redirectRoute="admin_customer_threads_index"
      * )
@@ -308,7 +309,7 @@ class CustomerThreadController extends FrameworkBundleAdminController
      * Delete customer thread
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_customer_threads"
      * )
      *
@@ -334,7 +335,7 @@ class CustomerThreadController extends FrameworkBundleAdminController
      * Bulk delete customer thread
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_customer_threads"
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnOrderStat
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\UpdateOrderReturnException;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\MerchandiseReturnFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -48,7 +49,7 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
      * Render merchandise returns grid and options.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller'))",
      *     redirectRoute="admin_merchandise_returns_index"
      * )
      *
@@ -89,7 +90,7 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
      * Edit existing order return
      *
      * @AdminSecurity(
-     *     "is_granted(['update'], request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_merchandise_returns_index"
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/OrderMessageController.php
@@ -36,6 +36,7 @@ use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageNotFoun
 use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Query\GetOrderMessageForEditing;
 use PrestaShop\PrestaShop\Core\Domain\OrderMessage\QueryResult\EditableOrderMessage;
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderMessageFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -50,7 +51,7 @@ class OrderMessageController extends FrameworkBundleAdminController
     /**
      * Show list of Order messages
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param OrderMessageFilters $filters
      * @param Request $request
@@ -81,7 +82,7 @@ class OrderMessageController extends FrameworkBundleAdminController
      * Create new order message
      *
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_order_messages_index"
      * )
      *
@@ -126,7 +127,7 @@ class OrderMessageController extends FrameworkBundleAdminController
      * Edit existing order message
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_order_messages_index"
      * )
      *
@@ -176,7 +177,7 @@ class OrderMessageController extends FrameworkBundleAdminController
      * Delete single order message
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_order_messages_index"
      * )
      *
@@ -201,7 +202,7 @@ class OrderMessageController extends FrameworkBundleAdminController
      * Delete order messages in bulk action
      *
      * @AdminSecurity(
-     *     "is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_order_messages_index"
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CartController.php
@@ -55,6 +55,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\Customizat
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\PackOutOfStockException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductCustomizationNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductOutOfStockException;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -64,7 +65,7 @@ use Symfony\Component\HttpFoundation\Response;
 class CartController extends FrameworkBundleAdminController
 {
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param int $cartId
@@ -103,7 +104,7 @@ class CartController extends FrameworkBundleAdminController
     /**
      * Gets requested cart information
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param int $cartId
      *
@@ -129,7 +130,7 @@ class CartController extends FrameworkBundleAdminController
     /**
      * Creates empty cart
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      *
@@ -153,7 +154,7 @@ class CartController extends FrameworkBundleAdminController
     /**
      * Changes the cart address information
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param int $cartId
      * @param Request $request
@@ -182,7 +183,7 @@ class CartController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param int $cartId
      * @param Request $request
@@ -207,7 +208,7 @@ class CartController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param int $cartId
      * @param Request $request
@@ -232,7 +233,7 @@ class CartController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      * @param int $cartId
@@ -258,7 +259,7 @@ class CartController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param int $cartId
@@ -292,7 +293,7 @@ class CartController extends FrameworkBundleAdminController
     /**
      * Adds cart rule to cart
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      * @param int $cartId
@@ -317,7 +318,7 @@ class CartController extends FrameworkBundleAdminController
     /**
      * Deletes cart rule from cart
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param int $cartId
      * @param int $cartRuleId
@@ -341,7 +342,7 @@ class CartController extends FrameworkBundleAdminController
     /**
      * Adds product to cart
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      * @param int $cartId
@@ -383,7 +384,7 @@ class CartController extends FrameworkBundleAdminController
      * Modifying a price for a product in the cart is actually performed by using generated specific prices,
      * that are used only for this cart and this product.
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      * @param int $cartId
@@ -418,7 +419,7 @@ class CartController extends FrameworkBundleAdminController
     /**
      * Changes product in cart quantity
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      * @param int $cartId
@@ -458,7 +459,7 @@ class CartController extends FrameworkBundleAdminController
     /**
      * Deletes product from cart
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      * @param int $cartId

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/CreditSlipController.php
@@ -35,6 +35,7 @@ use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CreditSlipGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\PDF\Exception\MissingDataException;
 use PrestaShop\PrestaShop\Core\Search\Filters\CreditSlipFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Order\CreditSlip\GeneratePdfByDateType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
@@ -51,7 +52,7 @@ class CreditSlipController extends FrameworkBundleAdminController
     /**
      * Show credit slips listing page.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param CreditSlipFilters $creditSlipFilters
@@ -101,7 +102,7 @@ class CreditSlipController extends FrameworkBundleAdminController
      *
      * Provides filters functionality
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -123,7 +124,7 @@ class CreditSlipController extends FrameworkBundleAdminController
     /**
      * Generates PDF of requested credit slip by provided id
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param int $creditSlipId
      *
@@ -145,7 +146,7 @@ class CreditSlipController extends FrameworkBundleAdminController
     /**
      * Generates PDF of credit slips found by requested date range
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/DeliveryController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Sell\Order;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\Form\Form;
@@ -43,7 +44,7 @@ class DeliveryController extends FrameworkBundleAdminController
      * Main page for Delivery slips.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="Access denied."
      * )
      *
@@ -60,7 +61,7 @@ class DeliveryController extends FrameworkBundleAdminController
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()
-            && $this->isGranted('update', $request->attributes->get('_legacy_controller')
+            && $this->isGranted(Permission::UPDATE, $request->attributes->get('_legacy_controller')
         )) {
             $errors = $formHandler->save($form->getData());
             if (empty($errors)) {
@@ -90,7 +91,7 @@ class DeliveryController extends FrameworkBundleAdminController
      * Delivery slips PDF generator.
      *
      * @AdminSecurity(
-     *     "is_granted('read', request.get('_legacy_controller')) || is_granted('update', request.get('_legacy_controller')) || is_granted('create', request.get('_legacy_controller')) || is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::READ, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     message="Access denied."
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/InvoicesController.php
@@ -27,6 +27,7 @@
 namespace PrestaShopBundle\Controller\Admin\Sell\Order;
 
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -43,7 +44,7 @@ class InvoicesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return Response Template parameters
      */
@@ -70,7 +71,7 @@ class InvoicesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return RedirectResponse
      */
@@ -87,7 +88,7 @@ class InvoicesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return RedirectResponse
      */
@@ -104,7 +105,7 @@ class InvoicesController extends FrameworkBundleAdminController
      *
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @return RedirectResponse
      */
@@ -146,7 +147,7 @@ class InvoicesController extends FrameworkBundleAdminController
     /**
      * Generates PDF of given invoice ID.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", message="Access denied.")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", message="Access denied.")
      *
      * @param int $invoiceId
      */

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Order/OrderController.php
@@ -86,6 +86,7 @@ use PrestaShop\PrestaShop\Core\Form\ConfigurableFormChoiceProviderInterface;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\OrderGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Order\OrderSiblingProviderInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\OrderFilters;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
 use PrestaShopBundle\Exception\InvalidModuleException;
@@ -131,7 +132,7 @@ class OrderController extends FrameworkBundleAdminController
     /**
      * Shows list of orders
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      * @param OrderFilters $filters
@@ -188,7 +189,7 @@ class OrderController extends FrameworkBundleAdminController
     /**
      * Places an order from BO
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -223,7 +224,7 @@ class OrderController extends FrameworkBundleAdminController
      * Whole page dynamics are on javascript side.
      * To load specific cart pass cartId to url query params (handled by javascript)
      *
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -268,7 +269,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param Request $request
      *
@@ -290,7 +291,7 @@ class OrderController extends FrameworkBundleAdminController
     /**
      * Generates invoice PDF for given order
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      */
@@ -306,7 +307,7 @@ class OrderController extends FrameworkBundleAdminController
     /**
      * Generates delivery slip PDF for given order
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      */
@@ -322,7 +323,7 @@ class OrderController extends FrameworkBundleAdminController
     /**
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @return RedirectResponse
      */
@@ -349,7 +350,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param OrderFilters $filters
      *
@@ -407,7 +408,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param int $orderId
      * @param Request $request
@@ -579,7 +580,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -617,7 +618,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))"
      * )
      *
      * @param int $orderId
@@ -652,7 +653,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))"
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))"
      * )
      *
      * @param int $orderId
@@ -706,7 +707,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('create', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      * @param Request $request
@@ -795,7 +796,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      *
@@ -831,7 +832,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      */
@@ -851,7 +852,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      */
@@ -869,7 +870,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      */
@@ -888,7 +889,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -940,7 +941,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', 'AdminOrders')",
+     *     "is_granted(Permission::UPDATE, 'AdminOrders')",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -966,7 +967,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', 'AdminOrders')",
+     *     "is_granted(Permission::UPDATE, 'AdminOrders')",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -999,7 +1000,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      * @param int $orderDetailId
@@ -1059,7 +1060,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', 'AdminOrders')",
+     *     "is_granted(Permission::UPDATE, 'AdminOrders')",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -1112,7 +1113,7 @@ class OrderController extends FrameworkBundleAdminController
      * @param int $orderId
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @return RedirectResponse
      */
@@ -1150,7 +1151,7 @@ class OrderController extends FrameworkBundleAdminController
      * @param int $orderId
      * @param Request $request
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @return RedirectResponse
      */
@@ -1163,7 +1164,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', 'AdminOrders')",
+     *     "is_granted(Permission::UPDATE, 'AdminOrders')",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -1216,7 +1217,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param int $orderId
      *
@@ -1246,7 +1247,7 @@ class OrderController extends FrameworkBundleAdminController
     /**
      * Duplicates cart from specified order
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param int $orderId
      *
@@ -1266,7 +1267,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -1344,7 +1345,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', 'AdminOrders')",
+     *     "is_granted(Permission::UPDATE, 'AdminOrders')",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -1400,7 +1401,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -1441,7 +1442,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', 'AdminOrders')",
+     *     "is_granted(Permission::UPDATE, 'AdminOrders')",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -1474,7 +1475,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('delete', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::DELETE', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      * @param int $orderDetailId
@@ -1498,7 +1499,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      *
@@ -1516,7 +1517,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      *
@@ -1540,7 +1541,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      *
@@ -1565,7 +1566,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))", redirectRoute="admin_orders_index")
      *
      * @param int $orderId
      *
@@ -1614,7 +1615,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to generate this."
      * )
      *
@@ -1642,7 +1643,7 @@ class OrderController extends FrameworkBundleAdminController
     /**
      * Sends email with process order link to customer
      *
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller')) || is_granted('create', 'AdminOrders')")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller')) || is_granted(Permission::CREATE, 'AdminOrders')")
      *
      * @param Request $request
      *
@@ -1666,7 +1667,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('delete', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::DELETE', request.get('_legacy_controller'))",
      *     redirectRoute="admin_orders_view",
      *     redirectQueryParamsToKeep={"orderId"},
      *     message="You do not have permission to edit this."
@@ -1702,7 +1703,7 @@ class OrderController extends FrameworkBundleAdminController
     }
 
     /**
-     * @AdminSecurity("is_granted('update', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -1730,7 +1731,7 @@ class OrderController extends FrameworkBundleAdminController
     /**
      * Method for downloading customization picture
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param int $orderId
      * @param string $value
@@ -1769,7 +1770,7 @@ class OrderController extends FrameworkBundleAdminController
      * Set order internal note.
      *
      * @AdminSecurity(
-     *     "is_granted('update', request.get('_legacy_controller')) && is_granted('create', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::UPDATE, request.get('_legacy_controller')) && is_granted(Permission::CREATE, request.get('_legacy_controller'))",
      *     redirectRoute="admin_orders_index"
      * )
      *
@@ -1815,7 +1816,7 @@ class OrderController extends FrameworkBundleAdminController
 
     /**
      * @AdminSecurity(
-     *     "is_granted('create', request.get('_legacy_controller')) && is_granted('update', request.get('_legacy_controller'))",
+     *     "is_granted(Permission::CREATE, request.get('_legacy_controller')) && is_granted(Permission::UPDATE, request.get('_legacy_controller'))",
      *     message="You do not have permission to perform this search."
      * )
      *

--- a/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/SpecificPriceController.php
@@ -31,6 +31,7 @@ use Exception;
 use PrestaShop\PrestaShop\Adapter\Product\AdminProductWrapper;
 use PrestaShop\PrestaShop\Core\Foundation\Database\EntityDataInconsistencyException;
 use PrestaShop\PrestaShop\Core\Foundation\Database\EntityNotFoundException;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Form\Admin\Product\ProductSpecificPrice as SpecificPriceFormType;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -45,7 +46,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
     /**
      * Get specific price list for a product.
      *
-     * @AdminSecurity("is_granted('read', 'ADMINPRODUCTS_')")
+     * @AdminSecurity("is_granted(Permission::READ, 'ADMINPRODUCTS_')")
      *
      * @param string|int $idProduct The product ID
      *
@@ -89,7 +90,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
      * Add specific price Form process.
      *
      * @AdminSecurity(
-     *     "is_granted('create', 'ADMINPRODUCTS_') && is_granted('update', 'ADMINPRODUCTS_')"
+     *     "is_granted(Permission::CREATE, 'ADMINPRODUCTS_') && is_granted(Permission::UPDATE, 'ADMINPRODUCTS_')"
      * )
      *
      * @param Request $request The request
@@ -116,7 +117,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
      * Get one specific price list for a product.
      *
      * @AdminSecurity(
-     *     "is_granted('create', 'ADMINPRODUCTS_') && is_granted('update', 'ADMINPRODUCTS_')"
+     *     "is_granted(Permission::CREATE, 'ADMINPRODUCTS_') && is_granted(Permission::UPDATE, 'ADMINPRODUCTS_')"
      * )
      *
      * @param int $idSpecificPrice
@@ -166,7 +167,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
      * Update specific price Form process.
      *
      * @AdminSecurity(
-     *     "is_granted('create', 'ADMINPRODUCTS_') && is_granted('update', 'ADMINPRODUCTS_')"
+     *     "is_granted(Permission::CREATE, 'ADMINPRODUCTS_') && is_granted(Permission::UPDATE, 'ADMINPRODUCTS_')"
      * )
      *
      * @param int $idSpecificPrice
@@ -197,7 +198,7 @@ class SpecificPriceController extends FrameworkBundleAdminController
     /**
      * Delete a specific price.
      *
-     * @AdminSecurity("is_granted('delete', 'ADMINPRODUCTS_')")
+     * @AdminSecurity("is_granted(Permission::DELETE', 'ADMINPRODUCTS_')")
      *
      * @param int $idSpecificPrice The specific price ID
      * @param Request $request The request

--- a/src/PrestaShopBundle/Controller/Api/Improve/Design/PositionsController.php
+++ b/src/PrestaShopBundle/Controller/Api/Improve/Design/PositionsController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Api\Improve\Design;
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Controller\Api\ApiController;
 use PrestaShopBundle\Security\Annotation\AdminSecurity;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -36,7 +37,7 @@ class PositionsController extends ApiController
     /**
      * Update positions.
      *
-     * @AdminSecurity("is_granted(['update'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Api/StockMovementController.php
+++ b/src/PrestaShopBundle/Controller/Api/StockMovementController.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShopBundle\Controller\Api;
 
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShopBundle\Api\QueryStockMovementParamsCollection;
 use PrestaShopBundle\Entity\Repository\StockMovementRepository;
 use PrestaShopBundle\Exception\InvalidPaginationParamsException;
@@ -47,7 +48,7 @@ class StockMovementController extends ApiController
     public $queryParams;
 
     /**
-     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -68,7 +69,7 @@ class StockMovementController extends ApiController
     }
 
     /**
-     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -80,7 +81,7 @@ class StockMovementController extends ApiController
     }
 
     /**
-     * @AdminSecurity("is_granted(['read'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *

--- a/src/PrestaShopBundle/Controller/Api/TranslationController.php
+++ b/src/PrestaShopBundle/Controller/Api/TranslationController.php
@@ -28,6 +28,7 @@ namespace PrestaShopBundle\Controller\Api;
 
 use Exception;
 use PrestaShop\PrestaShop\Adapter\EntityTranslation\EntityTranslatorFactory;
+use PrestaShop\PrestaShop\Core\Security\Permission;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\CoreDomainProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\ModuleProviderDefinition;
 use PrestaShop\PrestaShop\Core\Translation\Storage\Provider\Definition\OthersProviderDefinition;
@@ -59,7 +60,7 @@ class TranslationController extends ApiController
     /**
      * Show translations for 1 domain & 1 locale given & 1 theme given (optional).
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -123,7 +124,7 @@ class TranslationController extends ApiController
     /**
      * Show tree for translation page with some params.
      *
-     * @AdminSecurity("is_granted('read', request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::READ, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -172,7 +173,7 @@ class TranslationController extends ApiController
     /**
      * Route to edit translation.
      *
-     * @AdminSecurity("is_granted(['create', 'update'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *
@@ -230,7 +231,7 @@ class TranslationController extends ApiController
     /**
      * Route to reset translation.
      *
-     * @AdminSecurity("is_granted(['create', 'update'], request.get('_legacy_controller'))")
+     * @AdminSecurity("is_granted(Permission::CREATE, request.get('_legacy_controller')) || is_granted(Permission::UPDATE, request.get('_legacy_controller'))")
      *
      * @param Request $request
      *


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This is a refactoring to use constants instead of string for permissions name. This will avoid typos in permissions names, etc.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | This is a refactoring of all permissions in all controllers, Test permission for one controller only with create update read operations.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   |
