### PR TITLE
Add install error message when a parameter is missing

### DIFF
--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -104,6 +104,14 @@ if (file_exists(_PS_CORE_DIR_.'/app/config/parameters.php')) {
         if (strpos($e->getMessage(), 'You can circumvent this by setting a \'server_version\' configuration value') === false) {
             throw $e;
         }
+    } catch (\Symfony\Component\DependencyInjection\Exception\RuntimeException $e) {
+        if (strpos($e->getMessage(), 'You have requested a non-existent parameter') === 0) {
+            die(sprintf('Error: %s', $e->getMessage())
+                .PHP_EOL.'A missing parameter was detected, which may be caused by old configuration files.'
+                .PHP_EOL.'Try clearing the /var/cache directory and deleting parameters.php and parameters.yml in the /app/config/ directory.'
+            );
+        }
+        throw $e;
     }
 }
 

--- a/install-dev/init.php
+++ b/install-dev/init.php
@@ -77,27 +77,27 @@ if (!defined('__PS_BASE_URI__')) {
 }
 
 if (!defined('_PS_CORE_DIR_')) {
-    define('_PS_CORE_DIR_', realpath(dirname(__FILE__).'/..'));
+    define('_PS_CORE_DIR_', realpath(dirname(__FILE__) . '/..'));
 }
 
 /* in dev mode - check if composer was executed */
