### PR TITLE
Optimize StockManager SQL queries for updating Physical and Reserved quantities

### DIFF
--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -103,29 +103,34 @@ class StockManager implements StockInterface
     {
         $this->updateReservedProductQuantity($shopId, $errorState, $cancellationState, $idProduct, $idOrder);
 
-        $updatePhysicalQuantityQuery = 'UPDATE {table_prefix}stock_available sa';
+        $updatePhysicalQuantityQuery = '
+            UPDATE {_DB_PREFIX_}stock_available sa
+                JOIN {_DB_PREFIX_}shop s ON sa.id_shop = s.id_shop {ID_SHOP_ASSOCIATION_CLAUSE}
+                JOIN {_DB_PREFIX_}order_detail od ON sa.id_product = od.product_id {ID_PRODUCT_ASSOCIATION_CLAUSE} {ID_ORDER_ASSOCIATION_CLAUSE}
+            SET
+                sa.physical_quantity = sa.quantity + sa.reserved_quantity';
 
-        if ($idOrder) {
-            $updatePhysicalQuantityQuery .= '
-                INNER JOIN (
-                    SELECT product_id
-                    FROM {table_prefix}order_detail
-                    WHERE id_order = ' . (int) $idOrder . '
-                ) od
-                ON sa.id_product = od.product_id
-            ';
+        $updatePhysicalQuantityQuery = str_replace('{_DB_PREFIX_}', _DB_PREFIX_, $updatePhysicalQuantityQuery);
+
+        $id_shop_association_clause = '';
+        if ($shopId) {
+            $id_shop_association_clause = ' AND s.id_shop = ' . $shopId;
         }
+        $updatePhysicalQuantityQuery = str_replace('{ID_SHOP_ASSOCIATION_CLAUSE}', $id_shop_association_clause, $updatePhysicalQuantityQuery);
 
-        $updatePhysicalQuantityQuery .= '
-            SET sa.physical_quantity = sa.quantity + sa.reserved_quantity
-            WHERE sa.id_shop = ' . (int) $shopId . '
-        ';
-
+        $id_product_association_clause = '';
         if ($idProduct) {
-            $updatePhysicalQuantityQuery .= ' AND sa.id_product = ' . (int) $idProduct;
+            $id_product_association_clause = ' AND sa.id_product = ' . $idProduct;
         }
+        $updatePhysicalQuantityQuery = str_replace('{ID_PRODUCT_ASSOCIATION_CLAUSE}', $id_product_association_clause, $updatePhysicalQuantityQuery);
 
-        $updatePhysicalQuantityQuery = str_replace('{table_prefix}', _DB_PREFIX_, $updatePhysicalQuantityQuery);
+        $id_order_association_clause = '';
+        if ($idOrder) {
+            $id_order_association_clause = ' AND od.id_order = ' . $idOrder;
+        }
+        $updatePhysicalQuantityQuery = str_replace('{ID_ORDER_ASSOCIATION_CLAUSE}', $id_order_association_clause, $updatePhysicalQuantityQuery);
+
+        $updatePhysicalQuantityQuery = str_replace('{_DB_PREFIX_}', _DB_PREFIX_, $updatePhysicalQuantityQuery);
 
         return Db::getInstance()->execute($updatePhysicalQuantityQuery);
     }
@@ -168,10 +173,10 @@ class StockManager implements StockInterface
                     WHERE (
                             o.valid = 1
                             OR (
-                        os.id_order_state != :error_state AND
-                        os.id_order_state != :cancellation_state
-                    )
-            )
+                                os.id_order_state != :error_state AND
+                                os.id_order_state != :cancellation_state
+                            )
+                        )
                         AND sa.id_product = od.product_id
                         AND sa.id_product_attribute = od.product_attribute_id
                         {ID_PRODUCT_ASSOCIATION_CLAUSE}

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -111,7 +111,7 @@ class StockManager implements StockInterface
                     SELECT product_id
                     FROM {table_prefix}order_detail
                     WHERE id_order = ' . (int) $idOrder . '
-                ) od 
+                ) od
                 ON sa.id_product = od.product_id
             ';
         }
