### PR TITLE
Don't call Hook::getHookModuleExecList('displayAdminStatsModules') twice

### DIFF
--- a/controllers/admin/AdminStatsTabController.php
+++ b/controllers/admin/AdminStatsTabController.php
@@ -174,12 +174,13 @@ abstract class AdminStatsTabControllerCore extends AdminController
 
     protected function getModules()
     {
-        if (true === is_array(Hook::getHookModuleExecList('displayAdminStatsModules'))) {
+        $moduleList = Hook::getHookModuleExecList('displayAdminStatsModules');
+        if (true === is_array($moduleList)) {
             return array_map(
                 function ($moduleArray) {
                     return ['name' => $moduleArray['module']];
                 },
-                Hook::getHookModuleExecList('displayAdminStatsModules')
+                $moduleList
             );
         }
 


### PR DESCRIPTION
Follow up of #30178, this method is expensive, and there is really no need to call it twice

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Please be specific when describing the PR. <br> Every detail helps: versions, browser/server configuration, specific module/theme, etc. Feel free to add more information below this table.
| Type?             | improvement
| Category?         |  BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | NA
| Related PRs       | #30178