-if ((!is_dir(_PS_CORE_DIR_.DIRECTORY_SEPARATOR.'vendor') ||
-    !file_exists(_PS_CORE_DIR_.DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR.'autoload.php'))) {
+if ((!is_dir(_PS_CORE_DIR_ . DIRECTORY_SEPARATOR . 'vendor') ||
+    !file_exists(_PS_CORE_DIR_ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php'))) {
     die('Error : please install <a href="https://getcomposer.org/">composer</a>. Then run "php composer.phar install"');
 }
 
-require_once _PS_CORE_DIR_.'/config/defines.inc.php';
-require_once _PS_CORE_DIR_.'/config/autoload.php';
+require_once _PS_CORE_DIR_ . '/config/defines.inc.php';
+require_once _PS_CORE_DIR_ . '/config/autoload.php';
 
-if (file_exists(_PS_CORE_DIR_.'/app/config/parameters.php')) {
-    require_once _PS_CORE_DIR_.'/config/bootstrap.php';
+if (file_exists(_PS_CORE_DIR_ . '/app/config/parameters.php')) {
+    require_once _PS_CORE_DIR_ . '/config/bootstrap.php';
 
     global $kernel;
     try {
         $kernel = new AppKernel(_PS_ENV_, _PS_MODE_DEV_);
         $kernel->boot();
     } catch (DBALException $e) {
-        /**
+        /*
          * Doctrine couldn't be loaded because database settings point to a
          * non existence database
          */
@@ -107,8 +107,8 @@ if (file_exists(_PS_CORE_DIR_.'/app/config/parameters.php')) {
     } catch (\Symfony\Component\DependencyInjection\Exception\RuntimeException $e) {
         if (strpos($e->getMessage(), 'You have requested a non-existent parameter') === 0) {
             die(sprintf('Error: %s', $e->getMessage())
-                .PHP_EOL.'A missing parameter was detected, which may be caused by old configuration files.'
-                .PHP_EOL.'Try clearing the /var/cache directory and deleting parameters.php and parameters.yml in the /app/config/ directory.'
+                . PHP_EOL . 'A missing parameter was detected, which may be caused by old configuration files.'
+                . PHP_EOL . 'Try clearing the /var/cache directory and deleting parameters.php and parameters.yml in the /app/config/ directory.'
             );
         }
         throw $e;
@@ -124,7 +124,7 @@ if (!defined('_THEME_NAME_')) {
          * @deprecated since 1.7.5.x to be removed in 1.8.x
          * Rely on "PS_THEME_NAME" environment variable value
          */
-        $dirThemes = dirname(__DIR__).'/themes/';
+        $dirThemes = dirname(__DIR__) . '/themes/';
         $fileConfig = '/config/theme.yml';
         $defaultTheme = 'classic';
         // Choose classic theme as default
@@ -146,24 +146,24 @@ if (!defined('_THEME_NAME_')) {
     }
 }
 
-require_once _PS_CORE_DIR_.'/config/defines_uri.inc.php';
+require_once _PS_CORE_DIR_ . '/config/defines_uri.inc.php';
 
 // Generate common constants
 define('PS_INSTALLATION_IN_PROGRESS', true);
-define('PS_INSTALLATION_LOCK_FILE',  _PS_CORE_DIR_ . '/var/.install.prestashop');
-define('_PS_INSTALL_PATH_', dirname(__FILE__).'/');
-define('_PS_INSTALL_DATA_PATH_', _PS_INSTALL_PATH_.'data/');
-define('_PS_INSTALL_CONTROLLERS_PATH_', _PS_INSTALL_PATH_.'controllers/');
-define('_PS_INSTALL_MODELS_PATH_', _PS_INSTALL_PATH_.'models/');
-define('_PS_INSTALL_LANGS_PATH_', _PS_INSTALL_PATH_.'langs/');
-define('_PS_INSTALL_FIXTURES_PATH_', _PS_INSTALL_PATH_.'fixtures/');
+define('PS_INSTALLATION_LOCK_FILE', _PS_CORE_DIR_ . '/var/.install.prestashop');
+define('_PS_INSTALL_PATH_', dirname(__FILE__) . '/');
+define('_PS_INSTALL_DATA_PATH_', _PS_INSTALL_PATH_ . 'data/');
+define('_PS_INSTALL_CONTROLLERS_PATH_', _PS_INSTALL_PATH_ . 'controllers/');
+define('_PS_INSTALL_MODELS_PATH_', _PS_INSTALL_PATH_ . 'models/');
+define('_PS_INSTALL_LANGS_PATH_', _PS_INSTALL_PATH_ . 'langs/');
+define('_PS_INSTALL_FIXTURES_PATH_', _PS_INSTALL_PATH_ . 'fixtures/');
 
 // PrestaShop autoload is used to load some helpful classes like Tools.
 // Add classes used by installer bellow.
 
-require_once _PS_CORE_DIR_.'/config/alias.php';
-require_once _PS_INSTALL_PATH_.'classes/exception.php';
-require_once _PS_INSTALL_PATH_.'classes/session.php';
+require_once _PS_CORE_DIR_ . '/config/alias.php';
+require_once _PS_INSTALL_PATH_ . 'classes/exception.php';
+require_once _PS_INSTALL_PATH_ . 'classes/session.php';
 
 @set_time_limit(0);
 // Work around lack of validation for timezone
@@ -172,7 +172,6 @@ if (!in_array(@ini_get('date.timezone'), timezone_identifiers_list())) {
     @date_default_timezone_set('UTC');
     ini_set('date.timezone', 'UTC');
 }
-
 
 function psinstall_get_octets($option)
 {


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | This PR adds a helpful message when installation fails because of a missing parameter.
| Type?             | improvement
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Read below
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA

## The problem

PrestaShop 8.1 introduces two new symfony "parameters" (configurations): `api_public_key` and `api_private_key`. If you try to install PrestaShop 8.1 using a `parameters.php` file from a previous version, the installation will fail with a cryptic error similar to this one:

<img width="1764" alt="Screenshot 2023-04-03 at 16 28 09" src="https://user-images.githubusercontent.com/1009343/229553152-95b4315c-71a9-43a8-ad7f-7c944cf90800.png">

## The solution

This change brings a more legible error message and proposes tips to solve this particular problem:

<img width="1725" alt="Screenshot 2023-04-03 at 17 17 04" src="https://user-images.githubusercontent.com/1009343/229553465-1a210d00-a7c7-4a92-ac21-bc93ec83feae.png">

## To test it

1. Install PrestaShop in the 8.1.x branch
2. Switch to this PR
3. Edit `/app/config/parameters.php` and rename 'api_private_key' to '1api_private_key' (or something else)
4. Clear the contents of `/var/cache/*`
5. Try to reinstall
6. See error