### PR TITLE
Revert bump pdfjs-dist from 3.4.120 to 3.5.141 in /tests/UI

### DIFF
--- a/tests/UI/package-lock.json
+++ b/tests/UI/package-lock.json
@@ -5091,9 +5091,9 @@
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ=="
     },
     "pdfjs-dist": {
-      "version": "3.5.141",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.5.141.tgz",
-      "integrity": "sha512-lYIvyi5grtYOIatsfCifIKwxHeAJ8eHyP22DTdvY4pm0yWVSFQnMafpgCPSw8gaNRDDdcHnBVOkqMsyK8SRxZg==",
+      "version": "3.4.120",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.4.120.tgz",
+      "integrity": "sha512-B1hw9ilLG4m/jNeFA0C2A0PZydjxslP8ylU+I4XM7Bzh/xWETo9EiBV848lh0O0hLut7T6lK1V7cpAXv5BhxWw==",
       "requires": {
         "canvas": "^2.11.0",
         "path2d-polyfill": "^2.0.1",

--- a/tests/UI/package.json
+++ b/tests/UI/package.json
@@ -114,7 +114,7 @@
     "mocha": "^10.2.0",
     "mochawesome": "^7.1.3",
     "module-alias": "^2.2.2",
-    "pdfjs-dist": "^3.5.141",
+    "pdfjs-dist": "^3.4.120",
     "playwright": "^1.32.3"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Revert #32090 : pdfjs-dist is only usable with Node >= 16
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4667994499
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp
