### PR TITLE
No need to check error_get_last exist it exists since PHP 5.2

### DIFF
--- a/config/alias.php
+++ b/config/alias.php
@@ -54,10 +54,7 @@ function bqSQL($string)
 
 function displayFatalError()
 {
-    $error = null;
-    if (function_exists('error_get_last')) {
-        $error = error_get_last();
-    }
+    $error = error_get_last();
     if ($error !== null && in_array($error['type'], array(E_ERROR, E_PARSE, E_COMPILE_ERROR))) {
         echo '[PrestaShop] Fatal error in module file: '.$error['file'].':'.$error['line'].'<br />'.$error['message'];
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | No need to check error_get_last exist it exists since PHP 5.2 https://www.php.net/manual/en/function.error-get-last.php
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | No need to test
| Fixed ticket?     | 
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
