### PR TITLE
SymfonyCacheClearer service can clear multiple environments

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3324,7 +3324,7 @@ exit;
     /**
      * Clear Symfony cache.
      *
-     * @param string $env
+     * @param string|null $env
      */
     public static function clearSf2Cache($env = null)
     {
@@ -3332,6 +3332,8 @@ exit;
         // it should not be used anymore and will be removed. Until then, it fallbacks on the proper SymfonyCacheClearer service
         $container = SymfonyContainer::getInstance();
         if (null === $container) {
+            static::removeSymfonyCache($env);
+
             return;
         }
 
@@ -3352,6 +3354,21 @@ exit;
         if ($symfonyCacheClearer) {
             $symfonyCacheClearer->clear();
         }
+    }
+
+    public static function removeSymfonyCache(?string $env = null): void
+    {
+        if (null === $env) {
+            $env = _PS_ENV_;
+        }
+
+        $dir = _PS_ROOT_DIR_ . '/var/cache/' . $env . '/';
+
+        register_shutdown_function(function () use ($dir) {
+            $fs = new Filesystem();
+            $fs->remove($dir);
+            Hook::exec('actionClearSf2Cache');
+        });
     }
 
     /**

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3335,8 +3335,20 @@ exit;
             return;
         }
 
+        switch ($env) {
+            case 'prod':
+                $cacheClearService = 'prestashop.adapter.cache.clearer.symfony_cache_clearer.prod';
+                break;
+            case 'dev':
+                $cacheClearService = 'prestashop.adapter.cache.clearer.symfony_cache_clearer.dev';
+                break;
+            default:
+                $cacheClearService = 'prestashop.adapter.cache.clearer.symfony_cache_clearer';
+                break;
+        }
+
         /** @var CacheClearerInterface|null $symfonyCacheClearer */
-        $symfonyCacheClearer = $container->get('prestashop.adapter.cache.clearer.symfony_cache_clearer');
+        $symfonyCacheClearer = $container->get($cacheClearService);
         if ($symfonyCacheClearer) {
             $symfonyCacheClearer->clear();
         }

--- a/src/PrestaShopBundle/Resources/config/services/adapter/cache.yml
+++ b/src/PrestaShopBundle/Resources/config/services/adapter/cache.yml
@@ -14,5 +14,15 @@ services:
   prestashop.adapter.cache.clearer.symfony_cache_clearer:
     class: 'PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer'
 
+  prestashop.adapter.cache.clearer.symfony_cache_clearer.prod:
+    class: 'PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer'
+    arguments:
+      - 'prod'
+
+  prestashop.adapter.cache.clearer.symfony_cache_clearer.dev:
+    class: 'PrestaShop\PrestaShop\Adapter\Cache\Clearer\SymfonyCacheClearer'
+    arguments:
+      - 'dev'
+
   prestashop.adapter.cache.clearer.xml_cache_clearer:
     class: 'PrestaShop\PrestaShop\Adapter\Cache\Clearer\XmlCacheClearer'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | SymfonyCacheClearer service can now clear a specific environment, this allows clearing prod and dev environment in the same process
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | ~
| Fixed ticket?     | ~
| Related PRs       | ~
| Sponsor company   | ~
