### PR TITLE
Remove deprecated method `setPriorities` in class `SpecificPrice`

### DIFF
--- a/classes/SpecificPrice.php
+++ b/classes/SpecificPrice.php
@@ -23,9 +23,6 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-
-use PrestaShop\PrestaShop\Adapter\Product\SpecificPrice\Update\SpecificPricePriorityUpdater;
-
 class SpecificPriceCore extends ObjectModel
 {
     public const ORDER_DEFAULT_FROM_QUANTITY = 1;
@@ -577,37 +574,6 @@ class SpecificPriceCore extends ObjectModel
         }
 
         return self::$_specificPriceCache[$key];
-    }
-
-    /**
-     * @deprecated since 8.0 and will be removed in next major version.
-     * @see SpecificPricePriorityUpdater::updateDefaultPriorities()
-     *
-     * @param array $priorities
-     *
-     * @return bool
-     */
-    public static function setPriorities($priorities)
-    {
-        @trigger_error(
-            sprintf(
-                '%s is deprecated since version 8.0. Use %s instead.',
-                __METHOD__,
-                SpecificPricePriorityUpdater::class . '::updateDefaultPriorities()'
-            ),
-            E_USER_DEPRECATED
-        );
-
-        $value = '';
-        if (is_array($priorities)) {
-            foreach ($priorities as $priority) {
-                $value .= pSQL($priority) . ';';
-            }
-        }
-
-        SpecificPrice::deletePriorities();
-
-        return Configuration::updateValue('PS_SPECIFIC_PRICE_PRIORITIES', rtrim($value, ';'));
     }
 
     /**

--- a/tests/Resources/modules_tests/override/AdminProductsController.php
+++ b/tests/Resources/modules_tests/override/AdminProductsController.php
@@ -1,6 +1,9 @@
 <?php
 
+use PrestaShop\PrestaShop\Adapter\Product\SpecificPrice\Update\SpecificPricePriorityUpdater;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Addon\Module\ModuleManagerBuilder;
+use PrestaShop\PrestaShop\Core\Exception\CoreException;
 
 class AdminProductsController extends AdminProductsControllerCore
 {
@@ -890,10 +893,14 @@ class AdminProductsController extends AdminProductsControllerCore
         if (!$priorities = Tools::getValue('specificPricePriority')) {
             $this->errors[] = Tools::displayError('Please specify priorities.');
         } elseif (Tools::isSubmit('specificPricePriorityToAll')) {
-            if (!SpecificPrice::setPriorities($priorities)) {
-                $this->errors[] = Tools::displayError('An error occurred while updating priorities.');
-            } else {
-                $this->confirmations[] = $this->l('The price rule has successfully updated');
+            $sfContainer = SymfonyContainer::getInstance();
+            $specificPricePriorityUpdater = $sfContainer->get(SpecificPricePriorityUpdater::class);
+
+            try {
+                $specificPricePriorityUpdater->updateDefaultPriorities($priorities);
+                $this->confirmations[] = 'The price rule has successfully updated';
+            } catch (CoreException $e) {
+                $this->errors[] = $this->trans('An error occurred while updating priorities.', [], 'Admin.Catalog.Notification');
             }
         } elseif (!SpecificPrice::setSpecificPriority((int) $obj->id, $priorities)) {
             $this->errors[] = Tools::displayError('An error occurred while setting priorities.');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Remove deprecated method `setPriorities` in class `SpecificPrice`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/5089595740
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## BC Breaks
* Remove deprecated method `setPriorities` in class `SpecificPrice`