### PR TITLE
Fix help card in popup instead of full page on create webservice

### DIFF
--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -99,6 +99,7 @@ class WebserviceController extends FrameworkBundleAdminController
             [
                 'webserviceKeyForm' => $form->createView(),
                 'layoutTitle' => $this->trans('New webservice key', 'Admin.Navigation.Menu'),
+                'enableSidebar' => true,
             ]
         );
     }

--- a/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Configure/AdvancedParameters/WebserviceController.php
@@ -100,6 +100,7 @@ class WebserviceController extends FrameworkBundleAdminController
                 'webserviceKeyForm' => $form->createView(),
                 'layoutTitle' => $this->trans('New webservice key', 'Admin.Navigation.Menu'),
                 'enableSidebar' => true,
+                'help_link' => $this->generateSidebarLink('AdminWebservice'),
             ]
         );
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | The Help button on the create webservice page of the BO was redirecting to a different page. This PR makes this button open a modal with the help page content as it is done on the rest of the BO.
| Type?             | bug fix 
| Category?         | BO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to BO > Advanced Parameters > WebService,  Clic on "Add new webservice key", Clic on Help button
| Fixed ticket?     | Fixes #31943
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).


## DETAILS : 
~~The content of the popup is a bit unusual because a screenshot is present in this help card. The doc from which the help card is filled is not part of the codebase. I'll inform on the side the person managing the doc to see if it's possible to make this part responsive.~~