### PR TITLE
Problems with actionValidateCustomerAddressForm hook

### DIFF
--- a/classes/Hook.php
+++ b/classes/Hook.php
@@ -818,7 +818,7 @@ class HookCore extends ObjectModel
                 $hookRegistry->collect();
             }
 
-            return ($array_return) ? [] : false;
+            return ($array_return) ? [] : null;
         }
 
         // Store list of executed hooks on this page

--- a/classes/form/CustomerAddressForm.php
+++ b/classes/form/CustomerAddressForm.php
@@ -134,8 +134,8 @@ class CustomerAddressFormCore extends AbstractForm
             }
         }
 
-        if (($hookReturn = Hook::exec('actionValidateCustomerAddressForm', ['form' => $this])) !== '') {
-            $is_valid &= (bool) $hookReturn;
+        if ($is_valid && Hook::exec('actionValidateCustomerAddressForm', ['form' => $this]) === false) {
+            $is_valid = false;
         }
 
         return $is_valid && parent::validate();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | If the actionValidateCustomerAddressForm hook is disabled or does not exist, this validation is never valid.
| Type?             | bug fix 
| Category?         | FO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | First, disable or delete the hook actionValidateCustomerAddressForm, then try to create or edit an address in the "My Account" section in the front office. Before and after this PR.
| Fixed ticket?     | 
| Related PRs       | 
| Sponsor company   | Kijam López
