### PR TITLE
Removed deprecated method Tools::isBright

### DIFF
--- a/admin-dev/themes/default/template/helpers/list/list_content.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_content.tpl
@@ -65,7 +65,7 @@
 				{if isset($params.badge_warning) && $params.badge_warning && isset($tr.badge_warning) && $tr.badge_warning == $params.badge_warning}<span class="badge badge-warning">{/if}
 				{if isset($params.badge_danger) && $params.badge_danger && isset($tr.badge_danger) && $tr.badge_danger == $params.badge_danger}<span class="badge badge-danger">{/if}
 				{if isset($params.color) && isset($tr[$params.color])}
-					<span class="label color_field" style="background-color:{$tr[$params.color]};color:{if !Tools::isBright($tr[$params.color])}white{else}#383838{/if}">
+					<span class="label color_field" style="background-color:{$tr[$params.color]};color:{if !isBrightColor($tr[$params.color])}white{else}#383838{/if}">
 				{/if}
 				{if isset($tr.$key)}
 					{if isset($params.active)}

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -33,7 +33,6 @@ use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepositor
 use PrestaShop\PrestaShop\Core\Security\Hashing;
 use PrestaShop\PrestaShop\Core\Security\OpenSsl\OpenSSL;
 use PrestaShop\PrestaShop\Core\Security\PasswordGenerator;
-use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator;
 use PrestaShop\PrestaShop\Core\Util\String\StringModifier;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
@@ -2094,60 +2093,6 @@ class ToolsCore
         return Tools::strtolower(
             preg_replace('/([a-z])([A-Z])/', '$1-$2', $string)
         );
-    }
-
-    /**
-     * @deprecated since 8.1 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead
-     *
-     * @param string $hex
-     *
-     * @return float|int|string
-     */
-    public static function getBrightness($hex)
-    {
-        @trigger_error(
-            sprintf(
-                '%s is deprecated since version 8.1.0. use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead.',
-                __METHOD__
-            ),
-            E_USER_DEPRECATED
-        );
-
-        if (Tools::strtolower($hex) == 'transparent') {
-            return '129';
-        }
-
-        $hex = str_replace('#', '', $hex);
-
-        if (Tools::strlen($hex) == 3) {
-            $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
-        }
-
-        $r = hexdec(substr($hex, 0, 2));
-        $g = hexdec(substr($hex, 2, 2));
-        $b = hexdec(substr($hex, 4, 2));
-
-        return (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
-    }
-
-    /**
-     * @deprecated since 8.1 use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead
-     */
-    public static function isBright($hex)
-    {
-        @trigger_error(
-            sprintf(
-                '%s is deprecated since version 8.1.0. use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead.',
-                __METHOD__
-            ),
-            E_USER_DEPRECATED
-        );
-
-        if (null === self::$colorBrightnessCalculator) {
-            self::$colorBrightnessCalculator = new ColorBrightnessCalculator();
-        }
-
-        return self::$colorBrightnessCalculator->isBright($hex);
     }
 
     public static function parserSQL($sql)

--- a/config/smartyadmin.config.inc.php
+++ b/config/smartyadmin.config.inc.php
@@ -44,11 +44,17 @@ smartyRegisterFunction($smarty, 'function', 'displayAddressDetail', array('Addre
 smartyRegisterFunction($smarty, 'function', 'getWidthSize', array('Image', 'getWidth'));
 smartyRegisterFunction($smarty, 'function', 'getHeightSize', array('Image', 'getHeight'));
 smartyRegisterFunction($smarty, 'function', 'addJsDef', array('Media', 'addJsDef'));
+smartyRegisterFunction($smarty, 'function', 'isBrightColor', 'isBrightColor');
 smartyRegisterFunction($smarty, 'block', 'addJsDefL', array('Media', 'addJsDefL'));
 smartyRegisterFunction($smarty, 'modifier', 'secureReferrer', array('Tools', 'secureReferrer'));
 
 $module_resources['modules'] = _PS_MODULE_DIR_;
 $smarty->registerResource('module', new SmartyResourceModule($module_resources, $isAdmin = true));
+
+function isBrightColor(string $params): bool {
+    $colorBrightnessCalculator = new PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator();
+    return $colorBrightnessCalculator->isBright($params);
+}
 
 function toolsConvertPrice($params, &$smarty)
 {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated method Tools::isBright
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4407120743
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks 
* Remove method `getBrightness` from class `Tools`
* Remove method `isBright` from class `Tools`