### PR TITLE
Improve cart performance when multiple product combinations

### DIFF
--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -767,7 +767,7 @@ class CartCore extends ObjectModel
         // Reset the cache before the following return, or else an empty cart will add dozens of queries
         $products_ids = [];
         $pa_ids = [];
-        $grouped_quantity = [];
+        $cart_base_product_quantity = [];
         if (is_iterable($products)) {
             foreach ($products as $key => $product) {
                 $products_ids[] = $product['id_product'];
@@ -794,17 +794,18 @@ class CartCore extends ObjectModel
 
                 $products[$key] = array_merge($product, $reduction_type_row);
 
-                if (!isset($grouped_quantity[$product['id_product']])) {
-                    $grouped_quantity[$product['id_product']] = $product['cart_quantity'];
+                if (!isset($cart_base_product_quantity[$product['id_product']])) {
+                    $cart_base_product_quantity[$product['id_product']] = $product['cart_quantity'];
                 } else {
-                    $grouped_quantity[$product['id_product']] += $product['cart_quantity'];
+                    $cart_base_product_quantity[$product['id_product']] += $product['cart_quantity'];
                 }
             }
 
             foreach ($products as &$product) {
-                $product['grouped_quantity'] = isset($grouped_quantity[$product['id_product']]) ? $grouped_quantity[$product['id_product']] : 0;
+                $product['cart_base_product_quantity'] = isset($cart_base_product_quantity[$product['id_product']]) ? $cart_base_product_quantity[$product['id_product']] : 0;
             }
         }
+
         // Thus you can avoid one query per product, because there will be only one query for all the products of the cart
         Product::cacheProductsFeatures($products_ids);
         Cart::cacheSomeAttributesLists($pa_ids, (int) $this->getAssociatedLanguage()->getId());

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -767,6 +767,7 @@ class CartCore extends ObjectModel
         // Reset the cache before the following return, or else an empty cart will add dozens of queries
         $products_ids = [];
         $pa_ids = [];
+        $grouped_quantity = [];
         if (is_iterable($products)) {
             foreach ($products as $key => $product) {
                 $products_ids[] = $product['id_product'];
@@ -792,6 +793,16 @@ class CartCore extends ObjectModel
                 }
 
                 $products[$key] = array_merge($product, $reduction_type_row);
+
+                if (!isset($grouped_quantity[$product['id_product']])) {
+                    $grouped_quantity[$product['id_product']] = $product['cart_quantity'];
+                } else {
+                    $grouped_quantity[$product['id_product']] += $product['cart_quantity'];
+                }
+            }
+
+            foreach ($products as &$product) {
+                $product['grouped_quantity'] = isset($grouped_quantity[$product['id_product']]) ? $grouped_quantity[$product['id_product']] : 0;
             }
         }
         // Thus you can avoid one query per product, because there will be only one query for all the products of the cart

--- a/classes/Cart.php
+++ b/classes/Cart.php
@@ -801,8 +801,10 @@ class CartCore extends ObjectModel
                 }
             }
 
