### PR TITLE
Add missing attribute in search categories API

### DIFF
--- a/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
+++ b/src/PrestaShopBundle/Resources/config/routing/admin/sell/catalog/categories.yml
@@ -162,6 +162,7 @@ admin_categories_get_ajax_categories:
   methods: [ GET ]
   defaults:
     _controller: PrestaShopBundle\Controller\Admin\Sell\Catalog\CategoryController::getAjaxCategoriesAction
+    _legacy_controller: AdminCategories
     _format: json
     limit: 20
   requirements:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | 8.1.x
| Description?      | Fix the API that was copied in another controller from this PR #32194
| Type?             | bug fix
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Go to product page V2 in SEO tab set the redirection to a category (the type of redirection is not important), use the search input to select a category, the input should display some categories based on your input<br /><br />It may be useful to test the other part modified by the previous PR, I though the automated tests were enough but I was wrong so here is an exhaustive list of things to check:<br />- in product page v1, create a category in the right column, it should be assigned to the product (in `Create a new category` section)<br />- check that stock movement behave as usual (in product edition, and when product are order and shipped)
| Fixed ticket?     | ~ 
| Related PRs       | ~
| Sponsor company   | ~
