### PR TITLE
Fix jquery deprecations

### DIFF
--- a/admin-dev/filemanager/ajax_calls.php
+++ b/admin-dev/filemanager/ajax_calls.php
@@ -195,7 +195,7 @@ if (isset($_GET['action'])) {
                 ?>
 
 				<script type="text/javascript">
-					$(document).ready(function () {
+					$(function () {
 
 						$("#jquery_jplayer_1").jPlayer({
 							ready: function () {
@@ -227,7 +227,7 @@ if (isset($_GET['action'])) {
                 ?>
 
 				<script type="text/javascript">
-					$(document).ready(function () {
+					$(function () {
 
 						$("#jquery_jplayer_1").jPlayer({
 							ready: function () {

--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -136,10 +136,12 @@ $(() => {
   $('.nav-bar')
     .find('.link-levelone')
     .on(
-      'hover',
+      'mouseenter',
       function () {
         $(this).addClass('-hover');
       },
+    ).on(
+      'mouseleave',
       function () {
         $(this).removeClass('-hover');
       },

--- a/admin-dev/themes/default/js/admin-theme.js
+++ b/admin-dev/themes/default/js/admin-theme.js
@@ -52,11 +52,11 @@ function confirm_modal(
       + '</div>'
       + '</div>',
   );
-  confirmModal.find('#confirm-modal-left-button').click(() => {
+  confirmModal.find('#confirm-modal-left-button').on('click', () => {
     leftButtonCallback();
     confirmModal.modal('hide');
   });
-  confirmModal.find('#confirm-modal-right-button').click(() => {
+  confirmModal.find('#confirm-modal-right-button').on('click', () => {
     rightButtonCallback();
     confirmModal.modal('hide');
   });
@@ -85,7 +85,7 @@ function error_modal(heading, msg) {
       + '</div>'
       + '</div>',
   );
-  errorModal.find('#error_modal_right_button').click(() => {
+  errorModal.find('#error_modal_right_button').on('click', () => {
     errorModal.modal('hide');
   });
   errorModal.modal('show');
@@ -110,7 +110,7 @@ function scroll_if_anchor(href) {
     }
   }
 }
-$(document).ready(() => {
+$(() => {
   const $mainMenu = $('.main-menu');
   const $navBar = $('.nav-bar');
   const $body = $('body');
@@ -135,7 +135,8 @@ $(document).ready(() => {
 
   $('.nav-bar')
     .find('.link-levelone')
-    .hover(
+    .on(
+      'hover',
       function () {
         $(this).addClass('-hover');
       },
@@ -378,7 +379,7 @@ $(document).ready(() => {
   });
 
   let timer;
-  $(window).scroll(() => {
+  $(window).on('scroll', () => {
     if (timer) {
       window.clearTimeout(timer);
     }
@@ -395,7 +396,7 @@ $(document).ready(() => {
       .focus();
   });
 
-  $('.page-sidebar-closed').click(() => {
+  $('.page-sidebar-closed').on('click', () => {
     $('.searchtab').removeClass('search-expanded');
   });
 
@@ -426,7 +427,7 @@ $(document).ready(() => {
   });
 
   // search with nav sidebar opened
-  $('.page-sidebar').click(() => {
+  $('.page-sidebar').on('click', () => {
     $('#header_search .form-group').removeClass('focus-search');
   });
 
@@ -457,7 +458,7 @@ $(document).ready(() => {
   $('body').on('click', 'a.anchor', scroll_if_anchor);
 
   // manage curency status switcher
-  $('#currencyStatus input').change(function () {
+  $('#currencyStatus input').on('change', function () {
     const parentZone = $(this)
       .parent()
       .parent()
@@ -474,7 +475,7 @@ $(document).ready(() => {
     }
   });
 
-  $('#currencyCronjobLiveExchangeRate input').change(function () {
+  $('#currencyCronjobLiveExchangeRate input').on('change', function () {
     let enable = 0;
     const parentZone = $(this)
       .parent()

--- a/admin-dev/themes/default/js/bundle/default.js
+++ b/admin-dev/themes/default/js/bundle/default.js
@@ -1,7 +1,7 @@
 /**
  * Default layout instanciation
  */
-$(document).ready(function () {
+$(function () {
   const $this = $(this);
   const $ajaxSpinner = $('.ajax-spinner');
   $('[data-toggle="tooltip"]').tooltip();

--- a/admin-dev/themes/default/js/bundle/modal-confirmation.js
+++ b/admin-dev/themes/default/js/bundle/modal-confirmation.js
@@ -17,14 +17,14 @@ window.modalConfirmation = (function () {
     },
   };
 
-  modal.find('button.cancel').click(() => {
+  modal.find('button.cancel').on('click', () => {
     if (typeof actionsCallbacks.onCancel === 'function') {
       actionsCallbacks.onCancel();
     }
     modalConfirmation.hide();
   });
 
-  modal.find('button.continue').click(() => {
+  modal.find('button.continue').on('click', () => {
     if (typeof actionsCallbacks.onContinue === 'function') {
       actionsCallbacks.onContinue();
     }

--- a/admin-dev/themes/default/js/bundle/pagination.js
+++ b/admin-dev/themes/default/js/bundle/pagination.js
@@ -23,12 +23,12 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-$(document).ready(() => {
+$(() => {
   /*
   * Link action on the select list in the navigator toolbar.
   * When change occurs, the page is refreshed (location.href redirection)
   */
-  $('select[name="paginator_select_page_limit"]').change(function () {
+  $('select[name="paginator_select_page_limit"]').on('change', function () {
     const url = $(this).attr('psurl').replace(/_limit/, $('option:selected', this).val());
     window.location.href = url;
     return false;

--- a/admin-dev/themes/default/js/bundle/product/catalog.js
+++ b/admin-dev/themes/default/js/bundle/product/catalog.js
@@ -27,14 +27,14 @@
 
 const {$} = window;
 
-$(document).ready(() => {
+$(() => {
   const form = $('form#product_catalog_list');
 
   /*
    * Tree behavior: collapse/expand system and radio button change event.
    */
   $('div#product_catalog_category_tree_filter').categorytree();
-  $('div#product_catalog_category_tree_filter div.radio > label > input:radio').change(function () {
+  $('div#product_catalog_category_tree_filter div.radio > label > input:radio').on('change', function () {
     if ($(this).is(':checked')) {
       $('form#product_catalog_list input[name="filter_category"]').val($(this).val());
       $('form#product_catalog_list').submit();
@@ -49,7 +49,7 @@ $(document).ready(() => {
   /*
    * Click on a column header ordering icon to change orderBy / orderWay (location.href redirection)
    */
-  $('[psorderby][psorderway]', form).click(function () {
+  $('[psorderby][psorderway]', form).on('click', function () {
     const orderBy = $(this).attr('psorderby');
     const orderWay = $(this).attr('psorderway');
     productOrderTable(orderBy, orderWay);
@@ -58,7 +58,7 @@ $(document).ready(() => {
   /*
    * Checkboxes behavior with bulk actions
    */
-  $('input:checkbox[name="bulk_action_selected_products[]"]', form).change(() => {
+  $('input:checkbox[name="bulk_action_selected_products[]"]', form).on('change', () => {
     updateBulkMenu();
   });
 
@@ -91,7 +91,7 @@ $(document).ready(() => {
   /*
    * Form submit pre action
    */
-  form.submit(function (e) {
+  form.on('submit', function (e) {
     e.preventDefault();
     $('#filter_column_id_product', form).val($('#filter_column_id_product', form).attr('sql'));
     $('#filter_column_price', form).val($('#filter_column_price', form).attr('sql'));

--- a/admin-dev/themes/default/js/bundle/product/form.js
+++ b/admin-dev/themes/default/js/bundle/product/form.js
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-$(document).ready(() => {
+$(() => {
   window.form.init();
   nav.init();
   featuresCollection.init();
@@ -51,12 +51,12 @@ $(document).ready(() => {
   BOEvent.emitEvent('Product Combinations Management started', 'CustomEvent');
 
   /** Type product fields display management */
-  $('#form_step1_type_product').change(() => {
+  $('#form_step1_type_product').on('change', () => {
     displayFieldsManager.refresh();
   });
 
   // Validate price fields on input change
-  $(".money-type input[type='text']").change(function validate() {
+  $(".money-type input[type='text']").on('change', function validate() {
     const inputValue = priceCalculation.normalizePrice($(this).val());
     const parsedValue = truncateDecimals(inputValue, 6);
 
@@ -104,7 +104,7 @@ window.displayFieldsManager = (function () {
       managedVirtualProduct = virtualProduct;
 
       /** Type product fields display management */
-      $('#form_step1_type_product').change(() => {
+      $('#form_step1_type_product').on('change', () => {
         displayFieldsManager.refresh();
       });
 
@@ -371,10 +371,10 @@ const formCategory = (function () {
     init() {
       const that = this;
       /** remove all categories from selector, except pre defined */
-      $('#add-categories button.save').click(() => {
+      $('#add-categories button.save').on('click', () => {
         send(that);
       });
-      $('#add-categories button[type="reset"]').click(() => {
+      $('#add-categories button[type="reset"]').on('click', () => {
         that.hideBlock();
       });
     },
@@ -487,7 +487,7 @@ const supplier = (function () {
     init() {
       /** On supplier select, hide or show the default supplier selector */
       const supplierInput = $('#form_step6_suppliers input[name="form[step6][suppliers][]"]');
-      supplierInput.change(function () {
+      supplierInput.on('change', function () {
         supplierInputManage($(this));
         supplierCombinations.refresh();
       });
@@ -870,19 +870,19 @@ window.form = (function () {
         step1CheckBox.prop('checked', !step1CheckBox.is(':checked'));
       });
 
-      elem.submit((event) => {
+      elem.on('submit', (event) => {
         replaceBadLocaleCharacters();
         event.preventDefault();
         send();
       });
 
-      elem.find('#form_switch_language').change((event) => {
+      elem.find('#form_switch_language').on('change', (event) => {
         event.preventDefault();
         switchLanguage(event.target.value);
       });
 
       /** on save with duplicate|new|preview */
-      $('.btn-submit, .preview', elem).click(function (event) {
+      $('.btn-submit, .preview', elem).on('click', function (event) {
         event.preventDefault();
         send($(this).attr('data-redirect'), $(this).attr('target'));
       });
@@ -910,7 +910,7 @@ window.form = (function () {
       });
 
       /** on delete product */
-      $('.product-footer .delete', elem).click(function (e) {
+      $('.product-footer .delete', elem).on('click', function (e) {
         e.preventDefault();
         const that = $(this);
         modalConfirmation.create(translate_javascripts['Are you sure you want to delete this item?'], null, {
@@ -1106,7 +1106,7 @@ window.virtualProduct = (function () {
         }
       });
 
-      $('#form_step3_virtual_product_file').change(function () {
+      $('#form_step3_virtual_product_file').on('change', function () {
         if ($(this)[0].files !== undefined) {
           const {files} = $(this)[0];
           let name = '';
@@ -1129,7 +1129,7 @@ window.virtualProduct = (function () {
       }
 
       /** delete attached file */
-      $('#form_step3_virtual_product_file_details .delete').click(function (e) {
+      $('#form_step3_virtual_product_file_details .delete').on('click', function (e) {
         e.preventDefault();
         const $deleteButton = $(this);
 
@@ -1141,7 +1141,7 @@ window.virtualProduct = (function () {
       });
 
       /** save virtual product */
-      $('#form_step3_virtual_product_save').click(function () {
+      $('#form_step3_virtual_product_save').on('click', function () {
         const that = $(this);
         const data = new FormData();
 
@@ -1222,7 +1222,7 @@ window.attachmentProduct = (function () {
       const buttonSave = $('#form_step6_attachment_product_add');
       const buttonCancel = $('#form_step6_attachment_product_cancel');
 
-      buttonCancel.click(() => {
+      buttonCancel.on('click', () => {
         resetAttachmentForm();
       });
 
@@ -1238,7 +1238,7 @@ window.attachmentProduct = (function () {
 
       /** add attachment */
       // eslint-disable-next-line
-      $('#form_step6_attachment_product_add').click(function () {
+      $('#form_step6_attachment_product_add').on('click', function () {
         const data = new FormData();
 
         if ($('#form_step6_attachment_product_file')[0].files[0]) {
@@ -1740,7 +1740,7 @@ window.priceCalculation = (function () {
 
     init() {
       /** on update tax recalculate tax include price */
-      taxElem.change(() => {
+      taxElem.on('change', () => {
         if (reTaxElem.val() !== taxElem.val()) {
           reTaxElem.val(taxElem.val()).trigger('change');
         }
@@ -1749,12 +1749,12 @@ window.priceCalculation = (function () {
         priceTTCElem.change();
       });
 
-      reTaxElem.change(() => {
+      reTaxElem.on('change', () => {
         taxElem.val(reTaxElem.val()).trigger('change');
       });
 
       /** update without tax price and shortcut price field on change */
-      $('#form_step1_price_shortcut, #form_step2_price').keyup(function () {
+      $('#form_step1_price_shortcut, #form_step2_price').on('keyup', function () {
         const price = priceCalculation.normalizePrice($(this).val());
 
         if ($(this).attr('id') === 'form_step1_price_shortcut') {
@@ -1767,7 +1767,7 @@ window.priceCalculation = (function () {
       });
 
       /** update HT price and shortcut price field on change */
-      $('#form_step1_price_ttc_shortcut, #form_step2_price_ttc').keyup(function () {
+      $('#form_step1_price_ttc_shortcut, #form_step2_price_ttc').on('keyup', function () {
         const price = priceCalculation.normalizePrice($(this).val());
 
         if ($(this).attr('id') === 'form_step1_price_ttc_shortcut') {
@@ -1780,7 +1780,7 @@ window.priceCalculation = (function () {
       });
 
       /** on price change, update final retails prices */
-      $('#form_step2_price, #form_step2_price_ttc').change(() => {
+      $('#form_step2_price, #form_step2_price_ttc').on('change', () => {
         const taxExcludedPrice = priceCalculation.normalizePrice($('#form_step2_price').val());
         const taxIncludedPrice = priceCalculation.normalizePrice($('#form_step2_price_ttc').val());
 
@@ -1793,7 +1793,7 @@ window.priceCalculation = (function () {
       });
 
       /** update HT price and shortcut price field on change */
-      $('#form_step2_ecotax').keyup(() => {
+      $('#form_step2_ecotax').on('keyup', () => {
         priceCalculation.taxExclude();
       });
 
@@ -2262,18 +2262,18 @@ window.seo = (function () {
       updateRemoteUrl();
 
       /** On redirect type select change */
-      redirectTypeElem.change(() => {
+      redirectTypeElem.on('change', () => {
         productRedirect.find('#form_step5_id_type_redirected-data').html('');
         hideShowRedirectToProduct();
       });
 
       /** On product title change, update friendly URL */
-      $('#form_step1_names.friendly-url-force-update input').keyup(function () {
+      $('#form_step1_names.friendly-url-force-update input').on('keyup', function () {
         updateFriendlyUrl($(this));
       });
 
       /** Reset all languages title to friendly url */
-      $('#seo-url-regenerate').click(() => {
+      $('#seo-url-regenerate').on('click', () => {
         $.each($('#form_step1_names input'), function () {
           updateFriendlyUrl($(this));
         });

--- a/admin-dev/themes/default/js/calendar.js
+++ b/admin-dev/themes/default/js/calendar.js
@@ -310,7 +310,7 @@ function setPreviousYear() {
 let datepickerStart;
 let datepickerEnd;
 
-$(document).ready(() => {
+$(() => {
   // Instanciate datepickers
   datepickerStart = $('.datepicker1').daterangepicker({
     dates: window.translated_dates,
@@ -346,21 +346,21 @@ $(document).ready(() => {
   }
 
   // Events binding
-  $('#date-start').focus(function () {
+  $('#date-start').on('focus', function () {
     datepickerStart.setCompare(false);
     datepickerEnd.setCompare(false);
     $('.date-input').removeClass('input-selected');
     $(this).addClass('input-selected');
   });
 
-  $('#date-end').focus(function () {
+  $('#date-end').on('focus', function () {
     datepickerStart.setCompare(false);
     datepickerEnd.setCompare(false);
     $('.date-input').removeClass('input-selected');
     $(this).addClass('input-selected');
   });
 
-  $('#date-start-compare').focus(function () {
+  $('#date-start-compare').on('focus', function () {
     datepickerStart.setCompare(true);
     datepickerEnd.setCompare(true);
     $('#compare-options').val(3);
@@ -368,7 +368,7 @@ $(document).ready(() => {
     $(this).addClass('input-selected');
   });
 
-  $('#date-end-compare').focus(function () {
+  $('#date-end-compare').on('focus', function () {
     datepickerStart.setCompare(true);
     datepickerEnd.setCompare(true);
     $('#compare-options').val(3);
@@ -376,16 +376,16 @@ $(document).ready(() => {
     $(this).addClass('input-selected');
   });
 
-  $('#datepicker-cancel').click(() => {
+  $('#datepicker-cancel').on('click', () => {
     $('#datepicker').addClass('hide');
   });
 
-  $('#datepicker').show(() => {
+  $('#datepicker').on('show', () => {
     $('#date-start').focus();
     $('#date-start').trigger('change');
   });
 
-  $('#datepicker-compare').click(function () {
+  $('#datepicker-compare').on('click', function () {
     if ($(this).prop('checked')) {
       $('#compare-options').trigger('change');
       $('#form-date-body-compare').show();
@@ -401,7 +401,7 @@ $(document).ready(() => {
     }
   });
 
-  $('#compare-options').change(function () {
+  $('#compare-options').on('change', function () {
     if (this.value === '1') setPreviousPeriod();
 
     if (this.value === '2') setPreviousYear();

--- a/admin-dev/themes/default/js/theme.js
+++ b/admin-dev/themes/default/js/theme.js
@@ -29,7 +29,7 @@ import '@openfonts/ubuntu-condensed_latin';
 
 import PerfectScrollBar from 'perfect-scrollbar';
 
-$(document).ready(() => {
+$(() => {
   const $navBarOverflow = $('.nav-bar-overflow');
 
   if ($navBarOverflow.length > 0) {

--- a/admin-dev/themes/default/js/tree.js
+++ b/admin-dev/themes/default/js/tree.js
@@ -35,8 +35,9 @@ Tree.prototype = {
   init() {
     const name = this.$element.parent().find('ul.tree input').first().attr('name');
     const idTree = this.$element.parent().find('.cattree.tree').first().attr('id');
-    this.$element.find('label.tree-toggler, .icon-folder-close, .icon-folder-open').unbind('click');
-    this.$element.find('label.tree-toggler, .icon-folder-close, .icon-folder-open').click(
+    this.$element.find('label.tree-toggler, .icon-folder-close, .icon-folder-open').off('click');
+    this.$element.find('label.tree-toggler, .icon-folder-close, .icon-folder-open').on(
+      'click',
       function () {
         if ($(this).parent().parent().children('ul.tree')
           .is(':visible')) {
@@ -96,8 +97,9 @@ Tree.prototype = {
         }
       },
     );
-    this.$element.find('li').unbind('click');
-    this.$element.find('li').click(
+    this.$element.find('li').off('click');
+    this.$element.find('li').on(
+      'click',
       () => {
         $('.tree-selected').removeClass('tree-selected');
         $('li input:checked').parent().addClass('tree-selected');
@@ -106,8 +108,8 @@ Tree.prototype = {
 
     if (typeof (idTree) !== 'undefined') {
       if ($('select#id_category_default').length) {
-        this.$element.find(':input[type=checkbox]').unbind('click');
-        this.$element.find(':input[type=checkbox]').click(function () {
+        this.$element.find(':input[type=checkbox]').off('click');
+        this.$element.find(':input[type=checkbox]').on('click', function () {
           // eslint-disable-next-line
           if ($(this).prop('checked')) addDefaultCategory($(this));
           else {
@@ -120,10 +122,10 @@ Tree.prototype = {
         });
       }
       if (typeof (treeClickFunc) !== 'undefined') {
-        this.$element.find(':input[type=radio]').unbind('click');
+        this.$element.find(':input[type=radio]').off('click');
 
         // eslint-disable-next-line
-        this.$element.find(':input[type=radio]').click(treeClickFunc);
+        this.$element.find(':input[type=radio]').on('click', treeClickFunc);
       }
     }
 

--- a/admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/access/helpers/form/form.tpl
@@ -23,10 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *}
 <script type="text/javascript">
-   $(document).ready(function() {
+   $(function() {
       var id_tab_parentmodule = {$id_tab_parentmodule|intval};
       var id_tab_module = {$id_tab_module|intval};
-      $('tr.child-'+id_tab_parentmodule+' > td > input.view.'+id_tab_module).change( function () {
+      $('tr.child-'+id_tab_parentmodule+' > td > input.view.'+id_tab_module).on('change', function () {
          if (!$(this).prop('checked'))
          {
             $('#table_module_2 thead th:eq(1) input').trigger('click');
@@ -34,7 +34,7 @@
                $('#table_module_2 thead th:eq(1) input').trigger('click');
          }
       });
-      $('tr.child-'+id_tab_parentmodule+' > td > input.edit.'+id_tab_module).change( function () {
+      $('tr.child-'+id_tab_parentmodule+' > td > input.edit.'+id_tab_module).on('change', function () {
          if (!$(this).prop('checked'))
          {
             $('#table_module_2 thead th:eq(2) input').trigger('click');
@@ -46,7 +46,7 @@
       $('div.productTabs').find('a').each(function() {
          $(this).attr('href', '#');
       });
-      $('div.productTabs a').click(function() {
+      $('div.productTabs a').on('click', function() {
          var id = $(this).attr('id');
          $('.nav-profile').removeClass('selected');
          $(this).addClass('selected active');
@@ -64,7 +64,7 @@
          }
          return false;
       }
-      $('.ajaxPower').change(function(){
+      $('.ajaxPower').on('change', function(){
          var tout = $(this).data('rel').split('||');
          var rel = $(this).data('rel');
          var id_tab = tout[0];
@@ -190,7 +190,7 @@
             }
          });
       });
-      $(".changeModuleAccess").change(function(){
+      $(".changeModuleAccess").on('change', function(){
          var tout = $(this).data('rel').split('||');
          var id_module = tout[0];
          var perm = tout[1];

--- a/admin-dev/themes/default/template/controllers/attributes/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/attributes/helpers/form/form.tpl
@@ -72,7 +72,7 @@
 
 	displayColorFieldsOption();
 
-	$('#id_attribute_group').change(displayColorFieldsOption);
+	$('#id_attribute_group').on('change', displayColorFieldsOption);
 
 	var shop_associations = {$fields[0]['form']['shop_associations']};
 	var changeAssociationGroup = function()
@@ -90,6 +90,6 @@
 			}
 		});
 	};
-	$('#id_attribute_group').change(changeAssociationGroup);
+	$('#id_attribute_group').on('change', changeAssociationGroup);
 	changeAssociationGroup();
 {/block}

--- a/admin-dev/themes/default/template/controllers/attributes_groups/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/controllers/attributes_groups/helpers/list/list_header.tpl
@@ -26,7 +26,7 @@
 {extends file="helpers/list/list_header.tpl"}
 {block name=leadin}
 	<script type="text/javascript">
-		$(document).ready(function() {
+		$(function() {
 			$(location.hash).click();
 		});
 	</script>

--- a/admin-dev/themes/default/template/controllers/cart_rules/form.js
+++ b/admin-dev/themes/default/template/controllers/cart_rules/form.js
@@ -107,14 +107,14 @@ window.restrictions = new Array('country', 'carrier', 'group', 'cart_rule', 'sho
 
 for (i in restrictions) {
   toggleCartRuleFilter($(`#${restrictions[i]}_restriction`));
-  $(`#${restrictions[i]}_restriction`).change(function () { toggleCartRuleFilter(this); });
-  $(`#${restrictions[i]}_select_remove`).click(function () { removeCartRuleOption(this); });
-  $(`#${restrictions[i]}_select_add`).click(function () { addCartRuleOption(this); });
+  $(`#${restrictions[i]}_restriction`).on('change', function () { toggleCartRuleFilter(this); });
+  $(`#${restrictions[i]}_select_remove`).on('click', function () { removeCartRuleOption(this); });
+  $(`#${restrictions[i]}_select_add`).on('click', function () { addCartRuleOption(this); });
 }
 
 toggleCartRuleFilter($('#product_restriction'));
 
-$('#group_restriction').change(function () {
+$('#group_restriction').on('change', function () {
   $('#customerFilter').prop('disabled', $(this).prop('checked'));
 }).change();
 
@@ -122,7 +122,7 @@ $('#customerFilter').on('change keyup', function () {
   $('#group_restriction').prop('disabled', $(this).val() !== '');
 }).change();
 
-$('#product_restriction').change(function () {
+$('#product_restriction').on('change', function () {
   toggleCartRuleFilter(this);
 
   if ($(this).prop('checked')) {
@@ -134,7 +134,7 @@ $('#product_restriction').change(function () {
   }
 });
 
-$('#apply_discount_to_selection_shortcut').click((e) => {
+$('#apply_discount_to_selection_shortcut').on('click', (e) => {
   displayCartRuleTab('conditions');
   $('#product_restriction').focus();
   e.preventDefault();
@@ -201,57 +201,57 @@ function toggleGiftProduct() {
   }
 }
 
-$('#apply_discount_percent').click(() => {
+$('#apply_discount_percent').on('click', () => {
   toggleApplyDiscount(true, false, true);
 });
 if ($('#apply_discount_percent').prop('checked')) toggleApplyDiscount(true, false, true);
 
-$('#apply_discount_amount').click(() => {
+$('#apply_discount_amount').on('click', () => {
   toggleApplyDiscount(false, true, true);
 });
 if ($('#apply_discount_amount').prop('checked')) toggleApplyDiscount(false, true, true);
 
-$('#apply_discount_off').click(() => {
+$('#apply_discount_off').on('click', () => {
   toggleApplyDiscount(false, false, false);
 });
 if ($('#apply_discount_off').prop('checked')) toggleApplyDiscount(false, false, false);
 
-$('#apply_discount_to_order').click(() => {
+$('#apply_discount_to_order').on('click', () => {
   toggleApplyDiscountTo();
 },
 );
 if ($('#apply_discount_to_order').prop('checked')) toggleApplyDiscountTo();
 
-$('#apply_discount_to_product').click(() => {
+$('#apply_discount_to_product').on('click', () => {
   toggleApplyDiscountTo();
 },
 );
 if ($('#apply_discount_to_product').prop('checked')) toggleApplyDiscountTo();
 
-$('#apply_discount_to_cheapest').click(() => {
+$('#apply_discount_to_cheapest').on('click', () => {
   toggleApplyDiscountTo();
 },
 );
 if ($('#apply_discount_to_cheapest').prop('checked')) toggleApplyDiscountTo();
 
-$('#apply_discount_to_selection').click(() => {
+$('#apply_discount_to_selection').on('click', () => {
   toggleApplyDiscountTo();
 },
 );
 if ($('#apply_discount_to_selection').prop('checked')) toggleApplyDiscountTo();
 
-$('#free_gift_on').click(() => {
+$('#free_gift_on').on('click', () => {
   toggleGiftProduct();
 },
 );
-$('#free_gift_off').click(() => {
+$('#free_gift_off').on('click', () => {
   toggleGiftProduct();
 },
 );
 toggleGiftProduct();
 
 // Main form submit
-$('#cart_rule_form').submit(() => {
+$('#cart_rule_form').on('submit', () => {
   if ($('#customerFilter').val() == '') $('#id_customer').val('0');
 
   for (i in restrictions) {
@@ -447,8 +447,8 @@ function displayProductAttributes() {
   }
 }
 
-$(document).ready(() => {
-  $(window).keydown((event) => {
+$(() => {
+  $(window).on('keydown', (event) => {
     if (event.keyCode == 13) {
 	  		event.preventDefault();
 	  		return false;

--- a/admin-dev/themes/default/template/controllers/cart_rules/informations.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/informations.tpl
@@ -150,8 +150,8 @@
 </div>
 <script type="text/javascript">
 	$(".textarea-autosize").autosize();
-	$(document).ready(function() {
-    $('#code').bind('keyup change', function() {
+	$(function() {
+    $('#code').on('keyup change', function() {
       $('#cart-rules-highlight').toggle($(this).val() !== "");
     });
   });

--- a/admin-dev/themes/default/template/controllers/cart_rules/product_rule.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/product_rule.tpl
@@ -58,5 +58,5 @@
     width: 900,
     autoHeight: true,
   });
-	$(document).ready(function() { updateProductRuleShortDescription($('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_add')); });
+	$(function() { updateProductRuleShortDescription($('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_add')); });
 </script>

--- a/admin-dev/themes/default/template/controllers/cart_rules/product_rule_itemlist.tpl
+++ b/admin-dev/themes/default/template/controllers/cart_rules/product_rule_itemlist.tpl
@@ -52,7 +52,7 @@
 </div>
 
 <script type="text/javascript">
-	$('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_remove').click(function() { removeCartRuleOption(this); updateProductRuleShortDescription(this); });
-	$('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_add').click(function() { addCartRuleOption(this); updateProductRuleShortDescription(this); });
-	$(document).ready(function() { updateProductRuleShortDescription($('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_add')); });
+	$('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_remove').on('click', function() { removeCartRuleOption(this); updateProductRuleShortDescription(this); });
+	$('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_add').on('click', function() { addCartRuleOption(this); updateProductRuleShortDescription(this); });
+	$(function() { updateProductRuleShortDescription($('#product_rule_select_{$product_rule_group_id|intval}_{$product_rule_id|intval}_add')); });
 </script>

--- a/admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/countries/helpers/form/form.tpl
@@ -80,22 +80,22 @@
 
 {block name=script}
 
-	$(document).ready(function() {
+	$(function() {
 
-		$('.addPattern').click(function() {
+		$('.addPattern').on('click', function() {
 			addFieldsToCursorPosition($(this).attr("id"))
 			lastLayoutModified = $("#ordered_fields").val();
 		});
 
-		$('#ordered_fields').keyup(function() {
+		$('#ordered_fields').on('keyup', function() {
 			lastLayoutModified = $(this).val();
 		});
 
-		$('#need_zip_code_on, #need_zip_code_off').change(function() {
+		$('#need_zip_code_on, #need_zip_code_off').on('change', function() {
 			disableZipFormat();
 		});
 
-		$('#iso_code').change(function() {
+		$('#iso_code').on('change', function() {
 			disableTAASC();
 		});
 		disableTAASC();
@@ -110,7 +110,7 @@
 		$("#ordered_fields").val(unescape(defaultLayout.replace(/\+/g, " ")));
 	}
 
-	$('#custom-address-fields a').click(function (e) {
+	$('#custom-address-fields a').on('click', function (e) {
   		e.preventDefault();
   		$(this).tab('show')
 	})

--- a/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/customer_threads/helpers/view/view.tpl
@@ -136,8 +136,8 @@
 {/if}
 <script type="text/javascript">
 	var timer;
-		$(document).ready(function(){
-			$('select[name=id_employee_forward]').change(function(){
+		$(function(){
+			$('select[name=id_employee_forward]').on('change', function(){
 				if ($(this).val() >= 0)
 					$('#message_forward').show(400);
 				else
@@ -147,7 +147,7 @@
 				else
 					$('#message_forward_email').hide(200);
 			});
-			$('textarea[name=message_forward]').click(function(){
+			$('textarea[name=message_forward]').on('click', function(){
 				if($(this).val() == '{l s='You can add a comment here.'}')
 				{
 					$(this).val('');

--- a/admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/groups/helpers/form/form.tpl
@@ -43,7 +43,7 @@
 	{if $input['type'] == 'group_discount_category'}
 	<div {if !$form_id}class="hide"{/if}>
 		<script type="text/javascript">
-		$(document).ready(function() {
+		$(function() {
 			$("#group_discount_category").fancybox({
 				beforeLoad: function () {
 					$('#group_discount_category_fancybox').show();
@@ -171,12 +171,12 @@
 	{elseif $input['type'] == 'modules'}
 	<div {if !$form_id}class="hide"{/if}>
 		<script type="text/javascript">
-			$(document).ready(function() {
-				$('#authorized-modules').find('[value="0"]').click(function() {
+			$(function() {
+				$('#authorized-modules').find('[value="0"]').on('click', function() {
 					$(this).parent().parent().find('input[type=hidden]').attr('name', 'modulesBoxUnauth[]');
 				});
 
-				$('#authorized-modules').find('[value="1"]').click(function() {
+				$('#authorized-modules').find('[value="1"]').on('click', function() {
 					$(this).parent().parent().find('input[type=hidden]').attr('name', 'modulesBoxAuth[]');
 				});
 			});

--- a/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_categories.tpl
+++ b/admin-dev/themes/default/template/controllers/groups/helpers/tree/tree_categories.tpl
@@ -56,7 +56,7 @@
 		}
 	{/if}
 	{if isset($use_search) && $use_search == true}
-		$("#{$id|escape:'html':'UTF-8'}-categories-search").bind("typeahead:selected", function(obj, datum) {
+		$("#{$id|escape:'html':'UTF-8'}-categories-search").on("typeahead:selected", function(obj, datum) {
 		    $("#{$id|escape:'html':'UTF-8'}").find(":input").each(
 				function()
 				{
@@ -78,7 +78,7 @@
 			);
 		});
 	{/if}
-	$(document).ready(function () {
+	$(function () {
 		$("#{$id|escape:'html':'UTF-8'}").tree("collapseAll");
 
 		{if isset($selected_categories)}

--- a/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/import/helpers/view/view.tpl
@@ -42,14 +42,14 @@
 			current = nb;
 			$('#table' + current).show();
 		}
-		$(document).ready(function() {
+		$(function() {
 			var btn_save_import = $('span[class~="process-icon-save-import"]').parent();
 			var btn_submit_import = $('#import');
 			if (btn_save_import.length > 0 && btn_submit_import.length > 0) {
 				btn_submit_import.closest('.form-group').hide();
 				btn_save_import.find('span').removeClass('process-icon-save-import');
 				btn_save_import.find('span').addClass('process-icon-save');
-				btn_save_import.click(function(){
+				btn_save_import.on('click', function(){
 					btn_submit_import.before('<input type="hidden" name="' + btn_submit_import.attr("name") + '" value="1" />');
 					$('#import_form').submit();
 				});

--- a/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
+++ b/admin-dev/themes/default/template/controllers/modules_positions/form.tpl
@@ -129,12 +129,12 @@
 			str = val.join(', ');
 		obj.closest('form').find('#em_text_' + shopID).val(str);
 	}
-	$(document).ready(function(){
+	$(function(){
 		$('form[id="hook_module_form"] input[id^="em_text_"]').each(function(){
-			$(this).change(position_exception_textchange).change();
+			$(this).on('change', position_exception_textchange).change();
 		});
 		$('form[id="hook_module_form"] select[id^="em_list_"]').each(function(){
-			$(this).change(position_exception_listchange);
+			$(this).on('change', position_exception_listchange);
 		});
 		$('select[name=id_hook]').on('change', function() {
 			$('#new_hook').attr('value', $(this).val());

--- a/admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/shop/helpers/form/form.tpl
@@ -44,8 +44,8 @@
 	{else}
 		{if $input.type == 'select' && $input.name == 'id_category'}
 			<script type="text/javascript">
-				$(document).ready(function(){
-					$('#id_category').change(function(){
+				$(function(){
+					$('#id_category').on('change', function(){
 						doAdminAjax(
 							{
 							ajax: '1',
@@ -136,8 +136,8 @@
 	{foreach $ids_category as $key => $id_category}
 		ids_category[{$key}] = {$id_category};
 	{/foreach}
-	$(document).ready(function() {
-		$('input[name=useImportData]').click(function()	{
+	$(function() {
+		$('input[name=useImportData]').on('click', function()	{
 			if ($(this).attr('id') == 'useImportData_on')
 			{
 				$('input[name^="importData["]').prop('checked', true);
@@ -149,7 +149,7 @@
 				$('#shop_list, #data_list').slideUp('slow');
 			}
 		});
-		$('#id_category, #importFromShop').change(function(){
+		$('#id_category, #importFromShop').on('change', function(){
 			shop_id = $('#importFromShop').val();
 			category_id = $('#id_category').val();
 			if (ids_category[shop_id] != category_id)

--- a/admin-dev/themes/default/template/controllers/shop_group/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/shop_group/helpers/form/form.tpl
@@ -45,21 +45,21 @@
 		}
 	}
 
-	$(document).ready(function() {
+	$(function() {
 		if (!$("input[name=share_order]").prop('disabled'))
 		{
 			toggleShareOrders();
-			$('input[name=share_customer]').click(function()
+			$('input[name=share_customer]').on('click', function()
 			{
 				toggleShareOrders();
 			});
-			$('input[name=share_stock]').click(function()
+			$('input[name=share_stock]').on('click', function()
 			{
 				toggleShareOrders();
 			});
 		}
 
-		$('#useImportData').click(function() {
+		$('#useImportData').on('click', function() {
 			$('#importList').slideToggle('slow');
 		});
 	});

--- a/admin-dev/themes/default/template/controllers/shop_url/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/shop_url/helpers/form/form.tpl
@@ -25,24 +25,24 @@
 {extends file="helpers/form/form.tpl"}
 
 {block name=script}
-	$(document).ready(function(){
+	$(function(){
 		fillShopUrl();
 		checkMainUrlInfo();
-		$('#domain, #physical_uri, #virtual_uri').keyup(fillShopUrl);
+		$('#domain, #physical_uri, #virtual_uri').on('keyup', fillShopUrl);
 
 		var change_domain_value = false;
-		$('#domain').keydown(function()
+		$('#domain').on('keydown', function()
 		{
 			if (!$('#domain_ssl').val() || $('#domain_ssl').val() == $('#domain').val())
 				change_domain_value = true;
 		});
 
-		$('#domain_ssl').keydown(function()
+		$('#domain_ssl').on('keydown', function()
 		{
 			change_domain_value = false;
 		});
 
-		$('#domain').blur(function()
+		$('#domain').on('blur', function()
 		{
 			if (change_domain_value)
 			{
@@ -51,7 +51,7 @@
 			}
 		});
 
-		$('#domain, #domain_ssl, #physical_uri, #virtual_uri').blur(function()
+		$('#domain, #domain_ssl, #physical_uri, #virtual_uri').on('blur', function()
 		{
 			$(this).val($.trim($(this).val().replace(/ /g, '-')));
 		});

--- a/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/specific_price_rule/helpers/form/form.tpl
@@ -208,8 +208,8 @@ function appendConditionToGroup(html)
 	$('#condition_group_'+current_id_condition_group+' table tbody').append(html);
 }
 
-$(document).ready(function() {
-	$('#leave_bprice_on').click(function() {
+$(function() {
+	$('#leave_bprice_on').on('click', function() {
 		if (this.checked)
 			$('#price').attr('disabled', 'disabled');
 		else
@@ -222,17 +222,17 @@ $(document).ready(function() {
 		$('#conditions').append(html);
 	});
 
-	$('#id_feature').change(function() {
+	$('#id_feature').on('change', function() {
 		$('.id_feature_value').hide();
 		$('#id_feature_'+$(this).val()).show();
 	});
 
-	$('#id_attribute_group').change(function() {
+	$('#id_attribute_group').on('change', function() {
 		$('.id_attribute').hide();
 		$('#id_attribute_'+$(this).val()).show();
 	});
 
-	$('#add_condition_category').click(function() {
+	$('#add_condition_category').on('click', function() {
 		var id_condition = add_condition(current_id_condition_group, 'category', $('#id_category option:selected').val());
 		if (!id_condition)
 			return false;
@@ -243,7 +243,7 @@ $(document).ready(function() {
 		return false;
 	});
 
-	$('#add_condition_manufacturer').click(function() {
+	$('#add_condition_manufacturer').on('click', function() {
 		var id_condition = add_condition(current_id_condition_group, 'manufacturer', $('#id_manufacturer option:selected').val());
 		if (!id_condition)
 			return false;
@@ -254,7 +254,7 @@ $(document).ready(function() {
 		return false;
 	});
 
-	$('#add_condition_supplier').click(function() {
+	$('#add_condition_supplier').on('click', function() {
 		var id_condition = add_condition(current_id_condition_group, 'supplier', $('#id_supplier option:selected').val());
 		if (!id_condition)
 			return false;
@@ -265,7 +265,7 @@ $(document).ready(function() {
 		return false;
 	});
 
-	$('#add_condition_attribute').click(function() {
+	$('#add_condition_attribute').on('click', function() {
 		var id_condition = add_condition(current_id_condition_group, 'attribute', $('#id_attribute_'+$('#id_attribute_group option:selected').val()+' option:selected').val());
 		if (!id_condition)
 			return false;
@@ -276,7 +276,7 @@ $(document).ready(function() {
 		return false;
 	});
 
-	$('#add_condition_feature').click(function() {
+	$('#add_condition_feature').on('click', function() {
 		var id_condition = add_condition(current_id_condition_group, 'feature', $('#id_feature_'+$('#id_feature option:selected').val()+' option:selected').val());
 		if (!id_condition)
 			return false;
@@ -287,7 +287,7 @@ $(document).ready(function() {
 		return false;
 	});
 
-	$('#add_condition_group').click(function() {
+	$('#add_condition_group').on('click', function() {
 		new_condition_group();
 		return false;
 	});

--- a/admin-dev/themes/default/template/controllers/stats/helpers/view/view.tpl
+++ b/admin-dev/themes/default/template/controllers/stats/helpers/view/view.tpl
@@ -34,7 +34,7 @@
 			if (btn_save_calendar.length > 0 && btn_submit_calendar.length > 0)
 			{
 				btn_submit_calendar.hide();
-				btn_save_calendar.click(function() {
+				btn_save_calendar.on('click', function() {
 					btn_submit_calendar.before('<input type="hidden" name="'+btn_submit_calendar.attr("name")+'" value="1" />');
 
 					$('#calendar_form').submit();
@@ -47,7 +47,7 @@
 			if (btn_save_settings.length > 0 && btn_submit_settings.length > 0)
 			{
 				btn_submit_settings.hide();
-				btn_save_settings.click(function() {
+				btn_save_settings.on('click', function() {
 					btn_submit_settings.before('<input type="hidden" name="'+btn_submit_settings.attr("name")+'" value="1" />');
 
 					$('#settings_form').submit();

--- a/admin-dev/themes/default/template/controllers/statuses/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/statuses/helpers/form/form.tpl
@@ -109,8 +109,8 @@
 {/block}
 
 {block name="script"}
-	$(document).ready(function() {
-		$('#send_email_on').click(function() {
+	$(function() {
+		$('#send_email_on').on('click', function() {
 			$('#tpl').slideToggle();
 		});
 	});

--- a/admin-dev/themes/default/template/controllers/stores/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/stores/helpers/form/form.tpl
@@ -25,8 +25,8 @@
 {extends file="helpers/form/form.tpl"}
 
 {block name=script}
-	$(document).ready(function() {
-		$('#latitude, #longitude').keyup(function() {
+	$(function() {
+		$('#latitude, #longitude').on('keyup', function() {
 			$(this).val($(this).val().replace(/,/g, '.'));
 		});
 	});

--- a/admin-dev/themes/default/template/controllers/stores/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/controllers/stores/helpers/options/options.tpl
@@ -50,12 +50,12 @@
     });
 }
 
-$(document).ready(function(){
+$(function(){
     {if isset($categoryData.fields.PS_SHOP_STATE_ID.value)}
 	    if ($('#PS_SHOP_COUNTRY_ID') && $('#PS_SHOP_STATE_ID'))
 	    {
 			ajaxStoreStates({$categoryData.fields.PS_SHOP_STATE_ID.value});
-			$('#PS_SHOP_COUNTRY_ID').change(function() {
+			$('#PS_SHOP_COUNTRY_ID').on('change', function() {
 			    ajaxStoreStates();
 			});
 	    }

--- a/admin-dev/themes/default/template/controllers/tags/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/tags/helpers/form/form.tpl
@@ -57,11 +57,11 @@
 
 
 	<script type="text/javascript">
-	$(document).ready(function(){
-		$('#move_to_right').click(function(){
+	$(function(){
+		$('#move_to_right').on('click', function(){
 			return !$('#select_left option:selected').remove().appendTo('#select_right');
 		})
-		$('#move_to_left').click(function(){
+		$('#move_to_left').on('click', function(){
 			return !$('#select_right option:selected').remove().appendTo('#select_left');
 		});
 		$(document).on('dblclick', '#select_left option', function(e) {
@@ -71,7 +71,7 @@
 			$(this).remove().appendTo('#select_left');
 		});
 	});
-	$('#tag_form').submit(function()
+	$('#tag_form').on('submit', function()
 	{
 		$('#select_right option').each(function(i){
 			$(this).prop('selected', 'selected');

--- a/admin-dev/themes/default/template/controllers/tax_rules/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/controllers/tax_rules/helpers/form/form.tpl
@@ -35,8 +35,8 @@
 {/block}
 
 {block name="script"}
-	$(document).ready(function() {
-		$('#country').change(function() {
+	$(function() {
+		$('#country').on('change', function() {
 			populateStates($(this).val(), '');
 		});
 
@@ -52,7 +52,7 @@
 		else
 		{
 			$('#tax_rule_form').hide();
-			$('#page-header-desc-tax_rule-new').click(function() {
+			$('#page-header-desc-tax_rule-new').on('click', function() {
 				initForm();
 				$('#tax_rule_form').slideToggle();
 				return false;

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_errors.tpl
@@ -53,8 +53,8 @@
 		</div>
 
 		<script type="text/javascript">
-			$(document).ready(function(){
-				$('a.useSpecialSyntax').click(function(){
+			$(function(){
+				$('a.useSpecialSyntax').on('click', function(){
 					var syntax = $(this).find('img').attr('alt');
 					$('#BoxUseSpecialSyntax .syntax span').html(syntax+".");
 				});

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_form.tpl
@@ -65,13 +65,13 @@
 				<input type="hidden" name="theme" value="{$theme}" />
 
 				<script type="text/javascript">
-					$(document).ready(function(){
-						$('a.useSpecialSyntax').click(function(){
+					$(function(){
+						$('a.useSpecialSyntax').on('click', function(){
 							var syntax = $(this).find('img').attr('alt');
 							$('#BoxUseSpecialSyntax .syntax span').html(syntax+".");
 						});
 
-						$("a.sidetoggle").click(function(){
+						$("a.sidetoggle").on('click', function(){
 							$('#'+$(this).attr('data-slidetoggle')).slideToggle();
 							return false;
 						});

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_mails.tpl
@@ -55,8 +55,8 @@
 				<input type="hidden" name="type" value="{$type}" />
 				<input type="hidden" name="selected-theme" value="{$theme}" />
 				<script type="text/javascript">
-					$(document).ready(function(){
-						$('a.useSpecialSyntax').click(function(){
+					$(function(){
+						$('a.useSpecialSyntax').on('click', function(){
 							var syntax = $(this).find('img').attr('alt');
 							$('#BoxUseSpecialSyntax .syntax span').html(syntax+".");
 						});
@@ -104,7 +104,7 @@
 				{literal}
 				<script type="text/javascript">
 				//<![CDATA[
-					$(document).ready(function () {
+					$(function () {
 						$('.mails_field').on('shown.bs.collapse', function () {
 							// get active email
 							var active_email = $(this).find('.email-collapse.in');

--- a/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
+++ b/admin-dev/themes/default/template/controllers/translations/helpers/view/translation_modules.tpl
@@ -78,8 +78,8 @@
 					</div>
 				</div>
 				<script type="text/javascript">
-					$(document).ready(function(){
-						$('a.useSpecialSyntax').click(function(){
+					$(function(){
+						$('a.useSpecialSyntax').on('click', function(){
 							var syntax = $(this).find('img').attr('alt');
 							$('#BoxUseSpecialSyntax .syntax span').html(syntax+".");
 						});

--- a/admin-dev/themes/default/template/footer_toolbar.tpl
+++ b/admin-dev/themes/default/template/footer_toolbar.tpl
@@ -123,7 +123,7 @@
 			//hide standard submit button
 			btn_submit.hide();
 			//bind enter key press to validate form
-			$('#{$table}_form').find('input').keypress(function (e) {
+			$('#{$table}_form').find('input').on('keypress', function (e) {
 				if (e.which == 13 && e.target.localName != 'textarea' && !$(e.target).parent().hasClass('tagify-container'))
 					$('#desc-{$table}-save').click();
 			});

--- a/admin-dev/themes/default/template/form_date_range_picker.tpl
+++ b/admin-dev/themes/default/template/form_date_range_picker.tpl
@@ -64,7 +64,7 @@
 	</form>
 </div>
 <script type="text/javascript">
-	$(document).ready(function() {
+	$(function() {
 		if ($("form#calendar_form .datepicker").length > 0)
 			$("form#calendar_form .datepicker").datepicker({
 				prevText: '',

--- a/admin-dev/themes/default/template/form_submit_ajax.tpl
+++ b/admin-dev/themes/default/template/form_submit_ajax.tpl
@@ -24,8 +24,8 @@
  *}
 
 <script type="text/javascript">
-	$(document).ready(function() {
-		$('#{$table}_form').submit(function(e) {
+	$(function() {
+		$('#{$table}_form').on('submit', function(e) {
 			e.preventDefault();
 			var form_datas = new Object;
 			form_datas['liteDisplaying'] = 1;

--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -119,7 +119,7 @@
 															$().ready(function () {
 																var input_id = '{/literal}{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}{literal}';
 																$('#'+input_id).tagify({delimiters: [13,44], addTagPrompt: '{/literal}{l s='Add tag' js=1}{literal}'});
-																$({/literal}'#{$table}{literal}_form').submit( function() {
+																$({/literal}'#{$table}{literal}_form').on('submit', function() {
 																	$(this).find('#'+input_id).val($('#'+input_id).tagify('serialize'));
 																});
 															});
@@ -179,7 +179,7 @@
 									{/foreach}
 									{if isset($input.maxchar) && $input.maxchar}
 									<script type="text/javascript">
-									$(document).ready(function(){
+									$(function(){
 									{foreach from=$languages item=language}
 										countDown($("#{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}"), $("#{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}_counter"));
 									{/foreach}
@@ -196,7 +196,7 @@
 												$().ready(function () {
 													var input_id = '{/literal}{if isset($input.id)}{$input.id}{else}{$input.name}{/if}{literal}';
 													$('#'+input_id).tagify({delimiters: [13,44], addTagPrompt: '{/literal}{l s='Add tag'}{literal}'});
-													$({/literal}'#{$table}{literal}_form').submit( function() {
+													$({/literal}'#{$table}{literal}_form').on('submit', function() {
 														$(this).find('#'+input_id).val($('#'+input_id).tagify('serialize'));
 													});
 												});
@@ -240,7 +240,7 @@
 										{/if}
 										{if isset($input.maxchar) && $input.maxchar}
 										<script type="text/javascript">
-										$(document).ready(function(){
+										$(function(){
 											countDown($("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}"), $("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}_counter"));
 										});
 										</script>
@@ -287,7 +287,7 @@
 									</div>
 									{if isset($input.maxchar) && $input.maxchar}
 									<script type="text/javascript">
-										$(document).ready(function() {
+										$(function() {
 											countDown($("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}"), $("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}_counter"));
 										});
 									</script>
@@ -467,7 +467,7 @@
 										{/foreach}
 										{if isset($input.maxchar) && $input.maxchar}
 											<script type="text/javascript">
-											$(document).ready(function(){
+											$(function(){
 											{foreach from=$languages item=language}
 												countDown($("#{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}"), $("#{if isset($input.id)}{$input.id}_{$language.id_lang}{else}{$input.name}_{$language.id_lang}{/if}_counter"));
 											{/foreach}
@@ -483,7 +483,7 @@
 										<textarea{if isset($input.readonly) && $input.readonly} readonly="readonly"{/if} name="{$input.name}" id="{if isset($input.id)}{$input.id}{else}{$input.name}{/if}" {if isset($input.cols)}cols="{$input.cols}"{/if} {if isset($input.rows)}rows="{$input.rows}"{/if} class="{if isset($input.autoload_rte) && $input.autoload_rte}rte autoload_rte{else}textarea-autosize{/if}{if isset($input.class)} {$input.class}{/if}"{if isset($input.maxlength) && $input.maxlength} maxlength="{$input.maxlength|intval}"{/if}{if isset($input.maxchar) && $input.maxchar} data-maxchar="{$input.maxchar|intval}"{/if}>{$fields_value[$input.name]|default|escape:'html':'UTF-8'}</textarea>
 										{if isset($input.maxchar) && $input.maxchar}
 											<script type="text/javascript">
-											$(document).ready(function(){
+											$(function(){
 												countDown($("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}"), $("#{if isset($input.id)}{$input.id}{else}{$input.name}{/if}_counter"));
 											});
 											</script>
@@ -734,7 +734,7 @@
 	var pathCSS = '{$smarty.const._THEME_CSS_DIR_|addslashes}';
 	var ad = '{$ad|addslashes}';
 
-	$(document).ready(function(){
+	$(function(){
 		{block name="autoload_tinyMCE"}
 			tinySetup({
 				editor_selector :"autoload_rte"
@@ -767,15 +767,15 @@
 		allowEmployeeFormLang = {$allowEmployeeFormLang|intval};
 		displayFlags(languages, id_language, allowEmployeeFormLang);
 
-		$(document).ready(function() {
+		$(function() {
 
-			$(".show_checkbox").click(function () {
+			$(".show_checkbox").on('click', function () {
 				$(this).addClass('hidden')
 				$(this).siblings('.checkbox').removeClass('hidden');
 				$(this).siblings('.hide_checkbox').removeClass('hidden');
 				return false;
 			});
-			$(".hide_checkbox").click(function () {
+			$(".hide_checkbox").on('click', function () {
 				$(this).addClass('hidden')
 				$(this).siblings('.checkbox').addClass('hidden');
 				$(this).siblings('.show_checkbox').removeClass('hidden');
@@ -786,14 +786,14 @@
 				if ($('#id_country') && $('#id_state'))
 				{
 					ajaxStates({$fields_value.id_state});
-					$('#id_country').change(function() {
+					$('#id_country').on('change', function() {
 						ajaxStates();
 					});
 				}
 			{/if}
 
 			dniRequired();
-			$('#id_country').change(dniRequired);
+			$('#id_country').on('change', dniRequired);
 
 			if ($(".datepicker").length > 0)
 				$(".datepicker").datepicker({

--- a/admin-dev/themes/default/template/helpers/list/list_header.tpl
+++ b/admin-dev/themes/default/template/helpers/list/list_header.tpl
@@ -26,7 +26,7 @@
 {if $ajax}
 	<script type="text/javascript">
 		$(function () {
-			$(".ajax_table_link").click(function () {
+			$(".ajax_table_link").on('click', function () {
 				var link = $(this);
 				$.post($(this).attr('href'), function (data) {
 				  // If response comes from symfony controller
@@ -69,7 +69,7 @@
 {if !$simple_header}
 	<script type="text/javascript">
 		$(function() {
-			$('table.{$list_id} .filter').keypress(function(e){
+			$('table.{$list_id} .filter').on('keypress', function(e){
 				var key = (e.keyCode ? e.keyCode : e.which);
 				if (key == 13)
 				{
@@ -77,7 +77,7 @@
 					formSubmit(e, 'submitFilterButton{$list_id}');
 				}
 			})
-			$('#submitFilterButton{$list_id}').click(function() {
+			$('#submitFilterButton{$list_id}').on('click', function() {
 				$('#submitFilter{$list_id}').val(1);
 			});
 
@@ -209,14 +209,14 @@
 						//hide standard submit button
 						btn_submit.hide();
 						//bind enter key press to validate form
-						$('#{$table}_form').keypress(function (e) {
+						$('#{$table}_form').on('keypress', function (e) {
 							if (e.which == 13 && e.target.localName != 'textarea') {
 								$('#desc-{$table}-save').click();
 							}
 						});
 						//submit the form
 						{block name=formSubmit}
-							btn_save.click(function() {
+							btn_save.on('click', function() {
 								// Avoid double click
 								if (submited) {
 									return false;
@@ -228,7 +228,7 @@
 								return false;
 							});
 							if (btn_save_and_stay) {
-								btn_save_and_stay.click(function() {
+								btn_save_and_stay.on('click', function() {
 									//add hidden input to emulate submit button click when posting the form -> field name posted
 									btn_submit.before('<input type="hidden" name="'+btn_submit.attr("name")+'AndStay" value="1" />');
 									$('#{$table}_form').submit();

--- a/admin-dev/themes/default/template/helpers/options/options.tpl
+++ b/admin-dev/themes/default/template/helpers/options/options.tpl
@@ -291,7 +291,7 @@
 													</div>
 												{/foreach}
 												<script type="text/javascript">
-													$(document).ready(function() {
+													$(function() {
 														$(".textarea-autosize").autosize();
 													});
 												</script>
@@ -381,7 +381,7 @@
 	var pathCSS = '{$smarty.const._THEME_CSS_DIR_|addslashes}';
 	var ad = '{$ad|addslashes}';
 
-	$(document).ready(function(){
+	$(function(){
 		{block name="autoload_tinyMCE"}
 			tinySetup({
 				editor_selector :"autoload_rte"

--- a/admin-dev/themes/default/template/helpers/tree/tree_associated_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_associated_categories.tpl
@@ -75,7 +75,7 @@
 		}
 	{/if}
 	{if isset($use_search) && $use_search == true}
-		$('#{$id|escape:'html':'UTF-8'}-categories-search').bind('typeahead:selected', function(obj, datum){
+		$('#{$id|escape:'html':'UTF-8'}-categories-search').on('typeahead:selected', function(obj, datum){
 			var match = $('#{$id|escape:'html':'UTF-8'}').find(':input[value="'+datum.id_category+'"]').first();
 			if (match.length)
 			{
@@ -130,9 +130,9 @@
 			}
 		});
 	{/if}
-	$(document).ready(function(){
+	$(function(){
 		$('#{$id|escape:'html':'UTF-8'}').tree('collapseAll');
-		$('#{$id|escape:'html':'UTF-8'}').find(':input[type=radio]').click(treeClickFunc);
+		$('#{$id|escape:'html':'UTF-8'}').find(':input[type=radio]').on('click', treeClickFunc);
 
 		{if isset($selected_categories)}
 			$('#no_default_category').hide();

--- a/admin-dev/themes/default/template/helpers/tree/tree_categories.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_categories.tpl
@@ -56,7 +56,7 @@
 		}
 	{/if}
 	{if isset($use_search) && $use_search == true}
-		$("#{$id|escape:'html':'UTF-8'}-categories-search").bind("typeahead:selected", function(obj, datum) {
+		$("#{$id|escape:'html':'UTF-8'}-categories-search").on("typeahead:selected", function(obj, datum) {
 		    $("#{$id|escape:'html':'UTF-8'}").find(":input").each(
 				function()
 				{
@@ -76,7 +76,7 @@
 			);
 		});
 	{/if}
-	$(document).ready(function () {
+	$(function () {
 		$("#{$id|escape:'html':'UTF-8'}").tree("collapseAll");
 
 		{if isset($selected_categories)}

--- a/admin-dev/themes/default/template/helpers/tree/tree_shops.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_shops.tpl
@@ -53,10 +53,11 @@
 		);
 	}
 
-	$(document).ready(function () {
+	$(function () {
 		$("#{$id|escape:'html':'UTF-8'}").tree("expandAll");
-		$("#{$id|escape:'html':'UTF-8'}").find(":input[type=checkbox]").click(
-			function()
+		$("#{$id|escape:'html':'UTF-8'}").find(":input[type=checkbox]").on(
+      'click',
+      function()
 			{
 				if($(this).is(':checked'))
 				{

--- a/admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl
+++ b/admin-dev/themes/default/template/helpers/tree/tree_toolbar_search.tpl
@@ -35,7 +35,7 @@
 {if isset($typeahead_source) && isset($id) && isset($name)}
 
 <script type="text/javascript">
-	$(document).ready(
+	$(
 		function()
 		{
 			$("#{$id|escape:'html':'UTF-8'}").typeahead(
@@ -45,7 +45,7 @@
 				local: [{$typeahead_source}]
 			});
 
-			$("#{$id|escape:'html':'UTF-8'}").keypress(function( event ) {
+			$("#{$id|escape:'html':'UTF-8'}").on('keypress', function( event ) {
 				if ( event.which == 13 ) {
 					event.stopPropagation();
 				}

--- a/admin-dev/themes/default/template/helpers/uploader/ajax.tpl
+++ b/admin-dev/themes/default/template/helpers/uploader/ajax.tpl
@@ -115,7 +115,7 @@
 			{if isset($drop_zone)}dropZone: {$drop_zone},{/if}
 			start: function (e) {
 				{$id|escape:'html':'UTF-8'}_upload_button.start();
-				$('#{$id|escape:'html':'UTF-8'}-upload-button').unbind('click'); //Important as we bind it for every elements in add function
+				$('#{$id|escape:'html':'UTF-8'}-upload-button').off('click'); //Important as we bind it for every elements in add function
 			},
 			fail: function (e, data) {
 				$('#{$id|escape:'html':'UTF-8'}-errors').html(data.errorThrown.message).parent().show();
@@ -160,7 +160,7 @@
 				if ({$id|escape:'html':'UTF-8'}_total_files == 0)
 				{
 					{$id|escape:'html':'UTF-8'}_upload_button.stop();
-					$('#{$id|escape:'html':'UTF-8'}-upload-button').unbind('click');
+					$('#{$id|escape:'html':'UTF-8'}-upload-button').off('click');
 					$('#{$id|escape:'html':'UTF-8'}-files-list').parent().hide();
 				}
 		}).on('fileuploadadd', function(e, data) {
@@ -188,7 +188,7 @@
 			});
 
 			$('#{$id|escape:'html':'UTF-8'}-files-list').parent().show();
-			$('#{$id|escape:'html':'UTF-8'}-upload-button').show().bind('click', function () {
+			$('#{$id|escape:'html':'UTF-8'}-upload-button').show().on('click', function () {
 				if (data.files != null)
 					data.submit();
 			});

--- a/admin-dev/themes/default/template/helpers/uploader/simple.tpl
+++ b/admin-dev/themes/default/template/helpers/uploader/simple.tpl
@@ -81,12 +81,12 @@
 	var {$id|escape:'html':'UTF-8'}_max_files = {$max_files - ($files|count)};
 {/if}
 
-	$(document).ready(function(){
-		$('#{$id|escape:'html':'UTF-8'}-selectbutton').click(function(e) {
+	$(function(){
+		$('#{$id|escape:'html':'UTF-8'}-selectbutton').on('click', function(e) {
 			$('#{$id|escape:'html':'UTF-8'}').trigger('click');
 		});
 
-		$('#{$id|escape:'html':'UTF-8'}-name').click(function(e) {
+		$('#{$id|escape:'html':'UTF-8'}-name').on('click', function(e) {
 			$('#{$id|escape:'html':'UTF-8'}').trigger('click');
 		});
 
@@ -107,7 +107,7 @@
 			$(this).val(files[0].name);
 		});
 
-		$('#{$id|escape:'html':'UTF-8'}').change(function(e) {
+		$('#{$id|escape:'html':'UTF-8'}').on('change', function(e) {
 			if ($(this)[0].files !== undefined)
 			{
 				var files = $(this)[0].files;

--- a/admin-dev/themes/default/template/search_form.tpl
+++ b/admin-dev/themes/default/template/search_form.tpl
@@ -80,7 +80,7 @@
 	</div>
 	<script>
 		{if isset($search_type) && $search_type}
-			$(document).ready(function() {
+			$(function() {
 				$('.search-option a[data-value='+{$search_type|intval}+']').click();
 			});
 		{/if}

--- a/admin-dev/themes/default/template/toolbar.tpl
+++ b/admin-dev/themes/default/template/toolbar.tpl
@@ -72,13 +72,13 @@
 						//hide standard submit button
 						btn_submit.hide();
 						//bind enter key press to validate form
-						$('#{$table}_form').keypress(function (e) {
+						$('#{$table}_form').on('keypress', function (e) {
 							if (e.which == 13 && e.target.localName != 'textarea' && !e.target.hasClass('tagify'))
 								$('#desc-{$table}-save').click();
 						});
 						//submit the form
 						{block name=formSubmit}
-							btn_save.click(function() {
+							btn_save.on('click', function() {
 								// Vars
 								var btn_submit = $('#{$table}_form_submit_btn');
 
@@ -96,7 +96,7 @@
 
 							if (btn_save_and_stay)
 							{
-								btn_save_and_stay.click(function() {
+								btn_save_and_stay.on('click', function() {
 									//add hidden input to emulate submit button click when posting the form -> field name posted
 									btn_submit.before('<input type="hidden" name="'+btn_submit.attr("name")+'AndStay" value="1" />');
 

--- a/admin-dev/themes/new-theme/js/app/utils/sql-manager.js
+++ b/admin-dev/themes/new-theme/js/app/utils/sql-manager.js
@@ -31,7 +31,7 @@ const {$} = window;
 class SqlManager {
   showLastSqlQuery() {
     $('#catalog_sql_query_modal_content textarea[name="sql"]').val($('tbody.sql-manager').data('query'));
-    $('#catalog_sql_query_modal .btn-sql-submit').click(() => {
+    $('#catalog_sql_query_modal .btn-sql-submit').on('click', () => {
       $('#catalog_sql_query_modal_content').submit();
     });
     $('#catalog_sql_query_modal').modal('show');

--- a/admin-dev/themes/new-theme/js/components/auto-complete-search.ts
+++ b/admin-dev/themes/new-theme/js/components/auto-complete-search.ts
@@ -183,10 +183,10 @@ export default class AutoCompleteSearch {
     /* eslint-disable */
     this.$searchInput
       .typeahead(<TypeaheadJQueryOptions>typeaheadOptions, <TypeaheadJQueryDataset>dataSetConfig)
-      .bind('typeahead:select', (e: any, selectedItem: any) =>
+      .on('typeahead:select', (e: any, selectedItem: any) =>
         this.config.onSelect(selectedItem, e, this.$searchInput)
       )
-      .bind('typeahead:close', (e: any) => {
+      .on('typeahead:close', (e: any) => {
         this.config.onClose(e, this.$searchInput);
       });
     /* eslint-enable */

--- a/admin-dev/themes/new-theme/js/components/grid/extension/link-row-action-extension.ts
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/link-row-action-extension.ts
@@ -86,17 +86,17 @@ export default class LinkRowActionExtension {
             $parentCell,
           );
           let isDragging = false;
-          clickableCells.addClass('cursor-pointer').mousedown(() => {
-            $(window).mousemove(() => {
+          clickableCells.addClass('cursor-pointer').on('mousedown', () => {
+            $(window).on('mousemove', () => {
               isDragging = true;
-              $(window).unbind('mousemove');
+              $(window).off('mousemove');
             });
           });
 
-          clickableCells.mouseup(() => {
+          clickableCells.on('mouseup', () => {
             const wasDragging = isDragging;
             isDragging = false;
-            $(window).unbind('mousemove');
+            $(window).off('mousemove');
 
             if (!wasDragging) {
               const confirmMessage = $rowAction.data('confirm-message');

--- a/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.ts
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.ts
@@ -70,13 +70,16 @@ export default class PositionExtension {
     grid
       .getContainer()
       .find('.js-drag-handle')
-      .hover(
-        function hover() {
+      .on(
+        'mouseenter',
+        function () {
           $(this)
             .closest('tr')
             .addClass('hover');
-        },
-        function stopHover() {
+        }
+      ).on(
+        'mouseleave',
+        function () {
           $(this)
             .closest('tr')
             .removeClass('hover');

--- a/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.ts
+++ b/admin-dev/themes/new-theme/js/components/grid/extension/position-extension.ts
@@ -76,7 +76,7 @@ export default class PositionExtension {
           $(this)
             .closest('tr')
             .addClass('hover');
-        }
+        },
       ).on(
         'mouseleave',
         function () {

--- a/admin-dev/themes/new-theme/js/components/navbar-handler.ts
+++ b/admin-dev/themes/new-theme/js/components/navbar-handler.ts
@@ -94,7 +94,7 @@ export default class NavbarHandler {
   }
 
   private watchTabLinks(): void {
-    $('.tab-link').click((event) => {
+    $('.tab-link').on('click', (event) => {
       event.preventDefault();
       const target = $(event.target).attr('href');
 

--- a/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
+++ b/admin-dev/themes/new-theme/js/components/pagination/dynamic-paginator.ts
@@ -190,7 +190,7 @@ export default class DynamicPaginator {
     });
     this.$paginationContainer
       .find(this.selectorsMap.jumpToPageInput)
-      .keypress((e) => {
+      .on('keypress', (e) => {
         if (e.which === 13) {
           e.preventDefault();
           const input = <HTMLInputElement>e.currentTarget;

--- a/admin-dev/themes/new-theme/js/nav_bar.ts
+++ b/admin-dev/themes/new-theme/js/nav_bar.ts
@@ -61,15 +61,17 @@ export default class NavBar {
           });
         }
 
-        $navBar.find('.link-levelone').hover(
-          function onMouseEnter() {
+        $navBar.find('.link-levelone').on(
+          'mouseenter',
+          function () {
             const itemOffsetTop = $(this).position().top;
             $(this).addClass('link-hover');
             $(this)
               .find('ul.submenu')
               .css('top', itemOffsetTop);
-          },
-          function onMouseLeave() {
+          }
+        ).on('mouseleave',
+          function () {
             $(this).removeClass('link-hover');
           },
         );

--- a/admin-dev/themes/new-theme/js/nav_bar.ts
+++ b/admin-dev/themes/new-theme/js/nav_bar.ts
@@ -69,7 +69,7 @@ export default class NavBar {
             $(this)
               .find('ul.submenu')
               .css('top', itemOffsetTop);
-          }
+          },
         ).on('mouseleave',
           function () {
             $(this).removeClass('link-hover');

--- a/admin-dev/themes/new-theme/js/pages/address/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/address/form.ts
@@ -31,7 +31,7 @@ import addressFormMap from './address-form-map';
 
 const {$} = window;
 
-$(document).ready(() => {
+$(() => {
   new AutocompleteWithEmail(addressFormMap.addressEmailInput, {
     firstName: addressFormMap.addressFirstnameInput,
     lastName: addressFormMap.addressLastnameInput,

--- a/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/catalog/product/specific-price-form-handler.ts
@@ -164,7 +164,7 @@ class SpecificPriceFormHandler {
     const usePrefixForCreate = true;
     const selectorPrefix = this.getPrefixSelector(usePrefixForCreate);
 
-    $(SpecificMap.cancel).click(() => {
+    $(SpecificMap.cancel).on('click', () => {
       this.resetCreatePriceFormDefaultValues();
       $(SpecificMap.priceForm).collapse('hide');
     });
@@ -190,12 +190,12 @@ class SpecificPriceFormHandler {
     const usePrefixForCreate = false;
     const selectorPrefix = this.getPrefixSelector(usePrefixForCreate);
 
-    $(SpecificMap.modalCancel).click(() => this.closeEditPriceModalAndRemoveForm(),
+    $(SpecificMap.modalCancel).on('click', () => this.closeEditPriceModalAndRemoveForm(),
     );
-    $(SpecificMap.modalClose).click(() => this.closeEditPriceModalAndRemoveForm(),
+    $(SpecificMap.modalClose).on('click', () => this.closeEditPriceModalAndRemoveForm(),
     );
 
-    $(SpecificMap.modalSave).click(() => this.submitEditPriceForm());
+    $(SpecificMap.modalSave).on('click', () => this.submitEditPriceForm());
 
     this.loadAndFillOptionsForSelectCombinationInput(usePrefixForCreate);
 

--- a/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.ts
+++ b/admin-dev/themes/new-theme/js/pages/currency/form/currency-form.ts
@@ -139,11 +139,13 @@ export default class CurrencyForm {
   }
 
   initListeners(): void {
-    this.$currencySelector.change(this.onCurrencySelectorChange.bind(this));
-    this.$isUnofficialCheckbox.change(
+    this.$currencySelector.on('change', this.onCurrencySelectorChange.bind(this));
+    this.$isUnofficialCheckbox.on(
+      'change',
       this.onIsUnofficialCheckboxChange.bind(this),
     );
-    this.$resetDefaultSettingsButton.click(
+    this.$resetDefaultSettingsButton.on(
+      'click',
       this.onResetDefaultSettingsClick.bind(this),
     );
   }

--- a/admin-dev/themes/new-theme/js/pages/feature-flag/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/feature-flag/index.ts
@@ -39,11 +39,11 @@ $(() => {
   const initialState = $form.serialize();
   const initialFormData = $form.serializeArray();
 
-  $betaFormInputs.change(() => {
+  $betaFormInputs.on('change', () => {
     $submitButton.prop('disabled', initialState === $form.serialize());
   });
 
-  $stableFormInputs.change(() => {
+  $stableFormInputs.on('change', () => {
     $stableFormSubmitButton.prop('disabled', $stableFormInitialState === $stableForm.serialize());
   });
 

--- a/admin-dev/themes/new-theme/js/pages/improve/design_positions/positions-list-handler.ts
+++ b/admin-dev/themes/new-theme/js/pages/improve/design_positions/positions-list-handler.ts
@@ -127,7 +127,7 @@ class PositionsListHandler {
       }
     });
 
-    self.$panelSelection.find('button').click(() => {
+    self.$panelSelection.find('button').on('click', () => {
       $('button[name="unhookform"]').trigger('click');
     });
 

--- a/admin-dev/themes/new-theme/js/pages/language/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/language/index.ts
@@ -39,7 +39,7 @@ import FiltersSubmitButtonEnablerExtension
 
 const {$} = window;
 
-$(document).ready(() => {
+$(() => {
   const grid = new Grid('language');
 
   grid.addExtension(new ReloadListActionExtension());

--- a/admin-dev/themes/new-theme/js/pages/manufacturer/manufacturer_address_form.ts
+++ b/admin-dev/themes/new-theme/js/pages/manufacturer/manufacturer_address_form.ts
@@ -29,7 +29,7 @@ import CountryDniRequiredToggler from '@components/country-dni-required-toggler'
 
 const {$} = window;
 
-$(document).ready(() => {
+$(() => {
   new CountryStateSelectionToggler(
     ManufacturerAddressMap.manufacturerAddressCountrySelect,
     ManufacturerAddressMap.manufacturerAddressStateSelect,

--- a/admin-dev/themes/new-theme/js/pages/module/loader.ts
+++ b/admin-dev/themes/new-theme/js/pages/module/loader.ts
@@ -36,7 +36,7 @@ class ModuleLoader {
 
   static handleImport(): void {
     const moduleImport = $('#module-import');
-    moduleImport.click(() => {
+    moduleImport.on('click', () => {
       // @ts-ignore
       moduleImport.addClass('onclick', 250, validate);
     });

--- a/admin-dev/themes/new-theme/js/pages/order-states/form.ts
+++ b/admin-dev/themes/new-theme/js/pages/order-states/form.ts
@@ -60,7 +60,7 @@ $(() => {
     }
   }
 
-  $(document).ready(() => {
+  $(() => {
     if (!$(FormMap.sendEmailSelector).is(':checked')) {
       $(FormMap.mailTemplateSelector).hide();
     }

--- a/admin-dev/themes/new-theme/js/pages/order/create.ts
+++ b/admin-dev/themes/new-theme/js/pages/order/create.ts
@@ -61,7 +61,7 @@ function refreshCart(): void {
   orderPageManager.refreshCart();
 }
 
-$(document).ready(() => {
+$(() => {
   orderPageManager = new CreateOrderPage();
 });
 

--- a/admin-dev/themes/new-theme/js/pages/permission/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/permission/index.ts
@@ -27,7 +27,7 @@ import PermissionApp from '@app/pages/permission/index';
 
 const {$} = window;
 
-$(document).ready(() => {
+$(() => {
   $('.js-permissions-content').each((i: number, element: HTMLElement): void => {
     new PermissionApp(
       $(element).data('profile-id'),

--- a/admin-dev/themes/new-theme/js/pages/product/edit/manager/redirect-option-manager.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/manager/redirect-option-manager.ts
@@ -85,7 +85,7 @@ export default class RedirectOptionManager {
   private watchRedirectType(): void {
     this.lastSelectedType = this.$redirectTypeInput.val();
 
-    this.$redirectTypeInput.change(() => {
+    this.$redirectTypeInput.on('change', () => {
       const redirectType = this.$redirectTypeInput.val();
 
       switch (redirectType) {

--- a/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
+++ b/admin-dev/themes/new-theme/js/pages/product/edit/product-partial-updater.ts
@@ -103,10 +103,10 @@ export default class ProductPartialUpdater {
    */
   private watch(): void {
     // Avoid submitting form when pressing Enter
-    this.$productForm.keypress((e) => e.which !== 13);
+    this.$productForm.on('keypress', (e) => e.which !== 13);
     this.$productFormSubmitButton.prop('disabled', true);
     this.initialData = this.getFormDataAsObject();
-    this.$productForm.submit(() => this.updatePartialForm());
+    this.$productForm.on('submit', () => this.updatePartialForm());
     // 'dp.change' event allows tracking datepicker input changes
     this.$productForm.on('keyup change dp.change',
       // listen for all inputs except combination filters

--- a/admin-dev/themes/new-theme/js/pages/sql-manager/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/sql-manager/index.ts
@@ -134,6 +134,6 @@ class SqlManagerPage {
   }
 }
 
-$(document).ready(() => {
+$(() => {
   new SqlManagerPage();
 });

--- a/admin-dev/themes/new-theme/js/pages/state/index.ts
+++ b/admin-dev/themes/new-theme/js/pages/state/index.ts
@@ -55,6 +55,6 @@ class StatePage {
   }
 }
 
-$(document).ready(() => {
+$(() => {
   new StatePage();
 });

--- a/admin-dev/themes/new-theme/js/pages/supplier/supplier-form.ts
+++ b/admin-dev/themes/new-theme/js/pages/supplier/supplier-form.ts
@@ -28,7 +28,7 @@ import SupplierMap from './supplier-map';
 
 const {$} = window;
 
-$(document).ready(() => {
+$(() => {
   new window.prestashop.component.ChoiceTree('#supplier_shop_association').enableAutoCheckChildren();
   new window.prestashop.component.CountryStateSelectionToggler(
     SupplierMap.supplierCountrySelect,

--- a/admin-dev/themes/new-theme/js/product-page/attributes.js
+++ b/admin-dev/themes/new-theme/js/product-page/attributes.js
@@ -24,8 +24,8 @@
  */
 
 export default function () {
-  $(document).ready(() => {
-    $('.js-attribute-checkbox').change((event) => {
+  $(() => {
+    $('.js-attribute-checkbox').on('change', (event) => {
       if ($(event.target).is(':checked')) {
         if ($(`.token[data-value="${$(event.target).data('value')}"] .close`).length === 0) {
           $('#form_step3_attributes').tokenfield(

--- a/admin-dev/themes/new-theme/js/product-page/combination.js
+++ b/admin-dev/themes/new-theme/js/product-page/combination.js
@@ -1,7 +1,7 @@
 const {$} = window;
 
 export default function () {
-  $(document).ready(() => {
+  $(() => {
     const $jsCombinationsList = $('.js-combinations-list');
 
     // If we are not on the product page, return
@@ -23,7 +23,7 @@ export default function () {
       }
     });
 
-    $('#create-combinations').click((event) => {
+    $('#create-combinations').on('click', (event) => {
       event.preventDefault();
       window.form.send(false, false, generate);
     });
@@ -49,7 +49,7 @@ export default function () {
       refreshDefaultImage();
     });
 
-    $('#product_combination_bulk_impact_on_price_ti, #product_combination_bulk_impact_on_price_te').keyup(function () {
+    $('#product_combination_bulk_impact_on_price_ti, #product_combination_bulk_impact_on_price_te').on('keyup', function () {
       const self = $(this);
       const price = window.priceCalculation.normalizePrice(self.val());
 

--- a/admin-dev/themes/new-theme/js/product-page/combination.js
+++ b/admin-dev/themes/new-theme/js/product-page/combination.js
@@ -49,16 +49,21 @@ export default function () {
       refreshDefaultImage();
     });
 
-    $('#product_combination_bulk_impact_on_price_ti, #product_combination_bulk_impact_on_price_te').on('keyup', function () {
-      const self = $(this);
-      const price = window.priceCalculation.normalizePrice(self.val());
+    $('#product_combination_bulk_impact_on_price_ti, #product_combination_bulk_impact_on_price_te')
+      .on('keyup', function () {
+        const self = $(this);
+        const price = window.priceCalculation.normalizePrice(self.val());
 
-      if (self.attr('id') === 'product_combination_bulk_impact_on_price_ti') {
-        $('#product_combination_bulk_impact_on_price_te').val(window.priceCalculation.removeCurrentTax(price)).change();
-      } else {
-        $('#product_combination_bulk_impact_on_price_ti').val(window.priceCalculation.addCurrentTax(price)).change();
-      }
-    });
+        if (self.attr('id') === 'product_combination_bulk_impact_on_price_ti') {
+          $('#product_combination_bulk_impact_on_price_te')
+            .val(window.priceCalculation.removeCurrentTax(price))
+            .change();
+        } else {
+          $('#product_combination_bulk_impact_on_price_ti')
+            .val(window.priceCalculation.addCurrentTax(price))
+            .change();
+        }
+      });
 
     const getCombinations = (combinationsImages) => {
       const $jsCombinationsBulkForm = $('#combinations-bulk-form');

--- a/admin-dev/themes/new-theme/js/product-page/product-search-autocomplete.js
+++ b/admin-dev/themes/new-theme/js/product-page/product-search-autocomplete.js
@@ -25,7 +25,7 @@
 import Bloodhound from 'typeahead.js';
 
 export default function () {
-  $(document).ready(() => {
+  $(() => {
     $('.autocomplete-search').each(function () {
       loadAutocomplete($(this), false);
     });
@@ -96,7 +96,7 @@ export default function () {
           return `<div><img src="${item.image}" style="width:50px" /> ${item.name}</div>`;
         },
       },
-    }).bind('typeahead:select', (e, suggestion) => {
+    }).on('typeahead:select', (e, suggestion) => {
       // if collection length is up to limit, return
 
       const formIdItem = $(`#${autocompleteFormId}-data li`);
@@ -130,7 +130,7 @@ export default function () {
       $(`#${autocompleteFormId}-data`).append(html);
 
       return true;
-    }).bind('typeahead:close', (e) => {
+    }).on('typeahead:close', (e) => {
       $(e.target).val('');
     });
   }

--- a/admin-dev/themes/new-theme/js/translation-page/messages-edition.ts
+++ b/admin-dev/themes/new-theme/js/translation-page/messages-edition.ts
@@ -32,7 +32,7 @@ export default function (search: typeof Jets): void {
       .find('*[name=default]')
       .val();
 
-    $(button).click(() => {
+    $(button).on('click', () => {
       $editTranslationForm
         .find('*[name=translation_value]')
         .val(<string>defaultTranslationValue);
@@ -41,7 +41,7 @@ export default function (search: typeof Jets): void {
   });
 
   const showFlashMessageOnEdit = (form: HTMLElement) => {
-    $(form).submit((event) => {
+    $(form).on('submit', (event) => {
       event.preventDefault();
 
       const $editTranslationForm = $(event.target);

--- a/admin-dev/themes/new-theme/js/translation-page/messages-pagination.ts
+++ b/admin-dev/themes/new-theme/js/translation-page/messages-pagination.ts
@@ -82,7 +82,7 @@ export default function (): void {
     );
   };
 
-  $('.translation-domain .go-to-pagination-bar').click((event) => {
+  $('.translation-domain .go-to-pagination-bar').on('click', (event) => {
     const paginationBar = $(event.target)
       .parents('.translation-domain')
       .find('.pagination')[0];
@@ -108,14 +108,14 @@ export default function (): void {
 
     $(nav)
       .find('.page-link')
-      .click((event) => {
+      .on('click', (event) => {
         const paginationBar = $(event.target).parents('.pagination')[0];
         scrollToPreviousPaginationBar(paginationBar);
       });
 
     $(nav)
       .find('.page-item')
-      .click((event) => {
+      .on('click', (event) => {
         const pageLink = $(event.target);
         const domain = pageLink
           .parents('.translation-domains')

--- a/admin-dev/themes/new-theme/js/translation-page/messages-search.ts
+++ b/admin-dev/themes/new-theme/js/translation-page/messages-search.ts
@@ -27,7 +27,7 @@ import Jets from 'jets/jets';
 export default function (): typeof Jets | boolean {
   $(() => {
     const searchSelector = '.search-translation';
-    $(`${searchSelector} form`).submit((event) => {
+    $(`${searchSelector} form`).on('submit', (event) => {
       event.preventDefault();
 
       $('#jetsContent form').addClass('hide');
@@ -57,7 +57,7 @@ export default function (): typeof Jets | boolean {
       return false;
     });
 
-    $(`${searchSelector} input[type=reset]`).click((event) => {
+    $(`${searchSelector} input[type=reset]`).on('click', (event) => {
       event.preventDefault();
 
       $('#jetsSearch').val('');

--- a/admin-dev/themes/new-theme/js/translation-page/messages-tree.ts
+++ b/admin-dev/themes/new-theme/js/translation-page/messages-tree.ts
@@ -81,7 +81,7 @@ export default function (): void {
       domainActions,
     );
 
-    $(domainToggler).click((event) => {
+    $(domainToggler).on('click', (event) => {
       let domainTitle;
 
       if ($(event.target).hasClass('domain-first-part')) {
@@ -127,7 +127,7 @@ export default function (): void {
     }
   }($('#jetsContent form').length, allDomainsMissingTranslations));
 
-  $('.domain-actions').click((event) => {
+  $('.domain-actions').on('click', (event) => {
     let domainActions = $(event.target);
 
     if (!$(event.target).hasClass('domain-actions')) {
@@ -138,7 +138,7 @@ export default function (): void {
     domainFirstPart.click();
   });
 
-  $('.btn-expand').click(() => {
+  $('.btn-expand').on('click', () => {
     $('.domain-first-part').each((index, domainToggler) => {
       const domainTitle = $(domainToggler);
       const isDomainExpanded = domainTitle.find('i').hasClass('expanded');
@@ -149,7 +149,7 @@ export default function (): void {
     });
   });
 
-  $('.btn-reduce').click(() => {
+  $('.btn-reduce').on('click', () => {
     $('.domain-first-part').each((index, domainToggler) => {
       const domainTitle = $(domainToggler);
       const isDomainExpanded = domainTitle.find('i').hasClass('expanded');

--- a/admin-dev/themes/new-theme/js/translation-page/messages-visibility.ts
+++ b/admin-dev/themes/new-theme/js/translation-page/messages-visibility.ts
@@ -140,7 +140,7 @@ export default function (callback: () => void): void {
 
   (() => {
     $(`.show-${buttonSuffix}`).each((buttonIndex, button) => {
-      $(button).click((event) => {
+      $(button).on('click', (event) => {
         const showTranslationsFormButton = $(event.target);
 
         const translationDomain = showTranslationsFormButton.parent();
@@ -167,7 +167,7 @@ export default function (callback: () => void): void {
 
     $('.domain-part .delegate-toggle-messages').each(
       (togglerIndex, toggler) => {
-        $(toggler).click((event) => {
+        $(toggler).on('click', (event) => {
           let title = $(event.target);
 
           if (!$(event.target).hasClass('domain-part')) {

--- a/admin-dev/themes/new-theme/template/components/layout/search_form.tpl
+++ b/admin-dev/themes/new-theme/template/components/layout/search_form.tpl
@@ -55,7 +55,7 @@
 </form>
 
 <script type="text/javascript">
- $(document).ready(function(){
+ $(function(){
   {if isset($search_type) && $search_type}
     $('.search-option a[data-value='+{$search_type|intval}+']').click();
   {/if}

--- a/controllers/admin/AdminTranslationsController.php
+++ b/controllers/admin/AdminTranslationsController.php
@@ -1573,7 +1573,7 @@ class AdminTranslationsControllerCore extends AdminController
         $str_output = '
         <script type="text/javascript">';
         if (Tools::getValue('type') == 'mails') {
-            $str_output .= '$(document).ready(function(){
+            $str_output .= '$(function(){
                 toggleDiv(\'' . $this->type_selected . '_div\'); toggleButtonValue(this.id, openAll, closeAll);
                 });';
         }

--- a/install-dev/theme/js/configure.js
+++ b/install-dev/theme/js/configure.js
@@ -23,10 +23,10 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-$(document).ready(function() {
+$(function() {
   checkTimeZone($('#infosCountry'));
   // When a country is changed
-  $('#infosCountry').change(function()
+  $('#infosCountry').on('change', function()
 	{
 	  checkTimeZone(this);
   });

--- a/install-dev/theme/js/content.js
+++ b/install-dev/theme/js/content.js
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-$(document).ready(function() {
+$(function() {
   const $modulesContainer = $('#modules-container');
   const $modulesList = $('input[name="modules[]"]');
   const $selectAllButton = $('input[name="select-all"]');

--- a/install-dev/theme/js/database.js
+++ b/install-dev/theme/js/database.js
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-$(document).ready(function()
+$(function()
 {
 	// Check rewrite engine availability
 	$.ajax({
@@ -34,7 +34,7 @@ $(document).ready(function()
 	});
 
 	// Check database configuration
-	$('#btTestDB').click(function()
+	$('#btTestDB').on('click', function()
 	{
 		$("#dbResultCheck")
 			.removeClass('errorBlock')
@@ -91,7 +91,7 @@ $(document).ready(function()
 function bindCreateDB()
 {
 	// Attempt to create the database
-	$('#btCreateDB').click(function()
+	$('#btCreateDB').on('click', function()
 	{
 		$("#dbResultCheck").slideUp('fast');
 		$.ajax({

--- a/install-dev/theme/js/install.js
+++ b/install-dev/theme/js/install.js
@@ -23,9 +23,9 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-$(document).ready(function()
+$(function()
 {
-	$('#mainForm').submit(function() {
+	$('#mainForm').on('submit', function() {
 		$('#btNext').hide();
 	});
 

--- a/install-dev/theme/js/license.js
+++ b/install-dev/theme/js/license.js
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-$(document).ready(function()
+$(function()
 {
 	// Desactivate next button if licence checkbox is not checked
 	if (!$('#set_license').prop('checked'))
@@ -32,7 +32,7 @@ $(document).ready(function()
 	}
 
 	// Activate / desactivate next button when licence checkbox is clicked
-	$('#set_license').click(function()
+	$('#set_license').on('click', function()
 	{
 		if ($(this).prop('checked'))
 			$('#btNext').removeClass('disabled').attr('disabled', false);

--- a/install-dev/theme/js/process.js
+++ b/install-dev/theme/js/process.js
@@ -24,8 +24,8 @@
  */
 
 var is_installing = false;
-$(document).ready(function() {
-  $("#loaderSpace").unbind('ajaxStart');
+$(function() {
+  $("#loaderSpace").off('ajaxStart');
   start_install();
 });
 

--- a/install-dev/theme/js/welcome.js
+++ b/install-dev/theme/js/welcome.js
@@ -23,8 +23,8 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-$(document).ready(function() {
-	$('#langList').change(function() {
+$(function() {
+	$('#langList').on('change', function() {
 		$('#mainForm').submit();
 	});
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -248,7 +248,7 @@ function displayFlags(languages, defaultLanguageID, employee_cookie)
             .addClass('pointer')
             .attr('src', '../img/l/' + defaultLanguage['id_lang'] + '.jpg')
             .attr('alt', defaultLanguage['name'])
-            .click(function() {
+            .on('click', function() {
               toggleLanguageFlags(this);
             })
           );
@@ -261,7 +261,7 @@ function displayFlags(languages, defaultLanguageID, employee_cookie)
             .css('margin', '2px 2px')
             .attr('src', '../img/l/' + language['id_lang'] + '.jpg')
             .attr('alt', language['name'])
-            .click(function() {
+            .on('click', function() {
               changeFormLanguage(language['id_lang'], language['iso_code'], employee_cookie);
             });
           languagesFlags.append(img);
@@ -536,11 +536,11 @@ function showRedirectProductOptions(show)
 function redirectSelectChange()
 {
   redirectTypeValue = $('#redirect_type :selected').val();
-  if (redirectTypeValue == '404' || 
-      redirectTypeValue == '410' || 
-      redirectTypeValue == 'default' || 
-      redirectTypeValue == '200-displayed' || 
-      redirectTypeValue == '404-displayed' || 
+  if (redirectTypeValue == '404' ||
+      redirectTypeValue == '410' ||
+      redirectTypeValue == 'default' ||
+      redirectTypeValue == '200-displayed' ||
+      redirectTypeValue == '404-displayed' ||
       redirectTypeValue == '410-displayed')
     showRedirectProductSelectOptions(false);
   else
@@ -687,7 +687,7 @@ function showNoticeMessage(msg) {
   $.growl.notice({ title: "", message:msg});
 }
 
-$(document).ready(function()
+$(function()
 {
   if (typeof helper_tabs != 'undefined' && typeof unique_field_id != 'undefined')
   {
@@ -780,7 +780,7 @@ $(document).ready(function()
     });
 
   //Check filters value on submit filter
-  $("[name='submitFilter']").click(function(event) {
+  $("[name='submitFilter']").on('click', function(event) {
     var list_id = $(this).data('list-id');
     var empty_filters = true;
 
@@ -882,7 +882,7 @@ $(document).ready(function()
       bindSwapButton('add', 'available', 'selected', this);
       bindSwapButton('remove', 'selected', 'available', this);
 
-      $('button:submit').click(function() {
+      $('button:submit').on('click', function() {
         bindSwapSave(swap_container);
       });
     }
@@ -1442,7 +1442,7 @@ function countDown($source, $target) {
   var max = $source.attr("data-maxchar");
   $target.html(max-$source.val().length);
 
-  $source.keyup(function(){
+  $source.on('keyup', function(){
     $target.html(max-$source.val().length);
   });
 }

--- a/js/admin/carrier_wizard.js
+++ b/js/admin/carrier_wizard.js
@@ -25,7 +25,7 @@
 
 var fees_is_hide = false;
 
-$(document).ready(function() {
+$(function() {
 	carriersRangeInputs.watchCarriersRangeInputChange();
 	bind_inputs();
 	initCarrierWizard();
@@ -33,15 +33,15 @@ $(document).ready(function() {
 		is_freeClick($('input[name="is_free"]:checked'));
 	displayRangeType();
 
-	$('#attachement_fileselectbutton').click(function(e) {
+	$('#attachement_fileselectbutton').on('click', function(e) {
 		$('#carrier_logo_input').trigger('click');
 	});
 
-	$('#attachement_filename').click(function(e) {
+	$('#attachement_filename').on('click', function(e) {
 		$('#carrier_logo_input').trigger('click');
 	});
 
-	$('#carrier_logo_input').change(function(e) {
+	$('#carrier_logo_input').on('change', function(e) {
 		var name  = '';
 		if ($(this)[0].files !== undefined)
 		{
@@ -60,7 +60,7 @@ $(document).ready(function() {
 		}
 	});
 
-	$('#carrier_logo_remove').click(function(e) {
+	$('#carrier_logo_remove').on('click', function(e) {
 		$('#attachement_filename').val('');
 	});
 
@@ -70,12 +70,12 @@ $(document).ready(function() {
 		$('#shipping_handling_on').prop('disabled', true).prop('checked', false);
 	}
 
-	$('#is_free_on').click(function(e) {
+	$('#is_free_on').on('click', function(e) {
 		$('#shipping_handling_off').prop('checked', true).prop('disabled', true);
 		$('#shipping_handling_on').prop('disabled', true).prop('checked', false);
 	});
 
-	$('#is_free_off').click(function(e) {
+	$('#is_free_off').on('click', function(e) {
 		if ($('#shipping_handling_off').prop('disabled') === true)
 		{
 			$('#shipping_handling_off').prop('disabled', false).prop('checked', false);
@@ -302,7 +302,7 @@ function validateSteps(fromStep, toStep)
 				if (datas.has_error)
 				{
 					is_ok = false;
-					$('div.input-group input').focus(function () {
+					$('div.input-group input').on('focus', function () {
 						$(this).closest('div.input-group').removeClass('has-error');
 					});
 					displayError(datas.errors, fromStep);
@@ -334,7 +334,7 @@ function displayError(errors, step_number)
 
 function bind_inputs()
 {
-	$('input').focus(function () {
+	$('input').on('focus', function () {
 		$(this).closest('div.input-group').removeClass('has-error');
 		$('#carrier_wizard .actionBar a.btn').removeClass('disabled');
 		$('.wizard_error').fadeOut('fast', function () { $(this).remove()});
@@ -376,7 +376,7 @@ function bind_inputs()
 		return false;
 	});
 
-	$('tr.range_sup td input:text, tr.range_inf td input:text').keypress(function (evn) {
+	$('tr.range_sup td input:text, tr.range_inf td input:text').on('keypress', function (evn) {
 		index = $(this).closest('td').index();
 		if (evn.keyCode == 13)
 		{
@@ -388,7 +388,7 @@ function bind_inputs()
 		}
 	});
 
-	$('tr.fees_all td input:text').keypress(function (evn) {
+	$('tr.fees_all td input:text').on('keypress', function (evn) {
 		index = $(this).parent('td').index();
 		if (evn.keyCode == 13)
 			return false;

--- a/js/admin/dashboard.js
+++ b/js/admin/dashboard.js
@@ -258,7 +258,7 @@ function saveDashConfig(widget_name) {
 	});
 }
 
-$(document).ready( function () {
+$( function () {
 	$('#calendar_form input[type="submit"]').on('click', function(elt) {
 		elt.preventDefault();
 		setDashboardDateRange(elt.currentTarget.name);
@@ -269,7 +269,7 @@ $(document).ready( function () {
 	bindCancelDashConfig();
 
 	$('#page-header-desc-configuration-switch_demo i').removeClass('btn-primary');
-	$('#page-header-desc-configuration-switch_demo').tooltip().click(function(e) {
+	$('#page-header-desc-configuration-switch_demo').tooltip().on('click', function(e) {
 		$.ajax({
 			url : dashboard_ajax_url,
 			data : {

--- a/js/admin/dnd.js
+++ b/js/admin/dnd.js
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 
-$(document).ready(function() {
+$(function() {
 	initTableDnD();
 });
 

--- a/js/admin/email.js
+++ b/js/admin/email.js
@@ -27,7 +27,7 @@
  * /!\ This file is deprecated, it will be deleted in next major release /!\
  */
 
-$(document).ready(function() {
+$(function() {
 	if ($('input[name=PS_MAIL_METHOD]:checked').val() == 2)
 		$('#mail_fieldset_smtp').show();
 	else

--- a/js/admin/import.js
+++ b/js/admin/import.js
@@ -26,9 +26,9 @@
 var importCancelRequest = false;
 var importContinueRequest = false;
 
-$(document).ready(function(){
+$(function(){
 
-	$('#saveImportMatchs').unbind('click').click(function(){
+	$('#saveImportMatchs').off('click').on('click', function(){
 
 	var newImportMatchs = $('#newImportMatchs').val();
 	if (newImportMatchs == '')
@@ -60,7 +60,7 @@ $(document).ready(function(){
 	}
 	});
 
-	$('#loadImportMatchs').unbind('click').click(function(){
+	$('#loadImportMatchs').off('click').on('click', function(){
 
 		var idToLoad = $('select#valueImportMatchs option:selected').attr('id');
 		$.ajax({
@@ -85,7 +85,7 @@ $(document).ready(function(){
 		   });
 	});
 
-	$('#deleteImportMatchs').unbind('click').click(function(){
+	$('#deleteImportMatchs').off('click').on('click', function(){
 
 		var idToDelete = $('select#valueImportMatchs option:selected').attr('id');
 		$.ajax({
@@ -109,7 +109,7 @@ $(document).ready(function(){
 
 	});
 
-	$('#import_stop_button').unbind('click').click(function(){
+	$('#import_stop_button').off('click').on('click', function(){
 		if (importContinueRequest) {
 			$('#importProgress').modal('hide');
 			importContinueRequest = false;
@@ -124,7 +124,7 @@ $(document).ready(function(){
 		}
 	});
 
-	$('#import_continue_button').unbind('click').click(function(){
+	$('#import_continue_button').off('click').on('click', function(){
 		$('#import_continue_button').hide();
 		importContinueRequest = false;
 		$('#import_progress_div').show();

--- a/js/admin/login.js
+++ b/js/admin/login.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+$(function() {
 	// Initialize events
 	$("#login_form").validate({
 		rules: {

--- a/js/admin/modules-position.js
+++ b/js/admin/modules-position.js
@@ -72,7 +72,7 @@ $(function(){
 			}
 		});
 
-		panel_selection.find("button").click(function () {
+		panel_selection.find("button").on('click', function () {
 			$("button[name='unhookform']").trigger("click");
 		});
 
@@ -88,16 +88,16 @@ $(function(){
 
 		var show_modules = $("#show_modules");
 		show_modules.select2();
-		show_modules.bind("change", function () {
+		show_modules.on("change", function () {
 			modulesPositionFilterHooks();
 		});
 
 		var hook_position = $("#hook_position");
-		hook_position.bind("change", function () {
+		hook_position.on("change", function () {
 			modulesPositionFilterHooks();
 		});
 
-		$('#hook_search').bind('input', function () {
+		$('#hook_search').on('input', function () {
 			modulesPositionFilterHooks();
 		});
 
@@ -161,7 +161,7 @@ $(function(){
 	//
 	// Used for the anchor module page
 	//
-	$("#hook_module_form").find("select[name='id_module']").change(function(){
+	$("#hook_module_form").find("select[name='id_module']").on('change', function(){
 
 		var $this = $(this);
 		var hook_select = $("select[name='id_hook']");

--- a/js/admin/notifications.js
+++ b/js/admin/notifications.js
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-$(document).ready(function () {
+$(function () {
   if (youEditFieldFor) {
     $('.translatable span.hint').append(`<br /><span class="red">${youEditFieldFor}</span>`);
   }

--- a/js/admin/products.js
+++ b/js/admin/products.js
@@ -82,7 +82,7 @@ function ProductTabsManager(){
 
 		// onReady() is always called after the dom has been created for the tab (similar to $(document).ready())
 		if (container.hasClass('not-loaded'))
-			container.bind('loaded', callback);
+			container.on('loaded', callback);
 		else
 			callback();
 	}
@@ -419,7 +419,7 @@ product_tabs['Combinations'] = new function(){
 	};
 
 	this.bindToggleAddCombination = function (){
-		$('#desc-product-newCombination').click(function(e) {
+		$('#desc-product-newCombination').on('click', function(e) {
 			e.preventDefault();
 
 			if ($(this).children('i').first().hasClass('process-icon-new'))
@@ -703,7 +703,7 @@ product_tabs['Prices'] = new function(){
 	var self = this;
 	// Bind to show/hide new specific price form
 	this.toggleSpecificPrice = function (){
-		$('#show_specific_price').click(function()
+		$('#show_specific_price').on('click', function()
 		{
 			$('#add_specific_price').slideToggle();
 
@@ -714,7 +714,7 @@ product_tabs['Prices'] = new function(){
 			return false;
 		});
 
-		$('#hide_specific_price').click(function()
+		$('#hide_specific_price').on('click', function()
 		{
 			$('#add_specific_price').slideToggle();
 			$('#add_specific_price').find('input[name=submitPriceAddition]').remove();
@@ -782,7 +782,7 @@ product_tabs['Prices'] = new function(){
 		self.deleteSpecificPrice();
 		self.bindDelete();
 
-		$('#sp_id_shop').change(function() {
+		$('#sp_id_shop').on('change', function() {
 			self.loadInformations('#sp_id_group','getGroupsOptions');
 			self.loadInformations('#spm_currency_0', 'getCurrenciesOptions');
 			self.loadInformations('#sp_id_country', 'getCountriesOptions');
@@ -960,7 +960,7 @@ product_tabs['Attachments'] = new function(){
 			});
 			return !$("#selectAttachment1 option:selected").remove().appendTo("#selectAttachment2");
 		});
-		$("#product").submit(function() {
+		$("#product").on('submit', function() {
 			$("#selectAttachment1 option").each(function(i) {
 				$(this).attr("selected", "selected");
 			});
@@ -1011,7 +1011,7 @@ product_tabs['Shipping'] = new function(){
 product_tabs['Informations'] = new function(){
 	var self = this;
 	this.bindAvailableForOrder = function (){
-		$("#available_for_order").click(function()
+		$("#available_for_order").on('click', function()
 		{
 			if ($(this).is(':checked') || ($('input[name=\'multishop_check[show_price]\']').length && !$('input[name=\'multishop_check[show_price]\']').prop('checked')))
 			{
@@ -1032,7 +1032,7 @@ product_tabs['Informations'] = new function(){
 		else
 			showRedirectProductOptions(true);
 
-		$('#redirect_type').change(function () {
+		$('#redirect_type').on('change', function () {
 			redirectSelectChange();
 		});
 
@@ -1065,12 +1065,12 @@ product_tabs['Informations'] = new function(){
 			$('#resultImage').val(tag);
 		}
 		changeTagImage();
-		$('#createImageDescription input').change(function(){
+		$('#createImageDescription input').on('change', function(){
 			changeTagImage();
 		});
 
 		var i = 0;
-		$('.addImageDescription').click(function(){
+		$('.addImageDescription').on('click', function(){
 			if (i == 0){
 				$('#createImageDescription').animate({
 					opacity: 1, height: 'toggle'
@@ -1130,10 +1130,10 @@ product_tabs['Informations'] = new function(){
 				{
 					$('#product-pack-container').show();
 					// If the pack tab has not finished loaded the changes will be made when the loading event is triggered
-					$("#product-tab-content-Pack").bind('loaded', function(){
+					$("#product-tab-content-Pack").on('loaded', function(){
 						$('#ppack').val(1).attr('checked', true).attr('disabled', true);
 					});
-					$("#product-tab-content-Quantities").bind('loaded', function(){
+					$("#product-tab-content-Quantities").on('loaded', function(){
 						$('.stockForVirtualProduct').show();
 					});
 
@@ -1213,7 +1213,7 @@ product_tabs['Informations'] = new function(){
 					showOptions(checked);
 				}
 			};
-			$('input[name=\'multishop_check[active]\']').click(active_click);
+			$('input[name=\'multishop_check[active]\']').on('click', active_click);
 			active_click();
 		}
 	};
@@ -1478,7 +1478,7 @@ product_tabs['Quantities'] = new function(){
 			dateFormat: 'yy-mm-dd'
 		});
 
-		$('.depends_on_stock').click(function(e)
+		$('.depends_on_stock').on('click', function(e)
 		{
 			self.refreshQtyAvailabilityForm();
 			self.ajaxCall( { actionQty: 'depends_on_stock', value: $(this).val() } );
@@ -1486,7 +1486,7 @@ product_tabs['Quantities'] = new function(){
 				$('.available_quantity input').trigger('change');
 		});
 
-		$('.advanced_stock_management').click(function(e)
+		$('.advanced_stock_management').on('click', function(e)
 		{
 			var val = 0;
 			if ($(this).prop('checked'))
@@ -1509,12 +1509,12 @@ product_tabs['Quantities'] = new function(){
 			self.refreshQtyAvailabilityForm();
 		});
 
-		$('.available_quantity').find('input').change(function(e, init_val)
+		$('.available_quantity').find('input').on('change', function(e, init_val)
 		{
 			self.ajaxCall({actionQty: 'set_qty', id_product_attribute: $(this).parent().attr('id').split('_')[1], value: $(this).val()});
 		});
 
-		$('.out_of_stock').click(function(e)
+		$('.out_of_stock').on('click', function(e)
 		{
 			self.refreshQtyAvailabilityForm();
 			self.ajaxCall({actionQty: 'out_of_stock', value: $(this).val()});
@@ -1522,7 +1522,7 @@ product_tabs['Quantities'] = new function(){
 		if (display_multishop_checkboxes)
 			ProductMultishop.checkAllQuantities();
 
-		$('.pack_stock_type').click(function(e)
+		$('.pack_stock_type').on('click', function(e)
 		{
 			self.refreshQtyAvailabilityForm();
 			self.ajaxCall({actionQty: 'pack_stock_type', value: $(this).val()});
@@ -1651,7 +1651,7 @@ product_tabs['VirtualProduct'] = new function(){
 
 product_tabs['Warehouses'] = new function(){
 	this.onReady = function(){
-		$('.check_all_warehouse').click(function() {
+		$('.check_all_warehouse').on('click', function() {
 			//get all checkboxes of current warehouse
 			var checkboxes = $('input[name*="'+$(this).val()+'"]');
 			var checked = false;
@@ -1892,7 +1892,7 @@ var ProductMultishop = new function()
 var tabs_manager = new ProductTabsManager();
 tabs_manager.setTabs(product_tabs);
 
-$(document).ready(function() {
+$(function() {
 	// The manager schedules the onReady() methods of each tab to be called when the tab is loaded
 	tabs_manager.init();
 	updateCurrentText();
@@ -1913,7 +1913,7 @@ $(document).ready(function() {
 		return (code == 13) ? false : true;
 	});
 
-	$('#product_form').submit(function(e) {
+	$('#product_form').on('submit', function(e) {
 		$('#selectedCarriers option').attr('selected', 'selected');
 		$('#selectAttachment1 option').attr('selected', 'selected');
 		return true;

--- a/js/admin/themes.js
+++ b/js/admin/themes.js
@@ -36,26 +36,30 @@ function toggleShopModuleCheckbox(id_shop, toggle){
 }
 
 $(function(){
-	$('div.thumbnail-wrapper').hover(
-		function() {
-			var w = $(this).parent('div').outerWidth(true);
-			var h = $(this).parent('div').outerHeight(true);
-			$(this).children('.action-wrapper').css('width', w+'px');
-			$(this).children('.action-wrapper').css('height', h+'px');
-			$(this).children('.action-wrapper').show();
-		}, function() {
-			$('.thumbnail-wrapper .action-wrapper').hide();
-		}
-	);
+  $('div.thumbnail-wrapper').on(
+    'mouseenter',
+    function() {
+      var w = $(this).parent('div').outerWidth(true);
+      var h = $(this).parent('div').outerHeight(true);
+      $(this).children('.action-wrapper').css('width', w + 'px');
+      $(this).children('.action-wrapper').css('height', h + 'px');
+      $(this).children('.action-wrapper').show();
+    })
+    .on(
+      'mouseleave',
+      function() {
+        $('.thumbnail-wrapper .action-wrapper').hide();
+      }
+    );
 
-	$("[name^='checkBoxShopGroupAsso_theme']").change(function(){
+	$("[name^='checkBoxShopGroupAsso_theme']").on('change', function(){
 		$(this).parents('.tree-folder').find("[name^='checkBoxShopAsso_theme']").each(function(){
 			var id = $(this).attr('value');
 			var checked = $(this).prop('checked');
 			toggleShopModuleCheckbox(id, checked);
 		});
 	});
-	$("[name^='checkBoxShopAsso_theme']").click(function(){
+	$("[name^='checkBoxShopAsso_theme']").on('click', function(){
 		var id = $(this).attr('value');
 		var checked = $(this).prop('checked');
 		toggleShopModuleCheckbox(id, checked);

--- a/js/admin/tinymce_loader.js
+++ b/js/admin/tinymce_loader.js
@@ -22,7 +22,7 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
-$(document).ready(function() {
+$(function() {
   tinySetup({
     editor_selector: 'autoload_rte',
     setup: function(ed) {

--- a/js/jquery/plugins/timepicker/jquery-ui-timepicker-addon.js
+++ b/js/jquery/plugins/timepicker/jquery-ui-timepicker-addon.js
@@ -3,12 +3,12 @@
 * By: Trent Richardson [http://trentrichardson.com]
 * Version 0.9.9
 * Last Modified: 02/05/2012
-* 
+*
 * Copyright 2012 Trent Richardson
 * Dual licensed under the MIT and GPL licenses.
 * http://trentrichardson.com/Impromptu/GPL-LICENSE.txt
 * http://trentrichardson.com/Impromptu/MIT-LICENSE.txt
-* 
+*
 * HERES THE CSS:
 * .ui-timepicker-div .ui-widget-header { margin-bottom: 8px; }
 * .ui-timepicker-div dl { text-align: left; }
@@ -133,7 +133,7 @@ $.extend(Timepicker.prototype, {
 	_newInst: function($input, o) {
 		var tp_inst = new Timepicker(),
 			inlineSettings = {};
-			
+
 		for (var attrName in this._defaults) {
 			var attrValue = $input.attr('time:' + attrName);
 			if (attrValue) {
@@ -188,7 +188,7 @@ $.extend(Timepicker.prototype, {
 			tp_inst.$altInput = $(o.altField)
 				.css({ cursor: 'pointer' })
 				.focus(function(){ $input.trigger("focus"); });
-		
+
 		if(tp_inst._defaults.minDate==0 || tp_inst._defaults.minDateTime==0)
 		{
 			tp_inst._defaults.minDate=new Date();
@@ -197,7 +197,7 @@ $.extend(Timepicker.prototype, {
 		{
 			tp_inst._defaults.maxDate=new Date();
 		}
-		
+
 		// datepicker needs minDate/maxDate, timepicker needs minDateTime/maxDateTime..
 		if(tp_inst._defaults.minDate !== undefined && tp_inst._defaults.minDate instanceof Date)
 			tp_inst._defaults.minDateTime = new Date(tp_inst._defaults.minDate.getTime());
@@ -215,7 +215,7 @@ $.extend(Timepicker.prototype, {
 	//########################################################################
 	_addTimePicker: function(dp_inst) {
 		var currDT = (this.$altInput && this._defaults.altFieldTimeOnly) ?
-				this.$input.val() + ' ' + this.$altInput.val() : 
+				this.$input.val() + ' ' + this.$altInput.val() :
 				this.$input.val();
 
 		this.timeDefined = this._parseTime(currDT);
@@ -249,7 +249,7 @@ $.extend(Timepicker.prototype, {
 			var specials = new RegExp("[.*+?|()\\[\\]{}\\\\]", "g");
 			regstr = '^.{' + dp_dateFormat.length + ',}?' + this._defaults.separator.replace(specials, "\\$&") + regstr;
 		}
-		
+
 		treg = timeString.match(new RegExp(regstr, 'i'));
 
 		if (treg) {
@@ -297,7 +297,7 @@ $.extend(Timepicker.prototype, {
 				}
 				this.timezone = tz;
 			}
-			
+
 			return true;
 
 		}
@@ -472,7 +472,7 @@ $.extend(Timepicker.prototype, {
 				}
 			});
 
-			
+
 			// Updated by Peter Medeiros:
 			// - Pass in Event and UI instance into slide function
 			this.minute_slider = $tp.find('#ui_tpicker_minute_'+ dp_id).slider({
@@ -520,7 +520,7 @@ $.extend(Timepicker.prototype, {
 				})
 			);
 			this.timezone_select.val((typeof this.timezone != "undefined" && this.timezone != null && this.timezone != "") ? this.timezone : o.timezone);
-			this.timezone_select.change(function() {
+			this.timezone_select.on('change', function() {
 				tp_inst._onTimeChange();
 			});
 
@@ -634,7 +634,7 @@ $.extend(Timepicker.prototype, {
 			this.minute_slider.bind('slidestop',onSelectDelegate);
 			this.second_slider.bind('slidestop',onSelectDelegate);
 			this.millisec_slider.bind('slidestop',onSelectDelegate);
-			
+
 			// slideAccess integration: http://trentrichardson.com/2011/11/11/jquery-ui-sliders-and-touch-accessibility/
 			if (this._defaults.addSliderAccess){
 				var sliderAccessArgs = this._defaults.sliderAccessArgs;
@@ -651,7 +651,7 @@ $.extend(Timepicker.prototype, {
 									oldMarginLeft = $g.css('marginLeft').toString().replace('%',''),
 									newWidth = oldWidth - sliderAccessWidth,
 									newMarginLeft = ((oldMarginLeft * newWidth)/oldWidth) + '%';
-						
+
 								$g.css({ width: newWidth, marginLeft: newMarginLeft });
 							});
 						}
@@ -659,7 +659,7 @@ $.extend(Timepicker.prototype, {
 				},0);
 			}
 			// end slideAccess integration
-			
+
 		}
 	},
 
@@ -770,7 +770,7 @@ $.extend(Timepicker.prototype, {
 
 	},
 
-	
+
 	//########################################################################
 	// when a slider moves, set the internal time...
 	// on time change is also called when the time is updated in the text field
@@ -803,7 +803,7 @@ $.extend(Timepicker.prototype, {
 				|| (this.ampm.length > 0
 				    && (hour < 12) != ($.inArray(this.ampm.toUpperCase(), this.amNames) !== -1))
 				|| timezone != this.timezone);
-		
+
 		if (hasChanged) {
 
 			if (hour !== false)this.hour = hour;
@@ -811,22 +811,22 @@ $.extend(Timepicker.prototype, {
 			if (second !== false) this.second = second;
 			if (millisec !== false) this.millisec = millisec;
 			if (timezone !== false) this.timezone = timezone;
-			
+
 			if (!this.inst) this.inst = $.datepicker._getInst(this.$input[0]);
-			
+
 			this._limitMinMaxDateTime(this.inst, true);
 		}
 		if (o.ampm) this.ampm = ampm;
-		
+
 		//this._formatTime();
 		this.formattedTime = $.datepicker.formatTime(this._defaults.timeFormat, this, this._defaults);
 		if (this.$timeObj) this.$timeObj.text(this.formattedTime + o.timeSuffix);
 		this.timeDefined = true;
 		if (hasChanged) this._updateDateTime();
 	},
-    
+
 	//########################################################################
-	// call custom onSelect. 
+	// call custom onSelect.
 	// bind to sliders slidestop, and grid click.
 	//########################################################################
 	_onSelectHandler: function() {
@@ -845,7 +845,7 @@ $.extend(Timepicker.prototype, {
 		var tmptime = (format || this._defaults.timeFormat).toString();
 
 		tmptime = $.datepicker.formatTime(tmptime, time, this._defaults);
-		
+
 		if (arguments.length) return tmptime;
 		else this.formattedTime = tmptime;
 	},
@@ -883,7 +883,7 @@ $.extend(Timepicker.prototype, {
 		} else {
 			this.$input.val(formattedDateTime);
 		}
-		
+
 		this.$input.trigger("change");
 	}
 
@@ -913,9 +913,9 @@ $.fn.extend({
 		tmp_args = arguments;
 
 		if (typeof(o) == 'string'){
-			if(o == 'getDate') 
+			if(o == 'getDate')
 				return $.fn.datepicker.apply($(this[0]), tmp_args);
-			else 
+			else
 				return this.each(function() {
 					var $t = $(this);
 					$t.datepicker.apply($t, tmp_args);
@@ -930,7 +930,7 @@ $.fn.extend({
 });
 
 //########################################################################
-// format the time all pretty... 
+// format the time all pretty...
 // format = string format of the time
 // time = a {}, not a Date() for timezones
 // options = essentially the regional[].. amNames, pmNames, ampm
@@ -939,7 +939,7 @@ $.datepicker.formatTime = function(format, time, options) {
 	options = options || {};
 	options = $.extend($.timepicker._defaults, options);
 	time = $.extend({hour:0, minute:0, second:0, millisec:0, timezone:'+0000'}, time);
-	
+
 	var tmptime = format;
 	var ampmName = options['amNames'][0];
 
@@ -1015,9 +1015,9 @@ $.datepicker._updateDatepicker = function(inst) {
 	}
 
 	if (typeof(inst.stay_open) !== 'boolean' || inst.stay_open === false) {
-				
+
 		this._base_updateDatepicker(inst);
-		
+
 		// Reload the time control when changing something in the input text field.
 		var tp_inst = this._get(inst, 'timepicker');
 		if(tp_inst) tp_inst._addTimePicker(inst);
@@ -1055,7 +1055,7 @@ $.datepicker._doKeyPress = function(event) {
 			return event.ctrlKey || (chr < ' ' || !dateChars || datetimeChars.indexOf(chr) > -1);
 		}
 	}
-	
+
 	return $.datepicker._base_doKeyPress(event);
 };
 
@@ -1102,7 +1102,7 @@ $.datepicker._gotoToday = function(id) {
 		tp_inst.timezone_select.val(tzoffset);
 	}
 	this._setTime(inst, now);
-	$( '.ui-datepicker-today', $dp).click(); 
+	$( '.ui-datepicker-today', $dp).click();
 };
 
 //#######################################################################################
@@ -1252,7 +1252,7 @@ $.datepicker._formatDate = function(inst, day, month, year){
 	{
 		if(day)
 			var b = this._base_formatDate(inst, day, month, year);
-		tp_inst._updateDateTime(inst);	
+		tp_inst._updateDateTime(inst);
 		return tp_inst.$input.val();
 	}
 	return this._base_formatDate(inst);
@@ -1289,7 +1289,7 @@ $.datepicker._optionDatepicker = function(target, name, value) {
 				min=new Date();
 			else
 				min= new Date(min);
-			
+
 			tp_inst._defaults.minDate = min;
 			tp_inst._defaults.minDateTime = min;
 		} else if (max){ //if max was set

--- a/js/tools.js
+++ b/js/tools.js
@@ -737,10 +737,10 @@ function getStorageAvailable() {
 	}
 }
 
-$(document).ready(function()
+$(function()
 {
 	// Hide all elements with .hideOnSubmit class when parent form is submit
-	$('form').submit(function() {
+	$('form').on('submit', function() {
 		$(this).find('.hideOnSubmit').hide();
 	});
 

--- a/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Configure/AdvancedParameters/system_information.html.twig
@@ -248,7 +248,7 @@
 </div>
 
 <script>
-  $(document).ready(function()
+  $(function()
   {
     var translations = {
       missing: '{{ 'Missing files'|trans({}, 'Admin.Advparameters.Notification')|e('js') }}',

--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/bootstrap_popup.html.twig
@@ -78,7 +78,7 @@
     </div>
 </div>
 <script>
-    $(document).ready(function() {
+    $(function() {
         var closable = {% if closable is defined and closable == true %}true{% else %}false{% endif %};
         $('#{{ id }}').modal({
             backdrop: (closable ? true : 'static'),

--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_inputs.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_inputs.html.twig
@@ -24,7 +24,7 @@
  *#}
 {# Display a range input with min/max controls #}
 <script>
-    $(document).ready(function() {
+    $(function() {
         var sliderInput = $('#{{ input_name }}');
         var minInput = $('#{{ input_name }}_min');
         var maxInput = $('#{{ input_name }}_max');

--- a/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/Helpers/range_slider.html.twig
@@ -23,7 +23,7 @@
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  *#}
 <script>
-    $(document).ready(function() {
+    $(function() {
         var sliderInput = $('#{{ input_name }}');
 
         // parse and fix init value

--- a/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
+++ b/src/PrestaShopBundle/Resources/views/Admin/TwigTemplateForm/typeahead.html.twig
@@ -128,7 +128,7 @@
                     }).show();
                 });
 
-                $('#{{ form.vars.id }}-curPackItemAdd').click(function(e){
+                $('#{{ form.vars.id }}-curPackItemAdd').on('click', function(e){
                     e.preventDefault();
                     if($(this).data('currentItem')){
                         var number = $('#{{ form.vars.id }}-curPackItemQty').val();
@@ -208,7 +208,7 @@
                                    '</table></div>'
                         }
                     }
-                }).bind('typeahead:select', function(ev, suggestion) {
+                }).on('typeahead:select', function(ev, suggestion) {
                     $('#{{ form.vars.id }}-curPackItemAdd').data('currentItem', suggestion);
                 });
             });
@@ -283,7 +283,7 @@
                         return '<div>'+ item.{{ mapping_name }} +'</div>'
                     }
                 }
-            }).bind('typeahead:select', function(ev, suggestion) {
+            }).on('typeahead:select', function(ev, suggestion) {
 
                 //if collection length is up to limit, return
                 if({{ limit }} != 0 && $('#{{ form.vars.id }}-data li').length >= {{ limit }}){
@@ -302,7 +302,7 @@
                 $('#{{ form.vars.id }}-data').show();
                 $('#{{ form.vars.id }}-data').append(html);
 
-            }).bind('typeahead:close', function(ev) {
+            }).on('typeahead:close', function(ev) {
                 $(ev.target).val('');
             });
         });

--- a/themes/_core/js/address.js
+++ b/themes/_core/js/address.js
@@ -38,7 +38,7 @@ function handleCountryChange(selectors) {
   });
 }
 
-$(document).ready(() => {
+$(() => {
   handleCountryChange({
     country: '.js-country',
     address: '.js-address-form',

--- a/themes/_core/js/cart.js
+++ b/themes/_core/js/cart.js
@@ -26,7 +26,7 @@ import $ from 'jquery';
 import prestashop from 'prestashop';
 import {refreshCheckoutPage} from './common';
 
-$(document).ready(() => {
+$(() => {
   prestashop.on('updateCart', (event) => {
     prestashop.cart = event.resp.cart;
     const getCartViewUrl = $('.js-cart').data('refresh-url');

--- a/themes/_core/js/checkout.js
+++ b/themes/_core/js/checkout.js
@@ -60,7 +60,7 @@ function handleCheckoutStepChange() {
 function handleSubmitButton() {
   // prevents rage clicking on submit button and related issues
   const formSelector = prestashop.selectors.checkout.form;
-  $(formSelector).submit(function (e) {
+  $(formSelector).on('submit', function (e) {
     if ($(this).data('disabled') === true) {
       e.preventDefault();
     }
@@ -69,7 +69,7 @@ function handleSubmitButton() {
   });
 }
 
-$(document).ready(() => {
+$(() => {
   if ($('#checkout').length === 1) {
     setUpCheckout();
   }

--- a/themes/_core/js/facets.js
+++ b/themes/_core/js/facets.js
@@ -69,7 +69,7 @@ function makeQuery(url) {
   });
 }
 
-$(document).ready(() => {
+$(() => {
   prestashop.on('updateFacets', (param) => {
     makeQuery(param);
   });

--- a/themes/_core/js/listing.js
+++ b/themes/_core/js/listing.js
@@ -25,7 +25,7 @@
 import $ from 'jquery';
 import prestashop from 'prestashop';
 
-$(document).ready(() => {
+$(() => {
   $('body').on('click', prestashop.selectors.listing.quickview, (event) => {
     prestashop.emit('clickQuickView', {
       dataset: $(event.target).closest(prestashop.selectors.product.miniature).data(),

--- a/themes/_core/js/product.js
+++ b/themes/_core/js/product.js
@@ -361,7 +361,7 @@ function showError($container, textError) {
   $container.replaceWith($error);
 }
 
-$(document).ready(() => {
+$(() => {
   const $productActions = $(prestashop.selectors.product.actions);
 
   // Listen on all form elements + those who have a data-product-attribute

--- a/themes/_core/js/selectors.js
+++ b/themes/_core/js/selectors.js
@@ -106,6 +106,6 @@ prestashop.selectors = {
   },
 };
 
-$(document).ready(() => {
+$(() => {
   prestashop.emit('selectorsInit');
 });

--- a/themes/_core/js/theme.js
+++ b/themes/_core/js/theme.js
@@ -45,7 +45,7 @@ import initEmailFields from './email-idn';
 window.$ = $;
 window.jQuery = $;
 
-$(document).ready(() => {
+$(() => {
   psShowHide();
   initEmailFields('input[type="email"]');
 });


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | This change fixes a TON of deprecations pointed out by jquery migrate. Some remain though, in old libraries, in modules, and on the classic theme. It's easy to review, albeit a little long... sorry!
| Type?             | refacto
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Unless a typo has been made somewhere, it should work fine. Otherwise anything may have broken everywhere in the BO.
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop SA
