### PR TITLE
Remove step for install npm in tests

### DIFF
--- a/.github/actions/setup-prestashop-env/action.yml
+++ b/.github/actions/setup-prestashop-env/action.yml
@@ -64,10 +64,6 @@ runs:
           tests/**/package-lock.json
           themes/**/package-lock.json
 
-    - name: Setup NPM
-      shell: bash
-      run: npm i -g npm@${{ inputs.npm-version }}
-
     - name: Get Composer Cache Directory
       shell: bash
       id: composer-cache

--- a/.github/workflows/cron_js_routing.yml
+++ b/.github/workflows/cron_js_routing.yml
@@ -54,9 +54,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Setup NPM
-        run: npm install -g npm@7
-
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/cron_nightly_build.yml
+++ b/.github/workflows/cron_nightly_build.yml
@@ -60,9 +60,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Setup NPM
-        run: npm install -g npm@7
-
       - name: Create Release directory
         run: mkdir -p ${{ env.RELEASE_DIR }}
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,9 +40,6 @@ jobs:
         with:
           node-version: '16'
 
-      - name: Setup NPM
-        run: npm install -g npm@7
-
       - uses: actions/checkout@v3
 
       - name: PrestaShop Configuration

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -24,9 +24,6 @@ jobs:
         with:
           node-version: ${{ matrix.js }}
 
-      - name: Setup NPM
-        run: npm install -g npm@7
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,6 @@ jobs:
         with:
           node-version: '16.x'
 
-      - name: Setup NPM
-        run: npm install -g npm@7
-
       - name: BackOffice Theme `new-theme`
         run: cd ./admin-dev/themes/new-theme && npm ci && npm run scss-lint
 
@@ -42,9 +39,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16.x'
-
-      - name: Setup NPM
-        run: npm install -g npm@7
 
       - name: Validate npm config
         run: >-

--- a/.github/workflows/ui_tests_code_checks.yml
+++ b/.github/workflows/ui_tests_code_checks.yml
@@ -13,7 +13,6 @@ defaults:
 
 env:
   NODE_VERSION: '16'
-  NPM_VERSION: '7'
 
 concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -40,9 +39,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Setup NPM
-        run: npm install -g npm@${{ env.NPM_VERSION }}
-
       - name: Install dependencies in UI tests directory
         run: npm ci
 
@@ -67,9 +63,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
-
-      - name: Setup NPM
-        run: npm install -g npm@${{ env.NPM_VERSION }}
 
       - name: Install dependencies in UI tests directory
         run: npm ci


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | setup-node@v3 already installs npm, skip our own install step for it
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check that CI is green
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | 

Couldn't test this easily without really opening a PR so lets see what happens.
