### PR TITLE
No longer try to include obsolete errors.php and admin.php

### DIFF
--- a/admin-dev/init.php
+++ b/admin-dev/init.php
@@ -41,9 +41,6 @@ try {
     }
 
     $iso = $context->language->iso_code;
-    if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/errors.php')) {
-        include _PS_TRANSLATIONS_DIR_.$iso.'/errors.php';
-    }
     if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/fields.php')) {
         @trigger_error(
             'Translating ObjectModel fields using fields.php is deprecated since version 8.0.0.',

--- a/admin-dev/init.php
+++ b/admin-dev/init.php
@@ -48,9 +48,6 @@ try {
         );
         include _PS_TRANSLATIONS_DIR_.$iso.'/fields.php';
     }
-    if (file_exists(_PS_TRANSLATIONS_DIR_.$iso.'/admin.php')) {
-        include _PS_TRANSLATIONS_DIR_.$iso.'/admin.php';
-    }
 
     /* Server Params */
     $protocol_link = (Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://';

--- a/classes/Language.php
+++ b/classes/Language.php
@@ -132,14 +132,6 @@ class LanguageCore extends ObjectModel implements LanguageInterface
         'objectsNodeName' => 'languages',
     ];
 
-    protected $translationsFilesAndVars = [
-        'fields' => '_FIELDS',
-        'errors' => '_ERRORS',
-        'admin' => '_LANGADM',
-        'pdf' => '_LANGPDF',
-        'tabs' => 'tabs',
-    ];
-
     public static function resetStaticCache()
     {
         parent::resetStaticCache();


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | errors.php and admin.php were ancient files containing translations, and have been removed in 1.7. There were no uses left for their variables `$_ERRORS` and `$_LANGADM` in the project, so they can be safely removed. I also removed a protected property `Language::$translationsFilesAndVars` that had no references.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes - the files are no longer loaded
| Deprecations?     | no
| How to test?      | Should not need any tests because the referenced files are never there, and the removed variable has no references.
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA
