### PR TITLE
Use htmlspecialchars on trans parameters and deprecate _raw parameter

### DIFF
--- a/admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl
+++ b/admin-dev/themes/default/template/controllers/import/modal_import_progress.tpl
@@ -63,7 +63,7 @@
                   '[1]' => '<span id="validate_progression_done">',
                   '%percentage%' => '0',
                   '[/1]' => '</span>'
-                  ] d="Admin.Advparameters.Notification"}
+                  ] d="Admin.Advparameters.Notification" html=true}
         </span>
       </div>
       <div class="progress-bar progress-bar-info" role="progressbar" id="validate_progressbar_next" style="opacity: 0.5 ;width: 0%">
@@ -85,7 +85,7 @@
           '[1]' => '<span id="import_progression_done">',
           '%size%' => '0',
           '[/1]' => '</span>'
-          ] d="Admin.Advparameters.Notification"}
+          ] d="Admin.Advparameters.Notification" html=true}
         </span>
       </div>
       <div class="progress-bar progress-bar-success progress-bar-stripes active" role="progressbar" id="import_progressbar_next" style="opacity: 0.5 ;width: 0%">

--- a/classes/Address.php
+++ b/classes/Address.php
@@ -381,7 +381,7 @@ class AddressCore extends ObjectModel
 
             return $this->trans(
                 'Property %s is empty.',
-                [get_class($this) . '->' . $field],
+                [get_class($this) . '->' . htmlspecialchars($field)],
                 'Admin.Notifications.Error'
             );
         }

--- a/classes/AddressFormat.php
+++ b/classes/AddressFormat.php
@@ -250,7 +250,7 @@ class AddressFormatCore extends ObjectModel
             if (!in_array($requiredField, $fieldList)) {
                 $this->_errorFormatList[] = $this->trans(
                     'The %s field (in tab %s) is required.',
-                    [$requiredField, $this->getFieldTabName($requiredField)],
+                    [htmlspecialchars($requiredField), htmlspecialchars($this->getFieldTabName($requiredField))],
                     'Admin.Notifications.Error');
             }
         }

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -905,7 +905,7 @@ class CartRuleCore extends ObjectModel
                         $cart_rule = new CartRule((int) $otherCartRule['id_cart_rule'], $cart->id_lang);
                         // The cart rules are not combinable and the cart rule currently in the cart has priority over the one tested
                         if ($cart_rule->priority <= $this->priority) {
-                            return (!$display_error) ? false : $this->trans('This voucher is not combinable with an other voucher already in your cart: %s', [$cart_rule->name], 'Shop.Notifications.Error');
+                            return (!$display_error) ? false : $this->trans('This voucher is not combinable with an other voucher already in your cart: %s', [htmlspecialchars($cart_rule->name)], 'Shop.Notifications.Error');
                         } else {
                             // But if the cart rule that is tested has priority over the one in the cart, we remove the one in the cart and keep this new one
                             $cart->removeCartRule($cart_rule->id);

--- a/classes/ObjectModel.php
+++ b/classes/ObjectModel.php
@@ -292,17 +292,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             }
         }
 
