### PR TITLE
Update Validate.php

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -1331,7 +1331,7 @@ class ValidateCore
 
     public static function isPrestaShopVersion($version)
     {
-        return preg_match('/^[0-1]\.[0-9]{1,2}(\.[0-9]{1,2}){0,2}$/', $version) && ip2long($version);
+        return preg_match('/^[0-9]\.[0-9]{1,2}(\.[0-9]{1,2}){0,2}$/', $version) && ip2long($version);
     }
 
     public static function isOrderInvoiceNumber($id)


### PR DESCRIPTION
Change isPrestaShopVersion() for version 8 & 9.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix isPrestaShopVersion() for prestashop 8 & more. The old way just work for 1.X versions.
| Type?             | bug fix
| Category?         | FO / BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Indicate how to verify that this change works as expected.
| Fixed ticket?     | 
| Related PRs       |
| Sponsor company   | @fixo94 
