### PR TITLE
Deprecate PS1.6 product list colors + formatting

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -659,11 +660,14 @@ class ProductCore extends ObjectModel
                     ],
                 ],
             ],
-            'tags' => ['resource' => 'tag',
+            'tags' => [
+                'resource' => 'tag',
                 'fields' => [
                     'id' => ['required' => true],
-                ], ],
-            'stock_availables' => ['resource' => 'stock_available',
+                ],
+            ],
+            'stock_availables' => [
+                'resource' => 'stock_available',
                 'fields' => [
                     'id' => ['required' => true],
                     'id_product_attribute' => ['required' => true],
@@ -683,7 +687,8 @@ class ProductCore extends ObjectModel
                 'fields' => [
                     'id' => [
                         'required' => true,
-                        'xlink_resource' => 'products', ],
+                        'xlink_resource' => 'products',
+                    ],
                 ],
             ],
             'product_bundle' => [
@@ -918,10 +923,12 @@ class ProductCore extends ObjectModel
             }
             $address_infos = Address::getCountryAndState($id_address);
 
-            if (self::$_taxCalculationMethod != PS_TAX_EXC
+            if (
+                self::$_taxCalculationMethod != PS_TAX_EXC
                 && !empty($address_infos['vat_number'])
                 && $address_infos['id_country'] != Configuration::get('VATNUMBER_COUNTRY')
-                && Configuration::get('VATNUMBER_MANAGEMENT')) {
+                && Configuration::get('VATNUMBER_MANAGEMENT')
+            ) {
                 self::$_taxCalculationMethod = PS_TAX_EXC;
             }
         } else {
@@ -957,12 +964,12 @@ class ProductCore extends ObjectModel
      */
     public function updatePosition($way, $position)
     {
-        if (!$res = Db::getInstance()->executeS('
-            SELECT cp.`id_product`, cp.`position`, cp.`id_category`
+        if (!$res = Db::getInstance()->executeS(
+            'SELECT cp.`id_product`, cp.`position`, cp.`id_category`
             FROM `' . _DB_PREFIX_ . 'category_product` cp
             WHERE cp.`id_category` = ' . (int) Tools::getValue('id_category', 1) . '
-            ORDER BY cp.`position` ASC')
-            ) {
+            ORDER BY cp.`position` ASC'
+        )) {
             return false;
         }
 
@@ -1323,7 +1330,8 @@ class ProductCore extends ObjectModel
         }
 
         Hook::exec('actionProductDelete', ['id_product' => (int) $this->id, 'product' => $this]);
-        if (!$result ||
+        if (
+            !$result ||
             !$this->deleteProductAttributes() ||
             !$this->deleteImages() ||
             !GroupReduction::deleteProductReduction($this->id) ||
@@ -1341,7 +1349,8 @@ class ProductCore extends ObjectModel
             !$this->deleteFromAccessories() ||
             !$this->deleteFromSupplier() ||
             !$this->deleteDownload() ||
-            !$this->deleteFromCartRules()) {
+            !$this->deleteFromCartRules()
+        ) {
             return false;
         }
 
@@ -2525,16 +2534,17 @@ class ProductCore extends ObjectModel
      */
     public static function updateCacheAttachment($id_product)
     {
-        $value = (bool) Db::getInstance()->getValue('
-                                SELECT id_attachment
-                                FROM ' . _DB_PREFIX_ . 'product_attachment
-                                WHERE id_product=' . (int) $id_product);
+        $value = (bool) Db::getInstance()->getValue(
+            'SELECT id_attachment
+            FROM ' . _DB_PREFIX_ . 'product_attachment
+            WHERE id_product=' . (int) $id_product
+        );
 
         return Db::getInstance()->update(
-                        'product',
-                        ['cache_has_attachments' => (int) $value],
-                        'id_product = ' . (int) $id_product
-                    );
+            'product',
+            ['cache_has_attachments' => (int) $value],
+            'id_product = ' . (int) $id_product
+        );
     }
 
     /**
@@ -2782,18 +2792,18 @@ class ProductCore extends ObjectModel
         }
 
         $sql = 'SELECT pa.*, product_attribute_shop.*, ag.`id_attribute_group`, ag.`is_color_group`, agl.`name` AS group_name, al.`name` AS attribute_name, ' .
-             'a.`id_attribute`, stock.location ' .
-             'FROM `' . _DB_PREFIX_ . 'product_attribute` pa ' .
-             Shop::addSqlAssociation('product_attribute', 'pa') . ' ' .
-             'LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac ON pac.`id_product_attribute` = pa.`id_product_attribute` ' .
-             'LEFT JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.`id_attribute` = pac.`id_attribute` ' .
-             'LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag ON ag.`id_attribute_group` = a.`id_attribute_group` ' .
-             'LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = ' . (int) $id_lang . ') ' .
-             'LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int) $id_lang . ') ' .
-             'LEFT JOIN `' . _DB_PREFIX_ . 'stock_available` stock ON (stock.id_product = pa.id_product AND stock.id_product_attribute = IFNULL(pa.`id_product_attribute`, 0)) ' .
-             'WHERE pa.`id_product` = ' . (int) $this->id . ' ' .
-             'GROUP BY pa.`id_product_attribute`' . ($groupByIdAttributeGroup ? ', ag.`id_attribute_group` ' : '') .
-             'ORDER BY pa.`id_product_attribute`';
+            'a.`id_attribute`, stock.location ' .
+            'FROM `' . _DB_PREFIX_ . 'product_attribute` pa ' .
+            Shop::addSqlAssociation('product_attribute', 'pa') . ' ' .
+            'LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac ON pac.`id_product_attribute` = pa.`id_product_attribute` ' .
+            'LEFT JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.`id_attribute` = pac.`id_attribute` ' .
+            'LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag ON ag.`id_attribute_group` = a.`id_attribute_group` ' .
+            'LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = ' . (int) $id_lang . ') ' .
+            'LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int) $id_lang . ') ' .
+            'LEFT JOIN `' . _DB_PREFIX_ . 'stock_available` stock ON (stock.id_product = pa.id_product AND stock.id_product_attribute = IFNULL(pa.`id_product_attribute`, 0)) ' .
+            'WHERE pa.`id_product` = ' . (int) $this->id . ' ' .
+            'GROUP BY pa.`id_product_attribute`' . ($groupByIdAttributeGroup ? ', ag.`id_attribute_group` ' : '') .
+            'ORDER BY pa.`id_product_attribute`';
 
         $res = Db::getInstance()->executeS($sql);
 
@@ -3680,10 +3690,12 @@ class ProductCore extends ObjectModel
             $usetax = false;
         }
 
-        if ($usetax != false
+        if (
+            $usetax != false
             && !empty($address->vat_number)
             && $address->id_country != Configuration::get('VATNUMBER_COUNTRY')
-            && Configuration::get('VATNUMBER_MANAGEMENT')) {
+            && Configuration::get('VATNUMBER_MANAGEMENT')
+        ) {
             $usetax = false;
         }
 
@@ -4417,9 +4429,9 @@ class ProductCore extends ObjectModel
                 WHERE product_attribute_shop.`default_on` = 1
                 AND pa.`id_product` = ' . (int) $this->id) > Shop::getTotalShops(true)) {
             Db::getInstance()->execute('UPDATE ' . _DB_PREFIX_ . 'product_attribute_shop product_attribute_shop, ' . _DB_PREFIX_ . 'product_attribute pa
-                    SET product_attribute_shop.default_on=NULL, pa.default_on = NULL
-                    WHERE product_attribute_shop.id_product_attribute=pa.id_product_attribute AND pa.id_product=' . (int) $this->id
-                    . Shop::addSqlRestriction(false, 'product_attribute_shop'));
+                SET product_attribute_shop.default_on=NULL, pa.default_on = NULL
+                WHERE product_attribute_shop.id_product_attribute=pa.id_product_attribute AND pa.id_product=' . (int) $this->id
+                . Shop::addSqlRestriction(false, 'product_attribute_shop'));
         }
 
         $row = Db::getInstance()->getRow(
@@ -4472,8 +4484,7 @@ class ProductCore extends ObjectModel
 
         $check_stock = !Configuration::get('PS_DISP_UNAVAILABLE_ATTR');
         if (!$res = Db::getInstance()->executeS(
-            '
-            SELECT pa.`id_product`, a.`color`, pac.`id_product_attribute`, ' . ($check_stock ? 'SUM(IF(stock.`quantity` > 0, 1, 0))' : '0') . ' qty, a.`id_attribute`, al.`name`, IF(color = "", a.id_attribute, color) group_by
+            'SELECT pa.`id_product`, a.`color`, pac.`id_product_attribute`, ' . ($check_stock ? 'SUM(IF(stock.`quantity` > 0, 1, 0))' : '0') . ' qty, a.`id_attribute`, al.`name`, IF(color = "", a.id_attribute, color) group_by
             FROM `' . _DB_PREFIX_ . 'product_attribute` pa
             ' . Shop::addSqlAssociation('product_attribute', 'pa') .
             ($check_stock ? Product::sqlStock('pa', 'pa') : '') . '
@@ -4485,8 +4496,7 @@ class ProductCore extends ObjectModel
             GROUP BY pa.`id_product`, a.`id_attribute`, `group_by`
             ' . ($check_stock ? 'HAVING qty > 0' : '') . '
             ORDER BY a.`position` ASC;'
-            )
-        ) {
+        )) {
             return false;
         }
 
@@ -5379,8 +5389,10 @@ class ProductCore extends ObjectModel
 
             unset($customization_field['id_customization_field']);
 
-            if (!Db::getInstance()->insert('customization_field', $customization_field)
-                || !$customization_field_id = Db::getInstance()->Insert_ID()) {
+            if (
+                !Db::getInstance()->insert('customization_field', $customization_field)
+                || !$customization_field_id = Db::getInstance()->Insert_ID()
+            ) {
                 return false;
             }
 
@@ -5440,8 +5452,8 @@ class ProductCore extends ObjectModel
     public static function duplicateCarriers(int $oldProductId, int $newProductId): bool
     {
         //@todo: this will copy carriers from all shops. todo - Handle multishop according context & specifications.
-        $oldProductCarriers = Db::getInstance()->executeS('
-            SELECT *
+        $oldProductCarriers = Db::getInstance()->executeS(
+            'SELECT *
             FROM `' . _DB_PREFIX_ . 'product_carrier`
             WHERE `id_product` = ' . (int) $oldProductId
         );
@@ -5466,8 +5478,8 @@ class ProductCore extends ObjectModel
      */
     public static function duplicateAttachmentAssociation(int $oldProductId, int $newProductId): bool
     {
-        $oldProductAttachments = Db::getInstance()->executeS('
-            SELECT *
+        $oldProductAttachments = Db::getInstance()->executeS(
+            'SELECT *
             FROM `' . _DB_PREFIX_ . 'product_attachment`
             WHERE `id_product` = ' . (int) $oldProductId
         );
@@ -5564,9 +5576,14 @@ class ProductCore extends ObjectModel
         // Product::getDefaultAttribute is only called if id_product_attribute is missing from the SQL query at the origin of it:
         // consider adding it in order to avoid unnecessary queries
         $row['allow_oosp'] = Product::isAvailableWhenOutOfStock($row['out_of_stock']);
-        if (Combination::isFeatureActive() && $id_product_attribute === null
-            && ((isset($row['cache_default_attribute']) && ($ipa_default = $row['cache_default_attribute']) !== null)
-                || ($ipa_default = Product::getDefaultAttribute($row['id_product'], (int) !$row['allow_oosp'])))) {
+        if (
+            Combination::isFeatureActive() &&
+            $id_product_attribute === null &&
+            (
+                (isset($row['cache_default_attribute']) && ($ipa_default = $row['cache_default_attribute']) !== null)
+                || ($ipa_default = Product::getDefaultAttribute($row['id_product'], (int) !$row['allow_oosp']))
+            )
+        ) {
             $id_product_attribute = $row['id_product_attribute'] = $ipa_default;
         }
         if (!Combination::isFeatureActive() || !isset($row['id_product_attribute'])) {
@@ -5640,8 +5657,7 @@ class ProductCore extends ObjectModel
                 true,
                 $quantity
             );
-            $row['price_without_reduction'] =
-            $row['price_without_reduction_without_tax'] = Product::getPriceStatic(
+            $row['price_without_reduction'] = $row['price_without_reduction_without_tax'] = Product::getPriceStatic(
                 (int) $row['id_product'],
                 false,
                 $id_product_attribute,
@@ -5976,8 +5992,8 @@ class ProductCore extends ObjectModel
      */
     public function getAssociatedAttachmentIds(): array
     {
-        $results = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS('
-            SELECT id_attachment
+        $results = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS(
+            'SELECT id_attachment
             FROM ' . _DB_PREFIX_ . 'product_attachment
             WHERE id_product = ' . (int) $this->id
         );
@@ -6195,14 +6211,12 @@ class ProductCore extends ObjectModel
         ];
 
         /* Get customization field ids */
-        if ((
-            $result = Db::getInstance()->executeS(
+        if (($result = Db::getInstance()->executeS(
             'SELECT `id_customization_field`, `type`
             FROM `' . _DB_PREFIX_ . 'customization_field`
             WHERE `id_product` = ' . (int) $this->id . '
             ORDER BY `id_customization_field`'
-            )
-        ) === false) {
+        )) === false) {
             return false;
         }
 
@@ -6223,27 +6237,33 @@ class ProductCore extends ObjectModel
         $extra_text = count($customization_fields[Product::CUSTOMIZE_TEXTFIELD]) - $max[Product::CUSTOMIZE_TEXTFIELD];
 
         /* If too much inside the database, deletion */
-        if ($extra_file > 0 && count($customization_fields[Product::CUSTOMIZE_FILE]) - $extra_file >= 0 &&
-        (!Db::getInstance()->execute(
-            'DELETE `' . _DB_PREFIX_ . 'customization_field`,`' . _DB_PREFIX_ . 'customization_field_lang`
-            FROM `' . _DB_PREFIX_ . 'customization_field` JOIN `' . _DB_PREFIX_ . 'customization_field_lang`
-            WHERE `' . _DB_PREFIX_ . 'customization_field`.`id_product` = ' . (int) $this->id . '
-            AND `' . _DB_PREFIX_ . 'customization_field`.`type` = ' . Product::CUSTOMIZE_FILE . '
-            AND `' . _DB_PREFIX_ . 'customization_field_lang`.`id_customization_field` = `' . _DB_PREFIX_ . 'customization_field`.`id_customization_field`
-            AND `' . _DB_PREFIX_ . 'customization_field`.`id_customization_field` >= ' . (int) $customization_fields[Product::CUSTOMIZE_FILE][count($customization_fields[Product::CUSTOMIZE_FILE]) - $extra_file]
-        ))) {
+        if (
+            $extra_file > 0 &&
+            count($customization_fields[Product::CUSTOMIZE_FILE]) - $extra_file >= 0 &&
+            (!Db::getInstance()->execute(
+                'DELETE `' . _DB_PREFIX_ . 'customization_field`,`' . _DB_PREFIX_ . 'customization_field_lang`
+                FROM `' . _DB_PREFIX_ . 'customization_field` JOIN `' . _DB_PREFIX_ . 'customization_field_lang`
+                WHERE `' . _DB_PREFIX_ . 'customization_field`.`id_product` = ' . (int) $this->id . '
+                AND `' . _DB_PREFIX_ . 'customization_field`.`type` = ' . Product::CUSTOMIZE_FILE . '
+                AND `' . _DB_PREFIX_ . 'customization_field_lang`.`id_customization_field` = `' . _DB_PREFIX_ . 'customization_field`.`id_customization_field`
+                AND `' . _DB_PREFIX_ . 'customization_field`.`id_customization_field` >= ' . (int) $customization_fields[Product::CUSTOMIZE_FILE][count($customization_fields[Product::CUSTOMIZE_FILE]) - $extra_file]
+            ))
+        ) {
             return false;
         }
 
-        if ($extra_text > 0 && count($customization_fields[Product::CUSTOMIZE_TEXTFIELD]) - $extra_text >= 0 &&
-        (!Db::getInstance()->execute(
-            'DELETE `' . _DB_PREFIX_ . 'customization_field`,`' . _DB_PREFIX_ . 'customization_field_lang`
-            FROM `' . _DB_PREFIX_ . 'customization_field` JOIN `' . _DB_PREFIX_ . 'customization_field_lang`
-            WHERE `' . _DB_PREFIX_ . 'customization_field`.`id_product` = ' . (int) $this->id . '
-            AND `' . _DB_PREFIX_ . 'customization_field`.`type` = ' . Product::CUSTOMIZE_TEXTFIELD . '
-            AND `' . _DB_PREFIX_ . 'customization_field_lang`.`id_customization_field` = `' . _DB_PREFIX_ . 'customization_field`.`id_customization_field`
-            AND `' . _DB_PREFIX_ . 'customization_field`.`id_customization_field` >= ' . (int) $customization_fields[Product::CUSTOMIZE_TEXTFIELD][count($customization_fields[Product::CUSTOMIZE_TEXTFIELD]) - $extra_text]
-        ))) {
+        if (
+            $extra_text > 0 &&
+            count($customization_fields[Product::CUSTOMIZE_TEXTFIELD]) - $extra_text >= 0 &&
+            (!Db::getInstance()->execute(
+                'DELETE `' . _DB_PREFIX_ . 'customization_field`,`' . _DB_PREFIX_ . 'customization_field_lang`
+                FROM `' . _DB_PREFIX_ . 'customization_field` JOIN `' . _DB_PREFIX_ . 'customization_field_lang`
+                WHERE `' . _DB_PREFIX_ . 'customization_field`.`id_product` = ' . (int) $this->id . '
+                AND `' . _DB_PREFIX_ . 'customization_field`.`type` = ' . Product::CUSTOMIZE_TEXTFIELD . '
+                AND `' . _DB_PREFIX_ . 'customization_field_lang`.`id_customization_field` = `' . _DB_PREFIX_ . 'customization_field`.`id_customization_field`
+                AND `' . _DB_PREFIX_ . 'customization_field`.`id_customization_field` >= ' . (int) $customization_fields[Product::CUSTOMIZE_TEXTFIELD][count($customization_fields[Product::CUSTOMIZE_TEXTFIELD]) - $extra_text]
+            ))
+        ) {
             return false;
         }
 
@@ -6262,10 +6282,12 @@ class ProductCore extends ObjectModel
     protected function _createLabel($languages, $type)
     {
         // Label insertion
-        if (!Db::getInstance()->execute('
-            INSERT INTO `' . _DB_PREFIX_ . 'customization_field` (`id_product`, `type`, `required`)
-            VALUES (' . (int) $this->id . ', ' . (int) $type . ', 0)') ||
-            !$id_customization_field = (int) Db::getInstance()->Insert_ID()) {
+        if (
+            !Db::getInstance()->execute('
+                INSERT INTO `' . _DB_PREFIX_ . 'customization_field` (`id_product`, `type`, `required`)
+                VALUES (' . (int) $this->id . ', ' . (int) $type . ', 0)')
+            || !$id_customization_field = (int) Db::getInstance()->Insert_ID()
+        ) {
             return false;
         }
 
@@ -6431,8 +6453,7 @@ class ProductCore extends ObjectModel
         }
 
         return (bool) Db::getInstance()->executeS(
-            '
-            SELECT 1
+            'SELECT 1
             FROM `' . _DB_PREFIX_ . 'customization_field`
             WHERE `id_product` = ' . (int) $this->id . '
             AND `required` = 1
@@ -6449,10 +6470,11 @@ class ProductCore extends ObjectModel
             return [];
         }
 
-        return Db::getInstance()->executeS('
-            SELECT `id_customization_field`, `type`, `required`
+        return Db::getInstance()->executeS(
+            'SELECT `id_customization_field`, `type`, `required`
             FROM `' . _DB_PREFIX_ . 'customization_field`
-            WHERE `id_product` = ' . (int) $this->id);
+            WHERE `id_product` = ' . (int) $this->id
+        );
     }
 
     /**
@@ -6464,8 +6486,8 @@ class ProductCore extends ObjectModel
             return [];
         }
 
-        $results = Db::getInstance()->executeS('
-            SELECT `id_customization_field`
+        $results = Db::getInstance()->executeS(
+            'SELECT `id_customization_field`
             FROM `' . _DB_PREFIX_ . 'customization_field`
             WHERE `is_deleted` = 0
             AND `id_product` = ' . (int) $this->id
@@ -6485,12 +6507,10 @@ class ProductCore extends ObjectModel
      */
     public function countCustomizationFields(?int $fieldType = null): int
     {
-        $query = '
-            SELECT COUNT(`id_customization_field`) as customizations_count
+        $query = 'SELECT COUNT(`id_customization_field`) as customizations_count
             FROM `' . _DB_PREFIX_ . 'customization_field`
             WHERE `is_deleted` = 0
-            AND `id_product` = ' . (int) $this->id
-        ;
+            AND `id_product` = ' . (int) $this->id;
 
         if (null !== $fieldType) {
             $query .= sprintf(' AND type = %d', $fieldType);
@@ -6924,15 +6944,15 @@ class ProductCore extends ObjectModel
         $ids = array_unique($ids);
 
         $positions = Db::getInstance()->executeS(
-                'SELECT `id_category`, `position`
-                FROM `' . _DB_PREFIX_ . 'category_product`
-                WHERE `id_product` = ' . (int) $this->id
+            'SELECT `id_category`, `position`
+            FROM `' . _DB_PREFIX_ . 'category_product`
+            WHERE `id_product` = ' . (int) $this->id
         );
 
         $max_positions = Db::getInstance()->executeS(
-                'SELECT `id_category`, max(`position`) as maximum
-                FROM `' . _DB_PREFIX_ . 'category_product`
-                GROUP BY id_category'
+            'SELECT `id_category`, max(`position`) as maximum
+            FROM `' . _DB_PREFIX_ . 'category_product`
+            GROUP BY id_category'
         );
 
         $positions_lookup = [];
@@ -7053,7 +7073,11 @@ class ProductCore extends ObjectModel
         }
 
         $all_ids = [];
-        $all = Db::getInstance()->executeS('SELECT pa.`id_product_attribute` as id FROM `' . _DB_PREFIX_ . 'product_attribute` pa ' . Shop::addSqlAssociation('product_attribute', 'pa'));
+        $all = Db::getInstance()->executeS(
+            'SELECT pa.`id_product_attribute` as id
+            FROM `' . _DB_PREFIX_ . 'product_attribute` pa
+            ' . Shop::addSqlAssociation('product_attribute', 'pa')
+        );
         if (is_array($all)) {
             foreach ($all as $id) {
                 $all_ids[] = $id['id'];
@@ -7101,11 +7125,13 @@ class ProductCore extends ObjectModel
      */
     public function getWsProductOptionValues()
     {
-        $result = Db::getInstance()->executeS('SELECT DISTINCT pac.id_attribute as id
+        $result = Db::getInstance()->executeS(
+            'SELECT DISTINCT pac.id_attribute as id
             FROM `' . _DB_PREFIX_ . 'product_attribute` pa
             ' . Shop::addSqlAssociation('product_attribute', 'pa') . '
             LEFT JOIN `' . _DB_PREFIX_ . 'product_attribute_combination` pac ON (pac.id_product_attribute = pa.id_product_attribute)
-            WHERE pa.id_product = ' . (int) $this->id);
+            WHERE pa.id_product = ' . (int) $this->id
+        );
 
         return $result;
     }
@@ -7121,7 +7147,8 @@ class ProductCore extends ObjectModel
             'SELECT `position`
             FROM `' . _DB_PREFIX_ . 'category_product`
             WHERE `id_category` = ' . (int) $this->id_category_default . '
-            AND `id_product` = ' . (int) $this->id);
+            AND `id_product` = ' . (int) $this->id
+        );
         if (count($result) > 0) {
             return $result[0]['position'];
         }
@@ -7692,8 +7719,11 @@ class ProductCore extends ObjectModel
             $manager = StockManagerFactory::getManager();
         }
 
-        if (Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT') && Product::usesAdvancedStockManagement($id_product) &&
-            StockAvailable::dependsOnStock($id_product, $id_shop)) {
+        if (
+            Configuration::get('PS_ADVANCED_STOCK_MANAGEMENT')
+            && Product::usesAdvancedStockManagement($id_product)
+            && StockAvailable::dependsOnStock($id_product, $id_shop)
+        ) {
             return $manager->getProductRealQuantities($id_product, $id_product_attribute, $id_warehouse, true);
         } else {
             return StockAvailable::getQuantityAvailableByProduct($id_product, $id_product_attribute, $id_shop);
@@ -7785,9 +7815,9 @@ class ProductCore extends ObjectModel
     {
         return (bool) Db::getInstance()->getValue(
             'SELECT `advanced_stock_management`
-                FROM ' . _DB_PREFIX_ . 'product_shop
-                WHERE id_product=' . (int) $this->id . Shop::addSqlRestriction()
-            );
+            FROM ' . _DB_PREFIX_ . 'product_shop
+            WHERE id_product=' . (int) $this->id . Shop::addSqlRestriction()
+        );
     }
 
     /**
@@ -7798,8 +7828,10 @@ class ProductCore extends ObjectModel
     public function setAdvancedStockManagement($value)
     {
         $this->advanced_stock_management = (bool) $value;
-        if (Context::getContext()->shop->getContext() == Shop::CONTEXT_GROUP
-            && Context::getContext()->shop->getContextShopGroup()->share_stock == 1) {
+        if (
+            Context::getContext()->shop->getContext() == Shop::CONTEXT_GROUP
+            && Context::getContext()->shop->getContextShopGroup()->share_stock == 1
+        ) {
             Db::getInstance()->execute(
                 '
                 UPDATE `' . _DB_PREFIX_ . 'product_shop`
@@ -7842,10 +7874,11 @@ class ProductCore extends ObjectModel
      */
     public static function getShopsByProduct($id_product)
     {
-        return Db::getInstance()->executeS('
-            SELECT `id_shop`
+        return Db::getInstance()->executeS(
+            'SELECT `id_shop`
             FROM `' . _DB_PREFIX_ . 'product_shop`
-            WHERE `id_product` = ' . (int) $id_product);
+            WHERE `id_product` = ' . (int) $id_product
+        );
     }
 
     /**
@@ -7908,19 +7941,18 @@ class ProductCore extends ObjectModel
     public static function getIdTaxRulesGroupMostUsed()
     {
         return Db::getInstance()->getValue(
-            '
-                    SELECT id_tax_rules_group
-                    FROM (
-                        SELECT COUNT(*) n, product_shop.id_tax_rules_group
-                        FROM ' . _DB_PREFIX_ . 'product p
-                        ' . Shop::addSqlAssociation('product', 'p') . '
-                        JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg ON (product_shop.id_tax_rules_group = trg.id_tax_rules_group)
-                        WHERE trg.active = 1 AND trg.deleted = 0
-                        GROUP BY product_shop.id_tax_rules_group
-                        ORDER BY n DESC
-                        LIMIT 1
-                    ) most_used'
-                );
+            'SELECT id_tax_rules_group
+            FROM (
+                SELECT COUNT(*) n, product_shop.id_tax_rules_group
+                FROM ' . _DB_PREFIX_ . 'product p
+                ' . Shop::addSqlAssociation('product', 'p') . '
+                JOIN ' . _DB_PREFIX_ . 'tax_rules_group trg ON (product_shop.id_tax_rules_group = trg.id_tax_rules_group)
+                WHERE trg.active = 1 AND trg.deleted = 0
+                GROUP BY product_shop.id_tax_rules_group
+                ORDER BY n DESC
+                LIMIT 1
+            ) most_used'
+        );
     }
 
     /**
@@ -8100,6 +8132,8 @@ class ProductCore extends ObjectModel
     }
 
     /**
+     * @deprecated since 8.1 and will be removed in next major version.
+     *
      * @param int $id_product Product identifier
      * @param bool $full
      *
@@ -8286,11 +8320,11 @@ class ProductCore extends ObjectModel
         }
 
         $sql = 'UPDATE `' . _DB_PREFIX_ . 'product` ' .
-             'SET ' .
-             'id_supplier = %d, ' .
-             'supplier_reference = "%s", ' .
-             'wholesale_price = "%s" ' .
-             'WHERE id_product = %d';
+            'SET ' .
+            'id_supplier = %d, ' .
+            'supplier_reference = "%s", ' .
+            'wholesale_price = "%s" ' .
+            'WHERE id_product = %d';
 
         return Db::getInstance()->execute(
             sprintf(

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -23,6 +24,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use Composer\CaBundle\CaBundle;
 use PHPSQLParser\PHPSQLParser;
 use PrestaShop\PrestaShop\Adapter\ContainerFinder;
@@ -563,8 +565,12 @@ class ToolsCore
         }
 
         /* Automatically detect language if not already defined, detect_language is set in Cookie::update */
-        if (!Tools::getValue('isolang') && !Tools::getValue('id_lang') && (!$cookie->id_lang || isset($cookie->detect_language))
-            && isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+        if (
+            !Tools::getValue('isolang') &&
+            !Tools::getValue('id_lang') &&
+            (!$cookie->id_lang || isset($cookie->detect_language))
+            && isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])
+        ) {
             $array = explode(',', Tools::strtolower($_SERVER['HTTP_ACCEPT_LANGUAGE']));
             $string = $array[0];
 
@@ -641,7 +647,8 @@ class ToolsCore
     public static function getCountry($address = null)
     {
         $countryId = Tools::getValue('id_country');
-        if (Validate::isInt($countryId)
+        if (
+            Validate::isInt($countryId)
             && (int) $countryId > 0
             && !empty(Country::getIsoById((int) $countryId))
         ) {
@@ -713,8 +720,7 @@ class ToolsCore
     public static function displayPrice($price, $currency = null, $no_utf8 = false, Context $context = null)
     {
         @trigger_error(
-            'Tools::displayPrice() is deprecated since version 1.7.6.0. '
-            . 'Use ' . Locale::class . '::formatPrice() instead.',
+            'Tools::displayPrice() is deprecated since version 1.7.6.0. Use ' . Locale::class . '::formatPrice() instead.',
             E_USER_DEPRECATED
         );
 
@@ -783,8 +789,7 @@ class ToolsCore
     public static function displayNumber($number, $currency = null)
     {
         @trigger_error(
-            'Tools::displayNumber() is deprecated since version 1.7.5.0. '
-            . 'Use ' . Locale::class . ' instead.',
+            'Tools::displayNumber() is deprecated since version 1.7.5.0. Use ' . Locale::class . ' instead.',
             E_USER_DEPRECATED
         );
 
@@ -1614,8 +1619,7 @@ class ToolsCore
     public static function stripslashes($string)
     {
         @trigger_error(
-            'Tools::stripslashes() is deprecated since version 8.0.0.'
-            . 'Use PHP\'s stripslashes instead.',
+            'Tools::stripslashes() is deprecated since version 8.0.0. Use PHP\'s stripslashes instead.',
             E_USER_DEPRECATED
         );
 
@@ -1802,17 +1806,21 @@ class ToolsCore
         if ($value >= 0.0) {
             $tmp_value = floor($value + 0.5);
 
-            if (($mode == PS_ROUND_HALF_DOWN && $value == (-0.5 + $tmp_value)) ||
+            if (
+                ($mode == PS_ROUND_HALF_DOWN && $value == (-0.5 + $tmp_value)) ||
                 ($mode == PS_ROUND_HALF_EVEN && $value == (0.5 + 2 * floor($tmp_value / 2.0))) ||
-                ($mode == PS_ROUND_HALF_ODD && $value == (0.5 + 2 * floor($tmp_value / 2.0) - 1.0))) {
+                ($mode == PS_ROUND_HALF_ODD && $value == (0.5 + 2 * floor($tmp_value / 2.0) - 1.0))
+            ) {
                 $tmp_value = $tmp_value - 1.0;
             }
         } else {
             $tmp_value = ceil($value - 0.5);
 
-            if (($mode == PS_ROUND_HALF_DOWN && $value == (0.5 + $tmp_value)) ||
+            if (
+                ($mode == PS_ROUND_HALF_DOWN && $value == (0.5 + $tmp_value)) ||
                 ($mode == PS_ROUND_HALF_EVEN && $value == (-0.5 + 2 * ceil($tmp_value / 2.0))) ||
-                ($mode == PS_ROUND_HALF_ODD && $value == (-0.5 + 2 * ceil($tmp_value / 2.0) + 1.0))) {
+                ($mode == PS_ROUND_HALF_ODD && $value == (-0.5 + 2 * ceil($tmp_value / 2.0) + 1.0))
+            ) {
                 $tmp_value = $tmp_value + 1.0;
             }
         }
@@ -1969,7 +1977,8 @@ class ToolsCore
             $content = curl_exec($curl);
 
             if (false === $content && _PS_MODE_DEV_) {
-                $errorMessage = sprintf('file_get_contents_curl failed to download %s : (error code %d) %s',
+                $errorMessage = sprintf(
+                    'file_get_contents_curl failed to download %s : (error code %d) %s',
                     $url,
                     curl_errno($curl),
                     curl_error($curl)
@@ -2171,7 +2180,7 @@ class ToolsCore
     {
         @trigger_error(
             sprintf(
-                '%s is deprecated since version 8.1.0. use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead.',
+                '%s is deprecated since version 8.1.0. Use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead.',
                 __METHOD__
             ),
             E_USER_DEPRECATED
@@ -2201,7 +2210,7 @@ class ToolsCore
     {
         @trigger_error(
             sprintf(
-                '%s is deprecated since version 8.1.0. use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead.',
+                '%s is deprecated since version 8.1.0. Use PrestaShop\PrestaShop\Core\Util\ColorBrightnessCalculator::isBright function instead.',
                 __METHOD__
             ),
             E_USER_DEPRECATED
@@ -2318,7 +2327,8 @@ class ToolsCore
 
     public static function generateHtaccess($path = null, $rewrite_settings = null, $cache_control = null, $specific = '', $disable_multiviews = null, $medias = false, $disable_modsec = null)
     {
-        if (defined('_PS_IN_TEST_')
+        if (
+            defined('_PS_IN_TEST_')
             || (defined('PS_INSTALLATION_IN_PROGRESS') && $rewrite_settings === null)
         ) {
             return true;
@@ -2391,7 +2401,9 @@ class ToolsCore
 
         fwrite($write_fd, "RewriteEngine on\n");
 
-        if (!$medias && Configuration::getMultiShopValues('PS_MEDIA_SERVER_1')
+        if (
+            !$medias
+            && Configuration::getMultiShopValues('PS_MEDIA_SERVER_1')
             && Configuration::getMultiShopValues('PS_MEDIA_SERVER_2')
             && Configuration::getMultiShopValues('PS_MEDIA_SERVER_3')
         ) {
@@ -3322,6 +3334,8 @@ exit;
     }
 
     /**
+     * @deprecated since 8.1 and will be removed in next major version.
+     *
      * @param int|bool $id_product
      */
     public static function clearColorListCache($id_product = false)
@@ -3930,18 +3944,15 @@ exit;
      * highest $sort_column.
      *
      * E.g.:
-     *
      * $rows = [['a' => 5.1], ['a' => 8.2]];
-     *
      * spreadAmount(0.3, 1, $rows, 'a');
-     *
      * => $rows is [['a' => 8.4], ['a' => 5.2]]
      *
      * @param float $amount The amount to spread across the rows
      * @param int $precision Rounding precision
-     *                       e.g. if $amount is 1, $precision is 0 and $rows = [['a' => 2], ['a' => 1]]
-     *                       then the resulting $rows will be [['a' => 3], ['a' => 1]]
-     *                       But if $precision were 1, then the resulting $rows would be [['a' => 2.5], ['a' => 1.5]]
+     * e.g. if $amount is 1, $precision is 0 and $rows = [['a' => 2], ['a' => 1]]
+     * then the resulting $rows will be [['a' => 3], ['a' => 1]]
+     * But if $precision were 1, then the resulting $rows would be [['a' => 2.5], ['a' => 1.5]]
      * @param array $rows An array, associative or not, containing arrays that have at least $column and $sort_column fields
      * @param string $column The column on which to perform adjustments
      */
@@ -3951,7 +3962,9 @@ exit;
             return;
         }
 
-        $sort_function = function ($a, $b) use ($column) { return $b[$column] > $a[$column] ? 1 : -1; };
+        $sort_function = function ($a, $b) use ($column) {
+            return $b[$column] > $a[$column] ? 1 : -1;
+        };
 
         uasort($rows, $sort_function);
 
@@ -4035,10 +4048,10 @@ exit;
                     $index_link = Context::getContext()->link->getAdminLink('AdminCategories', true, $link_params);
                     $edit = '<a href="' . Tools::safeOutput($edit_link) . '" title="' . ($category['id_category'] == Category::getRootCategory()->id_category ? 'Home' : 'Modify') . '"><i class="icon-' . (($category['id_category'] == Category::getRootCategory()->id_category || $home) ? 'home' : 'pencil') . '"></i></a> ';
                     $full_path .= $edit .
-                                  ($n < $n_categories ? '<a href="' . Tools::safeOutput($index_link) . '" title="' . htmlentities($category['name'], ENT_NOQUOTES, 'UTF-8') . '">' : '') .
-                                  (!empty($highlight) ? str_ireplace($highlight, '<span class="highlight">' . htmlentities($highlight, ENT_NOQUOTES, 'UTF-8') . '</span>', $category['name']) : $category['name']) .
-                                  ($n < $n_categories ? '</a>' : '') .
-                                  (($n++ != $n_categories || !empty($path)) ? ' > ' : '');
+                        ($n < $n_categories ? '<a href="' . Tools::safeOutput($index_link) . '" title="' . htmlentities($category['name'], ENT_NOQUOTES, 'UTF-8') . '">' : '') .
+                        (!empty($highlight) ? str_ireplace($highlight, '<span class="highlight">' . htmlentities($highlight, ENT_NOQUOTES, 'UTF-8') . '</span>', $category['name']) : $category['name']) .
+                        ($n < $n_categories ? '</a>' : '') .
+                        (($n++ != $n_categories || !empty($path)) ? ' > ' : '');
                 }
 
                 return $full_path . $path;

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3950,9 +3950,9 @@ exit;
      *
      * @param float $amount The amount to spread across the rows
      * @param int $precision Rounding precision
-     * e.g. if $amount is 1, $precision is 0 and $rows = [['a' => 2], ['a' => 1]]
-     * then the resulting $rows will be [['a' => 3], ['a' => 1]]
-     * But if $precision were 1, then the resulting $rows would be [['a' => 2.5], ['a' => 1.5]]
+     *                       e.g. if $amount is 1, $precision is 0 and $rows = [['a' => 2], ['a' => 1]]
+     *                       then the resulting $rows will be [['a' => 3], ['a' => 1]]
+     *                       But if $precision were 1, then the resulting $rows would be [['a' => 2.5], ['a' => 1.5]]
      * @param array $rows An array, associative or not, containing arrays that have at least $column and $sort_column fields
      * @param string $column The column on which to perform adjustments
      */

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -23,6 +24,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
+
 use PrestaShop\PrestaShop\Adapter\Configuration as ConfigurationAdapter;
 use PrestaShop\PrestaShop\Adapter\ContainerBuilder;
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
@@ -376,7 +378,8 @@ class FrontControllerCore extends Controller
                 PrestaShopLogger::addLog('Frontcontroller::init - Cart cannot be loaded or an order has already been placed using this cart', 1, null, 'Cart', (int) $this->context->cookie->id_cart, true);
                 unset($this->context->cookie->id_cart, $cart, $this->context->cookie->checkedTOS);
                 $this->context->cookie->check_cgv = false;
-            } elseif ((int) (Configuration::get('PS_GEOLOCATION_ENABLED'))
+            } elseif (
+                (int) (Configuration::get('PS_GEOLOCATION_ENABLED'))
                 && !in_array(strtoupper($this->context->cookie->iso_code_country), explode(';', Configuration::get('PS_ALLOWED_COUNTRIES')))
                 && $cart->nbProducts()
                 && (int) (Configuration::get('PS_GEOLOCATION_NA_BEHAVIOR')) != -1
@@ -386,7 +389,11 @@ class FrontControllerCore extends Controller
                 /* Delete product of cart, if user can't make an order from his country */
                 PrestaShopLogger::addLog('Frontcontroller::init - GEOLOCATION is deleting a cart', 1, null, 'Cart', (int) $this->context->cookie->id_cart, true);
                 unset($this->context->cookie->id_cart, $cart);
-            } elseif ($this->context->cookie->id_customer != $cart->id_customer || $this->context->cookie->id_lang != $cart->id_lang || $currency->id != $cart->id_currency) {
+            } elseif (
+                $this->context->cookie->id_customer != $cart->id_customer
+                || $this->context->cookie->id_lang != $cart->id_lang
+                || $currency->id != $cart->id_currency
+            ) {
                 // update cart values
                 if ($this->context->cookie->id_customer) {
                     $cart->id_customer = (int) $this->context->cookie->id_customer;
@@ -396,8 +403,11 @@ class FrontControllerCore extends Controller
                 $cart->update();
             }
             /* Select an address if not set */
-            if (isset($cart) && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0 ||
-                    !isset($cart->id_address_invoice) || $cart->id_address_invoice == 0) && $this->context->cookie->id_customer) {
+            if (
+                isset($cart)
+                && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0 || !isset($cart->id_address_invoice) || $cart->id_address_invoice == 0)
+                && $this->context->cookie->id_customer
+            ) {
                 $to_update = false;
                 if ($this->automaticallyAllocateDeliveryAddress && (!isset($cart->id_address_delivery) || $cart->id_address_delivery == 0)) {
                     $to_update = true;
@@ -1436,6 +1446,8 @@ class FrontControllerCore extends Controller
     /**
      * Renders and adds color list HTML for each product in a list.
      *
+     * @deprecated since 8.1 and will be removed in next major version.
+     *
      * @param array $products
      */
     public function addColorsToProductList(&$products)
@@ -1473,6 +1485,8 @@ class FrontControllerCore extends Controller
 
     /**
      * Returns cache ID for product color list.
+     *
+     * @deprecated since 8.1 and will be removed in next major version.
      *
      * @param int $id_product
      *
@@ -2133,7 +2147,8 @@ class FrontControllerCore extends Controller
         $excluded_key = ['isolang', 'id_lang', 'controller', 'fc', 'id_product', 'id_category', 'id_manufacturer', 'id_supplier', 'id_cms'];
         $excluded_key = array_merge($excluded_key, $this->redirectionExtraExcludedKeys);
         foreach ($_GET as $key => $value) {
-            if (in_array($key, $excluded_key)
+            if (
+                in_array($key, $excluded_key)
                 || !Validate::isUrl($key)
                 || !$this->validateInputAsUrl($value)
             ) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Deprecate methods specific to PS 1.6 themes, not used since PS 1.7. Should be removed in PS 9. Also some code formatting.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Nothing to test
| Fixed ticket?     | ~
| Related PRs       | ~
| Sponsor company   | ~

#### Deprecated methods
`Product::getColorsListCacheId`
`Tools::clearColorListCache`
`FrontController::addColorsToProductList`
`FrontController::getColorsListCacheId`