### PR TITLE
Fix ProductCore::getDefaultCategory to return an int consistently

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7846,7 +7846,7 @@ class ProductCore extends ObjectModel
             WHERE p.`id_product` = ' . (int) $this->id
         );
 
-        return $default_category ? (int)$default_category : Context::getContext()->shop->id_category;
+        return (int) $defaultCategory ?? Context::getContext()->shop->id_category;
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7843,7 +7843,7 @@ class ProductCore extends ObjectModel
             'SELECT product_shop.`id_category_default`
             FROM `' . _DB_PREFIX_ . 'product` p
             ' . Shop::addSqlAssociation('product', 'p') . '
-            WHERE p.`id_product` = ' . (int)$this->id
+            WHERE p.`id_product` = ' . (int) $this->id
         );
 
         return $default_category ? (int)$default_category : Context::getContext()->shop->id_category;

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7839,7 +7839,7 @@ class ProductCore extends ObjectModel
      */
     public function getDefaultCategory(): int
     {
-        $default_category = Db::getInstance()->getValue(
+        $defaultCategory = Db::getInstance()->getValue(
             'SELECT product_shop.`id_category_default`
             FROM `' . _DB_PREFIX_ . 'product` p
             ' . Shop::addSqlAssociation('product', 'p') . '

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7846,7 +7846,7 @@ class ProductCore extends ObjectModel
             WHERE p.`id_product` = ' . (int) $this->id
         );
 
-        return (int) $defaultCategory ?? Context::getContext()->shop->id_category;
+        return (int) ($defaultCategory ?? Context::getContext()->shop->id_category);
     }
 
     /**

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -7833,24 +7833,20 @@ class ProductCore extends ObjectModel
     }
 
     /**
-     * Get the default category according to the shop.
+     * Get the default category id according to the shop.
      *
-     * @return array{id_category_default: int}|int
+     * @return int
      */
-    public function getDefaultCategory()
+    public function getDefaultCategory(): int
     {
         $default_category = Db::getInstance()->getValue(
             'SELECT product_shop.`id_category_default`
             FROM `' . _DB_PREFIX_ . 'product` p
             ' . Shop::addSqlAssociation('product', 'p') . '
-            WHERE p.`id_product` = ' . (int) $this->id
+            WHERE p.`id_product` = ' . (int)$this->id
         );
 
-        if (!$default_category) {
-            return ['id_category_default' => Context::getContext()->shop->id_category];
-        } else {
-            return (int) $default_category;
-        }
+        return $default_category ? (int)$default_category : Context::getContext()->shop->id_category;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `ProductCore->getDefaultCategory` inconsistently returned an array or an int. <br> This fixes the return value to be always an int.
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Check the default Category in Dashboardproducts is correctly pulled in the dashboard.
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#31747
| Related PRs       | Needs PrestaShop/dashproducts#47 to be merged to correctly handle the returned int default_category_id .
| Sponsor company   | BM Services
