### PR TITLE
Removed deprecated methods `stripslashes` & `safePostVars` in class `Tools`

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -954,23 +954,6 @@ class ToolsCore
     }
 
     /**
-     * @deprecated Since 8.0.0
-     */
-    public static function safePostVars()
-    {
-        @trigger_error(
-            'Tools::safePostVars() is deprecated since version 8.0.0.',
-            E_USER_DEPRECATED
-        );
-
-        if (!is_array($_POST)) {
-            $_POST = [];
-        } else {
-            $_POST = array_map(['Tools', 'htmlentitiesUTF8'], $_POST);
-        }
-    }
-
-    /**
      * Delete directory and subdirectories.
      *
      * @param string $dirname Directory name
@@ -1541,20 +1524,6 @@ class ToolsCore
         $str = html_entity_decode($str, ENT_COMPAT, 'UTF-8');
 
         return mb_strlen($str, $encoding);
-    }
-
-    /**
-     * @deprecated Since 8.0.0
-     */
-    public static function stripslashes($string)
-    {
-        @trigger_error(
-            'Tools::stripslashes() is deprecated since version 8.0.0.'
-            . 'Use PHP\'s stripslashes instead.',
-            E_USER_DEPRECATED
-        );
-
-        return $string;
     }
 
     public static function strtoupper($str)

--- a/src/PrestaShopBundle/Bridge/Smarty/HeaderConfigurator.php
+++ b/src/PrestaShopBundle/Bridge/Smarty/HeaderConfigurator.php
@@ -173,7 +173,7 @@ class HeaderConfigurator implements ConfiguratorInterface
             $currentTabLevel = isset($tab['current_level']) ? $tab['current_level'] : $currentTabLevel;
         }
 
-        $controllerConfiguration->templateVars['bo_query'] = Tools::safeOutput(Tools::stripslashes(Tools::getValue('bo_query')));
+        $controllerConfiguration->templateVars['bo_query'] = Tools::safeOutput(Tools::getValue('bo_query'));
         $controllerConfiguration->templateVars['collapse_menu'] = isset($this->cookie->collapse_menu) ? (int) $this->cookie->collapse_menu : 0;
         $controllerConfiguration->templateVars['default_tab_link'] = $this->link->getAdminLink(Tab::getClassNameById((int) $controllerConfiguration->getUser()->getData()->default_tab));
         $controllerConfiguration->templateVars['employee'] = $controllerConfiguration->getUser()->getData();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated methods `stripslashes` & `safePostVars` in class `Tools`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4512337152
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks
* Removed method `safePostVars` in class `Tools`
* Removed method `stripslashes` in class `Tools`