### PR TITLE
Fix module active flag with group & shop contexts

### DIFF
--- a/src/Adapter/Module/ModuleDataProvider.php
+++ b/src/Adapter/Module/ModuleDataProvider.php
@@ -145,10 +145,10 @@ class ModuleDataProvider
         $from = ' FROM `' . _DB_PREFIX_ . 'module` m';
 
         $id_shops = (new Context())->getContextListShopID();
-        if (count($id_shops) === 1) {
+        if (count($id_shops) > 0) {
             $select .= ', ms.`id_module` as active, ms.`enable_device` as active_on_mobile';
             $from .= ' LEFT JOIN `' . _DB_PREFIX_ . 'module_shop` ms ON ms.`id_module` = m.`id_module`';
-            $from .= ' AND ms.`id_shop` = ' . reset($id_shops);
+            $from .= ' AND ms.`id_shop` IN (' . implode(',', array_map('intval', $id_shops)) . ')';
         }
 
         $results = Db::getInstance()->executeS($select . $from);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | In this PR, I try to fix module active status for all contexts (all shops, group shops or shops).<br>Before this fix, we check only if modules are actived with id_shop but not a list of id_shop.<br>That behaviour throw an `The module module_name is inactive.` error.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #29005
| Fixed ticket?     | Fixes #29005
| Related PRs       | 
| Sponsor company   | 
