### PR TITLE
Consider cart rule allow list as a block list

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/conditions.tpl
@@ -256,7 +256,7 @@
 				<table  class="table">
 					<tr>
 						<td>
-							<p>{l s='Uncombinable cart rules' d='Admin.Catalog.Feature'}</p>
+							<p>{l s='Allow List' d='Admin.Catalog.Feature'}</p>
 							<input id="cart_rule_select_1_filter" autocomplete="off" class="form-control uncombinable_search_filter" type="text" name="uncombinable_filter" placeholder="{l s='Search' d='Admin.Actions'}" value="">
 							<select id="cart_rule_select_1" class="jscroll" multiple="">
 							</select>
@@ -264,7 +264,7 @@
 							<a id="cart_rule_select_add" class="btn btn-default btn-block clearfix">{l s='Add' d='Admin.Actions'} <i class="icon-arrow-right"></i></a>
 						</td>
 						<td>
-							<p>{l s='Combinable cart rules' d='Admin.Catalog.Feature'}</p>
+							<p>{l s='Block List' d='Admin.Catalog.Feature'}</p>
 							<input id="cart_rule_select_2_filter" autocomplete="off" class="form-control combinable_search_filter" type="text" name="combinable_filter" placeholder="{l s='Search' d='Admin.Actions'}" value="">
 							<select name="cart_rule_select[]" class="jscroll" id="cart_rule_select_2" multiple>
 							</select>

--- a/classes/CartRule.php
+++ b/classes/CartRule.php
@@ -77,7 +77,7 @@ class CartRuleCore extends ObjectModel
     /** @var bool */
     public $group_restriction;
     /** @var bool */
-    public $cart_rule_restriction;
+    public $cart_rule_restriction = 1;
     /** @var bool */
     public $product_restriction;
     /** @var bool */
@@ -155,6 +155,12 @@ class CartRuleCore extends ObjectModel
             ],
         ],
     ];
+
+    public function __construct($id = null, $id_lang = null, $id_shop = null)
+    {
+        parent::__construct($id, $id_lang, $id_shop);
+        $this->cart_rule_restriction = 1;
+    }
 
     public static function resetStaticCache()
     {
@@ -896,7 +902,7 @@ class CartRuleCore extends ObjectModel
                 }
 
                 if ($this->cart_rule_restriction && $otherCartRule['cart_rule_restriction'] && $otherCartRule['id_cart_rule'] != $this->id) {
-                    $combinable = Db::getInstance()->getValue('
+                    $combinable = !Db::getInstance()->getValue('
 					SELECT id_cart_rule_1
 					FROM ' . _DB_PREFIX_ . 'cart_rule_combination
 					WHERE (id_cart_rule_1 = ' . (int) $this->id . ' AND id_cart_rule_2 = ' . (int) $otherCartRule['id_cart_rule'] . ')
@@ -1525,8 +1531,7 @@ class CartRuleCore extends ObjectModel
 		LEFT JOIN ' . _DB_PREFIX_ . 'cart_rule_lang crl ON (cr.id_cart_rule = crl.id_cart_rule AND crl.id_lang = ' . (int) Context::getContext()->language->id . ')
 		WHERE cr.id_cart_rule != ' . (int) $this->id . ($search ? ' AND crl.name LIKE "%' . pSQL($search) . '%"' : '') . '
 		AND (
-			cr.cart_rule_restriction = 0
-			OR EXISTS (
+			EXISTS (
 				SELECT 1
 				FROM ' . _DB_PREFIX_ . 'cart_rule_combination
 				WHERE cr.id_cart_rule = ' . _DB_PREFIX_ . 'cart_rule_combination.id_cart_rule_1 AND ' . (int) $this->id . ' = id_cart_rule_2
@@ -1544,8 +1549,8 @@ class CartRuleCore extends ObjectModel
 		INNER JOIN ' . _DB_PREFIX_ . 'cart_rule_lang crl ON (cr.id_cart_rule = crl.id_cart_rule AND crl.id_lang = ' . (int) Context::getContext()->language->id . ')
 		LEFT JOIN ' . _DB_PREFIX_ . 'cart_rule_combination crc1 ON (cr.id_cart_rule = crc1.id_cart_rule_1 AND crc1.id_cart_rule_2 = ' . (int) $this->id . ')
 		LEFT JOIN ' . _DB_PREFIX_ . 'cart_rule_combination crc2 ON (cr.id_cart_rule = crc2.id_cart_rule_2 AND crc2.id_cart_rule_1 = ' . (int) $this->id . ')
-		WHERE cr.cart_rule_restriction = 1
-		AND cr.id_cart_rule != ' . (int) $this->id . ($search ? ' AND crl.name LIKE "%' . pSQL($search) . '%"' : '') . '
+		WHERE
+		cr.id_cart_rule != ' . (int) $this->id . ($search ? ' AND crl.name LIKE "%' . pSQL($search) . '%"' : '') . '
 		AND crc1.id_cart_rule_1 IS NULL
 		AND crc2.id_cart_rule_1 IS NULL  ORDER BY cr.id_cart_rule' . $sql_limit);
 
@@ -1613,6 +1618,10 @@ class CartRuleCore extends ObjectModel
                 (in_array($type, ['carrier', 'shop']) ? ' ORDER BY t.name ASC ' : '') .
                 (in_array($type, ['country', 'group', 'cart_rule']) && $i18n ? ' ORDER BY tl.name ASC ' : '') .
                 $sql_limit);
+            if ($type == 'cart_rule') {
+                $array['unselected'] = $array['selected'];
+                $array['selected'] = [];
+            }
         } else {
             if ($type == 'cart_rule') {
                 $array = $this->getCartRuleCombinations($offset, $limit, $search_cart_rule_name);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Fix the cart rule compatibility issues by considering that `ps_cart_rule_combination` now wants to hold uncombinable cart rules.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | yes (kind of, for the reason that merchants need to empty the table and add uncombinable items to block list)
| Deprecations?     | no
| How to test?      | just try to add new cart rules, and try to add other cart rules to block list and allow list. Meanwhile watch the `ps_cart_rule_combination` table to verify that only blocked items are added and combinable cart rules are not added to this table.
| Fixed ticket?     | Fixes #19935 
| Related PRs       | I did not found any
| Sponsor company   | Beisat.com
