### PR TITLE
An unexpected assignment in the CartPresenter method call in the front CartController::initContent

### DIFF
--- a/controllers/front/CartController.php
+++ b/controllers/front/CartController.php
@@ -106,7 +106,7 @@ class CartControllerCore extends FrontController
             $this->checkCartProductsMinimalQuantities();
         }
         $presenter = new CartPresenter();
-        $presented_cart = $presenter->present($this->context->cart, $shouldSeparateGifts = true);
+        $presented_cart = $presenter->present($this->context->cart, true);
 
         $this->context->smarty->assign([
             'cart' => $presented_cart,


### PR DESCRIPTION
Removed an assignment from the CartPresenter method call in the front CartController::initContent.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 1.7.8.x
| Description?      | In the Front CartController::initContent method an unused assignment the CartPresenter method call.
| Type?             | refacto
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