-        if (isset($parameters['_raw'])) {
-            @trigger_error(
-                'The _raw parameter is deprecated and will be removed in the next major version.',
-                E_USER_DEPRECATED
-            );
-            unset($parameters['_raw']);
-
-            return $this->translator->trans($id, $parameters, $domain, $locale);
-        }
-
-        return htmlspecialchars($this->translator->trans($id, $parameters, $domain, $locale), ENT_NOQUOTES);
+        return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
     /**
@@ -1196,9 +1186,9 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
             if (!in_array('required', $skip) && (!empty($data['required']) || in_array($field, $required_fields))) {
                 if (Tools::isEmpty($value)) {
                     if ($human_errors) {
-                        return $this->trans('The %s field is required.', [$this->displayFieldName($field, get_class($this))], 'Admin.Notifications.Error');
+                        return $this->trans('The %s field is required.', [htmlspecialchars($this->displayFieldName($field, get_class($this)))], 'Admin.Notifications.Error');
                     } else {
-                        return $this->trans('Property %s is empty.', [get_class($this) . '->' . $field], 'Admin.Notifications.Error');
+                        return $this->trans('Property %s is empty.', [get_class($this) . '->' . htmlspecialchars($field)], 'Admin.Notifications.Error');
                     }
                 }
             }
@@ -1212,7 +1202,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
 
         // Check field values
         if (!in_array('values', $skip) && !empty($data['values']) && is_array($data['values']) && !in_array($value, $data['values'])) {
-            return $this->trans('Property %1$s has a bad value (allowed values are: %2$s).', [get_class($this) . '->' . $field, implode(', ', $data['values'])], 'Admin.Notifications.Error');
+            return $this->trans('Property %1$s has a bad value (allowed values are: %2$s).', [get_class($this) . '->' . htmlspecialchars($field), implode(', ', $data['values'])], 'Admin.Notifications.Error');
         }
 
         // Check field size
@@ -1237,7 +1227,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                     return $this->trans(
                         'The length of property %1$s is currently %2$d chars. It must be between %3$d and %4$d chars.',
                         [
-                            get_class($this) . '->' . $field,
+                            get_class($this) . '->' . htmlspecialchars($field),
                             $length,
                             $size['min'],
                             $size['max'],
@@ -1255,8 +1245,8 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                 return $this->trans(
                     'The range of property %1$s is currently %2$d. It must be between %3$d and %4$d.',
                     [
-                        get_class($this) . '->' . $field,
-                        $value,
+                        get_class($this) . '->' . htmlspecialchars($field),
+                        htmlspecialchars($value),
                         $range['min'],
                         $range['max'],
                     ],
@@ -1286,7 +1276,7 @@ abstract class ObjectModelCore implements \PrestaShop\PrestaShop\Core\Foundation
                     if ($human_errors) {
                         return $this->trans('The %s field is invalid.', [$this->displayFieldName($field, get_class($this))], 'Admin.Notifications.Error');
                     } else {
-                        return $this->trans('Property %s is not valid', [get_class($this) . '->' . $field], 'Admin.Notifications.Error');
+                        return $this->trans('Property %s is not valid', [get_class($this) . '->' . htmlspecialchars($field)], 'Admin.Notifications.Error');
                     }
                 }
             }

--- a/classes/PaymentModule.php
+++ b/classes/PaymentModule.php
@@ -315,7 +315,7 @@ abstract class PaymentModuleCore extends Module
                         Tools::redirect('index.php?controller=order&submitAddDiscount=1&discount_name=' . urlencode($rule->code));
                     } else {
                         $rule_name = isset($rule->name[(int) $this->context->cart->id_lang]) ? $rule->name[(int) $this->context->cart->id_lang] : $rule->code;
-                        $error = $this->trans('The cart rule named "%1s" (ID %2s) used in this cart is not valid and has been withdrawn from cart', [$rule_name, (int) $rule->id], 'Admin.Payment.Notification');
+                        $error = $this->trans('The cart rule named "%1s" (ID %2s) used in this cart is not valid and has been withdrawn from cart', [htmlspecialchars($rule_name), (int) $rule->id], 'Admin.Payment.Notification');
                         PrestaShopLogger::addLog($error, 3, 2, 'Cart', (int) $this->context->cart->id);
                     }
                 }

--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -1219,7 +1219,7 @@ class AdminControllerCore extends Controller
                     ' <b>' . $this->table . ' (' . Db::getInstance()->getMsgError() . ')</b>';
             } elseif (($_POST[$this->identifier] = $this->object->id /* voluntary do affectation here */) && $this->postImage($this->object->id) && count($this->errors) === 0 && $this->_redirect) {
                 PrestaShopLogger::addLog(
-                    $this->trans('%s addition', [$this->className]),
+                    $this->trans('%s addition', [htmlspecialchars($this->className)]),
                     1,
                     null,
                     $this->className,
@@ -1654,8 +1654,8 @@ class AdminControllerCore extends Controller
                             (is_array($obj->{$this->identifier_name})
                                 && isset($obj->{$this->identifier_name}[$this->context->employee->id_lang])
                             )
-                                ? $obj->{$this->identifier_name}[$this->context->employee->id_lang]
-                                : $obj->{$this->identifier_name},
+                                ? htmlspecialchars($obj->{$this->identifier_name}[$this->context->employee->id_lang])
+                                : htmlspecialchars($obj->{$this->identifier_name}),
                         ],
                         'Admin.Actions'
                     );
