### PR TITLE
Revert displaying Customer Groups migrated page

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/customer_groups.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/configure/shop_parameters/customer_groups.yml
@@ -4,7 +4,7 @@ admin_customer_groups_index:
   defaults:
     _controller: 'PrestaShopBundle\Controller\Admin\Configure\ShopParameters\CustomerGroupsController::indexAction'
     _legacy_controller: AdminGroups
-    _legacy_link: AdminGroups
+    # _legacy_link: AdminGroups
 
 admin_customer_groups_search:
   path: /


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Revert displaying the migrated Customer Groups page that has been enabled by accident here : https://github.com/PrestaShop/PrestaShop/pull/31583/files#diff-50751cb72752e582f16213b742173d62bf88b6acf7192e05c98a56cbfe787267R7
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Make sure the legacy page still shows up in Shop Paramaters > Customer Settings > Groups tab
| Fixed ticket?     | N/A
| Related PRs       | #31583 
| Sponsor company   | PrestaShop SA
