### PR TITLE
Create security_test.yml and move default credentials for api in it

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -7,7 +7,8 @@ parameters:
   AdapterSecurityAdminClass: Tests\Integration\Utility\AdapterSecurityAdmin
 
 imports:
-  - { resource: config_dev.yml }
+  - { resource: config.yml }
+  - { resource: security_test.yml }
   - { resource: "../../tests/Resources/config/services.yml" }
 
 framework:
@@ -30,3 +31,27 @@ doctrine:
     connections:
       default:
         dbname: "test_%database_name%"
+
+monolog:
+  handlers:
+    main:
+      type: rotating_file
+      max_files: '%env(PS_LOG_MAX_FILES)%'
+      path: '%env(PS_LOG_OUTPUT)%'
+      level: debug
+      channels: [ "!event" ]
+    console:
+      type: console
+      bubble: false
+      verbosity_levels:
+        VERBOSITY_VERBOSE: INFO
+        VERBOSITY_VERY_VERBOSE: DEBUG
+      channels: [ "!doctrine" ]
+    console_very_verbose:
+      type: console
+      bubble: false
+      verbosity_levels:
+        VERBOSITY_VERBOSE: NOTICE
+        VERBOSITY_VERY_VERBOSE: NOTICE
+        VERBOSITY_DEBUG: DEBUG
+      channels: [ "doctrine" ]

--- a/app/config/security_dev.yml
+++ b/app/config/security_dev.yml
@@ -1,19 +1,18 @@
 # To get started with security, check out the documentation:
-# http://symfony.com/doc/current/book/security.html
+# https://symfony.com/doc/current/security.html
 security:
 
-  # http://symfony.com/doc/current/book/security.html#where-do-users-come-from-user-providers
+  # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
   providers:
     in_memory:
       memory: ~
     admin:
       id: prestashop.security.admin.provider
 
-    # Temporary provider & encoder to be able to use the new BO API in dev mode
+    # Empty provider until a real provider is developed
     oauth2:
       memory:
         users:
-          my_client_id: { password: 'prestashop' }
 
   encoders:
     Symfony\Component\Security\Core\User\User: plaintext

--- a/app/config/security_test.yml
+++ b/app/config/security_test.yml
@@ -9,16 +9,28 @@ security:
     admin:
       id: prestashop.security.admin.provider
 
-    # Empty provider until a real provider is developed
+    # Temporary provider & encoder to be able to use the new BO API in test mode
     oauth2:
       memory:
         users:
+          my_client_id: { password: 'prestashop' }
+
+  encoders:
+    Symfony\Component\Security\Core\User\User: plaintext
 
   firewalls:
     # disables authentication for assets and the profiler, adapt it according to your needs
     dev:
       pattern: ^/(_(profiler|wdt)|css|images|js)/
       security: false
+
+    api:
+      pattern: '^%api_base_path%'
+      stateless: true
+      provider: 'oauth2'
+      guard:
+        authenticator:
+          - PrestaShop\PrestaShop\Core\Security\TokenAuthenticator
 
     main:
       anonymous: ~


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Create security_test.yml and move default credentials for api in it
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Old credentials not works anymore. Add them in security_dev.yml to make new api works
| Fixed ticket?     | Fixes #31694 
| Related PRs       | -
| Sponsor company   | Prestashop SA
