### PR TITLE
Merchandise return pdf printing

### DIFF
--- a/controllers/admin/AdminStatusesController.php
+++ b/controllers/admin/AdminStatusesController.php
@@ -24,6 +24,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\OrderReturnSettings;
+
 /**
  * @property OrderState $object
  */
@@ -242,7 +244,16 @@ class AdminStatusesControllerCore extends AdminController
         //init and render the second list
         $this->list_skip_actions = [];
         $this->_filter = false;
-        $this->addRowActionSkipList('delete', [1, 2, 3, 4, 5]);
+        $this->addRowActionSkipList(
+            'delete',
+            [
+                OrderReturnSettings::ORDER_RETURN_STATE_WAITING_FOR_CONFIRMATION,
+                OrderReturnSettings::ORDER_RETURN_STATE_WAITING_FOR_PACKAGE_ID,
+                OrderReturnSettings::ORDER_RETURN_STATE_PACKAGE_RECEIVED,
+                OrderReturnSettings::ORDER_RETURN_STATE_RETURN_DENIED,
+                OrderReturnSettings::ORDER_RETURN_STATE_RETURN_COMPLETED,
+            ]
+        );
         $this->initOrdersReturnsList();
         $this->checkFilterForOrdersReturnsList();
 

--- a/controllers/front/OrderReturnController.php
+++ b/controllers/front/OrderReturnController.php
@@ -26,6 +26,7 @@
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderReturnLazyArray;
 use PrestaShop\PrestaShop\Adapter\Presenter\Order\OrderReturnPresenter;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\OrderReturnSettings;
 
 class OrderReturnControllerCore extends FrontController
 {
@@ -57,7 +58,7 @@ class OrderReturnControllerCore extends FrontController
             if (Validate::isLoadedObject($order_return) && $order_return->id_customer == $this->context->cookie->id_customer) {
                 $order = new Order((int) ($order_return->id_order));
                 if (Validate::isLoadedObject($order)) {
-                    if ($order_return->state == 1) {
+                    if ($order_return->state == OrderReturnSettings::ORDER_RETURN_STATE_WAITING_FOR_CONFIRMATION) {
                         $this->warning[] = $this->trans('You must wait for confirmation before returning any merchandise.', [], 'Shop.Notifications.Warning');
                     }
 

--- a/controllers/front/PdfOrderReturnController.php
+++ b/controllers/front/PdfOrderReturnController.php
@@ -1,4 +1,7 @@
 <?php
+
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\OrderReturnSettings;
+
 /**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
@@ -53,7 +56,7 @@ class PdfOrderReturnControllerCore extends FrontController
             die($this->trans('Order return not found.', [], 'Shop.Notifications.Error'));
         } elseif (!$from_admin && $this->orderReturn->id_customer != $this->context->customer->id) {
             die($this->trans('Order return not found.', [], 'Shop.Notifications.Error'));
-        } elseif ($this->orderReturn->state < 2) {
+        } elseif ($this->orderReturn->state < OrderReturnSettings::ORDER_RETURN_STATE_WAITING_FOR_PACKAGE_ID) {
             die($this->trans('Order return not confirmed.', [], 'Shop.Notifications.Error'));
         }
     }

--- a/src/Adapter/PDF/OrderReturnPdfGenerator.php
+++ b/src/Adapter/PDF/OrderReturnPdfGenerator.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\PrestaShop\Adapter\PDF;
+
+use Context;
+use PDF;
+use PrestaShop\PrestaShop\Adapter\OrderReturn\Repository\OrderReturnRepository;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\OrderReturnSettings;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\ValueObject\OrderReturnId;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
+use PrestaShop\PrestaShop\Core\PDF\PDFGeneratorInterface;
+use RuntimeException;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Validate;
+
+/**
+ * Generates invoice for given order.
+ */
+final class OrderReturnPdfGenerator implements PDFGeneratorInterface
+{
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * @var OrderReturnRepository
+     */
+    private $orderReturnRepository;
+
+    /**
+     * @param TranslatorInterface $translator
+     * @param OrderReturnRepository $orderReturnRepository
+     */
+    public function __construct(TranslatorInterface $translator, OrderReturnRepository $orderReturnRepository)
+    {
+        $this->translator = $translator;
+        $this->orderReturnRepository = $orderReturnRepository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function generatePDF(array $orderReturnId)
+    {
+        if (count($orderReturnId) !== 1) {
+            throw new CoreException(sprintf('"%s" supports generating order return for single order only.', get_class($this)));
+        }
+
+        $orderReturnId = reset($orderReturnId);
+        $orderReturn = $this->orderReturnRepository->get(new OrderReturnId((int) $orderReturnId));
+        if (!Validate::isLoadedObject($orderReturn)) {
+            throw new RuntimeException($this->translator->trans('The order return cannot be found within your database.', [], 'Admin.Orderscustomers.Notification'));
+        }
+
+        if ($orderReturn->state < OrderReturnSettings::ORDER_RETURN_STATE_WAITING_FOR_PACKAGE_ID) {
+            throw new RuntimeException($this->translator->trans('The order return was not confirmed.', [], 'Admin.Orderscustomers.Notification'));
+        }
+
+        $pdf = new PDF($orderReturn, PDF::TEMPLATE_ORDER_RETURN, Context::getContext()->smarty);
+
+        return $pdf->render();
+    }
+}

--- a/src/Core/Domain/OrderReturn/OrderReturnSettings.php
+++ b/src/Core/Domain/OrderReturn/OrderReturnSettings.php
@@ -1,4 +1,5 @@
-{#**
+<?php
+/**
  * Copyright since 2007 PrestaShop SA and Contributors
  * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
  *
@@ -21,31 +22,13 @@
  * @author    PrestaShop SA and Contributors <contact@prestashop.com>
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
- *#}
+ */
 
-{% form_theme orderReturnForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+declare(strict_types=1);
 
-{{ form_start(orderReturnForm) }}
-<div class="card">
-  <h3 class="card-header">
-    <i class="material-icons">person</i>
-    {{ 'Merchandise returns'|trans({}, 'Admin.Orderscustomers.Feature') }}
-  </h3>
+namespace PrestaShop\PrestaShop\Core\Domain\OrderReturn;
 
-  <div class="card-body">
-    <div class="form-wrapper">
-      {{ form_widget(orderReturnForm) }}
-    </div>
-  </div>
-
-  <div class="card-footer">
-    <a href="{{ path('admin_merchandise_returns_index') }}" class="btn btn-outline-secondary">
-      {{ 'Cancel'|trans({}, 'Admin.Actions') }}
-    </a>
-
-    <button class="btn btn-primary float-right">
-      {{ 'Save'|trans({}, 'Admin.Actions') }}
-    </button>
-  </div>
-</div>
-{{ form_end(orderReturnForm) }}
+class OrderReturnSettings
+{
+    public const ORDER_RETURN_STATE_WAITING_FOR_PACKAGE_ID = 2;
+}

--- a/src/Core/Domain/OrderReturn/OrderReturnSettings.php
+++ b/src/Core/Domain/OrderReturn/OrderReturnSettings.php
@@ -30,5 +30,15 @@ namespace PrestaShop\PrestaShop\Core\Domain\OrderReturn;
 
 class OrderReturnSettings
 {
+    /**
+     * Order return status ID's are hardcoded here because they are also hardcoded during the installation.
+     * In Legacy plain ID's where used, they should all be replaced with constants here.
+     * In case new Order Return status is added as part of update to the project then it should be saved in configuration table.
+     * In that case this part should be refactored so ID's here also stored in configuration table for consistency.
+     */
+    public const ORDER_RETURN_STATE_WAITING_FOR_CONFIRMATION = 1;
     public const ORDER_RETURN_STATE_WAITING_FOR_PACKAGE_ID = 2;
+    public const ORDER_RETURN_STATE_PACKAGE_RECEIVED = 3;
+    public const ORDER_RETURN_STATE_RETURN_DENIED = 4;
+    public const ORDER_RETURN_STATE_RETURN_COMPLETED = 5;
 }

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -130,6 +130,7 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
         }
         $allowPrintingOrderReturnPdf =
             $editableOrderReturn->getOrderReturnStateId() === OrderReturnSettings::ORDER_RETURN_STATE_WAITING_FOR_PACKAGE_ID;
+
         return $this->render('@PrestaShop/Admin/Sell/CustomerService/MerchandiseReturn/edit.html.twig', [
             'allowPrintingOrderReturnPdf' => $allowPrintingOrderReturnPdf,
             'editableOrderReturn' => $editableOrderReturn,

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -108,11 +108,6 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
         $formHandler = $this->get('prestashop.core.form.identifiable_object.handler.order_return_form_handler');
 
         try {
-            $editableOrderReturn = $this->getQueryBus()->handle(
-                new GetOrderReturnForEditing(
-                    $orderReturnId
-                )
-            );
             $form = $formBuilder->getFormFor($orderReturnId);
             $form->handleRequest($request);
 
@@ -128,12 +123,14 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
 
             return $this->redirectToRoute('admin_merchandise_returns_index');
         }
+        $orderStateId = (int) $form->getData()['order_return_state'];
+
         $allowPrintingOrderReturnPdf =
-            $editableOrderReturn->getOrderReturnStateId() === OrderReturnSettings::ORDER_RETURN_STATE_WAITING_FOR_PACKAGE_ID;
+            $orderStateId === OrderReturnSettings::ORDER_RETURN_STATE_WAITING_FOR_PACKAGE_ID;
 
         return $this->render('@PrestaShop/Admin/Sell/CustomerService/MerchandiseReturn/edit.html.twig', [
             'allowPrintingOrderReturnPdf' => $allowPrintingOrderReturnPdf,
-            'editableOrderReturn' => $editableOrderReturn,
+            'orderReturnId' => $orderReturnId,
             'orderReturnForm' => $form->createView(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'enableSidebar' => true,

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -33,7 +33,6 @@ use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnNotFoundE
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnOrderStateConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\UpdateOrderReturnException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\OrderReturnSettings;
-use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Query\GetOrderReturnForEditing;
 use PrestaShop\PrestaShop\Core\Form\FormHandlerInterface;
 use PrestaShop\PrestaShop\Core\Search\Filters\MerchandiseReturnFilters;
 use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;

--- a/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
+++ b/src/PrestaShopBundle/Controller/Admin/Sell/CustomerService/MerchandiseReturnController.php
@@ -130,14 +130,17 @@ class MerchandiseReturnController extends FrameworkBundleAdminController
         }
         $allowPrintingOrderReturnPdf =
             $editableOrderReturn->getOrderReturnStateId() === OrderReturnSettings::ORDER_RETURN_STATE_WAITING_FOR_PACKAGE_ID;
-
         return $this->render('@PrestaShop/Admin/Sell/CustomerService/MerchandiseReturn/edit.html.twig', [
             'allowPrintingOrderReturnPdf' => $allowPrintingOrderReturnPdf,
             'editableOrderReturn' => $editableOrderReturn,
             'orderReturnForm' => $form->createView(),
             'help_link' => $this->generateSidebarLink($request->attributes->get('_legacy_controller')),
             'enableSidebar' => true,
-            'layoutTitle' => $this->trans('Return merchandise authorization (RMA)', 'Admin.Navigation.Menu'),
+            'layoutTitle' => $this->trans(
+                'Editing merchandise return %orderReturnId%',
+                'Admin.Navigation.Menu',
+                ['%orderReturnId%' => $orderReturnId]
+            ),
         ]);
     }
 

--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/merchandise_return.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/customer_service/merchandise_return.yml
@@ -48,3 +48,13 @@ admin_order_returns_update:
       id_order_return: orderReturnId
   requirements:
     orderReturnId: \d+
+
+admin_order_returns_generate_pdf:
+  path: /{orderReturnId}/generate-order-return-pdf
+  methods: [ GET ]
+  defaults:
+    _controller: PrestaShopBundle:Admin/Sell/CustomerService/MerchandiseReturn:generateOrderReturnPdf
+    _legacy_controller: AdminReturn
+    _legacy_feature_flag: order_return
+  requirements:
+    orderReturnId: \d+

--- a/src/PrestaShopBundle/Resources/config/services/adapter/order_return.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/order_return.yml
@@ -1,6 +1,7 @@
 services:
   _defaults:
-    public: true
+    public: false
+    autowire: true
 
   prestashop.adapter.order_return.query_handler.get_order_return_for_editing_handler:
     class: 'PrestaShop\PrestaShop\Adapter\OrderReturn\QueryHandler\GetOrderReturnForEditingHandler'
@@ -21,10 +22,14 @@ services:
       - '@prestashop.adapter.order_return.repository.order_return_repository'
       - '@prestashop.adapter.order_return_state.repository.order_return_state_repository'
 
+  PrestaShop\PrestaShop\Adapter\OrderReturn\Validator\OrderReturnValidator:
+
+  PrestaShop\PrestaShop\Adapter\OrderReturn\Repository\OrderReturnRepository:
+
   prestashop.adapter.order_return.repository.order_return_repository:
-    class: 'PrestaShop\PrestaShop\Adapter\OrderReturn\Repository\OrderReturnRepository'
-    arguments:
-      [ '@prestashop.adapter.order_return.validator.order_return_validator' ]
+    alias: PrestaShop\PrestaShop\Adapter\OrderReturn\Repository\OrderReturnRepository
+    deprecated: ~
 
   prestashop.adapter.order_return.validator.order_return_validator:
-    class: 'PrestaShop\PrestaShop\Adapter\OrderReturn\Validator\OrderReturnValidator'
+    alias: PrestaShop\PrestaShop\Adapter\OrderReturn\Validator\OrderReturnValidator
+    deprecated: ~

--- a/src/PrestaShopBundle/Resources/config/services/adapter/pdf/generator.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/pdf/generator.yml
@@ -32,3 +32,6 @@ services:
 
   prestashop.adapter.pdf.generator.single_invoice:
     class: PrestaShop\PrestaShop\Adapter\PDF\InvoicePdfGenerator
+
+  PrestaShop\PrestaShop\Adapter\PDF\OrderReturnPdfGenerator:
+    autowire: true

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/form.html.twig
@@ -28,12 +28,13 @@
 {{ form_start(orderReturnForm) }}
 <div class="card">
   <h3 class="card-header">
-    <i class="material-icons">person</i>
-    {{ 'Merchandise returns'|trans({}, 'Admin.Orderscustomers.Feature') }}
+    <i class="material-icons">content-copy</i>
+    {{ 'Return merchandise authorization (RMA)'|trans({}, 'Admin.Orderscustomers.Feature') }}
   </h3>
 
   <div class="card-body">
     <div class="form-wrapper">
+      {{ form_widget(orderReturnForm) }}
       {% if allowPrintingOrderReturnPdf %}
         <div class="form-group row">
           <label class="form-control-label">
@@ -47,7 +48,6 @@
           </div>
         </div>
       {% endif %}
-      {{ form_widget(orderReturnForm) }}
     </div>
   </div>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/form.html.twig
@@ -42,7 +42,7 @@
           </label>
 
           <div class="col-sm form-control-value">
-            <a href="{{ path('admin_order_returns_generate_pdf', {'orderReturnId': editableOrderReturn.orderReturnId }) }}" class="btn btn-outline-secondary">
+            <a href="{{ path('admin_order_returns_generate_pdf', {'orderReturnId': orderReturnId }) }}" class="btn btn-outline-secondary">
               {{ 'Print out'|trans({}, 'Admin.Actions') }}
             </a>
           </div>

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/form.html.twig
@@ -1,0 +1,64 @@
+{#**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ *#}
+
+{% form_theme orderReturnForm '@PrestaShop/Admin/TwigTemplateForm/prestashop_ui_kit.html.twig' %}
+
+{{ form_start(orderReturnForm) }}
+<div class="card">
+  <h3 class="card-header">
+    <i class="material-icons">person</i>
+    {{ 'Merchandise returns'|trans({}, 'Admin.Orderscustomers.Feature') }}
+  </h3>
+
+  <div class="card-body">
+    <div class="form-wrapper">
+      {% if allowPrintingOrderReturnPdf %}
+        <div class="form-group row">
+          <label class="form-control-label">
+            {{ 'Returns form'|trans({}, 'Admin.Orderscustomers.Feature') }}
+          </label>
+
+          <div class="col-sm form-control-value">
+            <a href="{{ path('admin_order_returns_generate_pdf', {'orderReturnId': editableOrderReturn.orderReturnId }) }}" class="btn btn-outline-secondary">
+              {{ 'Print out'|trans({}, 'Admin.Actions') }}
+            </a>
+          </div>
+        </div>
+      {% endif %}
+      {{ form_widget(orderReturnForm) }}
+    </div>
+  </div>
+
+  <div class="card-footer">
+    <a href="{{ path('admin_merchandise_returns_index') }}" class="btn btn-outline-secondary">
+      {{ 'Cancel'|trans({}, 'Admin.Actions') }}
+    </a>
+
+    <button class="btn btn-primary float-right">
+      {{ 'Save'|trans({}, 'Admin.Actions') }}
+    </button>
+  </div>
+</div>
+{{ form_end(orderReturnForm) }}

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/form.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/form.html.twig
@@ -28,7 +28,7 @@
 {{ form_start(orderReturnForm) }}
 <div class="card">
   <h3 class="card-header">
-    <i class="material-icons">content-copy</i>
+    <i class="material-icons">content_paste</i>
     {{ 'Return merchandise authorization (RMA)'|trans({}, 'Admin.Orderscustomers.Feature') }}
   </h3>
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/edit.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Sell/CustomerService/MerchandiseReturn/edit.html.twig
@@ -27,7 +27,7 @@
 {% block content %}
   <div class="row justify-content-center">
     <div class="col">
-      {% include '@PrestaShop/Admin/Sell/CustomerService/OrderReturn/Blocks/form.html.twig' %}
+      {% include '@PrestaShop/Admin/Sell/CustomerService/MerchandiseReturn/Blocks/form.html.twig' %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | This PR adds PDF printing to migrated merchandise return page
| Type?         | refacto
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/PrestaShop/issues/24421
| How to test?  | In migrated merchandise return page you should be able to succesfuly print order return PDF if it's confirmed(Not at status "waiting for confirmation")
