### PR TITLE
Removed deprecated parameters in `OrderReturn`

### DIFF
--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -62,15 +62,13 @@ class OrderReturnCore extends ObjectModel
         ],
     ];
 
-    public function addReturnDetail($order_detail_list, $product_qty_list, $customization_ids = null, $customization_qty_input = null)
+    /**
+     * @param int[] $order_detail_list
+     * @param int[] $product_qty_list
+     * @return void
+     */
+    public function addReturnDetail($order_detail_list, $product_qty_list)
     {
-        if ($customization_ids !== null || $customization_qty_input !== null) {
-            @trigger_error(
-                'Passing customization infos is deprecated since version 9.0.0. The customization is already included in the order details.',
-                E_USER_DEPRECATED
-            );
-        }
-
         /* Classic product return */
         if ($order_detail_list) {
             foreach ($order_detail_list as $key => $order_detail) {
@@ -83,15 +81,13 @@ class OrderReturnCore extends ObjectModel
         }
     }
 
-    public function checkEnoughProduct($order_detail_list, $product_qty_list, $customization_ids = null, $customization_qty_input = null)
+    /**
+     * @param int[] $order_detail_list
+     * @param int[] $product_qty_list
+     * @return bool|void
+     */
+    public function checkEnoughProduct($order_detail_list, $product_qty_list)
     {
-        if ($customization_ids !== null || $customization_qty_input !== null) {
-            @trigger_error(
-                'Passing customization infos is deprecated since version 9.0.0. The customization is already included in the order details.',
-                E_USER_DEPRECATED
-            );
-        }
-
         $order = new Order((int) $this->id_order);
         if (!Validate::isLoadedObject($order)) {
             die(Tools::displayError());

--- a/classes/order/OrderReturn.php
+++ b/classes/order/OrderReturn.php
@@ -65,6 +65,7 @@ class OrderReturnCore extends ObjectModel
     /**
      * @param int[] $order_detail_list
      * @param int[] $product_qty_list
+     *
      * @return void
      */
     public function addReturnDetail($order_detail_list, $product_qty_list)
@@ -84,6 +85,7 @@ class OrderReturnCore extends ObjectModel
     /**
      * @param int[] $order_detail_list
      * @param int[] $product_qty_list
+     *
      * @return bool|void
      */
     public function checkEnoughProduct($order_detail_list, $product_qty_list)

--- a/tests/Integration/Behaviour/Features/Context/OrderReturnFeatureContext.php
+++ b/tests/Integration/Behaviour/Features/Context/OrderReturnFeatureContext.php
@@ -72,12 +72,12 @@ class OrderReturnFeatureContext extends AbstractPrestaShopFeatureContext
         $orderReturn->question = 'Why?';
         $orderReturn->state = 1;
         $orderReturn->add();
-        $orderDetailIds = $quantities = $customizationIds = $customizationQuantityIds = [];
+        $orderDetailIds = $quantities = [];
         foreach ($order->getProducts() as $product) {
             $orderDetailIds[] = $product['id_order_detail'];
             $quantities[] = $product['product_quantity'];
         }
-        $orderReturn->addReturnDetail($orderDetailIds, $quantities, $customizationIds, $customizationQuantityIds);
+        $orderReturn->addReturnDetail($orderDetailIds, $quantities);
         SharedStorage::getStorage()->set($orderReturnReference, $orderReturn->id);
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated parameters in `OrderReturn`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/4958812909
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks
* Changed the signature for `addReturnDetail` in `OrderReturn`
  * Before :  `addReturnDetail($order_detail_list, $product_qty_list, $customization_ids = null, $customization_qty_input = null)`
  * Now :  `addReturnDetail($order_detail_list, $product_qty_list)`
* Changed the signature for `checkEnoughProduct` in `OrderReturn`
  * Before :  `checkEnoughProduct($order_detail_list, $product_qty_list, $customization_ids = null, $customization_qty_input = null)`
  * Now :  `checkEnoughProduct($order_detail_list, $product_qty_list)`
