### PR TITLE
Removed deprecated support of translation for ObjectModel field using fields.php

### DIFF
--- a/admin-dev/init.php
+++ b/admin-dev/init.php
@@ -44,13 +44,6 @@ try {
     if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/errors.php')) {
         include _PS_TRANSLATIONS_DIR_.$iso.'/errors.php';
     }
-    if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/fields.php')) {
-        @trigger_error(
-            'Translating ObjectModel fields using fields.php is deprecated since version 8.0.0.',
-            E_USER_DEPRECATED
-        );
-        include _PS_TRANSLATIONS_DIR_.$iso.'/fields.php';
-    }
     if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php')) {
         include _PS_TRANSLATIONS_DIR_.$iso.'/admin.php';
     }

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -374,7 +374,7 @@ class AddressCore extends ObjectModel
             if ($human_errors) {
                 return $this->trans(
                     'The %s field is required.',
-                    [$this->displayFieldName($field, get_class($this))],
+                    [$field],
                     'Admin.Notifications.Error'
                 );
             }

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -362,7 +362,7 @@ class LanguageCore extends ObjectModel implements LanguageInterface
             $mPath_to = _PS_MAIL_DIR_ . (string) $iso_to . '/';
         }
 
-        $lFiles = ['admin.php', 'errors.php', 'fields.php', 'pdf.php', 'tabs.php'];
+        $lFiles = ['admin.php', 'errors.php', 'pdf.php', 'tabs.php'];
 
         // Added natives mails files
         $mFiles = [

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1309,19 +1309,6 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
     {
         global $_FIELDS;
 
-        if (!isset($context)) {
-            $context = Context::getContext();
-        }
-
-        if ($_FIELDS === null && file_exists(_PS_TRANSLATIONS_DIR_ . $context->language->iso_code . '/fields.php')) {
-            @trigger_error(
-                 'Translating ObjectModel fields using fields.php is deprecated since version 8.0.0.',
-                E_USER_DEPRECATED
-            );
-
-            include_once _PS_TRANSLATIONS_DIR_ . $context->language->iso_code . '/fields.php';
-        }
-
         $key = $class . '_' . md5($field);
 
         return (is_array($_FIELDS) && array_key_exists($key, $_FIELDS)) ? ($htmlentities ? htmlentities($_FIELDS[$key], ENT_QUOTES, 'utf-8') : $_FIELDS[$key]) : $field;

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -1196,7 +1196,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             if (!in_array('required', $skip) && (!empty($data['required']) || in_array($field, $required_fields))) {
                 if (Tools::isEmpty($value)) {
                     if ($human_errors) {
-                        return $this->trans('The %s field is required.', [$this->displayFieldName($field, get_class($this))], 'Admin.Notifications.Error');
+                        return $this->trans('The %s field is required.', [$field], 'Admin.Notifications.Error');
                     } else {
                         return $this->trans('Property %s is empty.', [get_class($this) . '->' . $field], 'Admin.Notifications.Error');
                     }
@@ -1229,9 +1229,9 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                     if (isset($data['lang']) && $data['lang']) {
                         $language = new Language((int) $id_lang);
 
-                        return $this->trans('Your entry in field %1$s (language %2$s) exceeds max length %3$d chars (incl. html tags).', [$this->displayFieldName($field, get_class($this)), $language->name, $size['max']], 'Admin.Notifications.Error');
+                        return $this->trans('Your entry in field %1$s (language %2$s) exceeds max length %3$d chars (incl. html tags).', [$field, $language->name, $size['max']], 'Admin.Notifications.Error');
                     } else {
-                        return $this->trans('The %1$s field is too long (%2$d chars max).', [$this->displayFieldName($field, get_class($this)), $size['max']], 'Admin.Notifications.Error');
+                        return $this->trans('The %1$s field is too long (%2$d chars max).', [$field, $size['max']], 'Admin.Notifications.Error');
                     }
                 } else {
                     return $this->trans(
@@ -1284,7 +1284,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                 }
                 if (!$res) {
                     if ($human_errors) {
-                        return $this->trans('The %s field is invalid.', [$this->displayFieldName($field, get_class($this))], 'Admin.Notifications.Error');
+                        return $this->trans('The %s field is invalid.', [$field], 'Admin.Notifications.Error');
                     } else {
                         return $this->trans('Property %s is not valid', [get_class($this) . '->' . $field], 'Admin.Notifications.Error');
                     }
@@ -1293,25 +1293,6 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
         }
 
         return true;
-    }
-
-    /**
-     * Returns field name translation.
-     *
-     * @param string $field Field name
-     * @param string $class ObjectModel class name
-     * @param bool $htmlentities If true, applies htmlentities() to result string
-     * @param Context|null $context Context object
-     *
-     * @return string
-     */
-    public static function displayFieldName($field, $class = __CLASS__, $htmlentities = true, Context $context = null)
-    {
-        global $_FIELDS;
-
-        $key = $class . '_' . md5($field);
-
-        return (is_array($_FIELDS) && array_key_exists($key, $_FIELDS)) ? ($htmlentities ? htmlentities($_FIELDS[$key], ENT_QUOTES, 'utf-8') : $_FIELDS[$key]) : $field;
     }
 
     /**
@@ -1336,7 +1317,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             // Checking for required fields
             if (isset($data['required']) && $data['required'] && empty($value) && $value !== '0') {
                 if (!$this->id || $field != 'passwd') {
-                    $errors[$field] = '<b>' . self::displayFieldName($field, get_class($this), $htmlentities) . '</b> ' . $this->trans('is required.', [], 'Admin.Notifications.Error');
+                    $errors[$field] = '<b>' . $field . '</b> ' . $this->trans('is required.', [], 'Admin.Notifications.Error');
                 }
             }
 
@@ -1344,7 +1325,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             if (isset($data['size']) && !empty($value) && Tools::strlen($value) > $data['size']) {
                 $errors[$field] = $this->trans(
                     '%1$s is too long. Maximum length: %2$d',
-                    [self::displayFieldName($field, get_class($this), $htmlentities), $data['size']],
+                    [$field, $data['size']],
                     'Admin.Notifications.Error'
                 );
             }
@@ -1356,7 +1337,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                     $errors[$field] = $this->trans(
                             '%s is invalid.',
                             [
-                                '<b>' . self::displayFieldName($field, get_class($this), $htmlentities) . '</b>',
+                                '<b>' . $field . '</b>',
                             ],
                             'Admin.Notifications.Error'
                         );
@@ -1554,7 +1535,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             $value = Tools::getValue($field, null);
 
             if ($value === null) {
-                $errors[$field] = $this->trans('The %s field is required.', [self::displayFieldName($field, get_class($this), $htmlentities)], 'Admin.Notifications.Error');
+                $errors[$field] = $this->trans('The %s field is required.', [$field], 'Admin.Notifications.Error');
             }
         }
 

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -3650,7 +3650,7 @@ class AdminControllerCore extends Controller
                     if (!isset($value) || '' == $value) {
                         $this->errors[$field . '_' . $default_language->id] = $this->trans(
                             'The field %field_name% is required at least in %lang%.',
-                            ['%field_name%' => $object->displayFieldName($field, $class_name), '%lang%' => $default_language->name],
+                            ['%field_name%' => $field, '%lang%' => $default_language->name],
                             'Admin.Notifications.Error'
                         );
                     }

--- a/classes/stock/SupplyOrderDetail.php
+++ b/classes/stock/SupplyOrderDetail.php
@@ -299,7 +299,7 @@ class SupplyOrderDetailCore extends ObjectModel
                     $errors[] = $this->trans(
                         '%s is required.',
                         [
-                            '<b>' . SupplyOrderDetail::displayFieldName($field, get_class($this), $htmlentities) . '</b>',
+                            '<b>' . $field . '</b>',
                         ],
                         'Shop.Notifications.Error'
                     );
@@ -313,7 +313,7 @@ class SupplyOrderDetailCore extends ObjectModel
             if ($value && Tools::strlen($value) > $max_length) {
                 $errors[] = $this->trans(
                     'The %1$s field is too long (%2$d chars max).',
-                    [SupplyOrderDetail::displayFieldName($field, get_class($this), $htmlentities), $max_length],
+                    [$field, $max_length],
                     'Shop.Notifications.Error'
                 );
             }
@@ -323,7 +323,7 @@ class SupplyOrderDetailCore extends ObjectModel
         foreach ($this->fieldsValidate as $field => $function) {
             if ($value = $this->{$field}) {
                 if (!Validate::$function($value)) {
-                    $errors[] = '<b>' . SupplyOrderDetail::displayFieldName($field, get_class($this), $htmlentities) . '</b> ' . $this->trans('is invalid.', [], 'Shop.Notifications.Error');
+                    $errors[] = '<b>' . $field . '</b> ' . $this->trans('is invalid.', [], 'Shop.Notifications.Error');
                 } elseif ($field == 'passwd') {
                     if ($value = Tools::getValue($field)) {
                         $this->{$field} = Tools::hash($value);
@@ -335,15 +335,15 @@ class SupplyOrderDetailCore extends ObjectModel
         }
 
         if ($this->quantity_expected <= 0) {
-            $errors[] = '<b>' . SupplyOrderDetail::displayFieldName('quantity_expected', get_class($this)) . '</b> ' . $this->trans('is invalid.', [], 'Shop.Notifications.Error');
+            $errors[] = '<b>' . 'quantity_expected' . '</b> ' . $this->trans('is invalid.', [], 'Shop.Notifications.Error');
         }
 
         if ($this->tax_rate < 0 || $this->tax_rate > 100) {
-            $errors[] = '<b>' . SupplyOrderDetail::displayFieldName('tax_rate', get_class($this)) . '</b> ' . $this->trans('is invalid.', [], 'Shop.Notifications.Error');
+            $errors[] = '<b>' . 'tax_rate' . '</b> ' . $this->trans('is invalid.', [], 'Shop.Notifications.Error');
         }
 
         if ($this->discount_rate < 0 || $this->discount_rate > 100) {
-            $errors[] = '<b>' . SupplyOrderDetail::displayFieldName('discount_rate', get_class($this)) . '</b> ' . $this->trans('is invalid.', [], 'Shop.Notifications.Error');
+            $errors[] = '<b>' . 'discount_rate' . '</b> ' . $this->trans('is invalid.', [], 'Shop.Notifications.Error');
         }
 
         return $errors;

--- a/controllers/admin/AdminCarrierWizardController.php
+++ b/controllers/admin/AdminCarrierWizardController.php
@@ -954,11 +954,6 @@ class AdminCarrierWizardControllerCore extends AdminController
         return $definition;
     }
 
-    public static function displayFieldName($field)
-    {
-        return $field;
-    }
-
     public function duplicateLogo($new_id, $old_id)
     {
         $old_logo = _PS_SHIP_IMG_DIR_ . '/' . (int) $old_id . '.jpg';

--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -518,7 +518,7 @@ class AdminCountriesControllerCore extends AdminController
 
             foreach (AddressFormat::getValidateFields($class_name) as $name) {
                 $fields[] = '<a href="javascript:void(0);" class="addPattern btn btn-default btn-xs" id="' . ($class_name == 'Address' ? $name : $class_name . ':' . $name) . '">
-					<i class="icon-plus-sign"></i>&nbsp;' . ObjectModel::displayFieldName($name, $class_name) . '</a>';
+					<i class="icon-plus-sign"></i>&nbsp;' . $name . '</a>';
             }
             $html_tabcontent .= '
 				<div class="tab-pane availableFieldsList panel ' . $class_tab_active . '" id="availableListFieldsFor_' . $class_name . '">

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2048,7 +2048,7 @@ class AdminProductsControllerCore extends AdminController
                 if (Tools::getValue('id_' . $this->table) && $field == 'passwd') {
                     continue;
                 }
-                $this->errors[] = $this->trans('The %name% field is required.', ['%name%' => call_user_func([$this->className, 'displayFieldName'], $field, $this->className)], 'Admin.Notifications.Error');
+                $this->errors[] = $this->trans('The %name% field is required.', ['%name%' => $field], 'Admin.Notifications.Error');
             }
         }
 
@@ -2058,7 +2058,7 @@ class AdminProductsControllerCore extends AdminController
                 $this->errors[] = $this->trans(
                     'This %1$s field is required at least in %2$s',
                     [
-                        call_user_func([$this->className, 'displayFieldName'], $fieldLang, $this->className),
+                        $fieldLang,
                         $default_language->name,
                     ],
                     'Admin.Catalog.Notification'
@@ -2072,7 +2072,7 @@ class AdminProductsControllerCore extends AdminController
                 $this->errors[] = $this->trans(
                     'The %1$s field is too long (%2$d chars max).',
                     [
-                        call_user_func([$this->className, 'displayFieldName'], $field, $this->className),
+                        $field,
                         $maxLength,
                     ],
                     'Admin.Catalog.Notification'
@@ -2107,7 +2107,7 @@ class AdminProductsControllerCore extends AdminController
                     $this->errors[] = $this->trans(
                         'This %1$s field (%2$s) is too long: %3$d chars max (current count %4$d).',
                         [
-                            call_user_func([$this->className, 'displayFieldName'], 'description_short'),
+                            'description_short',
                             $language['name'],
                             $limit,
                             Tools::strlen(strip_tags($value)),
@@ -2126,7 +2126,7 @@ class AdminProductsControllerCore extends AdminController
                     $this->errors[] = $this->trans(
                         'The %1$s field is too long (%2$d chars max).',
                         [
-                            call_user_func([$this->className, 'displayFieldName'], $fieldLang, $this->className),
+                            $fieldLang,
                             $maxLength,
                         ],
                         'Admin.Catalog.Notification'
@@ -2155,7 +2155,7 @@ class AdminProductsControllerCore extends AdminController
                     $this->errors[] = $this->trans(
                         'The %s field is invalid.',
                         [
-                            call_user_func([$this->className, 'displayFieldName'], $field, $this->className),
+                            $field,
                         ],
                         'Admin.Notifications.Error'
                     );
@@ -2170,7 +2170,7 @@ class AdminProductsControllerCore extends AdminController
                         $this->errors[] = $this->trans(
                             'The %1$s field (%2$s) is invalid.',
                             [
-                                call_user_func([$this->className, 'displayFieldName'], $fieldLang, $this->className),
+                                $fieldLang,
                                 $language['name'],
                             ],
                             'Admin.Notifications.Error'

--- a/tests/Resources/modules_tests/override/AdminProductsController.php
+++ b/tests/Resources/modules_tests/override/AdminProductsController.php
@@ -1805,7 +1805,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 }
                 $this->errors[] = sprintf(
                     Tools::displayError('The %s field is required.'),
-                    call_user_func([$className, 'displayFieldName'], $field, $className)
+                    $field
                 );
             }
         }
@@ -1813,7 +1813,7 @@ class AdminProductsController extends AdminProductsControllerCore
             if ($this->isProductFieldUpdated($fieldLang, $default_language->id) && !Tools::getValue($fieldLang . '_' . $default_language->id)) {
                 $this->errors[] = sprintf(
                     Tools::displayError('This %1$s field is required at least in %2$s'),
-                    call_user_func([$className, 'displayFieldName'], $fieldLang, $className),
+                    $fieldLang,
                     $default_language->name
                 );
             }
@@ -1822,7 +1822,7 @@ class AdminProductsController extends AdminProductsControllerCore
             if ($this->isProductFieldUpdated($field) && ($value = Tools::getValue($field)) && Tools::strlen($value) > $maxLength) {
                 $this->errors[] = sprintf(
                     Tools::displayError('The %1$s field is too long (%2$d chars max).'),
-                    call_user_func([$className, 'displayFieldName'], $field, $className),
+                    $field,
                     $maxLength
                 );
             }
@@ -1840,7 +1840,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 if (Tools::strlen(strip_tags($value)) > $limit) {
                     $this->errors[] = sprintf(
                         Tools::displayError('This %1$s field (%2$s) is too long: %3$d chars max (current count %4$d).'),
-                        call_user_func([$className, 'displayFieldName'], 'description_short'),
+                        'description_short',
                         $language['name'],
                         $limit,
                         Tools::strlen(strip_tags($value))
@@ -1854,7 +1854,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 if ($value && Tools::strlen($value) > $maxLength) {
                     $this->errors[] = sprintf(
                         Tools::displayError('The %1$s field is too long (%2$d chars max).'),
-                        call_user_func([$className, 'displayFieldName'], $fieldLang, $className),
+                        $fieldLang,
                         $maxLength
                     );
                 }
@@ -1876,7 +1876,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 if (!$res) {
                     $this->errors[] = sprintf(
                         Tools::displayError('The %s field is invalid.'),
-                        call_user_func([$className, 'displayFieldName'], $field, $className)
+                        $field
                     );
                 }
             }
@@ -1887,7 +1887,7 @@ class AdminProductsController extends AdminProductsControllerCore
                     if (!Validate::$function($value, (int) Configuration::get('PS_ALLOW_HTML_IFRAME'))) {
                         $this->errors[] = sprintf(
                             Tools::displayError('The %1$s field (%2$s) is invalid.'),
-                            call_user_func([$className, 'displayFieldName'], $fieldLang, $className),
+                            $fieldLang,
                             $language['name']
                         );
                     }

--- a/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -1809,7 +1809,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 }
                 $this->errors[] = sprintf(
                     Tools::displayError('The %s field is required.'),
-                    call_user_func([$className, 'displayFieldName'], $field, $className)
+                    $field
                 );
             }
         }
@@ -1819,7 +1819,7 @@ class AdminProductsController extends AdminProductsControllerCore
             if ($this->isProductFieldUpdated($fieldLang, $default_language->id) && !Tools::getValue($fieldLang . '_' . $default_language->id)) {
                 $this->errors[] = sprintf(
                     Tools::displayError('This %1$s field is required at least in %2$s'),
-                    call_user_func([$className, 'displayFieldName'], $fieldLang, $className),
+                    $fieldLang,
                     $default_language->name
                 );
             }
@@ -1830,7 +1830,7 @@ class AdminProductsController extends AdminProductsControllerCore
             if ($this->isProductFieldUpdated($field) && ($value = Tools::getValue($field)) && Tools::strlen($value) > $maxLength) {
                 $this->errors[] = sprintf(
                     Tools::displayError('The %1$s field is too long (%2$d chars max).'),
-                    call_user_func([$className, 'displayFieldName'], $field, $className),
+                    $field,
                     $maxLength
                 );
             }
@@ -1851,7 +1851,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 if (Tools::strlen(strip_tags($value)) > $limit) {
                     $this->errors[] = sprintf(
                         Tools::displayError('This %1$s field (%2$s) is too long: %3$d chars max (current count %4$d).'),
-                        call_user_func([$className, 'displayFieldName'], 'description_short'),
+                        'description_short',
                         $language['name'],
                         $limit,
                         Tools::strlen(strip_tags($value))
@@ -1867,7 +1867,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 if ($value && Tools::strlen($value) > $maxLength) {
                     $this->errors[] = sprintf(
                         Tools::displayError('The %1$s field is too long (%2$d chars max).'),
-                        call_user_func([$className, 'displayFieldName'], $fieldLang, $className),
+                        $fieldLang,
                         $maxLength
                     );
                 }
@@ -1893,7 +1893,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 if (!$res) {
                     $this->errors[] = sprintf(
                         Tools::displayError('The %s field is invalid.'),
-                        call_user_func([$className, 'displayFieldName'], $field, $className)
+                        $field
                     );
                 }
             }
@@ -1905,7 +1905,7 @@ class AdminProductsController extends AdminProductsControllerCore
                     if (!Validate::$function($value, (int) Configuration::get('PS_ALLOW_HTML_IFRAME'))) {
                         $this->errors[] = sprintf(
                             Tools::displayError('The %1$s field (%2$s) is invalid.'),
-                            call_user_func([$className, 'displayFieldName'], $fieldLang, $className),
+                            $fieldLang,
                             $language['name']
                         );
                     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated support of translation for ObjectModel field using fields.php
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4407116734
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks
* Removed method `displayFieldName` in class `ObjectModel`