### PR TITLE
Update CheckoutAddressesStep.php

### DIFF
--- a/classes/checkout/CheckoutAddressesStep.php
+++ b/classes/checkout/CheckoutAddressesStep.php
@@ -108,7 +108,7 @@ class CheckoutAddressesStepCore extends AbstractCheckoutStep
                 $id_address = $this->addressForm->getAddress()->id;
                 if ($requestParams['saveAddress'] === 'delivery') {
                     $this->getCheckoutSession()->setIdAddressDelivery($id_address);
-                    $idAddressInvoice = $this->use_same_address ? $id_address : null;
+                    $idAddressInvoice = $this->use_same_address ? $id_address : $this->getCheckoutSession()->getIdAddressInvoice();
                     $this->getCheckoutSession()->setIdAddressInvoice($idAddressInvoice);
                 } else {
                     $this->getCheckoutSession()->setIdAddressInvoice($id_address);


### PR DESCRIPTION
Fix: If edit and save delivery address, invoice address is null

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop / 8.1.x / 8.0.x / 1.7.8.x
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | bug fix / improvement / new feature / refacto
| Category?         | FO / BO / CO / IN / WS / TE / LO / ME / PM
| BC breaks?        | yes / no
| Deprecations?     | yes / no
| How to test?      | Indicate how to verify that this change works as expected.
| Fixed ticket?     | Fixes #{issue number here}, Fixes #{another issue number here}
| Related PRs       | If theme, autoupgrade or other module change is needed to make this change work, provide a link to related PRs here.
| Sponsor company   | Your company or customer's name goes here (if applicable).
