### PR TITLE
Add admin breadcrumb hook

### DIFF
--- a/classes/controller/AdminController.php
+++ b/classes/controller/AdminController.php
@@ -673,6 +673,8 @@ class AdminControllerCore extends Controller
                 break;
         }
 
+        Hook::exec('actionAdminBreadcrumbModifier', ['tabs' => $tabs, 'breadcrumb' => &$breadcrumbs2], null, true);
+
         $this->context->smarty->assign([
             'breadcrumbs2' => $breadcrumbs2,
             'quick_access_current_link_name' => Tools::safeOutput($breadcrumbs2['tab']['name'] . ' - ' . $breadcrumbs2['action']['name']),

--- a/install-dev/data/xml/hook.xml
+++ b/install-dev/data/xml/hook.xml
@@ -4499,5 +4499,10 @@
       <title>Modify back office menu</title>
       <description>This hook allows modifying back office menu tabs</description>
     </hook>
+    <hook id="actionAdminBreadcrumbModifier">
+      <name>actionAdminBreadcrumbModifier</name>
+      <title>Modify back office breadcrumb</title>
+      <description>This hook allows modifying back office breadcrumb</description>
+    </hook>
   </entities>
 </entity_hook>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Hooks: Allow customizing the admin breadcrumb for user navigation
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | You can test it using ps_qualityassurance module, all the details available below
| Fixed ticket?     | N/A
| Related PRs       | https://github.com/PrestaShop/autoupgrade/pull/580
| Sponsor company   | 

Using the ps_qualityassurance module

Register the `actionAdminBreadcrumbModifier` hook and assign the `breadcrumb` param:

```php
public function hookActionAdminBreadcrumbModifier(array &$params): void
{
    $params['breadcrumb']['container']['name'] = 'HELLO';
}
```

In the back-office, you should see the updated breadcrumb with the HELLO text.