### PR TITLE
Verify file exists before parsing it in ThemeValidatorTest

### DIFF
--- a/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
@@ -90,7 +90,7 @@ class ThemeValidatorTest extends TestCase
         }
         $themeDir = __DIR__ . '/../../../../Resources/themes/minimal-' . $name . '-theme/';
         $themeConfigFile = $themeDir . 'config/theme.yml';
-        
+
         try {
             $themeConfigContent = file_get_contents($themeConfigFile);
         } catch (\Throwable $exception) {

--- a/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
+++ b/tests/Unit/Core/Addon/Theme/ThemeValidatorTest.php
@@ -90,6 +90,12 @@ class ThemeValidatorTest extends TestCase
         }
         $themeDir = __DIR__ . '/../../../../Resources/themes/minimal-' . $name . '-theme/';
         $themeConfigFile = $themeDir . 'config/theme.yml';
+        
+        try {
+            $themeConfigContent = file_get_contents($themeConfigFile);
+        } catch (\Throwable $exception) {
+            throw new \RuntimeException(sprintf('Unable to read theme config file %s', $themeConfigFile));
+        }
 
         $config = (new Parser())->parse(file_get_contents($themeConfigFile));
         $config['directory'] = $themeDir;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | You must verify file exists before parsing it in ThemeValidatorTest. It makes debugging more easy.
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Unit tests must run
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 