@@ -2739,29 +2739,6 @@ class AdminControllerCore extends Controller
     }
 
     /**
-     * Translates a wording
-     *
-     * @deprecated Use $this->trans instead
-     *
-     * @param string $string Term or expression in english
-     * @param string|null $class Name of the class
-     * @param bool $addslashes If set to true, the return value will pass through addslashes(). Otherwise, stripslashes().
-     * @param bool $htmlentities If set to true(default), the return value will pass through htmlentities($string, ENT_QUOTES, 'utf-8')
-     *
-     * @return string the translation if available, or the english default text
-     */
-    protected function l($string, $class = null, $addslashes = false, $htmlentities = true)
-    {
-        @trigger_error(__FUNCTION__ . 'is deprecated. Use AdminController::trans instead.', E_USER_DEPRECATED);
-
-        if ($htmlentities === true) {
-            return htmlspecialchars($this->translator->trans($string, []), ENT_NOQUOTES);
-        }
-
-        return $this->translator->trans($string, []);
-    }
-
-    /**
      * Init context and dependencies, handles POST and GET.
      */
     public function init()
@@ -3652,7 +3629,7 @@ class AdminControllerCore extends Controller
                     if (!isset($value) || '' == $value) {
                         $this->errors[$field . '_' . $default_language->id] = $this->trans(
                             'The field %field_name% is required at least in %lang%.',
-                            ['%field_name%' => $object->displayFieldName($field, $class_name), '%lang%' => $default_language->name],
+                            ['%field_name%' => htmlspecialchars($object->displayFieldName($field, $class_name)), '%lang%' => htmlspecialchars($default_language->name)],
                             'Admin.Notifications.Error'
                         );
                     }
