### PR TITLE
Removed deprecated methods `displayNumber` & `displayPrice` in class `Tools`

### DIFF
--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -662,46 +662,6 @@ class ToolsCore
     }
 
     /**
-     * Return price with currency sign for a given product.
-     *
-     * @deprecated Since 1.7.6.0. Please use Locale::formatPrice() instead
-     * @see PrestaShop\PrestaShop\Core\Localization\Locale
-     *
-     * @param float $price Product price
-     * @param int|Currency|array|null $currency Current currency (object, id_currency, NULL => context currency)
-     * @param bool $no_utf8 Not used anymore
-     * @param Context|null $context
-     *
-     * @return string Price correctly formatted (sign, decimal separator...)
-     *                if you modify this function, don't forget to modify the Javascript function formatCurrency (in tools.js)
-     *
-     * @throws LocalizationException
-     */
-    public static function displayPrice($price, $currency = null, $no_utf8 = false, Context $context = null)
-    {
-        @trigger_error(
-            'Tools::displayPrice() is deprecated since version 1.7.6.0. Use ' . Locale::class . '::formatPrice() instead.',
-            E_USER_DEPRECATED
-        );
-
-        if (!is_numeric($price)) {
-            return $price;
-        }
-
-        $context = $context ?: Context::getContext();
-        $currency = $currency ?: $context->currency;
-
-        if (is_int($currency)) {
-            $currency = Currency::getCurrencyInstance($currency);
-        }
-
-        $locale = static::getContextLocale($context);
-        $currencyCode = is_array($currency) ? $currency['iso_code'] : $currency->iso_code;
-
-        return $locale->formatPrice($price, $currencyCode);
-    }
-
-    /**
      * Return current locale
      *
      * @param Context $context
@@ -730,33 +690,6 @@ class ToolsCore
         );
 
         return $locale;
-    }
-
-    /**
-     * Returns a well formatted number.
-     *
-     * @deprecated Since 1.7.6.0. Please use Locale::formatNumber() instead
-     * @see Locale
-     *
-     * @param int|float|string $number The number to format
-     * @param null $currency not used anymore
-     *
-     * @return string The formatted number
-     *
-     * @throws Exception
-     * @throws LocalizationException
-     */
-    public static function displayNumber($number, $currency = null)
-    {
-        @trigger_error(
-            'Tools::displayNumber() is deprecated since version 1.7.5.0. Use ' . Locale::class . ' instead.',
-            E_USER_DEPRECATED
-        );
-
-        $context = Context::getContext();
-        $locale = static::getContextLocale($context);
-
-        return $locale->formatNumber($number);
     }
 
     public static function displayPriceSmarty($params, &$smarty)

--- a/classes/Tools.php
+++ b/classes/Tools.php
@@ -30,7 +30,6 @@ use PrestaShop\PrestaShop\Adapter\ContainerFinder;
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\PrestaShop\Core\Cache\Clearer\CacheClearerInterface;
 use PrestaShop\PrestaShop\Core\Foundation\Filesystem\FileSystem as PsFileSystem;
-use PrestaShop\PrestaShop\Core\Localization\Exception\LocalizationException;
 use PrestaShop\PrestaShop\Core\Localization\Locale;
 use PrestaShop\PrestaShop\Core\Localization\Locale\Repository as LocaleRepository;
 use PrestaShop\PrestaShop\Core\Security\Hashing;

