### PR TITLE
Use 'npm ci' instead of 'npm i'

### DIFF
--- a/.github/workflows/cron_nightly_tests_reusable.yml
+++ b/.github/workflows/cron_nightly_tests_reusable.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ inputs.TESTS_DIR }}
-        run: npm install
+        run: npm ci
 
       # Run tests (if error, we continue for uploading report)
       - name: Run tests
@@ -186,7 +186,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ${{ env.TESTS_DIR }}
-        run: npm install
+        run: npm ci
 
       - name: Combine reports
         working-directory: ${{ env.TESTS_DIR }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -38,5 +38,5 @@ jobs:
           restore-keys: ${{ runner.os }}-node-
 
       - name: Run tests
-        run: npm install && npm run test
+        run: npm ci && npm run test
         working-directory: ./admin-dev/themes/new-theme

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,10 +27,10 @@ jobs:
         run: npm install -g npm@7
 
       - name: BackOffice Theme `new-theme`
-        run: cd ./admin-dev/themes/new-theme && npm install && npm run scss-lint
+        run: cd ./admin-dev/themes/new-theme && npm ci && npm run scss-lint
 
       - name: BackOffice Theme `default`
-        run: cd ./admin-dev/themes/default && npm install && npm run scss-lint
+        run: cd ./admin-dev/themes/default && npm ci && npm run scss-lint
 
   eslint:
     name: ESLint
@@ -53,10 +53,10 @@ jobs:
             && (cd themes && npm ci)
 
       - name: BackOffice Theme `default`
-        run: cd ./admin-dev/themes/default && npm install && npm run lint
+        run: cd ./admin-dev/themes/default && npm ci && npm run lint
 
       - name: BackOffice Theme `new-theme`
-        run: cd ./admin-dev/themes/new-theme && npm install && npm run lint
+        run: cd ./admin-dev/themes/new-theme && npm ci && npm run lint
 
   yamllint_sf:
     name: YAML Lint (Symfony Check)

--- a/.github/workflows/sanity-productV2.yml
+++ b/.github/workflows/sanity-productV2.yml
@@ -45,7 +45,7 @@ jobs:
           key: ${{ runner.os }}-browsers
 
       - name: Run tests
-        run: npm install && npm run test:sanity:productV2:fast-fail
+        run: npm ci && npm run test:sanity:productV2:fast-fail
         env:
           URL_FO: http://localhost/
           DB_NAME: prestashop

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ./tests/UI
 
       - name: Run tests
-        run: npm install && npm run test:sanity:fast-fail
+        run: npm ci && npm run test:sanity:fast-fail
         working-directory: ./tests/UI
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ui_tests_code_checks.yml
+++ b/.github/workflows/ui_tests_code_checks.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm install -g npm@${{ env.NPM_VERSION }}
 
       - name: Install dependencies in UI tests directory
-        run: npm install
+        run: npm ci
 
       - name: Check eslint errors
         run: npm run lint
@@ -72,7 +72,7 @@ jobs:
         run: npm install -g npm@${{ env.NPM_VERSION }}
 
       - name: Install dependencies in UI tests directory
-        run: npm install
+        run: npm ci
 
       - name: Generate mocha reports with failed steps
         run: GENERATE_FAILED_STEPS=true npm run test:all

--- a/admin-dev/themes/new-theme/js/app/README.md
+++ b/admin-dev/themes/new-theme/js/app/README.md
@@ -10,7 +10,7 @@ It you need to work on it to add some features or to debug, you need to follow t
 - Edit your `/app/config/config.yml` to set `twig > globals > webpack_server` to `true`
 - Clean your Symfony cache (`app:console cache:clear` in the project root folder)
 - Go to `/admin-dev/themes/new-theme/`
-- Run `npm install`
+- Run `npm ci`
 - Run `npm run start-dev-server`
 
 Then, you can edit the files and you'll see your modifications live.

--- a/tests/UI/README.md
+++ b/tests/UI/README.md
@@ -2,7 +2,7 @@
 
 ## Requirement
 
-Before begin working on tests, make sure you have installed 
+Before begin working on tests, make sure you have installed
 
 * [nodejs](https://nodejs.org/) v10.x or newer
 * [npm](https://www.npmjs.com/) v6.x or newer
@@ -14,7 +14,7 @@ Before begin working on tests, make sure you have installed
 git clone https://github.com/PrestaShop/PrestaShop/
 # Install dependencies in UI folder
 cd tests/UI/
-npm install
+npm ci
 ```
 
 ## Available command line parameters
@@ -55,7 +55,7 @@ npm install
 
 Before running tests, you should install your shop manually or run the install script **`campaigns/sanity/01_installShop/*`** with the [`test:specific` command](README.md#specific-test).
 
-## Sanity tests 
+## Sanity tests
 
 This campaign includes a non-exhaustive set of tests and will ensure that the most important functions work.
 
@@ -69,7 +69,7 @@ npm run test:sanity
 ```
 
 #### With custom values
-You can add parameters that you need in the beginning of your command 
+You can add parameters that you need in the beginning of your command
 ```bash
 HEADLESS=false URL_BO="Your_Shop_URL_BO" URL_FO="Your_Shop_URL_FO" npm run test:sanity
 ```
@@ -81,15 +81,15 @@ If you want to run all sanity tests "safely", you can use the Travis-specific co
 npm run test:sanity:fast-fail
 ```
 
-## Functional tests 
-This campaign verifies that each function of the software application operate in conformance with the functional requirements. 
+## Functional tests
+This campaign verifies that each function of the software application operate in conformance with the functional requirements.
 Each and every functionality of the system is tested by providing appropriate input, verifying the output, and comparing the actual results with the expected results.
 
 ```bash
 URL_FO="Your_Shop_URL_FO" npm run test:functional
 ```
 
-## Specific test 
+## Specific test
 If you want to run only one test from a campaign or a couple of tests in the same folder, you can use **`test:specific`** command.
 
 To specify which test to run, you can add the **`TEST_PATH`** parameter in the beginning of the command
@@ -97,7 +97,7 @@ To specify which test to run, you can add the **`TEST_PATH`** parameter in the b
 ```bash
 # To run the **Filter Products** test from sanity campaign
 TEST_PATH="sanity/03_productsBO/01_filterProducts" URL_FO="Your_Shop_URL_FO" npm run test:specific
-# To run all **Products BO** tests 
+# To run all **Products BO** tests
 TEST_PATH="sanity/03_productsBO/*" URL_FO="Your_Shop_URL_FO" npm run test:specific
 ```
 
@@ -112,7 +112,7 @@ You **must** disable the Security Token before running this script ! Add this li
 
 ```bash
 SetEnv _TOKEN_ disabled
-``` 
+```
 
 #### With default values
 
@@ -135,7 +135,7 @@ To help contributors find more documentation about UI tests, [JS-DOC](https://js
 To install `jsdoc-to-markdown` :
 ```shell
 cd tests/UI
-npm install
+npm ci
 ```
 
 ### Generate documentation

--- a/tools/assets/build.sh
+++ b/tools/assets/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ###
-# This script rebuilds all the static assets, running npm install as needed
+# This script rebuilds all the static assets, running npm install-clean as needed
 #
 
 #http://redsymbol.net/articles/unofficial-bash-strict-mode/
@@ -25,7 +25,7 @@ function build {
     rm -rf node_modules
   fi
 
-  npm install
+  npm ci
   npm run build
   popd
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Use `npm ci` instead of `npm i` in CI processes and update README's to use it also. See: https://docs.npmjs.com/cli/v9/commands/npm-ci
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check that CI goes green
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

As a side note I think all of the `Setup NPM` steps can be omitted as `actions/setup-node@v3` already sets up npm (I think)

And the node version should really come from one single source of truth for future, but lets keep this iterative :)