@@ -4007,7 +3984,7 @@ class AdminControllerCore extends Controller
 
                     if ($delete_ok) {
                         PrestaShopLogger::addLog(
-                            $this->trans('%s deletion', [$this->className]),
+                            $this->trans('%s deletion', [htmlspecialchars($this->className)]),
                             1,
                             null,
                             $this->className,

--- a/classes/controller/Controller.php
+++ b/classes/controller/Controller.php
@@ -346,17 +346,7 @@ abstract class ControllerCore
 
     protected function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
-        if (isset($parameters['_raw'])) {
-            @trigger_error(
-                'The _raw parameter is deprecated and will be removed in the next major version.',
-                E_USER_DEPRECATED
-            );
-            unset($parameters['_raw']);
-
-            return $this->translator->trans($id, $parameters, $domain, $locale);
-        }
-
-        return htmlspecialchars($this->translator->trans($id, $parameters, $domain, $locale), ENT_NOQUOTES);
+        return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
     /**

--- a/classes/controller/FrontController.php
+++ b/classes/controller/FrontController.php
@@ -319,7 +319,7 @@ class FrontControllerCore extends Controller
 
         // If the theme is missing, we need to throw an Exception
         if (!is_dir(_PS_THEME_DIR_)) {
-            throw new PrestaShopException($this->trans('Current theme is unavailable. Please check your theme\'s directory name ("%s") and permissions.', [basename(rtrim(_PS_THEME_DIR_, '/\\'))], 'Admin.Design.Notification'));
+            throw new PrestaShopException($this->trans('Current theme is unavailable. Please check your theme\'s directory name ("%s") and permissions.', [htmlspecialchars(basename(rtrim(_PS_THEME_DIR_, '/\\')))], 'Admin.Design.Notification'));
         }
 
         if (Configuration::get('PS_GEOLOCATION_ENABLED')) {
@@ -871,7 +871,7 @@ class FrontControllerCore extends Controller
                                 $this->restrictedCountry = Country::GEOLOC_FORBIDDEN;
                             } elseif (Configuration::get('PS_GEOLOCATION_BEHAVIOR') == _PS_GEOLOCATION_NO_ORDER_) {
                                 $this->restrictedCountry = Country::GEOLOC_CATALOG_MODE;
-                                $this->warning[] = $this->trans('You cannot place a new order from your country (%s).', [$record->country->name], 'Shop.Notifications.Warning');
+                                $this->warning[] = $this->trans('You cannot place a new order from your country (%s).', [htmlspecialchars($record->country->name)], 'Shop.Notifications.Warning');
                             }
                         } else {
                             $hasBeenSet = !isset($this->context->cookie->iso_code_country);
@@ -904,7 +904,7 @@ class FrontControllerCore extends Controller
                     }
                     $this->warning[] = $this->trans(
                         'You cannot place a new order from your country (%s).',
-                        [$countryName],
+                        [htmlspecialchars($countryName)],
                         'Shop.Notifications.Warning'
                     );
                 }

--- a/classes/controller/ModuleAdminController.php
+++ b/classes/controller/ModuleAdminController.php
@@ -95,26 +95,4 @@ abstract class ModuleAdminControllerCore extends AdminController
             $templatePath,
         ];
     }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated Use $this->trans instead
-     */
-    protected function l($string, $class = null, $addslashes = false, $htmlentities = true)
-    {
-        $translated = parent::l($string, $class, $addslashes, $htmlentities);
-
-        if ($translated === $string) {
-            // legacy fallback
-
-            if ($class === null || $class == 'AdminTab') {
-                $class = get_class($this);
-            }
-
-            $translated = Translate::getModuleTranslation($this->module->name, $string, $class, null, $addslashes, null, true, $htmlentities);
-        }
-
-        return $translated;
-    }
 }

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -3360,17 +3360,7 @@ abstract class ModuleCore implements ModuleInterface
 
     protected function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
-        if (isset($parameters['_raw'])) {
-            @trigger_error(
-                'The _raw parameter is deprecated and will be removed in the next major version.',
-                E_USER_DEPRECATED
-            );
-            unset($parameters['_raw']);
-
-            return $this->getTranslator()->trans($id, $parameters, $domain, $locale);
-        }
-
-        return htmlspecialchars($this->getTranslator()->trans($id, $parameters, $domain, $locale), ENT_NOQUOTES);
+        return $this->getTranslator()->trans($id, $parameters, $domain, $locale);
     }
 
     /**

--- a/classes/order/OrderHistory.php
+++ b/classes/order/OrderHistory.php
@@ -142,7 +142,7 @@ class OrderHistoryCore extends ObjectModel
                 foreach ($assign as $product) {
                     $complementaryText = [];
                     if (isset($product['deadline'])) {
-                        $complementaryText[] = $this->trans('expires on %s.', [$product['deadline']], 'Admin.Orderscustomers.Notification');
+                        $complementaryText[] = $this->trans('expires on %s.', [htmlspecialchars($product['deadline'])], 'Admin.Orderscustomers.Notification');
                     }
                     if (isset($product['downloadable'])) {
                         $complementaryText[] = $this->trans('downloadable %d time(s)', [(int) $product['downloadable']], 'Admin.Orderscustomers.Notification');

--- a/classes/stock/StockManagerModule.php
+++ b/classes/stock/StockManagerModule.php
@@ -41,13 +41,13 @@ abstract class StockManagerModuleCore extends Module
         $class_file = _PS_MODULE_DIR_ . '/' . $this->name . '/' . $this->stock_manager_class . '.php';
 
         if (!isset($this->stock_manager_class) || !file_exists($class_file)) {
-            die($this->trans('Incorrect Stock Manager class [%s]', [$this->stock_manager_class], 'Admin.Catalog.Notification'));
+            die($this->trans('Incorrect Stock Manager class [%s]', [htmlspecialchars($this->stock_manager_class)], 'Admin.Catalog.Notification'));
         }
 
         require_once $class_file;
 
         if (!class_exists($this->stock_manager_class)) {
-            die($this->trans('Stock Manager class not found [%s]', [$this->stock_manager_class], 'Admin.Catalog.Notification'));
+            die($this->trans('Stock Manager class not found [%s]', [htmlspecialchars($this->stock_manager_class)], 'Admin.Catalog.Notification'));
         }
 
         $class = $this->stock_manager_class;

--- a/classes/tax/TaxManagerModule.php
+++ b/classes/tax/TaxManagerModule.php
@@ -37,13 +37,13 @@ abstract class TaxManagerModuleCore extends Module
         $class_file = _PS_MODULE_DIR_ . '/' . $this->name . '/' . $this->tax_manager_class . '.php';
 
         if (!isset($this->tax_manager_class) || !file_exists($class_file)) {
-            die($this->trans('Incorrect Tax Manager class [%s]', [$this->tax_manager_class], 'Admin.International.Notification'));
+            die($this->trans('Incorrect Tax Manager class [%s]', [htmlspecialchars($this->tax_manager_class)], 'Admin.International.Notification'));
         }
 
         require_once $class_file;
 
         if (!class_exists($this->tax_manager_class)) {
-            die($this->trans('Tax Manager class not found [%s]', [$this->tax_manager_class], 'Admin.International.Notification'));
+            die($this->trans('Tax Manager class not found [%s]', [htmlspecialchars($this->tax_manager_class)], 'Admin.International.Notification'));
         }
 
         $class = $this->tax_manager_class;

--- a/controllers/admin/AdminAttributesGroupsController.php
+++ b/controllers/admin/AdminAttributesGroupsController.php
@@ -517,7 +517,7 @@ class AdminAttributesGroupsControllerCore extends AdminController
         } else {
             $adminPerformanceUrl = $this->context->link->getAdminLink('AdminPerformance');
             $url = '<a href="' . $adminPerformanceUrl . '#featuresDetachables">' . $this->trans('Performance', [], 'Admin.Global') . '</a>';
-            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %link%.', ['_raw' => true, '%link%' => $url], 'Admin.Catalog.Notification'));
+            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %link%.', ['%link%' => $url], 'Admin.Catalog.Notification'));
         }
 
         $this->context->smarty->assign([

--- a/controllers/admin/AdminFeaturesController.php
+++ b/controllers/admin/AdminFeaturesController.php
@@ -453,7 +453,7 @@ class AdminFeaturesControllerCore extends AdminController
         } else {
             $adminPerformanceUrl = $this->context->link->getAdminLink('AdminPerformance');
             $url = '<a href="' . $adminPerformanceUrl . '#featuresDetachables">' . $this->trans('Performance', [], 'Admin.Global') . '</a>';
-            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %url%.', ['_raw' => true, '%url%' => $url], 'Admin.Catalog.Notification'));
+            $this->displayWarning($this->trans('This feature has been disabled. You can activate it here: %url%.', ['%url%' => $url], 'Admin.Catalog.Notification'));
         }
 
         $this->context->smarty->assign([

--- a/controllers/admin/AdminGroupsController.php
+++ b/controllers/admin/AdminGroupsController.php
@@ -657,9 +657,9 @@ class AdminGroupsControllerCore extends AdminController
         $guest = new Group((int) Configuration::get('PS_GUEST_GROUP'));
         $default = new Group((int) Configuration::get('PS_CUSTOMER_GROUP'));
 
-        $unidentified_group_information = $this->trans('%group_name% - All persons without a customer account or customers that are not logged in.', ['_raw' => true, '%group_name%' => '<b>' . $unidentified->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
-        $guest_group_information = $this->trans('%group_name% - All persons who placed an order through Guest Checkout.', ['_raw' => true, '%group_name%' => '<b>' . $guest->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
-        $default_group_information = $this->trans('%group_name% - All persons who created an account on this site.', ['_raw' => true, '%group_name%' => '<b>' . $default->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
+        $unidentified_group_information = $this->trans('%group_name% - All persons without a customer account or customers that are not logged in.', ['%group_name%' => '<b>' . $unidentified->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
+        $guest_group_information = $this->trans('%group_name% - All persons who placed an order through Guest Checkout.', ['%group_name%' => '<b>' . $guest->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
+        $default_group_information = $this->trans('%group_name% - All persons who created an account on this site.', ['%group_name%' => '<b>' . $default->name[$this->context->language->id] . '</b>'], 'Admin.Shopparameters.Help');
 
         $this->displayInformation($this->trans('PrestaShop has three default customer groups:', [], 'Admin.Shopparameters.Help'));
         $this->displayInformation($unidentified_group_information);

--- a/controllers/admin/AdminLoginController.php
+++ b/controllers/admin/AdminLoginController.php
@@ -92,7 +92,7 @@ class AdminLoginControllerCore extends AdminController
                 $url = 'https://' . Tools::safeOutput(Tools::getServerName()) . Tools::safeOutput($_SERVER['REQUEST_URI']);
                 $warningSslMessage = $this->trans(
                     'SSL is activated. Please connect using the following link to [1]log in to secure mode (https://)[/1]',
-                    ['_raw' => true, '[1]' => '<a href="' . $url . '">', '[/1]' => '</a>'],
+                    ['[1]' => '<a href="' . $url . '">', '[/1]' => '</a>'],
                     'Admin.Login.Notification'
                 );
             }

--- a/controllers/admin/AdminShopController.php
+++ b/controllers/admin/AdminShopController.php
@@ -406,7 +406,6 @@ class AdminShopControllerCore extends AdminController
                     'desc' => [
                         $this->trans('This field does not refer to the shop name visible in the front office.', [], 'Admin.Shopparameters.Help'),
                         $this->trans('Follow [1]this link[/1] to edit the shop name used on the front office.', [
-                            '_raw' => true,
                             '[1]' => '<a href="' . $this->context->link->getAdminLink('AdminStores') . '#store_fieldset_general">',
                             '[/1]' => '</a>',
                         ], 'Admin.Shopparameters.Help'), ],

--- a/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
+++ b/src/PrestaShopBundle/Translation/PrestaShopTranslatorTrait.php
@@ -48,14 +48,6 @@ trait PrestaShopTranslatorTrait
      */
     public function trans($id, array $parameters = [], $domain = null, $locale = null)
     {
-        if (isset($parameters['legacy'])) {
-            @trigger_error(
-                'The legacy parameter is deprecated and will be removed in the next major version.',
-                E_USER_DEPRECATED
-            );
-            unset($parameters['legacy']);
-        }
-
         $isSprintf = !empty($parameters) && $this->isSprintfString($id);
 
         if (empty($locale)) {

--- a/tests/Integration/Classes/ObjectModelTest.php
+++ b/tests/Integration/Classes/ObjectModelTest.php
@@ -96,7 +96,7 @@ class ObjectModelTest extends TestCase
     }
 
     /**
-     * Check if html in trans is not escaped when the _raw parameter is used
+     * Check if html in trans is not escaped by trans method but escaped with htmlspecialchars on parameters
      *
      * @return void
      *
@@ -107,11 +107,11 @@ class ObjectModelTest extends TestCase
         $newObject = new TestableObjectModel();
         $transMethod = new \ReflectionMethod($newObject, 'trans');
         $transMethod->setAccessible(true);
-        $trans = $transMethod->invoke($newObject, '<a href="test">%d Succesful deletion "%s"</a>', ['_raw' => true, 10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
+        $trans = $transMethod->invoke($newObject, '<a href="test">%d Succesful deletion "%s"</a>', [10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
         $this->assertEquals('<a href="test">10 Succesful deletion "<b>stringTest</b>"</a>', $trans);
 
-        $trans = $transMethod->invoke($newObject, '<a href="test">%d Succesful deletion "%s"</a>', [10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
-        $this->assertEquals('&lt;a href="test"&gt;10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"&lt;/a&gt;', $trans);
+        $trans = $transMethod->invoke($newObject, '<a href="test">%d Succesful deletion "%s"</a>', [10, htmlspecialchars('<b>stringTest</b>')], 'Admin.Notifications.Success');
+        $this->assertEquals('<a href="test">10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"</a>', $trans);
     }
 
     public function testAdd(): void

--- a/tests/Integration/Classes/controller/AdminControllerTest.php
+++ b/tests/Integration/Classes/controller/AdminControllerTest.php
@@ -93,7 +93,7 @@ class AdminControllerTest extends TestCase
     }
 
     /**
-     * Check if html in trans is not escaped when the _raw parameter is used
+     * Check if html in trans is not escaped by trans method but escaped with htmlspecialchars on parameters
      *
      * @dataProvider getControllersClasses
      *
@@ -106,11 +106,11 @@ class AdminControllerTest extends TestCase
         $testedController = new $controllerClass();
         $transMethod = new \ReflectionMethod($testedController, 'trans');
         $transMethod->setAccessible(true);
-        $trans = $transMethod->invoke($testedController, '<a href="test">%d Succesful deletion "%s"</a>', ['_raw' => true, 10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
+        $trans = $transMethod->invoke($testedController, '<a href="test">%d Succesful deletion "%s"</a>', [10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
         $this->assertEquals('<a href="test">10 Succesful deletion "<b>stringTest</b>"</a>', $trans);
 
-        $trans = $transMethod->invoke($testedController, '<a href="test">%d Succesful deletion "%s"</a>', [10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
-        $this->assertEquals('&lt;a href="test"&gt;10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"&lt;/a&gt;', $trans);
+        $trans = $transMethod->invoke($testedController, '<a href="test">%d Succesful deletion "%s"</a>', [10, htmlspecialchars('<b>stringTest</b>')], 'Admin.Notifications.Success');
+        $this->assertEquals('<a href="test">10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"</a>', $trans);
     }
 
     /**

--- a/tests/Integration/Classes/module/ModuleTest.php
+++ b/tests/Integration/Classes/module/ModuleTest.php
@@ -62,7 +62,7 @@ class ModuleTest extends TestCase
     }
 
     /**
-     * Check if html in trans is escaped when the _raw parameter is used
+     * Check if html in trans is not escaped by trans method but escaped with htmlspecialchars on parameters
      *
      * @dataProvider providerModulesOnDisk
      *
@@ -73,11 +73,11 @@ class ModuleTest extends TestCase
         $module = Module::getInstanceByName($moduleName);
         $transMethod = new \ReflectionMethod($module, 'trans');
         $transMethod->setAccessible(true);
-        $trans = $transMethod->invoke($module, '<a href="test">%d Succesful deletion "%s"</a>', ['_raw' => true, 10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
+        $trans = $transMethod->invoke($module, '<a href="test">%d Succesful deletion "%s"</a>', [10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
         $this->assertEquals('<a href="test">10 Succesful deletion "<b>stringTest</b>"</a>', $trans);
 
-        $trans = $transMethod->invoke($module, '<a href="test">%d Succesful deletion "%s"</a>', [10, '<b>stringTest</b>'], 'Admin.Notifications.Success');
-        $this->assertEquals('&lt;a href="test"&gt;10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"&lt;/a&gt;', $trans);
+        $trans = $transMethod->invoke($module, '<a href="test">%d Succesful deletion "%s"</a>', [10, htmlspecialchars('<b>stringTest</b>')], 'Admin.Notifications.Success');
+        $this->assertEquals('<a href="test">10 Succesful deletion "&lt;b&gt;stringTest&lt;/b&gt;"</a>', $trans);
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use htmlspecialchars on trans parameters and deprecate _raw parameter, next decision of this PR https://github.com/PrestaShop/PrestaShop/pull/30415
| Type?             | improvement
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | yes
| How to test?      | See https://github.com/PrestaShop/PrestaShop/pull/30415 and https://github.com/PrestaShop/PrestaShop/issues/28877 and https://github.com/PrestaShop/PrestaShop/issues/29959 and https://github.com/PrestaShop/PrestaShop/issues/29940
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/30539
| Related PRs       | https://github.com/PrestaShop/PrestaShop/pull/30415
| Sponsor company   | Prestashop SA