### PR TITLE
Bug FIX - inline js

### DIFF
--- a/classes/assets/JavascriptManager.php
+++ b/classes/assets/JavascriptManager.php
@@ -68,6 +68,9 @@ class JavascriptManagerCore extends AbstractAssetManager
     ) {
         if ('remote' === $server) {
             $this->add($id, $relativePath, $position, $priority, $inline, $attribute, $server, $version);
+        } elseif ($inline) {
+            $fullPath = _PS_CORE_DIR_ . $this->getFullPath($relativePath);
+            $this->add($id, $fullPath, $position, $priority, $inline, $attribute, $server);
         } elseif ($fullPath = $this->getFullPath($relativePath)) {
             $this->add($id, $fullPath, $position, $priority, $inline, $attribute, $server, $version);
         }


### PR DESCRIPTION
Warning: file_get_contents(/modules/xxx/js/xxx.js): failed to open stream: No such file or directory We need to modify file path from relative to full. Without this modification inline js not working.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x / 8.0.x / 1.7.8.x
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | FO / BO / CO / IN / WS / TE / LO / ME / PM
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| How to test?      | Indicate how to verify that this change works as expected.
| Fixed ticket?     | Fixes #{issue number here}, Fixes #{another issue number here}
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
