### PR TITLE
Add discounted unit price and initial price to formatted specific price

### DIFF
--- a/classes/product/SpecificPriceFormatter.php
+++ b/classes/product/SpecificPriceFormatter.php
@@ -162,6 +162,10 @@ class SpecificPriceFormatterCore
         }
 
         $this->specificPrice['save'] = $priceFormatter->format((($initialPrice * $this->specificPrice['quantity']) - ($discountPrice * $this->specificPrice['quantity'])));
+        $this->specificPrice['discounted_unit_price'] = $priceFormatter->format($discountPrice);
+        $this->specificPrice['discounted_unit_price_raw'] = $discountPrice;
+        $this->specificPrice['initial_price'] = $priceFormatter->format($initialPrice);
+        $this->specificPrice['initial_price_raw'] = $initialPrice;
 
         return $this->specificPrice;
     }

--- a/tests/Integration/Classes/product/SpecificPriceFormatterTest.php
+++ b/tests/Integration/Classes/product/SpecificPriceFormatterTest.php
@@ -114,8 +114,15 @@ class SpecificPriceFormatterTest extends KernelTestCase
         $formattedSpecificPrice = $specificPriceFormatter->formatSpecificPrice($price, $taxRate, $ecotaxAmount);
 
         $priceFormatter = new PriceFormatter();
-        $this->assertEquals($priceFormatter->format($expected[0]['discount']), $formattedSpecificPrice['discount']);
-        $this->assertEquals($priceFormatter->format($expected[0]['save']), $formattedSpecificPrice['save']);
+
+        $checkKeys = ['discount', 'save', 'discounted_unit_price', 'initial_price'];
+        foreach ($checkKeys as $checkKey) {
+            $this->assertEquals(
+                $priceFormatter->format($expected[0][$checkKey]),
+                $formattedSpecificPrice[$checkKey],
+                "checkKey: $checkKey"
+            );
+        }
     }
 
     public function dataProviderSpecificPriceFormatter(): array
@@ -223,6 +230,8 @@ class SpecificPriceFormatterTest extends KernelTestCase
                     [
                         'discount' => 7.80,
                         'save' => 117.00,
+                        'discounted_unit_price' => 23.40,
+                        'initial_price' => 31.2,
                     ],
                 ],
             ],
@@ -237,6 +246,8 @@ class SpecificPriceFormatterTest extends KernelTestCase
                     [
                         'discount' => 6.00,
                         'save' => 90.00,
+                        'discounted_unit_price' => 18,
+                        'initial_price' => 24,
                     ],
                 ],
             ],
@@ -251,6 +262,8 @@ class SpecificPriceFormatterTest extends KernelTestCase
                     [
                         'discount' => 6.63,
                         'save' => 99.45,
+                        'discounted_unit_price' => 24.57,
+                        'initial_price' => 31.2,
                     ],
                 ],
             ],
@@ -265,6 +278,8 @@ class SpecificPriceFormatterTest extends KernelTestCase
                     [
                         'discount' => 5.10,
                         'save' => 76.50,
+                        'discounted_unit_price' => 18.90,
+                        'initial_price' => 24,
                     ],
                 ],
             ],
@@ -279,6 +294,8 @@ class SpecificPriceFormatterTest extends KernelTestCase
                     [
                         'discount' => 11.70,
                         'save' => 175.50,
+                        'discounted_unit_price' => 19.50,
+                        'initial_price' => 31.2,
                     ],
                 ],
             ],
@@ -293,6 +310,8 @@ class SpecificPriceFormatterTest extends KernelTestCase
                     [
                         'discount' => 9.00,
                         'save' => 135.00,
+                        'discounted_unit_price' => 15.00,
+                        'initial_price' => 24,
                     ],
                 ],
             ],
@@ -307,6 +326,8 @@ class SpecificPriceFormatterTest extends KernelTestCase
                     [
                         'discount' => 2.46,
                         'save' => 24.60,
+                        'discounted_unit_price' => 9.84,
+                        'initial_price' => 12.30,
                     ],
                 ],
             ],
@@ -321,6 +342,8 @@ class SpecificPriceFormatterTest extends KernelTestCase
                     [
                         'discount' => 4.26,
                         'save' => 12.78,
+                        'discounted_unit_price' => 11.22,
+                        'initial_price' => 15.48,
                     ],
                 ],
             ],


### PR DESCRIPTION



<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Add unit price and initial price to formatted SpecificPrice. This helps designers to create nice quantity discount tables in the product page in the future
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | PR contains integration test. No visible changes.
| Fixed ticket?     | Fix https://github.com/PrestaShop/PrestaShop/issues/31962
| Related PRs       | 
| Sponsor company   | 
