### PR TITLE
Smarty htmlspecialchars

### DIFF
--- a/config/smarty.config.inc.php
+++ b/config/smarty.config.inc.php
@@ -112,6 +112,7 @@ smartyRegisterFunction($smarty, 'modifier', 'strval','strval');
 smartyRegisterFunction($smarty, 'modifier', 'trim', 'trim');
 smartyRegisterFunction($smarty, 'modifier', 'ucfirst', 'ucfirst');
 smartyRegisterFunction($smarty, 'modifier', 'urlencode','urlencode');
+smartyRegisterFunction($smarty, 'modifier', 'htmlspecialchars','htmlspecialchars');
 
 function smarty_modifier_htmlentitiesUTF8($string)
 {


### PR DESCRIPTION

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.0.x
| Description?      | Register `htmlspecialchars` for Smarty to suppress an error when accessing the BO (the Dashboard)
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | yes
| Deprecations?     | no
| How to test?      | Access the dashboard
| Fixed ticket?     | N/A
| Related PRs       | N/A
| Sponsor company   | PrestaShop
