### PR TITLE
Handle fallback in Tools::clearSf2Cache when container is not available

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -3332,6 +3332,8 @@ exit;
         // it should not be used anymore and will be removed. Until then, it fallbacks on the proper SymfonyCacheClearer service
         $container = SymfonyContainer::getInstance();
         if (null === $container) {
+            self::removeSymfonyCache($env);
+
             return;
         }
 
@@ -3340,6 +3342,21 @@ exit;
         if ($symfonyCacheClearer) {
             $symfonyCacheClearer->clear();
         }
+    }
+
+    private static function removeSymfonyCache(?string $env = null): void
+    {
+        if (null === $env) {
+            $env = _PS_ENV_;
+        }
+
+        $dir = _PS_ROOT_DIR_ . '/var/cache/' . $env . '/';
+
+        register_shutdown_function(function () use ($dir) {
+            $fs = new Filesystem();
+            $fs->remove($dir);
+            Hook::exec('actionClearSf2Cache');
+        });
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Handle fallback in Tools::clearSf2Cache when container is not available because in some cases, like during installation, the Symfony container is not available when this method is called This was actually the initial behaviour of this legacy method before https://github.com/PrestaShop/PrestaShop/pull/31820
| Type?             | bug fix
| Category?         | IN
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI green and https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/4667431754 green
| Fixed ticket?     | Fixes #32052 and Fixes #32053 
| Related PRs       | ~
| Sponsor company   | ~