-            foreach ($products as &$product) {
-                $product['cart_base_product_quantity'] = isset($cart_base_product_quantity[$product['id_product']]) ? $cart_base_product_quantity[$product['id_product']] : 0;
+            foreach ($products as $key => $product) {
+                $products[$key]['cart_base_product_quantity'] = isset($cart_base_product_quantity[$product['id_product']])
+                    ? $cart_base_product_quantity[$product['id_product']]
+                    : 0;
             }
         }
 

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -378,6 +378,7 @@ class OrderCore extends ObjectModel
     public function getCartProducts()
     {
         $product_id_list = [];
+        $grouped_quantity = [];
         $products = $this->getProducts();
         foreach ($products as &$product) {
             $product['id_product_attribute'] = $product['product_attribute_id'];
@@ -386,6 +387,12 @@ class OrderCore extends ObjectModel
                 . $product['product_id'] . '_'
                 . $product['product_attribute_id'] . '_'
                 . (isset($product['id_customization']) ? $product['id_customization'] : '0');
+
+            if (!isset($grouped_quantity[$product['id_product']])) {
+                $grouped_quantity[$product['id_product']] = $product['cart_quantity'];
+            } else {
+                $grouped_quantity[$product['id_product']] += $product['cart_quantity'];
+            }
         }
         unset($product);
 
@@ -395,6 +402,8 @@ class OrderCore extends ObjectModel
                 . $product['id_product'] . '_'
                 . (isset($product['id_product_attribute']) ? $product['id_product_attribute'] : '0') . '_'
                 . (isset($product['id_customization']) ? $product['id_customization'] : '0');
+
+            $product['grouped_quantity'] = isset($grouped_quantity[$product['id_product']]) ? $grouped_quantity[$product['id_product']] : 0;
 
             if (in_array($key, $product_id_list)) {
                 $product_list[] = $product;

--- a/classes/order/Order.php
+++ b/classes/order/Order.php
@@ -378,7 +378,7 @@ class OrderCore extends ObjectModel
     public function getCartProducts()
     {
         $product_id_list = [];
-        $grouped_quantity = [];
+        $cart_base_product_quantity = [];
         $products = $this->getProducts();
         foreach ($products as &$product) {
             $product['id_product_attribute'] = $product['product_attribute_id'];
@@ -388,10 +388,10 @@ class OrderCore extends ObjectModel
                 . $product['product_attribute_id'] . '_'
                 . (isset($product['id_customization']) ? $product['id_customization'] : '0');
 
-            if (!isset($grouped_quantity[$product['id_product']])) {
-                $grouped_quantity[$product['id_product']] = $product['cart_quantity'];
+            if (!isset($cart_base_product_quantity[$product['id_product']])) {
+                $cart_base_product_quantity[$product['id_product']] = $product['cart_quantity'];
             } else {
-                $grouped_quantity[$product['id_product']] += $product['cart_quantity'];
+                $cart_base_product_quantity[$product['id_product']] += $product['cart_quantity'];
             }
         }
         unset($product);
@@ -403,7 +403,7 @@ class OrderCore extends ObjectModel
                 . (isset($product['id_product_attribute']) ? $product['id_product_attribute'] : '0') . '_'
                 . (isset($product['id_customization']) ? $product['id_customization'] : '0');
 
-            $product['grouped_quantity'] = isset($grouped_quantity[$product['id_product']]) ? $grouped_quantity[$product['id_product']] : 0;
+            $product['cart_base_product_quantity'] = isset($cart_base_product_quantity[$product['id_product']]) ? $cart_base_product_quantity[$product['id_product']] : 0;
 
             if (in_array($key, $product_id_list)) {
                 $product_list[] = $product;

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -59,11 +59,6 @@ class CartRow
     public const ROUND_MODE_TOTAL = 'total';
 
     /**
-     * static cache key pattern.
-     */
-    public const PRODUCT_PRICE_CACHE_ID_PATTERN = 'Product::getPriceStatic_%d-%d';
-
-    /**
      * @var PriceCalculator adapter to calculate price
      */
     protected $priceCalculator;
@@ -303,6 +298,7 @@ class CartRow
     {
         $productId = (int) $rowData['id_product'];
         $quantity = (int) $rowData['cart_quantity'];
+        $cartQuantity = (int) $rowData['grouped_quantity'];
 
         $addressId = $cart->getProductAddressId();
         if (!$addressId) {
@@ -322,23 +318,6 @@ class CartRow
         }
         if (!$groupId) {
             $groupId = (int) $this->groupDataProvider->getCurrent()->id;
-        }
-
-        $cartQuantity = 0;
-        if ((int) $cart->id) {
-            $cacheId = sprintf(self::PRODUCT_PRICE_CACHE_ID_PATTERN, (int) $productId, (int) $cart->id);
-            if (!$this->cacheAdapter->isStored($cacheId)
-                || ($cartQuantity = $this->cacheAdapter->retrieve($cacheId)
-                                    != (int) $quantity)) {
-                $sql = 'SELECT SUM(`quantity`)
-				FROM `' . _DB_PREFIX_ . 'cart_product`
-				WHERE `id_product` = ' . (int) $productId . '
-				AND `id_cart` = ' . (int) $cart->id;
-                $cartQuantity = (int) $this->databaseAdapter->getValue($sql, _PS_USE_SQL_SLAVE_);
-                $this->cacheAdapter->store($cacheId, (string) $cartQuantity);
-            } else {
-                $cartQuantity = (int) $this->cacheAdapter->retrieve($cacheId);
-            }
         }
 
         // The $null variable below is not used,

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -298,7 +298,7 @@ class CartRow
     {
         $productId = (int) $rowData['id_product'];
         $quantity = (int) $rowData['cart_quantity'];
-        $cartQuantity = (int) $rowData['grouped_quantity'];
+        $cartBaseProductQuantity = (int) $rowData['cart_base_product_quantity'];
 
         $addressId = $cart->getProductAddressId();
         if (!$addressId) {
@@ -367,7 +367,7 @@ class CartRow
                     (int) $cart->id_customer ? (int) $cart->id_customer : null,
                     true,
                     (int) $cart->id,
-                    $cartQuantity,
+                    $cartBaseProductQuantity,
                     (int) $rowData['id_customization']
                 );
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | See below
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| Ui tests              | https://github.com/MattKelvin/ga.tests.ui.pr/actions/runs/17645108578
| How to test?      | See below
| Fixed ticket?     | None
| Related PRs       | None
| Sponsor company   | Mademoiselle bio

**Description**

The issue

When you have different combinations of the same product in cart, the cache doesn't seem to work as expected.

The improvements

Better way to keep the total quantity of a product 

**How to test**

1) Active the profiler. 
2) Choose a product with combinations and add two different one. 
3) Go to your cart and check the profiler. You will see something like "Stopwatch SQL - 300 queries" and a lot of doubles queries `SELECT SUM(`quantity`) FROM `XXXX_cart_product` WHERE `id_product` = XX AND `id_cart` = XX LIMIT XX`. 
3) Now switch to my branch, refresh the page the sql queries should be better (around 250)

Let me know what you think :)