### PR TITLE
Removed deprecated method `Translate::getAdminTranslation`

### DIFF
--- a/admin-dev/functions.php
+++ b/admin-dev/functions.php
@@ -394,9 +394,9 @@ function runAdminTab($tab, $ajax_mode = false)
                 echo '<div class="multishop_info">';
                 if (Shop::getContext() == Shop::CONTEXT_GROUP) {
                     $shop_group = new ShopGroup((int)Shop::getContextShopGroupID());
-                    printf(Translate::getAdminTranslation('You are configuring your store for group shop %s'), '<b>'.$shop_group->name.'</b>');
+                    printf(Context::getContext()->getTranslator()->trans('You are configuring your store for group shop %s'), '<b>'.$shop_group->name.'</b>');
                 } elseif (Shop::getContext() == Shop::CONTEXT_SHOP) {
-                    printf(Translate::getAdminTranslation('You are configuring your store for shop %s'), '<b>'.Context::getContext()->shop->name.'</b>');
+                    printf(Context::getContext()->getTranslator()->trans('You are configuring your store for shop %s'), '<b>'.Context::getContext()->shop->name.'</b>');
                 }
                 echo '</div>';
             }
@@ -470,7 +470,7 @@ function runAdminTab($tab, $ajax_mode = false)
                         }
 
                         // we can display the correct url