--- a/composer.lock
+++ b/composer.lock
@@ -5435,16 +5435,16 @@
         },
         {
             "name": "prestashop/dashtrends",
-            "version": "v2.1.1",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/dashtrends.git",
-                "reference": "c0ffb850abf1896ae8650522c8c8f4cff1c1dd80"
+                "reference": "e2cbdb088241a17118a8c4424b468a36216f8316"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/dashtrends/zipball/c0ffb850abf1896ae8650522c8c8f4cff1c1dd80",
-                "reference": "c0ffb850abf1896ae8650522c8c8f4cff1c1dd80",
+                "url": "https://api.github.com/repos/PrestaShop/dashtrends/zipball/e2cbdb088241a17118a8c4424b468a36216f8316",
+                "reference": "e2cbdb088241a17118a8c4424b468a36216f8316",
                 "shasum": ""
             },
             "require": {
@@ -5472,9 +5472,9 @@
             "description": "PrestaShop module dashtrends",
             "homepage": "https://github.com/PrestaShop/dashtrends",
             "support": {
-                "source": "https://github.com/PrestaShop/dashtrends/tree/v2.1.1"
+                "source": "https://github.com/PrestaShop/dashtrends/tree/v2.1.2"
             },
-            "time": "2023-03-24T13:19:08+00:00"
+            "time": "2023-06-19T13:25:37+00:00"
         },
         {
             "name": "prestashop/decimal",

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -541,9 +541,13 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         if (!$order->isVirtual()) {
             foreach ($shipping as $item) {
                 if ($taxCalculationMethod == PS_TAX_INC) {
-                    $price = $this->locale->formatPrice($item['shipping_cost_tax_incl'], $currency->iso_code);
+                    $price = $item['shipping_cost_tax_incl']
+                        ? $this->locale->formatPrice($item['shipping_cost_tax_incl'], $currency->iso_code)
+                        : $item['shipping_cost_tax_incl'];
                 } else {
-                    $price = $this->locale->formatPrice($item['shipping_cost_tax_excl'], $currency->iso_code);
+                    $price = $item['shipping_cost_tax_excl']
+                        ? $this->locale->formatPrice($item['shipping_cost_tax_excl'], $currency->iso_code)
+                        : $item['shipping_cost_tax_excl'];
                 }
 
                 $trackingUrl = null;

--- a/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
+++ b/src/Adapter/Order/QueryHandler/GetOrderForViewingHandler.php
@@ -541,9 +541,9 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
         if (!$order->isVirtual()) {
             foreach ($shipping as $item) {
                 if ($taxCalculationMethod == PS_TAX_INC) {
-                    $price = Tools::displayPrice($item['shipping_cost_tax_incl'], $currency);
+                    $price = $this->locale->formatPrice($item['shipping_cost_tax_incl'], $currency->iso_code);
                 } else {
-                    $price = Tools::displayPrice($item['shipping_cost_tax_excl'], $currency);
+                    $price = $this->locale->formatPrice($item['shipping_cost_tax_excl'], $currency->iso_code);
                 }
 
                 $trackingUrl = null;
@@ -766,13 +766,13 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
             new DecimalNumber((string) $shippingRefundable),
             new DecimalNumber((string) $taxesAmount),
             new DecimalNumber((string) $totalAmount),
-            Tools::displayPrice($productsPrice, $currency),
-            Tools::displayPrice($discountsAmount, $currency),
-            Tools::displayPrice($wrappingPrice, $currency),
-            Tools::displayPrice($shippingPrice, $currency),
-            Tools::displayPrice($shippingRefundable, $currency),
-            Tools::displayPrice($taxesAmount, $currency),
-            Tools::displayPrice($totalAmount, $currency)
+            $this->locale->formatPrice($productsPrice, $currency->iso_code),
+            $this->locale->formatPrice($discountsAmount, $currency->iso_code),
+            $this->locale->formatPrice($wrappingPrice, $currency->iso_code),
+            $this->locale->formatPrice($shippingPrice, $currency->iso_code),
+            $this->locale->formatPrice($shippingRefundable, $currency->iso_code),
+            $this->locale->formatPrice($taxesAmount, $currency->iso_code),
+            $this->locale->formatPrice($totalAmount, $currency->iso_code)
         );
     }
 
@@ -796,7 +796,7 @@ final class GetOrderForViewingHandler extends AbstractOrderHandler implements Ge
                 (int) $discount['id_order_cart_rule'],
                 $discount['name'],
                 new DecimalNumber((string) $discountAmount),
-                Tools::displayPrice($discountAmount, $currency)
+                $this->locale->formatPrice($discountAmount, $currency->iso_code)
             );
         }
 

--- a/src/Adapter/Presenter/Cart/CartPresenter.php
+++ b/src/Adapter/Presenter/Cart/CartPresenter.php
@@ -153,12 +153,10 @@ class CartPresenter implements PresenterInterface
         }
 
         if ($this->includeTaxes()) {
-            $rawProduct['price_amount'] = $rawProduct['price_wt'];
-            $rawProduct['price'] = $this->priceFormatter->format($rawProduct['price_wt']);
+            $rawProduct['price_amount'] = $rawProduct['price'] = $rawProduct['price_wt'];
             $rawProduct['unit_price'] = $rawProduct['unit_price_tax_included'];
         } else {
-            $rawProduct['price_amount'] = $rawProduct['price'];
-            $rawProduct['price'] = $rawProduct['price_tax_exc'] = $this->priceFormatter->format($rawProduct['price']);
+            $rawProduct['price_amount'] = $rawProduct['price_tax_exc'] = $rawProduct['price'];
             $rawProduct['unit_price'] = $rawProduct['unit_price_tax_excluded'];
         }
 

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Presenter\Product;
 
