### PR TITLE
Handle custom lock file during the cache clear and force module actions one by one

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/module/controller.js
+++ b/admin-dev/themes/new-theme/js/pages/module/controller.js
@@ -956,52 +956,30 @@ class AdminModuleController {
       return;
     }
 
-    let modulesRequestedCountdown = actionMenuLinks.length - 1;
-    let spinnerObj = $('<button class="btn-primary-reverse onclick unbind spinner "></button>');
+    // Begin actions one after another
+    unstackModulesActions();
 
-    if (actionMenuLinks.length > 1) {
-      // Loop through all the modules except the last one which waits for other
-      // requests and then call its request with cache clear enabled
-      $.each(actionMenuLinks, (index, actionMenuLink) => {
-        if (index >= actionMenuLinks.length - 1) {
-          return;
-        }
-        requestModuleAction(actionMenuLink, true, countdownModulesRequest);
-      });
-      // Display a spinner for the last module
-      const lastMenuLink = actionMenuLinks[actionMenuLinks.length - 1];
-      const actionMenuObj = lastMenuLink.closest(self.moduleCardController.moduleItemActionsSelector);
-      actionMenuObj.hide();
-      actionMenuObj.after(spinnerObj);
-    } else {
-      requestModuleAction(actionMenuLinks[0]);
-    }
+    function requestModuleAction(actionMenuLink) {
+      if (self.moduleCardController.hasPendingRequest()) {
+        actionMenuLinks.push(actionMenuLink);
+        return;
+      }
 
-    function requestModuleAction(actionMenuLink, disableCacheClear, requestEndCallback) {
       self.moduleCardController.requestToController(
         bulkModuleAction,
         actionMenuLink,
         forceDeletion,
-        disableCacheClear,
-        requestEndCallback,
+        unstackModulesActions,
       );
     }
 
-    function countdownModulesRequest() {
-      modulesRequestedCountdown -= 1;
-      // Now that all other modules have performed their action WITHOUT cache clear, we
-      // can request the last module request WITH cache clear
-      if (modulesRequestedCountdown <= 0) {
-        if (spinnerObj) {
-          spinnerObj.remove();
-          spinnerObj = null;
-        }
-
-        const lastMenuLink = actionMenuLinks[actionMenuLinks.length - 1];
-        const actionMenuObj = lastMenuLink.closest(self.moduleCardController.moduleItemActionsSelector);
-        actionMenuObj.fadeIn();
-        requestModuleAction(lastMenuLink);
+    function unstackModulesActions() {
+      if (actionMenuLinks.length <= 0) {
+        return;
       }
+
+      const actionMenuLink = actionMenuLinks.shift();
+      requestModuleAction(actionMenuLink);
     }
 
     function filterAllowedActions(actions) {

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -39,6 +39,14 @@ class AppKernel extends Kernel
     const RELEASE_VERSION = 2;
 
     /**
+     * Lock stream is saved as static field, this way if multiple AppKernel are instanciated (this can happen in
+     * test environment, they will be able to detect that a lock has already been made by the current process).
+     *
+     * @var resource|null
+     */
+    protected static $lockStream = null;
+
+    /**
      * {@inheritdoc}
      */
     public function registerBundles()
@@ -81,8 +89,50 @@ class AppKernel extends Kernel
      */
     public function boot()
     {
+        $this->waitUntilCacheClearIsOver();
         parent::boot();
         $this->cleanKernelReferences();
+    }
+
+    /**
+     * Perform a lock on a file before cache clear is performed, this lock will be unlocked once the cache has been cleared.
+     * Until then any other process will have to wait until the file is unlocked.
+     *
+     * @return bool Returns boolean indicating if the lock file was successfully locked.
+     */
+    public function locksCacheClear(): bool
+    {
+        $clearCacheLockPath = $this->getContainerClearCacheLockPath();
+        $lockStream = fopen($clearCacheLockPath, 'w');
+        if (false === $lockStream) {
+            // Could not open writable lock for some reason
+            return false;
+        }
+
+        // Non-blocking flock, if false is returned it means the file is already locked (meaning the cache is being cleared by another process)
+        $clearCacheLocked = flock($lockStream, LOCK_EX | LOCK_NB);
+        if (false === $clearCacheLocked) {
+            // Clear cache is already locked by another process, so we simply return
+            fclose($lockStream);
+            return false;
+        }
+
+        // Save the locked stream so that we can close it later and most importantly, the process doesn't block it self
+        // during the cache clear operation which reboots the app
+        self::$lockStream = $lockStream;
+
+        return true;
+    }
+
+    public function unlocksCacheClear(): void
+    {
+        if (null === self::$lockStream) {
+            return;
+        }
+
+        flock(self::$lockStream, LOCK_UN);
+        fclose(self::$lockStream);
+        self::$lockStream = null;
     }
 
     /**
@@ -219,5 +269,38 @@ class AppKernel extends Kernel
         }
 
         return $activeModules;
+    }
+
+    protected function getContainerClearCacheLockPath(): string
+    {
+        $class = $this->getContainerClass();
+        $cacheDir = $this->getCacheDir();
+
+        return sprintf('%s/%s.php.cache_clear.lock', $cacheDir, $class);
+    }
+
+    protected function waitUntilCacheClearIsOver(): void
+    {
+        if (null !== self::$lockStream) {
+            // If lockStream is not null it means we are actually in the process that locked it, we don't wait for anything
+            // or the cache clear will never happen
+            return;
+        }
+
+        $clearCacheLockPath = $this->getContainerClearCacheLockPath();
+        $lockStream = fopen($clearCacheLockPath, 'w');
+        if (false === $lockStream) {
+            // Could not open writable lock for some reason
+            return;
+        }
+
+        // Check if the lock file is currently locked (see locksCacheClear responsible for locking this file), this
+        // function call is blocking until the lock has been released.
+        flock($lockStream, LOCK_SH);
+
+        // Now that the file is unlocked it means the cache has been cleared we can safely continue the process as the container
+        // has been rebuilt and is good to go.
+        flock($lockStream, LOCK_UN);
+        fclose($lockStream);
     }
 }

--- a/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
+++ b/src/Adapter/Cache/Clearer/SymfonyCacheClearer.php
@@ -26,13 +26,12 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Cache\Clearer;
 
+use AppKernel;
 use Hook;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\HttpKernel\KernelInterface;
-use Tools;
 
 /**
  * Class SymfonyCacheClearer clears Symfony cache directly from filesystem.
@@ -41,32 +40,27 @@ use Tools;
  */
 final class SymfonyCacheClearer implements CacheClearerInterface
 {
-    private $shutdownRegistered = false;
-
     /**
      * {@inheritdoc}
      */
     public function clear()
     {
-        /*  @var KernelInterface */
+        /* @var AppKernel */
         global $kernel;
-
-        if (empty($kernel)) {
-            Tools::clearSf2Cache();
-
+        if (!$kernel) {
             return;
         }
 
-        if ($this->shutdownRegistered) {
+        $cacheClearLocked = $kernel->locksCacheClear();
+        if (false === $cacheClearLocked) {
+            // The lock was not possible for some reason we should exit
             return;
         }
 
-        $this->shutdownRegistered = true;
+        // If we reach here it means the clear lock file is locked, we register a shutdown function that will clear the cache once
+        // the current process is over.
         register_shutdown_function(function () use ($kernel) {
-            // The cache may have been removed by Tools::clearSf2Cache, it happens during install
-            // process, in which case we don't run the cache:clear command because it is not only
-            // useless it will simply fail as the container caches classes have been removed
-            $cacheDir = _PS_ROOT_DIR_ . '/var/cache/' . _PS_ENV_ . '/';
+            $cacheDir = $kernel->getCacheDir();
             if (!file_exists($cacheDir)) {
                 return;
             }
@@ -78,13 +72,18 @@ final class SymfonyCacheClearer implements CacheClearerInterface
             $input = new ArrayInput([
                 'command' => 'cache:clear',
                 '--no-optional-warmers' => true,
-                '--env' => _PS_ENV_,
+                '--env' => $kernel->getEnvironment(),
             ]);
 
             $output = new NullOutput();
             $application->run($input, $output);
 
             Hook::exec('actionClearSf2Cache');
+        });
+
+        // Unlock is registered in another separate function to make sure it will be called no matter what
+        register_shutdown_function(function () use ($kernel) {
+            $kernel->unlocksCacheClear();
         });
     }
 }

--- a/src/Core/Module/EventSubscriber.php
+++ b/src/Core/Module/EventSubscriber.php
@@ -44,9 +44,6 @@ class EventSubscriber implements EventSubscriberInterface
      */
     private $cacheClearer;
 
-    /** @var bool */
-    private $cleared = false;
-
     public function __construct(ModuleRepository $moduleRepository, SymfonyCacheClearer $cacheClearer)
     {
         $this->moduleRepository = $moduleRepository;
@@ -75,9 +72,6 @@ class EventSubscriber implements EventSubscriberInterface
     public function onModuleInstalledOrUninstalled(ModuleManagementEvent $event): void
     {
         $this->onModuleStateChanged($event);
-        if (!$this->cleared && $event->getSystemClearCache()) {
-            $this->cacheClearer->clear();
-            $this->cleared = true;
-        }
+        $this->cacheClearer->clear();
     }
 }

--- a/src/Core/Module/ModuleManager.php
+++ b/src/Core/Module/ModuleManager.php
@@ -65,9 +65,6 @@ class ModuleManager implements ModuleManagerInterface
     /** @var Filesystem */
     private $filesystem;
 
-    /** @var bool */
-    private $systemClearCache = true;
-
     public function __construct(
         ModuleRepository $moduleRepository,
         ModuleDataProvider $moduleDataProvider,
@@ -383,11 +380,6 @@ class ModuleManager implements ModuleManagerInterface
 
     private function dispatch(string $event, ModuleInterface $module): void
     {
-        $this->eventDispatcher->dispatch(new ModuleManagementEvent($module, $this->systemClearCache), $event);
-    }
-
-    public function disableSystemClearCache(): void
-    {
-        $this->systemClearCache = false;
+        $this->eventDispatcher->dispatch(new ModuleManagementEvent($module), $event);
     }
 }

--- a/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Improve/ModuleController.php
@@ -217,13 +217,6 @@ class ModuleController extends ModuleAbstractController
                 $args[] = (bool) ($request->request->get('actionParams', [])['deletion'] ?? false);
                 $response[$module]['refresh_needed'] = $this->moduleNeedsReload($moduleRepository->getModule($module));
             }
-            $systemCacheClearEnabled = filter_var(
-                $request->request->get('actionParams', [])['cacheClearEnabled'] ?? true,
-                FILTER_VALIDATE_BOOLEAN
-            );
-            if (!$systemCacheClearEnabled) {
-                $moduleManager->disableSystemClearCache();
-            }
             $response[$module]['status'] = call_user_func([$moduleManager, $action], ...$args);
         } catch (Exception $e) {
             $response[$module]['status'] = false;

--- a/src/PrestaShopBundle/Event/ModuleManagementEvent.php
+++ b/src/PrestaShopBundle/Event/ModuleManagementEvent.php
@@ -44,22 +44,13 @@ class ModuleManagementEvent extends Event
     /** @var ModuleInterface */
     private $module;
 
-    /** @var bool */
-    private $systemClearCache;
-
-    public function __construct(ModuleInterface $module, bool $systemClearCache = true)
+    public function __construct(ModuleInterface $module)
     {
         $this->module = $module;
-        $this->systemClearCache = $systemClearCache;
     }
 
     public function getModule(): ModuleInterface
     {
         return $this->module;
-    }
-
-    public function getSystemClearCache(): bool
-    {
-        return $this->systemClearCache;
     }
 }

--- a/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Module/common.html.twig
@@ -55,5 +55,6 @@
   "Bulk Action - One module minimum": "You need to select at least one module to use the bulk action."|trans({}, 'Admin.Modules.Notification'),
   "Bulk Action - Request not found": 'The action "[1]" is not available, impossible to perform your request.'|trans({}, 'Admin.Modules.Notification'),
   "Bulk Action - Request not available for module": "The action [1] is not available for module [2]. Skipped."|trans({}, 'Admin.Modules.Notification'),
+  "An action is already in progress please wait for it to finish.": 'An action is already in progress please wait for it to finish.'|trans({}, 'Admin.Modules.Notification'),
 }|merge(js_translatable)
 %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Handle custom lock file during the cache clear to make sure other processes have to wait until the new container is ready This is an alternative to the solution proposed in this PR https://github.com/PrestaShop/PrestaShop/pull/31419
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | The lock happens when Symfony cache is clear, mainly during any module operation (enable, disable, install, uninstall, ...) During the cache clearing, any other process (from a different tab) should be blocked until the cache is available again. We need to make sure that the shop doesn't end up in a blocked state for some reason, and we also should probably test that this doesn't impact the auto-upgrade process It could also be interesting to check that the use case related to this PR https://github.com/PrestaShop/PrestaShop/pull/30962 is still valid as it was also a complex use case related to cache clearing<br><br>The module management has also been modified, now the bulk actions are forced one by one and when you try to perform two actions at the same time (by clicking on a button for a module while an action is in progress on another) the action is blocked and a warning message warns you that you need to wait
| Fixed ticket?     | Fixes #31562 and Fixes #28304
| Related PRs       | ~
| Sponsor company   | ~