@@ -141,55 +141,69 @@ class StockManager implements StockInterface
      */
     private function updateReservedProductQuantity($shopId, $errorState, $cancellationState, $idProduct = null, $idOrder = null)
     {
-        $updateReservedQuantityQuery = 'UPDATE {table_prefix}stock_available sa';
-
-        if ($idOrder) {
-            $updateReservedQuantityQuery .= '
-                INNER JOIN (
-                    SELECT product_id
-                    FROM {table_prefix}order_detail
-                    WHERE id_order = :order_id
-                ) od2
-                ON sa.id_product = od2.product_id
-            ';
-        }
-
-        $updateReservedQuantityQuery .= '
+        $updateReservedQuantityQuery = '
+            UPDATE {_DB_PREFIX_}stock_available sa
+                JOIN {_DB_PREFIX_}shop s ON (
+                    s.id_shop = sa.id_shop {ID_SHOP_ASSOCIATION_CLAUSE}
+                )
+                JOIN {_DB_PREFIX_}order_detail od ON (
+                    od.product_id = sa.id_product AND od.product_attribute_id = sa.id_product_attribute {ID_PRODUCT_ASSOCIATION_CLAUSE}
+                )
+                JOIN {_DB_PREFIX_}orders o ON (
+                    o.id_order = od.id_order {ID_ORDER_ASSOCIATION_CLAUSE}
+                )
             SET sa.reserved_quantity = (
-                SELECT SUM(od.product_quantity - od.product_quantity_refunded)
-                FROM {table_prefix}orders o
-                INNER JOIN {table_prefix}order_detail od ON od.id_order = o.id_order
-                INNER JOIN {table_prefix}order_state os ON os.id_order_state = o.current_state
-                WHERE o.id_shop = :shop_id AND
-                os.shipped != 1 AND (
-                    o.valid = 1 OR (
+                    SELECT
+                        SUM(
+                            od.product_quantity - od.product_quantity_refunded
+                        )
+                    FROM {_DB_PREFIX_}orders o
+                        JOIN {_DB_PREFIX_}shop s ON s.id_shop = o.id_shop {ID_SHOP_ASSOCIATION_CLAUSE}
+                        JOIN {_DB_PREFIX_}order_detail od ON (
+                            od.id_order = o.id_order {ID_ORDER_ASSOCIATION_CLAUSE}
+                        )
+                        JOIN {_DB_PREFIX_}order_state os ON (
+                            os.id_order_state = o.current_state AND os.shipped != 1
+                        )
+                    WHERE (
+                            o.valid = 1
+                            OR (
                         os.id_order_state != :error_state AND
                         os.id_order_state != :cancellation_state
                     )
-                ) AND sa.id_product = od.product_id AND
-                sa.id_product_attribute = od.product_attribute_id
-                GROUP BY od.product_id, od.product_attribute_id
             )
-            WHERE sa.id_shop = :shop_id
+                        AND sa.id_product = od.product_id
+                        AND sa.id_product_attribute = od.product_attribute_id
+                        {ID_PRODUCT_ASSOCIATION_CLAUSE}
+                    GROUP BY
+                        od.product_id,
+                        od.product_attribute_id
+                )
         ';
 
-        $strParams = [
-            '{table_prefix}' => _DB_PREFIX_,
-            ':shop_id' => (int) $shopId,
-            ':error_state' => (int) $errorState,
-            ':cancellation_state' => (int) $cancellationState,
-        ];
+        $updateReservedQuantityQuery = str_replace('{_DB_PREFIX_}', _DB_PREFIX_, $updateReservedQuantityQuery);
 
+        $id_shop_association_clause = '';
+        if ($shopId) {
+            $id_shop_association_clause = ' AND s.id_shop = ' . $shopId;
+        }
+        $updateReservedQuantityQuery = str_replace('{ID_SHOP_ASSOCIATION_CLAUSE}', $id_shop_association_clause, $updateReservedQuantityQuery);
+
+        $id_product_association_clause = '';
         if ($idProduct) {
-            $updateReservedQuantityQuery .= ' AND sa.id_product = :product_id';
-            $strParams[':product_id'] = (int) $idProduct;
+            $id_product_association_clause = ' AND sa.id_product = ' . $idProduct;
         }
+        $updateReservedQuantityQuery = str_replace('{ID_PRODUCT_ASSOCIATION_CLAUSE}', $id_product_association_clause, $updateReservedQuantityQuery);
 
+        $id_order_association_clause = '';
         if ($idOrder) {
-            $strParams[':order_id'] = (int) $idOrder;
+            $id_order_association_clause = ' AND od.id_order = ' . $idOrder;
         }
+        $updateReservedQuantityQuery = str_replace('{ID_ORDER_ASSOCIATION_CLAUSE}', $id_order_association_clause, $updateReservedQuantityQuery);
 
-        $updateReservedQuantityQuery = strtr($updateReservedQuantityQuery, $strParams);
+        $updateReservedQuantityQuery = str_replace(':error_state', $errorState, $updateReservedQuantityQuery);
+
+        $updateReservedQuantityQuery = str_replace(':cancellation_state', $cancellationState, $updateReservedQuantityQuery);
 
         return Db::getInstance()->execute($updateReservedQuantityQuery);
     }

--- a/src/Adapter/StockManager.php
+++ b/src/Adapter/StockManager.php
@@ -206,9 +206,9 @@ class StockManager implements StockInterface
         }
         $updateReservedQuantityQuery = str_replace('{ID_ORDER_ASSOCIATION_CLAUSE}', $id_order_association_clause, $updateReservedQuantityQuery);
 
-        $updateReservedQuantityQuery = str_replace(':error_state', $errorState, $updateReservedQuantityQuery);
+        $updateReservedQuantityQuery = str_replace(':error_state', (string) $errorState, $updateReservedQuantityQuery);
 
-        $updateReservedQuantityQuery = str_replace(':cancellation_state', $cancellationState, $updateReservedQuantityQuery);
+        $updateReservedQuantityQuery = str_replace(':cancellation_state', (string) $cancellationState, $updateReservedQuantityQuery);
 
         return Db::getInstance()->execute($updateReservedQuantityQuery);
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | I have been facing a bad performance on PaymentModule::validateOrder and after some research I found out that the issue is with bad queries.
| Type?             | improvement 
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Described after this table
| Fixed ticket?     | Fixes #14703 
| Related PRs       | Not found
| Sponsor company   | Your company or customer's name goes here (if applicable).

### How to test?

1. Make a huge shop (+ 120k products and many combinations)
2. Log the time before and after calling `$StockManager->updatePhysicalProductQuantity()` in these files:
3. `classes/PaymentModule.php`
4. `classes/order/OrderHistory.php`
5. Log the time before and after calling `$StockManager->updateReservedProductQuantity()` in this file:
6. `src/Adapter/StockManager.php`


This is just a copy of this #31065 https://github.com/PrestaShop/PrestaShop/pull/31065
I made a mistake and I had to add it again