### PR TITLE
Improvement: displaying header toolbar on mobile

### DIFF
--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -71,6 +71,7 @@
     &:not(.toolbar-icons--persistent) {
       @include media-breakpoint-down(sm) {
         display: none;
+
         > .wrapper {
           .btn-help {
             display: none;
@@ -86,6 +87,7 @@
 
       @include media-breakpoint-down(sm) {
         justify-content: flex-start;
+
         #recommended-modules-button {
           display: none;
         }

--- a/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
+++ b/admin-dev/themes/new-theme/scss/components/layout/_header_toolbar.scss
@@ -68,8 +68,15 @@
   }
   // toolbar buttons
   .toolbar-icons {
-    @include media-breakpoint-down(sm) {
-      display: none;
+    &:not(.toolbar-icons--persistent) {
+      @include media-breakpoint-down(sm) {
+        display: none;
+        > .wrapper {
+          .btn-help {
+            display: none;
+          }
+        }
+      }
     }
 
     > .wrapper {
@@ -79,11 +86,7 @@
 
       @include media-breakpoint-down(sm) {
         justify-content: flex-start;
-      }
-
-      @include media-breakpoint-down(sm) {
-        #recommended-modules-button,
-        .btn-help {
+        #recommended-modules-button {
           display: none;
         }
       }

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -19,8 +19,8 @@
         </ol>
       </nav>
     {/block}
-
-    <div class="title-row">
+    {$persistent_help_btn= isset($help_link) and $help_link != false and empty($toolbar_btn)}
+    <div class="title-row {if $persistent_help_btn}flex-nowrap flex-md-wrap{/if}">
       {block name=pageTitle}
           <h1 class="title">
             {if is_array($title)}{$title|end|escape}{else}{$title|escape}{/if}
@@ -28,7 +28,7 @@
       {/block}
 
       {block name=toolbarBox}
-        <div class="toolbar-icons">
+        <div class="toolbar-icons{if $persistent_help_btn} toolbar-icons--persistent{/if}">
           <div class="wrapper">
             {hook h='displayDashboardToolbarTopMenu'}
             {foreach from=$toolbar_btn item=btn key=k}
@@ -123,50 +123,52 @@
     </div>
   {/if}
 
-  <div class="btn-floating">
-    <button class="btn btn-primary collapsed" data-toggle="collapse" data-target=".btn-floating-container" aria-expanded="false">
-      <i class="material-icons">add</i>
-    </button>
-    <div class="btn-floating-container collapse">
-      <div class="btn-floating-menu">
-        {hook h='displayDashboardToolbarTopMenu'}
-        {foreach from=$toolbar_btn item=btn key=k}
-          {if $k != 'back' && $k != 'modules-list'}
-            <a
-              class="btn btn-floating-item {if isset($btn.floating_class) && $btn.floating_class}{$btn.floating_class|escape}{/if} {if isset($btn.target) && $btn.target} _blank{/if} pointer"{if isset($btn.href)}
-              id="page-header-desc-floating-{$table}-{if isset($btn.imgclass)}{$btn.imgclass|escape}{else}{$k}{/if}"
-              href="{$btn.href|escape}"{/if}
-              title="{if isset($btn.help)}{$btn.help}{else}{$btn.desc|escape}{/if}"{if isset($btn.js) && $btn.js}
-              onclick="{$btn.js}"{/if}{if isset($btn.modal_target) && $btn.modal_target}
-              data-target="{$btn.modal_target}"
-              data-toggle="modal"{/if}{if isset($btn.help)}
-              data-toggle="pstooltip"
-              data-placement="bottom"{/if}
-            >
-              {$btn.desc|escape}
-              {if !empty($btn.icon)}<i class="material-icons">{$btn.icon}</i>{/if}
-            </a>
-          {/if}
-        {/foreach}
+  {if not empty($toolbar_btn)}
+    <div class="btn-floating">
+      <button class="btn btn-primary collapsed" data-toggle="collapse" data-target=".btn-floating-container" aria-expanded="false">
+        <i class="material-icons">add</i>
+      </button>
+      <div class="btn-floating-container collapse">
+        <div class="btn-floating-menu">
+          {hook h='displayDashboardToolbarTopMenu'}
+          {foreach from=$toolbar_btn item=btn key=k}
+            {if $k != 'back' && $k != 'modules-list'}
+              <a
+                class="btn btn-floating-item {if isset($btn.floating_class) && $btn.floating_class}{$btn.floating_class|escape}{/if} {if isset($btn.target) && $btn.target} _blank{/if} pointer"{if isset($btn.href)}
+                id="page-header-desc-floating-{$table}-{if isset($btn.imgclass)}{$btn.imgclass|escape}{else}{$k}{/if}"
+                href="{$btn.href|escape}"{/if}
+                title="{if isset($btn.help)}{$btn.help}{else}{$btn.desc|escape}{/if}"{if isset($btn.js) && $btn.js}
+                onclick="{$btn.js}"{/if}{if isset($btn.modal_target) && $btn.modal_target}
+                data-target="{$btn.modal_target}"
+                data-toggle="modal"{/if}{if isset($btn.help)}
+                data-toggle="pstooltip"
+                data-placement="bottom"{/if}
+              >
+                {$btn.desc|escape}
+                {if !empty($btn.icon)}<i class="material-icons">{$btn.icon}</i>{/if}
+              </a>
+            {/if}
+          {/foreach}
 
-        {if isset($help_link) and $help_link != false}
-          {if $enableSidebar}
-            <a class="btn btn-floating-item btn-help btn-sidebar" href="#"
-               title="{l s='Help' d='Admin.Global'}"
-               data-toggle="sidebar"
-               data-target="#right-sidebar"
-               data-url="{$help_link|escape}"
-            >
-              {l s='Help' d='Admin.Global'}
-            </a>
-          {else}
-            <a class="btn btn-floating-item btn-help" href="{$help_link|escape}" title="{l s='Help' d='Admin.Global'}">
-              {l s='Help' d='Admin.Global'}
-            </a>
+          {if isset($help_link) and $help_link != false}
+            {if $enableSidebar}
+              <a class="btn btn-floating-item btn-help btn-sidebar" href="#"
+                 title="{l s='Help' d='Admin.Global'}"
+                 data-toggle="sidebar"
+                 data-target="#right-sidebar"
+                 data-url="{$help_link|escape}"
+              >
+                {l s='Help' d='Admin.Global'}
+              </a>
+            {else}
+              <a class="btn btn-floating-item btn-help" href="{$help_link|escape}" title="{l s='Help' d='Admin.Global'}">
+                {l s='Help' d='Admin.Global'}
+              </a>
+            {/if}
           {/if}
-        {/if}
+        </div>
       </div>
     </div>
-  </div>
+  {/if}
   {hook h='displayDashboardTop'}
 </div>

--- a/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
+++ b/admin-dev/themes/new-theme/template/page_header_toolbar.tpl
@@ -66,7 +66,17 @@
             {if isset($help_link) and $help_link != false}
 
               {if $enableSidebar}
-                <a class="btn btn-outline-secondary btn-help btn-sidebar" href="#"
+
+                <a class="toolbar-button d-inline-block d-md-none" href="#"
+                   title="{l s='Help' d='Admin.Global'}"
+                   data-toggle="sidebar"
+                   data-target="#right-sidebar"
+                   data-url="{$help_link|escape}"
+                   id="product_form_open_help"
+                >
+                  <i class="material-icons">help_outline</i>
+                </a>
+                <a class="btn btn-outline-secondary btn-help btn-sidebar d-none d-md-inline-block" href="#"
                    title="{l s='Help' d='Admin.Global'}"
                    data-toggle="sidebar"
                    data-target="#right-sidebar"
@@ -76,7 +86,10 @@
                   {l s='Help' d='Admin.Global'}
                 </a>
               {else}
-                <a class="btn btn-outline-secondary btn-help" href="{$help_link|escape}" title="{l s='Help' d='Admin.Global'}">
+                <a class="toolbar-button d-inline-block d-md-none" href="{$help_link|escape}" title="{l s='Help' d='Admin.Global'}">
+                  <i class="material-icons">help_outline</i>
+                </a>
+                <a class="btn btn-outline-secondary btn-help d-none d-md-inline-block" href="{$help_link|escape}" title="{l s='Help' d='Admin.Global'}">
                   {l s='Help' d='Admin.Global'}
                 </a>
               {/if}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | In mobile version: The plus (+) button is not rendered if there is only the help button present in the toolbar as well as if there is no button. Moreover, if the help button is the only one present in the toolbar, it will remain displayed at the top but in material icon and will no longer make a line break.
| Type?             | improvement
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | navigate in any page on BO with just help button on toolbar and resize to be on mobile ⇒ the help button persist, and the (+) button is not shown. If you navigate to other page with much button, you can see the toolbar disappears and the (+) button is rendered.
| Fixed ticket?     | Linked to the discussion #32151
| Sponsor company   | @PrestaShopCorp

![image](https://user-images.githubusercontent.com/52718717/231787293-85337498-d5bd-4e40-a13a-9a98dd22c4b0.png)
![image](https://user-images.githubusercontent.com/52718717/232458005-bed8c609-7d03-4843-a3e4-713b3418f108.png)