-                        die(json_encode(Translate::getAdminTranslation('Invalid security token')));
+                        die(json_encode(Context::getContext()->getTranslator()->trans('Invalid security token')));
                     } else {
                         // If this is an XSS attempt, then we should only display a simple, secure page
                         if (ob_get_level() && ob_get_length() > 0) {
@@ -483,17 +483,17 @@ function runAdminTab($tab, $ajax_mode = false)
                             $url .= '&token='.$admin_obj->token;
                         }
 
-                        $message = Translate::getAdminTranslation('Invalid security token');
+                        $message = Context::getContext()->getTranslator()->trans('Invalid security token');
                         echo '<html><head><title>'.$message.'</title></head><body style="font-family:Arial,Verdana,Helvetica,sans-serif;background-color:#EC8686">
 							<div style="background-color:#FAE2E3;border:1px solid #000000;color:#383838;font-weight:700;line-height:20px;margin:0 0 10px;padding:10px 15px;width:500px">
 								<img src="../img/admin/error2.png" style="margin:-4px 5px 0 0;vertical-align:middle">
 								'.$message.'
 							</div>';
                         echo '<a href="'.htmlentities($url).'" method="get" style="float:left;margin:10px">
-								<input type="button" value="'.Tools::htmlentitiesUTF8(Translate::getAdminTranslation('I understand the risks and I really want to display this page')).'" style="height:30px;margin-top:5px" />
+								<input type="button" value="'.Tools::htmlentitiesUTF8(Context::getContext()->getTranslator()->trans('I understand the risks and I really want to display this page')).'" style="height:30px;margin-top:5px" />
 							</a>
 							<a href="index.php" method="get" style="float:left;margin:10px">
-								<input type="button" value="'.Tools::htmlentitiesUTF8(Translate::getAdminTranslation('Take me out of here!')).'" style="height:40px" />
+								<input type="button" value="'.Tools::htmlentitiesUTF8(Context::getContext()->getTranslator()->trans('Take me out of here!')).'" style="height:40px" />
 							</a>
 						</body></html>';
                         die;

--- a/classes/Translate.php
+++ b/classes/Translate.php
@@ -73,41 +73,6 @@ class TranslateCore
     }
 
     /**
-     * Get a translation for an admin controller.
-     *
-     * @deprecated Use Context::getContext()->getTranslator()->trans()
-     *
-     * @param string $string
-     * @param string $class
-     * @param bool $addslashes
-     * @param bool $htmlentities
-     * @param array|null $sprintf
-     *
-     * @return string
-     */
-    public static function getAdminTranslation($string, $class = 'AdminTab', $addslashes = false, $htmlentities = true, $sprintf = null)
-    {
-        @trigger_error(__FUNCTION__ . 'is deprecated. Use Context::getContext()->getTranslator()->trans() instead.', E_USER_DEPRECATED);
-
-        $str = Context::getContext()->getTranslator()->trans($string);
-
-        if ($htmlentities) {
-            $str = htmlspecialchars($str, ENT_QUOTES, 'utf-8');
-        }
-        $str = str_replace('"', '&quot;', $str);
-
-        if (
-            $sprintf !== null &&
-            (!is_array($sprintf) || !empty($sprintf)) &&
-            !(count($sprintf) === 1 && isset($sprintf['legacy']))
-        ) {
-            $str = Translate::checkAndReplaceArgs($str, $sprintf);
-        }
-
-        return $addslashes ? addslashes($str) : $str;
-    }
-
-    /**
      * Get a translation for a module.
      *
      * @param string|ModuleCore $module

--- a/classes/helper/HelperShop.php
+++ b/classes/helper/HelperShop.php
@@ -72,9 +72,9 @@ class HelperShopCore extends Helper
 
         $current_shop_name = '';
         if ($this->noShopSelection()) {
-            $current_shop_name = Translate::getAdminTranslation('All shops');
+            $current_shop_name = Context::getContext()->getTranslator()->trans('All shops');
         } elseif ($shop_context == Shop::CONTEXT_GROUP) {
-            $current_shop_name = sprintf(Translate::getAdminTranslation('%s group'), $tree[Shop::getContextShopGroupID()]['name']);
+            $current_shop_name = sprintf(Context::getContext()->getTranslator()->trans('%s group'), $tree[Shop::getContextShopGroupID()]['name']);
         } else {
             foreach ($tree as $group_data) {
                 foreach ($group_data['shops'] as $shop_id => $shop_data) {

--- a/controllers/admin/AdminCountriesController.php
+++ b/controllers/admin/AdminCountriesController.php
@@ -514,7 +514,7 @@ class AdminCountriesControllerCore extends AdminController
             }
             $fields = [];
             $html_tabnav .= '<li' . ($class_tab_active ? ' class="' . $class_tab_active . '"' : '') . '>
-				<a href="#availableListFieldsFor_' . $class_name . '"><i class="icon-caret-down"></i>&nbsp;' . Translate::getAdminTranslation($class_name, 'AdminCountries') . '</a></li>';
+				<a href="#availableListFieldsFor_' . $class_name . '"><i class="icon-caret-down"></i>&nbsp;' . Context::getContext()->getTranslator()->trans($class_name, [], 'AdminCountries') . '</a></li>';
 
             foreach (AddressFormat::getValidateFields($class_name) as $name) {
                 $fields[] = '<a href="javascript:void(0);" class="addPattern btn btn-default btn-xs" id="' . ($class_name == 'Address' ? $name : $class_name . ':' . $name) . '">

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1251,7 +1251,7 @@ class AdminTranslationsControllerCore extends AdminController
                 if ($type_file == 'php') {
                     $regex = '/this->l\((\')' . _PS_TRANS_PATTERN_ . '\'[\)|\,]/U';
                 } elseif ($type_file == 'specific') {
-                    $regex = '/Translate::getAdminTranslation\((\')' . _PS_TRANS_PATTERN_ . '\'(?:,.*)*\)/U';
+                    $regex = '/Context::getContext\(\)->getTranslator\(\)->trans\((\')' . _PS_TRANS_PATTERN_ . '\'(?:,.*)*\)/U';
                 } else {
                     $regex = '/\{l\s*s\s*=([\'\"])' . _PS_TRANS_PATTERN_ . '\1(\s*sprintf=.*)?(\s*js=1)?(\s*slashes=1)?.*\}/U';
                 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated method `Translate::getAdminTranslation`
| Type?             | refacto
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4407124937
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks 
* Remove method `getAdminTranslation` of the class `Translate`
