### PR TITLE
Nicer docker compose & co for fast dev environment startup

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -17,7 +17,7 @@ RUN chown -R www-data:www-data /var/www/.npm
 RUN mkdir -p /var/www/.composer
 RUN chown -R www-data:www-data /var/www/.composer
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt install -y nodejs
 
 # Install mailutils to make sendmail work

--- a/.docker/docker_run_git.sh
+++ b/.docker/docker_run_git.sh
@@ -32,7 +32,7 @@ set -e
 
 if [ $PS_DEV_MODE -ne 1 ]; then
   echo "\n* Disabling DEV mode ...";
-  sed -ie "s/define('_PS_MODE_DEV_', true);/define('_PS_MODE_DEV_',\ false);/g" /var/www/html/config/defines.inc.php
+  sed -i -e "s/define('_PS_MODE_DEV_', true);/define('_PS_MODE_DEV_',\ false);/g" /var/www/html/config/defines.inc.php
 fi
 
 if [ ! -f ./config/settings.inc.php ]; then
@@ -76,7 +76,7 @@ fi
 
 if [ $PS_DEMO_MODE -ne 0 ]; then
     echo "\n* Enabling DEMO mode ...";
-    sed -ie "s/define('_PS_MODE_DEMO_', false);/define('_PS_MODE_DEMO_',\ true);/g" /var/www/html/config/defines.inc.php
+    sed -i -e "s/define('_PS_MODE_DEMO_', false);/define('_PS_MODE_DEMO_',\ true);/g" /var/www/html/config/defines.inc.php
 fi
 
 echo "\n* Almost ! Starting web server now\n";

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ MySQL credentials can also be found and modified in this file if needed.
 If you expect the container to (re)install your shop, remove this file if it exists. And make sure the container user `www-data`
 has write access to the whole workspace.
 
-To fully reset your repo and get a frest start run (CAREFUL: this removes all your extra files):
+To fully reset your repo and get a fresh start, run (be careful: this removes all your extra files):
 
 ```
-# clean everything not in repo (node_modules etc)
+# clean everything that is not part of the original repository (node_modules, etc.)
 git fetch origin
 git reset --hard origin/develop
 git clean -dfx

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ About the 'develop' branch
 --------
 
 The 'develop' branch of this repository contains the work in progress source code for the next version of PrestaShop.
- 
+
 For more information on our branch system, read our guide on [installing PrestaShop for development][install-guide-dev].
 
 The first stable version of PrestaShop 8.0, was released on October 26th, 2022. Further updates have been released since then. Learn more about it on [the Build devblog](https://build.prestashop-project.org/tag/8.0/).
@@ -62,8 +62,25 @@ Docker will bind your port 8001 to the web server. If you want to use other port
 MySQL credentials can also be found and modified in this file if needed.
 
 **Note:**  Before auto-installing PrestaShop, this container checks the file *config/settings.inc.php* does not exist on startup.
-If you expect the container to (re)install your shop, remove this file if it exists. And make sure the container user `www-data` 
+If you expect the container to (re)install your shop, remove this file if it exists. And make sure the container user `www-data`
 has write access to the whole workspace.
+
+To fully reset your repo and get a frest start run (CAREFUL: this removes all your extra files):
+
+```
+# clean everything not in repo (node_modules etc)
+git fetch origin
+git reset --hard origin/develop
+git clean -dfx
+
+# inform build scripts to reinstall shop
+rm config/settings.inc.php
+
+# clear all docker caches and rebuild everything
+docker compose down -v
+docker compose build --no-cache
+docker-compose up --build --force-recreate
+```
 
 Documentation
 --------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       PS_FOLDER_INSTALL: ${PS_FOLDER_INSTALL:-install-dev}
       PS_FOLDER_ADMIN: ${PS_FOLDER_ADMIN:-admin-dev}
       PS_COUNTRY: ${PS_COUNTRY:-fr}
-      PS_LANGUAGE: ${PS_LANGUAGE:-fr}
+      PS_LANGUAGE: ${PS_LANGUAGE:-en}
       PS_DEV_MODE: ${PS_DEV_MODE:-1}
       ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}
       ADMIN_PASSWD: ${ADMIN_PASSWD:-Correct Horse Battery Staple}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ volumes:
 
 services:
   mysql:
-    image: mysql:5
+    image: mysql:8
     ports:
       - "3306"
     volumes:
@@ -18,7 +18,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: prestashop
       MYSQL_DATABASE: prestashop
-    restart: always
+    restart: unless-stopped
+
   prestashop-git:
     build:
       dockerfile: .docker/Dockerfile
@@ -47,3 +48,5 @@ services:
       - "8001:80"
     volumes:
       - ./:/var/www/html:delegated
+    depends_on:
+        - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       PS_FOLDER_ADMIN: ${PS_FOLDER_ADMIN:-admin-dev}
       PS_COUNTRY: ${PS_COUNTRY:-fr}
       PS_LANGUAGE: ${PS_LANGUAGE:-fr}
-      PS_DEV_MODE: ${PS_DEV_MODE:-0}
+      PS_DEV_MODE: ${PS_DEV_MODE:-1}
       ADMIN_MAIL: ${ADMIN_MAIL:-demo@prestashop.com}
       ADMIN_PASSWD: ${ADMIN_PASSWD:-Correct Horse Battery Staple}
     command: ["/tmp/wait-for-it.sh", "--timeout=60", "--strict", "mysql:3306", "--", "/tmp/docker_run_git.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,3 +50,4 @@ services:
       - ./:/var/www/html:delegated
     depends_on:
         - mysql
+


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix some problems with the current `docker-compose up` for development.  See below for more
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | git clone && docker-compose up
| Fixed ticket?     | Discussion: https://github.com/PrestaShop/PrestaShop/discussions/31969
| Related PRs       | 
| Sponsor company   | 

* Up mysql to version 8
  * much faster startup for db, supported version
* Fix `sed` parameters in docker_run_git.sh
  * does not create `defines.inc.phpe` anymore
  * this same problem seems to be here also: `.github/actions/setup-prestashop-env/action.yml` didn't touch that though
* Up nodejs to version 16
  * fixes changing the package-json.lock files on startup
  * side note version 18 does not work
* Default to dev mode
  * yes, developers want dev mode
* Default to english language
  * most developers speak English (French is still available easily)
* Update readme for "full reset" of your docker environment
  * Can prevent issues like this: https://github.com/PrestaShop/PrestaShop/issues/30979 https://github.com/PrestaShop/PrestaShop/issues/10934