### PR TITLE
Don't attach logo to emails if text only mails is configured

### DIFF
--- a/classes/Mail.php
+++ b/classes/Mail.php
@@ -525,7 +525,7 @@ class MailCore extends ObjectModel
             }
             ShopUrl::cacheMainDomainForShop((int) $idShop);
             /* don't attach the logo as */
-            if (isset($logo)) {
+            if (isset($logo) && $configuration['PS_MAIL_TYPE'] != Mail::TYPE_TEXT) {
                 $templateVars['{shop_logo}'] = $message->embed(\Swift_Image::fromPath($logo));
             }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Don't attach logo to emails if text only mails is configured
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Setup text only mails, send email, expect no logo attachment
| Fixed ticket?     | #19070
| Related PRs       | none
| Sponsor company   | headissue GmbH
