### PR TITLE
Remove deprecated displayFlags

### DIFF
--- a/admin-dev/themes/default/template/controllers/cart_rules/form.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.tpl
@@ -66,16 +66,6 @@
 		var hourText = '{l s='Hour' js=1 d='Admin.Global'}';
 		var minuteText = '{l s='Minute' js=1 d='Admin.Catalog.Feature'}';
 
-		var languages = new Array();
-		{foreach from=$languages item=language key=k}
-			languages[{$k}] = {
-				id_lang: {$language.id_lang},
-				iso_code: '{$language.iso_code|escape:'quotes'}',
-				name: '{$language.name|escape:'quotes'}'
-			};
-		{/foreach}
-		displayFlags(languages, {$id_lang_default});
-
     {if isset($refresh_cart) }
       if (typeof window.parent.order_create !== "undefined") {
         window.parent.order_create.refreshCart();

--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -753,8 +753,6 @@
 		var module_dir = '{$smarty.const._MODULE_DIR_}';
 		var id_language = {$defaultFormLanguage|intval};
 		var languages = new Array();
-		// Multilang field setup must happen before document is ready so that calls to displayFlags() to avoid
-		// precedence conflicts with other document.ready() blocks
 		{foreach $languages as $k => $language}
 			languages[{$k}] = {
 				id_lang: {$language.id_lang|escape:'javascript'},
@@ -765,7 +763,6 @@
 		{/foreach}
 		// we need allowEmployeeFormLang var in ajax request
 		allowEmployeeFormLang = {$allowEmployeeFormLang|intval};
-		displayFlags(languages, id_language, allowEmployeeFormLang);
 
 		$(function() {
 

--- a/classes/module/Module.php
+++ b/classes/module/Module.php
@@ -1003,47 +1003,6 @@ abstract class ModuleCore implements ModuleInterface
     }
 
     /**
-     * Display flags in forms for translations.
-     *
-     * @deprecated since 1.6.0.10
-     *
-     * @param array $languages All languages available
-     * @param int $default_language Default language id
-     * @param string $ids Multilingual div ids in form
-     * @param string $id Current div id]
-     * @param bool $return define the return way : false for a display, true for a return
-     * @param bool $use_vars_instead_of_ids use an js vars instead of ids seperate by "¤"
-     *
-     * @return bool|string|void
-     */
-    public function displayFlags($languages, $default_language, $ids, $id, $return = false, $use_vars_instead_of_ids = false)
-    {
-        if (count($languages) == 1) {
-            return false;
-        }
-
-        $output = '
-        <div class="displayed_flag">
-            <img src="../img/l/' . $default_language . '.jpg" class="pointer" id="language_current_' . $id . '" onclick="toggleLanguageFlags(this);" alt="" />
-        </div>
-        <div id="languages_' . $id . '" class="language_flags">
-            ' . $this->getTranslator()->trans('Choose language:', [], 'Admin.Actions') . '<br /><br />';
-        foreach ($languages as $language) {
-            if ($use_vars_instead_of_ids) {
-                $output .= '<img src="../img/l/' . (int) $language['id_lang'] . '.jpg" class="pointer" alt="' . $language['name'] . '" title="' . $language['name'] . '" onclick="changeLanguage(\'' . $id . '\', ' . $ids . ', ' . $language['id_lang'] . ', \'' . $language['iso_code'] . '\');" /> ';
-            } else {
-                $output .= '<img src="../img/l/' . (int) $language['id_lang'] . '.jpg" class="pointer" alt="' . $language['name'] . '" title="' . $language['name'] . '" onclick="changeLanguage(\'' . $id . '\', \'' . $ids . '\', ' . $language['id_lang'] . ', \'' . $language['iso_code'] . '\');" /> ';
-            }
-        }
-        $output .= '</div>';
-
-        if ($return) {
-            return $output;
-        }
-        echo $output;
-    }
-
-    /**
      * Connect module to a hook.
      *
      * @param string|array $hook_name Hook name

--- a/js/admin.js
+++ b/js/admin.js
@@ -228,53 +228,6 @@ function changeFormLanguage(id_language_new, iso_code, employee_cookie)
   updateCurrentText();
 }
 
-function displayFlags(languages, defaultLanguageID, employee_cookie)
-{
-  if ($('.translatable'))
-  {
-    $('.translatable').each(function() {
-      if (!$(this).find('.displayed_flag').length > 0) {
-        $.each(languages, function(key, language) {
-          if (language['id_lang'] == defaultLanguageID)
-          {
-            defaultLanguage = language;
-            return false;
-          }
-        });
-        var displayFlags = $('<div></div>')
-          .addClass('displayed_flag')
-          .append($('<img>')
-            .addClass('language_current')
-            .addClass('pointer')
-            .attr('src', '../img/l/' + defaultLanguage['id_lang'] + '.jpg')
-            .attr('alt', defaultLanguage['name'])
-            .on('click', function() {
-              toggleLanguageFlags(this);
-            })
-          );
-        var languagesFlags = $('<div></div>')
-          .addClass('language_flags')
-          .html(choose_language_translate+':<br /><br />');
-        $.each(languages, function(key, language) {
-          var img = $('<img>')
-            .addClass('pointer')
-            .css('margin', '2px 2px')
-            .attr('src', '../img/l/' + language['id_lang'] + '.jpg')
-            .attr('alt', language['name'])
-            .on('click', function() {
-              changeFormLanguage(language['id_lang'], language['iso_code'], employee_cookie);
-            });
-          languagesFlags.append(img);
-        });
-        if ($(this).find('p:last-child').hasClass('clear'))
-          $(this).find('p:last-child').before(displayFlags).before(languagesFlags);
-        else
-          $(this).append(displayFlags).append(languagesFlags);
-      }
-    });
-  }
-}
-
 function checkAll(pForm)
 {
   for (i = 0, n = pForm.elements.length; i < n; i++)

--- a/js/admin/products.js
+++ b/js/admin/products.js
@@ -692,8 +692,6 @@ product_tabs['Seo'] = new function(){
 		// Enable writing of the product name when the friendly url field in tab SEO is loaded
 		$('.copy2friendlyUrl').removeAttr('disabled');
 
-		displayFlags(languages, id_language, allowEmployeeFormLang);
-
 		if (display_multishop_checkboxes)
 			ProductMultishop.checkAllSeo();
 	};
@@ -1405,15 +1403,9 @@ product_tabs['Pack'] = new function() {
 }
 
 product_tabs['Images'] = new function(){
-	this.onReady = function(){
-		displayFlags(languages, id_language, allowEmployeeFormLang);
-	}
 }
 
 product_tabs['Features'] = new function(){
-	this.onReady = function(){
-		displayFlags(languages, id_language, allowEmployeeFormLang);
-	}
 }
 
 product_tabs['Quantities'] = new function(){


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `displayFlags()` was apparently used in the past to display flags in language selectors for multilanguage fields. These selectors have been displaying iso codes instead for a very long time, so this function should no longer be needed.
| Type?             | improvement
| Category?         | CO
| BC breaks?        | yes - `displayFlags()` has been removed
| Deprecations?     | no
| How to test?      | This change can only impact legacy pages using helper form (so legacy form pages). I checked AdminCartRules and AdminAttributes and they have already been changed to use iso codes instead of flags a very long time ago. I think only very old modules might be affected by this change, and native ones don't seem to use the `translatable` CSS class that would give away the use of this feature.
| Fixed ticket?     | N/A
| Related PRs       | 
| Sponsor company   | PrestaShop SA
