### PR TITLE
Removed deprecated method `isAnything` in class `Validate`

### DIFF
--- a/classes/Validate.php
+++ b/classes/Validate.php
@@ -63,19 +63,6 @@ class ValidateCore
     }
 
     /**
-     * @deprecated since PrestaShop 8.1 and will be removed in Prestashop 9.0
-     */
-    public static function isAnything()
-    {
-        @trigger_error(
-            'This function is deprecated PrestaShop 8.1 and will be removed in Prestashop 9.0.',
-            E_USER_DEPRECATED
-        );
-
-        return true;
-    }
-
-    /**
      * Check for e-mail validity.
      *
      * @param string $email e-mail address to validate

--- a/tests/Unit/Classes/ValidateCoreTest.php
+++ b/tests/Unit/Classes/ValidateCoreTest.php
@@ -40,16 +40,6 @@ class ValidateCoreTest extends TestCase
     }
 
     /**
-     * @deprecated since PrestaShop 8.1 and will be removed in Prestashop 9.0
-     *
-     * @return void
-     */
-    public function testIsAnything()
-    {
-        $this->assertTrue(Validate::isAnything());
-    }
-
-    /**
      * @dataProvider isEmailDataProvider
      */
     public function testIsEmail($expected, $input)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated method `isAnything` in class `Validate`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4512067965
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks
* Removed method `isAnything` in class `Validate`
