### PR TITLE
Use index for connections.date_add

### DIFF
--- a/controllers/admin/AdminCartsController.php
+++ b/controllers/admin/AdminCartsController.php
@@ -53,7 +53,7 @@ class AdminCartsControllerCore extends AdminController
             o.id_order,
             IF (
 		        IFNULL(o.id_order, \'' . $this->trans('Non ordered', [], 'Admin.Orderscustomers.Feature') . '\') = \'' . $this->trans('Non ordered', [], 'Admin.Orderscustomers.Feature') . '\',
-		        IF(TIME_TO_SEC(TIMEDIFF(\'' . pSQL(date('Y-m-d H:i:00', time())) . '\', a.`date_add`)) > 86400, \'' . $this->trans('Abandoned cart', [], 'Admin.Orderscustomers.Feature') . '\',
+		        IF(a.`date_add` > date_add(\'' . pSQL(date('Y-m-d H:i:00', time())) . '\', interval 1 day), \'' . $this->trans('Abandoned cart', [], 'Admin.Orderscustomers.Feature') . '\',
 		        \'' . $this->trans('Non ordered', [], 'Admin.Orderscustomers.Feature') . '\'),
 		        o.id_order
             ) AS status,
@@ -67,8 +67,7 @@ class AdminCartsControllerCore extends AdminController
 		LEFT JOIN (
             SELECT DISTINCT `id_guest`
             FROM `' . _DB_PREFIX_ . 'connections`
-            WHERE
-                TIME_TO_SEC(TIMEDIFF(\'' . pSQL(date('Y-m-d H:i:00', time())) . '\', `date_add`)) < 1800
+            WHERE `date_add` > date_add(\'' . pSQL(date('Y-m-d H:i:00', time())) . '\', interval -30 minute)
        ) AS co ON co.`id_guest` = a.`id_guest`';
 
         if (Tools::getValue('action') && Tools::getValue('action') == 'filterOnlyAbandonedCarts') {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fixes an inefficient query. Use index instead of full table scan, 1 math operation per query instead of 1 per row.
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Displaying the list of Carts in the BO still works the same, but MUCH faster (0.5s instead of minutes)
| Fixed ticket?     | Fixes #31727
| Related PRs       | None
| Sponsor company   | Société Biblique de Genève
