### PR TITLE
Removed deprecated methods `generateDeliverySlipPDFByIdOrder` & `generateInvoicePDFByIdOrder` in class `AdminPdfController`

### DIFF
--- a/controllers/admin/AdminPdfController.php
+++ b/controllers/admin/AdminPdfController.php
@@ -1,4 +1,7 @@
 <?php
+
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -55,7 +58,12 @@ class AdminPdfControllerCore extends AdminController
     public function processGenerateInvoicePdf()
     {
         if (Tools::isSubmit('id_order')) {
-            $this->generateInvoicePDFByIdOrder(Tools::getValue('id_order'));
+            $sfContainer = SymfonyContainer::getInstance();
+            $sfRouter = $sfContainer->get('router');
+            Tools::redirectAdmin($sfRouter->generate(
+                'admin_orders_generate_invoice_pdf',
+                ['orderId' => (int) Tools::getValue('id_order')]
+            ));
         } elseif (Tools::isSubmit('id_order_invoice')) {
             $this->generateInvoicePDFByIdOrderInvoice(Tools::getValue('id_order_invoice'));
         } else {
@@ -77,13 +85,21 @@ class AdminPdfControllerCore extends AdminController
 
     public function processGenerateDeliverySlipPDF()
     {
+        $sfContainer = SymfonyContainer::getInstance();
+        $sfRouter = $sfContainer->get('router');
         if (Tools::isSubmit('id_order')) {
-            $this->generateDeliverySlipPDFByIdOrder((int) Tools::getValue('id_order'));
+            Tools::redirectAdmin($sfRouter->generate(
+                'admin_orders_generate_delivery_slip_pdf',
+                ['orderId' => (int) Tools::getValue('id_order')]
+            ));
         } elseif (Tools::isSubmit('id_order_invoice')) {
             $this->generateDeliverySlipPDFByIdOrderInvoice((int) Tools::getValue('id_order_invoice'));
         } elseif (Tools::isSubmit('id_delivery')) {
             $order = Order::getByDelivery((int) Tools::getValue('id_delivery'));
-            $this->generateDeliverySlipPDFByIdOrder((int) $order->id);
+            Tools::redirectAdmin($sfRouter->generate(
+                'admin_orders_generate_delivery_slip_pdf',
+                ['orderId' => (int) $order->id]
+            ));
         } else {
             die($this->trans('The order ID -- or the invoice order ID -- is missing.', [], 'Admin.Orderscustomers.Notification'));
         }
@@ -158,33 +174,6 @@ class AdminPdfControllerCore extends AdminController
         $this->generatePDF($supply_order, PDF::TEMPLATE_SUPPLY_ORDER_FORM);
     }
 
-    /**
-     * @deprecated Since 8.1.0, use the route `admin_orders_generate_delivery_slip_pdf` instead.
-     *
-     * @param int $id_order
-     *
-     * @return void
-     */
-    public function generateDeliverySlipPDFByIdOrder($id_order)
-    {
-        @trigger_error(
-            sprintf(
-                '%s is deprecated since version 8.1.0. Use the route %s instead.',
-                __METHOD__,
-                'admin_orders_generate_delivery_slip_pdf'
-            ),
-            E_USER_DEPRECATED
-        );
-
-        $order = new Order((int) $id_order);
-        if (!Validate::isLoadedObject($order)) {
-            throw new PrestaShopException('Can\'t load Order object');
-        }
-
-        $order_invoice_collection = $order->getInvoicesCollection();
-        $this->generatePDF($order_invoice_collection, PDF::TEMPLATE_DELIVERY_SLIP);
-    }
-
     public function generateDeliverySlipPDFByIdOrderInvoice($id_order_invoice)
     {
         $order_invoice = new OrderInvoice((int) $id_order_invoice);
@@ -193,34 +182,6 @@ class AdminPdfControllerCore extends AdminController
         }
 
         $this->generatePDF($order_invoice, PDF::TEMPLATE_DELIVERY_SLIP);
-    }
-
-    /**
-     * @deprecated Since 8.1.0, use the route `admin_orders_generate_invoice_pdf` instead.
-     *
-     * @param int $id_order
-     *
-     * @return void
-     */
-    public function generateInvoicePDFByIdOrder($id_order)
-    {
-        @trigger_error(
-            sprintf(
-                '%s is deprecated since version 8.1.0. Use the route %s instead.',
-                __METHOD__,
-                'admin_orders_generate_invoice_pdf'
-            ),
-            E_USER_DEPRECATED
-        );
-
-        $order = new Order((int) $id_order);
-        if (!Validate::isLoadedObject($order)) {
-            die($this->trans('The order cannot be found within your database.', [], 'Admin.Orderscustomers.Notification'));
-        }
-
-        $order_invoice_list = $order->getInvoicesCollection();
-        Hook::exec('actionPDFInvoiceRender', ['order_invoice_list' => $order_invoice_list]);
-        $this->generatePDF($order_invoice_list, PDF::TEMPLATE_INVOICE);
     }
 
     public function generateInvoicePDFByIdOrderInvoice($id_order_invoice)


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated methods `generateDeliverySlipPDFByIdOrder` & `generateInvoicePDFByIdOrder` in class `AdminPdfController`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4512705115
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks
* Removed method `generateDeliverySlipPDFByIdOrder` in class `AdminPdfController`
* Removed method `generateInvoicePDFByIdOrder` in class `AdminPdfController`
