### PR TITLE
Add link to type and category information in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,13 @@
 <!-----------------------------------------------------------------------------
-Thank you for contributing to the PrestaShop project! 
+Thank you for contributing to the PrestaShop project!
 
 Please take the time to edit the "Answers" rows below with the necessary information.
 
 Check out our contribution guidelines to find out how to complete it:
 https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
+
+For type and category see:
+https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
 ------------------------------------------------------------------------------>
 
 | Questions         | Answers


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Every time I make a PR I have to stop and think on the Category question. This adds a link to the documentation about the different categories in the PR template comment section. (even now I had to double check from the link in my pr what is the correct category for this :)
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Open a new PR, see nice link in the comment section on how to define the correct category for your PR
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 