+use Context;
 use DateTime;
 use Language;
 use Link;
@@ -764,8 +765,8 @@ class ProductLazyArray extends AbstractLazyArray
             $presNegativeReduction = $negativeReduction->round(2, Rounding::ROUND_HALF_UP);
 
             // TODO: add percent sign according to locale preferences
-            $this->product['discount_percentage'] = $this->context->getCurrentLocale()->formatNumber($presNegativeReduction) . '%';
-            $this->product['discount_percentage_absolute'] = $this->context->getCurrentLocale()->formatNumber($presAbsoluteReduction) . '%';
+            $this->product['discount_percentage'] = Context::getContext()->getCurrentLocale()->formatNumber($presNegativeReduction) . '%';
+            $this->product['discount_percentage_absolute'] = Context::getContext()->getCurrentLocale()->formatNumber($presAbsoluteReduction) . '%';
             if ($settings->include_taxes) {
                 $regular_price = $product['price_without_reduction'];
                 $this->product['discount_amount'] = $this->priceFormatter->format(

--- a/src/Adapter/Presenter/Product/ProductLazyArray.php
+++ b/src/Adapter/Presenter/Product/ProductLazyArray.php
@@ -764,8 +764,8 @@ class ProductLazyArray extends AbstractLazyArray
             $presNegativeReduction = $negativeReduction->round(2, Rounding::ROUND_HALF_UP);
 
             // TODO: add percent sign according to locale preferences
-            $this->product['discount_percentage'] = Tools::displayNumber($presNegativeReduction) . '%';
-            $this->product['discount_percentage_absolute'] = Tools::displayNumber($presAbsoluteReduction) . '%';
+            $this->product['discount_percentage'] = $this->context->getCurrentLocale()->formatNumber($presNegativeReduction) . '%';
+            $this->product['discount_percentage_absolute'] = $this->context->getCurrentLocale()->formatNumber($presAbsoluteReduction) . '%';
             if ($settings->include_taxes) {
                 $regular_price = $product['price_without_reduction'];
                 $this->product['discount_amount'] = $this->priceFormatter->format(

--- a/src/Adapter/Product/PriceFormatter.php
+++ b/src/Adapter/Product/PriceFormatter.php
@@ -54,10 +54,11 @@ class PriceFormatter
      */
     public function format($price, $currency = null)
     {
-        return Context::getContext()->getCurrentLocale()->formatPrice(
-            $price,
-            is_array($currency) ? $currency['iso_code'] : ($currency instanceof Currency ? $currency->iso_code : null)
-        );
+        $priceCurrency = is_array($currency) ? $currency['iso_code'] : null;
+        $priceCurrency = !$priceCurrency && $currency instanceof Currency ? $currency->iso_code : $priceCurrency;
+        $priceCurrency = !$priceCurrency ? Context::getContext()->currency->iso_code : $priceCurrency;
+
+        return Context::getContext()->getCurrentLocale()->formatPrice($price, $priceCurrency);
     }
 
     /**

--- a/src/Adapter/Product/PriceFormatter.php
+++ b/src/Adapter/Product/PriceFormatter.php
@@ -26,6 +26,7 @@
 
 namespace PrestaShop\PrestaShop\Adapter\Product;
 
+use Context;
 use Currency;
 use Tools;
 
@@ -53,7 +54,10 @@ class PriceFormatter
      */
     public function format($price, $currency = null)
     {
-        return Tools::displayPrice($price, $currency);
+        return Context::getContext()->getCurrentLocale()->formatPrice(
+            $price,
+            is_array($currency) ? $currency['iso_code'] : ($currency instanceof Currency ? $currency->iso_code : null)
+        );
     }
 
     /**

--- a/src/Adapter/Product/PriceFormatter.php
+++ b/src/Adapter/Product/PriceFormatter.php
@@ -54,11 +54,12 @@ class PriceFormatter
      */
     public function format($price, $currency = null)
     {
+        $context = Context::getContext();
         $priceCurrency = is_array($currency) ? $currency['iso_code'] : null;
         $priceCurrency = !$priceCurrency && $currency instanceof Currency ? $currency->iso_code : $priceCurrency;
-        $priceCurrency = !$priceCurrency ? Context::getContext()->currency->iso_code : $priceCurrency;
+        $priceCurrency = !$priceCurrency ? $context->currency->iso_code : $priceCurrency;
 
-        return Context::getContext()->getCurrentLocale()->formatPrice($price, $priceCurrency);
+        return Tools::getContextLocale($context)->formatPrice($price, $priceCurrency);
     }
 
     /**

--- a/src/Core/Domain/CustomerService/QueryHandler/GetCustomerThreadForViewingHandler.php
+++ b/src/Core/Domain/CustomerService/QueryHandler/GetCustomerThreadForViewingHandler.php
@@ -45,6 +45,7 @@ use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThread
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadMessageType;
 use PrestaShop\PrestaShop\Core\Domain\CustomerService\ValueObject\CustomerThreadStatus;
 use PrestaShop\PrestaShop\Core\Domain\Language\ValueObject\LanguageId;
+use PrestaShop\PrestaShop\Core\Localization\Locale;
 use Product;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Tools;
@@ -66,12 +67,19 @@ class GetCustomerThreadForViewingHandler implements GetCustomerThreadForViewingH
     private $translator;
 
     /**
-     * @param Context $context
+     * @var Locale
      */
-    public function __construct(Context $context)
+    protected $locale;
+
+    /**
+     * @param Context $context
+     * @param Locale $locale
+     */
+    public function __construct(Context $context, Locale $locale)
     {
         $this->context = $context;
         $this->translator = $context->getTranslator();
+        $this->locale = $locale;
     }
 
     /**
@@ -349,7 +357,7 @@ class GetCustomerThreadForViewingHandler implements GetCustomerThreadForViewingH
                 }
 
                 $orders[$key]['date_add'] = Tools::displayDate($order['date_add']);
-                $orders[$key]['total_paid_real'] = $this->context->getCurrentLocale()->formatPrice(
+                $orders[$key]['total_paid_real'] = $this->locale->formatPrice(
                     $order['total_paid_real'],
                     (new Currency((int) $order['id_currency']))->iso_code
                 );

--- a/src/Core/Domain/CustomerService/QueryHandler/GetCustomerThreadForViewingHandler.php
+++ b/src/Core/Domain/CustomerService/QueryHandler/GetCustomerThreadForViewingHandler.php
@@ -349,9 +349,9 @@ class GetCustomerThreadForViewingHandler implements GetCustomerThreadForViewingH
                 }
 
                 $orders[$key]['date_add'] = Tools::displayDate($order['date_add']);
-                $orders[$key]['total_paid_real'] = Tools::displayPrice(
+                $orders[$key]['total_paid_real'] = $this->context->getCurrentLocale()->formatPrice(
                     $order['total_paid_real'],
-                    new Currency((int) $order['id_currency'])
+                    (new Currency((int) $order['id_currency']))->iso_code
                 );
             }
         }
@@ -362,7 +362,9 @@ class GetCustomerThreadForViewingHandler implements GetCustomerThreadForViewingH
             $customer->lastname,
             $thread->email,
             count($ordersOk),
-            $totalOk ? Tools::displayPrice($totalOk, $this->context->currency) : $totalOk,
+            $totalOk
+                ? $this->context->getCurrentLocale()->formatPrice($totalOk, $this->context->currency->iso_code)
+                : $totalOk,
             (new DateTime($customer->date_add))->format($this->context->language->date_format_lite)
         );
     }

--- a/src/PrestaShopBundle/Resources/config/services/core/domain/customer_service.yml
+++ b/src/PrestaShopBundle/Resources/config/services/core/domain/customer_service.yml
@@ -34,6 +34,7 @@ services:
     class: 'PrestaShop\PrestaShop\Core\Domain\CustomerService\QueryHandler\GetCustomerThreadForViewingHandler'
     arguments:
       - '@=service("prestashop.adapter.legacy.context").getContext()'
+      - '@prestashop.core.localization.locale.context_locale'
     tags:
       - name: tactician.handler
         command: 'PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadForViewing'

--- a/tests/Resources/modules_tests/override/AdminProductsController.php
+++ b/tests/Resources/modules_tests/override/AdminProductsController.php
@@ -2805,12 +2805,12 @@ class AdminProductsController extends AdminProductsControllerCore
                     $combinations[$attribute['id_product_attribute']]['attributes'] = '';
                 }
                 $combinations[$attribute['id_product_attribute']]['attributes'] .= $attribute['attribute_name'] . ' - ';
-                $combinations[$attribute['id_product_attribute']]['price'] = Tools::displayPrice(
+                $combinations[$attribute['id_product_attribute']]['price'] = $this->context->getContextLocale()->formatPrice(
                     Tools::convertPrice(
                         Product::getPriceStatic((int) $obj->id, false, $attribute['id_product_attribute']),
                         $this->context->currency
                     ),
-                    $this->context->currency
+                    $this->context->currency->iso_code
                 );
             }
             foreach ($combinations as &$combination) {
@@ -3120,7 +3120,10 @@ class AdminProductsController extends AdminProductsControllerCore
                 if ($specific_price['reduction_type'] == 'percentage') {
                     $impact = '- ' . ($specific_price['reduction'] * 100) . ' %';
                 } elseif ($specific_price['reduction'] > 0) {
-                    $impact = '- ' . Tools::displayPrice(Tools::ps_round($specific_price['reduction'], 2), $current_specific_currency) . ' ';
+                    $impact = '- ' . $this->context->getContextLocale()->formatPrice(
+                        Tools::ps_round($specific_price['reduction'], 2),
+                        $current_specific_currency['iso_code']
+                    ) . ' ';
                     if ($specific_price['reduction_tax']) {
                         $impact .= '(' . $this->l('Tax incl.') . ')';
                     } else {
@@ -3167,7 +3170,7 @@ class AdminProductsController extends AdminProductsControllerCore
 						<td>' . ($id_shop_sp ? $shops[$id_shop_sp]['name'] : $this->l('All shops')) . '</td>';
                     }
                     $price = Tools::ps_round($specific_price['price'], 2);
-                    $fixed_price = ($price == Tools::ps_round($obj->price, 2) || $specific_price['price'] == -1) ? '--' : Tools::displayPrice($price, $current_specific_currency);
+                    $fixed_price = ($price == Tools::ps_round($obj->price, 2) || $specific_price['price'] == -1) ? '--' : $this->context->getContextLocale()->formatPrice($price, $current_specific_currency['iso_code']);
                     $content .= '
 						<td>' . ($specific_price['id_currency'] ? $currencies[$specific_price['id_currency']]['name'] : $this->l('All currencies')) . '</td>
 						<td>' . ($specific_price['id_country'] ? $countries[$specific_price['id_country']]['name'] : $this->l('All countries')) . '</td>
@@ -3889,7 +3892,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 $combination_images = $product->getCombinationImages($this->context->language->id);
                 foreach ($combinations as $k => $combination) {
                     $price_to_convert = Tools::convertPrice($combination['price'], $currency);
-                    $price = Tools::displayPrice($price_to_convert, $currency);
+                    $price = $this->context->getContextLocale()->formatPrice($price_to_convert, $currency['iso_code']);
                     $container['id_product_attribute'] = $combination['id_product_attribute'];
                     $container['attributes'][] = [$combination['group_name'], $combination['attribute_name'], $combination['id_attribute']];
                     $container['wholesale_price'] = $combination['wholesale_price'];

--- a/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
+++ b/tests/Resources/modules_tests/pscsx32412/override/controllers/admin/AdminProductsController.php
@@ -2919,12 +2919,12 @@ class AdminProductsController extends AdminProductsControllerCore
                 }
                 $combinations[$attribute['id_product_attribute']]['attributes'] .= $attribute['attribute_name'] . ' - ';
 
-                $combinations[$attribute['id_product_attribute']]['price'] = Tools::displayPrice(
+                $combinations[$attribute['id_product_attribute']]['price'] = $this->context->getContextLocale()->formatPrice(
                     Tools::convertPrice(
                         Product::getPriceStatic((int) $obj->id, false, $attribute['id_product_attribute']),
                         $this->context->currency
                     ),
-                    $this->context->currency
+                    $this->context->currency->iso_code
                 );
             }
             foreach ($combinations as &$combination) {
@@ -3253,7 +3253,10 @@ class AdminProductsController extends AdminProductsControllerCore
                 if ($specific_price['reduction_type'] == 'percentage') {
                     $impact = '- ' . ($specific_price['reduction'] * 100) . ' %';
                 } elseif ($specific_price['reduction'] > 0) {
-                    $impact = '- ' . Tools::displayPrice(Tools::ps_round($specific_price['reduction'], 2), $current_specific_currency) . ' ';
+                    $impact = '- ' . $this->context->getContextLocale()->formatPrice(
+                        Tools::ps_round($specific_price['reduction'], 2),
+                        $current_specific_currency['iso_code']
+                    ) . ' ';
                     if ($specific_price['reduction_tax']) {
                         $impact .= '(' . $this->l('Tax incl.') . ')';
                     } else {
@@ -3305,7 +3308,7 @@ class AdminProductsController extends AdminProductsControllerCore
 						<td>' . ($id_shop_sp ? $shops[$id_shop_sp]['name'] : $this->l('All shops')) . '</td>';
                     }
                     $price = Tools::ps_round($specific_price['price'], 2);
-                    $fixed_price = ($price == Tools::ps_round($obj->price, 2) || $specific_price['price'] == -1) ? '--' : Tools::displayPrice($price, $current_specific_currency);
+                    $fixed_price = ($price == Tools::ps_round($obj->price, 2) || $specific_price['price'] == -1) ? '--' : $this->context->getContextLocale()->formatPrice($price, $current_specific_currency['iso_code']);
                     $content .= '
 						<td>' . ($specific_price['id_currency'] ? $currencies[$specific_price['id_currency']]['name'] : $this->l('All currencies')) . '</td>
 						<td>' . ($specific_price['id_country'] ? $countries[$specific_price['id_country']]['name'] : $this->l('All countries')) . '</td>
@@ -4062,7 +4065,7 @@ class AdminProductsController extends AdminProductsControllerCore
                 $combination_images = $product->getCombinationImages($this->context->language->id);
                 foreach ($combinations as $k => $combination) {
                     $price_to_convert = Tools::convertPrice($combination['price'], $currency);
-                    $price = Tools::displayPrice($price_to_convert, $currency);
+                    $price = $this->context->getContextLocale()->formatPrice($price_to_convert, $currency['iso_code']);
 
                     $container['id_product_attribute'] = $combination['id_product_attribute'];
                     $container['attributes'][] = [$combination['group_name'], $combination['attribute_name'], $combination['id_attribute']];


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | Removed deprecated methods `displayNumber` & `displayPrice` in class `Tools`
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | CI is :green_circle: & Nightly is :green_circle: : https://github.com/Progi1984/ga.tests.ui.pr/actions/runs/5288656229
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp

## Linked PR : 
* PrestaShop/dashtrends#62
* PrestaShop/dashtrends#64
* PrestaShop/dashtrends#65

## BC Breaks
* Remove deprecated method `displayNumber` in class `Tools`
* Remove deprecated method `displayPrice` in class `Tools`
