### PR TITLE
Fix path of category generated for product

### DIFF
--- a/classes/Link.php
+++ b/classes/Link.php
@@ -219,10 +219,14 @@ class LinkCore
         }
 
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'category', $idShop)) {
+            $params['category'] = $category;
             if (!$category) {
                 $product = $this->getProductObject($product, $idLang, $idShop);
-            }
-            $params['category'] = (!$category) ? $product->category : $category;
+		        if ( !empty($product->id_category_default) ) {
+		            $cat_url  = $this->getCategoryLink($product->id_category_default, null, $idLang); 
+		            $params['category'] = trim( str_replace($url, '', $cat_url), '/');
+		        }
+            }   
         }
 
         if ($dispatcher->hasKeyword('product_rule', $idLang, 'reference', $idShop)) {

--- a/classes/Link.php
+++ b/classes/Link.php
@@ -237,7 +237,8 @@ class LinkCore
             foreach ($product->getParentCategories($idLang) as $cat) {
                 if (!in_array($cat['id_category'], Link::$category_disable_rewrite)) {
                     //remove root and home category from the URL
-                    $cats[] = $cat['link_rewrite'];
+                    $cat_url  = $this->getCategoryLink($cat['id_category'], null, $idLang); 
+                    $cats[] = trim( str_replace($url, '', $cat_url), '/');
                 }
             }
             $params['categories'] = implode('/', $cats);


### PR DESCRIPTION
fix #31827

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop 
| Description?      | Fix path of category in product url
| Type?             | bug fix
| Category?         | FO 
| BC breaks?        |  no
| Deprecations?     |no
| How to test?      |  Go to a product page assigned to a category, the category part in the path is not corresponding to the category Url
| Fixed ticket?     | Fixes #31827
| Related PRs       | 
| Sponsor company   | 