### PR TITLE
Removed deprecated method `addJquery` in `Controller` class

### DIFF
--- a/classes/Media.php
+++ b/classes/Media.php
@@ -748,21 +748,8 @@ class MediaCore
                     ];
 
                     foreach ($patterns as $pattern) {
-                        $matches = [];
-                        if (preg_match($pattern, $src, $matches)) {
-                            $minifier = $version = false;
-                            if (isset($matches[2]) && $matches[2]) {
-                                $minifier = (bool) $matches[2];
-                            }
-                            if (isset($matches[1]) && $matches[1]) {
-                                $version = $matches[1];
-                            }
-                            if ($version) {
-                                if ($version != _PS_JQUERY_VERSION_) {
-                                    Context::getContext()->controller->addJquery($version, null, $minifier);
-                                }
-                                Media::$inline_script_src[] = $src;
-                            }
+                        if (preg_match($pattern, $src)) {
+                            Media::$inline_script_src[] = $src;
                         }
                     }
                     if (!in_array($src, Media::$inline_script_src) && !$script->getAttribute(Media::$pattern_keepinline)) {

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -566,23 +566,6 @@ abstract class ControllerCore
     }
 
     /**
-     * Adds jQuery library file to queued JS file list.
-     *
-     * @param string|null $version jQuery library version
-     * @param string|null $folder jQuery file folder
-     * @param bool $minifier if set tot true, a minified version will be included
-     *
-     * @deprecated 1.7.7 jQuery is always included, this method should no longer be used
-     */
-    public function addJquery($version = null, $folder = null, $minifier = true)
-    {
-        @trigger_error(
-            'Controller->addJquery() is deprecated since version 1.7.7.0, jQuery is always included',
-            E_USER_DEPRECATED
-        );
-    }
-
-    /**
      * Adds jQuery UI component(s) to queued JS file list.
      *
      * @param string|array $component


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated method `addJquery` in `Controller` class
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4512057786
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks
* Removed method `addJquery` in class `Controller`