### PR TITLE
Fix WS error: add product with empty unit-price

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -884,10 +884,10 @@ class ProductCore extends ObjectModel
     protected function fillUnitRatio(bool $ecotaxEnabled): void
     {
         // Update instance field
-        $unitPrice = new DecimalNumber((string) ($this->unit_price ?? 0));
-        $price = new DecimalNumber((string) ($this->price ?? 0));
+        $unitPrice = new DecimalNumber((string) ($this->unit_price ?: 0));
+        $price = new DecimalNumber((string) ($this->price ?: 0));
         if ($ecotaxEnabled) {
-            $price = $price->plus(new DecimalNumber((string) ($this->ecotax ?? 0)));
+            $price = $price->plus(new DecimalNumber((string) ($this->ecotax ?: 0)));
         }
         if ($unitPrice->isGreaterThanZero()) {
             $this->unit_price_ratio = (float) (string) $price->dividedBy($unitPrice);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | If we add a new product with WS and set unit-price tag with no value on it, we throw an exception for empty string in a `new DecimalNumber()`. This PR fix simply this error.
| Type?             | bug fix
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #29315
| Fixed ticket?     | Fixes #29315 
| Related PRs       |
| Sponsor company   |

FYI, with `?:` instead of `??` and for each PHP version supported by PrestaShop: 
```php
<?php
var_export (false ?? 'value2');   // false
var_export (true  ?? 'value2');   // true
var_export (null  ?? 'value2');   // value2
var_export (''    ?? 'value2');   // ""
var_export (0     ?? 'value2');   // 0

var_export (false ?: 'value2');   // value2
var_export (true  ?: 'value2');   // true
var_export (null  ?: 'value2');   // value2
var_export (''    ?: 'value2');   // value2
var_export (0     ?: 'value2');   // value2
```