### PR TITLE
Fix resetLanguage for Currencies

### DIFF
--- a/admin-dev/themes/new-theme/js/pages/currency/form/components/CurrencyFormatter.vue
+++ b/admin-dev/themes/new-theme/js/pages/currency/form/components/CurrencyFormatter.vue
@@ -91,6 +91,8 @@
         this.currencyData.symbols[language.id] = language.currencySymbol;
 
         showGrowl('success', this.$t('list.reset.success'));
+
+        EventEmitter.emit(CurrencyFormEventMap.refreshCurrencyApp, this.currencyData);
       },
       applyCustomization(customData) {
         const selectedPattern = this.selectedLanguage.transformations[

--- a/tests/UI/campaigns/cldr/07_editSymbolFormatCurrency.ts
+++ b/tests/UI/campaigns/cldr/07_editSymbolFormatCurrency.ts
@@ -121,27 +121,11 @@ describe('CLDR : Edit symbol / format currency', async () => {
     await expect(exampleFormat).to.endWith(` ${customSymbol}`);
   });
 
-  // @todo : Enable when https://github.com/PrestaShop/PrestaShop/issues/31759 is fixed
-  it.skip('should reset the currency format', async function () {
+  it('should reset the currency format', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'resetCurrencyFormat', baseContext);
 
     const growlMessage = await addCurrencyPage.resetCurrencyFormat(page, 1);
     await expect(growlMessage).to.be.eq(addCurrencyPage.resetCurrencyFormatMessage);
-
-    const exampleFormat = await addCurrencyPage.getTextColumnFromTable(page, 1, 2);
-    await expect(exampleFormat).to.startWith(Currencies.euro.symbol);
-  });
-
-  // @todo : Remove when https://github.com/PrestaShop/PrestaShop/issues/31759 is fixed
-  it(`should update the symbol by ${Currencies.euro.symbol} & the format`, async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'resetCurrencyFormatBypass', baseContext);
-
-    const isModalVisible = await addCurrencyPage.editCurrencyFormat(page, 1);
-    await expect(isModalVisible).to.be.true;
-
-    await addCurrencyPage.setCurrencyFormatSymbol(page, Currencies.euro.symbol);
-    await addCurrencyPage.setCurrencyFormatFormat(page, 'leftWithoutSpace');
-    await addCurrencyPage.saveCurrencyFormat(page);
 
     const exampleFormat = await addCurrencyPage.getTextColumnFromTable(page, 1, 2);
     await expect(exampleFormat).to.startWith(Currencies.euro.symbol);

--- a/tests/UI/campaigns/cldr/08_resetSymbolFormatSettings.ts
+++ b/tests/UI/campaigns/cldr/08_resetSymbolFormatSettings.ts
@@ -139,26 +139,11 @@ describe('CLDR : Reset symbol / format settings', async () => {
     await expect(pageTitle).to.contains(addCurrencyPage.pageTitle);
   });
 
-  // @todo : Enable when https://github.com/PrestaShop/PrestaShop/issues/31759 is fixed
-  it.skip('should reset the currency format', async function () {
+  it('should reset the currency format', async function () {
     await testContext.addContextItem(this, 'testIdentifier', 'resetCurrencyFormat', baseContext);
 
     const growlMessage = await addCurrencyPage.resetCurrencyFormat(page, 1);
     await expect(growlMessage).to.be.eq(addCurrencyPage.resetCurrencyFormatMessage);
-
-    const exampleFormat = await addCurrencyPage.getTextColumnFromTable(page, 1, 2);
-    await expect(exampleFormat).to.startWith(Currencies.euro.symbol);
-  });
-
-  // @todo : Remove when https://github.com/PrestaShop/PrestaShop/issues/31759 is fixed
-  it(`should update the symbol by ${Currencies.euro.symbol}`, async function () {
-    await testContext.addContextItem(this, 'testIdentifier', 'resetCurrencyFormatBypass', baseContext);
-
-    const isModalVisible = await addCurrencyPage.editCurrencyFormat(page, 1);
-    await expect(isModalVisible).to.be.true;
-
-    await addCurrencyPage.setCurrencyFormatSymbol(page, Currencies.euro.symbol);
-    await addCurrencyPage.saveCurrencyFormat(page);
 
     const exampleFormat = await addCurrencyPage.getTextColumnFromTable(page, 1, 2);
     await expect(exampleFormat).to.startWith(Currencies.euro.symbol);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix `resetLanguage` function in `CurrencyFormatter.vue` to refresh properly currency data.
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | See #31759 
| Fixed ticket?     | Fixes #31759 
| Related PRs       | 
| Sponsor company   | 
