### PR TITLE
FIX: SKIP resizing ORIGINAL product IMAGE on uploading

### DIFF
--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -181,6 +181,7 @@ class ImageManagerCore
      * @param int $quality Needed by AdminImportController to speed up the import process
      * @param int $sourceWidth Needed by AdminImportController to speed up the import process
      * @param int $sourceHeight Needed by AdminImportController to speed up the import process
+     * @param bool $copy_raw_image To ignore resampling the original image and just save the raw image
      *
      *@return bool Operation result
      */

--- a/classes/ImageManager.php
+++ b/classes/ImageManager.php
@@ -196,7 +196,8 @@ class ImageManagerCore
         &$targetHeight = null,
         $quality = 5,
         &$sourceWidth = null,
-        &$sourceHeight = null
+        &$sourceHeight = null,
+        $copy_raw_image = false
     ) {
         clearstatcache(true, $sourceFile);
 
@@ -297,6 +298,10 @@ class ImageManagerCore
             $error = self::ERROR_MEMORY_LIMIT;
 
             return false;
+        }
+
+        if ($copy_raw_image) {
+            return file_put_contents($destinationFile, file_get_contents($sourceFile));
         }
 
         $targetWidth = $destinationWidth;

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2849,7 +2849,7 @@ class AdminProductsControllerCore extends AdminController
 
                 $error = 0;
 
-                if (!ImageManager::resize($file['save_path'], $new_path . '.' . $image->image_format, null, null, 'jpg', false, $error)) {
+                if (!ImageManager::resize($file['save_path'], $new_path . '.' . $image->image_format, null, null, 'jpg', false, $error, null, null, 5, null, null, true)) {
                     switch ($error) {
                         case ImageManager::ERROR_FILE_NOT_EXIST:
                             $file['error'] = $this->trans('An error occurred while copying image, the file does not exist anymore.', [], 'Admin.Catalog.Notification');

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2849,7 +2849,7 @@ class AdminProductsControllerCore extends AdminController
 
                 $error = 0;
 
-                if (!file_put_contents($new_path . '.' . $image->image_format, file_get_contents($file['save_path']))) {
+                if (!ImageManager::resize($file['save_path'], $new_path . '.' . $image->image_format, null, null, 'jpg', false, $error)) {
                     switch ($error) {
                         case ImageManager::ERROR_FILE_NOT_EXIST:
                             $file['error'] = $this->trans('An error occurred while copying image, the file does not exist anymore.', [], 'Admin.Catalog.Notification');

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2849,7 +2849,12 @@ class AdminProductsControllerCore extends AdminController
 
                 $error = 0;
 
-                if (!ImageManager::resize($file['save_path'], $new_path . '.' . $image->image_format, null, null, 'jpg', false, $error, null, null, 5, null, null, true)) {
+                $_targetWidth = null;
+                $_targetHeight = null;
+                $_sourceWidth = null;
+                $_sourceHeight = null;
+
+                if (!ImageManager::resize($file['save_path'], $new_path . '.' . $image->image_format, null, null, 'jpg', false, $error, $_targetWidth, $_targetHeight, 5, $_sourceWidth, $_sourceHeight, true)) {
                     switch ($error) {
                         case ImageManager::ERROR_FILE_NOT_EXIST:
                             $file['error'] = $this->trans('An error occurred while copying image, the file does not exist anymore.', [], 'Admin.Catalog.Notification');

--- a/controllers/admin/AdminProductsController.php
+++ b/controllers/admin/AdminProductsController.php
@@ -2849,7 +2849,7 @@ class AdminProductsControllerCore extends AdminController
 
                 $error = 0;
 
-                if (!ImageManager::resize($file['save_path'], $new_path . '.' . $image->image_format, null, null, 'jpg', false, $error)) {
+                if (!file_put_contents($new_path . '.' . $image->image_format, file_get_contents($file['save_path']))) {
                     switch ($error) {
                         case ImageManager::ERROR_FILE_NOT_EXIST:
                             $file['error'] = $this->trans('An error occurred while copying image, the file does not exist anymore.', [], 'Admin.Catalog.Notification');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | When uploading an image in product form, the original image must stay untouched, but prestashop uses resize methods and modifies the original image. This image is usable when using product image sliders and customer can take benefit of zooming in a high quality image.
| Type?             | refacto
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Check this issue #26111 for how to verify the issue exists. Then use this PR to verify uploaded original image is not modified at all.
| Fixed ticket?     | Fixes #26111 
| Related PRs       | I could not find any
| Sponsor company   | Beisat.com
