### PR TITLE
Remove triggered errors and deprecated for Grid

### DIFF
--- a/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
+++ b/src/Core/Grid/Definition/Factory/AbstractGridDefinitionFactory.php
@@ -37,7 +37,6 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinition;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollection;
 use PrestaShop\PrestaShop\Core\Grid\Filter\FilterCollectionInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use PrestaShopBundle\Translation\TranslatorAwareTrait;
 use Symfony\Component\DependencyInjection\Container;
 
@@ -54,27 +53,10 @@ abstract class AbstractGridDefinitionFactory implements GridDefinitionFactoryInt
     protected $hookDispatcher;
 
     /**
-     * @param HookDispatcherInterface|null $hookDispatcher
-     */
-    public function __construct(HookDispatcherInterface $hookDispatcher = null)
-    {
-        if (null === $hookDispatcher) {
-            @trigger_error('The $hookDispatcher parameter should not be null, inject your main HookDispatcherInterface service, or NullDispatcher if you don\'t need hooks.', E_USER_DEPRECATED);
-        }
-        $this->hookDispatcher = $hookDispatcher ? $hookDispatcher : new NullDispatcher();
-    }
-
-    /**
-     * Set hook dispatcher.
-     *
      * @param HookDispatcherInterface $hookDispatcher
-     *
-     * @deprecated
      */
-    final public function setHookDispatcher(HookDispatcherInterface $hookDispatcher)
+    public function __construct(HookDispatcherInterface $hookDispatcher)
     {
-        @trigger_error('The AbstractGridDefinitionFactory::setHookDispatcher method is deprecated as of 1.7.5.1 Please use the constructor instead', E_USER_DEPRECATED);
-
         $this->hookDispatcher = $hookDispatcher;
     }
 

--- a/src/Core/Grid/Filter/GridFilterFormFactory.php
+++ b/src/Core/Grid/Filter/GridFilterFormFactory.php
@@ -29,7 +29,6 @@ namespace PrestaShop\PrestaShop\Core\Grid\Filter;
 use PrestaShop\PrestaShop\Core\Grid\Definition\GridDefinitionInterface;
 use PrestaShop\PrestaShop\Core\Grid\Exception\ColumnNotFoundException;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -51,18 +50,14 @@ final class GridFilterFormFactory implements GridFilterFormFactoryInterface
 
     /**
      * @param FormFactoryInterface $formFactory
-     * @param HookDispatcherInterface|null $hookDispatcher
+     * @param HookDispatcherInterface $hookDispatcher
      */
     public function __construct(
         FormFactoryInterface $formFactory,
-        HookDispatcherInterface $hookDispatcher = null
+        HookDispatcherInterface $hookDispatcher
     ) {
         $this->formFactory = $formFactory;
-
-        if (null === $hookDispatcher) {
-            @trigger_error('The $hookDispatcher parameter should not be null, inject your main HookDispatcherInterface service, or NullDispatcher if you don\'t need hooks.', E_USER_DEPRECATED);
-        }
-        $this->hookDispatcher = $hookDispatcher ? $hookDispatcher : new NullDispatcher();
+        $this->hookDispatcher = $hookDispatcher;
     }
 
     /**

--- a/src/Core/Grid/GridFactory.php
+++ b/src/Core/Grid/GridFactory.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Grid\Definition\Factory\GridDefinitionFactoryInte
 use PrestaShop\PrestaShop\Core\Grid\Filter\GridFilterFormFactoryInterface;
 use PrestaShop\PrestaShop\Core\Grid\Search\SearchCriteriaInterface;
 use PrestaShop\PrestaShop\Core\Hook\HookDispatcherInterface;
-use PrestaShopBundle\Event\Dispatcher\NullDispatcher;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
@@ -63,22 +62,18 @@ final class GridFactory implements GridFactoryInterface
      * @param GridDefinitionFactoryInterface $definitionFactory
      * @param GridDataFactoryInterface $dataFactory
      * @param GridFilterFormFactoryInterface $filterFormFactory
-     * @param HookDispatcherInterface|null $hookDispatcher
+     * @param HookDispatcherInterface $hookDispatcher
      */
     public function __construct(
         GridDefinitionFactoryInterface $definitionFactory,
         GridDataFactoryInterface $dataFactory,
         GridFilterFormFactoryInterface $filterFormFactory,
-        HookDispatcherInterface $hookDispatcher = null
+        HookDispatcherInterface $hookDispatcher
     ) {
         $this->definitionFactory = $definitionFactory;
         $this->dataFactory = $dataFactory;
         $this->filterFormFactory = $filterFormFactory;
-
-        if (null === $hookDispatcher) {
-            @trigger_error('The $hookDispatcher parameter should not be null, inject your main HookDispatcherInterface service, or NullDispatcher if you don\'t need hooks.', E_USER_DEPRECATED);
-        }
-        $this->hookDispatcher = $hookDispatcher ? $hookDispatcher : new NullDispatcher();
+        $this->hookDispatcher = $hookDispatcher;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove triggered errors and deprecated for Grid
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4576331269 (2 :red_circle: are :red_circle: in the nightly so it's :ok_hand:)
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks
* Removed the method  `setHookDispatcher` in class `PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory`
* Changed the signature for the constructor in class `PrestaShop\PrestaShop\Core\Grid\Definition\Factory\AbstractGridDefinitionFactory`
* Changed the signature for the constructor in class `PrestaShop\PrestaShop\Core\Grid\Filter\GridFilterFormFactory`
* Changed the signature for the constructor in class `PrestaShop\PrestaShop\Core\Grid\GridFactory`

