### PR TITLE
Migrate customer bought and viewed products to grids

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/customer/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/customer/index.ts
@@ -83,6 +83,12 @@ $(() => {
   customerCartsGrid.addExtension(new SubmitRowActionExtension());
   customerCartsGrid.addExtension(new LinkRowActionExtension());
 
+  const customerBoughtProductsGrid = new Grid('customer_bought_product');
+  customerBoughtProductsGrid.addExtension(new SortingExtension());
+
+  const customerViewedProductsGrid = new Grid('customer_viewed_product');
+  customerViewedProductsGrid.addExtension(new SortingExtension());
+
   const showcaseCard = new ShowcaseCard('customersShowcaseCard');
   showcaseCard.addExtension(new ShowcaseCardCloseExtension());
 

--- a/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
+++ b/src/Core/Domain/Customer/QueryResult/ViewableCustomer.php
@@ -56,6 +56,8 @@ class ViewableCustomer
     private $cartsInformation;
 
     /**
+     * @deprecated Since 9.0.0, returns empty ProductsInformation object with no data.
+     *
      * @var ProductsInformation
      */
     private $productsInformation;
@@ -176,6 +178,8 @@ class ViewableCustomer
     }
 
     /**
+     * @deprecated Since 9.0.0, returns empty ProductsInformation object with no data.
+     *
      * @return ProductsInformation
      */
     public function getProductsInformation()

--- a/src/Core/Grid/Definition/Factory/CustomerBoughtProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerBoughtProductGridDefinitionFactory.php
@@ -84,7 +84,7 @@ final class CustomerBoughtProductGridDefinitionFactory extends AbstractGridDefin
     {
         return (new ColumnCollection())
             ->add((new DateTimeColumn('date_add'))
-            ->setName($this->trans('Order date', [], 'Admin.Global'))
+            ->setName($this->trans('Date', [], 'Admin.Global'))
             ->setOptions([
                 'field' => 'date_add',
                 'format' => $this->contextDateFormat,

--- a/src/Core/Grid/Definition/Factory/CustomerBoughtProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerBoughtProductGridDefinitionFactory.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DataColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+
+/**
+ * Class CustomerBoughtProductGridDefinitionFactory defines customer's bought products grid structure.
+ */
+final class CustomerBoughtProductGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    use DeleteActionTrait;
+
+    public const GRID_ID = 'customer_bought_product';
+
+    /**
+     * @var string
+     */
+    private $contextDateFormat;
+
+    /**
+     * @param HookDispatcherInterface $hookDispatcher
+     * @param string $contextDateFormat
+     */
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        $contextDateFormat
+    ) {
+        parent::__construct($hookDispatcher);
+        $this->contextDateFormat = $contextDateFormat;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId()
+    {
+        return self::GRID_ID;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName()
+    {
+        return $this->trans('Purchased products', [], 'Admin.Orderscustomers.Feature');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns()
+    {
+        return (new ColumnCollection())
+            ->add((new DateTimeColumn('date_add'))
+            ->setName($this->trans('Order date', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'date_add',
+                'format' => $this->contextDateFormat,
+                'clickable' => true,
+            ])
+            )
+            ->add(
+                (new LinkColumn('product_name'))
+                    ->setName($this->trans('Name', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'product_name',
+                        'route' => 'admin_orders_view',
+                        'route_param_name' => 'orderId',
+                        'route_param_field' => 'id_order',
+                    ])
+            )
+            ->add((new DataColumn('product_quantity'))
+            ->setName($this->trans('Quantity', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'product_quantity',
+            ])
+            )
+            ->add(
+                (new LinkColumn('id_order'))
+                    ->setName($this->trans('Order ID', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'id_order',
+                        'route' => 'admin_orders_view',
+                        'route_param_name' => 'orderId',
+                        'route_param_field' => 'id_order',
+                    ])
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getViewOptions()
+    {
+        return (new ViewOptionsCollection())
+            ->add('display_name', false);
+    }
+}

--- a/src/Core/Grid/Definition/Factory/CustomerViewedProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerViewedProductGridDefinitionFactory.php
@@ -83,7 +83,7 @@ final class CustomerViewedProductGridDefinitionFactory extends AbstractGridDefin
     {
         return (new ColumnCollection())
             ->add((new DateTimeColumn('date_add'))
-            ->setName($this->trans('Added to cart', [], 'Admin.Global'))
+            ->setName($this->trans('Date', [], 'Admin.Global'))
             ->setOptions([
                 'field' => 'date_add',
                 'format' => $this->contextDateFormat,

--- a/src/Core/Grid/Definition/Factory/CustomerViewedProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerViewedProductGridDefinitionFactory.php
@@ -73,7 +73,7 @@ final class CustomerViewedProductGridDefinitionFactory extends AbstractGridDefin
      */
     protected function getName()
     {
-        return $this->trans('Viewed products', [], 'Admin.Orderscustomers.Feature');
+        return $this->trans('Products in carts', [], 'Admin.Orderscustomers.Feature');
     }
 
     /**
@@ -83,7 +83,7 @@ final class CustomerViewedProductGridDefinitionFactory extends AbstractGridDefin
     {
         return (new ColumnCollection())
             ->add((new DateTimeColumn('date_add'))
-            ->setName($this->trans('Date added to cart', [], 'Admin.Global'))
+            ->setName($this->trans('Added to cart', [], 'Admin.Global'))
             ->setOptions([
                 'field' => 'date_add',
                 'format' => $this->contextDateFormat,

--- a/src/Core/Grid/Definition/Factory/CustomerViewedProductGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/CustomerViewedProductGridDefinitionFactory.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Definition\Factory;
+
+use PrestaShop\PrestaShop\Core\Grid\Action\ViewOptionsCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\ColumnCollection;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\DateTimeColumn;
+use PrestaShop\PrestaShop\Core\Grid\Column\Type\Common\LinkColumn;
+use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
+
+/**
+ * Class CustomerViewedProductGridDefinitionFactory defines customer's viewed products grid structure.
+ */
+final class CustomerViewedProductGridDefinitionFactory extends AbstractGridDefinitionFactory
+{
+    use DeleteActionTrait;
+
+    public const GRID_ID = 'customer_viewed_product';
+
+    /**
+     * @var string
+     */
+    private $contextDateFormat;
+
+    /**
+     * @param HookDispatcherInterface $hookDispatcher
+     * @param string $contextDateFormat
+     */
+    public function __construct(
+        HookDispatcherInterface $hookDispatcher,
+        $contextDateFormat
+    ) {
+        parent::__construct($hookDispatcher);
+        $this->contextDateFormat = $contextDateFormat;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getId()
+    {
+        return self::GRID_ID;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getName()
+    {
+        return $this->trans('Viewed products', [], 'Admin.Orderscustomers.Feature');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getColumns()
+    {
+        return (new ColumnCollection())
+            ->add((new DateTimeColumn('date_add'))
+            ->setName($this->trans('Date added to cart', [], 'Admin.Global'))
+            ->setOptions([
+                'field' => 'date_add',
+                'format' => $this->contextDateFormat,
+                'clickable' => true,
+            ])
+            )
+            ->add(
+                (new LinkColumn('product_name'))
+                    ->setName($this->trans('Name', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'product_name',
+                        'route' => 'admin_products_v2_preview',
+                        'route_param_name' => 'productId',
+                        'route_param_field' => 'id_product',
+                    ])
+            )
+            ->add(
+                (new LinkColumn('id_cart'))
+                    ->setName($this->trans('Cart ID', [], 'Admin.Global'))
+                    ->setOptions([
+                        'field' => 'id_cart',
+                        'route' => 'admin_carts_view',
+                        'route_param_name' => 'cartId',
+                        'route_param_field' => 'id_cart',
+                    ])
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getViewOptions()
+    {
+        return (new ViewOptionsCollection())
+            ->add('display_name', false);
+    }
+}

--- a/src/Core/Grid/Query/CustomerBoughtProductQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerBoughtProductQueryBuilder.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Builds search & count queries for customer's bought products grid.
+ */
+final class CustomerBoughtProductQueryBuilder extends AbstractDoctrineQueryBuilder
+{
+    /**
+     * @var DoctrineSearchCriteriaApplicatorInterface
+     */
+    private $searchCriteriaApplicator;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
+     */
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
+    ) {
+        parent::__construct($connection, $dbPrefix);
+        $this->searchCriteriaApplicator = $searchCriteriaApplicator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->getQueryBuilder($searchCriteria->getFilters());
+        $qb->select('o.`date_add`, od.`product_name`, od.`product_quantity`, od.`id_order`');
+
+        $this->searchCriteriaApplicator
+            ->applyPagination($searchCriteria, $qb)
+            ->applySorting($searchCriteria, $qb);
+
+        return $qb;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        return $this->getQueryBuilder($searchCriteria->getFilters())
+            ->select('COUNT(DISTINCT od.`id_order_detail`)');
+    }
+
+    /**
+     * Gets query builder with the common sql used for displaying bought products list and applying filter actions.
+     *
+     * @param array $filters
+     *
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder(array $filters): QueryBuilder
+    {
+        $qb = $this->connection
+            ->createQueryBuilder()
+            ->from($this->dbPrefix . 'order_detail', 'od')
+            ->where('o.`id_customer` != 0');
+
+        $qb->innerJoin(
+            'od',
+            $this->dbPrefix . 'orders',
+            'o',
+            'od.`id_order` = o.`id_order`'
+        );
+
+        $this->applyFilters($qb, $filters);
+
+        return $qb;
+    }
+
+    /**
+     * Apply filters to bought products query builder.
+     *
+     * @param array $filters
+     * @param QueryBuilder $qb
+     */
+    private function applyFilters(QueryBuilder $qb, array $filters)
+    {
+        $allowedFiltersMap = [
+            'id_customer' => 'o.id_customer',
+        ];
+
+        foreach ($filters as $filterName => $value) {
+            if (!array_key_exists($filterName, $allowedFiltersMap) || empty($value)) {
+                continue;
+            }
+
+            if ('id_customer' === $filterName) {
+                $qb->andWhere('o.`id_customer` = :' . $filterName);
+                $qb->setParameter($filterName, $value);
+            }
+        }
+    }
+}

--- a/src/Core/Grid/Query/CustomerBoughtProductQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerBoughtProductQueryBuilder.php
@@ -77,7 +77,7 @@ final class CustomerBoughtProductQueryBuilder extends AbstractDoctrineQueryBuild
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         return $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('COUNT(DISTINCT od.`id_order_detail`)');
+            ->select('COUNT(od.`id_order_detail`)');
     }
 
     /**

--- a/src/Core/Grid/Query/CustomerViewedProductQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerViewedProductQueryBuilder.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Grid\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
+
+/**
+ * Builds search & count queries for customer's viewed products grid.
+ */
+final class CustomerViewedProductQueryBuilder extends AbstractDoctrineQueryBuilder
+{
+    /**
+     * @var DoctrineSearchCriteriaApplicatorInterface
+     */
+    private $searchCriteriaApplicator;
+
+    /**
+     * @var int
+     */
+    private $contextLanguageId;
+
+    /**
+     * @param Connection $connection
+     * @param string $dbPrefix
+     * @param DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator
+     * @param int $contextLanguageId
+     */
+    public function __construct(
+        Connection $connection,
+        string $dbPrefix,
+        DoctrineSearchCriteriaApplicatorInterface $searchCriteriaApplicator,
+        int $contextLanguageId
+    ) {
+        parent::__construct($connection, $dbPrefix);
+        $this->searchCriteriaApplicator = $searchCriteriaApplicator;
+        $this->contextLanguageId = $contextLanguageId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSearchQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        $qb = $this->getQueryBuilder($searchCriteria->getFilters());
+        $qb->select('
+            cp.`date_add`,
+            cp.`id_product`,
+            cp.`id_cart`,
+            cp.`id_shop`,
+            pl.`name` as product_name
+       ');
+
+        $this->searchCriteriaApplicator
+            ->applyPagination($searchCriteria, $qb)
+            ->applySorting($searchCriteria, $qb);
+
+        return $qb;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
+    {
+        return $this->getQueryBuilder($searchCriteria->getFilters())
+            ->select('COUNT(DISTINCT cp.`id_product`)');
+    }
+
+    /**
+     * Gets query builder with the common sql used for displaying viewed products list and applying filter actions.
+     *
+     * @param array $filters
+     *
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder(array $filters): QueryBuilder
+    {
+        $qb = $this->connection
+            ->createQueryBuilder()
+            ->from($this->dbPrefix . 'cart_product', 'cp')
+            ->where('c.`id_customer` != 0')
+            ->where('cp.`id_cart` NOT IN (SELECT `id_cart` FROM ' . $this->dbPrefix . 'orders)')
+            ;
+
+        $qb->innerJoin(
+            'cp',
+            $this->dbPrefix . 'cart',
+            'c',
+            'cp.`id_cart` = c.`id_cart`'
+        );
+        $qb->innerJoin(
+            'cp',
+            $this->dbPrefix . 'product_lang',
+            'pl',
+            'cp.`id_product` = pl.`id_product` AND pl.`id_lang` = :langId'
+        )->setParameter('langId', $this->contextLanguageId);
+
+        $this->applyFilters($qb, $filters);
+
+        return $qb;
+    }
+
+    /**
+     * Apply filters to viewed products query builder.
+     *
+     * @param array $filters
+     * @param QueryBuilder $qb
+     */
+    private function applyFilters(QueryBuilder $qb, array $filters)
+    {
+        $allowedFiltersMap = [
+            'id_customer' => 'c.id_customer',
+        ];
+
+        foreach ($filters as $filterName => $value) {
+            if (!array_key_exists($filterName, $allowedFiltersMap) || empty($value)) {
+                continue;
+            }
+
+            if ('id_customer' === $filterName) {
+                $qb->andWhere('c.`id_customer` = :' . $filterName);
+                $qb->setParameter($filterName, $value);
+            }
+        }
+    }
+}

--- a/src/Core/Grid/Query/CustomerViewedProductQueryBuilder.php
+++ b/src/Core/Grid/Query/CustomerViewedProductQueryBuilder.php
@@ -91,7 +91,7 @@ final class CustomerViewedProductQueryBuilder extends AbstractDoctrineQueryBuild
     public function getCountQueryBuilder(SearchCriteriaInterface $searchCriteria): QueryBuilder
     {
         return $this->getQueryBuilder($searchCriteria->getFilters())
-            ->select('COUNT(DISTINCT cp.`id_product`)');
+            ->select('COUNT(cp.`id_product`)');
     }
 
     /**

--- a/src/Core/Search/Filters/CustomerBoughtProductFilters.php
+++ b/src/Core/Search/Filters/CustomerBoughtProductFilters.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,17 +22,34 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if customerBoughtProductGrid.data.records_total > 0 %}
-<div class="card customer-bought-products-card">
-  <h3 class="card-header">
-    <i class="material-icons">attach_money</i>
-    {{ 'Purchased products'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    <span class="badge badge-primary rounded">{{ customerBoughtProductGrid.data.records_total }}</span>
-  </h3>
-  <div class="card-body">
-    {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerBoughtProductGrid} %}
-  </div>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerBoughtProductGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+/**
+ * Default customer's order list filters
+ */
+final class CustomerBoughtProductFilters extends Filters
+{
+    /** @var string */
+    protected $filterId = CustomerBoughtProductGridDefinitionFactory::GRID_ID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults(): array
+    {
+        return [
+            'limit' => 20,
+            'offset' => 0,
+            'orderBy' => 'date_add',
+            'sortOrder' => 'desc',
+            'filters' => [],
+        ];
+    }
+}

--- a/src/Core/Search/Filters/CustomerViewedProductFilters.php
+++ b/src/Core/Search/Filters/CustomerViewedProductFilters.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,17 +22,34 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% if customerBoughtProductGrid.data.records_total > 0 %}
-<div class="card customer-bought-products-card">
-  <h3 class="card-header">
-    <i class="material-icons">attach_money</i>
-    {{ 'Purchased products'|trans({}, 'Admin.Orderscustomers.Feature') }}
-    <span class="badge badge-primary rounded">{{ customerBoughtProductGrid.data.records_total }}</span>
-  </h3>
-  <div class="card-body">
-    {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerBoughtProductGrid} %}
-  </div>
-</div>
-{% endif %}
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Core\Search\Filters;
+
+use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerViewedProductGridDefinitionFactory;
+use PrestaShop\PrestaShop\Core\Search\Filters;
+
+/**
+ * Default customer's order list filters
+ */
+final class CustomerViewedProductFilters extends Filters
+{
+    /** @var string */
+    protected $filterId = CustomerViewedProductGridDefinitionFactory::GRID_ID;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getDefaults(): array
+    {
+        return [
+            'limit' => 20,
+            'offset' => 0,
+            'orderBy' => 'date_add',
+            'sortOrder' => 'desc',
+            'filters' => [],
+        ];
+    }
+}

--- a/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/Customer/CustomerController.php
@@ -58,10 +58,12 @@ use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\Query\GetShowcaseCardIsClosed
 use PrestaShop\PrestaShop\Core\Domain\ShowcaseCard\ValueObject\ShowcaseCard;
 use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerGridDefinitionFactory;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerAddressFilters;
+use PrestaShop\PrestaShop\Core\Search\Filters\CustomerBoughtProductFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerCartFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerDiscountFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerFilters;
 use PrestaShop\PrestaShop\Core\Search\Filters\CustomerOrderFilters;
+use PrestaShop\PrestaShop\Core\Search\Filters\CustomerViewedProductFilters;
 use PrestaShopBundle\Component\CsvResponse;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController as AbstractAdminController;
 use PrestaShopBundle\Form\Admin\Sell\Customer\DeleteCustomersType;
@@ -275,6 +277,8 @@ class CustomerController extends AbstractAdminController
      * @param CustomerAddressFilters $customerAddressFilters
      * @param CustomerCartFilters $customerCartFilters
      * @param CustomerOrderFilters $customerOrderFilters
+     * @param CustomerBoughtProductFilters $customerBoughtProductFilters
+     * @param CustomerViewedProductFilters $customerViewedProductFilters
      *
      * @return Response
      */
@@ -284,7 +288,9 @@ class CustomerController extends AbstractAdminController
         CustomerDiscountFilters $customerDiscountFilters,
         CustomerAddressFilters $customerAddressFilters,
         CustomerCartFilters $customerCartFilters,
-        CustomerOrderFilters $customerOrderFilters
+        CustomerOrderFilters $customerOrderFilters,
+        CustomerBoughtProductFilters $customerBoughtProductFilters,
+        CustomerViewedProductFilters $customerViewedProductFilters
     ) {
         try {
             /** @var ViewableCustomer $customerInformation */
@@ -329,6 +335,16 @@ class CustomerController extends AbstractAdminController
         $customerCartFilters->addFilter(['id_customer' => $customerId]);
         $customerCartGrid = $customerCartGridFactory->getGrid($customerCartFilters);
 
+        // Bought products listing
+        $customerBoughtProductGridFactory = $this->get('prestashop.core.grid.factory.customer.bought_product');
+        $customerBoughtProductFilters->addFilter(['id_customer' => $customerId]);
+        $customerBoughtProductGrid = $customerBoughtProductGridFactory->getGrid($customerBoughtProductFilters);
+
+        // Viewed products listing
+        $customerViewedProductGridFactory = $this->get('prestashop.core.grid.factory.customer.viewed_product');
+        $customerViewedProductFilters->addFilter(['id_customer' => $customerId]);
+        $customerViewedProductGrid = $customerViewedProductGridFactory->getGrid($customerViewedProductFilters);
+
         if ($request->query->has('conf')) {
             $this->manageLegacyFlashes($request->query->get('conf'));
         }
@@ -341,6 +357,8 @@ class CustomerController extends AbstractAdminController
             'customerAddressGrid' => $this->presentGrid($customerAddressGrid),
             'customerOrderGrid' => $this->presentGrid($customerOrderGrid),
             'customerCartGrid' => $this->presentGrid($customerCartGrid),
+            'customerBoughtProductGrid' => $this->presentGrid($customerBoughtProductGrid),
+            'customerViewedProductGrid' => $this->presentGrid($customerViewedProductGrid),
             'isMultistoreEnabled' => $this->get('prestashop.adapter.feature.multistore')->isActive(),
             'transferGuestAccountForm' => $transferGuestAccountForm,
             'privateNoteForm' => $privateNoteForm->createView(),

--- a/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/customer.yml
@@ -7,7 +7,6 @@ services:
     arguments:
       - '@translator'
       - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
-      - "@=service('prestashop.adapter.legacy.context').getContext().link"
       - "@prestashop.core.localization.locale.context_locale"
     tags:
       - name: tactician.handler

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/doctrine_query_builder.yml
@@ -114,6 +114,24 @@ services:
       - '@=service("prestashop.adapter.shop.context").getContextListShopIDUsingCustomerSharingSettings()'
     public: true
 
+  prestashop.core.grid.query_builder.customer_bought_product:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Query\CustomerBoughtProductQueryBuilder'
+    parent: 'prestashop.core.grid.abstract_query_builder'
+    arguments:
+      - '@prestashop.core.query.doctrine_search_criteria_applicator'
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - '@=service("prestashop.adapter.shop.context").getContextListShopIDUsingCustomerSharingSettings()'
+    public: true
+
+  prestashop.core.grid.query_builder.customer_viewed_product:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Query\CustomerViewedProductQueryBuilder'
+    parent: 'prestashop.core.grid.abstract_query_builder'
+    arguments:
+      - '@prestashop.core.query.doctrine_search_criteria_applicator'
+      - "@=service('prestashop.adapter.legacy.context').getContext().language.id"
+      - '@=service("prestashop.adapter.shop.context").getContextListShopIDUsingCustomerSharingSettings()'
+    public: true
+
   prestashop.core.grid.quer_.builder.language:
     class: 'PrestaShop\PrestaShop\Core\Grid\Query\LanguageQueryBuilder'
     parent: 'prestashop.core.grid.abstract_query_builder'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_data_factory.yml
@@ -122,6 +122,22 @@ services:
       - '@prestashop.core.grid.query.doctrine_query_parser'
       - 'customer_order'
 
+  prestashop.core.grid.data_provider.customer_bought_product:
+    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+    arguments:
+      - '@prestashop.core.grid.query_builder.customer_bought_product'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.core.grid.query.doctrine_query_parser'
+      - 'customer_bought_product'
+
+  prestashop.core.grid.data_provider.customer_viewed_product:
+    class: '%prestashop.core.grid.data.factory.doctrine_grid_data_factory%'
+    arguments:
+      - '@prestashop.core.grid.query_builder.customer_viewed_product'
+      - '@prestashop.core.hook.dispatcher'
+      - '@prestashop.core.grid.query.doctrine_query_parser'
+      - 'customer_viewed_product'
+
   prestashop.core.grid.data_provider.customer_address_decorator:
     class: 'PrestaShop\PrestaShop\Core\Grid\Data\Factory\CustomerAddressGridDataFactoryDecorator'
     arguments:

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_definition_factory.yml
@@ -100,6 +100,20 @@ services:
       - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
     public: true
 
+  prestashop.core.grid.definition.factory.customer.bought_product:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerBoughtProductGridDefinitionFactory'
+    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+    arguments:
+      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
+    public: true
+
+  prestashop.core.grid.definition.factory.customer.viewed_product:
+    class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\CustomerViewedProductGridDefinitionFactory'
+    parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'
+    arguments:
+      - '@=service("prestashop.adapter.legacy.context").getContext().language.date_format_full'
+    public: true
+
   prestashop.core.grid.definition.factory.language:
     class: 'PrestaShop\PrestaShop\Core\Grid\Definition\Factory\LanguageGridDefinitionFactory'
     parent: 'prestashop.core.grid.definition.factory.abstract_grid_definition'

--- a/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/grid/grid_factory.yml
@@ -120,6 +120,22 @@ services:
       - '@prestashop.core.grid.filter.form_factory'
       - '@prestashop.core.hook.dispatcher'
 
+  prestashop.core.grid.factory.customer.bought_product:
+    class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+    arguments:
+      - '@prestashop.core.grid.definition.factory.customer.bought_product'
+      - '@prestashop.core.grid.data_provider.customer_bought_product'
+      - '@prestashop.core.grid.filter.form_factory'
+      - '@prestashop.core.hook.dispatcher'
+
+  prestashop.core.grid.factory.customer.viewed_product:
+    class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
+    arguments:
+      - '@prestashop.core.grid.definition.factory.customer.viewed_product'
+      - '@prestashop.core.grid.data_provider.customer_viewed_product'
+      - '@prestashop.core.grid.filter.form_factory'
+      - '@prestashop.core.hook.dispatcher'
+
   prestashop.core.grid.factory.language:
     class: 'PrestaShop\PrestaShop\Core\Grid\GridFactory'
     arguments:

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/viewed_products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/viewed_products.html.twig
@@ -27,7 +27,7 @@
   <div class="card customer-viewed-products-card">
     <h3 class="card-header">
       <i class="material-icons">remove_red_eye</i>
-      {{ 'Viewed products'|trans({}, 'Admin.Orderscustomers.Feature') }}
+      {{ 'Products in carts'|trans({}, 'Admin.Orderscustomers.Feature') }}
       <span class="badge badge-primary rounded">{{ customerViewedProductGrid.data.records_total }}</span>
     </h3>
     <div class="card-body">

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/viewed_products.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/Customer/Blocks/View/viewed_products.html.twig
@@ -23,34 +23,15 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 
-{% if customerInformation.productsInformation.viewedProductsInformation is not empty %}
+{% if customerViewedProductGrid.data.records_total > 0 %}
   <div class="card customer-viewed-products-card">
     <h3 class="card-header">
       <i class="material-icons">remove_red_eye</i>
       {{ 'Viewed products'|trans({}, 'Admin.Orderscustomers.Feature') }}
-      <span class="badge badge-primary rounded">{{ customerInformation.productsInformation.viewedProductsInformation|length }}</span>
+      <span class="badge badge-primary rounded">{{ customerViewedProductGrid.data.records_total }}</span>
     </h3>
     <div class="card-body">
-      <table class="table">
-        <thead>
-          <tr>
-            <th>{{ 'ID'|trans({}, 'Admin.Global') }}</th>
-            <th>{{ 'Name'|trans({}, 'Admin.Global') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for product in customerInformation.productsInformation.viewedProductsInformation %}
-            <tr class="customer-viewed-product">
-              <td class="customer-viewed-product-id">{{ product.productId }}</td>
-              <td class="customer-viewed-product-name">
-                <a class="customer-viewed-product-link" href="{{ product.productUrl }}">
-                  {{ product.productName }}
-                </a>
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+      {% include '@PrestaShop/Admin/Common/Grid/grid.html.twig' with {'grid': customerViewedProductGrid} %}
     </div>
   </div>
 {% endif %}

--- a/tests/UI/campaigns/functional/BO/02_orders/01_orders/createOrders/01_searchViewCustomer.ts
+++ b/tests/UI/campaigns/functional/BO/02_orders/01_orders/createOrders/01_searchViewCustomer.ts
@@ -186,7 +186,7 @@ describe('BO - Orders - Create order : Search and view customer details from new
     [
       {args: {blockName: 'Orders', number: 5}},
       {args: {blockName: 'Carts', number: 6}},
-      {args: {blockName: 'Viewed products', number: 6}},
+      {args: {blockName: 'Purchased products', number: 6}},
       {args: {blockName: 'Messages', number: 0}},
       {args: {blockName: 'Vouchers', number: 0}},
       {args: {blockName: 'Last emails', number: 0}},

--- a/tests/UI/campaigns/functional/BO/04_customers/01_customers/08_viewCustomer.ts
+++ b/tests/UI/campaigns/functional/BO/04_customers/01_customers/08_viewCustomer.ts
@@ -335,7 +335,7 @@ describe('BO - Customers - Customers : View information about customer', async (
     [
       {args: {blockName: 'Orders', number: 1}},
       {args: {blockName: 'Carts', number: 1}},
-      {args: {blockName: 'Viewed products', number: 1}},
+      {args: {blockName: 'Purchased products', number: 1}},
       {args: {blockName: 'Messages', number: 1}},
       {args: {blockName: 'Vouchers', number: 0}},
       {args: {blockName: 'Last emails', number: 2}},
@@ -370,10 +370,10 @@ describe('BO - Customers - Customers : View information about customer', async (
       expect(carts).to.contains(Products.demo_1.finalPrice);
     });
 
-    it('should check viewed products', async function () {
-      await testContext.addContextItem(this, 'testIdentifier', 'checkViewedProduct', baseContext);
+    it('should check purchased products', async function () {
+      await testContext.addContextItem(this, 'testIdentifier', 'checkPurchasedProduct', baseContext);
 
-      const viewedProduct = await viewCustomerPage.getTextFromElement(page, 'Viewed products');
+      const viewedProduct = await viewCustomerPage.getTextFromElement(page, 'Purchased products');
       expect(viewedProduct).to.contains(Products.demo_1.name);
     });
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | see below
| Type?             | refacto
| Category?         | BO
| BC breaks?        | partial - CustomerForViewing object now returns empty array for bought and viewed products.
| Deprecations?     | no
| How to test?      | see below
| Fixed ticket?     | Fixes #15444
| Related PRs       | 
| Sponsor company   | 

### Details
- Right now, the bought and viewed product tables on customer details were manually rendered tables. I changed their implementation to grid components like I did with orders and carts in https://github.com/PrestaShop/PrestaShop/pull/31442.
- **This has following advantages:**
  -  Introduces pagination so there is not a kilometer of bought products and the page is actually usable for bigger clients,
  -  Makes the page load faster.
  - Allows the use of standard hooks so people can customize these tables.
  - Bought products - I added a column Order ID, for better clarity.
  - Viewed products - I added a column Cart ID with a link to the cart in backoffice.

### Behavior and wording change
Purchased products now include products from all orders, not just the valid ones. You now see also products from orders that are waiting for payment. Before, they contained only products from valid orders. If the product is bought, it's bought. Follows a simmilar information as in here - https://github.com/PrestaShop/PrestaShop/pull/31440.

Simmilarily, viewed products now contain only products from carts that have not been ordered. ( = not in ps_orders table.) Previously, it contained all products from carts that have not been ordered OR not in a valid order.

The name of `Viewed products` was changed to `Products in carts` to better reflect what it means.

### Screenshot
**Before - chrome did not even want to make me a full height screenshot :D**
https://user-images.githubusercontent.com/6097524/224347878-985f7b3c-5b15-4ff1-8d9f-2f0d7eb8edb9.jpg

**After**
![Snímek obrazovky 2023-03-13 142201](https://user-images.githubusercontent.com/6097524/224714218-31f8bc12-815e-4b47-a046-95e2c41d697a.jpg)

### How to test
- Open customer detail page in backoffice and check blocks with bought and viewed products.
- See that everything works the same, but limits the amount of shown products to 20, adds pagination, allows sorting and there is a bit more information. 
- Beware that `Viewed products` block is a bit misleading, what it really means is `Products in unordered carts`.
- Beware that you can see a bit different data with and without this PR. With this PR, you can see more products in `Bought products` and less in `Viewed products`.
- Beware that if customer has no bought products and no products in cart, the block is not shown, like before.