### PR TITLE
Removed deprecated parameter in class Cart

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -4971,20 +4971,13 @@ class CartCore extends ObjectModel
      * Are all products of the Cart in stock?
      *
      * @param bool $ignoreVirtual Ignore virtual products
-     * @param bool $exclusive (DEPRECATED) If true, the validation is exclusive : it must be present product in stock and out of stock
      *
      * @since 1.5.0
      *
      * @return bool False if not all products in the cart are in stock
      */
-    public function isAllProductsInStock($ignoreVirtual = false, $exclusive = false)
+    public function isAllProductsInStock($ignoreVirtual = false)
     {
-        if (func_num_args() > 1) {
-            @trigger_error(
-                '$exclusive parameter is deprecated since version 1.7.3.2 and will be removed in the next major version.',
-                E_USER_DEPRECATED
-            );
-        }
         $productOutOfStock = 0;
         $productInStock = 0;
 
@@ -5002,20 +4995,8 @@ class CartCore extends ObjectModel
                 $product['id_customization']
             );
 
-            if (!$exclusive
-                && ($productQuantity < 0 && !$availableOutOfStock)
-            ) {
+            if ($productQuantity < 0 && !$availableOutOfStock) {
                 return false;
-            } elseif ($exclusive) {
-                if ($productQuantity <= 0) {
-                    ++$productOutOfStock;
-                } else {
-                    ++$productInStock;
-                }
-
-                if ($productInStock > 0 && $productOutOfStock > 0) {
-                    return false;
-                }
             }
         }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated parameter in class Cart
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4407106258
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks 
* Remove parameter 2 `$exclusive` for the method `isAllProductsInStock` in class `Cart`