### PR TITLE
Fix issue 32097 Rounding error in Round on each line mode

### DIFF
--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -277,15 +277,15 @@ class CartRow
         $quantity = (int) $rowData['cart_quantity'];
         $this->initialUnitPrice = $this->getProductPrice($cart, $rowData);
 
+        $tools = new Tools();
+
         // store not rounded values, except in round_mode_item, we still need to round individual items
         if ($this->roundType == self::ROUND_MODE_ITEM) {
-            $tools = new Tools();
             $this->initialTotalPrice = new AmountImmutable(
                 $tools->round($this->initialUnitPrice->getTaxIncluded(), $this->precision) * $quantity,
                 $tools->round($this->initialUnitPrice->getTaxExcluded(), $this->precision) * $quantity
             );
         } elseif ($this->roundType == self::ROUND_MODE_LINE) {
-            $tools = new Tools();
             $this->initialTotalPrice = new AmountImmutable(
                 $tools->round($this->initialUnitPrice->getTaxIncluded() * $quantity, $this->precision),
                 $tools->round($this->initialUnitPrice->getTaxExcluded() * $quantity, $this->precision)

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -284,6 +284,12 @@ class CartRow
                 $tools->round($this->initialUnitPrice->getTaxIncluded(), $this->precision) * $quantity,
                 $tools->round($this->initialUnitPrice->getTaxExcluded(), $this->precision) * $quantity
             );
+        } else if ($this->roundType == self::ROUND_MODE_LINE) {
+            $tools = new Tools();
+            $this->initialTotalPrice = new AmountImmutable(
+                $tools->round($this->initialUnitPrice->getTaxIncluded() * $quantity, $this->precision),
+                $tools->round($this->initialUnitPrice->getTaxExcluded() * $quantity, $this->precision)
+            );
         } else {
             $this->initialTotalPrice = new AmountImmutable(
                 $this->initialUnitPrice->getTaxIncluded() * $quantity,

--- a/src/Core/Cart/CartRow.php
+++ b/src/Core/Cart/CartRow.php
@@ -284,7 +284,7 @@ class CartRow
                 $tools->round($this->initialUnitPrice->getTaxIncluded(), $this->precision) * $quantity,
                 $tools->round($this->initialUnitPrice->getTaxExcluded(), $this->precision) * $quantity
             );
-        } else if ($this->roundType == self::ROUND_MODE_LINE) {
+        } elseif ($this->roundType == self::ROUND_MODE_LINE) {
             $tools = new Tools();
             $this->initialTotalPrice = new AmountImmutable(
                 $tools->round($this->initialUnitPrice->getTaxIncluded() * $quantity, $this->precision),


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | There is an annoying rounding error in "Round on each line" mode, fixed forgotten rounding in calcs
| Type?             | bug fix 
| Category?         | CO 
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See **How to reproduce** section of issue #32097
| Fixed ticket?     | Fixes issue #32097
| Related PRs       | -
| Sponsor company   | -
